### PR TITLE
fix(headless): get queryCorrections from fetched response instead of retried response

### DIFF
--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -36,19 +36,22 @@ export class AtomicDidYouMean {
     }
 
     if (this.state.wasAutomaticallyCorrected) {
-      return (
-        <div>
-          Query was automatically corrected to {this.state.wasCorrectedTo}
-        </div>
-      );
+      return [
+        <p>
+          No results for{' '}
+          <b>{this.state.queryCorrection.wordCorrections[0].originalWord}</b>
+        </p>,
+        <p>
+          Query was automatically corrected to{' '}
+          <b>{this.state.wasCorrectedTo}</b>
+        </p>,
+      ];
     }
 
     return (
-      <div>
-        <button onClick={() => this.applyCorrection()}>
-          Did you mean: {this.state.queryCorrection.correctedQuery} ?
-        </button>
-      </div>
+      <button onClick={() => this.applyCorrection()}>
+        Did you mean: {this.state.queryCorrection.correctedQuery} ?
+      </button>
     );
   }
 

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -157,7 +157,10 @@ export const executeSearch = createAsyncThunk<
 
     return {
       ...retried,
-      response: retried.response.success,
+      response: {
+        ...retried.response.success,
+        queryCorrections: fetched.response.success.queryCorrections,
+      },
       automaticallyCorrected: true,
       analyticsAction: logDidYouMeanAutomatic(),
     };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-312