### PR TITLE
docs(headless): implement actions parser

### DIFF
--- a/packages/headless/docs.config.json
+++ b/packages/headless/docs.config.json
@@ -7,15 +7,135 @@
   "actions": {
     "sections": [
       {
-        "name": "Configuration",
+        "name": "AdvancedSearchQueriesActions",
+        "sources": [
+          "src/features/advanced-search-queries/advanced-search-queries-actions"
+        ]
+      },
+      {
+        "name": "BreadcrumbActions",
+        "sources": [
+          "src/features/facets/generic/facet-actions"
+        ]
+      },
+      {
+        "name": "CategoryFacetSetActions",
+        "sources": [
+          "src/features/facets/category-facet-set/category-facet-set-actions"
+        ]
+      },
+      {
+        "name": "ConfigurationActions",
         "sources": [
           "src/features/configuration/configuration-actions"
         ]
       },
       {
-        "name": "Did-You-Mean",
+        "name": "ContextActions",
+        "sources": [
+          "src/features/context/context-actions"
+        ]
+      },
+      {
+        "name": "DateFacetActions",
+        "sources": [
+          "src/features/facets/range-facets/date-facet-set/date-facet-actions"
+        ]
+      },
+      {
+        "name": "DidYouMeanActions",
         "sources": [
           "src/features/did-you-mean/did-you-mean-actions"
+        ]
+      },
+      {
+        "name": "FacetActions",
+        "sources": [
+          "src/features/facets/facet-set/facet-set-actions"
+        ]
+      },
+      {
+        "name": "FieldActions",
+        "sources": [
+          "src/features/fields/fields-actions"
+        ]
+      },
+      {
+        "name": "HistoryActions",
+        "sources": [
+          "src/features/history/history-actions"
+        ]
+      },
+      {
+        "name": "NumericFacetActions",
+        "sources": [
+          "src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions"
+        ]
+      },
+      {
+        "name": "PaginationActions",
+        "sources": [
+          "src/features/pagination/pagination-actions"
+        ]
+      },
+      {
+        "name": "PipelineActions",
+        "sources": [
+          "src/features/pipeline/pipeline-actions"
+        ]
+      },
+      {
+        "name": "ProductRecommendationActions",
+        "sources": [
+          "src/features/product-recommendations/product-recommendations-actions"
+        ]
+      },
+      {
+        "name": "QueryActions",
+        "sources": [
+          "src/features/query/query-actions"
+        ]
+      },
+      {
+        "name": "QuerySetActions",
+        "sources": [
+          "src/features/query-set/query-set-actions"
+        ]
+      },
+      {
+        "name": "QuerySuggestActions",
+        "sources": [
+          "src/features/query-suggest/query-suggest-actions"
+        ]
+      },
+      {
+        "name": "RedirectionActions",
+        "sources": [
+          "src/features/redirection/redirection-actions"
+        ]
+      },
+      {
+        "name": "SearchActions",
+        "sources": [
+          "src/features/search/search-actions"
+        ]
+      },
+      {
+        "name": "SearchHubActions",
+        "sources": [
+          "src/features/search-hub/search-hub-actions"
+        ]
+      },
+      {
+        "name": "SortCriterionActions",
+        "sources": [
+          "src/features/sort-criteria/sort-criteria-actions"
+        ]
+      },
+      {
+        "name": "RecommendationActions",
+        "sources": [
+          "src/features/recommendation/recommendation-actions"
         ]
       }
     ]

--- a/packages/headless/docs/actions-parser.ts
+++ b/packages/headless/docs/actions-parser.ts
@@ -1,19 +1,15 @@
-import {Config, DocComment, DocGen, Entity, Module} from './doc-json-types';
+import {Config, DocComment, DocGen, Entity} from './doc-json-types';
 import {getDesc, getModule} from './utils';
 
 export function parseActions(docgen: DocGen, config: Config) {
   return config.actions.sections.map((section) => {
-    const sectionModules: Module[] = section.sources.map((source) =>
+    const sectionModules = section.sources.map((source) =>
       getModule(docgen, source)
     );
     return {
       section: section.name,
       actions: sectionModules
-        .map((sectionModule) => {
-          return sectionModule.children.map((entity) => {
-            return parseAction(entity);
-          });
-        })
+        .map((sectionModule) => sectionModule.children.map(parseAction))
         .reduce((acc, val) => acc.concat(val), []),
     };
   });

--- a/packages/headless/docs/actions-parser.ts
+++ b/packages/headless/docs/actions-parser.ts
@@ -1,3 +1,39 @@
-export function parseActions() {
-  return {};
+import {Config, DocComment, DocGen, Entity, Module} from './doc-json-types';
+import {getDesc, getModule} from './utils';
+
+export function parseActions(docgen: DocGen, config: Config) {
+  return config.actions.sections.map((section) => {
+    const sectionModules: Module[] = section.sources.map((source) =>
+      getModule(docgen, source)
+    );
+    return {
+      section: section.name,
+      actions: sectionModules
+        .map((sectionModule) => {
+          return sectionModule.children.map((entity) => {
+            return parseAction(entity);
+          });
+        })
+        .reduce((acc, val) => acc.concat(val), []),
+    };
+  });
+}
+
+function parseAction(entity: Entity) {
+  return {
+    name: entity.name,
+    text: getDesc(entity.comment),
+    parameters: parseActionParameters(entity.comment),
+  };
+}
+
+function parseActionParameters(comment: DocComment | undefined) {
+  if (!comment || !comment.tags) return [];
+
+  return comment.tags.map((param) => {
+    return {
+      name: param.param,
+      text: getDesc(param),
+    };
+  });
 }

--- a/packages/headless/docs/doc-json-parser.ts
+++ b/packages/headless/docs/doc-json-parser.ts
@@ -12,7 +12,7 @@ function parse(docgen: DocGen, config: Config) {
   return {
     engine: parseEngine(),
     controllers: parseControllers(docgen, config),
-    actions: parseActions(),
+    actions: parseActions(docgen, config),
   };
 }
 


### PR DESCRIPTION
I know actions are lower priority than controllers, but the logic was already almost complete in the old version of the parser, so I added it in here. We'll need to add the rest of the actions to the config as well.