### PR TITLE
fix(atomic): fix purge css in prod

### DIFF
--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -1,8 +1,14 @@
+const isDevWatch =
+  process.argv &&
+  process.argv.indexOf('--dev') > -1 &&
+  process.argv.indexOf('--watch') > -1;
+
 module.exports = {
   purge: {
     content: [
       './src/**/*.tsx', './src/index.html', './src/**/*.css'
-    ]
+    ],
+    enabled: !isDevWatch
   },
   darkMode: false, // or 'media' or 'class'
   theme: {

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -1,7 +1,4 @@
-const isDevWatch =
-  process.argv &&
-  process.argv.indexOf('--dev') > -1 &&
-  process.argv.indexOf('--watch') > -1;
+const isDevWatch = process.argv.indexOf('--dev') > -1;
 
 module.exports = {
   purge: {


### PR DESCRIPTION
KIT-377

https://coveord.atlassian.net/browse/KIT-377

Right now purge isn't running because process.NODE_ENV isn't by Stencil. I used is dev watch to enable/disable purge instead.