### PR TITLE
docs(headless): place documentation on Context controller interfaces

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -9,18 +9,26 @@ const apiModel = new ApiModel();
 const apiPackage = apiModel.loadPackage('temp/headless.api.json');
 const entryPoint = apiPackage.entryPoints[0];
 
-const config: ControllerConfiguration = {
-  initializer: 'buildPager',
-  samplePaths: {
-    react_class: [
-      'packages/samples/headless-react/src/components/pager/pager.class.tsx',
-    ],
-    react_fn: [
-      'packages/samples/headless-react/src/components/pager/pager.fn.tsx',
-    ],
+const controllers: ControllerConfiguration[] = [
+  {
+    initializer: 'buildPager',
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/pager/pager.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/pager/pager.fn.tsx',
+      ],
+    },
   },
-};
+  {
+    initializer: 'buildContext',
+    samplePaths: {},
+  },
+];
 
-const result = resolveController(entryPoint, config);
+const result = controllers.map((controller) =>
+  resolveController(entryPoint, controller)
+);
 
 writeFileSync('dist/parsed_doc.json', JSON.stringify(result, null, 2));

--- a/packages/headless/doc-parser/mocks/mock-api-doc-comment.ts
+++ b/packages/headless/doc-parser/mocks/mock-api-doc-comment.ts
@@ -1,0 +1,8 @@
+import {TSDocParser} from '@microsoft/tsdoc';
+import {ApiFunction} from '@microsoft/api-extractor-model';
+
+export function buildMockApiDocComment(comment: string) {
+  const parser = new TSDocParser();
+  return (parser.parseString(comment)
+    .docComment as unknown) as ApiFunction['tsdocComment'];
+}

--- a/packages/headless/doc-parser/src/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/controller-resolver.ts
@@ -1,4 +1,9 @@
-import {ApiEntryPoint, ApiFunction} from '@microsoft/api-extractor-model';
+import {
+  ApiEntryPoint,
+  ApiFunction,
+  ApiItem,
+  ApiItemKind,
+} from '@microsoft/api-extractor-model';
 import {findApi} from './api-finder';
 import {FuncEntity} from './entity';
 import {resolveFunction} from './function-resolver';
@@ -24,19 +29,30 @@ export function resolveController(
   entry: ApiEntryPoint,
   config: ControllerConfiguration
 ): Controller {
-  const initializer = resolveControllerFunction(entry, config.initializer);
+  const initializer = resolveControllerInitializer(entry, config.initializer);
   const utils = (config.utils || []).map((util) => resolveUtility(entry, util));
   const codeSampleInfo = resolveCodeSamplePaths(config.samplePaths);
 
   return {initializer, utils, codeSampleInfo};
 }
 
