### PR TITLE
refactor(headless): explicitly write Facet and CategoryFacet option interfaces for jsdoc

### DIFF
--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-options.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-options.ts
@@ -1,10 +1,8 @@
 import {Schema, StringValue} from '@coveo/bueno';
-import {CategoryFacetRegistrationOptions} from '../../../features/facets/category-facet-set/interfaces/options';
 import {
   categoryFacetSortCriteria,
   CategoryFacetSortCriterion,
 } from '../../../features/facets/category-facet-set/interfaces/request';
-import {FacetSearchRequestOptions} from '../../../features/facets/facet-search-set/facet-search-request-options';
 import {
   facetId,
   field,
@@ -17,12 +15,23 @@ import {
   facetSearch,
 } from '../_common/facet-option-definitions';
 
-export type CategoryFacetOptions = Omit<
-  CategoryFacetRegistrationOptions,
-  'facetId'
-> & {
+export type CategoryFacetOptions = {
+  field: string;
   facetId?: string;
-  facetSearch?: Partial<FacetSearchRequestOptions>;
+  basePath?: string[];
+  delimitingCharacter?: string;
+  filterByBasePath?: boolean;
+  filterFacetCount?: boolean;
+  injectionDepth?: number;
+  numberOfValues?: number;
+  sortCriteria?: CategoryFacetSortCriterion;
+  facetSearch?: CategoryFacetSearchOptions;
+};
+
+type CategoryFacetSearchOptions = {
+  captions?: Record<string, string>;
+  numberOfValues?: number;
+  query?: string;
 };
 
 export const categoryFacetOptionsSchema = new Schema<

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
@@ -29,6 +29,8 @@ import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-se
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 import {SearchAppState} from '../../../state/search-app-state';
 import * as FacetIdDeterminor from '../_common/facet-id-determinor';
+import {CategoryFacetRegistrationOptions} from '../../../features/facets/category-facet-set/interfaces/options';
+import {FacetSearchRequestOptions} from '../../../features/facets/facet-search-set/facet-search-request-options';
 
 describe('category facet', () => {
   const facetId = '1';
@@ -59,6 +61,27 @@ describe('category facet', () => {
     state = createMockState();
     setFacetRequest();
     initCategoryFacet();
+  });
+
+  it('the #CategoryFacetOptions type is valid', () => {
+    type Equal<A, B extends A> = ['pass', B];
+
+    type ExpectedOptions = CategoryFacetRegistrationOptions & {
+      facetSearch: Partial<FacetSearchRequestOptions>;
+    };
+
+    type AllCategoryFacetOptions = Required<CategoryFacetOptions>;
+    type TestCategoryFacetOptions = Equal<
+      ExpectedOptions,
+      AllCategoryFacetOptions
+    >;
+    type TestCategoryFacetSearchOptions = Equal<
+      FacetSearchRequestOptions,
+      Required<AllCategoryFacetOptions['facetSearch']>
+    >;
+
+    type Tests = TestCategoryFacetOptions | TestCategoryFacetSearchOptions;
+    expect((true as unknown) as Tests).toBe(true);
   });
 
   it('it calls #determineFacetId with the correct params', () => {

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -1,7 +1,8 @@
 import {Schema, StringValue} from '@coveo/bueno';
-import {FacetSearchRequestOptions} from '../../../features/facets/facet-search-set/facet-search-request-options';
-import {FacetRegistrationOptions} from '../../../features/facets/facet-set/interfaces/options';
-import {facetSortCriteria} from '../../../features/facets/facet-set/interfaces/request';
+import {
+  facetSortCriteria,
+  FacetSortCriterion,
+} from '../../../features/facets/facet-set/interfaces/request';
 import {
   facetId,
   field,
@@ -12,9 +13,21 @@ import {
   facetSearch,
 } from '../_common/facet-option-definitions';
 
-export type FacetOptions = Omit<FacetRegistrationOptions, 'facetId'> & {
+export type FacetOptions = {
+  field: string;
   facetId?: string;
-  facetSearch?: Partial<FacetSearchRequestOptions>;
+  delimitingCharacter?: string;
+  filterFacetCount?: boolean;
+  injectionDepth?: number;
+  numberOfValues?: number;
+  sortCriteria?: FacetSortCriterion;
+  facetSearch?: FacetSearchOptions;
+};
+
+type FacetSearchOptions = {
+  captions?: Record<string, string>;
+  numberOfValues?: number;
+  query?: string;
 };
 
 export const facetOptionsSchema = new Schema<Required<FacetOptions>>({

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -20,6 +20,8 @@ import {SearchAppState} from '../../../state/search-app-state';
 import * as FacetIdDeterminor from '../_common/facet-id-determinor';
 import {buildMockFacetSearch} from '../../../test/mock-facet-search';
 import * as FacetSearch from '../facet-search/specific/headless-facet-search';
+import {FacetRegistrationOptions} from '../../../features/facets/facet-set/interfaces/options';
+import {FacetSearchRequestOptions} from '../../../features/facets/facet-search-set/facet-search-request-options';
 
 describe('facet', () => {
   const facetId = '1';
@@ -50,6 +52,24 @@ describe('facet', () => {
     setFacetRequest();
 
     initFacet();
+  });
+
+  it('the #FacetOptions type is valid', () => {
+    type Equal<A, B extends A> = ['pass', B];
+
+    type ExpectedOptions = FacetRegistrationOptions & {
+      facetSearch: Partial<FacetSearchRequestOptions>;
+    };
+
+    type AllFacetOptions = Required<FacetOptions>;
+    type TestFacetOptions = Equal<ExpectedOptions, AllFacetOptions>;
+    type TestFacetSearchOptions = Equal<
+      FacetSearchRequestOptions,
+      Required<AllFacetOptions['facetSearch']>
+    >;
+
+    type Tests = TestFacetOptions | TestFacetSearchOptions;
+    expect((true as unknown) as Tests).toBe(true);
   });
 
   it('renders', () => {


### PR DESCRIPTION
**Context**

We want `Option` interfaces of all controllers to be strictly typed, while also having jsdoc to provide useful information such as descriptions, default values, and other restrictions (e.g. min, max etc.) to end-users.

**Problem**
We are generating option interfaces in different ways, each with their own strength and weaknesses.

**Approach 1: Deriving from schemas**

For simple controllers where all options are optional (or required) (e.g. `Sort`, `Pager`), it is possible to derive interfaces from Bueno using `SchemaValues`.

However, when the options are complex, containing a mix of required and optional parameters, object parameters which contain additional keys, or properties that depend on other properties, it is not possible to derive a strict interface from Bueno schemas. I believe there is a way to adjust Bueno to make this possible, but I could not find how to do it after spending several days on the problem a few weeks ago.

**Approach 2: Deriving from interfaces**

All four facet controllers have complex options. The option interfaces are not derived from schemas, but from other types and interfaces. The benefit of this is we can precisely control the types, being as strict as possible, and guiding the end-user as to what they need to configure. The options are also always in-sync with the headless core and the search-api.

The issue with deriving is because there is no duplication, the different properties making up the interface are deeper in the project. Jsdoc annotations would be scattered all over the project. There is also no duplication, which means that jsdoc needs to be less specific and more abstract.

Example:
The Facet and CategoryFacet both support the `delimitingCharacter` param. However, each facet has a different default character. When there is a single source of truth, the jsdoc needs to mention both defaults, making the annotation less relevant in the context of a CategoryFacet.

**Proposed Solution 1**

This PR writes out every property of the Facet and CategoryFacet `Option` interfaces. This allows for strict, complex types, while also providing one central place to add jsdoc. Each interface being separate means there will be some duplication, but it also makes it possible to write specific annotations depending on the type of facet.

Duplicating the properties comes with the drawback of the interface going out-of-sync with the core. To defend against this, I added some type tests that assert the manually written types against the old derived interface approach. These tests will show a compile-time error if a key is:
1. Deleted.
2. Has the wrong name, or
3. Has the wrong type.

On the other hand, they will not catch optional -> required regressions. Some options were covered by unit tests, others were not. If a new option is added to the core, the test would alert us to expose it on the controller.

**Proposed Solution 2**

Keep the derived interfaces as they were prior to this PR, and add documentation on the interface properties in the headless core. The main benefit of this approach is it would reduce duplication, as a single jsdoc will be reflected on the controllers and actions. The main disadvantage is the documentation would be more general, in effect similar to the how the search api documentation is right now.

Suggestions and feedback welcome,

https://coveord.atlassian.net/browse/KIT-306