### PR TITLE
fix(headless): logActionErrorMiddleware should only stop on SchemaValidationError

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -95,6 +95,7 @@ export namespace Components {
     }
     interface AtomicSearchBox {
         "_id": string;
+        "enableQuerySyntax": boolean;
         /**
           * Wether the submit button should be place before the input
          */
@@ -383,6 +384,7 @@ declare namespace LocalJSX {
     }
     interface AtomicSearchBox {
         "_id"?: string;
+        "enableQuerySyntax"?: boolean;
         /**
           * Wether the submit button should be place before the input
          */

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -41,6 +41,7 @@ export class AtomicSearchBox implements AtomicSearchBoxOptions {
   @Element() host!: HTMLDivElement;
   @State() searchBoxState!: SearchBoxState;
   @Prop() numberOfSuggestions = 5;
+  @Prop() enableQuerySyntax = false;
   @Prop() leadingSubmitButton = false;
   @Prop({reflect: true, attribute: 'data-id'}) _id = randomID(
     'atomic-search-box-'
@@ -83,6 +84,7 @@ export class AtomicSearchBox implements AtomicSearchBoxOptions {
     this.searchBox = buildSearchBox(this.engine, {
       options: {
         numberOfSuggestions: this.numberOfSuggestions,
+        enableQuerySyntax: this.enableQuerySyntax,
       },
     });
     this.unsubscribe = this.searchBox.subscribe(() => this.updateState());

--- a/packages/atomic/src/components/atomic-search-box/readme.md
+++ b/packages/atomic/src/components/atomic-search-box/readme.md
@@ -26,6 +26,7 @@
 | Property              | Attribute               | Description                                               | Type      | Default                                  |
 | --------------------- | ----------------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
 | `_id`                 | `data-id`               |                                                           | `string`  | `randomID(     'atomic-search-box-'   )` |
+| `enableQuerySyntax`   | `enable-query-syntax`   |                                                           | `boolean` | `false`                                  |
 | `leadingSubmitButton` | `leading-submit-button` | Wether the submit button should be place before the input | `boolean` | `false`                                  |
 | `numberOfSuggestions` | `number-of-suggestions` | Maximum number of suggestions to display                  | `number`  | `5`                                      |
 

--- a/packages/atomic/src/components/atomic-search-interface/readme.md
+++ b/packages/atomic/src/components/atomic-search-interface/readme.md
@@ -32,14 +32,14 @@ Type: `Promise<void>`
 
 ### Depends on
 
-- [atomic-relevance-inspector](../atomic-relevance-inspector)
 - [atomic-component-error](../atomic-component-error)
+- [atomic-relevance-inspector](../atomic-relevance-inspector)
 
 ### Graph
 ```mermaid
 graph TD;
-  atomic-search-interface --> atomic-relevance-inspector
   atomic-search-interface --> atomic-component-error
+  atomic-search-interface --> atomic-relevance-inspector
   style atomic-search-interface fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
@@ -7,6 +7,7 @@ import {
 } from '../facet-set/facet-set-actions';
 import {CategoryFacetSortCriterion} from './interfaces/request';
 import {
+  serializeSchemaValidationError,
   validatePayload,
   validatePayloadAndThrow,
 } from '../../../utils/validate-payload';
@@ -20,7 +21,6 @@ import {
   ArrayValue,
   StringValue,
   NumberValue,
-  SchemaValidationError,
 } from '@coveo/bueno';
 import {validateCategoryFacetValue} from './category-facet-validate-payload';
 
@@ -63,7 +63,7 @@ export const toggleSelectCategoryFacetValue = createAction(
       validateCategoryFacetValue(payload.selection);
       return {payload, error: null};
     } catch (error) {
-      return {payload, error: error as SchemaValidationError};
+      return {payload, error: serializeSchemaValidationError(error)};
     }
   }
 );

--- a/packages/headless/src/utils/validate-payload.test.ts
+++ b/packages/headless/src/utils/validate-payload.test.ts
@@ -1,4 +1,4 @@
-import {NumberValue, Schema} from '@coveo/bueno';
+import {NumberValue, Schema, SchemaValidationError} from '@coveo/bueno';
 import {Engine} from '../app/headless-engine';
 import {buildMockSearchAppEngine} from '../test';
 import {
@@ -6,6 +6,7 @@ import {
   validatePayloadAndThrow,
   validateOptions,
   validateInitialState,
+  serializeSchemaValidationError,
 } from './validate-payload';
 
 const definition = {
@@ -110,5 +111,16 @@ describe('validateInitialState', () => {
     expect(() =>
       validateInitialState(engine, schema, {id: 11}, 'someFunction')
     ).toThrow();
+  });
+});
+
+describe('serializeSchemaValidationError', () => {
+  it('should serialize error correctly', () => {
+    const error = new SchemaValidationError('Hello');
+    expect(serializeSchemaValidationError(error)).toEqual({
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    });
   });
 });

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -4,7 +4,14 @@ import {
   Schema,
   SchemaValidationError,
 } from '@coveo/bueno';
+import {SerializedError} from '@reduxjs/toolkit';
 import {Engine} from '../app/headless-engine';
+
+export const serializeSchemaValidationError = ({
+  message,
+  name,
+  stack,
+}: SchemaValidationError): SerializedError => ({message, name, stack});
 
 /**
  * Validates an action payload and throws an error if invalid
@@ -39,11 +46,14 @@ export const validatePayloadAndThrow = <P>(
 export const validatePayload = <P>(
   payload: P,
   definition: SchemaDefinition<Required<P>> | SchemaValue<P>
-): {payload: P; error?: SchemaValidationError} => {
+): {payload: P; error?: SerializedError} => {
   try {
     return validatePayloadAndThrow(payload, definition);
   } catch (error) {
-    return {payload, error: error as SchemaValidationError};
+    return {
+      payload,
+      error: serializeSchemaValidationError(error),
+    };
   }
 };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-309

I also serialized the SchemaValidationError, since that's what redux toolkit does for errors thrown inside thunks (consistency). It also prevents the serializability check middleware from warning us in the console.

Basically, we don't want an action with a validation error to dispatch, but we want to let other types of errors dispatch, such as API errors.

Jira had a query syntax example, hence why I added the enableQuerySyntax prop on the Atomic component.