### PR TITLE
refactor(atomic): remove tailwind from each individual pcss file

### DIFF
--- a/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/atomic-category-facet/atomic-category-facet.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 :host {
   display: block;
 }

--- a/packages/atomic/src/components/atomic-component-error/atomic-component-error.pcss
+++ b/packages/atomic/src/components/atomic-component-error/atomic-component-error.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 :host {
   color: red;
 }

--- a/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.pcss
+++ b/packages/atomic/src/components/atomic-date-facet/atomic-date-facet.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 :host {
   display: block;
 }

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.pcss
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 .bold {
     font-weight: bold;
 }

--- a/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.pcss
+++ b/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 :host {
   display: block;
 }

--- a/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.pcss
+++ b/packages/atomic/src/components/atomic-numeric-facet/atomic-numeric-facet.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 :host {
   display: block;
 }

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.pcss
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.pcss
@@ -1,2 +1,0 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.pcss
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.pcss
@@ -1,2 +1,0 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";

--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.pcss
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 /**
  * @prop --atomic-query-summary-highlight-color: Color of the highlight
  */

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 .fetch-more-results {
   display: block;
   margin-top: 18px;

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.pcss
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.pcss
@@ -1,5 +1,0 @@
-/**
-Atomic Tab
- */
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.pcss
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.pcss
@@ -1,10 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
-:host {
-  display: block;
-}
-
 .suggestion[aria-selected="true"] {
   @apply bg-gray-200
 }

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.pcss
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.pcss
@@ -1,2 +1,0 @@
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";

--- a/packages/atomic/src/components/atomic-tab/atomic-tab.pcss
+++ b/packages/atomic/src/components/atomic-tab/atomic-tab.pcss
@@ -2,9 +2,6 @@
 Atomic Tab
  */
 
-@import "tailwindcss/base";
-@import "tailwindcss/utilities";
-
 .active {
   @apply border-black border-solid;
 }

--- a/packages/atomic/src/globals/global.pcss
+++ b/packages/atomic/src/globals/global.pcss
@@ -1,5 +1,5 @@
-@import "../../node_modules/tailwindcss/base.css";
-@import "../../node_modules/tailwindcss/utilities.css";
+@import "tailwindcss/base.css";
+@import "tailwindcss/utilities.css";
 
 atomic-search-interface:not(.hydrated) {
   display: none;

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -1,8 +1,14 @@
+const isDevWatch =
+  process.argv &&
+  process.argv.indexOf('--dev') > -1 &&
+  process.argv.indexOf('--watch') > -1;
+
 module.exports = {
   purge: {
     content: [
       './src/**/*.tsx', './src/index.html', './src/**/*.css'
-    ]
+    ],
+    enabled: !isDevWatch
   },
   darkMode: false, // or 'media' or 'class'
   theme: {

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -1,14 +1,8 @@
-const isDevWatch =
-  process.argv &&
-  process.argv.indexOf('--dev') > -1 &&
-  process.argv.indexOf('--watch') > -1;
-
 module.exports = {
   purge: {
     content: [
       './src/**/*.tsx', './src/index.html', './src/**/*.css'
-    ],
-    enabled: !isDevWatch
+    ]
   },
   darkMode: false, // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
KIT-378
https://coveord.atlassian.net/browse/KIT-378

We don't need the individual imports of Tailwind with shadow DOM disabled because all the components now have access to the global import of Tailwind. This speeds up the initial build quite a bit and prevents the DOM structure of `index.html` from getting too large in dev mode.