### PR TITLE
fix(atomic,bueno): validate isNaN for NumberValue (bueno) and remove some reflected props (atomic)

### DIFF
--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -44,11 +44,11 @@ export class AtomicPager implements InitializableComponent {
   /**
    * Specifies how many page buttons to display in the pager.
    */
-  @Prop({reflect: true}) numberOfPages = 5;
+  @Prop() numberOfPages = 5;
   /**
    * Specifies whether the **Previous** and **Next** buttons should appear at each end of the pager when appropriate.
    */
-  @Prop({reflect: true}) enableNavigationButtons = true;
+  @Prop() enableNavigationButtons = true;
 
   public initialize() {
     this.pager = buildPager(this.bindings.engine, {

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
@@ -45,11 +45,11 @@ export class AtomicResultsPerPage implements InitializableComponent {
   /**
    * List of possible results per page choices, separated by commas.
    */
-  @Prop({reflect: true}) choicesDisplayed = '10,25,50,100';
+  @Prop() choicesDisplayed = '10,25,50,100';
   /**
    * Initial choice for the number of result per page. Should be part of the `choicesDisplayed` option.
    */
-  @Prop({reflect: true}) initialChoice = 10;
+  @Prop() initialChoice = 10;
 
   public initialize() {
     this.resultPerPage = buildResultsPerPage(this.bindings.engine, {

--- a/packages/atomic/src/components/atomic-sort-criteria/atomic-sort-criteria.tsx
+++ b/packages/atomic/src/components/atomic-sort-criteria/atomic-sort-criteria.tsx
@@ -14,7 +14,7 @@ export class AtomicSortCriteria {
   /**
    * The non-localized caption to display for this criteria.
    */
-  @Prop({reflect: true}) caption!: string;
+  @Prop() caption!: string;
 
   /**
    * The sort criterion/criteria the end user can select/toggle between.
@@ -27,5 +27,5 @@ export class AtomicSortCriteria {
    *
    * You can specify multiple sort criteria to be used in the same request by separating them with a comma (e.g., `criteria="size ascending, date ascending"` ).
    */
-  @Prop({reflect: true}) criteria!: string;
+  @Prop() criteria!: string;
 }

--- a/packages/bueno/src/values/number-value.test.ts
+++ b/packages/bueno/src/values/number-value.test.ts
@@ -28,6 +28,12 @@ describe('number value', () => {
       expect(value.validate(('a string' as unknown) as number)).not.toBeNull();
     });
 
+    it(`when passing NaN
+    it returns an error description`, () => {
+      value = new NumberValue();
+      expect(value.validate(NaN)).not.toBeNull();
+    });
+
     it(`when a minimum is defined
     passing a value that is under it returns an error description`, () => {
       value = new NumberValue({min: 5});

--- a/packages/bueno/src/values/number-value.ts
+++ b/packages/bueno/src/values/number-value.ts
@@ -49,5 +49,5 @@ export function isNumberOrUndefined(
 }
 
 export function isNumber(value: unknown): value is number {
-  return typeof value === 'number';
+  return typeof value === 'number' && !isNaN(value);
 }


### PR DESCRIPTION
We don't really need to reflect most props, I only kept facets ids and some search interface props such as pipeline, searchhub
https://coveord.atlassian.net/browse/KIT-404
also opened this issue on the stencil side https://github.com/ionic-team/stencil/issues/2828