-function resolveControllerFunction(entry: ApiEntryPoint, name: string) {
-  const fn = findApi(entry, name) as ApiFunction;
+function resolveControllerInitializer(entry: ApiEntryPoint, name: string) {
+  const fn = findApi(entry, name);
+
+  if (!isFunction(fn)) {
+    throw new Error(
+      `controller initializer "${name}" must be a function. Instead found: ${fn.kind}`
+    );
+  }
+
   return resolveFunction(entry, fn, [0]);
 }
 
 function resolveUtility(entry: ApiEntryPoint, name: string) {
   const fn = findApi(entry, name) as ApiFunction;
   return resolveFunction(entry, fn, []);
+}
+
+function isFunction(item: ApiItem): item is ApiFunction {
+  return item.kind === ApiItemKind.Function;
 }

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -78,13 +78,13 @@ function getSummary(comment: DocComment | undefined) {
 
 function getParamDescription(param: Parameter) {
   const nodes = param.tsdocParamBlock?.content.getChildNodes() || [];
+  const description = emitAsTsDoc((nodes as unknown) as readonly DocNode[]);
 
-  try {
-    return emitAsTsDoc((nodes as unknown) as readonly DocNode[]);
-  } catch (e) {
-    console.log('failed to description for param:', param.name, e);
-    return '';
+  if (!description) {
+    throw new Error(`No description found for param: ${param.name}`);
   }
+
+  return description;
 }
 
 function removeBlockTagNodes(nodes: readonly DocNode[]) {

--- a/packages/headless/doc-parser/src/function-resolver.test.ts
+++ b/packages/headless/doc-parser/src/function-resolver.test.ts
@@ -1,6 +1,7 @@
 import {buildMockApiFunction} from '../mocks/mock-api-function';
 import {buildMockApiInterface} from '../mocks/mock-api-interface';
 import {buildMockApiPropertySignature} from '../mocks/mock-api-property-signature';
+import {buildMockApiDocComment} from '../mocks/mock-api-doc-comment';
 import {buildMockEntity} from '../mocks/mock-entity';
 import {buildMockEntryPoint} from '../mocks/mock-entry-point';
 import {
@@ -14,8 +15,13 @@ import {resolveFunction} from './function-resolver';
 describe('#resolveFunction', () => {
   it('resolves function with a an interface return type', () => {
     const entry = buildMockEntryPoint();
+    const comment = buildMockApiDocComment(
+      '/**\n * Creates a `NumericRangeRequest`.\n *\n * @param config - The options with which to create a `NumericRangeRequest`.\n *\n * @returns A new `NumericRangeRequest`.\n */\n'
+    );
+
     const fn = buildMockApiFunction({
       name: 'buildNumericRange',
+      docComment: comment,
       excerptTokens: [
         buildContentExcerptToken('declare function buildNumericRange(config: '),
         buildReferenceExcerptToken(
@@ -72,6 +78,7 @@ describe('#resolveFunction', () => {
     const optionsParam = buildMockObjEntity({
       name: 'config',
       type: 'NumericRangeOptions',
+      desc: 'The options with which to create a `NumericRangeRequest`.',
       members: [startProperty],
     });
 
@@ -83,6 +90,7 @@ describe('#resolveFunction', () => {
 
     const funcEntity = buildMockFuncEntity({
       name: 'buildNumericRange',
+      desc: 'Creates a `NumericRangeRequest`.',
       params: [optionsParam],
       returnType,
     });

--- a/packages/headless/doc-parser/src/interface-resolver.test.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.test.ts
@@ -1,4 +1,5 @@
 import {ApiMethodSignature, ReleaseTag} from '@microsoft/api-extractor-model';
+import {buildMockApiDocComment} from '../mocks/mock-api-doc-comment';
 import {buildMockApiInterface} from '../mocks/mock-api-interface';
 import {buildMockApiPropertySignature} from '../mocks/mock-api-property-signature';
 import {buildMockApiTypeAlias} from '../mocks/mock-api-type-alias';
@@ -91,8 +92,12 @@ describe('#resolveInterfaceMembers', () => {
     const entryPoint = buildMockEntryPoint();
     const pagerInterface = buildMockApiInterface({name: 'Pager'});
 
+    const docComment = buildMockApiDocComment(
+      '/**\n * Returns `true` when the current page is equal to the passed page, and `false` otherwise.\n *\n * @param page - The page number to check.\n *\n * @returns Whether the passed page is selected.\n */\n'
+    );
+
     const method = new ApiMethodSignature({
-      docComment: undefined,
+      docComment,
       excerptTokens: [
         buildContentExcerptToken('isCurrentPage(page: '),
         buildContentExcerptToken('number'),
@@ -118,9 +123,18 @@ describe('#resolveInterfaceMembers', () => {
     entryPoint.addMember(pagerInterface);
 
     const result = resolveInterfaceMembers(entryPoint, pagerInterface);
+
+    const paramEntity = buildMockEntity({
+      name: 'page',
+      type: 'number',
+      desc: 'The page number to check.',
+    });
+
     const funcEntity = buildMockFuncEntity({
       name: 'isCurrentPage',
-      params: [buildMockEntity({name: 'page', type: 'number'})],
+      desc:
+        'Returns `true` when the current page is equal to the passed page, and `false` otherwise.',
+      params: [paramEntity],
       returnType: 'boolean',
     });
     expect(result).toEqual([funcEntity]);

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -1,5 +1,5 @@
 import {Engine} from '../../app/headless-engine';
-import {buildController} from '../controller/headless-controller';
+import {buildController, Controller} from '../controller/headless-controller';
 import {
   Context as ContextPayload,
   ContextValue,
@@ -16,44 +16,70 @@ import {ContextSection} from '../../state/state-sections';
  *
  * See [Sending Custom Context Information](https://docs.coveo.com/en/399/).
  */
-export type Context = ReturnType<typeof buildContext>;
-export type ContextState = Context['state'];
+export interface Context extends Controller {
+  /**
+   * Set the context for the query. Replace any existing context by the new one.
+   *
+   *  @param ctx - The context to set in the query.
+   */
+  set(ctx: ContextPayload): void;
 
-export const buildContext = (engine: Engine<ContextSection>) => {
+  /**
+   * Add, or replace if already present, a new context key and value pair.
+   *
+   * @param contextKey - The context key to add.
+   * @param contextValue - The context value to add.
+   */
+  add(contextKey: string, contextValue: ContextValue): void;
+
+  /**
+   * Remove a context key from the query.
+   * @param key - The context key to remove.
+   */
+  remove(key: string): void;
+
+  /**
+   * The state of the `Context` controller.
+   */
+  state: ContextState;
+}
+
+export interface ContextState {
+  /**
+   * An object holding the context keys and their values.
+   */
+  values: Record<string, ContextValue>;
+}
+
+/**
+ * Creates a `Context` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @returns A `Context` controller instance.
+ */
+export function buildContext(engine: Engine<ContextSection>): Context {
   const controller = buildController(engine);
   const {dispatch} = engine;
 
   return {
     ...controller,
+
     get state() {
       return {
         values: engine.state.context.contextValues,
       };
     },
 
-    /**
-     * Set the context for the query. Replace any existing context by the new one.
-     *  @param ctx The context to set in the query.
-     */
     set(ctx: ContextPayload) {
       dispatch(setContext(ctx));
     },
 
-    /**
-     * Add, or replace if already present, a new context key and value pair.
-     * @param contextKey The context key to add.
-     * @param contextValue The context value to add.
-     */
     add(contextKey: string, contextValue: ContextValue) {
       dispatch(addContext({contextKey, contextValue}));
     },
 
-    /**
-     * Remove a context key from the query.
-     * @param key The context key to remove.
-     */
     remove(key: string) {
       dispatch(removeContext(key));
     },
   };
-};
+}


### PR DESCRIPTION
This PR adjusts the Context controller to be able to retrieve it's documentation.