### PR TITLE
fix(headless): refactored undoable to remove initial state and update only on snapshots

### DIFF
--- a/packages/atomic/src/components/atomic-history/atomic-history.tsx
+++ b/packages/atomic/src/components/atomic-history/atomic-history.tsx
@@ -1,7 +1,8 @@
 import {Component, h, State} from '@stencil/core';
-import {History, buildHistory} from '@coveo/headless';
+import {History, buildHistory, HistoryState} from '@coveo/headless';
 import {
   Bindings,
+  BindStateToController,
   InitializableComponent,
   InitializeBindings,
 } from '../../utils/initialization-utils';
@@ -12,9 +13,10 @@ import {
 })
 export class AtomicHistory implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
-  private history!: History;
+  public history!: History;
 
   @State() public error!: Error;
+  @BindStateToController('history') @State() historyState!: HistoryState;
 
   public initialize() {
     this.history = buildHistory(this.bindings.engine);
@@ -31,8 +33,18 @@ export class AtomicHistory implements InitializableComponent {
   public render() {
     return (
       <div>
-        <button onClick={() => this.back()}>BACK</button>
-        <button onClick={() => this.forward()}>FORWARD</button>
+        <button
+          disabled={!this.historyState.past.length}
+          onClick={() => this.back()}
+        >
+          Back
+        </button>
+        <button
+          disabled={!this.historyState.future.length}
+          onClick={() => this.forward()}
+        >
+          Forward
+        </button>
       </div>
     );
   }

--- a/packages/headless/src/app/search-app-reducers.ts
+++ b/packages/headless/src/app/search-app-reducers.ts
@@ -23,9 +23,9 @@ import {categoryFacetSetReducer} from '../features/facets/category-facet-set/cat
 import {categoryFacetSearchSetReducer} from '../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {facetOptionsReducer} from '../features/facet-options/facet-options-slice';
 import {advancedSearchQueriesReducer} from '../features/advanced-search-queries/advanced-search-queries-slice';
-import {getHistoryInitialState} from '../features/history/history-state';
 import {debugReducer} from '../features/debug/debug-slice';
 import {facetOrderReducer} from '../features/facets/facet-order/facet-order-slice';
+import {redo, snapshot, undo} from '../features/history/history-actions';
 
 /**
  * Map of reducers that make up the SearchAppState.
@@ -49,7 +49,14 @@ export const searchAppReducers: ReducersMapObject<SearchAppState> = {
   search: searchReducer,
   sortCriteria: sortCriteriaReducer,
   context: contextReducer,
-  history: undoable(historyReducer, getHistoryInitialState()),
+  history: undoable({
+    actionTypes: {
+      redo: redo.type,
+      undo: undo.type,
+      snapshot: snapshot.type,
+    },
+    reducer: historyReducer,
+  }),
   didYouMean: didYouMeanReducer,
   fields: fieldsReducer,
   pipeline: pipelineReducer,

--- a/packages/headless/src/app/undoable.ts
+++ b/packages/headless/src/app/undoable.ts
@@ -66,13 +66,7 @@ const updateHistory = <State>(options: {
     return makeHistory(newPresent);
   }
 
-  console.log(
-    'states are truly equal',
-    JSON.stringify(present) === JSON.stringify(newPresent)
-  );
-
   if (present === newPresent) {
-    console.log('updateHistory are equal!');
     return state;
   }
 

--- a/packages/headless/src/app/undoable.ts
+++ b/packages/headless/src/app/undoable.ts
@@ -1,12 +1,6 @@
 import {Reducer, AnyAction} from 'redux';
-import {createAction} from '@reduxjs/toolkit';
 
-const ActionTypes = {
-  UNDO: '@@undoable/UNDO',
-  REDO: '@@undoable/REDO',
-};
-
-export const makeHistory = <State>(state: State): StateWithHistory<State> => ({
+export const makeHistory = <State>(state?: State): StateWithHistory<State> => ({
   past: [],
   present: state,
   future: [],
@@ -14,17 +8,18 @@ export const makeHistory = <State>(state: State): StateWithHistory<State> => ({
 
 export interface StateWithHistory<State> {
   past: State[];
-  present: State;
+  present?: State;
   future: State[];
 }
 
-export const ActionCreators = {
-  undo: createAction(ActionTypes.UNDO),
-  redo: createAction(ActionTypes.REDO),
-};
-
-const undo = <State>(state: StateWithHistory<State>) => {
+const undo = <State>(
+  state: StateWithHistory<State>
+): StateWithHistory<State> => {
   const {past, present, future} = state;
+  if (!present) {
+    return state;
+  }
+
   if (past.length === 0) {
     return state;
   }
@@ -38,8 +33,13 @@ const undo = <State>(state: StateWithHistory<State>) => {
   };
 };
 
-const redo = <State>(state: StateWithHistory<State>) => {
+const redo = <State>(
+  state: StateWithHistory<State>
+): StateWithHistory<State> => {
   const {past, present, future} = state;
+  if (!present) {
+    return state;
+  }
 
   if (future.length === 0) {
     return state;
@@ -54,24 +54,26 @@ const redo = <State>(state: StateWithHistory<State>) => {
   };
 };
 
-const updateHistory = <State, Action extends AnyAction>(
-  state: StateWithHistory<State>,
-  emptyState: StateWithHistory<State>,
-  reducer: Reducer<State>,
-  action: Action
-) => {
+const updateHistory = <State>(options: {
+  state: StateWithHistory<State>;
+  reducer: Reducer<State>;
+  action: AnyAction;
+}) => {
+  const {action, state, reducer} = options;
   const {past, present} = state;
   const newPresent = reducer(present, action);
-
-  if (newPresent === emptyState.present || present === newPresent) {
-    return state;
+  if (!present) {
+    return makeHistory(newPresent);
   }
 
-  // Small special twist on the documented/standard redux undo recipe
-  // We want to make the "actual first valid initial state" the first one that ends up being different from the "empty state" passed into undoable
-  // This allows for slices to register themselves dynamically (Concrete example: facet-slice).
-  if (present === emptyState.present) {
-    return makeHistory(newPresent);
+  console.log(
+    'states are truly equal',
+    JSON.stringify(present) === JSON.stringify(newPresent)
+  );
+
+  if (present === newPresent) {
+    console.log('updateHistory are equal!');
+    return state;
   }
 
   return {
@@ -81,21 +83,36 @@ const updateHistory = <State, Action extends AnyAction>(
   };
 };
 
-export const undoable = <State, Action extends AnyAction>(
-  reducer: Reducer<State>,
-  emptyState: State
-) => {
-  const emptyStateWithHistory = makeHistory(emptyState);
-  return (state = emptyStateWithHistory, action: Action) => {
+export const undoable = <State>(options: {
+  reducer: Reducer<State>;
+  actionTypes: {
+    undo: string;
+    redo: string;
+    snapshot: string;
+  };
+}) => {
+  const {actionTypes, reducer} = options;
+  const emptyHistoryState = makeHistory<State>();
+  return (
+    state = emptyHistoryState,
+    action: AnyAction
+  ): StateWithHistory<State> => {
     switch (action.type) {
-      case ActionTypes.UNDO:
+      case actionTypes.undo:
         return undo(state);
 
-      case ActionTypes.REDO:
+      case actionTypes.redo:
         return redo(state);
 
+      case actionTypes.snapshot:
+        return updateHistory({
+          state,
+          reducer,
+          action,
+        });
+
       default:
-        return updateHistory(state, emptyStateWithHistory, reducer, action);
+        return state;
     }
   };
 };

--- a/packages/headless/src/controllers/history/headless-history.test.ts
+++ b/packages/headless/src/controllers/history/headless-history.test.ts
@@ -1,20 +1,47 @@
-import {buildMockSearchAppEngine} from '../../test/mock-engine';
+import {buildMockSearchAppEngine, MockEngine} from '../../test/mock-engine';
 import {buildHistory} from './headless-history';
-import {back, forward} from '../../features/history/history-actions';
-import {ActionCreators} from '../../app/undoable';
+import {
+  back,
+  forward,
+  redo,
+  undo,
+} from '../../features/history/history-actions';
+import {
+  extractHistory,
+  getHistoryInitialState,
+} from '../../features/history/history-state';
+import {SearchAppState} from '../../state/search-app-state';
 
 describe('history', () => {
-  it('should allow to navigate backward', () => {
-    const engine = buildMockSearchAppEngine();
-    buildHistory(engine).back();
-    expect(engine.actions[0].type).toBe(back.pending.type);
-    expect(engine.actions[1].type).toBe(ActionCreators.undo().type);
+  let engine: MockEngine<SearchAppState>;
+
+  beforeEach(() => {
+    engine = buildMockSearchAppEngine();
   });
 
-  it('should allow to navigate forward', () => {
-    const engine = buildMockSearchAppEngine();
+  it("won't navigate backwards when there is no past history", () => {
+    buildHistory(engine).back();
+    expect(engine.actions.length).toBe(0);
+  });
+
+  it('should allow to navigate backward when there is a past history', () => {
+    engine.state.history.present = getHistoryInitialState();
+    engine.state.history.past = [extractHistory({pipeline: 'test'})];
+    buildHistory(engine).back();
+    expect(engine.actions[0].type).toBe(back.pending.type);
+    expect(engine.actions[1].type).toBe(undo().type);
+  });
+
+  it("won't navigate backwards when there is no future history", () => {
+    buildHistory(engine).forward();
+    expect(engine.actions.length).toBe(0);
+  });
+
+  it('should allow to navigate forward when there is a future history', () => {
+    engine.state.history.present = getHistoryInitialState();
+    engine.state.history.future = [extractHistory({pipeline: 'test'})];
     buildHistory(engine).forward();
     expect(engine.actions[0].type).toBe(forward.pending.type);
-    expect(engine.actions[1].type).toBe(ActionCreators.redo().type);
+    expect(engine.actions[1].type).toBe(redo().type);
   });
 });

--- a/packages/headless/src/controllers/history/headless-history.ts
+++ b/packages/headless/src/controllers/history/headless-history.ts
@@ -28,6 +28,9 @@ export const buildHistory = (engine: Engine) => {
      * Move backward in the interface history.
      */
     async back() {
+      if (!this.state.past.length || !this.state.present) {
+        return;
+      }
       await dispatch(back());
       dispatch(executeSearch(logNavigateBackward()));
     },
@@ -36,6 +39,9 @@ export const buildHistory = (engine: Engine) => {
      * Move forward in the interface history.
      */
     async forward() {
+      if (!this.state.future.length || !this.state.present) {
+        return;
+      }
       await dispatch(forward());
       dispatch(executeSearch(logNavigateForward()));
     },

--- a/packages/headless/src/features/advanced-search-queries/advanced-search-queries-slice.ts
+++ b/packages/headless/src/features/advanced-search-queries/advanced-search-queries-slice.ts
@@ -19,7 +19,7 @@ export const advancedSearchQueriesReducer = createReducer(
       })
       .addCase(
         change.fulfilled,
-        (_, action) => action.payload.advancedSearchQueries
+        (state, action) => action.payload?.advancedSearchQueries ?? state
       )
       .addCase(restoreSearchParameters, (state, action) => {
         state.aq = action.payload.aq ?? state.aq;

--- a/packages/headless/src/features/context/context-slice.ts
+++ b/packages/headless/src/features/context/context-slice.ts
@@ -18,6 +18,9 @@ export const contextReducer = createReducer(
         delete state.contextValues[action.payload];
       })
       .addCase(change.fulfilled, (state, action) => {
+        if (!action.payload) {
+          return;
+        }
         state.contextValues = action.payload.context.contextValues;
       });
   }

--- a/packages/headless/src/features/facet-options/facet-options-slice.ts
+++ b/packages/headless/src/features/facet-options/facet-options-slice.ts
@@ -17,6 +17,9 @@ export const facetOptionsReducer = createReducer(
       .addCase(executeSearch.rejected, (state) => {
         state.freezeFacetOrder = false;
       })
-      .addCase(change.fulfilled, (_, action) => action.payload.facetOptions);
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.facetOptions ?? state
+      );
   }
 );

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -48,7 +48,10 @@ export const categoryFacetSetReducer = createReducer(
         const initialNumberOfValues = request.numberOfValues;
         state[facetId] = {request, initialNumberOfValues};
       })
