### PR TITLE
fix(headless): fix facet search for headless controllers facet controllers

### DIFF
--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -98,8 +98,8 @@ export class AtomicCategoryFacet {
   }
 
   private get facetSearchResults() {
-    const facetSearch = this.categoryFacet.facetSearch;
-    return facetSearch.state.values.map((searchResult) => (
+    console.log(this.state.facetSearch.values);
+    return this.state.facetSearch.values.map((searchResult) => (
       <div onClick={() => this.categoryFacet.facetSearch.select(searchResult)}>
         {searchResult.displayValue} {searchResult.count}
       </div>
@@ -107,14 +107,14 @@ export class AtomicCategoryFacet {
   }
 
   private get showMoreSearchResults() {
-    const facetSearch = this.categoryFacet.facetSearch;
-
-    if (!facetSearch.state.moreValuesAvailable) {
+    if (!this.state.facetSearch.moreValuesAvailable) {
       return null;
     }
 
     return (
-      <button onClick={() => facetSearch.showMoreResults()}>show more</button>
+      <button onClick={() => this.categoryFacet.facetSearch.showMoreResults()}>
+        show more
+      </button>
     );
   }
 

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -98,7 +98,6 @@ export class AtomicCategoryFacet {
   }
 
   private get facetSearchResults() {
-    console.log(this.state.facetSearch.values);
     return this.state.facetSearch.values.map((searchResult) => (
       <div onClick={() => this.categoryFacet.facetSearch.select(searchResult)}>
         {searchResult.displayValue} {searchResult.count}

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -86,23 +86,22 @@ export class AtomicFacet {
   }
 
   private get facetSearchResults() {
-    const facetSearch = this.facet.facetSearch;
-    return facetSearch.state.values.map((searchResult) => (
-      <div onClick={() => facetSearch.select(searchResult)}>
+    return this.state.facetSearch.values.map((searchResult) => (
+      <div onClick={() => this.facet.facetSearch.select(searchResult)}>
         {searchResult.displayValue} {searchResult.count}
       </div>
     ));
   }
 
   private get showMoreSearchResults() {
-    const facetSearch = this.facet.facetSearch;
-
-    if (!facetSearch.state.moreValuesAvailable) {
+    if (!this.state.facetSearch.moreValuesAvailable) {
       return null;
     }
 
     return (
-      <button onClick={() => facetSearch.showMoreResults()}>show more</button>
+      <button onClick={() => this.facet.facetSearch.showMoreResults()}>
+        show more
+      </button>
     );
   }
 

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
@@ -459,4 +459,24 @@ describe('category facet', () => {
       1
     );
   });
+
+  it('exposes a #facetSearch state', () => {
+    expect(categoryFacet.state.facetSearch).toBeTruthy();
+    expect(categoryFacet.state.facetSearch.values).toEqual([]);
+
+    const fakeResponseValue = {
+      count: 123,
+      displayValue: 'foo',
+      rawValue: 'foo',
+      path: ['bar', 'bazz'],
+    };
+
+    engine.state.categoryFacetSearchSet[facetId].response.values = [
+      fakeResponseValue,
+    ];
+
+    expect(categoryFacet.state.facetSearch.values[0]).toMatchObject(
+      fakeResponseValue
+    );
+  });
 });

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -86,9 +86,12 @@ export function buildCategoryFacet(
 
   dispatch(registerCategoryFacet(options));
 
+  const facetSearch = createFacetSearch();
+  const {state, ...restOfFacetSearch} = facetSearch;
+
   return {
     ...controller,
-    facetSearch: createFacetSearch(),
+    facetSearch: restOfFacetSearch,
 
     /**
      * Selects (deselects) the passed value if unselected (selected).
@@ -170,6 +173,7 @@ export function buildCategoryFacet(
         canShowMoreValues,
         canShowLessValues,
         sortCriteria: request.sortCriteria,
+        facetSearch: facetSearch.state,
       };
     },
   };

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -14,14 +14,12 @@ import {buildMockFacetValue} from '../../../test/mock-facet-value';
 import {executeSearch} from '../../../features/search/search-actions';
 import {FacetRequest} from '../../../features/facets/facet-set/interfaces/request';
 import {buildMockFacetRequest} from '../../../test/mock-facet-request';
-import * as FacetSearch from '../facet-search/specific/headless-facet-search';
+
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 import {SearchAppState} from '../../../state/search-app-state';
 import * as FacetIdDeterminor from '../_common/facet-id-determinor';
-
-jest.mock('../facet-search/specific/headless-facet-search', () => ({
-  buildFacetSearch: jest.fn(() => ({})),
-}));
+import {buildMockFacetSearch} from '../../../test/mock-facet-search';
+import * as FacetSearch from '../facet-search/specific/headless-facet-search';
 
 describe('facet', () => {
   const facetId = '1';
@@ -37,6 +35,7 @@ describe('facet', () => {
 
   function setFacetRequest(config: Partial<FacetRequest> = {}) {
     state.facetSet[facetId] = buildMockFacetRequest({facetId, ...config});
+    state.facetSearchSet[facetId] = buildMockFacetSearch();
   }
 
   beforeEach(() => {
@@ -430,7 +429,23 @@ describe('facet', () => {
   });
 
   it('exposes a #facetSearch property', () => {
+    jest.spyOn(FacetSearch, 'buildFacetSearch');
+    initFacet();
     expect(facet.facetSearch).toBeTruthy();
     expect(FacetSearch.buildFacetSearch).toHaveBeenCalled();
+  });
+
+  it('exposes a #facetSearch state', () => {
+    expect(facet.state.facetSearch).toBeTruthy();
+    expect(facet.state.facetSearch.values).toEqual([]);
+
+    const fakeResponseValue = {
+      count: 123,
+      displayValue: 'foo',
+      rawValue: 'foo',
+    };
+    engine.state.facetSearchSet[facetId].response.values = [fakeResponseValue];
+
+    expect(facet.state.facetSearch.values[0]).toMatchObject(fakeResponseValue);
   });
 });

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -91,10 +91,11 @@ export function buildFacet(
   };
 
   dispatch(registerFacet(options));
-
+  const facetSearch = createFacetSearch();
+  const {state, ...restOfFacetSearch} = facetSearch;
   return {
     ...controller,
-    facetSearch: createFacetSearch(),
+    facetSearch: restOfFacetSearch,
     /**
      * Selects (deselects) the passed value if unselected (selected).
      * @param selection The facet value to select or deselect.
@@ -195,6 +196,7 @@ export function buildFacet(
 
         /** @returns `true` if fewer values can be displayed and `false` otherwise.*/
         canShowLessValues: computeCanShowLessValues(),
+        facetSearch: facetSearch.state,
       };
     },
   };

--- a/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
@@ -31,7 +31,7 @@ export const executeFacetSearch = createAsyncThunk<
       facetId,
       new StringValue({required: true, emptyAllowed: false})
     );
-    if (isSpecificFacetSearchState(state)) {
+    if (isSpecificFacetSearchState(state, facetId)) {
       req = buildSpecificFacetSearchRequest(facetId, state);
     } else {
       req = buildCategoryFacetSearchRequest(
@@ -48,7 +48,12 @@ export const executeFacetSearch = createAsyncThunk<
 );
 
 const isSpecificFacetSearchState = (
-  s: StateNeededForFacetSearch
+  s: StateNeededForFacetSearch,
+  facetId: string
 ): s is StateNeededForSpecificFacetSearch => {
-  return s.facetSearchSet !== undefined && s.facetSet !== undefined;
+  return (
+    s.facetSearchSet !== undefined &&
+    s.facetSet !== undefined &&
+    s.facetSet[facetId] !== undefined
+  );
 };


### PR DESCRIPTION
With the previous way the destructuring was done, we'd get a copy of the original empty state for facet search.

Also fixed a problem with `isSpecificFacetSearchState`, because it would always evaluate to true if you had a CategoryFacet + Specific facet in the same page.

I also reworked how the facet search state was exposed on each controller:


```javascript
const facet = buildFacet(...)

// or select(),showMore() etc. All methods are still available
facet.search.search() 

// this was previously how you would reach the state for facet search
// this cause problem in your UI layer, since normally you subscribe to facet.state changes 
// and not facet.search.state changes
facet.search.state.values 

// I've changed it so the facet search state is included in the normal state object for headless facet
facet.state.search.values
```

https://coveord.atlassian.net/browse/KIT-292