### PR TITLE
fix(headless): remove #state attribute from FacetSearch interface

### DIFF
--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -134,8 +134,6 @@ export interface FacetSearch {
   search(): void;
   /** selects a result */
   select(value: SpecificFacetSearchResult): void;
-  /** state of the facet search */
-  readonly state: FacetSearchState;
 }
 
 export interface FacetSearchState {
@@ -217,11 +215,12 @@ export function buildFacet(
 
   dispatch(registerFacet(options));
   const facetSearch = createFacetSearch();
+  const {state, ...restOfFacetSearch} = facetSearch;
 
   return {
     ...controller,
 
-    facetSearch,
+    facetSearch: restOfFacetSearch,
 
     toggleSelect: (selection: FacetValue) =>
       dispatch(executeToggleFacetSelect({facetId: options.facetId, selection})),


### PR DESCRIPTION
I added the [state attribute](https://github.com/coveo/ui-kit/pull/482/files#diff-96f9b3bc380442a8d8022d8ca46d327f0b84e4407d328642b9d11a3cd7b4f6d4L102) to solve a tsc error when converting the facetSearch interfaces and forgot to remove it after finishing the conversion.

https://coveord.atlassian.net/browse/KIT-413