### PR TITLE
fix(headless): fix facet state analytics

### DIFF
--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -2436,9 +2436,9 @@
 			"dev": true
 		},
 		"coveo.analytics": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.14.0.tgz",
-			"integrity": "sha512-U8M67LaMJkEzVDfd6H4BE9Ta1mf+kXdzXMTHvDqm8ZMcw2JTZIiCwtx04qAq5Qdj7pYydCsRQVQ9YIgjGFwvVQ=="
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.15.0.tgz",
+			"integrity": "sha512-GBT8OtacV4cArFPnpq+jm9pavLZX2EC4BXH1QvcnqYywq0fMJU/5SyyQ34cHh3JpSLtn/qFe2G1feELgba3qrA=="
 		},
 		"create-ecdh": {
 			"version": "4.0.3",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -30,7 +30,7 @@
     "@coveo/bueno": "^0.1.0-alpha.81",
     "@reduxjs/toolkit": "^1.4.0",
     "@types/redux-mock-store": "^1.0.2",
-    "coveo.analytics": "^2.14.0",
+    "coveo.analytics": "^2.15.0",
     "cross-fetch": "^3.0.6",
     "dayjs": "^1.9.6",
     "exponential-backoff": "^3.1.0",

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
@@ -3,7 +3,6 @@ import {
   logFacetDeselect,
   logFacetSelect,
 } from '../facet-set/facet-set-analytics-actions';
-import {FacetSelectionChangeMetadata} from '../facet-set/facet-set-analytics-actions-utils';
 
 type CategoryFacetResponsePartition = {
   parents: CategoryFacetValue[];
@@ -39,7 +38,7 @@ export const getAnalyticsActionForCategoryFacetToggleSelect = (
   facetId: string,
   selection: CategoryFacetValue
 ) => {
-  const payload: FacetSelectionChangeMetadata = {
+  const payload = {
     facetId,
     facetValue: selection.value,
   };

--- a/packages/headless/src/features/facets/facet-api/request.ts
+++ b/packages/headless/src/features/facets/facet-api/request.ts
@@ -29,11 +29,11 @@ export interface Expandable {
   isFieldExpanded: boolean;
 }
 
-export interface Type<T extends AvailableType> {
+export interface Type<T extends FacetType> {
   type: T;
 }
 
-export type AvailableType =
+export type FacetType =
   | 'specific'
   | 'dateRange'
   | 'numericalRange'

--- a/packages/headless/src/features/facets/facet-api/request.ts
+++ b/packages/headless/src/features/facets/facet-api/request.ts
@@ -29,11 +29,15 @@ export interface Expandable {
   isFieldExpanded: boolean;
 }
 
-export interface Type<
-  T extends 'specific' | 'dateRange' | 'numericalRange' | 'hierarchical'
-> {
+export interface Type<T extends AvailableType> {
   type: T;
 }
+
+export type AvailableType =
+  | 'specific'
+  | 'dateRange'
+  | 'numericalRange'
+  | 'hierarchical';
 
 export interface SortCriteria<
   T extends

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-action-utils.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-action-utils.test.ts
@@ -1,0 +1,235 @@
+import {buildMockCategoryFacetRequest} from '../../../test/mock-category-facet-request';
+import {buildMockCategoryFacetResponse} from '../../../test/mock-category-facet-response';
+import {buildMockCategoryFacetValue} from '../../../test/mock-category-facet-value';
+import {buildMockDateFacetRequest} from '../../../test/mock-date-facet-request';
+import {buildMockDateFacetResponse} from '../../../test/mock-date-facet-response';
+import {buildMockDateFacetValue} from '../../../test/mock-date-facet-value';
+import {buildMockFacetRequest} from '../../../test/mock-facet-request';
+import {buildMockFacetResponse} from '../../../test/mock-facet-response';
+import {buildMockNumericFacetRequest} from '../../../test/mock-numeric-facet-request';
+import {buildMockNumericFacetResponse} from '../../../test/mock-numeric-facet-response';
+import {buildMockNumericFacetValue} from '../../../test/mock-numeric-facet-value';
+import {createMockState} from '../../../test/mock-state';
+import {buildFacetStateMetadata} from './facet-set-analytics-actions-utils';
+
+describe('facet-set-analytics-action-utils', () => {
+  describe('#buildFacetStateMetadata', () => {
+    describe('#specific facet', () => {
+      const getState = () => {
+        const state = createMockState();
+        const facetResponse = buildMockFacetResponse({
+          values: [
+            {numberOfResults: 1, value: 'should not appear', state: 'idle'},
+            {numberOfResults: 1, value: 'should appear', state: 'selected'},
+          ],
+        });
+        state.search.response.facets = [facetResponse];
+        state.facetSet = {
+          [facetResponse.facetId]: buildMockFacetRequest(),
+        };
+        return {state, facetResponse};
+      };
+
+      it('includes #selected values', () => {
+        const {state, facetResponse} = getState();
+        expect(buildFacetStateMetadata(state)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              field: facetResponse.field,
+              id: facetResponse.facetId,
+              value: facetResponse.values[1].value,
+              valuePosition: 2,
+              displayValue: facetResponse.values[1].value,
+              facetType: 'specific',
+              state: 'selected',
+              facetPosition: 1,
+              title: facetResponse.field,
+            }),
+          ])
+        );
+      });
+
+      it('does not include #idle values', () => {
+        const {state, facetResponse} = getState();
+
+        expect(buildFacetStateMetadata(state)).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              value: facetResponse.values[0].value,
+            }),
+          ])
+        );
+      });
+    });
+
+    describe('#hierarchical facet', () => {
+      const getState = () => {
+        const state = createMockState();
+        const facetResponse = buildMockCategoryFacetResponse({
+          values: [
+            buildMockCategoryFacetValue({
+              state: 'idle',
+              value: 'should not appear',
+            }),
+            buildMockCategoryFacetValue({
+              state: 'selected',
+              value: 'should appear',
+            }),
+          ],
+        });
+        state.search.response.facets = [facetResponse];
+        state.categoryFacetSet = {
+          [facetResponse.facetId]: buildMockCategoryFacetRequest(),
+        };
+        return {state, facetResponse};
+      };
+
+      it('includes #selected values', () => {
+        const {state, facetResponse} = getState();
+        expect(buildFacetStateMetadata(state)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              field: facetResponse.field,
+              id: facetResponse.facetId,
+              value: facetResponse.values[1].value,
+              valuePosition: 2,
+              displayValue: facetResponse.values[1].value,
+              facetType: 'hierarchical',
+              state: 'selected',
+              facetPosition: 1,
+              title: facetResponse.field,
+            }),
+          ])
+        );
+      });
+
+      it('does not include #idle values', () => {
+        const {state, facetResponse} = getState();
+
+        expect(buildFacetStateMetadata(state)).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              value: facetResponse.values[0].value,
+            }),
+          ])
+        );
+      });
+    });
+
+    describe('#numerical facet', () => {
+      const getState = () => {
+        const state = createMockState();
+        const facetResponse = buildMockNumericFacetResponse({
+          values: [
+            buildMockNumericFacetValue({
+              state: 'idle',
+              start: 1,
+              end: 10,
+            }),
+            buildMockNumericFacetValue({
+              state: 'selected',
+              start: 50,
+              end: 100,
+              endInclusive: true,
+              numberOfResults: 123,
+            }),
+          ],
+        });
+        state.search.response.facets = [facetResponse];
+        state.numericFacetSet = {
+          [facetResponse.facetId]: buildMockNumericFacetRequest(),
+        };
+        return {state, facetResponse};
+      };
+
+      it('includes #selected values', () => {
+        const {state, facetResponse} = getState();
+        expect(buildFacetStateMetadata(state)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              field: facetResponse.field,
+              id: facetResponse.facetId,
+              value: `${facetResponse.values[1].start}..${facetResponse.values[1].end}`,
+              valuePosition: 2,
+              displayValue: `${facetResponse.values[1].start}..${facetResponse.values[1].end}`,
+              facetType: 'numericalRange',
+              state: 'selected',
+              facetPosition: 1,
+              title: facetResponse.field,
+            }),
+          ])
+        );
+      });
+
+      it('does not include #idle values', () => {
+        const {state, facetResponse} = getState();
+
+        expect(buildFacetStateMetadata(state)).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              value: `${facetResponse.values[0].start}..${facetResponse.values[0].end}`,
+            }),
+          ])
+        );
+      });
+    });
+
+    describe('#date facet', () => {
+      const getState = () => {
+        const state = createMockState();
+        const facetResponse = buildMockDateFacetResponse({
+          values: [
+            buildMockDateFacetValue({
+              state: 'idle',
+              start: 'should not',
+              end: 'appear',
+            }),
+            buildMockDateFacetValue({
+              state: 'selected',
+              start: 'should',
+              end: 'appear',
+              endInclusive: true,
+              numberOfResults: 123,
+            }),
+          ],
+        });
+        state.search.response.facets = [facetResponse];
+        state.dateFacetSet = {
+          [facetResponse.facetId]: buildMockDateFacetRequest(),
+        };
+        return {state, facetResponse};
+      };
+
+      it('includes #selected values', () => {
+        const {state, facetResponse} = getState();
+        expect(buildFacetStateMetadata(state)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              field: facetResponse.field,
+              id: facetResponse.facetId,
+              value: `${facetResponse.values[1].start}..${facetResponse.values[1].end}`,
+              valuePosition: 2,
+              displayValue: `${facetResponse.values[1].start}..${facetResponse.values[1].end}`,
+              facetType: 'dateRange',
+              state: 'selected',
+              facetPosition: 1,
+              title: facetResponse.field,
+            }),
+          ])
+        );
+      });
+
+      it('does not include #idle values', () => {
+        const {state, facetResponse} = getState();
+
+        expect(buildFacetStateMetadata(state)).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              value: `${facetResponse.values[0].start}..${facetResponse.values[0].end}`,
+            }),
+          ])
+        );
+      });
+    });
+  });
+});

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -84,7 +84,7 @@ export const buildFacetStateMetadata = (
 
   state.search.response.facets.forEach((facetResponse, facetPosition) => {
     (facetResponse.values as Array<AnyFacetValue>).forEach(
-      (facetValue, facetValuePositition) => {
+      (facetValue, facetValuePosition) => {
         if (facetValue.state === 'selected') {
           const facetType = getFacetType(state, facetResponse.facetId);
 
@@ -95,7 +95,7 @@ export const buildFacetStateMetadata = (
 
           const facetValueAnalytics = mapFacetValueToAnalytics(
             facetValue,
-            facetValuePositition + 1,
+            facetValuePosition + 1,
             facetType
           );
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -1,16 +1,38 @@
+import {FacetStateMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAppState} from '../../../state/search-app-state';
 import {
   CategoryFacetSection,
   DateFacetSection,
   FacetSection,
   NumericFacetSection,
+  SearchSection,
 } from '../../../state/state-sections';
+import {getSearchInitialState} from '../../search/search-state';
+import {categoryFacetResponseSelector} from '../category-facet-set/category-facet-set-selectors';
+import {getCategoryFacetSetInitialState} from '../category-facet-set/category-facet-set-state';
+import {CategoryFacetValue} from '../category-facet-set/interfaces/response';
+import {AvailableType} from '../facet-api/request';
+import {
+  AnyFacetResponse,
+  AnyFacetValue,
+} from '../generic/interfaces/generic-facet-response';
+import {dateFacetResponseSelector} from '../range-facets/date-facet-set/date-facet-selectors';
+import {getDateFacetSetInitialState} from '../range-facets/date-facet-set/date-facet-set-state';
+import {DateFacetValue} from '../range-facets/date-facet-set/interfaces/response';
 import {RangeFacetSortCriterion} from '../range-facets/generic/interfaces/request';
+import {NumericFacetValue} from '../range-facets/numeric-facet-set/interfaces/response';
+import {numericFacetResponseSelector} from '../range-facets/numeric-facet-set/numeric-facet-selectors';
+import {getNumericFacetSetInitialState} from '../range-facets/numeric-facet-set/numeric-facet-set-state';
+import {facetResponseSelector} from './facet-set-selectors';
+import {getFacetSetInitialState} from './facet-set-state';
 import {FacetSortCriterion} from './interfaces/request';
+import {FacetValue} from './interfaces/response';
 
 export type SectionNeededForFacetMetadata = FacetSection &
   CategoryFacetSection &
   DateFacetSection &
-  NumericFacetSection;
+  NumericFacetSection &
+  SearchSection;
 
 export type FacetUpdateSortMetadata = {
   facetId: string;
@@ -20,4 +42,159 @@ export type FacetUpdateSortMetadata = {
 export type FacetSelectionChangeMetadata = {
   facetId: string;
   facetValue: string;
+};
+
+export const buildFacetBaseMetadata = (
+  facetId: string,
+  state: SectionNeededForFacetMetadata
+) => {
+  const facet =
+    state.facetSet[facetId] ||
+    state.categoryFacetSet[facetId] ||
+    state.dateFacetSet[facetId] ||
+    state.numericFacetSet[facetId];
+
+  const facetField = facet.field;
+  const facetTitle = `${facetField}_${facetId}`;
+
+  return {facetId, facetField, facetTitle};
+};
+
+export function buildFacetSelectionChangeMetadata(
+  payload: FacetSelectionChangeMetadata,
+  state: SectionNeededForFacetMetadata
+) {
+  const {facetId, facetValue} = payload;
+  const base = buildFacetBaseMetadata(facetId, state);
+
+  return {...base, facetValue};
+}
+
+export function getStateNeededForFacetMetadata(
+  s: Partial<SearchAppState>
+): SectionNeededForFacetMetadata {
+  return {
+    facetSet: s.facetSet || getFacetSetInitialState(),
+    categoryFacetSet: s.categoryFacetSet || getCategoryFacetSetInitialState(),
+    dateFacetSet: s.dateFacetSet || getDateFacetSetInitialState(),
+    numericFacetSet: s.numericFacetSet || getNumericFacetSetInitialState(),
+    search: s.search || getSearchInitialState(),
+  };
+}
+
+export const buildFacetStateMetadata = (
+  state: SectionNeededForFacetMetadata
+) => {
+  const facetState: FacetStateMetadata[] = [];
+
+  state.search.response.facets.forEach((facetResponse, facetPosition) => {
+    (facetResponse.values as Array<AnyFacetValue>).forEach(
+      (facetValue, facetValuePositition) => {
+        if (facetValue.state === 'selected') {
+          const facetType = getFacetType(state, facetResponse.facetId);
+
+          const facetResponseAnalytics = mapFacetResponseToAnalytics(
+            facetResponse,
+            facetPosition + 1
+          );
+
+          const facetValueAnalytics = mapFacetValueToAnalytics(
+            facetValue,
+            facetValuePositition + 1,
+            facetType
+          );
+
+          const facetDisplayValueAnalytics =
+            facetType === 'hierarchical' || facetType === 'specific'
+              ? mapFacetDisplayValueToAnalytics(
+                  facetValue as CategoryFacetValue | FacetValue
+                )
+              : mapRangeDisplayFacetValueToAnalytics(
+                  facetValue as NumericFacetValue | DateFacetValue
+                );
+
+          facetState.push({
+            ...facetResponseAnalytics,
+            ...facetValueAnalytics,
+            ...facetDisplayValueAnalytics,
+          });
+        }
+      }
+    );
+  });
+
+  return facetState;
+};
+
+const mapFacetValueToAnalytics = (
+  facetValue: AnyFacetValue,
+  valuePosition: number,
+  facetType: AvailableType
+) => {
+  return {
+    state: facetValue.state,
+    valuePosition,
+    facetType,
+  };
+};
+
+const mapRangeDisplayFacetValueToAnalytics = (
+  facetValue: DateFacetValue | NumericFacetValue
+) => {
+  return {
+    displayValue: `${facetValue.start}..${facetValue.end}`,
+    value: `${facetValue.start}..${facetValue.end}`,
+    start: facetValue.start,
+    end: facetValue.end,
+    endInclusive: facetValue.endInclusive,
+  };
+};
+
+const mapFacetDisplayValueToAnalytics = (
+  facetValue: CategoryFacetValue | FacetValue
+) => {
+  return {
+    displayValue: facetValue.value,
+    value: facetValue.value,
+  };
+};
+
+const mapFacetResponseToAnalytics = (
+  response: AnyFacetResponse,
+  facetPosition: number
+) => {
+  return {
+    title: response.facetId,
+    field: response.field,
+    id: response.facetId,
+    facetPosition,
+  };
+};
+
+const getFacetType = (
+  state: SearchSection &
+    FacetSection &
+    CategoryFacetSection &
+    DateFacetSection &
+    NumericFacetSection,
+  id: string
+): AvailableType => {
+  const facetResponse = facetResponseSelector(state, id);
+  if (facetResponse) {
+    return 'specific';
+  }
+  const categoryFacetResponse = categoryFacetResponseSelector(state, id);
+  if (categoryFacetResponse) {
+    return 'hierarchical';
+  }
+  const dateFacetResponse = dateFacetResponseSelector(state, id);
+  if (dateFacetResponse) {
+    return 'dateRange';
+  }
+  const numericFacetResponse = numericFacetResponseSelector(state, id);
+  if (numericFacetResponse) {
+    return 'numericalRange';
+  }
+
+  return 'specific';
 };

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -8,24 +8,23 @@ import {
   SearchSection,
 } from '../../../state/state-sections';
 import {getSearchInitialState} from '../../search/search-state';
-import {categoryFacetResponseSelector} from '../category-facet-set/category-facet-set-selectors';
 import {getCategoryFacetSetInitialState} from '../category-facet-set/category-facet-set-state';
+import {CategoryFacetRequest} from '../category-facet-set/interfaces/request';
 import {CategoryFacetValue} from '../category-facet-set/interfaces/response';
-import {AvailableType} from '../facet-api/request';
+import {FacetType} from '../facet-api/request';
 import {
   AnyFacetResponse,
   AnyFacetValue,
 } from '../generic/interfaces/generic-facet-response';
-import {dateFacetResponseSelector} from '../range-facets/date-facet-set/date-facet-selectors';
 import {getDateFacetSetInitialState} from '../range-facets/date-facet-set/date-facet-set-state';
+import {DateFacetRequest} from '../range-facets/date-facet-set/interfaces/request';
 import {DateFacetValue} from '../range-facets/date-facet-set/interfaces/response';
 import {RangeFacetSortCriterion} from '../range-facets/generic/interfaces/request';
+import {NumericFacetRequest} from '../range-facets/numeric-facet-set/interfaces/request';
 import {NumericFacetValue} from '../range-facets/numeric-facet-set/interfaces/response';
-import {numericFacetResponseSelector} from '../range-facets/numeric-facet-set/numeric-facet-selectors';
 import {getNumericFacetSetInitialState} from '../range-facets/numeric-facet-set/numeric-facet-set-state';
-import {facetResponseSelector} from './facet-set-selectors';
 import {getFacetSetInitialState} from './facet-set-state';
-import {FacetSortCriterion} from './interfaces/request';
+import {FacetRequest, FacetSortCriterion} from './interfaces/request';
 import {FacetValue} from './interfaces/response';
 
 export type SectionNeededForFacetMetadata = FacetSection &
@@ -48,11 +47,7 @@ export const buildFacetBaseMetadata = (
   facetId: string,
   state: SectionNeededForFacetMetadata
 ) => {
-  const facet =
-    state.facetSet[facetId] ||
-    state.categoryFacetSet[facetId] ||
-    state.dateFacetSet[facetId] ||
-    state.numericFacetSet[facetId];
+  const facet = getFacet(state, facetId);
 
   const facetField = facet.field;
   const facetTitle = `${facetField}_${facetId}`;
@@ -129,7 +124,7 @@ export const buildFacetStateMetadata = (
 const mapFacetValueToAnalytics = (
   facetValue: AnyFacetValue,
   valuePosition: number,
-  facetType: AvailableType
+  facetType: FacetType
 ) => {
   return {
     state: facetValue.state,
@@ -171,30 +166,26 @@ const mapFacetResponseToAnalytics = (
   };
 };
 
-const getFacetType = (
-  state: SearchSection &
-    FacetSection &
-    CategoryFacetSection &
-    DateFacetSection &
-    NumericFacetSection,
-  id: string
-): AvailableType => {
-  const facetResponse = facetResponseSelector(state, id);
-  if (facetResponse) {
-    return 'specific';
-  }
-  const categoryFacetResponse = categoryFacetResponseSelector(state, id);
-  if (categoryFacetResponse) {
-    return 'hierarchical';
-  }
-  const dateFacetResponse = dateFacetResponseSelector(state, id);
-  if (dateFacetResponse) {
-    return 'dateRange';
-  }
-  const numericFacetResponse = numericFacetResponseSelector(state, id);
-  if (numericFacetResponse) {
-    return 'numericalRange';
-  }
+const getFacet = (
+  state: SectionNeededForFacetMetadata,
+  facetId: string
+):
+  | FacetRequest
+  | CategoryFacetRequest
+  | DateFacetRequest
+  | NumericFacetRequest => {
+  return (
+    state.facetSet[facetId] ||
+    state.categoryFacetSet[facetId] ||
+    state.dateFacetSet[facetId] ||
+    state.numericFacetSet[facetId]
+  );
+};
 
-  return 'specific';
+const getFacetType = (
+  state: SectionNeededForFacetMetadata,
+  facetId: string
+) => {
+  const facet = getFacet(state, facetId);
+  return facet ? facet.type : 'specific';
 };

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -5,20 +5,18 @@ import {
   facetIdDefinition,
   requiredNonEmptyString,
 } from '../generic/facet-actions-validation';
-import {SearchAppState} from '../../../state/search-app-state';
-import {getFacetSetInitialState} from './facet-set-state';
-import {getDateFacetSetInitialState} from '../range-facets/date-facet-set/date-facet-set-state';
-import {getNumericFacetSetInitialState} from '../range-facets/numeric-facet-set/numeric-facet-set-state';
-import {getCategoryFacetSetInitialState} from '../category-facet-set/category-facet-set-state';
 import {Value} from '@coveo/bueno';
 import {
   AnalyticsType,
   makeAnalyticsAction,
 } from '../../analytics/analytics-utils';
 import {
+  buildFacetBaseMetadata,
   FacetSelectionChangeMetadata,
   FacetUpdateSortMetadata,
-  SectionNeededForFacetMetadata,
+  buildFacetStateMetadata,
+  getStateNeededForFacetMetadata,
+  buildFacetSelectionChangeMetadata,
 } from './facet-set-analytics-actions-utils';
 
 /**
@@ -67,11 +65,10 @@ export const logFacetSearch = (facetId: string) =>
     AnalyticsType.Search,
     (client, state) => {
       validatePayload(facetId, facetIdDefinition);
-      const metadata = buildFacetBaseMetadata(
-        facetId,
-        getStateNeededForFacetMetadata(state)
-      );
-      return client.logFacetSearch(metadata);
+      const stateForAnalytics = getStateNeededForFacetMetadata(state);
+      const metadata = buildFacetBaseMetadata(facetId, stateForAnalytics);
+      const facetState = buildFacetStateMetadata(stateForAnalytics);
+      return client.logFacetSearch(metadata, facetState);
     }
   )();
 /**
@@ -89,15 +86,15 @@ export const logFacetUpdateSort = (payload: FacetUpdateSortMetadata) =>
           required: true,
         }),
       });
+
       const {facetId, criterion} = payload;
+      const stateForAnalytics = getStateNeededForFacetMetadata(state);
 
-      const base = buildFacetBaseMetadata(
-        facetId,
-        getStateNeededForFacetMetadata(state)
-      );
+      const base = buildFacetBaseMetadata(facetId, stateForAnalytics);
       const metadata = {...base, criteria: criterion};
+      const facetState = buildFacetStateMetadata(stateForAnalytics);
 
-      return client.logFacetUpdateSort(metadata);
+      return client.logFacetUpdateSort(metadata, facetState);
     }
   )();
 
@@ -111,11 +108,12 @@ export const logFacetClearAll = (facetId: string) =>
     AnalyticsType.Search,
     (client, state) => {
       validatePayload(facetId, facetIdDefinition);
-      const metadata = buildFacetBaseMetadata(
-        facetId,
-        getStateNeededForFacetMetadata(state)
-      );
-      return client.logFacetClearAll(metadata);
+
+      const stateForAnalytics = getStateNeededForFacetMetadata(state);
+      const metadata = buildFacetBaseMetadata(facetId, stateForAnalytics);
+      const facetState = buildFacetStateMetadata(stateForAnalytics);
+
+      return client.logFacetClearAll(metadata, facetState);
     }
   )();
 
@@ -133,12 +131,14 @@ export const logFacetSelect = (payload: FacetSelectionChangeMetadata) =>
         facetValue: requiredNonEmptyString,
       });
 
+      const stateForAnalytics = getStateNeededForFacetMetadata(state);
       const metadata = buildFacetSelectionChangeMetadata(
         payload,
-        getStateNeededForFacetMetadata(state)
+        stateForAnalytics
       );
+      const facetState = buildFacetStateMetadata(stateForAnalytics);
 
-      return client.logFacetSelect(metadata);
+      return client.logFacetSelect(metadata, facetState);
     }
   )();
 
@@ -155,47 +155,13 @@ export const logFacetDeselect = (payload: FacetSelectionChangeMetadata) =>
         facetId: facetIdDefinition,
         facetValue: requiredNonEmptyString,
       });
+      const stateForAnalytics = getStateNeededForFacetMetadata(state);
       const metadata = buildFacetSelectionChangeMetadata(
         payload,
-        getStateNeededForFacetMetadata(state)
+        stateForAnalytics
       );
-      return client.logFacetDeselect(metadata);
+      const facetState = buildFacetStateMetadata(stateForAnalytics);
+
+      return client.logFacetDeselect(metadata, facetState);
     }
   )();
-
-function buildFacetSelectionChangeMetadata(
-  payload: FacetSelectionChangeMetadata,
-  state: SectionNeededForFacetMetadata
-) {
-  const {facetId, facetValue} = payload;
-  const base = buildFacetBaseMetadata(facetId, state);
-
-  return {...base, facetValue};
-}
-
-function getStateNeededForFacetMetadata(
-  s: Partial<SearchAppState>
-): SectionNeededForFacetMetadata {
-  return {
-    facetSet: s.facetSet || getFacetSetInitialState(),
-    categoryFacetSet: s.categoryFacetSet || getCategoryFacetSetInitialState(),
-    dateFacetSet: s.dateFacetSet || getDateFacetSetInitialState(),
-    numericFacetSet: s.numericFacetSet || getNumericFacetSetInitialState(),
-  };
-}
-
-function buildFacetBaseMetadata(
-  facetId: string,
-  state: SectionNeededForFacetMetadata
-) {
-  const facet =
-    state.facetSet[facetId] ||
-    state.categoryFacetSet[facetId] ||
-    state.dateFacetSet[facetId] ||
-    state.numericFacetSet[facetId];
-
-  const facetField = facet.field;
-  const facetTitle = `${facetField}_${facetId}`;
-
-  return {facetId, facetField, facetTitle};
-}

--- a/packages/headless/src/features/facets/generic/interfaces/generic-facet-response.ts
+++ b/packages/headless/src/features/facets/generic/interfaces/generic-facet-response.ts
@@ -1,8 +1,19 @@
-import {FacetResponse} from '../../facet-set/interfaces/response';
+import {FacetResponse, FacetValue} from '../../facet-set/interfaces/response';
 import {RangeFacetResponse} from '../../range-facets/generic/interfaces/range-facet';
-import {CategoryFacetResponse} from '../../category-facet-set/interfaces/response';
+import {
+  CategoryFacetResponse,
+  CategoryFacetValue,
+} from '../../category-facet-set/interfaces/response';
+import {NumericFacetValue} from '../../range-facets/numeric-facet-set/interfaces/response';
+import {DateFacetValue} from '../../range-facets/date-facet-set/interfaces/response';
 
 export type AnyFacetResponse =
   | FacetResponse
   | RangeFacetResponse
   | CategoryFacetResponse;
+
+export type AnyFacetValue =
+  | FacetValue
+  | NumericFacetValue
+  | CategoryFacetValue
+  | DateFacetValue;

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-selectors.test.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-selectors.test.ts
@@ -1,6 +1,6 @@
 import {SearchAppState} from '../../../../state/search-app-state';
 import {
-  dataFacetResponseSelector,
+  dateFacetResponseSelector,
   dateFacetSelectedValuesSelector,
 } from './date-facet-selectors';
 import {createMockState} from '../../../../test';
@@ -19,7 +19,7 @@ describe('date facet selectors', () => {
   });
 
   it('#dateFacetResponseSelector returns undefined if the response does not exist', () => {
-    const response = dataFacetResponseSelector(state, facetId);
+    const response = dateFacetResponseSelector(state, facetId);
     expect(response).toBeUndefined();
   });
 
@@ -28,7 +28,7 @@ describe('date facet selectors', () => {
     const mockResponse = buildMockDateFacetResponse({facetId});
     state.search.response.facets = [mockResponse];
 
-    const response = dataFacetResponseSelector(state, facetId);
+    const response = dateFacetResponseSelector(state, facetId);
     expect(response).toEqual(mockResponse);
   });
 
@@ -37,7 +37,7 @@ describe('date facet selectors', () => {
     const mockResponse = buildMockFacetResponse({facetId});
     state.search.response.facets = [mockResponse];
 
-    const response = dataFacetResponseSelector(state, facetId);
+    const response = dateFacetResponseSelector(state, facetId);
     expect(response).toBeUndefined();
   });
 

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-selectors.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-selectors.ts
@@ -13,7 +13,7 @@ function isDateFacetResponse(
   return !!response && response.facetId in state.dateFacetSet;
 }
 
-export const dataFacetResponseSelector = (
+export const dateFacetResponseSelector = (
   state: SearchSection & DateFacetSection,
   facetId: string
 ) => {
@@ -29,7 +29,7 @@ export const dateFacetSelectedValuesSelector = (
   state: SearchSection & DateFacetSection,
   facetId: string
 ): DateFacetValue[] => {
-  const facetResponse = dataFacetResponseSelector(state, facetId);
+  const facetResponse = dateFacetResponseSelector(state, facetId);
   if (!facetResponse) {
     return [];
   }


### PR DESCRIPTION
Goes hand in hand with https://github.com/coveo/coveo.analytics.js/pull/235

As for the problem with facet `title`, `position`, `displayValue` that we send to analytics possibly not being what is actually displayed in the app built on top of headless (because that's ultimately out of the control of headless), I asked in DNE slack channel, and got this answer: 

> displayValue and title are not essential, but they are used for debugging and understanding the date. I'd prefer that they'd be there if possible, and it's not the end of the world if they're not "perfect".

> As for facetPosition it's not used right now but I'd say that search impressions will have precedence over UA, so again, it's not the end of the world if it's not there.

> For position, we can send what we guess it will be from the response from the API



https://coveord.atlassian.net/browse/KIT-301