### PR TITLE
docs(headless): add React samples for headless result-list

### DIFF
--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -2,12 +2,19 @@ import logo from './logo.svg';
 import './App.css';
 import {SearchBox} from './components/search-box/search-box.class';
 import {SearchBox as SearchBoxFn} from './components/search-box/search-box.fn';
-import {buildSearchBox, SearchBoxOptions} from '@coveo/headless';
+import {ResultList} from './components/result-list/result-list.class';
+import {ResultList as ResultListFn} from './components/result-list/result-list.fn';
+import {
+  buildSearchBox,
+  SearchBoxOptions,
+  buildResultList,
+} from '@coveo/headless';
 import {engine} from './engine';
 import {Section} from './layout/section';
 
 const options: SearchBoxOptions = {numberOfSuggestions: 8};
 const searchBox = buildSearchBox(engine, {options});
+const resultList = buildResultList(engine);
 
 function App() {
   return (
@@ -17,6 +24,10 @@ function App() {
         <Section title="search-box">
           <SearchBox />
           <SearchBoxFn controller={searchBox} />
+        </Section>
+        <Section title="result-list">
+          <ResultList />
+          <ResultListFn controller={resultList} />
         </Section>
       </header>
     </div>

--- a/packages/samples/headless-react/src/components/result-list/result-list.class.tsx
+++ b/packages/samples/headless-react/src/components/result-list/result-list.class.tsx
@@ -1,0 +1,70 @@
+import {Component} from 'react';
+import {
+  buildResultList,
+  ResultList as ResultListController,
+  ResultListState,
+  Unsubscribe,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+export class ResultList extends Component {
+  private readonly controller: ResultListController;
+  public state: ResultListState;
+  private unsubscribe: Unsubscribe = () => {};
+
+  constructor(props: {}) {
+    super(props);
+
+    this.controller = buildResultList(engine);
+    this.state = this.controller.state;
+  }
+
+  componentDidMount() {
+    this.unsubscribe = this.controller.subscribe(() => this.updateState());
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  private updateState() {
+    this.setState(this.controller.state);
+  }
+
+  private showMore() {
+    this.controller.fetchMoreResults();
+  }
+
+  private get resultsAvailable() {
+    return this.state.results.length > 0;
+  }
+
+  private get results() {
+    return this.state.results.map((result) => (
+      <li key={result.uniqueId}>
+        <article>
+          <h2>
+            <a href={result.clickUri}>{result.title}</a>
+          </h2>
+          <p>{result.excerpt}</p>
+        </article>
+      </li>
+    ));
+  }
+
+  render() {
+    return (
+      <div>
+        <ul>{this.resultsAvailable ? this.results : <li>No results</li>}</ul>
+        {this.resultsAvailable && (
+          <button
+            onClick={() => this.showMore()}
+            disabled={this.state.isLoading}
+          >
+            Show more
+          </button>
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/samples/headless-react/src/components/result-list/result-list.fn.tsx
+++ b/packages/samples/headless-react/src/components/result-list/result-list.fn.tsx
@@ -1,0 +1,55 @@
+import {useEffect, useState, FunctionComponent} from 'react';
+import {
+  buildResultList,
+  ResultList as HeadlessResultList,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface ResultListProps {
+  controller: HeadlessResultList;
+}
+
+export const ResultList: FunctionComponent<ResultListProps> = (props) => {
+  const {controller} = props;
+  const [state, setState] = useState(controller.state);
+
+  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+
+  const showMore = () => {
+    controller.fetchMoreResults();
+  };
+
+  const resultsAvailable = () => {
+    return state.results.length > 0;
+  };
+
+  const results = () => {
+    return state.results.map((result) => (
+      <li key={result.uniqueId}>
+        <article>
+          <h2>
+            <a href={result.clickUri}>{result.title}</a>
+          </h2>
+          <p>{result.excerpt}</p>
+        </article>
+      </li>
+    ));
+  };
+
+  return (
+    <div>
+      <ul>{resultsAvailable() ? results() : <li>No results</li>}</ul>
+      {resultsAvailable() && (
+        <button onClick={() => showMore()} disabled={state.isLoading}>
+          Show more
+        </button>
+      )}
+    </div>
+  );
+};
+
+// usage
+
+const controller = buildResultList(engine);
+
+<ResultList controller={controller} />;


### PR DESCRIPTION
Some questions concerning this issue:
* Do you think `fieldsToInclude` should be demonstrated?
* Do you think "fetchMoreResults" should be included in this sample?
  * If so, do you think it should be as a "show more" button or should infinite scrolling be implemented?
* Do you think `App.tsx` should be sectionned by component (searchbox, resultlist, etc), component type (class vs function) or both?

https://coveord.atlassian.net/browse/KIT-382