### PR TITLE
feat(atomic): rework initialization process

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -7,7 +7,7 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Engine, LogLevel, Result, ResultTemplateCondition } from "@coveo/headless";
 import { i18n } from "i18next";
-import { InitializeOptions } from "./components/atomic-search-interface/atomic-search-interface";
+import { InitializationOptions } from "./components/atomic-search-interface/atomic-search-interface";
 export namespace Components {
     interface AtomicBreadcrumbManager {
         "categoryDivider": string;
@@ -118,7 +118,7 @@ export namespace Components {
         "engine"?: Engine;
         "executeFirstSearch": () => Promise<void>;
         "i18n": i18n;
-        "initialize": (options: InitializeOptions) => Promise<void>;
+        "initialize": (options: InitializationOptions) => Promise<void>;
         "language": string;
         "logLevel"?: LogLevel;
         "pipeline": string;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -118,6 +118,7 @@ export namespace Components {
         "engine"?: Engine;
         "i18n": i18n;
         "initialize": (options: Pick<HeadlessConfigurationOptions, 'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'>) => Promise<void>;
+        "lang": string;
         "logLevel"?: LogLevel;
         "pipeline": string;
         "sample": boolean;
@@ -422,6 +423,7 @@ declare namespace LocalJSX {
     interface AtomicSearchInterface {
         "engine"?: Engine;
         "i18n"?: i18n;
+        "lang"?: string;
         "logLevel"?: LogLevel;
         "pipeline"?: string;
         "sample"?: boolean;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -5,8 +5,9 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Engine, HeadlessConfigurationOptions, LogLevel, Result, ResultTemplateCondition } from "@coveo/headless";
+import { Engine, LogLevel, Result, ResultTemplateCondition } from "@coveo/headless";
 import { i18n } from "i18next";
+import { InitializeOptions } from "./components/atomic-search-interface/atomic-search-interface";
 export namespace Components {
     interface AtomicBreadcrumbManager {
         "categoryDivider": string;
@@ -115,12 +116,12 @@ export namespace Components {
     }
     interface AtomicSearchInterface {
         "engine"?: Engine;
+        "executeFirstSearch": () => Promise<void>;
         "i18n": i18n;
-        "initialize": (options: Pick<HeadlessConfigurationOptions, 'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'>) => Promise<void>;
+        "initialize": (options: InitializeOptions) => Promise<void>;
         "language": string;
         "logLevel"?: LogLevel;
         "pipeline": string;
-        "sample": boolean;
         "searchHub": string;
     }
     interface AtomicSortDropdown {
@@ -426,7 +427,6 @@ declare namespace LocalJSX {
         "logLevel"?: LogLevel;
         "onReady"?: (event: CustomEvent<any>) => void;
         "pipeline"?: string;
-        "sample"?: boolean;
         "searchHub"?: string;
     }
     interface AtomicSortDropdown {

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -425,7 +425,6 @@ declare namespace LocalJSX {
         "i18n"?: i18n;
         "language"?: string;
         "logLevel"?: LogLevel;
-        "onReady"?: (event: CustomEvent<any>) => void;
         "pipeline"?: string;
         "searchHub"?: string;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -114,11 +114,10 @@ export namespace Components {
         "numberOfSuggestions": number;
     }
     interface AtomicSearchInterface {
-        "afterInitialization": (callback: () => void) => Promise<void>;
         "engine"?: Engine;
         "i18n": i18n;
         "initialize": (options: Pick<HeadlessConfigurationOptions, 'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'>) => Promise<void>;
-        "lang": string;
+        "language": string;
         "logLevel"?: LogLevel;
         "pipeline": string;
         "sample": boolean;
@@ -423,8 +422,9 @@ declare namespace LocalJSX {
     interface AtomicSearchInterface {
         "engine"?: Engine;
         "i18n"?: i18n;
-        "lang"?: string;
+        "language"?: string;
         "logLevel"?: LogLevel;
+        "onReady"?: (event: CustomEvent<any>) => void;
         "pipeline"?: string;
         "sample"?: boolean;
         "searchHub"?: string;

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.spec.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.spec.tsx
@@ -5,10 +5,10 @@ describe('atomic-search-interface', () => {
   it('renders', async () => {
     const page = await newSpecPage({
       components: [AtomicSearchInterface],
-      html: '<atomic-search-interface sample></atomic-search-interface>',
+      html: '<atomic-search-interface></atomic-search-interface>',
     });
     expect(page.root).toEqualHtml(`
-      <atomic-search-interface language="en" pipeline="default" sample search-hub="default">
+      <atomic-search-interface language="en" pipeline="default" search-hub="default">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.spec.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.spec.tsx
@@ -8,9 +8,8 @@ describe('atomic-search-interface', () => {
       html: '<atomic-search-interface sample></atomic-search-interface>',
     });
     expect(page.root).toEqualHtml(`
-      <atomic-search-interface pipeline="default" sample="" search-hub="default">
+      <atomic-search-interface language="en" pipeline="default" sample search-hub="default">
         <mock:shadow-root>
-          <atomic-relevance-inspector></atomic-relevance-inspector>
           <slot></slot>
         </mock:shadow-root>
       </atomic-search-interface>

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -29,7 +29,7 @@ import {
 import i18next, {i18n} from 'i18next';
 import Backend, {BackendOptions} from 'i18next-http-backend';
 
-export type InitializeOptions = Pick<
+export type InitializationOptions = Pick<
   HeadlessConfigurationOptions,
   'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'
 >;
@@ -57,7 +57,7 @@ export class AtomicSearchInterface {
     return {engine: this.engine!, i18n: this.i18n};
   }
 
-  @Method() public async initialize(options: InitializeOptions) {
+  @Method() public async initialize(options: InitializationOptions) {
     if (this.engine) {
       this.engine.logger.warn(
         'The atomic-search-interface component "initialize" has already been called.',
@@ -95,7 +95,7 @@ export class AtomicSearchInterface {
     );
   }
 
-  private initEngine(options: InitializeOptions) {
+  private initEngine(options: InitializationOptions) {
     try {
       this.engine = new HeadlessEngine({
         configuration: {

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -183,14 +183,12 @@ export class AtomicSearchInterface {
       );
     }
 
-    if (!this.engine) {
-      return;
-    }
-
     return [
-      <atomic-relevance-inspector
-        engine={this.engine}
-      ></atomic-relevance-inspector>,
+      this.engine && (
+        <atomic-relevance-inspector
+          engine={this.engine}
+        ></atomic-relevance-inspector>
+      ),
       <slot></slot>,
     ];
   }

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -41,6 +41,7 @@ export class AtomicSearchInterface {
   @Prop({reflect: true}) searchHub = 'default';
   @Prop() logLevel?: LogLevel = 'silent';
   @Prop() i18n: i18n = i18next.createInstance();
+  @Prop({reflect: true}) lang = 'en'; // TODO: make watchable and update i18next language on change
   @Prop({mutable: true}) engine?: Engine;
   @State() error?: Error;
 
@@ -56,7 +57,7 @@ export class AtomicSearchInterface {
 
     this.i18n.use(Backend).init({
       debug: this.logLevel === 'debug',
-      lng: 'en', // TODO: add watchable "lang" prop
+      lng: this.lang,
       fallbackLng: ['en'],
       backend: {
         loadPath: `${getAssetPath('./lang/')}{{lng}}.json`,

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -57,21 +57,25 @@ export class AtomicSearchInterface {
     headless: false,
   };
 
-  async componentWillLoad() {
-    await this.i18n.use(Backend).init({
-      debug: this.logLevel === 'debug',
-      lng: this.language,
-      fallbackLng: ['en'],
-      backend: {
-        loadPath: `${getAssetPath('./lang/')}{{lng}}.json`,
-      } as BackendOptions,
-    });
+  componentWillLoad() {
+    this.i18n
+      .use(Backend)
+      .init({
+        debug: this.logLevel === 'debug',
+        lng: this.language,
+        fallbackLng: ['en'],
+        backend: {
+          loadPath: `${getAssetPath('./lang/')}{{lng}}.json`,
+        } as BackendOptions,
+      })
+      .then(() => this.systemInitialized('i18next'));
 
-    this.systemInitialized('i18next');
-  }
-
-  componentDidLoad() {
-    this.sample && this.initialize(HeadlessEngine.getSampleConfiguration());
+    if (this.sample) {
+      // Mimics calling the async "initialize" method from the DOM
+      setTimeout(() => {
+        this.initialize(HeadlessEngine.getSampleConfiguration());
+      }, 0);
+    }
   }
 
   disconnectedCallback() {

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -8,8 +8,6 @@ import {
   Element,
   State,
   getAssetPath,
-  Event,
-  EventEmitter,
 } from '@stencil/core';
 import {
   HeadlessEngine,
@@ -50,7 +48,6 @@ export class AtomicSearchInterface {
   @Prop({reflect: true}) language = 'en'; // TODO: make watchable and update i18next language on change
   @Prop({mutable: true}) engine?: Engine;
   @State() error?: Error;
-  @Event() ready!: EventEmitter;
 
   private unsubscribe: Unsubscribe = () => {};
   private hangingComponentsInitialization: InitializeEvent[] = [];

--- a/packages/atomic/src/components/atomic-search-interface/readme.md
+++ b/packages/atomic/src/components/atomic-search-interface/readme.md
@@ -14,7 +14,6 @@
 | `language`  | `language`   |             | `string`                                                                                | `'en'`                     |
 | `logLevel`  | `log-level`  |             | `"debug" \| "error" \| "fatal" \| "info" \| "silent" \| "trace" \| "warn" \| undefined` | `undefined`                |
 | `pipeline`  | `pipeline`   |             | `string`                                                                                | `'default'`                |
-| `sample`    | `sample`     |             | `boolean`                                                                               | `false`                    |
 | `searchHub` | `search-hub` |             | `string`                                                                                | `'default'`                |
 
 
@@ -27,7 +26,17 @@
 
 ## Methods
 
-### `initialize(options: Pick<HeadlessConfigurationOptions, 'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'>) => Promise<void>`
+### `executeFirstSearch() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `initialize(options: InitializeOptions) => Promise<void>`
 
 
 

--- a/packages/atomic/src/components/atomic-search-interface/readme.md
+++ b/packages/atomic/src/components/atomic-search-interface/readme.md
@@ -11,23 +11,21 @@
 | ----------- | ------------ | ----------- | --------------------------------------------------------------------------------------- | -------------------------- |
 | `engine`    | --           |             | `Engine<SearchAppState> \| undefined`                                                   | `undefined`                |
 | `i18n`      | --           |             | `i18n`                                                                                  | `i18next.createInstance()` |
-| `logLevel`  | `log-level`  |             | `"debug" \| "error" \| "fatal" \| "info" \| "silent" \| "trace" \| "warn" \| undefined` | `'silent'`                 |
+| `language`  | `language`   |             | `string`                                                                                | `'en'`                     |
+| `logLevel`  | `log-level`  |             | `"debug" \| "error" \| "fatal" \| "info" \| "silent" \| "trace" \| "warn" \| undefined` | `undefined`                |
 | `pipeline`  | `pipeline`   |             | `string`                                                                                | `'default'`                |
 | `sample`    | `sample`     |             | `boolean`                                                                               | `false`                    |
 | `searchHub` | `search-hub` |             | `string`                                                                                | `'default'`                |
 
 
+## Events
+
+| Event   | Description | Type               |
+| ------- | ----------- | ------------------ |
+| `ready` |             | `CustomEvent<any>` |
+
+
 ## Methods
-
-### `afterInitialization(callback: () => void) => Promise<void>`
-
-
-
-#### Returns
-
-Type: `Promise<void>`
-
-
 
 ### `initialize(options: Pick<HeadlessConfigurationOptions, 'accessToken' | 'organizationId' | 'renewAccessToken' | 'platformUrl'>) => Promise<void>`
 

--- a/packages/atomic/src/global.css
+++ b/packages/atomic/src/global.css
@@ -1,0 +1,4 @@
+/* Prevents displaying customer defined html before Stencil has a chance to load */
+atomic-search-interface:not(.hydrated) {
+  display: none;
+}

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -15,19 +15,20 @@
 
         // Initialization
         /* searchInterface.initialize({
-          accessToken: 'my_token',
-          organizationId: 'my_org',
+          accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+          organizationId: 'searchuisamples',
         }); */
 
-        searchInterface.afterInitialization(() => {
+        // Event emitted once the search interface is initialized correctly
+        searchInterface.addEventListener('ready', () => {
           // Add/modify a translation
           // searchInterface.i18n.addResource('en', 'translation', 'search', 'Make me feel lucky!');
           // Change the language of the interface dynamically
-          // searchInterface.i18n.changeLanguage('fr');
+          // searchInterface.i18n.changeLanguage('es');
           // Interact with the engine
           // searchInterface.engine.dispatch(...);
           // Get all strings for a language/namespace
-          // searchInterface.i18n.getResourceBundle('en', 'translation');
+          // const allStrings = searchInterface.i18n.getResourceBundle('en', 'translation');
         });
       })();
     </script>
@@ -94,7 +95,7 @@
       </div>
       <atomic-history></atomic-history>
     </atomic-search-interface>
-    <!-- <atomic-recommendation></atomic-recommendation>
-    <atomic-frequently-bought-together></atomic-frequently-bought-together> -->
+    <atomic-recommendation></atomic-recommendation>
+    <atomic-frequently-bought-together></atomic-frequently-bought-together>
   </body>
 </html>

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -7,6 +7,7 @@
 
     <script type="module" src="/build/atomic.esm.js"></script>
     <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/build/atomic.css" />
     <script>
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
@@ -93,7 +94,7 @@
       </div>
       <atomic-history></atomic-history>
     </atomic-search-interface>
-    <atomic-recommendation></atomic-recommendation>
-    <atomic-frequently-bought-together></atomic-frequently-bought-together>
+    <!-- <atomic-recommendation></atomic-recommendation>
+    <atomic-frequently-bought-together></atomic-frequently-bought-together> -->
   </body>
 </html>

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -14,22 +14,22 @@
         const searchInterface = document.querySelector('#search');
 
         // Initialization
-        /* searchInterface.initialize({
+        await searchInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
-        }); */
-
-        // Event emitted once the search interface is initialized correctly
-        searchInterface.addEventListener('ready', () => {
-          // Add/modify a translation
-          // searchInterface.i18n.addResource('en', 'translation', 'search', 'Make me feel lucky!');
-          // Change the language of the interface dynamically
-          // searchInterface.i18n.changeLanguage('fr');
-          // Interact with the engine
-          // searchInterface.engine.dispatch(...);
-          // Get all strings for a language/namespace
-          // const allStrings = searchInterface.i18n.getResourceBundle('en', 'translation');
         });
+
+        // Trigger a first search
+        searchInterface.executeFirstSearch();
+
+        // Add/modify a translation
+        // searchInterface.i18n.addResource('en', 'translation', 'search', 'Make me feel lucky!');
+        // Change the language of the interface dynamically
+        // searchInterface.i18n.changeLanguage('fr');
+        // Interact with the engine
+        // searchInterface.engine.dispatch(...);
+        // Get all strings for a language/namespace
+        // const allStrings = searchInterface.i18n.getResourceBundle('en', 'translation');
       })();
     </script>
     <style>

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -24,7 +24,7 @@
           // Add/modify a translation
           // searchInterface.i18n.addResource('en', 'translation', 'search', 'Make me feel lucky!');
           // Change the language of the interface dynamically
-          // searchInterface.i18n.changeLanguage('es');
+          // searchInterface.i18n.changeLanguage('fr');
           // Interact with the engine
           // searchInterface.engine.dispatch(...);
           // Get all strings for a language/namespace

--- a/packages/atomic/src/utils/initialization-utils.spec.ts
+++ b/packages/atomic/src/utils/initialization-utils.spec.ts
@@ -31,7 +31,7 @@ describe('Initialization decorator', () => {
     should render nothing `, () => {
       const component = new AtomicPager();
       Initialization()(component, 'initialize');
-      expect(component.render()).toBeUndefined();
+      expect(component.render()).toBe('atomic-pager_loading');
     });
 
     it(`when "engine" is defined

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -69,7 +69,8 @@ export function Initialization() {
       }
 
       if (!this[contextProperty]) {
-        return;
+        // TODO: add optional renderLoad() method to render placeholders
+        return `${getElement(this).nodeName.toLowerCase()}_loading`;
       }
 
       hasRendered = true;

--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -12,6 +12,7 @@ const isDevWatch: boolean =
 export const config: Config = {
   namespace: 'atomic',
   taskQueue: 'async',
+  globalStyle: 'src/global.css',
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
Regarding initialization
- Hide the interface content until Stencil initializes
- Adds a rudimentary loading state when Stencil is initialized but the interface is not "ready"
- When both the headless engine has been created & the strings have been loaded, it propagates the context to the sub-components, removing their loading states

Others
- Add language prop

https://coveord.atlassian.net/browse/KIT-243