### PR TITLE
fix(recommendations): remove maximum age from product recommendations

### DIFF
--- a/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
+++ b/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
@@ -3,7 +3,6 @@ import {
   BaseParam,
   ContextParam,
   MachineLearningParam,
-  MaximumAgeParam,
   NumberOfResultsParam,
   RecommendationParam,
   SearchHubParam,
@@ -16,6 +15,5 @@ export type ProductRecommendationsRequest = BaseParam &
   RecommendationParam &
   ContextParam &
   SearchHubParam &
-  MaximumAgeParam &
   ActionsHistoryParam &
   VisitorIDParam;

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -445,7 +445,6 @@ describe('search api client', () => {
             context: productRecommendationsState.context.contextValues,
             searchHub: productRecommendationsState.searchHub,
             actionsHistory: expect.any(Array),
-            maximumAge: 0,
             visitorId: expect.any(String),
             numberOfResults:
               productRecommendationsState.productRecommendations

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -126,8 +126,6 @@ export const buildProductRecommendationsRequest = (
     ...(s.configuration.analytics.enabled && {
       visitorId: getVisitorID(),
     }),
-    // TODO: Remove this workaround, see https://coveord.atlassian.net/browse/COM-696 for details.
-    maximumAge: 0,
     recommendation: s.productRecommendations.id,
     numberOfResults: s.productRecommendations.maxNumberOfRecommendations,
     mlParameters: {


### PR DESCRIPTION
[COM-696]

The Search API and ML teams looked into it and it is properly working now. No idea if this was just a mis-manipulation on my part or if something really changed in prod :shrug: 

[COM-696]: https://coveord.atlassian.net/browse/COM-696