### PR TITLE
docs(headless): add React samples for headless sort

### DIFF
--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -2,18 +2,40 @@ import logo from './logo.svg';
 import './App.css';
 import {SearchBox} from './components/search-box/search-box.class';
 import {SearchBox as SearchBoxFn} from './components/search-box/search-box.fn';
+import {Sort} from './components/sort/sort.class';
+import {Sort as SortFn} from './components/sort/sort.fn';
 import {ResultList} from './components/result-list/result-list.class';
 import {ResultList as ResultListFn} from './components/result-list/result-list.fn';
 import {
   buildSearchBox,
   SearchBoxOptions,
   buildResultList,
+  buildDateSortCriterion,
+  buildFieldSortCriterion,
+  buildNoSortCriterion,
+  buildQueryRankingExpressionSortCriterion,
+  buildRelevanceSortCriterion,
+  buildSort,
+  SortOrder,
 } from '@coveo/headless';
 import {engine} from './engine';
 import {Section} from './layout/section';
 
 const options: SearchBoxOptions = {numberOfSuggestions: 8};
 const searchBox = buildSearchBox(engine, {options});
+
+const criterions = {
+  Relevance: buildRelevanceSortCriterion(),
+  'Date (Ascending)': buildDateSortCriterion(SortOrder.Ascending),
+  'Date (Descending)': buildDateSortCriterion(SortOrder.Descending),
+  'Size (Ascending)': buildFieldSortCriterion('size', SortOrder.Ascending),
+  'Size (Descending)': buildFieldSortCriterion('size', SortOrder.Descending),
+  Suggested: buildQueryRankingExpressionSortCriterion(),
+  None: buildNoSortCriterion(),
+};
+const sort = buildSort(engine, {
+  initialState: {criterion: criterions.Suggested},
+});
 
 const fieldsToInclude = {author: 'Author', filetype: 'File type'};
 const resultList = buildResultList(engine, {
@@ -28,6 +50,10 @@ function App() {
         <Section title="search-box">
           <SearchBox />
           <SearchBoxFn controller={searchBox} />
+        </Section>
+        <Section title="sort">
+          <Sort />
+          <SortFn controller={sort} criterions={criterions} />
         </Section>
         <Section title="result-list">
           <ResultList />

--- a/packages/samples/headless-react/src/components/sort/sort.class.tsx
+++ b/packages/samples/headless-react/src/components/sort/sort.class.tsx
@@ -1,0 +1,80 @@
+import {Component} from 'react';
+import {
+  buildDateSortCriterion,
+  buildFieldSortCriterion,
+  buildNoSortCriterion,
+  buildQueryRankingExpressionSortCriterion,
+  buildRelevanceSortCriterion,
+  buildSort,
+  Sort as HeadlessSort,
+  SortOrder,
+  SortState,
+  Unsubscribe,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+const criterions = {
+  Relevance: buildRelevanceSortCriterion(),
+  'Date (Ascending)': buildDateSortCriterion(SortOrder.Ascending),
+  'Date (Descending)': buildDateSortCriterion(SortOrder.Descending),
+  'Size (Ascending)': buildFieldSortCriterion('size', SortOrder.Ascending),
+  'Size (Descending)': buildFieldSortCriterion('size', SortOrder.Descending),
+  Suggested: buildQueryRankingExpressionSortCriterion(),
+  None: buildNoSortCriterion(),
+};
+
+export class Sort extends Component {
+  private controller: HeadlessSort;
+  public state: SortState;
+  private unsubscribe: Unsubscribe = () => {};
+
+  constructor(props: {}) {
+    super(props);
+
+    this.controller = buildSort(engine, {
+      initialState: {criterion: criterions.Suggested},
+    });
+    this.state = this.controller.state;
+  }
+
+  componentDidMount() {
+    this.unsubscribe = this.controller.subscribe(() => this.updateState());
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  private updateState() {
+    this.setState(this.controller.state);
+  }
+
+  private get criterionNames() {
+    return Object.keys(criterions) as (keyof typeof criterions)[];
+  }
+
+  private sortBy(criterionName: keyof typeof criterions) {
+    this.controller.sortBy(criterions[criterionName]);
+  }
+
+  private isSortedBy(criterionName: keyof typeof criterions) {
+    return this.controller.isSortedBy(criterions[criterionName]);
+  }
+
+  render() {
+    return (
+      <ul>
+        {this.criterionNames.map((criterionName) => (
+          <li key={criterionName}>
+            <button
+              disabled={this.isSortedBy(criterionName)}
+              onClick={() => this.sortBy(criterionName)}
+            >
+              {criterionName}
+            </button>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+}

--- a/packages/samples/headless-react/src/components/sort/sort.fn.tsx
+++ b/packages/samples/headless-react/src/components/sort/sort.fn.tsx
@@ -1,0 +1,69 @@
+import {useEffect, useState, FunctionComponent} from 'react';
+import {
+  buildDateSortCriterion,
+  buildFieldSortCriterion,
+  buildNoSortCriterion,
+  buildQueryRankingExpressionSortCriterion,
+  buildRelevanceSortCriterion,
+  buildSort,
+  Sort as HeadlessSort,
+  SortCriterion,
+  SortOrder,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface SortProps {
+  controller: HeadlessSort;
+  criterions: {[criterionName: string]: SortCriterion};
+}
+
+export const Sort: FunctionComponent<SortProps> = (props) => {
+  const {controller} = props;
+  const [, setState] = useState(controller.state);
+
+  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+
+  const criterionNames = () => {
+    return Object.keys(props.criterions) as (keyof typeof props.criterions)[];
+  };
+
+  const sortBy = (criterionName: keyof typeof props.criterions) => {
+    controller.sortBy(props.criterions[criterionName]);
+  };
+
+  const isSortedBy = (criterionName: keyof typeof props.criterions) => {
+    return controller.isSortedBy(props.criterions[criterionName]);
+  };
+
+  return (
+    <ul>
+      {criterionNames().map((criterionName) => (
+        <li key={criterionName}>
+          <button
+            disabled={isSortedBy(criterionName)}
+            onClick={() => sortBy(criterionName)}
+          >
+            {criterionName}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// usage
+
+const criterions = {
+  Relevance: buildRelevanceSortCriterion(),
+  'Date (Ascending)': buildDateSortCriterion(SortOrder.Ascending),
+  'Date (Descending)': buildDateSortCriterion(SortOrder.Descending),
+  'Size (Ascending)': buildFieldSortCriterion('size', SortOrder.Ascending),
+  'Size (Descending)': buildFieldSortCriterion('size', SortOrder.Descending),
+  Suggested: buildQueryRankingExpressionSortCriterion(),
+  None: buildNoSortCriterion(),
+};
+const controller = buildSort(engine, {
+  initialState: {criterion: criterions.Suggested},
+});
+
+<Sort controller={controller} criterions={criterions} />;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-389

This will be rebased from master once [KIT-382](https://github.com/coveo/ui-kit/pull/451) is merged.