### PR TITLE
feat(atomic,headless): set atomic facet's facetId to deterministic value from controller.

### DIFF
--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.spec.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.spec.tsx
@@ -9,12 +9,4 @@ describe('atomic-category-facet', () => {
     });
     expect(page.root).toBeTruthy();
   });
-
-  it('initializes the facetId prop to a random value containing the type of facet', () => {
-    const facetId1 = new AtomicCategoryFacet().facetId;
-    const facetId2 = new AtomicCategoryFacet().facetId;
-
-    expect(facetId1).toContain('categoryFacet');
-    expect(facetId1).not.toEqual(facetId2);
-  });
 });

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -34,6 +34,7 @@ export class AtomicCategoryFacet {
       delimitingCharacter: ';',
     };
     this.categoryFacet = buildCategoryFacet(this.engine, {options});
+    this.facetId = this.categoryFacet.state.facetId;
     this.subscribe();
   }
 

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -10,7 +10,6 @@ import {
   CategoryFacetSortCriterion,
 } from '@coveo/headless';
 import {Initialization} from '../../utils/initialization-utils';
-import {randomID} from '../../utils/utils';
 
 @Component({
   tag: 'atomic-category-facet',
@@ -18,7 +17,7 @@ import {randomID} from '../../utils/utils';
   shadow: true,
 })
 export class AtomicCategoryFacet {
-  @Prop() facetId = randomID('categoryFacet');
+  @Prop() facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: CategoryFacetState;

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicCategoryFacet {
-  @Prop() facetId = '';
+  @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: CategoryFacetState;

--- a/packages/atomic/src/components/atomic-category-facet/readme.md
+++ b/packages/atomic/src/components/atomic-category-facet/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default                     |
-| --------- | ---------- | ----------- | -------- | --------------------------- |
-| `facetId` | `facet-id` |             | `string` | `randomID('categoryFacet')` |
-| `field`   | `field`    |             | `string` | `''`                        |
-| `label`   | `label`    |             | `string` | `'No label'`                |
+| Property  | Attribute  | Description | Type     | Default      |
+| --------- | ---------- | ----------- | -------- | ------------ |
+| `facetId` | `facet-id` |             | `string` | `''`         |
+| `field`   | `field`    |             | `string` | `''`         |
+| `label`   | `label`    |             | `string` | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.spec.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.spec.tsx
@@ -9,12 +9,4 @@ describe('atomic-date-facet', () => {
     });
     expect(page.root).toBeTruthy();
   });
-
-  it('initializes the facetId prop to a random value containing the type of facet', () => {
-    const facetId1 = new AtomicDateFacet().facetId;
-    const facetId2 = new AtomicDateFacet().facetId;
-
-    expect(facetId1).toContain('dateFacet');
-    expect(facetId1).not.toEqual(facetId2);
-  });
 });

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicDateFacet {
-  @Prop() facetId = '';
+  @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: DateFacetState;

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
@@ -10,7 +10,6 @@ import {
   Engine,
 } from '@coveo/headless';
 import {Initialization} from '../../utils/initialization-utils';
-import {randomID} from '../../utils/utils';
 
 @Component({
   tag: 'atomic-date-facet',
@@ -18,7 +17,7 @@ import {randomID} from '../../utils/utils';
   shadow: true,
 })
 export class AtomicDateFacet {
-  @Prop() facetId = randomID('dateFacet');
+  @Prop() facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: DateFacetState;

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
@@ -35,6 +35,7 @@ export class AtomicDateFacet {
     };
 
     this.facet = buildDateFacet(this.engine, {options});
+    this.facetId = this.facet.state.facetId;
     this.subscribe();
   }
 

--- a/packages/atomic/src/components/atomic-date-facet/readme.md
+++ b/packages/atomic/src/components/atomic-date-facet/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default                 |
-| --------- | ---------- | ----------- | -------- | ----------------------- |
-| `facetId` | `facet-id` |             | `string` | `randomID('dateFacet')` |
-| `field`   | `field`    |             | `string` | `''`                    |
-| `label`   | `label`    |             | `string` | `'No label'`            |
+| Property  | Attribute  | Description | Type     | Default      |
+| --------- | ---------- | ----------- | -------- | ------------ |
+| `facetId` | `facet-id` |             | `string` | `''`         |
+| `field`   | `field`    |             | `string` | `''`         |
+| `label`   | `label`    |             | `string` | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.spec.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.spec.tsx
@@ -9,12 +9,4 @@ describe('atomic-facet', () => {
     });
     expect(page.root).toBeTruthy();
   });
