### PR TITLE
feat(headless): added `ResultSelectionHelpers`

### DIFF
--- a/packages/atomic/src/utils/result-utils.ts
+++ b/packages/atomic/src/utils/result-utils.ts
@@ -1,5 +1,4 @@
-import {once} from './utils';
-import {Engine, ResultAnalyticsActions, Result} from '@coveo/headless';
+import {buildResultSelectionHelpers, Engine, Result} from '@coveo/headless';
 
 /**
  * Binds the logging of document
@@ -15,27 +14,15 @@ export function bindLogDocumentOpenOnResult(
   resultElement: Element,
   selector?: string
 ) {
-  const logDocumentOpenOnce = once(() => {
-    engine.dispatch(ResultAnalyticsActions.logDocumentOpen(result));
-  });
-  // 1 second is a reasonable amount of time to catch most longpress actions
-  const longpressDelay = 1000;
-  let longPressTimer: number;
-
-  const startPressTimer = () => {
-    longPressTimer = window.setTimeout(logDocumentOpenOnce, longpressDelay);
-  };
-  const clearPressTimer = () => {
-    longPressTimer && clearTimeout(longPressTimer);
-  };
+  const resultSelectionHelpers = buildResultSelectionHelpers(engine, result);
 
   const eventsMap: Record<string, EventListenerOrEventListenerObject> = {
-    contextmenu: logDocumentOpenOnce,
-    click: logDocumentOpenOnce,
-    mouseup: logDocumentOpenOnce,
-    mousedown: logDocumentOpenOnce,
-    touchstart: startPressTimer,
-    touchend: clearPressTimer,
+    contextmenu: () => resultSelectionHelpers.select(),
+    click: () => resultSelectionHelpers.select(),
+    mouseup: () => resultSelectionHelpers.select(),
+    mousedown: () => resultSelectionHelpers.select(),
+    touchstart: () => resultSelectionHelpers.beginDelayedSelect(),
+    touchend: () => resultSelectionHelpers.cancelPendingSelect(),
   };
   const elements = resultElement.querySelectorAll(
     selector || `a[href='${result.clickUri}']`

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -81,6 +81,11 @@ export {
 } from './result-list/headless-result-list';
 
 export {
+  ResultSelectionHelpers,
+  buildResultSelectionHelpers,
+} from './result-list/headless-result-selection-helpers';
+
+export {
   ResultsPerPageInitialState,
   ResultsPerPageProps,
   ResultsPerPageState,

--- a/packages/headless/src/controllers/result-list/headless-result-selection-helpers.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-selection-helpers.ts
@@ -1,0 +1,62 @@
+import {Result} from '../../api/search/search/result';
+import {Engine} from '../../app/headless-engine';
+import {ResultAnalyticsActions} from '../../features/analytics';
+
+// 1 second is a reasonable amount of time to catch most longpress actions
+const defaultDelay = 1000;
+
+/**
+ * Helpers that more easily allow sending analytics when a search result is selected.
+ */
+export type ResultSelectionHelpers = ReturnType<
+  typeof buildResultSelectionHelpers
+>;
+
+/**
+ * Creates helpers that more easily allow sending analytics when a search result is selected.
+ */
+export function buildResultSelectionHelpers(engine: Engine, result: Result) {
+  let wasOpened = false;
+  const logAnalyticsIfNeverOpened = () => {
+    if (wasOpened) {
+      return;
+    }
+    wasOpened = true;
+    engine.dispatch(ResultAnalyticsActions.logDocumentOpen(result));
+  };
+
+  let longPressTimer: NodeJS.Timeout;
+
+  return {
+    /**
+     * Selects the result, sending analytics if it was never selected before.
+     *
+     * In a DOM context, it's recommended to execute this on all the following events:
+     * * `contextmenu`
+     * * `click`
+     * * `mouseup`
+     * * `mousedown`
+     */
+    select: logAnalyticsIfNeverOpened,
+    /**
+     * Prepares to select the result after a certain delay, sending analytics if it was never selected before.
+     *
+     * This is especially useful in a DOM context to log analytics when a user long presses.
+     *
+     * In a DOM context, it's recommended to execute this on the `touchstart` event.
+     *
+     * @param delay The amount of time to wait before selecting the result.
+     */
+    beginDelayedSelect: (delay = defaultDelay) => {
+      longPressTimer = setTimeout(logAnalyticsIfNeverOpened, delay);
+    },
+    /**
+     * Cancels the pending selection caused by `beginDelayedSelect`.
+     *
+     * In a DOM context, it's recommended to execute this on the `touchend` event.
+     */
+    cancelPendingSelect: () => {
+      longPressTimer && clearTimeout(longPressTimer);
+    },
+  };
+}

--- a/packages/samples/headless-react/src/components/result-list/result-link.tsx
+++ b/packages/samples/headless-react/src/components/result-list/result-link.tsx
@@ -1,4 +1,4 @@
-import {Result, ResultAnalyticsActions} from '@coveo/headless';
+import {buildResultSelectionHelpers, Result} from '@coveo/headless';
 import {FunctionComponent, useEffect} from 'react';
 import {engine} from '../../engine';
 
@@ -7,37 +7,22 @@ interface LinkProps {
 }
 
 export const ResultLink: FunctionComponent<LinkProps> = (props) => {
-  let wasOpened = false;
-  const onOpen = () => {
-    if (wasOpened) {
-      return;
-    }
-    wasOpened = true;
-    engine.dispatch(ResultAnalyticsActions.logDocumentOpen(props.result));
-  };
+  const resultSelectionHelpers = buildResultSelectionHelpers(
+    engine,
+    props.result
+  );
 
-  // 1 second is a reasonable amount of time to catch most longpress actions
-  const longpressDelay = 1000;
-  let longPressTimer: number;
-
-  const startPressTimer = () => {
-    longPressTimer = window.setTimeout(onOpen, longpressDelay);
-  };
-  const clearPressTimer = () => {
-    longPressTimer && clearTimeout(longPressTimer);
-  };
-
-  useEffect(() => clearPressTimer, []);
+  useEffect(() => resultSelectionHelpers.cancelPendingSelect(), []);
 
   return (
     <a
       href={props.result.clickUri}
-      onClick={onOpen}
-      onContextMenu={onOpen}
-      onMouseDown={onOpen}
-      onMouseUp={onOpen}
-      onTouchStart={startPressTimer}
-      onTouchEnd={clearPressTimer}
+      onClick={() => resultSelectionHelpers.select()}
+      onContextMenu={() => resultSelectionHelpers.select()}
+      onMouseDown={() => resultSelectionHelpers.select()}
+      onMouseUp={() => resultSelectionHelpers.select()}
+      onTouchStart={() => resultSelectionHelpers.beginDelayedSelect()}
+      onTouchEnd={() => resultSelectionHelpers.cancelPendingSelect()}
     >
       {props.children}
     </a>

--- a/packages/samples/headless-react/src/components/result-list/result-link.tsx
+++ b/packages/samples/headless-react/src/components/result-list/result-link.tsx
@@ -12,7 +12,7 @@ export const ResultLink: FunctionComponent<LinkProps> = (props) => {
     props.result
   );
 
-  useEffect(() => resultSelectionHelpers.cancelPendingSelect(), []);
+  useEffect(() => () => resultSelectionHelpers.cancelPendingSelect(), []);
 
   return (
     <a


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-408

This PR is not intended to be merged yet, it's here for discussion first and will be re-opened with unit tests and the doc team added later.

This PR adds the `ResultSelectionHelpers` meant to simplify some of the code needed to log analytics when a result link is clicked.