### PR TITLE
chore: update @stencil/sass to latest

### DIFF
--- a/packages/atomic/package-lock.json
+++ b/packages/atomic/package-lock.json
@@ -1152,9 +1152,9 @@
       "dev": true
     },
     "@stencil/sass": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.0.tgz",
-      "integrity": "sha512-UFYuaM8zFvdqnBi7DN5urzCjNOtW3VBrnvfTze7vRY5zUz9catNiaguJI3yCYil6t/WThgAdPCpaTNWV+R+TcA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz",
+      "integrity": "sha512-aFKoqtxZ/8BRbvNFiWRycGiqvMI22Ifn5qsKfq0U23j43XD81jT6d7K0WQd55ejNpoSpdxJcbOuFgQy3mXizfA==",
       "dev": true
     },
     "@types/babel__core": {

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",
     "@stencil/core": "^2.0.3",
-    "@stencil/sass": "^1.4.0",
+    "@stencil/sass": "^1.4.1",
     "@types/jest": "^26.0.14",
     "@types/mustache": "^4.0.1",
     "@types/puppeteer": "5.4.0",

--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -39,7 +39,7 @@ export const config: Config = {
   plugins: [
     sass({
       includePaths: ['src/scss/'],
-      injectGlobalPaths: [['src/scss/_global.scss', '*']],
+      injectGlobalPaths: ['src/scss/_global.scss'],
     }),
   ],
   rollupPlugins: {


### PR DESCRIPTION
I could not start atomic after updating `@stencil/sass` to `1.4.0` because rollup could not resolve global sass module imports (e.g. `@module-name`). Good news is the ionic team [published a fix](https://github.com/ionic-team/stencil-sass/commits/master) yesterday!

https://coveord.atlassian.net/browse/KIT-287