-
-  it('initializes the facetId prop to a random value containing the type of facet', () => {
-    const facetId1 = new AtomicFacet().facetId;
-    const facetId2 = new AtomicFacet().facetId;
-
-    expect(facetId1).toContain('facet');
-    expect(facetId1).not.toEqual(facetId2);
-  });
 });

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -30,6 +30,7 @@ export class AtomicFacet {
   public initialize() {
     const options: FacetOptions = {facetId: this.facetId, field: this.field};
     this.facet = buildFacet(this.engine, {options});
+    this.facetId = this.facet.state.facetId;
     this.subscribe();
   }
 

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -10,7 +10,6 @@ import {
   Engine,
 } from '@coveo/headless';
 import {Initialization} from '../../utils/initialization-utils';
-import {randomID} from '../../utils/utils';
 
 @Component({
   tag: 'atomic-facet',
@@ -18,7 +17,7 @@ import {randomID} from '../../utils/utils';
   shadow: true,
 })
 export class AtomicFacet {
-  @Prop() facetId = randomID('facet');
+  @Prop() facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: FacetState;

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicFacet {
-  @Prop() facetId = '';
+  @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: FacetState;

--- a/packages/atomic/src/components/atomic-facet/readme.md
+++ b/packages/atomic/src/components/atomic-facet/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default             |
-| --------- | ---------- | ----------- | -------- | ------------------- |
-| `facetId` | `facet-id` |             | `string` | `randomID('facet')` |
-| `field`   | `field`    |             | `string` | `''`                |
-| `label`   | `label`    |             | `string` | `'No label'`        |
+| Property  | Attribute  | Description | Type     | Default      |
+| --------- | ---------- | ----------- | -------- | ------------ |
+| `facetId` | `facet-id` |             | `string` | `''`         |
+| `field`   | `field`    |             | `string` | `''`         |
+| `label`   | `label`    |             | `string` | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.spec.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.spec.tsx
@@ -9,12 +9,4 @@ describe('atomic-numeric-facet', () => {
     });
     expect(page.root).toBeTruthy();
   });
-
-  it('initializes the facetId prop to a random value containing the type of facet', () => {
-    const facetId1 = new AtomicNumericFacet().facetId;
-    const facetId2 = new AtomicNumericFacet().facetId;
-
-    expect(facetId1).toContain('numericFacet');
-    expect(facetId1).not.toEqual(facetId2);
-  });
 });

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -11,7 +11,6 @@ import {
   Engine,
 } from '@coveo/headless';
 import {Initialization} from '../../utils/initialization-utils';
