### PR TITLE
feat(headless): generate facet id when manually specified id is not unique 

### DIFF
--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.test.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.test.ts
@@ -1,6 +1,7 @@
 import {SearchAppState} from '../../../state/search-app-state';
 import {buildMockSearchAppEngine, MockEngine} from '../../../test';
 import {buildMockFacetIdConfig} from '../../../test/mock-facet-id-config';
+import {buildMockFacetRequest} from '../../../test/mock-facet-request';
 import {determineFacetId} from './facet-id-determinor';
 import * as FacetIdGenerator from './facet-id-generator';
 
@@ -11,9 +12,31 @@ describe('#determineFacetId', () => {
     engine = buildMockSearchAppEngine();
   });
 
-  it('when a #facetId key is passed, it returns it', () => {
+  it('when a #facetId is passed and not being used, it returns it', () => {
     const id = determineFacetId(engine, {facetId: 'a', field: 'author'});
     expect(id).toBe('a');
+  });
+
+  describe('when the #facetId is being used', () => {
+    const duplicateId = 'a';
+
+    beforeEach(() => {
+      engine.state.facetSet[duplicateId] = buildMockFacetRequest();
+    });
+
+    it('logs a warning', () => {
+      engine.logger.warn = jest.fn();
+
+      determineFacetId(engine, {facetId: duplicateId, field: 'author'});
+      expect(engine.logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls #generateFacetId', () => {
+      const spy = jest.spyOn(FacetIdGenerator, 'generateFacetId');
+
+      determineFacetId(engine, {facetId: duplicateId, field: 'author'});
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   it('when a #facetId key is empty, it calls #generateFacetId', () => {

--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
@@ -1,6 +1,6 @@
 import {Engine} from '../../../app/headless-engine';
 import {AllFacetSections} from '../../../features/facets/generic/interfaces/generic-facet-section';
-import {generateFacetId} from './facet-id-generator';
+import {generateFacetId, isBeingUsedAsFacetId} from './facet-id-generator';
 
 interface FacetIdConfig {
   facetId?: string;
@@ -13,5 +13,19 @@ export function determineFacetId(
 ) {
   const {state, logger} = engine;
   const {field, facetId} = config;
-  return facetId || generateFacetId({field, state}, logger);
+  const generateId = () => generateFacetId({field, state}, logger);
+
+  if (!facetId) {
+    return generateId();
+  }
+
+  if (isBeingUsedAsFacetId(state, facetId)) {
+    const message = `Generating a facet id because the passed facet id "${facetId}" is already being used.
+    Please ensure facet ids are unique.`;
+
+    engine.logger.warn(message);
+    return generateId();
+  }
+
+  return facetId;
 }

--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
@@ -20,8 +20,9 @@ export function determineFacetId(
   }
 
   if (isBeingUsedAsFacetId(state, facetId)) {
-    const message = `Generating a facet id because the passed facet id "${facetId}" is already being used.
-    Please ensure facet ids are unique.`;
+    const message = `
+    Generating a facet id because the passed id "${facetId}" is already being used.
+    Please ensure that manually specified facet ids are unique.`;
 
     engine.logger.warn(message);
     return generateId();

--- a/packages/headless/src/controllers/facets/_common/facet-id-generator.test.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-generator.test.ts
@@ -1,9 +1,14 @@
 import pino, {Logger} from 'pino';
+import {createMockState} from '../../../test';
 import {buildMockCategoryFacetRequest} from '../../../test/mock-category-facet-request';
 import {buildMockDateFacetRequest} from '../../../test/mock-date-facet-request';
 import {buildMockFacetRequest} from '../../../test/mock-facet-request';
 import {buildMockNumericFacetRequest} from '../../../test/mock-numeric-facet-request';
-import {generateFacetId, FacetIdConfig} from './facet-id-generator';
+import {
+  generateFacetId,
+  FacetIdConfig,
+  isBeingUsedAsFacetId,
+} from './facet-id-generator';
 
 describe('#generateFacetId', () => {
   let config: FacetIdConfig;
@@ -118,5 +123,19 @@ describe('#generateFacetId', () => {
 
     const id = getFacetId();
     expect(id).toBe(config.field);
+  });
+});
+
+describe('#isBeingUsedAsFacetId', () => {
+  it('when the facetId is not used, it returns false', () => {
+    const state = createMockState();
+    expect(isBeingUsedAsFacetId(state, 'a')).toBe(false);
+  });
+
+  it('when the facetId is used, it returns true', () => {
+    const state = createMockState();
+    state.facetSet = {a: buildMockFacetRequest()};
+
+    expect(isBeingUsedAsFacetId(state, 'a')).toBe(true);
   });
 });

--- a/packages/headless/src/controllers/facets/_common/facet-id-generator.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-generator.ts
@@ -9,7 +9,7 @@ export interface FacetIdConfig {
 export function generateFacetId(config: FacetIdConfig, logger: Logger) {
   const {field, state} = config;
 
-  if (!isFieldUsedAsFacetId(config)) {
+  if (!isBeingUsedAsFacetId(state, field)) {
     return field;
   }
 
@@ -21,11 +21,12 @@ export function generateFacetId(config: FacetIdConfig, logger: Logger) {
   return `${prefix}${id}`;
 }
 
-function isFieldUsedAsFacetId(config: FacetIdConfig) {
-  const {field, state} = config;
+export function isBeingUsedAsFacetId(
+  state: Partial<AllFacetSections>,
+  key: string
+) {
   const sets = extractFacetSets(state);
-
-  return sets.some((set) => set && field in set);
+  return sets.some((set) => set && key in set);
 }
 
 function calculateId(prefix: string, state: Partial<AllFacetSections>) {

--- a/packages/headless/src/test/mock-facet-id-config.ts
+++ b/packages/headless/src/test/mock-facet-id-config.ts
@@ -1,7 +1,7 @@
 import {FacetIdConfig} from '../controllers/facets/_common/facet-id-generator';
 
 export function buildMockFacetIdConfig(
-  config: Partial<FacetIdConfig>
+  config: Partial<FacetIdConfig> = {}
 ): FacetIdConfig {
   return {
     field: '',


### PR DESCRIPTION
When a developer manually specified an id, if it is not unique, headless will now ignore it, log a warning, and generate an id.