### PR TITLE
feat(atomic): wip! allow external components (outside of the atomic-search-interface component)

### DIFF
--- a/packages/atomic/src/components/atomic-component-error/readme.md
+++ b/packages/atomic/src/components/atomic-component-error/readme.md
@@ -18,6 +18,7 @@
 
  - [atomic-breadcrumb-manager](../atomic-breadcrumb-manager)
  - [atomic-category-facet](../atomic-category-facet)
+ - [atomic-context-provider](../atomic-context-provider)
  - [atomic-date-facet](../atomic-date-facet)
  - [atomic-did-you-mean](../atomic-did-you-mean)
  - [atomic-facet](../atomic-facet)
@@ -39,6 +40,7 @@
 graph TD;
   atomic-breadcrumb-manager --> atomic-component-error
   atomic-category-facet --> atomic-component-error
+  atomic-context-provider --> atomic-component-error
   atomic-date-facet --> atomic-component-error
   atomic-did-you-mean --> atomic-component-error
   atomic-facet --> atomic-component-error

--- a/packages/atomic/src/components/atomic-context-provider/readme.md
+++ b/packages/atomic/src/components/atomic-context-provider/readme.md
@@ -1,0 +1,30 @@
+# atomic-context-provider
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type     | Default |
+| --------- | --------- | ----------- | -------- | ------- |
+| `context` | `context` |             | `string` | `'{}'`  |
+
+
+## Dependencies
+
+### Depends on
+
+- [atomic-component-error](../atomic-component-error)
+
+### Graph
+```mermaid
+graph TD;
+  atomic-context-provider --> atomic-component-error
+  style atomic-context-provider fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -48,6 +48,7 @@ export class AtomicSearchBox implements AtomicSearchBoxOptions {
   );
 
   private engine!: Engine;
+  private error?: Error;
   private searchBox!: SearchBox;
   private unsubscribe: Unsubscribe = () => {};
   private inputRef!: HTMLInputElement;
@@ -221,6 +222,6 @@ export class AtomicSearchBox implements AtomicSearchBoxOptions {
   }
 
   public componentDidRender() {
-    this.combobox.updateAccessibilityAttributes();
+    !this.error && this.combobox.updateAccessibilityAttributes();
   }
 }

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -134,6 +134,7 @@ export class AtomicSearchInterface {
 
   @Listen('atomic/initializeComponent')
   public handleInitialization(event: InitializeEvent) {
+    event.preventDefault();
     event.stopPropagation();
 
     if (this.engine) {

--- a/packages/atomic/src/components/result-template-components/result-template-decorators.ts
+++ b/packages/atomic/src/components/result-template-components/result-template-decorators.ts
@@ -3,12 +3,6 @@ import {ComponentInterface, getElement} from '@stencil/core';
 export function ResultContext() {
   return (component: ComponentInterface, resultVariable: string) => {
     const {render} = component;
-    if (!render) {
-      console.error(
-        'The "render" lifecycle method has to be defined for the ResultTemplateComponent decorator to work.'
-      );
-      return;
-    }
 
     component.render = function () {
       const element = getElement(this);
@@ -19,7 +13,7 @@ export function ResultContext() {
         );
       }
       component[resultVariable] = parentResultComponent.result;
-      return render.call(this);
+      return render && render.call(this);
     };
   };
 }

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -45,19 +45,19 @@
 
   <body>
     <div class="container-xl">
+      <div class="row justify-content-center my-5">
+        <div class="col-8">
+          <atomic-search-box search-interface-id="search">
+            <span slot="submit-button">Go!</span>
+          </atomic-search-box>
+        </div>
+      </div>
       <atomic-search-interface id="search" sample>
         <div class="row justify-content-center">
           <atomic-tab class="col-auto" expression="">All Files</atomic-tab>
           <atomic-tab class="col-auto" expression='@author *= "BBC News"'>BBC News</atomic-tab>
         </div>
         <atomic-context-provider context='{"test":"value","test2":"value2"}'></atomic-context-provider>
-        <div class="row justify-content-center my-5">
-          <div class="col-8">
-            <atomic-search-box>
-              <span slot="submit-button">Go!</span>
-            </atomic-search-box>
-          </div>
-        </div>
         <div class="row">
           <div class="col-4">
             <atomic-facet-manager>

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -8,7 +8,7 @@ export type InitializeEvent = CustomEvent<InitializeEventHandler>;
 export class InitializationError extends Error {
   constructor(elementName: string) {
     super(
-      `The ${elementName} element must be the child of a configured atomic-search-interface element.`
+      `The ${elementName} element must be the child of a configured atomic-search-interface element or have a "search-interface-id" attribute referencing a atomic-search-interface element.`
     );
     this.name = 'InitializationError';
   }
@@ -41,6 +41,16 @@ export function Initialization(options?: InitializationOptions) {
 
     component.componentWillLoad = function () {
       const element = getElement(this);
+      const externalSearchInterfaceId = element.getAttribute(
+        'search-interface-id'
+      );
+      const searchInterfaceElement = externalSearchInterfaceId
+        ? document.querySelector(
+            `atomic-search-interface#${externalSearchInterfaceId}`
+          )
+        : null;
+      const dispatchElement = searchInterfaceElement ?? element;
+
       const event = new CustomEvent('atomic/initializeComponent', {
         detail: (engine: Engine) => {
           this[engineProperty] = engine;
@@ -53,7 +63,8 @@ export function Initialization(options?: InitializationOptions) {
         bubbles: true,
         cancelable: true,
       });
-      const canceled = element.dispatchEvent(event);
+
+      const canceled = dispatchElement.dispatchEvent(event);
       if (canceled) {
         this[errorProperty] = new InitializationError(
           element.nodeName.toLowerCase()

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -75,12 +75,6 @@ export function Initialization(options?: InitializationOptions) {
       return componentWillLoad && componentWillLoad.call(this);
     };
 
-    if (!render) {
-      console.error(
-        'The "render" lifecycle method has to be defined for the InitializeComponent decorator to work.'
-      );
-    }
-
     let hasRendered = false;
     let hasLoaded = false;
 

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -7,12 +7,6 @@ interface MapPropOptions {
 export function MapProp(opts?: MapPropOptions) {
   return (component: ComponentInterface, variableName: string) => {
     const {componentWillLoad} = component;
-    if (!componentWillLoad) {
-      console.error(
-        'The "componentWillLoad" lifecycle method has to be defined for the MapProp decorator to work.'
-      );
-      return;
-    }
 
     component.componentWillLoad = function () {
       const prefix = (opts && opts.attributePrefix) || variableName;
@@ -31,7 +25,7 @@ export function MapProp(opts?: MapPropOptions) {
         ] = `${attribute.value}`.split(',');
       }
 
-      componentWillLoad.call(this);
+      componentWillLoad && componentWillLoad.call(this);
     };
   };
 }

--- a/packages/atomic/src/utils/render-utils.tsx
+++ b/packages/atomic/src/utils/render-utils.tsx
@@ -3,12 +3,6 @@ import {ComponentInterface, h} from '@stencil/core';
 export function RenderError() {
   return (component: ComponentInterface, errorVariable: string) => {
     const {render} = component;
-    if (!render) {
-      console.error(
-        'The "render" lifecycle method has to be defined for the RenderError decorator to work. It is recommended to use the decorator directly on "render'
-      );
-      return;
-    }
 
     component.render = function () {
       if (this[errorVariable]) {
@@ -19,7 +13,7 @@ export function RenderError() {
         );
       }
 
-      return render.call(this);
+      return render && render.call(this);
     };
   };
 }

--- a/packages/atomic/src/utils/slot-utils.tsx
+++ b/packages/atomic/src/utils/slot-utils.tsx
@@ -5,13 +5,6 @@ const renderWhenPropertyDefined = (
   property: string
 ) => {
   const {render} = component;
-
-  if (!render) {
-    console.error(
-      'The "render" lifecycle method has to be defined for the ParentController decorator to work.'
-    );
-  }
-
   component.render = function () {
     if (!this[property]) {
       return;


### PR DESCRIPTION
I'll keep this PR open for a bit but won't merge it.

Basically allows Atomic components to have a search-interface-id prop with the ID of the search interface, and use this to pass the event, everything seems to initialize well. I'll add an example in the index.html

https://coveord.atlassian.net/browse/KIT-343
