### PR TITLE
ci(headless): pass COMMIT_HASH to deployment pipeline prod release step

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -57,6 +57,9 @@
         "job_name": "ui-kit-production-release",
         "prd": {
           "disabled": false
+        },
+        "extra_parameters": {
+          "COMMIT_HASH": "$[COMMIT_HASH]"
         }
       }
     }


### PR DESCRIPTION
Variable is needed by the production release jenkins job, but is currently not passed through.


https://coveord.atlassian.net/browse/KIT-359