### PR TITLE
docs(headless): extract complex types into dedicated array

### DIFF
--- a/packages/headless/doc-parser/mocks/mock-obj-entity.ts
+++ b/packages/headless/doc-parser/mocks/mock-obj-entity.ts
@@ -8,6 +8,7 @@ export function buildMockObjEntity(config: Partial<ObjEntity> = {}): ObjEntity {
     isOptional: false,
     members: [],
     isTypeExtracted: false,
+    typeName: '',
     ...config,
   };
 }

--- a/packages/headless/doc-parser/mocks/mock-obj-entity.ts
+++ b/packages/headless/doc-parser/mocks/mock-obj-entity.ts
@@ -7,7 +7,7 @@ export function buildMockObjEntity(config: Partial<ObjEntity> = {}): ObjEntity {
     desc: '',
     isOptional: false,
     members: [],
-    isExtracted: false,
+    isTypeExtracted: false,
     ...config,
   };
 }

--- a/packages/headless/doc-parser/mocks/mock-obj-entity.ts
+++ b/packages/headless/doc-parser/mocks/mock-obj-entity.ts
@@ -7,6 +7,7 @@ export function buildMockObjEntity(config: Partial<ObjEntity> = {}): ObjEntity {
     desc: '',
     isOptional: false,
     members: [],
+    isExtracted: false,
     ...config,
   };
 }

