### PR TITLE
docs(headless): add React samples for headless facet

### DIFF
--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -6,6 +6,7 @@ import {
   updateFacetSortCriterion,
   updateFacetNumberOfValues,
   updateFacetIsFieldExpanded,
+  removeFacet,
 } from '../../../features/facets/facet-set/facet-set-actions';
 import {
   facetRequestSelector,
@@ -171,6 +172,13 @@ export function buildFacet(
       dispatch(updateFacetIsFieldExpanded({facetId, isFieldExpanded: false}));
       dispatch(updateFacetOptions({freezeFacetOrder: true}));
       dispatch(executeSearch(logFacetShowLess(facetId)));
+    },
+
+    /**
+     * Removes a facet so that its id may be used again.
+     */
+    remove() {
+      dispatch(removeFacet(options.facetId));
     },
 
     /** The state of the `Facet` controller. */

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -1,5 +1,8 @@
 import {createAction} from '@reduxjs/toolkit';
-import {FacetRegistrationOptions} from './interfaces/options';
+import {
+  FacetRegistrationOptions,
+  FacetRemovalOptions,
+} from './interfaces/options';
 import {FacetSortCriterion} from './interfaces/request';
 import {validatePayload} from '../../../utils/validate-payload';
 import {
@@ -30,6 +33,15 @@ export const registerFacet = createAction(
   'facet/register',
   (payload: FacetRegistrationOptions) =>
     validatePayload(payload, facetRegistrationOptionsDefinition)
+);
+
+/**
+ * Removes a facet from the facet set.
+ * @param (FacetRemovalOptions) The options to remove the facet with.
+ */
+export const removeFacet = createAction(
+  'facet/remove',
+  (payload: FacetRemovalOptions) => validatePayload(payload, facetIdDefinition)
 );
 
 /**

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -8,6 +8,7 @@ import {
   updateFacetNumberOfValues,
   updateFacetIsFieldExpanded,
   updateFreezeCurrentValues,
+  removeFacet,
 } from './facet-set-actions';
 import {executeSearch} from '../../search/search-actions';
 import {selectFacetSearchResult} from '../facet-search-set/specific/specific-facet-search-actions';
@@ -38,6 +39,15 @@ export const facetSetReducer = createReducer(
         }
 
         state[facetId] = buildFacetRequest(action.payload);
+      })
+      .addCase(removeFacet, (state, action) => {
+        const facetId = action.payload;
+
+        if (!(facetId in state)) {
+          return;
+        }
+
+        delete state[facetId];
       })
       .addCase(change.fulfilled, (_, action) => {
         if (Object.keys(action.payload.facetSet).length === 0) {

--- a/packages/headless/src/features/facets/facet-set/interfaces/options.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/options.ts
@@ -13,3 +13,5 @@ export type FacetOptionalParameters = Pick<
 
 export type FacetRegistrationOptions = FacetRequiredParameters &
   Partial<FacetOptionalParameters>;
+
+export type FacetRemovalOptions = string;

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -20,6 +20,7 @@ export namespace CategoryFacetSetActions {
 
 import {
   registerFacet as registerFacetAlias,
+  removeFacet as removeFacetAlias,
   toggleSelectFacetValue as toggleSelectFacetValueAlias,
   updateFacetIsFieldExpanded as updateFacetIsFieldExpandedAlias,
   updateFacetNumberOfValues as updateFacetNumberOfValuesAlias,
@@ -29,6 +30,7 @@ import {
 } from './facets/facet-set/facet-set-actions';
 export namespace FacetActions {
   export const registerFacet = registerFacetAlias;
+  export const removeFacet = removeFacetAlias;
   export const toggleSelectFacetValue = toggleSelectFacetValueAlias;
   export const updateFacetIsFieldExpanded = updateFacetIsFieldExpandedAlias;
   export const updateFacetNumberOfValues = updateFacetNumberOfValuesAlias;

--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
           <QuerySummaryFn controller={querySummary} />
         </Section>
         <Section title="facet">
-          <Facet field="author" />
+          <Facet field="author" facetId="author" />
           <FacetFn controller={facet} />
         </Section>
         <Section title="result-list">

--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -9,15 +9,21 @@ import {
   SearchBoxOptions,
   buildQuerySummary,
   buildResultList,
+  buildFacet,
 } from '@coveo/headless';
 import {engine} from './engine';
 import {Section} from './layout/section';
 import {QuerySummary} from './components/query-summary/query-summary.class';
 import {QuerySummary as QuerySummaryFn} from './components/query-summary/query-summary.fn';
+import {Facet} from './components/facet/facet.class';
+import {Facet as FacetFn} from './components/facet/facet.fn';
 
 const options: SearchBoxOptions = {numberOfSuggestions: 8};
 const searchBox = buildSearchBox(engine, {options});
+
 const querySummary = buildQuerySummary(engine);
+
+const facet = buildFacet(engine, {options: {field: 'filetype'}});
 
 const resultList = buildResultList(engine);
 
@@ -33,6 +39,10 @@ function App() {
         <Section title="query-summary">
           <QuerySummary />
           <QuerySummaryFn controller={querySummary} />
+        </Section>
+        <Section title="facet">
+          <Facet field="author" />
+          <FacetFn controller={facet} />
         </Section>
         <Section title="result-list">
           <ResultList />

--- a/packages/samples/headless-react/src/components/facet/facet.class.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.class.tsx
@@ -1,0 +1,60 @@
+import {Component} from 'react';
+import {
+  buildFacet,
+  Facet as HeadlessFacet,
+  FacetState,
+  Unsubscribe,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface FacetProps {
+  field: string;
+}
+
+export class Facet extends Component<FacetProps> {
+  private controller: HeadlessFacet;
+  public state: FacetState;
+  private unsubscribe: Unsubscribe = () => {};
+
+  constructor(props: FacetProps) {
+    super(props);
+
+    this.controller = buildFacet(engine, {options: {field: props.field}});
+    this.state = this.controller.state;
+  }
+
+  componentDidMount() {
+    this.unsubscribe = this.controller.subscribe(() => this.updateState());
+    this.controller.showMoreValues();
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  private updateState() {
+    this.setState(this.controller.state);
+  }
+
+  render() {
+    if (!this.state.values.length) {
+      return <div>No facet values</div>;
+    }
+
+    return (
+      <ul>
+        {this.state.values.map((value) => (
+          <li key={value.value}>
+            <input
+              type="checkbox"
+              checked={this.controller.isValueSelected(value)}
+              onChange={() => this.controller.toggleSelect(value)}
+              disabled={this.state.isLoading}
+            />
+            {value.value} ({value.numberOfResults} results)
+          </li>
+        ))}
+      </ul>
+    );
+  }
+}

--- a/packages/samples/headless-react/src/components/facet/facet.class.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.class.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import {
   buildFacet,
   Facet as HeadlessFacet,
+  FacetActions,
   FacetState,
   Unsubscribe,
 } from '@coveo/headless';
@@ -9,6 +10,7 @@ import {engine} from '../../engine';
 
 interface FacetProps {
   field: string;
+  facetId: string;
 }
 
 export class Facet extends Component<FacetProps> {
@@ -18,6 +20,11 @@ export class Facet extends Component<FacetProps> {
 
   constructor(props: FacetProps) {
     super(props);
+    if (process.env.NODE_ENV === 'development') {
+      // When `React.StrictMode` is active in development, the constructor is executed twice.
+      // This ensures the facet isn't already defined from a previous execution.
+      engine.dispatch(FacetActions.removeFacet(this.props.facetId));
+    }
 
     this.controller = buildFacet(engine, {options: {field: props.field}});
     this.state = this.controller.state;
@@ -30,6 +37,7 @@ export class Facet extends Component<FacetProps> {
 
   componentWillUnmount() {
     this.unsubscribe();
+    this.controller.remove();
   }
 
   private updateState() {

--- a/packages/samples/headless-react/src/components/facet/facet.fn.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.fn.tsx
@@ -1,0 +1,45 @@
+import {useEffect, useState, FunctionComponent} from 'react';
+import {
+  buildFacet,
+  Facet as HeadlessFacet,
+  FacetOptions,
+} from '@coveo/headless';
+import {engine} from '../../engine';
+
+interface FacetProps {
+  controller: HeadlessFacet;
+}
+
+export const Facet: FunctionComponent<FacetProps> = (props) => {
+  const {controller} = props;
+  const [state, setState] = useState(controller.state);
+
+  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+
+  if (!state.values.length) {
+    return <div>No facet values</div>;
+  }
+
+  return (
+    <ul>
+      {state.values.map((value) => (
+        <li key={value.value}>
+          <input
+            type="checkbox"
+            checked={controller.isValueSelected(value)}
+            onChange={() => controller.toggleSelect(value)}
+            disabled={state.isLoading}
+          />
+          {value.value} ({value.numberOfResults} results)
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// usage
+
+const options: FacetOptions = {field: 'objecttype'};
+const controller = buildFacet(engine, {options});
+
+<Facet controller={controller} />;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-392

**Warning**: This PR is not intended to be merged. It's here for discussion.

Prior to the recent changes in this PR, this error appeared:
![image](https://user-images.githubusercontent.com/54454747/106320216-8ee91100-6240-11eb-9266-e989d7a50f9b.png)

Turns out that the cause was that `<React.StrictMode></React.StrictMode>` wrapped the whole app, which causes every class component's constructor along with some other state functions to be executed twice. To quote [their unit tests](https://github.com/facebook/react/blob/702fad4b1b48ac8f626ed3f35e8f86f5ea728084/packages/react/src/__tests__/ReactStrictMode-test.js#L106):
```js
expect(log).toEqual([
    'constructor',
    'constructor',
    'getDerivedStateFromProps',
    'getDerivedStateFromProps',
    'render',
    'render',
    'componentDidMount',
]);
```

While removing `StrictMode` or running in production removes the error, neither approach seemed advisable. Additionally, this unveiled the possible issue that a component whose constructor may be executed again after removal may cause issues.

This PR attempts to solve that (for testing & discussion purpose) by introducing a way to remove/clean facets.

Here are some questions I'd like to discuss:
* Should we introduce an action to clean facets?
  * What should it be named?
  * Should it automatically be called by the controller when unsubscribing?
  * Should more components feature a way to clean them?
  * Should it be introduced in this PR or a different one?

This PR doesn't include `facet-search`.