### PR TITLE
fix(headless): prevent logging search box sumbit when clicking a query suggestion.

### DIFF
--- a/packages/headless/src/controllers/search-box/headless-search-box.test.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.test.ts
@@ -22,6 +22,7 @@ import {buildMockQuerySuggest} from '../../test/mock-query-suggest';
 import {buildMockSearchAppEngine, MockEngine} from '../../test/mock-engine';
 import {updatePage} from '../../features/pagination/pagination-actions';
 import {SearchAppState} from '../../state/search-app-state';
+import {logNoopSearchEvent} from '../../features/analytics/analytics-actions';
 
 describe('headless searchBox', () => {
   const id = 'search-box-123';
@@ -165,14 +166,25 @@ describe('headless searchBox', () => {
     });
   });
 
-  it(`when calling selectSuggestion
-    should dispatch a selectQuerySuggestion action`, () => {
-    const value = 'i like this expression';
-    searchBox.selectSuggestion(value);
+  describe('#selectSuggestion', () => {
+    it('dispatches a selectQuerySuggestion action', () => {
+      const value = 'i like this expression';
+      searchBox.selectSuggestion(value);
 
-    expect(engine.actions).toContainEqual(
-      selectQuerySuggestion({id, expression: value})
-    );
+      expect(engine.actions).toContainEqual(
+        selectQuerySuggestion({id, expression: value})
+      );
+    });
+
+    it('dispatches executeSearch with a noop search event', () => {
+      const suggestion = 'a';
+      searchBox.selectSuggestion(suggestion);
+
+      const action = engine.findAsyncAction(executeSearch.pending);
+      expect(action && action.meta.arg.toString()).toBe(
+        logNoopSearchEvent().toString()
+      );
+    });
   });
 
   describe('when calling submit', () => {

--- a/packages/headless/src/controllers/search-box/headless-search-box.test.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.test.ts
@@ -22,7 +22,7 @@ import {buildMockQuerySuggest} from '../../test/mock-query-suggest';
 import {buildMockSearchAppEngine, MockEngine} from '../../test/mock-engine';
 import {updatePage} from '../../features/pagination/pagination-actions';
 import {SearchAppState} from '../../state/search-app-state';
-import {logNoopSearchEvent} from '../../features/analytics/analytics-actions';
+import {logQuerySuggestionClick} from '../../features/query-suggest/query-suggest-analytics-actions';
 
 describe('headless searchBox', () => {
   const id = 'search-box-123';
@@ -176,13 +176,13 @@ describe('headless searchBox', () => {
       );
     });
 
-    it('dispatches executeSearch with a noop search event', () => {
+    it('dispatches executeSearch with a logQuerySuggestionClick search event', () => {
       const suggestion = 'a';
       searchBox.selectSuggestion(suggestion);
 
       const action = engine.findAsyncAction(executeSearch.pending);
-      expect(action && action.meta.arg.toString()).toBe(
-        logNoopSearchEvent().toString()
+      expect(action!.meta.arg.toString()).toBe(
+        logQuerySuggestionClick({id, suggestion}).toString()
       );
     });
   });

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -80,7 +80,7 @@ export function buildSearchBox(
 
   const getValue = () => engine.state.querySet[options.id];
 
-  const submit = (analytics: SearchAction) => {
+  const performSearch = (analytics: SearchAction) => {
     const {enableQuerySyntax} = options;
 
     dispatch(updateQuery({q: getValue(), enableQuerySyntax}));
@@ -130,14 +130,14 @@ export function buildSearchBox(
      */
     selectSuggestion(value: string) {
       dispatch(selectQuerySuggestion({id, expression: value}));
-      submit(logQuerySuggestionClick({id, suggestion: value}));
+      performSearch(logQuerySuggestionClick({id, suggestion: value}));
     },
 
     /**
      * Triggers a search query.
      */
     submit() {
-      submit(logSearchboxSubmit());
+      performSearch(logSearchboxSubmit());
     },
 
     /**

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -31,10 +31,7 @@ import {validateOptions} from '../../utils/validate-payload';
 import {logQuerySuggestionClick} from '../../features/query-suggest/query-suggest-analytics-actions';
 import {randomID} from '../../utils/utils';
 import {QuerySuggestState} from '../../features/query-suggest/query-suggest-state';
-import {
-  logNoopSearchEvent,
-  SearchAction,
-} from '../../features/analytics/analytics-actions';
+import {SearchAction} from '../../features/analytics/analytics-actions';
 
 export {SearchBoxOptions};
 export interface SearchBoxProps {
@@ -132,9 +129,8 @@ export function buildSearchBox(
      * @param value The string value of the suggestion to select
      */
     selectSuggestion(value: string) {
-      dispatch(logQuerySuggestionClick({id, suggestion: value}));
       dispatch(selectQuerySuggestion({id, expression: value}));
-      submit(logNoopSearchEvent());
+      submit(logQuerySuggestionClick({id, suggestion: value}));
     },
 
     /**

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
@@ -10,6 +10,7 @@ import {buildMockQuerySuggest} from '../../test/mock-query-suggest';
 import {buildMockSearchAppEngine, MockEngine} from '../../test/mock-engine';
 import {SearchAppState} from '../../state/search-app-state';
 import {registerQuerySetQuery} from '../../features/query-set/query-set-actions';
+import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
 
 describe('headless standalone searchBox', () => {
   const id = 'search-box-123';
@@ -71,6 +72,23 @@ describe('headless standalone searchBox', () => {
       })),
       redirectTo: state.redirection.redirectTo,
       isLoading: false,
+    });
+  });
+
+  describe('#selectSuggestion', () => {
+    it('updates the query', () => {
+      const expression = 'a';
+      searchBox.selectSuggestion(expression);
+
+      const action = selectQuerySuggestion({id, expression});
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('calls #submit', () => {
+      jest.spyOn(searchBox, 'submit');
+      searchBox.selectSuggestion('a');
+
+      expect(searchBox.submit).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
@@ -80,8 +80,9 @@ describe('headless standalone searchBox', () => {
       const expression = 'a';
       searchBox.selectSuggestion(expression);
 
-      const action = selectQuerySuggestion({id, expression});
-      expect(engine.actions).toContainEqual(action);
+      expect(engine.actions).toContainEqual(
+        selectQuerySuggestion({id, expression})
+      );
     });
 
     it('calls #submit', () => {

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -1,4 +1,5 @@
 import {Engine} from '../../app/headless-engine';
+import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
 import {updateQuery} from '../../features/query/query-actions';
 import {checkForRedirection} from '../../features/redirection/redirection-actions';
 import {
@@ -62,6 +63,15 @@ export function buildStandaloneSearchBox(
 
   return {
     ...searchBox,
+
+    /**
+     * Selects a suggestion and calls `submit`.
+     * @param value The string value of the suggestion to select
+     */
+    selectSuggestion(value: string) {
+      dispatch(selectQuerySuggestion({id, expression: value}));
+      this.submit();
+    },
 
     /**
      * Triggers a redirection.

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -83,12 +83,6 @@ export interface GenericSearchEventPayload<T = unknown> {
   meta?: Record<string, T>;
 }
 
-export const logNoopSearchEvent = makeAnalyticsAction(
-  'analytics/search/noop',
-  AnalyticsType.Search,
-  () => {}
-);
-
 /**
  * Logs a generic search event.
  * @param p (GenericSearchEventPayload) The search event payload.

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -83,6 +83,12 @@ export interface GenericSearchEventPayload<T = unknown> {
   meta?: Record<string, T>;
 }
 
+export const logNoopSearchEvent = makeAnalyticsAction(
+  'analytics/search/noop',
+  AnalyticsType.Search,
+  () => {}
+);
+
 /**
  * Logs a generic search event.
  * @param p (GenericSearchEventPayload) The search event payload.

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -32,4 +32,4 @@ export const logQuerySuggestionClick = ({
 
       return;
     }
-  );
+  )();

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -80,9 +80,8 @@ function buildMockEngine<T extends AppState>(
       return store.getActions();
     },
     findAsyncAction<ThunkArg>(actionCreator: AsyncActionCreator<ThunkArg>) {
-      return this.actions.find((a) => a.type === actionCreator.type) as
-        | ReturnType<AsyncActionCreator<ThunkArg>>
-        | undefined;
+      const action = this.actions.find((a) => a.type === actionCreator.type);
+      return isAsyncAction<ThunkArg>(action) ? action : undefined;
     },
     ...config,
     renewAccessToken: mockRenewAccessToken,
@@ -98,3 +97,9 @@ const configureMockStore = () => {
     ...getDefaultMiddleware(),
   ]);
 };
+
+function isAsyncAction<ThunkArg>(
+  action: AnyAction | undefined
+): action is ReturnType<AsyncActionCreator<ThunkArg>> {
+  return action ? 'meta' in action : false;
+}


### PR DESCRIPTION
This PR makes the search-box log analytics just like in JSUI.

1. When selecting a suggestion from a search-box, only the suggestion click is logged, with no searchboxSubmit event.
2. When selecting a suggestion from a standalone search-box, only the redirect event is logged. The suggestion click is no longer logged, since this should happen when the redirect target page loads. There is no mechanism in place atm to do this. Will explore this in a dedicated PR,

I also added a `findAsyncAction` utility method on the mock-engine to make it easier to find these actions when writing unit tests.