-import {randomID} from '../../utils/utils';
 
 @Component({
   tag: 'atomic-numeric-facet',
@@ -19,7 +18,7 @@ import {randomID} from '../../utils/utils';
   shadow: true,
 })
 export class AtomicNumericFacet {
-  @Prop() facetId = randomID('numericFacet');
+  @Prop() facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: NumericFacetState;

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -43,6 +43,7 @@ export class AtomicNumericFacet {
     };
 
     this.facet = buildNumericFacet(this.engine, {options});
+    this.facetId = this.facet.state.facetId;
     this.subscribe();
   }
 

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -18,7 +18,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicNumericFacet {
-  @Prop() facetId = '';
+  @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: NumericFacetState;

--- a/packages/atomic/src/components/atomic-numeric-facet/readme.md
+++ b/packages/atomic/src/components/atomic-numeric-facet/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default                    |
-| --------- | ---------- | ----------- | -------- | -------------------------- |
-| `facetId` | `facet-id` |             | `string` | `randomID('numericFacet')` |
-| `field`   | `field`    |             | `string` | `''`                       |
-| `label`   | `label`    |             | `string` | `'No label'`               |
+| Property  | Attribute  | Description | Type     | Default      |
+| --------- | ---------- | ----------- | -------- | ------------ |
+| `facetId` | `facet-id` |             | `string` | `''`         |
+| `field`   | `field`    |             | `string` | `''`         |
+| `label`   | `label`    |             | `string` | `'No label'` |
 
 
 ## Dependencies

--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.test.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.test.ts
@@ -12,8 +12,20 @@ describe('#determineFacetId', () => {
   });
 
   it('when a #facetId key is passed, it returns it', () => {
-    const id = determineFacetId(engine, {facetId: '', field: 'author'});
-    expect(id).toBe('');
+    const id = determineFacetId(engine, {facetId: 'a', field: 'author'});
+    expect(id).toBe('a');
+  });
+
+  it('when a #facetId key is empty, it calls #generateFacetId', () => {
+    jest.spyOn(FacetIdGenerator, 'generateFacetId');
+    determineFacetId(engine, {facetId: '', field: 'author'});
+
+    const {state, logger} = engine;
+    const config = buildMockFacetIdConfig({field: 'author', state});
+    expect(FacetIdGenerator.generateFacetId).toHaveBeenCalledWith(
+      config,
+      logger
+    );
   });
 
   it('when the #facetId key is not passed, it calls #generateFacetId', () => {

--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
@@ -13,5 +13,5 @@ export function determineFacetId(
 ) {
   const {state, logger} = engine;
   const {field, facetId} = config;
-  return facetId ?? generateFacetId({field, state}, logger);
+  return facetId || generateFacetId({field, state}, logger);
 }

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
@@ -72,6 +72,10 @@ describe('category facet', () => {
     );
   });
 
+  it('#state.facetId exposes the facet id', () => {
+    expect(categoryFacet.state.facetId).toBe(facetId);
+  });
+
   it('registers a category facet with the passed options and default optional parameters', () => {
     const action = registerCategoryFacet({
       facetId,

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -163,6 +163,7 @@ export function buildCategoryFacet(
       const canShowLessValues = values.length > options.numberOfValues;
 
       return {
+        facetId,
         parents,
         values,
         isLoading,

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -99,6 +99,10 @@ describe('facet', () => {
     expect(() => initFacet()).toThrow('Check the options of buildFacet');
   });
 
+  it('#state.facetId exposes the facet id', () => {
+    expect(facet.state.facetId).toBe(facetId);
+  });
+
   it('when the search response is empty, the facet #state.values is an empty array', () => {
     expect(state.search.response.facets).toEqual([]);
     expect(facet.state.values).toEqual([]);

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -178,6 +178,9 @@ export function buildFacet(
       const canShowMoreValues = response ? response.moreValuesAvailable : false;
 
       return {
+        /** @returns the facet id */
+        facetId,
+
         /** @returns the values of the facet */
         values,
 

--- a/packages/headless/src/controllers/facets/range-facet/headless-range-facet.test.ts
+++ b/packages/headless/src/controllers/facets/range-facet/headless-range-facet.test.ts
@@ -41,6 +41,10 @@ describe('range facet', () => {
     expect(rangeFacet.subscribe).toBeDefined();
   });
 
+  it('#state.facetId exposes the facet id', () => {
+    expect(rangeFacet.state.facetId).toBe(facetId);
+  });
+
   it('#state.values holds the response values', () => {
     const values = [buildMockNumericFacetValue()];
     const facet = buildMockNumericFacetResponse({facetId, values});

--- a/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
@@ -92,6 +92,7 @@ export function buildRangeFacet<
       );
 
       return {
+        facetId,
         values,
         sortCriterion,
         hasActiveValues,


### PR DESCRIPTION
Facet ids were being generated randomly in the atomic facets.

By deferring id generation to the controller, and exposing the facetId from the controller, the atomic facets no longer need to handle this. The facet id prop is updated after initializing the controller so that the facet manager can continue to access the ids to sort the facets.