### PR TITLE
refactor(headless): requiredNonEmptyString refactor

### DIFF
--- a/packages/headless/src/controllers/search-box/headless-search-box-options.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box-options.ts
@@ -6,6 +6,7 @@ import {
   RecordValue,
 } from '@coveo/bueno';
 import {SuggestionHighlightingOptions} from '../../utils/highlight';
+import {requiredNonEmptyString} from '../../utils/validate-payload';
 
 export interface SearchBoxOptions extends DefaultSearchBoxOptions {
   id?: string;
@@ -32,7 +33,7 @@ export const searchBoxOptionDefinitions = {
    * A unique identifier for the controller.
    * By default, a unique random identifier is generated.
    */
-  id: new StringValue({required: true, emptyAllowed: false}),
+  id: requiredNonEmptyString,
   /**
    * The number of query suggestions to request from Coveo ML (e.g., `3`).
    *

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -1,5 +1,8 @@
 import {SearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
-import {validatePayload} from '../../utils/validate-payload';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 import {StringValue} from '@coveo/bueno';
 import {getAdvancedSearchQueriesInitialState} from '../advanced-search-queries/advanced-search-queries-state';
 import {Result} from '../../api/search/search/result';
@@ -38,7 +41,7 @@ export interface CustomEventPayload {
 
 const validateEvent = (p: {evt: string; type?: string}) =>
   validatePayload(p, {
-    evt: new StringValue({required: true, emptyAllowed: false}),
+    evt: requiredNonEmptyString,
     type: new StringValue({required: false, emptyAllowed: false}),
   });
 

--- a/packages/headless/src/features/context/context-actions.ts
+++ b/packages/headless/src/features/context/context-actions.ts
@@ -1,9 +1,12 @@
 import {createAction} from '@reduxjs/toolkit';
 import {Context, ContextValue} from './context-state';
-import {validatePayload} from '../../utils/validate-payload';
-import {StringValue, isString, ArrayValue} from '@coveo/bueno';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
+import {isString, ArrayValue} from '@coveo/bueno';
 
-const nonEmptyString = new StringValue({required: true, emptyAllowed: false});
+const nonEmptyString = requiredNonEmptyString;
 const nonEmptyArray = new ArrayValue({
   each: nonEmptyString,
   required: true,

--- a/packages/headless/src/features/context/context-actions.ts
+++ b/packages/headless/src/features/context/context-actions.ts
@@ -6,16 +6,15 @@ import {
 } from '../../utils/validate-payload';
 import {isString, ArrayValue} from '@coveo/bueno';
 
-const nonEmptyString = requiredNonEmptyString;
 const nonEmptyArray = new ArrayValue({
-  each: nonEmptyString,
+  each: requiredNonEmptyString,
   required: true,
 });
 
 const nonEmptyPayload = (contextKey: string, contextValue: ContextValue) => {
-  validatePayload(contextKey, nonEmptyString);
+  validatePayload(contextKey, requiredNonEmptyString);
   if (isString(contextValue)) {
-    validatePayload(contextValue, nonEmptyString);
+    validatePayload(contextValue, requiredNonEmptyString);
   } else {
     validatePayload(contextValue, nonEmptyArray);
   }
@@ -48,5 +47,5 @@ export const addContext = createAction(
  * @param key (string) The key to remove from the context (e.g., `"age"`).
  */
 export const removeContext = createAction('context/remove', (payload: string) =>
-  validatePayload(payload, nonEmptyString)
+  validatePayload(payload, requiredNonEmptyString)
 );

--- a/packages/headless/src/features/did-you-mean/did-you-mean-actions.ts
+++ b/packages/headless/src/features/did-you-mean/did-you-mean-actions.ts
@@ -1,6 +1,8 @@
 import {createAction} from '@reduxjs/toolkit';
-import {validatePayload} from '../../utils/validate-payload';
-import {StringValue} from '@coveo/bueno';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 
 /**
  * Enables did-you-mean.
@@ -17,9 +19,5 @@ export const disableDidYouMean = createAction('didYouMean/disable');
  */
 export const applyDidYouMeanCorrection = createAction(
   'didYouMean/correction',
-  (payload: string) =>
-    validatePayload(
-      payload,
-      new StringValue({required: true, emptyAllowed: false})
-    )
+  (payload: string) => validatePayload(payload, requiredNonEmptyString)
 );

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
@@ -10,11 +10,9 @@ import {
   serializeSchemaValidationError,
   validatePayload,
   validatePayloadAndThrow,
-} from '../../../utils/validate-payload';
-import {
-  facetIdDefinition,
   requiredNonEmptyString,
-} from '../generic/facet-actions-validation';
+} from '../../../utils/validate-payload';
+import {facetIdDefinition} from '../generic/facet-actions-validation';
 import {
   Value,
   BooleanValue,

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-controller-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-controller-actions.ts
@@ -14,12 +14,10 @@ import {
   toggleSelectCategoryFacetValue,
   updateCategoryFacetNumberOfValues,
 } from './category-facet-set-actions';
-import {
-  requiredNonEmptyString,
-  facetIdDefinition,
-} from '../generic/facet-actions-validation';
+import {facetIdDefinition} from '../generic/facet-actions-validation';
 import {validateCategoryFacetValue} from './category-facet-validate-payload';
 import {NumberValue} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../../utils/validate-payload';
 
 /**
  * Toggles the facet value and then executes a search with the appropriate analytics tag.

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-validate-payload.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-validate-payload.ts
@@ -6,8 +6,10 @@ import {
   ArrayValue,
   BooleanValue,
 } from '@coveo/bueno';
-import {requiredNonEmptyString} from '../generic/facet-actions-validation';
-import {validatePayloadAndThrow} from '../../../utils/validate-payload';
+import {
+  validatePayloadAndThrow,
+  requiredNonEmptyString,
+} from '../../../utils/validate-payload';
 import {CategoryFacetValue} from './interfaces/response';
 
 export const categoryFacetValueDefinition = {

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-actions.ts
@@ -1,21 +1,22 @@
 import {createAction} from '@reduxjs/toolkit';
 import {FacetSearchOptions} from '../facet-search-request-options';
 import {CategoryFacetSearchResult} from '../../../../api/search/facet-search/category-facet-search/category-facet-search-response';
-import {validatePayload} from '../../../../utils/validate-payload';
 import {
-  facetIdDefinition,
+  validatePayload,
   requiredNonEmptyString,
-} from '../../generic/facet-actions-validation';
-import {NumberValue, RecordValue, ArrayValue, StringValue} from '@coveo/bueno';
+  requiredEmptyAllowedString,
+} from '../../../../utils/validate-payload';
+import {facetIdDefinition} from '../../generic/facet-actions-validation';
+import {NumberValue, RecordValue, ArrayValue} from '@coveo/bueno';
 import {facetSearchOptionsDefinition} from '../generic/generic-facet-search-validate-payload';
 
 const categoryFacetSearchResultDefinition = {
   path: new ArrayValue({
     required: true,
-    each: new StringValue({required: true, emptyAllowed: false}),
+    each: requiredNonEmptyString,
   }),
-  displayValue: requiredNonEmptyString,
-  rawValue: requiredNonEmptyString,
+  displayValue: requiredEmptyAllowedString,
+  rawValue: requiredEmptyAllowedString,
   count: new NumberValue({required: true, min: 0}),
 };
 

--- a/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
@@ -11,7 +11,7 @@ import {
   StateNeededForFacetSearch,
   StateNeededForSpecificFacetSearch,
 } from './generic-facet-search-state';
-import {StringValue} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../../../utils/validate-payload';
 
 /**
  * Executes a facet search (i.e., a search for facet values in a facet search box).
@@ -29,10 +29,7 @@ export const executeFacetSearch = createAsyncThunk<
   ) => {
     const state = getState();
     let req: SpecificFacetSearchRequest | CategoryFacetSearchRequest;
-    validatePayload(
-      facetId,
-      new StringValue({required: true, emptyAllowed: false})
-    );
+    validatePayload(facetId, requiredNonEmptyString);
     if (isSpecificFacetSearchState(state, facetId)) {
       req = buildSpecificFacetSearchRequest(facetId, state);
     } else {

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-actions.ts
@@ -2,19 +2,19 @@ import {createAction} from '@reduxjs/toolkit';
 import {SpecificFacetSearchResult} from '../../../../api/search/facet-search/specific-facet-search/specific-facet-search-response';
 import {FacetSearchOptions} from '../facet-search-request-options';
 import {RecordValue, NumberValue} from '@coveo/bueno';
+import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {
-  facetIdDefinition,
-  requiredNonEmptyString,
-} from '../../generic/facet-actions-validation';
-import {validatePayload} from '../../../../utils/validate-payload';
+  validatePayload,
+  requiredEmptyAllowedString,
+} from '../../../../utils/validate-payload';
 import {facetSearchOptionsDefinition} from '../generic/generic-facet-search-validate-payload';
 
 const selectFacetSearchResultPayloadDefinition = {
   facetId: facetIdDefinition,
   value: new RecordValue({
     values: {
-      displayValue: requiredNonEmptyString,
-      rawValue: requiredNonEmptyString,
+      displayValue: requiredEmptyAllowedString,
+      rawValue: requiredEmptyAllowedString,
       count: new NumberValue({required: true, min: 0}),
     },
   }),

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -1,10 +1,10 @@
 import {FacetSortCriterion} from './interfaces/request';
 import {RangeFacetSortCriterion} from '../range-facets/generic/interfaces/request';
-import {validatePayload} from '../../../utils/validate-payload';
 import {
-  facetIdDefinition,
+  validatePayload,
   requiredNonEmptyString,
-} from '../generic/facet-actions-validation';
+} from '../../../utils/validate-payload';
+import {facetIdDefinition} from '../generic/facet-actions-validation';
 import {Value} from '@coveo/bueno';
 import {
   AnalyticsType,

--- a/packages/headless/src/features/facets/facet-set/facet-set-validate-payload.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-validate-payload.ts
@@ -1,5 +1,5 @@
-import {requiredNonEmptyString} from '../generic/facet-actions-validation';
 import {NumberValue} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../../utils/validate-payload';
 
 export const facetValueDefinition = {
   value: requiredNonEmptyString,

--- a/packages/headless/src/features/facets/generic/facet-actions-validation.ts
+++ b/packages/headless/src/features/facets/generic/facet-actions-validation.ts
@@ -1,11 +1,3 @@
-import {StringValue} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../../utils/validate-payload';
 
-export const requiredNonEmptyString = new StringValue({
-  required: true,
-  emptyAllowed: true,
-});
-
-export const facetIdDefinition = new StringValue({
-  required: true,
-  emptyAllowed: true,
-});
+export const facetIdDefinition = requiredNonEmptyString;

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
@@ -3,7 +3,10 @@ import {DateFacetRegistrationOptions} from './interfaces/options';
 import {DateFacetValue} from './interfaces/response';
 import {updateRangeFacetSortCriterion} from '../generic/range-facet-actions';
 import {deselectAllFacetValues} from '../../facet-set/facet-set-actions';
-import {validatePayload} from '../../../../utils/validate-payload';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../../../utils/validate-payload';
 import {
   NumberValue,
   BooleanValue,
@@ -11,10 +14,7 @@ import {
   Value,
   ArrayValue,
 } from '@coveo/bueno';
-import {
-  facetIdDefinition,
-  requiredNonEmptyString,
-} from '../../generic/facet-actions-validation';
+import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {RangeFacetSortCriterion} from '../generic/interfaces/request';
 import {dateFacetValueDefinition} from '../generic/range-facet-validate-payload';
 

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-validate-payload.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-validate-payload.ts
@@ -1,5 +1,5 @@
-import {requiredNonEmptyString} from '../../generic/facet-actions-validation';
 import {NumberValue, BooleanValue} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../../../utils/validate-payload';
 
 export const numericFacetValueDefinition = {
   state: requiredNonEmptyString,

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
@@ -3,11 +3,11 @@ import {NumericFacetRegistrationOptions} from './interfaces/options';
 import {NumericFacetValue} from './interfaces/response';
 import {updateRangeFacetSortCriterion} from '../generic/range-facet-actions';
 import {deselectAllFacetValues} from '../../facet-set/facet-set-actions';
-import {validatePayload} from '../../../../utils/validate-payload';
 import {
-  facetIdDefinition,
+  validatePayload,
   requiredNonEmptyString,
-} from '../../generic/facet-actions-validation';
+} from '../../../../utils/validate-payload';
+import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {
   RecordValue,
   NumberValue,

--- a/packages/headless/src/features/fields/fields-actions.ts
+++ b/packages/headless/src/features/fields/fields-actions.ts
@@ -1,8 +1,11 @@
 import {createAction} from '@reduxjs/toolkit';
-import {validatePayload} from '../../utils/validate-payload';
-import {ArrayValue, StringValue} from '@coveo/bueno';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
+import {ArrayValue} from '@coveo/bueno';
 
-const nonEmptyString = new StringValue({required: true, emptyAllowed: false});
+const nonEmptyString = requiredNonEmptyString;
 const nonEmptyArray = new ArrayValue({
   each: nonEmptyString,
   required: true,

--- a/packages/headless/src/features/fields/fields-actions.ts
+++ b/packages/headless/src/features/fields/fields-actions.ts
@@ -5,9 +5,8 @@ import {
 } from '../../utils/validate-payload';
 import {ArrayValue} from '@coveo/bueno';
 
-const nonEmptyString = requiredNonEmptyString;
 const nonEmptyArray = new ArrayValue({
-  each: nonEmptyString,
+  each: requiredNonEmptyString,
   required: true,
 });
 

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -10,7 +10,10 @@ import {
   ProductRecommendationsSection,
   ContextSection,
 } from '../../state/state-sections';
-import {validatePayload} from '../../utils/validate-payload';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 import {ArrayValue, NumberValue, StringValue} from '@coveo/bueno';
 import {getVisitorID, historyStore} from '../../api/analytics/analytics';
 import {ProductRecommendationsRequest} from '../../api/search/product-recommendations/product-recommendations-request';
@@ -34,7 +37,7 @@ export const setProductRecommendationsRecommenderId = createAction(
   'productrecommendations/setId',
   (payload: {id: string}) =>
     validatePayload(payload, {
-      id: new StringValue({required: true, emptyAllowed: false}),
+      id: requiredNonEmptyString,
     })
 );
 

--- a/packages/headless/src/features/query-set/query-set-actions.ts
+++ b/packages/headless/src/features/query-set/query-set-actions.ts
@@ -1,10 +1,13 @@
 import {createAction} from '@reduxjs/toolkit';
-import {validatePayload} from '../../utils/validate-payload';
-import {StringValue} from '@coveo/bueno';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+  requiredEmptyAllowedString,
+} from '../../utils/validate-payload';
 
 const querySetDefinition = {
-  id: new StringValue({required: true, emptyAllowed: false}),
-  query: new StringValue({required: true}),
+  id: requiredNonEmptyString,
+  query: requiredEmptyAllowedString,
 };
 /**
  * Registers a query in the query set.

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -1,5 +1,9 @@
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
-import {validatePayload} from '../../utils/validate-payload';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+  requiredEmptyAllowedString,
+} from '../../utils/validate-payload';
 import {NumberValue, StringValue} from '@coveo/bueno';
 import {QuerySuggestSuccessResponse} from '../../api/search/query-suggest/query-suggest-response';
 import {SearchAPIErrorWithStatusCode} from '../../api/search/search-api-error-response';
@@ -23,7 +27,7 @@ export type StateNeededByQuerySuggest = ConfigurationSection &
   Partial<ContextSection & PipelineSection & SearchHubSection>;
 
 const idDefinition = {
-  id: new StringValue({required: true, emptyAllowed: false}),
+  id: requiredNonEmptyString,
 };
 
 export interface QuerySuggestionID {
@@ -65,7 +69,7 @@ export const selectQuerySuggestion = createAction(
   (payload: {id: string; expression: string}) =>
     validatePayload(payload, {
       ...idDefinition,
-      expression: new StringValue({required: true}),
+      expression: requiredEmptyAllowedString,
     })
 );
 

--- a/packages/headless/src/features/recommendation/recommendation-actions.ts
+++ b/packages/headless/src/features/recommendation/recommendation-actions.ts
@@ -16,8 +16,10 @@ import {
   RecommendationSection,
   SearchHubSection,
 } from '../../state/state-sections';
-import {validatePayload} from '../../utils/validate-payload';
-import {StringValue} from '@coveo/bueno';
+import {
+  validatePayload,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 import {logRecommendationUpdate} from './recommendation-analytics-actions';
 import {SearchAction} from '../analytics/analytics-utils';
 
@@ -45,7 +47,7 @@ export const setRecommendationId = createAction(
   'recommendation/set',
   (payload: {id: string}) =>
     validatePayload(payload, {
-      id: new StringValue({required: true, emptyAllowed: false}),
+      id: requiredNonEmptyString,
     })
 );
 

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -3,9 +3,20 @@ import {
   SchemaValue,
   Schema,
   SchemaValidationError,
+  StringValue,
 } from '@coveo/bueno';
 import {SerializedError} from '@reduxjs/toolkit';
 import {Engine} from '../app/headless-engine';
+
+export const requiredNonEmptyString = new StringValue({
+  required: true,
+  emptyAllowed: false,
+});
+
+export const requiredEmptyAllowedString = new StringValue({
+  required: true,
+  emptyAllowed: true,
+});
 
 export const serializeSchemaValidationError = ({
   message,


### PR DESCRIPTION
`requiredEmptyString` for used only in `/facet` folder. Refactoring it so that all of `/features` have access to it to be more consistent. 

Also, I realized I didn't set the correct value initially. It had `emptyAllowed: true`. So I changed that 

Also created `requiredEmptyAllowedString` as well and used it in a few places to make it more consistent as well. 

The next thing would be the controllers, but I figured that could be done at the same time as the synchronization between `features` and `controller` validation to have only one source of truth as we mentioned a while ago. 