### PR TITLE
docs(headless): add React samples for headless facet

### DIFF
--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -9,15 +9,21 @@ import {
   SearchBoxOptions,
   buildQuerySummary,
   buildResultList,
+  buildFacet,
 } from '@coveo/headless';
 import {engine} from './engine';
 import {Section} from './layout/section';
 import {QuerySummary} from './components/query-summary/query-summary.class';
 import {QuerySummary as QuerySummaryFn} from './components/query-summary/query-summary.fn';
+import {Facet} from './components/facet/facet.class';
+import {Facet as FacetFn} from './components/facet/facet.fn';
 
 const options: SearchBoxOptions = {numberOfSuggestions: 8};
 const searchBox = buildSearchBox(engine, {options});
+
 const querySummary = buildQuerySummary(engine);
+
+const facet = buildFacet(engine, {options: {field: 'filetype'}});
 
 const resultList = buildResultList(engine);
 
@@ -33,6 +39,10 @@ function App() {
         <Section title="query-summary">
           <QuerySummary />
           <QuerySummaryFn controller={querySummary} />
+        </Section>
+        <Section title="facet">
+          <Facet field="author" />
+          <FacetFn controller={facet} />
         </Section>
         <Section title="result-list">
           <ResultList />

--- a/packages/samples/headless-react/src/components/facet/facet.class.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.class.tsx
@@ -1,0 +1,60 @@
+import {Component} from 'react';
+import {
+  buildFacet,
+  Facet as HeadlessFacet,
+  FacetState,
+  Unsubscribe,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface FacetProps {
+  field: string;
+}
+
+export class Facet extends Component<FacetProps> {
+  private controller: HeadlessFacet;
+  public state: FacetState;
+  private unsubscribe: Unsubscribe = () => {};
+
+  constructor(props: FacetProps) {
+    super(props);
+
+    this.controller = buildFacet(engine, {options: {field: props.field}});
+    this.state = this.controller.state;
+  }
+
+  componentDidMount() {
+    this.unsubscribe = this.controller.subscribe(() => this.updateState());
+    this.controller.showMoreValues();
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  private updateState() {
+    this.setState(this.controller.state);
+  }
+
+  render() {
+    if (!this.state.values.length) {
+      return <div>No facet values</div>;
+    }
+
+    return (
+      <ul>
+        {this.state.values.map((value) => (
+          <li key={value.value}>
+            <input
+              type="checkbox"
+              checked={this.controller.isValueSelected(value)}
+              onChange={() => this.controller.toggleSelect(value)}
+              disabled={this.state.isLoading}
+            />
+            {value.value} ({value.numberOfResults} results)
+          </li>
+        ))}
+      </ul>
+    );
+  }
+}

--- a/packages/samples/headless-react/src/components/facet/facet.fn.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.fn.tsx
@@ -1,0 +1,45 @@
+import {useEffect, useState, FunctionComponent} from 'react';
+import {
+  buildFacet,
+  Facet as HeadlessFacet,
+  FacetOptions,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface FacetProps {
+  controller: HeadlessFacet;
+}
+
+export const Facet: FunctionComponent<FacetProps> = (props) => {
+  const {controller} = props;
+  const [state, setState] = useState(controller.state);
+
+  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+
+  if (!state.values.length) {
+    return <div>No facet values</div>;
+  }
+
+  return (
+    <ul>
+      {state.values.map((value) => (
+        <li key={value.value}>
+          <input
+            type="checkbox"
+            checked={controller.isValueSelected(value)}
+            onChange={() => controller.toggleSelect(value)}
+            disabled={state.isLoading}
+          />
+          {value.value} ({value.numberOfResults} results)
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// usage
+
+const options: FacetOptions = {field: 'objecttype'};
+const controller = buildFacet(engine, {options});
+
+<Facet controller={controller} />;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-392

There is a bug in this PR but I believe some of you guys might already know the cause, so I'm opening a PR before fixing it.

Despite defining a single facet with "author" as its field in this PR, it logs the warning that there's more than one facet for the same field:
![image](https://user-images.githubusercontent.com/54454747/106320216-8ee91100-6240-11eb-9266-e989d7a50f9b.png)
Changing the field in `App.tsx` to `"size"` doesn't fix the error. Adding a `console.log` in the constructor and in `componentDidMount()` only logs once respectively. Does someone know why it's initializing the same facet twice? If not, I'll look deeper to find the cause.

This PR doesn't include `facet-search`.

This will be rebased from master once [KIT-382](https://github.com/coveo/ui-kit/pull/451) is merged