--- a/packages/headless/doc-parser/src/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/controller-resolver.ts
@@ -22,7 +22,7 @@ export interface ControllerConfiguration {
 
 interface Controller {
   initializer: FuncEntity;
-  types: ObjEntity[];
+  extractedTypes: ObjEntity[];
   utils: FuncEntity[];
   codeSampleInfo: CodeSampleInfo;
 }
@@ -32,11 +32,11 @@ export function resolveController(
   config: ControllerConfiguration
 ): Controller {
   const initializer = resolveControllerInitializer(entry, config.initializer);
-  const types = extractTypesFromInitializer(initializer);
+  const extractedTypes = extractTypesFromInitializer(initializer);
   const utils = (config.utils || []).map((util) => resolveUtility(entry, util));
   const codeSampleInfo = resolveCodeSamplePaths(config.samplePaths);
 
-  return {initializer, types, utils, codeSampleInfo};
+  return {initializer, extractedTypes, utils, codeSampleInfo};
 }
 
 function resolveControllerInitializer(entry: ApiEntryPoint, name: string) {

--- a/packages/headless/doc-parser/src/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/controller-resolver.ts
@@ -5,14 +5,14 @@ import {
   ApiItemKind,
 } from '@microsoft/api-extractor-model';
 import {findApi} from './api-finder';
-import {FuncEntity, ObjEntity} from './entity';
+import {FuncEntity, isObjectEntity, ObjEntity} from './entity';
 import {resolveFunction} from './function-resolver';
 import {
   resolveCodeSamplePaths,
   SamplePaths,
   CodeSampleInfo,
 } from './code-sample-resolver';
-import {isObjectEntity, extractTypes} from './extractor';
+import {extractTypes} from './extractor';
 
 export interface ControllerConfiguration {
   initializer: string;

--- a/packages/headless/doc-parser/src/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/controller-resolver.ts
@@ -5,13 +5,14 @@ import {
   ApiItemKind,
 } from '@microsoft/api-extractor-model';
 import {findApi} from './api-finder';
-import {FuncEntity} from './entity';
+import {FuncEntity, ObjEntity} from './entity';
 import {resolveFunction} from './function-resolver';
 import {
   resolveCodeSamplePaths,
   SamplePaths,
   CodeSampleInfo,
 } from './code-sample-resolver';
+import {isObjectEntity, extractTypes} from './extractor';
 
 export interface ControllerConfiguration {
   initializer: string;
@@ -21,6 +22,7 @@ export interface ControllerConfiguration {
 
 interface Controller {
   initializer: FuncEntity;
+  types: ObjEntity[];
   utils: FuncEntity[];
   codeSampleInfo: CodeSampleInfo;
 }
@@ -30,10 +32,11 @@ export function resolveController(
   config: ControllerConfiguration
 ): Controller {
   const initializer = resolveControllerInitializer(entry, config.initializer);
+  const types = extractTypesFromInitializer(initializer);
   const utils = (config.utils || []).map((util) => resolveUtility(entry, util));
   const codeSampleInfo = resolveCodeSamplePaths(config.samplePaths);
 
-  return {initializer, utils, codeSampleInfo};
+  return {initializer, types, utils, codeSampleInfo};
 }
 
 function resolveControllerInitializer(entry: ApiEntryPoint, name: string) {
@@ -55,4 +58,10 @@ function resolveUtility(entry: ApiEntryPoint, name: string) {
 
 function isFunction(item: ApiItem): item is ApiFunction {
   return item.kind === ApiItemKind.Function;
+}
+
+function extractTypesFromInitializer(entity: FuncEntity) {
+  return isObjectEntity(entity.returnType)
+    ? extractTypes(entity.returnType.members).types
+    : [];
 }

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -13,6 +13,11 @@ interface EntityOptions extends Comment {
   isOptional: boolean;
 }
 
+interface ObjEntityOptions {
+  entity: Entity;
+  members: AnyEntity[];
+}
+
 interface FuncEntityOptions extends Comment {
   name: string;
   params: AnyEntity[];
@@ -28,6 +33,16 @@ export function buildEntity(config: EntityOptions): Entity {
     isOptional: config.isOptional,
     type,
     desc,
+  };
+}
+
+export function buildObjEntity(config: ObjEntityOptions): ObjEntity {
+  const {entity, members} = config;
+
+  return {
+    ...entity,
+    members,
+    isExtracted: false,
   };
 }
 

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -42,7 +42,7 @@ export function buildObjEntity(config: ObjEntityOptions): ObjEntity {
   return {
     ...entity,
     members,
-    isExtracted: false,
+    isTypeExtracted: false,
   };
 }
 

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -16,6 +16,7 @@ interface EntityOptions extends Comment {
 interface ObjEntityOptions {
   entity: Entity;
   members: AnyEntity[];
+  typeName: string;
 }
 
 interface FuncEntityOptions extends Comment {
@@ -38,11 +39,13 @@ export function buildEntity(config: EntityOptions): Entity {
 
 export function buildObjEntity(config: ObjEntityOptions): ObjEntity {
   const {entity, members} = config;
+  const typeName = sanitizeType(config.typeName);
 
   return {
     ...entity,
     members,
     isTypeExtracted: false,
+    typeName,
   };
 }
 

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -7,6 +7,7 @@ export interface Entity {
 
 export interface ObjEntity extends Entity {
   members: AnyEntity[];
+  isExtracted: boolean;
 }
 
 export interface FuncEntity {

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -8,6 +8,7 @@ export interface Entity {
 export interface ObjEntity extends Entity {
   members: AnyEntity[];
   isTypeExtracted: boolean;
+  typeName: string;
 }
 
 export interface FuncEntity {

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -18,3 +18,11 @@ export interface FuncEntity {
 }
 
 export type AnyEntity = Entity | ObjEntity | FuncEntity;
+
+export function isObjectEntity(entity: unknown): entity is ObjEntity {
+  if (typeof entity !== 'object') {
+    return false;
+  }
+
+  return !!entity && 'members' in entity;
+}

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -7,7 +7,7 @@ export interface Entity {
 
 export interface ObjEntity extends Entity {
   members: AnyEntity[];
-  isExtracted: boolean;
+  isTypeExtracted: boolean;
 }
 
 export interface FuncEntity {

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -1,0 +1,76 @@
+import {buildMockEntity} from '../mocks/mock-entity';
+import {buildMockObjEntity} from '../mocks/mock-obj-entity';
+import {extractTypes} from './extractor';
+
+describe('#extractTypes', () => {
+  describe('given Facet.state.values with type #FacetValue[]', () => {
+    it('extracts #FacetValue as an entity', () => {
+      const numberOfResults = buildMockEntity({
+        name: 'numberOfResults',
+        type: 'number',
+      });
+
+      const values = buildMockObjEntity({
+        name: 'values',
+        type: 'FacetValue[]',
+        members: [numberOfResults],
+      });
+
+      const state = buildMockObjEntity({
+        name: 'state',
+        members: [values],
+      });
+
+      const {types} = extractTypes([state]);
+
+      const expectedEntity = buildMockObjEntity({
+        name: 'FacetValue[]',
+        type: 'FacetValue[]',
+        members: [numberOfResults],
+      });
+
+      expect(types).toEqual([expectedEntity]);
+    });
+  });
+
+  it(`given Facet.state.facetSearch.values with type #SpecificFacetSearchResult,
+  it extracts #FacetSearchState and #SpecificFacetSearchResult as type entities`, () => {
+    const displayValue = buildMockEntity({
+      name: 'displayValue',
+      type: 'string',
+    });
+
+    const values = buildMockObjEntity({
+      name: 'values',
+      type: 'SpecificFacetSearchResult[]',
+      members: [displayValue],
+    });
+
+    const facetSearch = buildMockObjEntity({
+      name: 'facetSearch',
+      type: 'FacetSearchState',
+      members: [values],
+    });
+
+    const state = buildMockObjEntity({
+      name: 'state',
+      members: [facetSearch],
+    });
+
+    const {types} = extractTypes([state]);
+
+    const expectedEntity1 = buildMockObjEntity({
+      name: 'FacetSearchState',
+      type: 'FacetSearchState',
+      members: [values],
+    });
+
+    const expectedEntity2 = buildMockObjEntity({
+      name: 'SpecificFacetSearchResult[]',
+      type: 'SpecificFacetSearchResult[]',
+      members: [displayValue],
+    });
+
+    expect(types).toEqual([expectedEntity1, expectedEntity2]);
+  });
+});

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -13,6 +13,7 @@ describe('#extractTypes', () => {
     const values = buildMockObjEntity({
       name: 'values',
       type: 'FacetValue[]',
+      typeName: 'FacetValue',
       members: [numberOfResults],
       isTypeExtracted: false,
     });
@@ -25,8 +26,7 @@ describe('#extractTypes', () => {
     const {types} = extractTypes([state]);
 
     const expectedEntity = buildMockObjEntity({
-      name: 'FacetValue[]',
-      type: 'FacetValue[]',
+      name: 'FacetValue',
       members: [numberOfResults],
     });
 
@@ -44,12 +44,14 @@ describe('#extractTypes', () => {
     const values = buildMockObjEntity({
       name: 'values',
       type: 'SpecificFacetSearchResult[]',
+      typeName: 'SpecificFacetSearchResult',
       members: [displayValue],
     });
 
     const facetSearch = buildMockObjEntity({
       name: 'facetSearch',
       type: 'FacetSearchState',
+      typeName: 'FacetSearchState',
       members: [values],
     });
 
@@ -62,13 +64,11 @@ describe('#extractTypes', () => {
 
     const expectedEntity1 = buildMockObjEntity({
       name: 'FacetSearchState',
-      type: 'FacetSearchState',
       members: [values],
     });
 
     const expectedEntity2 = buildMockObjEntity({
-      name: 'SpecificFacetSearchResult[]',
-      type: 'SpecificFacetSearchResult[]',
+      name: 'SpecificFacetSearchResult',
       members: [displayValue],
     });
 

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -73,4 +73,27 @@ describe('#extractTypes', () => {
 
     expect(types).toEqual([expectedEntity1, expectedEntity2]);
   });
+
+  it(`when multiple entities have strictly members with primitive types,
+  it does not extract anything`, () => {
+    const numberOfResults = buildMockEntity({
+      name: 'numberOfResults',
+      type: 'number',
+    });
+
+    const facetSearch = buildMockObjEntity({
+      name: 'facetSearch',
+      type: 'FacetSearchState',
+      members: [numberOfResults],
+    });
+
+    const state = buildMockObjEntity({
+      name: 'state',
+      type: 'FacetState',
+      members: [numberOfResults],
+    });
+
+    const {types} = extractTypes([state, facetSearch]);
+    expect(types).toEqual([]);
+  });
 });

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -3,8 +3,7 @@ import {buildMockObjEntity} from '../mocks/mock-obj-entity';
 import {extractTypes} from './extractor';
 
 describe('#extractTypes', () => {
-  it(`given Facet.state.values with type #FacetValue[],
-  it extracts #FacetValue as an entity, and sets #values.isTypeExtracted to true`, () => {
+  it('given Facet.state.values with type #FacetValue[], it extracts #FacetValue as an entity', () => {
     const numberOfResults = buildMockEntity({
       name: 'numberOfResults',
       type: 'number',
@@ -31,6 +30,22 @@ describe('#extractTypes', () => {
     });
 
     expect(types).toEqual([expectedEntity]);
+  });
+
+  it('when a type is extracted, it sets #members to an empty array and #isTypeExtracted to true on the entity', () => {
+    const numberOfResults = buildMockEntity({name: 'numberOfResults'});
+
+    const values = buildMockObjEntity({
+      name: 'values',
+      members: [numberOfResults],
+      isTypeExtracted: false,
+    });
+
+    const state = buildMockObjEntity({name: 'state', members: [values]});
+
+    extractTypes([state]);
+
+    expect(values.members.length).toBe(0);
     expect(values.isTypeExtracted).toBe(true);
   });
 

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -3,34 +3,35 @@ import {buildMockObjEntity} from '../mocks/mock-obj-entity';
 import {extractTypes} from './extractor';
 
 describe('#extractTypes', () => {
-  describe('given Facet.state.values with type #FacetValue[]', () => {
-    it('extracts #FacetValue as an entity', () => {
-      const numberOfResults = buildMockEntity({
-        name: 'numberOfResults',
-        type: 'number',
-      });
-
-      const values = buildMockObjEntity({
-        name: 'values',
-        type: 'FacetValue[]',
-        members: [numberOfResults],
-      });
-
-      const state = buildMockObjEntity({
-        name: 'state',
-        members: [values],
-      });
-
-      const {types} = extractTypes([state]);
-
-      const expectedEntity = buildMockObjEntity({
-        name: 'FacetValue[]',
-        type: 'FacetValue[]',
-        members: [numberOfResults],
-      });
-
-      expect(types).toEqual([expectedEntity]);
+  it(`given Facet.state.values with type #FacetValue[],
+  it extracts #FacetValue as an entity, and sets #values.isTypeExtracted to true`, () => {
+    const numberOfResults = buildMockEntity({
+      name: 'numberOfResults',
+      type: 'number',
     });
+
+    const values = buildMockObjEntity({
+      name: 'values',
+      type: 'FacetValue[]',
+      members: [numberOfResults],
+      isTypeExtracted: false,
+    });
+
+    const state = buildMockObjEntity({
+      name: 'state',
+      members: [values],
+    });
+
+    const {types} = extractTypes([state]);
+
+    const expectedEntity = buildMockObjEntity({
+      name: 'FacetValue[]',
+      type: 'FacetValue[]',
+      members: [numberOfResults],
+    });
+
+    expect(types).toEqual([expectedEntity]);
+    expect(values.isTypeExtracted).toBe(true);
   });
 
   it(`given Facet.state.facetSearch.values with type #SpecificFacetSearchResult,

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -1,5 +1,5 @@
 import {AnyEntity, ObjEntity} from './entity';
-import {buildEntity} from './entity-builder';
+import {buildEntity, buildObjEntity} from './entity-builder';
 
 interface Extraction {
   types: ObjEntity[];
@@ -34,7 +34,7 @@ function extract(entity: ObjEntity, extraction: Extraction, level: number) {
   }
 
   if (level === maxDepth) {
-    const typeHeading = {...buildTypeEntity(entity), members};
+    const typeHeading = buildTypeEntity(entity, members);
     extraction.types.push(typeHeading);
     processObjectEntities([typeHeading], extraction, 0);
 
@@ -44,15 +44,15 @@ function extract(entity: ObjEntity, extraction: Extraction, level: number) {
   processObjectEntities(members, extraction, level);
 }
 
-function buildTypeEntity(entity: ObjEntity) {
-  const type = buildEntity({
-    name: entity.type,
-    type: entity.type,
+function buildTypeEntity(originalEntity: ObjEntity, members: AnyEntity[]) {
+  const entity = buildEntity({
+    name: originalEntity.type,
+    type: originalEntity.type,
     isOptional: false,
     comment: undefined,
   });
 
-  return type;
+  return buildObjEntity({entity, members});
 }
 
 export function isObjectEntity(entity: unknown): entity is ObjEntity {

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -36,8 +36,9 @@ function extract(entity: ObjEntity, extraction: Extraction, level: number) {
   if (level === maxDepth) {
     const typeHeading = buildTypeEntity(entity, members);
     extraction.types.push(typeHeading);
-    processObjectEntities([typeHeading], extraction, 0);
+    entity.isTypeExtracted = true;
 
+    processObjectEntities([typeHeading], extraction, 0);
     return;
   }
 

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -47,11 +47,11 @@ function extract(entity: ObjEntity, extraction: Extraction, level: number) {
 
 function buildTypeEntity(originalEntity: ObjEntity, members: AnyEntity[]) {
   const entity = buildEntity({
-    name: originalEntity.type,
-    type: originalEntity.type,
+    name: originalEntity.typeName,
+    type: '',
     isOptional: false,
     comment: undefined,
   });
 
-  return buildObjEntity({entity, members});
+  return buildObjEntity({entity, members, typeName: ''});
 }

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -22,7 +22,7 @@ function processObjectEntities(
 ) {
   entities
     .filter(isObjectEntity)
-    .forEach((entity) => extract(entity, extraction, ++level));
+    .forEach((entity) => extract(entity, extraction, level + 1));
 }
 
 function extract(entity: ObjEntity, extraction: Extraction, level: number) {

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -36,7 +36,9 @@ function extract(entity: ObjEntity, extraction: Extraction, level: number) {
   if (level === maxDepth) {
     const typeHeading = buildTypeEntity(entity, members);
     extraction.types.push(typeHeading);
+
     entity.isTypeExtracted = true;
+    entity.members = [];
 
     processObjectEntities([typeHeading], extraction, 0);
     return;

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -1,4 +1,4 @@
-import {AnyEntity, ObjEntity} from './entity';
+import {AnyEntity, isObjectEntity, ObjEntity} from './entity';
 import {buildEntity, buildObjEntity} from './entity-builder';
 
 interface Extraction {
@@ -53,12 +53,4 @@ function buildTypeEntity(originalEntity: ObjEntity, members: AnyEntity[]) {
   });
 
   return buildObjEntity({entity, members});
-}
-
-export function isObjectEntity(entity: unknown): entity is ObjEntity {
-  if (typeof entity !== 'object') {
-    return false;
-  }
-
-  return !!entity && 'members' in entity;
 }

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -1,0 +1,64 @@
+import {AnyEntity, ObjEntity} from './entity';
+import {buildEntity} from './entity-builder';
+
+interface Extraction {
+  types: ObjEntity[];
+}
+
+export function extractTypes(headingEntities: AnyEntity[]): Extraction {
+  const extraction: Extraction = {
+    types: [],
+  };
+
+  processObjectEntities(headingEntities, extraction, 0);
+
+  return extraction;
+}
+
+function processObjectEntities(
+  entities: AnyEntity[],
+  extraction: Extraction,
+  level: number
+) {
+  entities
+    .filter(isObjectEntity)
+    .forEach((entity) => extract(entity, extraction, ++level));
+}
+
+function extract(entity: ObjEntity, extraction: Extraction, level: number) {
+  const maxDepth = 2;
+  const {members} = entity;
+
+  if (!members.length) {
+    return;
+  }
+
+  if (level === maxDepth) {
+    const typeHeading = {...buildTypeEntity(entity), members};
+    extraction.types.push(typeHeading);
+    processObjectEntities([typeHeading], extraction, 0);
+
+    return;
+  }
+
+  processObjectEntities(members, extraction, level);
+}
+
+function buildTypeEntity(entity: ObjEntity) {
+  const type = buildEntity({
+    name: entity.type,
+    type: entity.type,
+    isOptional: false,
+    comment: undefined,
+  });
+
+  return type;
+}
+
+export function isObjectEntity(entity: unknown): entity is ObjEntity {
+  if (typeof entity !== 'object') {
+    return false;
+  }
+
+  return !!entity && 'members' in entity;
+}

--- a/packages/headless/doc-parser/src/function-param-resolver.ts
+++ b/packages/headless/doc-parser/src/function-param-resolver.ts
@@ -32,10 +32,13 @@ function buildParamEntityBasedOnKind(entryPoint: ApiEntryPoint, p: Parameter) {
 }
 
 function buildObjEntityFromParam(entryPoint: ApiEntryPoint, p: Parameter) {
-  const type = p.parameterTypeExcerpt.text;
+  const typeExcerpt = p.parameterTypeExcerpt;
+
+  const type = typeExcerpt.text;
+  const typeName = typeExcerpt.spannedTokens[0].text;
   const apiInterface = findApi(entryPoint, type) as ApiInterface;
   const members = resolveInterfaceMembers(entryPoint, apiInterface);
   const entity = buildParamEntity(p);
 
-  return buildObjEntity({entity, members});
+  return buildObjEntity({entity, members, typeName});
 }

--- a/packages/headless/doc-parser/src/function-param-resolver.ts
+++ b/packages/headless/doc-parser/src/function-param-resolver.ts
@@ -6,8 +6,7 @@ import {
   Parameter,
 } from '@microsoft/api-extractor-model';
 import {findApi} from './api-finder';
-import {ObjEntity} from './entity';
-import {buildParamEntity} from './entity-builder';
+import {buildObjEntity, buildParamEntity} from './entity-builder';
 import {resolveInterfaceMembers} from './interface-resolver';
 
 export function resolveParams(
@@ -32,14 +31,11 @@ function buildParamEntityBasedOnKind(entryPoint: ApiEntryPoint, p: Parameter) {
     : buildParamEntity(p);
 }
 
-function buildObjEntityFromParam(
-  entryPoint: ApiEntryPoint,
-  p: Parameter
-): ObjEntity {
+function buildObjEntityFromParam(entryPoint: ApiEntryPoint, p: Parameter) {
   const type = p.parameterTypeExcerpt.text;
   const apiInterface = findApi(entryPoint, type) as ApiInterface;
   const members = resolveInterfaceMembers(entryPoint, apiInterface);
   const entity = buildParamEntity(p);
 
-  return {...entity, members};
+  return buildObjEntity({entity, members});
 }

--- a/packages/headless/doc-parser/src/function-resolver.test.ts
+++ b/packages/headless/doc-parser/src/function-resolver.test.ts
@@ -78,6 +78,7 @@ describe('#resolveFunction', () => {
     const optionsParam = buildMockObjEntity({
       name: 'config',
       type: 'NumericRangeOptions',
+      typeName: 'NumericRangeOptions',
       desc: 'The options with which to create a `NumericRangeRequest`.',
       members: [startProperty],
     });
@@ -85,6 +86,7 @@ describe('#resolveFunction', () => {
     const returnType = buildMockObjEntity({
       name: 'NumericRangeRequest',
       type: 'NumericRangeRequest',
+      typeName: 'NumericRangeRequest',
       members: [startProperty],
     });
 

--- a/packages/headless/doc-parser/src/function-resolver.ts
+++ b/packages/headless/doc-parser/src/function-resolver.ts
@@ -41,5 +41,5 @@ function buildObjEntityFromInterface(
     comment: (apiInterface.tsdocComment as unknown) as DocComment,
   });
 
-  return buildObjEntity({entity, members});
+  return buildObjEntity({entity, members, typeName: name});
 }

--- a/packages/headless/doc-parser/src/function-resolver.ts
+++ b/packages/headless/doc-parser/src/function-resolver.ts
@@ -5,8 +5,7 @@ import {
 } from '@microsoft/api-extractor-model';
 import {DocComment} from '@microsoft/tsdoc';
 import {findApi} from './api-finder';
-import {ObjEntity} from './entity';
-import {buildEntity, buildFuncEntity} from './entity-builder';
+import {buildEntity, buildFuncEntity, buildObjEntity} from './entity-builder';
 import {resolveParams} from './function-param-resolver';
 import {resolveInterfaceMembers} from './interface-resolver';
 
@@ -32,7 +31,7 @@ export function resolveFunction(
 function buildObjEntityFromInterface(
   entryPoint: ApiEntryPoint,
   apiInterface: ApiInterface
-): ObjEntity {
+) {
   const name = apiInterface.name;
   const members = resolveInterfaceMembers(entryPoint, apiInterface);
   const entity = buildEntity({
@@ -42,5 +41,5 @@ function buildObjEntityFromInterface(
     comment: (apiInterface.tsdocComment as unknown) as DocComment,
   });
 
-  return {...entity, members};
+  return buildObjEntity({entity, members});
 }

--- a/packages/headless/doc-parser/src/interface-resolver.test.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.test.ts
@@ -82,6 +82,7 @@ describe('#resolveInterfaceMembers', () => {
     const objEntity = buildMockObjEntity({
       name: 'state',
       type: 'PagerState',
+      typeName: 'PagerState',
       members: [entity],
     });
 
@@ -237,6 +238,7 @@ describe('#resolveInterfaceMembers', () => {
     const entity = buildMockObjEntity({
       name: 'values',
       type: 'SpecificFacetSearchResult[]',
+      typeName: 'SpecificFacetSearchResult',
     });
 
     expect(result).toEqual([entity]);

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -89,12 +89,15 @@ function buildObjEntityFromProperty(
   entry: ApiEntryPoint,
   p: ApiPropertySignature
 ) {
-  const type = p.propertyTypeExcerpt.text;
+  const typeExcerpt = p.propertyTypeExcerpt;
+
+  const type = typeExcerpt.text;
+  const typeName = typeExcerpt.spannedTokens[0].text;
   const apiInterface = findApi(entry, type) as ApiInterface;
   const members = resolveInterfaceMembers(entry, apiInterface);
   const entity = buildEntityFromProperty(p);
 
-  return buildObjEntity({entity, members});
+  return buildObjEntity({entity, members, typeName});
 }
 
 function buildEntityFromPropertyAndResolveTypeAlias(

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -10,8 +10,13 @@ import {
 } from '@microsoft/api-extractor-model';
 import {DocComment} from '@microsoft/tsdoc';
 import {findApi} from './api-finder';
-import {AnyEntity, Entity, ObjEntity} from './entity';
-import {buildEntity, buildFuncEntity, buildParamEntity} from './entity-builder';
+import {AnyEntity, Entity} from './entity';
+import {
+  buildEntity,
+  buildFuncEntity,
+  buildObjEntity,
+  buildParamEntity,
+} from './entity-builder';
 
 export function resolveInterfaceMembers(
   entry: ApiEntryPoint,
@@ -83,13 +88,13 @@ function buildEntityFromProperty(p: ApiPropertySignature) {
 function buildObjEntityFromProperty(
   entry: ApiEntryPoint,
   p: ApiPropertySignature
-): ObjEntity {
+) {
   const type = p.propertyTypeExcerpt.text;
   const apiInterface = findApi(entry, type) as ApiInterface;
   const members = resolveInterfaceMembers(entry, apiInterface);
   const entity = buildEntityFromProperty(p);
 
-  return {...entity, members};
+  return buildObjEntity({entity, members});
 }
 
 function buildEntityFromPropertyAndResolveTypeAlias(


### PR DESCRIPTION
There is a practical limit on displaying a deeply nested interface containing members that have interface types and so on.

The general layout of a page is `Section | Heading | key | type` where `key` and `type` are displayed inside a table.

```
Section | Heading | key | type

Initialize | buildFacet | props | FacetProps
Facet | state | canShowMoreValues | boolean
Facet | state | values | FacetValue[]
```

In this case, displaying `canShowMoreValues` is no problem, but displaying `FacetProps` and `FacetValue` would not be easy. To follow the pattern, they would need to be extracted to start a new chain.

This PR pulls out complex types on Interfaces and places them in an `extractedTypes` array. These will be displayed at the bottom of the reference under a dedicated section. e.g.

```
Types | FacetValue | rawValue | string
```

The next PR will extend the extraction to function parameters.