### PR TITLE
feat(atomic): wip! allow an engine to be added directly as prop to components

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -10,8 +10,10 @@ export namespace Components {
     interface AtomicBreadcrumbManager {
         "categoryDivider": string;
         "collapseThreshold": number;
+        "engine": Engine;
     }
     interface AtomicCategoryFacet {
+        "engine": Engine;
         "facetId": string;
         "field": string;
         "label": string;
@@ -21,20 +23,25 @@ export namespace Components {
     }
     interface AtomicContextProvider {
         "context": string;
+        "engine": Engine;
     }
     interface AtomicDateFacet {
+        "engine": Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicDidYouMean {
+        "engine": Engine;
     }
     interface AtomicFacet {
+        "engine": Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicFacetManager {
+        "engine": Engine;
     }
     interface AtomicFieldCondition {
         "conditions": ResultTemplateCondition[];
@@ -45,17 +52,22 @@ export namespace Components {
     interface AtomicFrequentlyBoughtTogether {
     }
     interface AtomicHistory {
+        "engine": Engine;
     }
     interface AtomicNumericFacet {
+        "engine": Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicPager {
+        "engine": Engine;
     }
     interface AtomicQueryError {
+        "engine": Engine;
     }
     interface AtomicQuerySummary {
+        "engine": Engine;
     }
     interface AtomicRelevanceInspector {
         "engine": Engine;
@@ -71,6 +83,7 @@ export namespace Components {
           * Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element
          */
         "enableInfiniteScroll": boolean;
+        "engine": Engine;
         "fieldsToInclude": string;
         /**
           * Css class for the list wrapper
@@ -91,6 +104,7 @@ export namespace Components {
         "value": string;
     }
     interface AtomicResultsPerPage {
+        "engine": Engine;
         /**
           * Initial value of the result per page option
          */
@@ -103,6 +117,7 @@ export namespace Components {
     interface AtomicSearchBox {
         "_id": string;
         "enableQuerySyntax": boolean;
+        "engine": Engine;
         /**
           * Wether the submit button should be place before the input
          */
@@ -120,10 +135,14 @@ export namespace Components {
         "searchHub": string;
     }
     interface AtomicSortDropdown {
+        "engine": Engine;
     }
     interface AtomicTab {
+        "engine": Engine;
         "expression": string;
         "isActive": boolean;
+    }
+    interface RandomCustomerComponent {
     }
 }
 declare global {
@@ -283,6 +302,12 @@ declare global {
         prototype: HTMLAtomicTabElement;
         new (): HTMLAtomicTabElement;
     };
+    interface HTMLRandomCustomerComponentElement extends Components.RandomCustomerComponent, HTMLStencilElement {
+    }
+    var HTMLRandomCustomerComponentElement: {
+        prototype: HTMLRandomCustomerComponentElement;
+        new (): HTMLRandomCustomerComponentElement;
+    };
     interface HTMLElementTagNameMap {
         "atomic-breadcrumb-manager": HTMLAtomicBreadcrumbManagerElement;
         "atomic-category-facet": HTMLAtomicCategoryFacetElement;
@@ -310,14 +335,17 @@ declare global {
         "atomic-search-interface": HTMLAtomicSearchInterfaceElement;
         "atomic-sort-dropdown": HTMLAtomicSortDropdownElement;
         "atomic-tab": HTMLAtomicTabElement;
+        "random-customer-component": HTMLRandomCustomerComponentElement;
     }
 }
 declare namespace LocalJSX {
     interface AtomicBreadcrumbManager {
         "categoryDivider"?: string;
         "collapseThreshold"?: number;
+        "engine": Engine;
     }
     interface AtomicCategoryFacet {
+        "engine": Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
@@ -327,20 +355,25 @@ declare namespace LocalJSX {
     }
     interface AtomicContextProvider {
         "context"?: string;
+        "engine": Engine;
     }
     interface AtomicDateFacet {
+        "engine": Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicDidYouMean {
+        "engine": Engine;
     }
     interface AtomicFacet {
+        "engine": Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicFacetManager {
+        "engine": Engine;
     }
     interface AtomicFieldCondition {
         "conditions"?: ResultTemplateCondition[];
@@ -350,17 +383,22 @@ declare namespace LocalJSX {
     interface AtomicFrequentlyBoughtTogether {
     }
     interface AtomicHistory {
+        "engine": Engine;
     }
     interface AtomicNumericFacet {
+        "engine": Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicPager {
+        "engine": Engine;
     }
     interface AtomicQueryError {
+        "engine": Engine;
     }
     interface AtomicQuerySummary {
+        "engine": Engine;
     }
     interface AtomicRelevanceInspector {
         "engine": Engine;
@@ -376,6 +414,7 @@ declare namespace LocalJSX {
           * Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element
          */
         "enableInfiniteScroll"?: boolean;
+        "engine": Engine;
         "fieldsToInclude"?: string;
         /**
           * Css class for the list wrapper
@@ -394,6 +433,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface AtomicResultsPerPage {
+        "engine": Engine;
         /**
           * Initial value of the result per page option
          */
@@ -406,6 +446,7 @@ declare namespace LocalJSX {
     interface AtomicSearchBox {
         "_id"?: string;
         "enableQuerySyntax"?: boolean;
+        "engine": Engine;
         /**
           * Wether the submit button should be place before the input
          */
@@ -422,10 +463,14 @@ declare namespace LocalJSX {
         "searchHub"?: string;
     }
     interface AtomicSortDropdown {
+        "engine": Engine;
     }
     interface AtomicTab {
+        "engine": Engine;
         "expression"?: string;
         "isActive"?: boolean;
+    }
+    interface RandomCustomerComponent {
     }
     interface IntrinsicElements {
         "atomic-breadcrumb-manager": AtomicBreadcrumbManager;
@@ -454,6 +499,7 @@ declare namespace LocalJSX {
         "atomic-search-interface": AtomicSearchInterface;
         "atomic-sort-dropdown": AtomicSortDropdown;
         "atomic-tab": AtomicTab;
+        "random-customer-component": RandomCustomerComponent;
     }
 }
 export { LocalJSX as JSX };
@@ -486,6 +532,7 @@ declare module "@stencil/core" {
             "atomic-search-interface": LocalJSX.AtomicSearchInterface & JSXBase.HTMLAttributes<HTMLAtomicSearchInterfaceElement>;
             "atomic-sort-dropdown": LocalJSX.AtomicSortDropdown & JSXBase.HTMLAttributes<HTMLAtomicSortDropdownElement>;
             "atomic-tab": LocalJSX.AtomicTab & JSXBase.HTMLAttributes<HTMLAtomicTabElement>;
+            "random-customer-component": LocalJSX.RandomCustomerComponent & JSXBase.HTMLAttributes<HTMLRandomCustomerComponentElement>;
         }
     }
 }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -10,10 +10,10 @@ export namespace Components {
     interface AtomicBreadcrumbManager {
         "categoryDivider": string;
         "collapseThreshold": number;
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicCategoryFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId": string;
         "field": string;
         "label": string;
@@ -23,25 +23,25 @@ export namespace Components {
     }
     interface AtomicContextProvider {
         "context": string;
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicDateFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicDidYouMean {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicFacetManager {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicFieldCondition {
         "conditions": ResultTemplateCondition[];
@@ -52,22 +52,22 @@ export namespace Components {
     interface AtomicFrequentlyBoughtTogether {
     }
     interface AtomicHistory {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicNumericFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId": string;
         "field": string;
         "label": string;
     }
     interface AtomicPager {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicQueryError {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicQuerySummary {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicRelevanceInspector {
         "engine": Engine;
@@ -83,7 +83,7 @@ export namespace Components {
           * Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element
          */
         "enableInfiniteScroll": boolean;
-        "engine": Engine;
+        "engine"?: Engine;
         "fieldsToInclude": string;
         /**
           * Css class for the list wrapper
@@ -104,7 +104,7 @@ export namespace Components {
         "value": string;
     }
     interface AtomicResultsPerPage {
-        "engine": Engine;
+        "engine"?: Engine;
         /**
           * Initial value of the result per page option
          */
@@ -117,7 +117,7 @@ export namespace Components {
     interface AtomicSearchBox {
         "_id": string;
         "enableQuerySyntax": boolean;
-        "engine": Engine;
+        "engine"?: Engine;
         /**
           * Wether the submit button should be place before the input
          */
@@ -135,10 +135,10 @@ export namespace Components {
         "searchHub": string;
     }
     interface AtomicSortDropdown {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicTab {
-        "engine": Engine;
+        "engine"?: Engine;
         "expression": string;
         "isActive": boolean;
     }
@@ -342,10 +342,10 @@ declare namespace LocalJSX {
     interface AtomicBreadcrumbManager {
         "categoryDivider"?: string;
         "collapseThreshold"?: number;
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicCategoryFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
@@ -355,25 +355,25 @@ declare namespace LocalJSX {
     }
     interface AtomicContextProvider {
         "context"?: string;
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicDateFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicDidYouMean {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicFacetManager {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicFieldCondition {
         "conditions"?: ResultTemplateCondition[];
@@ -383,22 +383,22 @@ declare namespace LocalJSX {
     interface AtomicFrequentlyBoughtTogether {
     }
     interface AtomicHistory {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicNumericFacet {
-        "engine": Engine;
+        "engine"?: Engine;
         "facetId"?: string;
         "field"?: string;
         "label"?: string;
     }
     interface AtomicPager {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicQueryError {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicQuerySummary {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicRelevanceInspector {
         "engine": Engine;
@@ -414,7 +414,7 @@ declare namespace LocalJSX {
           * Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element
          */
         "enableInfiniteScroll"?: boolean;
-        "engine": Engine;
+        "engine"?: Engine;
         "fieldsToInclude"?: string;
         /**
           * Css class for the list wrapper
@@ -433,7 +433,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface AtomicResultsPerPage {
-        "engine": Engine;
+        "engine"?: Engine;
         /**
           * Initial value of the result per page option
          */
@@ -446,7 +446,7 @@ declare namespace LocalJSX {
     interface AtomicSearchBox {
         "_id"?: string;
         "enableQuerySyntax"?: boolean;
-        "engine": Engine;
+        "engine"?: Engine;
         /**
           * Wether the submit button should be place before the input
          */
@@ -463,10 +463,10 @@ declare namespace LocalJSX {
         "searchHub"?: string;
     }
     interface AtomicSortDropdown {
-        "engine": Engine;
+        "engine"?: Engine;
     }
     interface AtomicTab {
-        "engine": Engine;
+        "engine"?: Engine;
         "expression"?: string;
         "isActive"?: boolean;
     }

--- a/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
@@ -29,12 +29,12 @@ import mainclear from '../../images/main-clear.svg';
   shadow: true,
 })
 export class AtomicBreadcrumbManager {
-  @State() state!: BreadcrumbManagerState;
-  @State() collapsedBreadcrumbsState: string[] = [];
+  @Prop({mutable: true}) engine!: Engine;
   @Prop() collapseThreshold = 5;
   @Prop() categoryDivider = '/';
+  @State() state!: BreadcrumbManagerState;
+  @State() collapsedBreadcrumbsState: string[] = [];
 
-  private engine!: Engine;
   private breadcrumbManager!: BreadcrumbManager;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
@@ -29,7 +29,7 @@ import mainclear from '../../images/main-clear.svg';
   shadow: true,
 })
 export class AtomicBreadcrumbManager {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop() collapseThreshold = 5;
   @Prop() categoryDivider = '/';
   @State() state!: BreadcrumbManagerState;
@@ -40,7 +40,7 @@ export class AtomicBreadcrumbManager {
 
   @Initialization()
   public initialize() {
-    this.breadcrumbManager = buildBreadcrumbManager(this.engine);
+    this.breadcrumbManager = buildBreadcrumbManager(this.engine!);
     this.subscribe();
   }
 

--- a/packages/atomic/src/components/atomic-breadcrumb-manager/readme.md
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property            | Attribute            | Description | Type     | Default |
-| ------------------- | -------------------- | ----------- | -------- | ------- |
-| `categoryDivider`   | `category-divider`   |             | `string` | `'/'`   |
-| `collapseThreshold` | `collapse-threshold` |             | `number` | `5`     |
+| Property            | Attribute            | Description | Type                                  | Default     |
+| ------------------- | -------------------- | ----------- | ------------------------------------- | ----------- |
+| `categoryDivider`   | `category-divider`   |             | `string`                              | `'/'`       |
+| `collapseThreshold` | `collapse-threshold` |             | `number`                              | `5`         |
+| `engine`            | --                   |             | `Engine<SearchAppState> \| undefined` | `undefined` |
 
 
 ## Shadow Parts

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -17,12 +17,12 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicCategoryFacet {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: CategoryFacetState;
 
-  private engine!: Engine;
   private categoryFacet!: CategoryFacet;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicCategoryFacet {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
@@ -33,7 +33,7 @@ export class AtomicCategoryFacet {
       field: this.field,
       delimitingCharacter: ';',
     };
-    this.categoryFacet = buildCategoryFacet(this.engine, {options});
+    this.categoryFacet = buildCategoryFacet(this.engine!, {options});
     this.facetId = this.categoryFacet.state.facetId;
     this.subscribe();
   }

--- a/packages/atomic/src/components/atomic-category-facet/readme.md
+++ b/packages/atomic/src/components/atomic-category-facet/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default      |
-| --------- | ---------- | ----------- | -------- | ------------ |
-| `facetId` | `facet-id` |             | `string` | `''`         |
-| `field`   | `field`    |             | `string` | `''`         |
-| `label`   | `label`    |             | `string` | `'No label'` |
+| Property  | Attribute  | Description | Type                                  | Default      |
+| --------- | ---------- | ----------- | ------------------------------------- | ------------ |
+| `engine`  | --         |             | `Engine<SearchAppState> \| undefined` | `undefined`  |
+| `facetId` | `facet-id` |             | `string`                              | `''`         |
+| `field`   | `field`    |             | `string`                              | `''`         |
+| `label`   | `label`    |             | `string`                              | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-context-provider/atomic-context-provider.tsx
+++ b/packages/atomic/src/components/atomic-context-provider/atomic-context-provider.tsx
@@ -7,8 +7,8 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicContextProvider {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop() context = '{}';
-  private engine!: Engine;
 
   @Initialization()
   public initialize() {

--- a/packages/atomic/src/components/atomic-context-provider/atomic-context-provider.tsx
+++ b/packages/atomic/src/components/atomic-context-provider/atomic-context-provider.tsx
@@ -7,12 +7,12 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicContextProvider {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop() context = '{}';
 
   @Initialization()
   public initialize() {
-    const context = buildContext(this.engine);
+    const context = buildContext(this.engine!);
     const contextObject = JSON.parse(this.context);
     context.set(contextObject);
   }

--- a/packages/atomic/src/components/atomic-context-provider/readme.md
+++ b/packages/atomic/src/components/atomic-context-provider/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property  | Attribute | Description | Type     | Default |
-| --------- | --------- | ----------- | -------- | ------- |
-| `context` | `context` |             | `string` | `'{}'`  |
+| Property  | Attribute | Description | Type                                  | Default     |
+| --------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `context` | `context` |             | `string`                              | `'{}'`      |
+| `engine`  | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
@@ -17,11 +17,11 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicDateFacet {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: DateFacetState;
-  private engine!: Engine;
 
   private facet!: DateFacet;
   private unsubscribe: Unsubscribe = () => {};

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicDateFacet {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
@@ -34,7 +34,7 @@ export class AtomicDateFacet {
       generateAutomaticRanges: true,
     };
 
-    this.facet = buildDateFacet(this.engine, {options});
+    this.facet = buildDateFacet(this.engine!, {options});
     this.facetId = this.facet.state.facetId;
     this.subscribe();
   }

--- a/packages/atomic/src/components/atomic-date-facet/readme.md
+++ b/packages/atomic/src/components/atomic-date-facet/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default      |
-| --------- | ---------- | ----------- | -------- | ------------ |
-| `facetId` | `facet-id` |             | `string` | `''`         |
-| `field`   | `field`    |             | `string` | `''`         |
-| `label`   | `label`    |             | `string` | `'No label'` |
+| Property  | Attribute  | Description | Type                                  | Default      |
+| --------- | ---------- | ----------- | ------------------------------------- | ------------ |
+| `engine`  | --         |             | `Engine<SearchAppState> \| undefined` | `undefined`  |
+| `facetId` | `facet-id` |             | `string`                              | `''`         |
+| `field`   | `field`    |             | `string`                              | `''`         |
+| `label`   | `label`    |             | `string`                              | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -14,7 +14,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicDidYouMean {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: DidYouMeanState;
 
   private didYouMean!: DidYouMean;
@@ -22,7 +22,7 @@ export class AtomicDidYouMean {
 
   @Initialization()
   public initialize() {
-    this.didYouMean = buildDidYouMean(this.engine);
+    this.didYouMean = buildDidYouMean(this.engine!);
     this.unsubscribe = this.didYouMean.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   DidYouMean,
   DidYouMeanState,
@@ -14,9 +14,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicDidYouMean {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: DidYouMeanState;
 
-  private engine!: Engine;
   private didYouMean!: DidYouMean;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-did-you-mean/readme.md
+++ b/packages/atomic/src/components/atomic-did-you-mean/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.tsx
+++ b/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.tsx
@@ -18,7 +18,7 @@ interface FacetElement extends HTMLElement {
   shadow: true,
 })
 export class AtomicFacetManager {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: FacetManagerState;
   @Element() host!: HTMLDivElement;
   private unsubscribe: Unsubscribe = () => {};
@@ -26,7 +26,7 @@ export class AtomicFacetManager {
 
   @Initialization()
   public initialize() {
-    this.facetManager = buildFacetManager(this.engine);
+    this.facetManager = buildFacetManager(this.engine!);
 
     this.unsubscribe = this.facetManager.subscribe(() => {
       this.updateStateToTriggerRender();

--- a/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.tsx
+++ b/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.tsx
@@ -1,4 +1,4 @@
-import {Component, h, Element, State} from '@stencil/core';
+import {Component, h, Element, State, Prop} from '@stencil/core';
 import {
   FacetManager,
   buildFacetManager,
@@ -18,9 +18,9 @@ interface FacetElement extends HTMLElement {
   shadow: true,
 })
 export class AtomicFacetManager {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: FacetManagerState;
   @Element() host!: HTMLDivElement;
-  private engine!: Engine;
   private unsubscribe: Unsubscribe = () => {};
   private facetManager!: FacetManager;
 

--- a/packages/atomic/src/components/atomic-facet-manager/readme.md
+++ b/packages/atomic/src/components/atomic-facet-manager/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -17,7 +17,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicFacet {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
@@ -29,7 +29,7 @@ export class AtomicFacet {
   @Initialization()
   public initialize() {
     const options: FacetOptions = {facetId: this.facetId, field: this.field};
-    this.facet = buildFacet(this.engine, {options});
+    this.facet = buildFacet(this.engine!, {options});
     this.facetId = this.facet.state.facetId;
     this.subscribe();
   }

--- a/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/atomic-facet/atomic-facet.tsx
@@ -17,11 +17,11 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicFacet {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: FacetState;
-  private engine!: Engine;
 
   private unsubscribe: Unsubscribe = () => {};
   private facet!: Facet;

--- a/packages/atomic/src/components/atomic-facet/readme.md
+++ b/packages/atomic/src/components/atomic-facet/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default      |
-| --------- | ---------- | ----------- | -------- | ------------ |
-| `facetId` | `facet-id` |             | `string` | `''`         |
-| `field`   | `field`    |             | `string` | `''`         |
-| `label`   | `label`    |             | `string` | `'No label'` |
+| Property  | Attribute  | Description | Type                                  | Default      |
+| --------- | ---------- | ----------- | ------------------------------------- | ------------ |
+| `engine`  | --         |             | `Engine<SearchAppState> \| undefined` | `undefined`  |
+| `facetId` | `facet-id` |             | `string`                              | `''`         |
+| `field`   | `field`    |             | `string`                              | `''`         |
+| `label`   | `label`    |             | `string`                              | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-history/atomic-history.tsx
+++ b/packages/atomic/src/components/atomic-history/atomic-history.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   History,
   HistoryState,
@@ -13,9 +13,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicHistory {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: HistoryState;
 
-  private engine!: Engine;
   private history!: History;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-history/atomic-history.tsx
+++ b/packages/atomic/src/components/atomic-history/atomic-history.tsx
@@ -13,7 +13,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicHistory {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: HistoryState;
 
   private history!: History;
@@ -21,7 +21,7 @@ export class AtomicHistory {
 
   @Initialization()
   public initialize() {
-    this.history = buildHistory(this.engine);
+    this.history = buildHistory(this.engine!);
     this.unsubscribe = this.history.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-history/readme.md
+++ b/packages/atomic/src/components/atomic-history/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -18,7 +18,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicNumericFacet {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
@@ -42,7 +42,7 @@ export class AtomicNumericFacet {
       ],
     };
 
-    this.facet = buildNumericFacet(this.engine, {options});
+    this.facet = buildNumericFacet(this.engine!, {options});
     this.facetId = this.facet.state.facetId;
     this.subscribe();
   }

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -18,12 +18,12 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicNumericFacet {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop({mutable: true}) facetId = '';
   @Prop() field = '';
   @Prop() label = 'No label';
   @State() state!: NumericFacetState;
 
-  private engine!: Engine;
   private unsubscribe: Unsubscribe = () => {};
   private facet!: NumericFacet;
 

--- a/packages/atomic/src/components/atomic-numeric-facet/readme.md
+++ b/packages/atomic/src/components/atomic-numeric-facet/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute  | Description | Type     | Default      |
-| --------- | ---------- | ----------- | -------- | ------------ |
-| `facetId` | `facet-id` |             | `string` | `''`         |
-| `field`   | `field`    |             | `string` | `''`         |
-| `label`   | `label`    |             | `string` | `'No label'` |
+| Property  | Attribute  | Description | Type                                  | Default      |
+| --------- | ---------- | ----------- | ------------------------------------- | ------------ |
+| `engine`  | --         |             | `Engine<SearchAppState> \| undefined` | `undefined`  |
+| `facetId` | `facet-id` |             | `string`                              | `''`         |
+| `field`   | `field`    |             | `string`                              | `''`         |
+| `label`   | `label`    |             | `string`                              | `'No label'` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -24,7 +24,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicPager {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: PagerState;
 
   private pager!: Pager;
@@ -32,7 +32,7 @@ export class AtomicPager {
 
   @Initialization()
   public initialize() {
-    this.pager = buildPager(this.engine);
+    this.pager = buildPager(this.engine!);
     this.unsubscribe = this.pager.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   Pager,
   PagerState,
@@ -24,9 +24,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicPager {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: PagerState;
 
-  private engine!: Engine;
   private pager!: Pager;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-pager/readme.md
+++ b/packages/atomic/src/components/atomic-pager/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Slots
 
 | Slot            | Description                |

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   QueryError,
   QueryErrorState,
@@ -14,9 +14,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicQueryError {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: QueryErrorState;
 
-  private engine!: Engine;
   private queryError!: QueryError;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
@@ -14,7 +14,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicQueryError {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: QueryErrorState;
 
   private queryError!: QueryError;
@@ -22,7 +22,7 @@ export class AtomicQueryError {
 
   @Initialization()
   public initialize() {
-    this.queryError = buildQueryError(this.engine);
+    this.queryError = buildQueryError(this.engine!);
     this.unsubscribe = this.queryError.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-query-error/readme.md
+++ b/packages/atomic/src/components/atomic-query-error/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   QuerySummary,
   QuerySummaryState,
@@ -22,9 +22,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicQuerySummary {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: QuerySummaryState;
 
-  private engine!: Engine;
   private querySummary!: QuerySummary;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
@@ -22,7 +22,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicQuerySummary {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: QuerySummaryState;
 
   private querySummary!: QuerySummary;
@@ -30,7 +30,7 @@ export class AtomicQuerySummary {
 
   @Initialization()
   public initialize() {
-    this.querySummary = buildQuerySummary(this.engine);
+    this.querySummary = buildQuerySummary(this.engine!);
     this.unsubscribe = this.querySummary.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-query-summary/readme.md
+++ b/packages/atomic/src/components/atomic-query-summary/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Shadow Parts
 
 | Part          | Description                            |

--- a/packages/atomic/src/components/atomic-relevance-inspector/atomic-relevance-inspector.tsx
+++ b/packages/atomic/src/components/atomic-relevance-inspector/atomic-relevance-inspector.tsx
@@ -19,7 +19,7 @@ export class AtomicRelevanceInspector {
   private unsubscribe: Unsubscribe = () => {};
 
   constructor() {
-    this.relevanceInspector = buildRelevanceInspector(this.engine, {
+    this.relevanceInspector = buildRelevanceInspector(this.engine!, {
       initialState: {
         // TODO: add enable/disable mechanism
         enabled: false,

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -22,6 +22,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicResultList {
+  @Prop({mutable: true}) engine!: Engine;
   /**
    * Whether to automatically retrieve an additional page of results and append it to the
    * current results when the user scrolls down to the bottom of element
@@ -39,7 +40,6 @@ export class AtomicResultList {
   @Element() host!: HTMLDivElement;
   @State() state!: ResultListState;
 
-  private engine!: Engine;
   private unsubscribe: Unsubscribe = () => {};
   private resultList!: ResultList;
   private resultTemplatesManager!: ResultTemplatesManager<string>;

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -22,7 +22,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicResultList {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   /**
    * Whether to automatically retrieve an additional page of results and append it to the
    * current results when the user scrolls down to the bottom of element
@@ -51,8 +51,8 @@ export class AtomicResultList {
 
   @Initialization()
   public initialize() {
-    this.resultTemplatesManager = buildResultTemplatesManager(this.engine);
-    this.resultList = buildResultList(this.engine, {
+    this.resultTemplatesManager = buildResultTemplatesManager(this.engine!);
+    this.resultList = buildResultList(this.engine!, {
       options: {fieldsToInclude: this.fields},
     });
     this.unsubscribe = this.resultList.subscribe(() => this.updateState());
@@ -98,7 +98,7 @@ export class AtomicResultList {
         part="list-element"
         class={this.listElementClass}
         result={result}
-        engine={this.engine}
+        engine={this.engine!}
         innerHTML={Mustache.render(
           this.resultTemplatesManager.selectTemplate(result) || '',
           result

--- a/packages/atomic/src/components/atomic-result-list/readme.md
+++ b/packages/atomic/src/components/atomic-result-list/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property               | Attribute                | Description                                                                                                                                              | Type      | Default |
-| ---------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `enableInfiniteScroll` | `enable-infinite-scroll` | Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element | `boolean` | `false` |
-| `fieldsToInclude`      | `fields-to-include`      |                                                                                                                                                          | `string`  | `''`    |
-| `listClass`            | `list-class`             | Css class for the list wrapper                                                                                                                           | `string`  | `''`    |
-| `listElementClass`     | `list-element-class`     | Css class for a list element                                                                                                                             | `string`  | `''`    |
+| Property               | Attribute                | Description                                                                                                                                              | Type                                  | Default     |
+| ---------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
+| `enableInfiniteScroll` | `enable-infinite-scroll` | Whether to automatically retrieve an additional page of results and append it to the current results when the user scrolls down to the bottom of element | `boolean`                             | `false`     |
+| `engine`               | --                       |                                                                                                                                                          | `Engine<SearchAppState> \| undefined` | `undefined` |
+| `fieldsToInclude`      | `fields-to-include`      |                                                                                                                                                          | `string`                              | `''`        |
+| `listClass`            | `list-class`             | Css class for the list wrapper                                                                                                                           | `string`                              | `''`        |
+| `listElementClass`     | `list-element-class`     | Css class for a list element                                                                                                                             | `string`                              | `''`        |
 
 
 ## Shadow Parts
@@ -25,6 +26,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [random-customer-component](../random-customer-component)
+
 ### Depends on
 
 - [atomic-result](../atomic-result)
@@ -35,6 +40,7 @@
 graph TD;
   atomic-result-list --> atomic-result
   atomic-result-list --> atomic-component-error
+  random-customer-component --> atomic-result-list
   style atomic-result-list fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
@@ -20,7 +20,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicResultsPerPage {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @State() state!: ResultsPerPageState;
 
   private resultsPerPage!: ResultsPerPage;
@@ -38,7 +38,7 @@ export class AtomicResultsPerPage {
 
   @Initialization()
   public initialize() {
-    this.resultsPerPage = buildResultsPerPage(this.engine, {
+    this.resultsPerPage = buildResultsPerPage(this.engine!, {
       initialState: {numberOfResults: this.initialOption},
     });
     this.unsubscribe = this.resultsPerPage.subscribe(() => this.updateState());

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
@@ -20,9 +20,9 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicResultsPerPage {
+  @Prop({mutable: true}) engine!: Engine;
   @State() state!: ResultsPerPageState;
 
-  private engine!: Engine;
   private resultsPerPage!: ResultsPerPage;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-results-per-page/readme.md
+++ b/packages/atomic/src/components/atomic-results-per-page/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                                    | Type     | Default          |
-| --------------- | ---------------- | -------------------------------------------------------------- | -------- | ---------------- |
-| `initialOption` | `initial-option` | Initial value of the result per page option                    | `number` | `10`             |
-| `options`       | `options`        | List of possible results per page options, separated by commas | `string` | `'10,25,50,100'` |
+| Property        | Attribute        | Description                                                    | Type                                  | Default          |
+| --------------- | ---------------- | -------------------------------------------------------------- | ------------------------------------- | ---------------- |
+| `engine`        | --               |                                                                | `Engine<SearchAppState> \| undefined` | `undefined`      |
+| `initialOption` | `initial-option` | Initial value of the result per page option                    | `number`                              | `10`             |
+| `options`       | `options`        | List of possible results per page options, separated by commas | `string`                              | `'10,25,50,100'` |
 
 
 ## Shadow Parts

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -38,7 +38,7 @@ export interface AtomicSearchBoxOptions {
   shadow: true,
 })
 export class AtomicSearchBox implements AtomicSearchBoxOptions {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop() numberOfSuggestions = 5;
   @Prop() enableQuerySyntax = false;
   @Prop() leadingSubmitButton = false;
@@ -82,7 +82,7 @@ export class AtomicSearchBox implements AtomicSearchBoxOptions {
 
   @Initialization()
   public initialize() {
-    this.searchBox = buildSearchBox(this.engine, {
+    this.searchBox = buildSearchBox(this.engine!, {
       options: {
         numberOfSuggestions: this.numberOfSuggestions,
         highlightOptions: {

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -38,16 +38,16 @@ export interface AtomicSearchBoxOptions {
   shadow: true,
 })
 export class AtomicSearchBox implements AtomicSearchBoxOptions {
-  @Element() host!: HTMLDivElement;
-  @State() searchBoxState!: SearchBoxState;
+  @Prop({mutable: true}) engine!: Engine;
   @Prop() numberOfSuggestions = 5;
   @Prop() enableQuerySyntax = false;
   @Prop() leadingSubmitButton = false;
   @Prop({reflect: true, attribute: 'data-id'}) _id = randomID(
     'atomic-search-box-'
   );
+  @Element() host!: HTMLDivElement;
+  @State() searchBoxState!: SearchBoxState;
 
-  private engine!: Engine;
   private error?: Error;
   private searchBox!: SearchBox;
   private unsubscribe: Unsubscribe = () => {};

--- a/packages/atomic/src/components/atomic-search-box/readme.md
+++ b/packages/atomic/src/components/atomic-search-box/readme.md
@@ -23,12 +23,13 @@
 
 ## Properties
 
-| Property              | Attribute               | Description                                               | Type      | Default                                  |
-| --------------------- | ----------------------- | --------------------------------------------------------- | --------- | ---------------------------------------- |
-| `_id`                 | `data-id`               |                                                           | `string`  | `randomID(     'atomic-search-box-'   )` |
-| `enableQuerySyntax`   | `enable-query-syntax`   |                                                           | `boolean` | `false`                                  |
-| `leadingSubmitButton` | `leading-submit-button` | Wether the submit button should be place before the input | `boolean` | `false`                                  |
-| `numberOfSuggestions` | `number-of-suggestions` | Maximum number of suggestions to display                  | `number`  | `5`                                      |
+| Property              | Attribute               | Description                                               | Type                                  | Default                                  |
+| --------------------- | ----------------------- | --------------------------------------------------------- | ------------------------------------- | ---------------------------------------- |
+| `_id`                 | `data-id`               |                                                           | `string`                              | `randomID(     'atomic-search-box-'   )` |
+| `enableQuerySyntax`   | `enable-query-syntax`   |                                                           | `boolean`                             | `false`                                  |
+| `engine`              | --                      |                                                           | `Engine<SearchAppState> \| undefined` | `undefined`                              |
+| `leadingSubmitButton` | `leading-submit-button` | Wether the submit button should be place before the input | `boolean`                             | `false`                                  |
+| `numberOfSuggestions` | `number-of-suggestions` | Maximum number of suggestions to display                  | `number`                              | `5`                                      |
 
 
 ## Slots
@@ -53,6 +54,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [random-customer-component](../random-customer-component)
+
 ### Depends on
 
 - [atomic-component-error](../atomic-component-error)
@@ -61,6 +66,7 @@
 ```mermaid
 graph TD;
   atomic-search-box --> atomic-component-error
+  random-customer-component --> atomic-search-box
   style atomic-search-box fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -138,7 +138,7 @@ export class AtomicSearchInterface {
     event.stopPropagation();
 
     if (this.engine) {
-      event.detail(this.engine);
+      event.detail(this.engine!);
       return;
     }
 

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
@@ -30,7 +30,7 @@ enum SortOption {
 })
 export class AtomicSortDropdown {
   @State() state!: SortState;
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
 
   private sort!: Sort;
   private unsubscribe: Unsubscribe = () => {};
@@ -38,7 +38,7 @@ export class AtomicSortDropdown {
   @Initialization()
   public initialize() {
     const initialState: Partial<SortInitialState> = {criterion: this.relevance};
-    this.sort = buildSort(this.engine, {initialState});
+    this.sort = buildSort(this.engine!, {initialState});
 
     this.unsubscribe = this.sort.subscribe(() => this.updateState());
   }

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State} from '@stencil/core';
+import {Component, h, Prop, State} from '@stencil/core';
 import {
   Sort,
   SortState,
@@ -30,8 +30,8 @@ enum SortOption {
 })
 export class AtomicSortDropdown {
   @State() state!: SortState;
+  @Prop({mutable: true}) engine!: Engine;
 
-  private engine!: Engine;
   private sort!: Sort;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-sort-dropdown/readme.md
+++ b/packages/atomic/src/components/atomic-sort-dropdown/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description | Type                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------- | ----------- |
+| `engine` | --        |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+
+
 ## Shadow Parts
 
 | Part       | Description        |

--- a/packages/atomic/src/components/atomic-tab/atomic-tab.tsx
+++ b/packages/atomic/src/components/atomic-tab/atomic-tab.tsx
@@ -18,11 +18,11 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicTab {
+  @Prop({mutable: true}) engine!: Engine;
   @Prop() expression = '';
   @Prop() isActive = false;
   @State() state!: TabState;
 
-  private engine!: Engine;
   private tab!: Tab;
   private unsubscribe: Unsubscribe = () => {};
 

--- a/packages/atomic/src/components/atomic-tab/atomic-tab.tsx
+++ b/packages/atomic/src/components/atomic-tab/atomic-tab.tsx
@@ -18,7 +18,7 @@ import {Initialization} from '../../utils/initialization-utils';
   shadow: true,
 })
 export class AtomicTab {
-  @Prop({mutable: true}) engine!: Engine;
+  @Prop({mutable: true}) engine?: Engine;
   @Prop() expression = '';
   @Prop() isActive = false;
   @State() state!: TabState;
@@ -36,7 +36,7 @@ export class AtomicTab {
         isActive: this.isActive,
       },
     };
-    this.tab = buildTab(this.engine, options);
+    this.tab = buildTab(this.engine!, options);
     this.unsubscribe = this.tab.subscribe(() => this.updateState());
   }
 

--- a/packages/atomic/src/components/atomic-tab/readme.md
+++ b/packages/atomic/src/components/atomic-tab/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property     | Attribute    | Description | Type      | Default |
-| ------------ | ------------ | ----------- | --------- | ------- |
-| `expression` | `expression` |             | `string`  | `''`    |
-| `isActive`   | `is-active`  |             | `boolean` | `false` |
+| Property     | Attribute    | Description | Type                                  | Default     |
+| ------------ | ------------ | ----------- | ------------------------------------- | ----------- |
+| `engine`     | --           |             | `Engine<SearchAppState> \| undefined` | `undefined` |
+| `expression` | `expression` |             | `string`                              | `''`        |
+| `isActive`   | `is-active`  |             | `boolean`                             | `false`     |
 
 
 ## Shadow Parts

--- a/packages/atomic/src/components/random-customer-component/random-customer-component.tsx
+++ b/packages/atomic/src/components/random-customer-component/random-customer-component.tsx
@@ -1,0 +1,23 @@
+import {Engine, HeadlessEngine, searchAppReducers} from '@coveo/headless';
+import {Component, h} from '@stencil/core';
+
+@Component({
+  tag: 'random-customer-component',
+  shadow: true,
+})
+export class RandomCustomerComponent {
+  engine: Engine;
+
+  constructor() {
+    this.engine = new HeadlessEngine({
+      configuration: HeadlessEngine.getSampleConfiguration(),
+      reducers: searchAppReducers,
+    });
+  }
+  render() {
+    return [
+      <atomic-search-box engine={this.engine}></atomic-search-box>,
+      <atomic-result-list engine={this.engine}></atomic-result-list>,
+    ];
+  }
+}

--- a/packages/atomic/src/components/random-customer-component/readme.md
+++ b/packages/atomic/src/components/random-customer-component/readme.md
@@ -1,0 +1,28 @@
+# random-customer-component
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Depends on
+
+- [atomic-search-box](../atomic-search-box)
+- [atomic-result-list](../atomic-result-list)
+
+### Graph
+```mermaid
+graph TD;
+  random-customer-component --> atomic-search-box
+  random-customer-component --> atomic-result-list
+  atomic-search-box --> atomic-component-error
+  atomic-result-list --> atomic-result
+  atomic-result-list --> atomic-component-error
+  style random-customer-component fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -44,6 +44,8 @@
   </head>
 
   <body>
+    <random-customer-component></random-customer-component>
+
     <div class="container-xl">
       <div class="row justify-content-center my-5">
         <div class="col-8">

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -40,6 +40,12 @@ export function Initialization(options?: InitializationOptions) {
     >;
 
     component.componentWillLoad = function () {
+      const engine = this[engineProperty];
+      if (engine) {
+        initialize.call(this);
+        return componentWillLoad && componentWillLoad.call(this);
+      }
+
       const element = getElement(this);
       const externalSearchInterfaceId = element.getAttribute(
         'search-interface-id'


### PR DESCRIPTION
I'll keep this PR open for a bit but won't merge it.

Basically allows Atomic components to have an engine prop. Useful for customers who create their own engine and their interfaces, but only want to have a single component from Atomic.

Just refer to the `initialization-utils.tsx` and the `random-customer-component.tsx`, rest is just changing engine to a prop and updating the readme.

https://coveord.atlassian.net/browse/KIT-343