-      .addCase(change.fulfilled, (_, action) => action.payload.categoryFacetSet)
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.categoryFacetSet ?? state
+      )
       .addCase(restoreSearchParameters, (state, action) => {
         const cf = action.payload.cf || {};
 

--- a/packages/headless/src/features/facets/facet-order/facet-order-slice.ts
+++ b/packages/headless/src/features/facets/facet-order/facet-order-slice.ts
@@ -6,11 +6,12 @@ import {getFacetOrderInitialState} from './facet-order-state';
 export const facetOrderReducer = createReducer(
   getFacetOrderInitialState(),
   (builder) => {
-    builder.addCase(executeSearch.fulfilled, (_, action) => {
-      return action.payload.response.facets.map((facet) => facet.facetId);
-    });
-    builder.addCase(change.fulfilled, (_, action) => {
-      return action.payload.facetOrder;
-    });
+    builder
+      .addCase(executeSearch.fulfilled, (_, action) => {
+        return action.payload.response.facets.map((facet) => facet.facetId);
+      })
+      .addCase(change.fulfilled, (state, action) => {
+        return action.payload?.facetOrder ?? state;
+      });
   }
 );

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -40,6 +40,10 @@ export const facetSetReducer = createReducer(
         state[facetId] = buildFacetRequest(action.payload);
       })
       .addCase(change.fulfilled, (_, action) => {
+        if (!action.payload) {
+          return;
+        }
+
         if (Object.keys(action.payload.facetSet).length === 0) {
           return;
         }

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-set-slice.ts
@@ -32,7 +32,10 @@ export const dateFacetSetReducer = createReducer(
         const request = buildDateFacetRequest(payload);
         registerRangeFacet<DateFacetRequest>(state, request);
       })
-      .addCase(change.fulfilled, (_, action) => action.payload.dateFacetSet)
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.dateFacetSet ?? state
+      )
       .addCase(restoreSearchParameters, (state, action) => {
         const df = action.payload.df || {};
         handleRangeFacetSearchParameterRestoration(state, df);

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice.ts
@@ -32,7 +32,10 @@ export const numericFacetSetReducer = createReducer(
         const request = buildNumericFacetRequest(payload);
         registerRangeFacet<NumericFacetRequest>(state, request);
       })
-      .addCase(change.fulfilled, (_, action) => action.payload.numericFacetSet)
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.numericFacetSet ?? state
+      )
       .addCase(restoreSearchParameters, (state, action) => {
         const nf = action.payload.nf || {};
         handleRangeFacetSearchParameterRestoration(state, nf);

--- a/packages/headless/src/features/history/history-actions.ts
+++ b/packages/headless/src/features/history/history-actions.ts
@@ -1,8 +1,9 @@
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
-
-import {ActionCreators} from '../../app/undoable';
 import {SearchAppState} from '../../state/search-app-state';
 import {HistoryState} from './history-state';
+
+export const undo = createAction('history/undo');
+export const redo = createAction('history/redo');
 
 /**
  * Creates a snapshot of the current request parameters and adds it to the interface history.
@@ -14,7 +15,7 @@ export const snapshot = createAction<HistoryState>('history/snapshot');
  * Moves backward in the interface history.
  */
 export const back = createAsyncThunk('history/back', async (_, {dispatch}) => {
-  await dispatch(ActionCreators.undo());
+  dispatch(undo());
   await dispatch(change());
 });
 
@@ -24,7 +25,7 @@ export const back = createAsyncThunk('history/back', async (_, {dispatch}) => {
 export const forward = createAsyncThunk(
   'history/forward',
   async (_, {dispatch}) => {
-    await dispatch(ActionCreators.redo());
+    dispatch(redo());
     await dispatch(change());
   }
 );

--- a/packages/headless/src/features/history/history-slice.test.ts
+++ b/packages/headless/src/features/history/history-slice.test.ts
@@ -1,5 +1,5 @@
 import {historyReducer} from './history-slice';
-import {snapshot} from './history-actions';
+import {redo, snapshot, undo} from './history-actions';
 import {Reducer} from 'redux';
 import {undoable, StateWithHistory, makeHistory} from '../../app/undoable';
 import {buildMockFacetRequest} from '../../test/mock-facet-request';
@@ -15,7 +15,14 @@ describe('history slice', () => {
   let undoableReducer: Reducer<StateWithHistory<HistoryState>>;
 
   beforeEach(() => {
-    undoableReducer = undoable(historyReducer, getHistoryInitialState());
+    undoableReducer = undoable({
+      reducer: historyReducer,
+      actionTypes: {
+        redo: redo.type,
+        undo: undo.type,
+        snapshot: snapshot.type,
+      },
+    });
   });
 
   const getSnapshot = (snap: Partial<HistoryState>) => ({

--- a/packages/headless/src/features/history/history-slice.ts
+++ b/packages/headless/src/features/history/history-slice.ts
@@ -47,6 +47,7 @@ const isEqual = (current: HistoryState, next: HistoryState) => {
 const isContextEqual = (current: ContextState, next: ContextState) =>
   JSON.stringify(current.contextValues) === JSON.stringify(next.contextValues);
 
+// TODO: compare all facets non-idle values, comparing current values changes history after 1st request
 const isFacetsEqual = (current: FacetSetState, next: FacetSetState) =>
   JSON.stringify(current) === JSON.stringify(next);
 

--- a/packages/headless/src/features/history/history-state.ts
+++ b/packages/headless/src/features/history/history-state.ts
@@ -4,6 +4,7 @@ import {getContextInitialState} from '../context/context-state';
 import {getDebugInitialState} from '../debug/debug-state';
 import {getFacetOptionsInitialState} from '../facet-options/facet-options-state';
 import {getCategoryFacetSetInitialState} from '../facets/category-facet-set/category-facet-set-state';
+import {getFacetOrderInitialState} from '../facets/facet-order/facet-order-state';
 import {getFacetSetInitialState} from '../facets/facet-set/facet-set-state';
 import {getDateFacetSetInitialState} from '../facets/range-facets/date-facet-set/date-facet-set-state';
 import {getNumericFacetSetInitialState} from '../facets/range-facets/numeric-facet-set/numeric-facet-set-state';
@@ -18,28 +19,28 @@ export interface HistoryState extends SearchParametersState {
   facetOrder: string[];
 }
 
-function getSearchParametersInitialState(): SearchParametersState {
-  return {
-    context: getContextInitialState(),
-    facetSet: getFacetSetInitialState(),
-    dateFacetSet: getDateFacetSetInitialState(),
-    numericFacetSet: getNumericFacetSetInitialState(),
-    categoryFacetSet: getCategoryFacetSetInitialState(),
-    facetOptions: getFacetOptionsInitialState(),
-    pagination: getPaginationInitialState(),
-    query: getQueryInitialState(),
-    advancedSearchQueries: getAdvancedSearchQueriesInitialState(),
-    sortCriteria: getSortCriteriaInitialState(),
-    querySet: getQuerySetInitialState(),
-    pipeline: getPipelineInitialState(),
-    searchHub: getSearchHubInitialState(),
-    debug: getDebugInitialState(),
-  };
+export function getHistoryInitialState(): HistoryState {
+  return extractHistory({});
 }
 
-export function getHistoryInitialState(): HistoryState {
+export function extractHistory(state: Partial<HistoryState>): HistoryState {
   return {
-    ...getSearchParametersInitialState(),
-    facetOrder: [],
+    context: state.context || getContextInitialState(),
+    facetSet: state.facetSet || getFacetSetInitialState(),
+    numericFacetSet: state.numericFacetSet || getNumericFacetSetInitialState(),
+    dateFacetSet: state.dateFacetSet || getDateFacetSetInitialState(),
+    categoryFacetSet:
+      state.categoryFacetSet || getCategoryFacetSetInitialState(),
+    pagination: state.pagination || getPaginationInitialState(),
+    query: state.query || getQueryInitialState(),
+    advancedSearchQueries:
+      state.advancedSearchQueries || getAdvancedSearchQueriesInitialState(),
+    querySet: state.querySet || getQuerySetInitialState(),
+    sortCriteria: state.sortCriteria || getSortCriteriaInitialState(),
+    pipeline: state.pipeline || getPipelineInitialState(),
+    searchHub: state.searchHub || getSearchHubInitialState(),
+    facetOptions: state.facetOptions || getFacetOptionsInitialState(),
+    facetOrder: state.facetOrder ?? getFacetOrderInitialState(),
+    debug: state.debug ?? getDebugInitialState(),
   };
 }

--- a/packages/headless/src/features/history/history-state.ts
+++ b/packages/headless/src/features/history/history-state.ts
@@ -20,27 +20,28 @@ export interface HistoryState extends SearchParametersState {
 }
 
 export function getHistoryInitialState(): HistoryState {
-  return extractHistory({});
+  return {
+    context: getContextInitialState(),
+    facetSet: getFacetSetInitialState(),
+    numericFacetSet: getNumericFacetSetInitialState(),
+    dateFacetSet: getDateFacetSetInitialState(),
+    categoryFacetSet: getCategoryFacetSetInitialState(),
+    pagination: getPaginationInitialState(),
+    query: getQueryInitialState(),
+    advancedSearchQueries: getAdvancedSearchQueriesInitialState(),
+    querySet: getQuerySetInitialState(),
+    sortCriteria: getSortCriteriaInitialState(),
+    pipeline: getPipelineInitialState(),
+    searchHub: getSearchHubInitialState(),
+    facetOptions: getFacetOptionsInitialState(),
+    facetOrder: getFacetOrderInitialState(),
+    debug: getDebugInitialState(),
+  };
 }
 
 export function extractHistory(state: Partial<HistoryState>): HistoryState {
   return {
-    context: state.context || getContextInitialState(),
-    facetSet: state.facetSet || getFacetSetInitialState(),
-    numericFacetSet: state.numericFacetSet || getNumericFacetSetInitialState(),
-    dateFacetSet: state.dateFacetSet || getDateFacetSetInitialState(),
-    categoryFacetSet:
-      state.categoryFacetSet || getCategoryFacetSetInitialState(),
-    pagination: state.pagination || getPaginationInitialState(),
-    query: state.query || getQueryInitialState(),
-    advancedSearchQueries:
-      state.advancedSearchQueries || getAdvancedSearchQueriesInitialState(),
-    querySet: state.querySet || getQuerySetInitialState(),
-    sortCriteria: state.sortCriteria || getSortCriteriaInitialState(),
-    pipeline: state.pipeline || getPipelineInitialState(),
-    searchHub: state.searchHub || getSearchHubInitialState(),
-    facetOptions: state.facetOptions || getFacetOptionsInitialState(),
-    facetOrder: state.facetOrder ?? getFacetOrderInitialState(),
-    debug: state.debug ?? getDebugInitialState(),
+    ...getHistoryInitialState(),
+    ...state,
   };
 }

--- a/packages/headless/src/features/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.ts
@@ -57,8 +57,10 @@ export const paginationReducer = createReducer(
         );
       })
       .addCase(change.fulfilled, (state, action) => {
-        state.numberOfResults = action.payload.pagination.numberOfResults;
-        state.firstResult = action.payload.pagination.firstResult;
+        if (action.payload) {
+          state.numberOfResults = action.payload.pagination.numberOfResults;
+          state.firstResult = action.payload.pagination.firstResult;
+        }
       })
       .addCase(restoreSearchParameters, (state, action) => {
         state.firstResult = action.payload.firstResult ?? state.firstResult;

--- a/packages/headless/src/features/pipeline/pipeline-slice.ts
+++ b/packages/headless/src/features/pipeline/pipeline-slice.ts
@@ -9,7 +9,10 @@ export const pipelineReducer = createReducer(
   (builder) => {
     builder
       .addCase(setPipeline, (_, action) => action.payload)
-      .addCase(change.fulfilled, (_, action) => action.payload.pipeline)
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.pipeline ?? state
+      )
       .addCase(
         updateSearchConfiguration,
         (state, action) => action.payload.pipeline || state

--- a/packages/headless/src/features/query-set/query-set-slice.ts
+++ b/packages/headless/src/features/query-set/query-set-slice.ts
@@ -31,6 +31,10 @@ export const querySetReducer = createReducer(
         Object.keys(state).forEach((q) => (state[q] = queryExecuted));
       })
       .addCase(change.fulfilled, (state, action) => {
+        if (!action.payload) {
+          return;
+        }
+
         for (const [id, query] of Object.entries(action.payload.querySet)) {
           updateQuery(state, id, query);
         }

--- a/packages/headless/src/features/query/query-slice.ts
+++ b/packages/headless/src/features/query/query-slice.ts
@@ -15,7 +15,10 @@ export const queryReducer = createReducer(getQueryInitialState(), (builder) =>
     .addCase(selectQuerySuggestion, (state, action) => {
       state.q = action.payload.expression;
     })
-    .addCase(change.fulfilled, (_, action) => action.payload.query)
+    .addCase(
+      change.fulfilled,
+      (state, action) => action.payload?.query ?? state
+    )
     .addCase(restoreSearchParameters, (state, action) => {
       state.q = action.payload.q ?? state.q;
       state.enableQuerySyntax =

--- a/packages/headless/src/features/search-hub/search-hub-slice.ts
+++ b/packages/headless/src/features/search-hub/search-hub-slice.ts
@@ -9,7 +9,10 @@ export const searchHubReducer = createReducer(
   (builder) => {
     builder
       .addCase(setSearchHub, (_, action) => action.payload)
-      .addCase(change.fulfilled, (_, action) => action.payload.searchHub)
+      .addCase(
+        change.fulfilled,
+        (state, action) => action.payload?.searchHub ?? state
+      )
       .addCase(
         updateSearchConfiguration,
         (state, action) => action.payload.searchHub || state

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -37,29 +37,13 @@ import {
 } from '../../api/analytics/analytics';
 import {AnyFacetRequest} from '../facets/generic/interfaces/generic-facet-request';
 import {SearchRequest} from '../../api/search/search/search-request';
-import {getContextInitialState} from '../context/context-state';
-import {getFacetSetInitialState} from '../facets/facet-set/facet-set-state';
-import {getNumericFacetSetInitialState} from '../facets/range-facets/numeric-facet-set/numeric-facet-set-state';
-import {getDateFacetSetInitialState} from '../facets/range-facets/date-facet-set/date-facet-set-state';
-import {
-  CategoryFacetSetState,
-  getCategoryFacetSetInitialState,
-} from '../facets/category-facet-set/category-facet-set-state';
-import {getPaginationInitialState} from '../pagination/pagination-state';
+import {CategoryFacetSetState} from '../facets/category-facet-set/category-facet-set-state';
 import {getQueryInitialState} from '../query/query-state';
-import {getAdvancedSearchQueriesInitialState} from '../advanced-search-queries/advanced-search-queries-state';
-import {getQuerySetInitialState} from '../query-set/query-set-state';
-import {getSortCriteriaInitialState} from '../sort-criteria/sort-criteria-state';
-import {getPipelineInitialState} from '../pipeline/pipeline-state';
-import {getSearchHubInitialState} from '../search-hub/search-hub-state';
-import {getFacetOptionsInitialState} from '../facet-options/facet-options-state';
-import {logFetchMoreResults, logQueryError} from './search-analytics-actions';
 import {SearchAction} from '../analytics/analytics-utils';
-import {HistoryState} from '../history/history-state';
+import {extractHistory} from '../history/history-state';
 import {sortFacets} from '../../utils/facet-utils';
-import {getDebugInitialState} from '../debug/debug-state';
-import {getFacetOrderInitialState} from '../facets/facet-order/facet-order-state';
 import {getSearchInitialState} from './search-state';
+import {logFetchMoreResults, logQueryError} from './search-analytics-actions';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -274,25 +258,6 @@ const shouldReExecuteTheQueryWithCorrections = (
   }
   return false;
 };
-
-const extractHistory = (state: StateNeededByExecuteSearch): HistoryState => ({
-  context: state.context || getContextInitialState(),
-  facetSet: state.facetSet || getFacetSetInitialState(),
-  numericFacetSet: state.numericFacetSet || getNumericFacetSetInitialState(),
-  dateFacetSet: state.dateFacetSet || getDateFacetSetInitialState(),
-  categoryFacetSet: state.categoryFacetSet || getCategoryFacetSetInitialState(),
-  pagination: state.pagination || getPaginationInitialState(),
-  query: state.query || getQueryInitialState(),
-  advancedSearchQueries:
-    state.advancedSearchQueries || getAdvancedSearchQueriesInitialState(),
-  querySet: state.querySet || getQuerySetInitialState(),
-  sortCriteria: state.sortCriteria || getSortCriteriaInitialState(),
-  pipeline: state.pipeline || getPipelineInitialState(),
-  searchHub: state.searchHub || getSearchHubInitialState(),
-  facetOptions: state.facetOptions || getFacetOptionsInitialState(),
-  facetOrder: state.facetOrder ?? getFacetOrderInitialState(),
-  debug: state.debug ?? getDebugInitialState(),
-});
 
 export const buildSearchRequest = (
   state: StateNeededByExecuteSearch

--- a/packages/headless/src/features/sort-criteria/sort-criteria-slice.ts
+++ b/packages/headless/src/features/sort-criteria/sort-criteria-slice.ts
@@ -19,7 +19,9 @@ export const sortCriteriaReducer = createReducer(
       .addCase(updateSortCriterion, (_, action) =>
         buildCriterionExpression(action.payload)
       )
-      .addCase(change.fulfilled, (_, action) => action.payload.sortCriteria)
+      .addCase(change.fulfilled, (state, action) => {
+        return action.payload?.sortCriteria ?? state;
+      })
       .addCase(restoreSearchParameters, (state, action) => {
         return action.payload.sortCriteria ?? state;
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-432

I basically removed the initial state inside undoable. The current history state is then “undefined” until a first “snapshot” is dispatched. Before it was calling “updateHistory” on every dispatch, now it only calls it on “snapshot”.

I scoped the action creators and types, passing them as options, this make the undoable plugin reusable and won’t trigger snapshot, undos, redos on other reducers.

I had to update the slices using history, preventing them to “change” is there is no history, realistically we would never even call “change” unless there is past/future.

Many tests will fail here, I'll have to refactor them in a separate branch, the current ones touches enough files 😅 