### PR TITLE
feat(headless): bump rtk to 1.5.0

### DIFF
--- a/packages/headless/jest.config.js
+++ b/packages/headless/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  silent: true,
+  verbose: true,
 };

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -413,11 +413,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@coveo/bueno": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.1.0.tgz",
-			"integrity": "sha512-z0v7HtT3uKYe5egoTKxcGKlIkq+UwHrEZzPm1sln4iRCrwzWoqYOao8GPqVSCjIt4CGVbOTAR+2DqeiKs1uQSQ=="
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1028,11 +1023,11 @@
 			}
 		},
 		"@reduxjs/toolkit": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.4.0.tgz",
-			"integrity": "sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.0.tgz",
+			"integrity": "sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==",
 			"requires": {
-				"immer": "^7.0.3",
+				"immer": "^8.0.0",
 				"redux": "^4.0.0",
 				"redux-thunk": "^2.3.0",
 				"reselect": "^4.0.0"
@@ -1290,8 +1285,7 @@
 		"@types/node": {
 			"version": "14.0.14",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-			"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
-			"dev": true
+			"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -1303,7 +1297,6 @@
 			"version": "6.3.4",
 			"resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.4.tgz",
 			"integrity": "sha512-03MpZ/HP6GlG0oo5dcb8NBpI21zNESswTbaA0VB4uuigXfVy+XLmzh39CY6VCAahPMxCPtuqSEdhwGeA3AOYXg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/pino-std-serializers": "*",
@@ -1314,7 +1307,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
 			"integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -1346,7 +1338,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
 			"integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -3589,7 +3580,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"gzip-size": {
 			"version": "5.1.1",
@@ -3832,9 +3824,9 @@
 			"dev": true
 		},
 		"immer": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-7.0.5.tgz",
-			"integrity": "sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg=="
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+			"integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
 		},
 		"import-local": {
 			"version": "3.0.2",
@@ -4083,6 +4075,7 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
@@ -6483,6 +6476,7 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
 			"integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"is-wsl": "^2.2.0",
@@ -6497,6 +6491,7 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -6506,6 +6501,7 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
 					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -6515,6 +6511,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -6523,7 +6520,8 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -7650,7 +7648,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"signal-exit": {
 			"version": "3.0.3",
@@ -8572,7 +8571,8 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"v8-to-istanbul": {
 			"version": "7.0.0",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@coveo/bueno": "^0.2.0",
-    "@reduxjs/toolkit": "^1.4.0",
+    "@reduxjs/toolkit": "^1.5.0",
     "@types/pino": "^6.3.4",
     "@types/redux-mock-store": "^1.0.2",
     "coveo.analytics": "^2.16.0",

--- a/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
@@ -44,13 +44,12 @@ describe('frequently-bought-together slice', () => {
   });
 
   it('set the error on rejection', () => {
-    const err = {message: 'message', statusCode: 500, type: 'type'};
-    const action = getProductRecommendations.rejected(
-      {message: 'asd', name: 'asd'},
-      '',
-      undefined,
-      err
-    );
+    const err = {
+      message: 'message',
+      statusCode: 500,
+      type: 'type',
+    };
+    const action = {type: 'productrecommendations/get/rejected', payload: err};
     const finalState = productRecommendationsReducer(state, action);
     expect(finalState.error).toEqual(err);
     expect(finalState.isLoading).toBe(false);

--- a/packages/headless/src/features/recommendation/recommendation-slice.test.ts
+++ b/packages/headless/src/features/recommendation/recommendation-slice.test.ts
@@ -52,12 +52,7 @@ describe('recommendation slice', () => {
 
   it('set the error on rejection', () => {
     const err = {message: 'message', statusCode: 500, type: 'type'};
-    const action = getRecommendations.rejected(
-      {message: 'asd', name: 'asd'},
-      '',
-      undefined,
-      err
-    );
+    const action = {type: 'recommendation/get/rejected', payload: err};
     const finalState = recommendationReducer(state, action);
     expect(finalState.error).toEqual(err);
     expect(finalState.isLoading).toBe(false);

--- a/packages/headless/src/features/search/search-slice.test.ts
+++ b/packages/headless/src/features/search/search-slice.test.ts
@@ -114,25 +114,23 @@ describe('search-slice', () => {
   });
 
   it('when a executeSearch rejected is received, set the error', () => {
-    const err = {message: 'message', statusCode: 500, type: 'type'};
-    const action = executeSearch.rejected(
-      {message: 'asd', name: 'asd'},
-      '',
-      logSearchboxSubmit(),
-      err
-    );
+    const err = {
+      message: 'message',
+      statusCode: 500,
+      type: 'type',
+    };
+    const action = {type: 'search/executeSearch/rejected', payload: err};
     const finalState = searchReducer(state, action);
     expect(finalState.error).toEqual(err);
   });
 
   it('when a fetchMoreResults rejected is received, set the error', () => {
-    const err = {message: 'message', statusCode: 500, type: 'type'};
-    const action = fetchMoreResults.rejected(
-      {message: 'asd', name: 'asd'},
-      '',
-      undefined,
-      err
-    );
+    const err = {
+      message: 'message',
+      statusCode: 500,
+      type: 'type',
+    };
+    const action = {type: 'search/fetchMoreResults/rejected', payload: err};
     const finalState = searchReducer(state, action);
     expect(finalState.error).toEqual(err);
   });


### PR DESCRIPTION
I had to modify some tests because the `.rejected` function to create a rejected async action is apparently an internal concern of RTK/not part of their API.


https://stackoverflow.com/a/65429810


https://coveord.atlassian.net/browse/KIT-401