### PR TITLE
docs(headless): resultlist controller annotations

### DIFF
--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -7,11 +7,6 @@ import {Schema, ArrayValue, StringValue} from '@coveo/bueno';
 import {validateOptions} from '../../utils/validate-payload';
 
 const optionsSchema = new Schema<ResultListOptions>({
-  /**
-   * A list of indexed fields to include in the objects returned by the result list.
-   * These results are included in addition to the default fields.
-   * If this is left empty only the default fields are included.
-   */
   fieldsToInclude: new ArrayValue({
     required: false,
     each: new StringValue<string>({
@@ -22,15 +17,24 @@ const optionsSchema = new Schema<ResultListOptions>({
 });
 
 type ResultListOptions = {
+  /**
+   * A list of indexed fields to include in the objects returned by the result list.
+   * These results are included in addition to the default fields.
+   * If this is left empty only the default fields are included.
+   */
   fieldsToInclude?: string[];
 };
 
 type ResultListProps = {
+  /** The options for the `ResultList` controller. */
   options?: ResultListOptions;
 };
 
-/** The state relevant to the `ResultList` controller.*/
+/** A scoped and simplified part of the headless state that is relevant to the `ResultList` controller.*/
 export type ResultListState = ResultList['state'];
+/**
+ * The `ResultList` headless controller offers a high-level interface for designing a common result list UI controller.
+ */
 export type ResultList = ReturnType<typeof buildResultList>;
 
 export function buildResultList(
@@ -55,7 +59,7 @@ export function buildResultList(
     ...controller,
 
     /**
-     * @returns The state of the `ResultList` controller.
+     * @returns (ResultListState) The state of the `ResultList` controller.
      */
     get state() {
       const state = engine.state;


### PR DESCRIPTION
I moved the options annotations onto the type instead of the schema, similar to what we did with facets, and intellisense seems to work with it.