### PR TITLE
fix(headless):  make validateResultPayload less strict 

### DIFF
--- a/packages/atomic/src/templates/default.html
+++ b/packages/atomic/src/templates/default.html
@@ -1,6 +1,8 @@
 <hr />
 <h3 class="h5">
-  <atomic-result-link class="text-primary"></atomic-result-link>
+  <!-- TODO: use result link when https://coveord.atlassian.net/browse/KIT-98 is resolved -->
+  <!-- <atomic-result-link></atomic-result-link> -->
+  <a href="{{clickUri}}"><h3>{{title}}</h3></a>
 </h3>
 <p>
   <atomic-result-value value="excerpt"> </atomic-result-value>

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -127,22 +127,17 @@ export const documentIdentifier = (result: Result): DocumentIdentifier => {
   };
 };
 
-const nonEmptyString = new StringValue({
-  required: false,
-  emptyAllowed: false,
-});
-
 const requiredNonEmptyString = new StringValue({
   required: true,
   emptyAllowed: false,
 });
 
 const rawPartialDefinition = {
-  collection: requiredNonEmptyString,
-  author: nonEmptyString,
-  urihash: requiredNonEmptyString,
-  source: requiredNonEmptyString,
-  permanentid: requiredNonEmptyString,
+  collection: new StringValue(),
+  author: new StringValue(),
+  urihash: new StringValue(),
+  source: new StringValue(),
+  permanentid: new StringValue(),
 };
 
 const resultPartialDefinition = {

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -127,6 +127,11 @@ export const documentIdentifier = (result: Result): DocumentIdentifier => {
   };
 };
 
+const nonEmptyString = new StringValue({
+  required: false,
+  emptyAllowed: false,
+});
+
 const requiredNonEmptyString = new StringValue({
   required: true,
   emptyAllowed: false,
@@ -134,7 +139,7 @@ const requiredNonEmptyString = new StringValue({
 
 const rawPartialDefinition = {
   collection: requiredNonEmptyString,
-  author: requiredNonEmptyString,
+  author: nonEmptyString,
   urihash: requiredNonEmptyString,
   source: requiredNonEmptyString,
   permanentid: requiredNonEmptyString,
@@ -144,8 +149,8 @@ const resultPartialDefinition = {
   uniqueId: requiredNonEmptyString,
   raw: new RecordValue({values: rawPartialDefinition}),
   title: requiredNonEmptyString,
-  uri: new StringValue({required: true, emptyAllowed: false, url: true}),
-  clickUri: new StringValue({required: true, emptyAllowed: false, url: true}),
+  uri: requiredNonEmptyString,
+  clickUri: requiredNonEmptyString,
   rankingModifier: new StringValue({required: false, emptyAllowed: true}),
 };
 


### PR DESCRIPTION
lots of thunks failed because the author was missing or the url wasn't a uri (e.g. file://)
https://coveord.atlassian.net/browse/KIT-340