### PR TITLE
docs(headless): range facets documentation

### DIFF
--- a/packages/headless/src/controllers/facets/range-facet/date-facet/date-range.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/date-range.ts
@@ -23,6 +23,10 @@ export function isSearchApiDate(date: string) {
   return formatForSearchApi(dayjs(date)) === date;
 }
 
+/** Creates a `DateRangeRequest`.
+ * @param config The options with which to create a `DateRangeRequest`.
+ * @returns A new `DateRangeRequest`.
+ */
 export function buildDateRange(config: DateRangeOptions): DateRangeRequest {
   const start = buildDate(config.start, config);
   const end = buildDate(config.end, config);

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -37,6 +37,10 @@ type DateRangeOptions = Partial<Omit<DateRangeRequest, 'start' | 'end'>> & {
   dateFormat?: string;
 };
 
+/** Creates a `DateRangeRequest`.
+ * @param config The options with which to create a `DateRangeRequest`.
+ * @returns A new `DateRangeRequest`.
+ */
 export function buildDateRange(config: DateRangeOptions): DateRangeRequest {
   const DATE_FORMAT = 'YYYY/MM/DD@HH:mm:ss';
   const start = config.useLocalTime
@@ -64,11 +68,15 @@ export function buildDateRange(config: DateRangeOptions): DateRangeRequest {
 
 export {DateFacetOptions};
 export type DateFacetProps = {
+  /** The options for the `DateFacet` controller. */
   options: DateFacetOptions;
 };
 
-/** The `DateFacet` controller makes it possible to create a facet with date ranges.*/
+/** The `DateFacet` controller makes it possible to create a facet with date ranges. */
 export type DateFacet = ReturnType<typeof buildDateFacet>;
+/**
+ * A scoped and simplified part of the headless state that is relevant to the `DateFacet` controller.
+ */
 export type DateFacetState = DateFacet['state'];
 
 export function buildDateFacet(
@@ -95,15 +103,19 @@ export function buildDateFacet(
   return {
     ...rangeFacet,
     /**
-     * Selects (deselects) the passed value if unselected (selected).
-     * @param selection The facet value to select or deselect.
+     * Toggles the specified facet value.
+     * @param selection The facet value to toggle.
      */
     toggleSelect: (selection: DateFacetValue) =>
       dispatch(executeToggleDateFacetSelect({facetId, selection})),
 
-    /** @returns The state of the `DateFacet` controller.*/
+    /** The state of the `DateFacet` controller.*/
     get state() {
-      return {...rangeFacet.state, isLoading: engine.state.search.isLoading};
+      return {
+        ...rangeFacet.state,
+        /** `true` if a search is in progress and `false` otherwise. */
+        isLoading: engine.state.search.isLoading,
+      };
     },
   };
 }

--- a/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
@@ -43,25 +43,29 @@ export function buildRangeFacet<
 
   return {
     ...controller,
-    /** Logs a deselect (select) value event when the passed value is active (idle), and executes a search.*/
+    /**
+     * Toggles the specified facet value.
+     * @param selection The facet value to toggle.
+     */
     toggleSelect: (selection: RangeFacetValue) =>
       dispatch(executeToggleRangeFacetSelect({facetId, selection})),
 
-    /** Returns `true` if the passed value is selected, and `false` otherwise.
-     * @param facetValue The facet value to check.
-     * @returns boolean.
+    /**
+     * Checks whether the specified facet value is selected.
+     * @param selection The facet value to check.
+     * @returns Whether the specified facet value is selected.
      */
     isValueSelected: isRangeFacetValueSelected,
 
-    /** Deselects all facet values.*/
+    /** Deselects all facet values. */
     deselectAll() {
       dispatch(deselectAllFacetValues(facetId));
       dispatch(updateFacetOptions({freezeFacetOrder: true}));
       dispatch(executeSearch(logFacetClearAll(facetId)));
     },
 
-    /** Sorts the facet values according to the passed criterion.
-     * @param {RangeFacetSortCriterion} criterion The criterion to sort values by.
+    /** Sorts the facet values according to the specified criterion.
+     * @param criterion The criterion to sort values by.
      */
     sortBy(criterion: RangeFacetSortCriterion) {
       dispatch(updateRangeFacetSortCriterion({facetId, criterion}));
@@ -70,14 +74,15 @@ export function buildRangeFacet<
     },
 
     /**
-     * Returns `true` if the facet values are sorted according to the passed criterion and `false` otherwise.
-     * @param {FacetSortCriterion} criterion The criterion to compare.
+     * Checks whether the facet values are sorted according to the specified criterion.
+     * @param criterion The criterion to compare.
+     * @returns Whether the facet values are sorted according to the specified criterion.
      */
     isSortedBy(criterion: RangeFacetSortCriterion) {
       return this.state.sortCriterion === criterion;
     },
 
-    /** @returns The state of the `RangeFacet` controller.*/
+    /** The state of the `RangeFacet` controller.*/
     get state() {
       const request = getRequest();
       const response = baseFacetResponseSelector(engine.state, facetId) as
@@ -92,10 +97,15 @@ export function buildRangeFacet<
       );
 
       return {
+        /** The facet id. */
         facetId,
+        /** The values of the facet. */
         values,
+        /** The active sortCriterion of the facet. */
         sortCriterion,
+        /** `true` if there is at least one non-idle value and `false` otherwise. */
         hasActiveValues,
+        /** `true` if a search is in progress and `false` otherwise. */
         isLoading,
       };
     },

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -26,6 +26,10 @@ import {determineFacetId} from '../../_common/facet-id-determinor';
 type NumericRangeOptions = Pick<NumericRangeRequest, 'start' | 'end'> &
   Partial<NumericRangeRequest>;
 
+/** Creates a `NumericRangeRequest`.
+ * @param config The options with which to create a `NumericRangeRequest`.
+ * @returns A new `NumericRangeRequest`.
+ */
 export function buildNumericRange(
   config: NumericRangeOptions
 ): NumericRangeRequest {
@@ -38,11 +42,15 @@ export function buildNumericRange(
 
 export {NumericFacetOptions};
 export type NumericFacetProps = {
+  /** The options for the `NumericFacet` controller. */
   options: NumericFacetOptions;
 };
 
-/** The `NumericFacet` controller makes it possible to create a facet with numeric ranges.*/
+/** The `NumericFacet` controller makes it possible to create a facet with numeric ranges. */
 export type NumericFacet = ReturnType<typeof buildNumericFacet>;
+/**
+ * A scoped and simplified part of the headless state that is relevant to the `NumericFacet` controller.
+ */
 export type NumericFacetState = NumericFacet['state'];
 
 export function buildNumericFacet(
@@ -74,13 +82,13 @@ export function buildNumericFacet(
   return {
     ...rangeFacet,
     /**
-     * Selects (deselects) the passed value if unselected (selected).
-     * @param selection The facet value to select or deselect.
+     * Toggles the specified facet value.
+     * @param selection The facet value to toggle.
      */
     toggleSelect: (selection: NumericFacetValue) =>
       dispatch(executeToggleNumericFacetSelect({facetId, selection})),
 
-    /** @returns The state of the `NumericFacet` controller.*/
+    /** The state of the `NumericFacet` controller.*/
     get state() {
       return rangeFacet.state;
     },


### PR DESCRIPTION
In this PR, I tried out not including any types for params and returns, and intellisense is still working correctly. Let me know if that approach makes sense.

However, I can't find where to document options so that they appear with intellisense- it doesn't seem to work the same way as the basic and category facets.