### PR TITLE
fix(headless): remove history initial state deconstruction

### DIFF
--- a/packages/headless/src/features/history/history-state.ts
+++ b/packages/headless/src/features/history/history-state.ts
@@ -20,28 +20,27 @@ export interface HistoryState extends SearchParametersState {
 }
 
 export function getHistoryInitialState(): HistoryState {
-  return {
-    context: getContextInitialState(),
-    facetSet: getFacetSetInitialState(),
-    numericFacetSet: getNumericFacetSetInitialState(),
-    dateFacetSet: getDateFacetSetInitialState(),
-    categoryFacetSet: getCategoryFacetSetInitialState(),
-    pagination: getPaginationInitialState(),
-    query: getQueryInitialState(),
-    advancedSearchQueries: getAdvancedSearchQueriesInitialState(),
-    querySet: getQuerySetInitialState(),
-    sortCriteria: getSortCriteriaInitialState(),
-    pipeline: getPipelineInitialState(),
-    searchHub: getSearchHubInitialState(),
-    facetOptions: getFacetOptionsInitialState(),
-    facetOrder: getFacetOrderInitialState(),
-    debug: getDebugInitialState(),
-  };
+  return extractHistory({});
 }
 
 export function extractHistory(state: Partial<HistoryState>): HistoryState {
   return {
-    ...getHistoryInitialState(),
-    ...state,
+    context: state.context || getContextInitialState(),
+    facetSet: state.facetSet || getFacetSetInitialState(),
+    numericFacetSet: state.numericFacetSet || getNumericFacetSetInitialState(),
+    dateFacetSet: state.dateFacetSet || getDateFacetSetInitialState(),
+    categoryFacetSet:
+      state.categoryFacetSet || getCategoryFacetSetInitialState(),
+    pagination: state.pagination || getPaginationInitialState(),
+    query: state.query || getQueryInitialState(),
+    advancedSearchQueries:
+      state.advancedSearchQueries || getAdvancedSearchQueriesInitialState(),
+    querySet: state.querySet || getQuerySetInitialState(),
+    sortCriteria: state.sortCriteria || getSortCriteriaInitialState(),
+    pipeline: state.pipeline || getPipelineInitialState(),
+    searchHub: state.searchHub || getSearchHubInitialState(),
+    facetOptions: state.facetOptions || getFacetOptionsInitialState(),
+    facetOrder: state.facetOrder ?? getFacetOrderInitialState(),
+    debug: state.debug ?? getDebugInitialState(),
   };
 }


### PR DESCRIPTION
Used the original history state design previous to the https://github.com/coveo/ui-kit/pull/498 PR. Removes the warnings, deconstructing the whole state on every search was a bit too intense performance-wise
https://coveord.atlassian.net/browse/KIT-442