### PR TITLE
feat(headless): add support for locale parameter + analytics language

### DIFF
--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -1103,9 +1103,9 @@
 			"dev": true
 		},
 		"@react-native-async-storage/async-storage": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.13.4.tgz",
-			"integrity": "sha512-P7cbA77XNhUFEBKAIaex17mKI/Db1RQHZVwplagskqzEnpqB+Yi+/l8QeOMr5OJdfmPkBA+V7DOmuWeB8Po6cQ==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.14.0.tgz",
+			"integrity": "sha512-aQwuC2qgwo15MjBSfv5gQC+/OdFTvP+ZFKI0wLlEuyX+yCdE9XfeAyv8geE+bBHMbTXX4VQVP4i91uF8imG1Xw==",
 			"requires": {
 				"deep-assign": "^3.0.0"
 			}
@@ -2748,9 +2748,9 @@
 			"dev": true
 		},
 		"coveo.analytics": {
-			"version": "2.18.4",
-			"resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.4.tgz",
-			"integrity": "sha512-6v0S9nMUG9FMxXfpYEflY8HKsZPmh3bugEbdbeLbFxZQxBpeizfMlGLoed5Z5+kuXwyd3I4/rk5t2q20jix+uw==",
+			"version": "2.18.7",
+			"resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.7.tgz",
+			"integrity": "sha512-e2StP6PF1qMup03Sm1VVcRz2OXyNerS5vKQll2hO2QuxZGcLesRAFzTh8ale13PYOgV4GP55xL2tfc4GiJX6SA==",
 			"requires": {
 				"@react-native-async-storage/async-storage": "^1.13.2"
 			}

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -33,7 +33,7 @@
     "@reduxjs/toolkit": "^1.5.0",
     "@types/pino": "^6.3.4",
     "@types/redux-mock-store": "^1.0.2",
-    "coveo.analytics": "^2.18.4",
+    "coveo.analytics": "^2.18.7",
     "cross-fetch": "^3.0.6",
     "dayjs": "^1.9.6",
     "exponential-backoff": "^3.1.0",

--- a/packages/headless/src/api/analytics/analytics.test.ts
+++ b/packages/headless/src/api/analytics/analytics.test.ts
@@ -114,5 +114,31 @@ describe('analytics', () => {
       const provider = new AnalyticsProvider(state);
       expect(provider.getOriginLevel1()).toEqual(searchHub);
     });
+
+    it('when a locale search parameter is configured, #getLanguage returns the correct value', () => {
+      const locale = 'fr-CA';
+      const state: StateNeededByAnalyticsProvider = {
+        ...baseState,
+        configuration: {
+          ...getConfigurationInitialState(),
+          search: {...getConfigurationInitialState().search, locale},
+        },
+      };
+      const provider = new AnalyticsProvider(state);
+      expect(provider.getLanguage()).toEqual('fr');
+    });
+
+    it('when a locale search parameter is configured to something invalid, #getLanguage returns the correct value', () => {
+      const locale = 'thisWillBlowUp';
+      const state: StateNeededByAnalyticsProvider = {
+        ...baseState,
+        configuration: {
+          ...getConfigurationInitialState(),
+          search: {...getConfigurationInitialState().search, locale},
+        },
+      };
+      const provider = new AnalyticsProvider(state);
+      expect(provider.getLanguage()).toEqual('en');
+    });
   });
 });

--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -21,6 +21,7 @@ import {
 } from '../../state/state-sections';
 import {Context} from '../../features/context/context-state';
 import {PreprocessRequest} from '../preprocess-request';
+import {getLanguage} from './shared-analytics';
 
 export type StateNeededByAnalyticsProvider = ConfigurationSection &
   Partial<
@@ -36,11 +37,7 @@ export class AnalyticsProvider implements SearchPageClientProvider {
   constructor(private state: StateNeededByAnalyticsProvider) {}
 
   public getLanguage() {
-    const langKey = this.state.configuration.search.locale.split('-')[0];
-    if (!langKey || langKey.length !== 2) {
-      return 'en';
-    }
-    return langKey;
+    return getLanguage(this.state);
   }
 
   public getSearchEventRequestPayload() {

--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -35,6 +35,14 @@ export type StateNeededByAnalyticsProvider = ConfigurationSection &
 export class AnalyticsProvider implements SearchPageClientProvider {
   constructor(private state: StateNeededByAnalyticsProvider) {}
 
+  public getLanguage() {
+    const langKey = this.state.configuration.search.locale.split('-')[0];
+    if (!langKey || langKey.length !== 2) {
+      return 'en';
+    }
+    return langKey;
+  }
+
   public getSearchEventRequestPayload() {
     return {
       queryText: this.queryText,

--- a/packages/headless/src/api/analytics/product-recommendations-analytics.ts
+++ b/packages/headless/src/api/analytics/product-recommendations-analytics.ts
@@ -17,6 +17,14 @@ export class ProductRecommendationAnalyticsProvider
     private state: StateNeededByProductRecommendationsAnalyticsProvider
   ) {}
 
+  public getLanguage() {
+    const langKey = this.state.configuration.search.locale.split('-')[0];
+    if (!langKey || langKey.length !== 2) {
+      return 'en';
+    }
+    return langKey;
+  }
+
   public getSearchEventRequestPayload() {
     return {
       queryText: '',

--- a/packages/headless/src/api/analytics/product-recommendations-analytics.ts
+++ b/packages/headless/src/api/analytics/product-recommendations-analytics.ts
@@ -6,6 +6,7 @@ import {
   ProductRecommendationsSection,
   SearchHubSection,
 } from '../../state/state-sections';
+import {getLanguage} from './shared-analytics';
 
 export type StateNeededByProductRecommendationsAnalyticsProvider = ConfigurationSection &
   Partial<SearchHubSection & ProductRecommendationsSection>;
@@ -18,11 +19,7 @@ export class ProductRecommendationAnalyticsProvider
   ) {}
 
   public getLanguage() {
-    const langKey = this.state.configuration.search.locale.split('-')[0];
-    if (!langKey || langKey.length !== 2) {
-      return 'en';
-    }
-    return langKey;
+    return getLanguage(this.state);
   }
 
   public getSearchEventRequestPayload() {

--- a/packages/headless/src/api/analytics/shared-analytics.ts
+++ b/packages/headless/src/api/analytics/shared-analytics.ts
@@ -1,0 +1,9 @@
+import {ConfigurationSection} from '../../state/state-sections';
+
+export const getLanguage = (state: ConfigurationSection) => {
+  const langKey = state.configuration.search.locale.split('-')[0];
+  if (!langKey || langKey.length !== 2) {
+    return 'en';
+  }
+  return langKey;
+};

--- a/packages/headless/src/api/search/plan/plan-request.ts
+++ b/packages/headless/src/api/search/plan/plan-request.ts
@@ -1,6 +1,7 @@
 import {
   BaseParam,
   ContextParam,
+  LocaleParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,
@@ -10,4 +11,5 @@ export type PlanRequest = BaseParam &
   SearchHubParam &
   ContextParam &
   QueryParam &
-  PipelineParam;
+  PipelineParam &
+  LocaleParam;

--- a/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
+++ b/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
@@ -2,6 +2,7 @@ import {
   ActionsHistoryParam,
   BaseParam,
   ContextParam,
+  LocaleParam,
   MachineLearningParam,
   NumberOfResultsParam,
   RecommendationParam,
@@ -16,4 +17,5 @@ export type ProductRecommendationsRequest = BaseParam &
   ContextParam &
   SearchHubParam &
   ActionsHistoryParam &
-  VisitorIDParam;
+  VisitorIDParam &
+  LocaleParam;

--- a/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
+++ b/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
@@ -2,6 +2,7 @@ import {
   ActionsHistoryParam,
   BaseParam,
   ContextParam,
+  LocaleParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,
@@ -12,6 +13,7 @@ export type QuerySuggestRequest = BaseParam &
   ContextParam &
   PipelineParam &
   SearchHubParam &
+  LocaleParam &
   ActionsHistoryParam & {
     count: number;
   };

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -182,6 +182,7 @@ describe('search api client', () => {
           cq: '',
           aq: '',
           debug: false,
+          locale: state.configuration.search.locale,
           numberOfResults: state.pagination.numberOfResults,
           sortCriteria: state.sortCriteria,
           firstResult: state.pagination.firstResult,

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -81,6 +81,10 @@ export interface DebugParam {
   debug?: boolean;
 }
 
+export interface LocaleParam {
+  locale?: string;
+}
+
 export interface MachineLearningECommerceParameters {
   itemIds?: string[];
   categoryFilter?: string;

--- a/packages/headless/src/api/search/search/search-request.ts
+++ b/packages/headless/src/api/search/search/search-request.ts
@@ -16,6 +16,7 @@ import {
   SortCriteriaParam,
   VisitorIDParam,
   DebugParam,
+  LocaleParam,
 } from '../search-api-params';
 
 export type SearchRequest = BaseParam &
@@ -34,4 +35,5 @@ export type SearchRequest = BaseParam &
   SearchHubParam &
   FacetOptionsParam &
   VisitorIDParam &
-  DebugParam;
+  DebugParam &
+  LocaleParam;

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -13,6 +13,7 @@ import {
   disableAnalytics,
   enableAnalytics,
   updateAnalyticsConfiguration,
+  localeValidation,
 } from '../features/configuration/configuration-actions';
 import {configureStore, Store, ThunkExtraArguments} from './store';
 import {SearchAPIClient} from '../api/search/search-api-client';
@@ -141,6 +142,14 @@ export interface HeadlessConfigurationOptions {
      *    When logging a Search usage analytics event for a query, the originLevel1 field of that event should be set to the value of the searchHub search request parameter.
      */
     searchHub?: string;
+    /**
+     * The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+     *
+     * Notes:
+     *  Coveo Machine Learning models use this information to provide contextually relevant output.
+     *  Moreover, this information can be referred to in query expressions and QPL statements by using the $locale object.
+     */
+    locale?: string;
     /**
      * Allows for augmenting a request (search, facet-search, query-suggest, etc.) before it is sent.
      * @deprecated Use `preprocessRequest` instead.
@@ -304,6 +313,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
             required: false,
             emptyAllowed: false,
           }),
+          locale: localeValidation,
         },
       }),
       analytics: new RecordValue({

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -3,6 +3,12 @@ import {validatePayload} from '../../utils/validate-payload';
 import {StringValue, BooleanValue, Value} from '@coveo/bueno';
 import {IRuntimeEnvironment} from 'coveo.analytics';
 
+export const localeValidation = new StringValue({
+  emptyAllowed: false,
+  required: false,
+  regex: /[a-z]{2}-[A-Z]{2}/,
+});
+
 const originSchemaOnConfigUpdate = () =>
   new StringValue({emptyAllowed: false, required: false});
 
@@ -37,11 +43,17 @@ export const updateBasicConfiguration = createAction(
  */
 export const updateSearchConfiguration = createAction(
   'configuration/updateSearchConfiguration',
-  (payload: {apiBaseUrl?: string; pipeline?: string; searchHub?: string}) =>
+  (payload: {
+    apiBaseUrl?: string;
+    pipeline?: string;
+    searchHub?: string;
+    locale?: string;
+  }) =>
     validatePayload(payload, {
       apiBaseUrl: new StringValue({url: true, emptyAllowed: false}),
       pipeline: new StringValue({emptyAllowed: false}),
       searchHub: new StringValue({emptyAllowed: false}),
+      locale: localeValidation,
     })
 );
 

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -40,6 +40,7 @@ export const updateBasicConfiguration = createAction(
  * @param apiBaseUrl (string) The Search API base URL to use (e.g., `https://platform.cloud.coveo.com/rest/search/v2`).
  * @param pipeline (string) The name of the query pipeline to use for the query (e.g., `External Search`). If not specified, the default query pipeline will be used.
  * @param searchHub (string) The first level of origin of the request, typically the identifier of the graphical search interface from which the request originates (e.g., `ExternalSearch`).
+ * @param locale (string) The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
  */
 export const updateSearchConfiguration = createAction(
   'configuration/updateSearchConfiguration',

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -24,6 +24,7 @@ describe('configuration slice', () => {
     organizationId: 'myorg',
     search: {
       apiBaseUrl: `${url}/rest/search/v2`,
+      locale: 'en-US',
     },
     analytics: {
       enabled: true,
@@ -132,6 +133,7 @@ describe('configuration slice', () => {
         ...getConfigurationInitialState(),
         search: {
           apiBaseUrl: 'http://test.com/search',
+          locale: 'fr-CA',
         },
       };
 
@@ -140,6 +142,7 @@ describe('configuration slice', () => {
           undefined,
           updateSearchConfiguration({
             apiBaseUrl: 'http://test.com/search',
+            locale: 'fr-CA',
           })
         )
       ).toEqual(expectedState);
@@ -149,6 +152,7 @@ describe('configuration slice', () => {
         ...existingState,
         search: {
           apiBaseUrl: 'http://test.com/search',
+          locale: 'fr-CA',
         },
       };
 
@@ -157,15 +161,17 @@ describe('configuration slice', () => {
           existingState,
           updateSearchConfiguration({
             apiBaseUrl: 'http://test.com/search',
+            locale: 'fr-CA',
           })
         )
       ).toEqual(expectedState);
     });
 
-    it('does not overwrite searchHub value when only pipeline is passed as argument', () => {
+    it('does not overwrite other values when only pipeline is passed as argument', () => {
       const search = {
         pipeline: 'initPipeline',
         searchHub: 'initSearchHub',
+        locale: 'en-US',
       };
       const reducer = createReducer(search, (builder) =>
         builder.addCase(updateSearchConfiguration, (state, action) => {
@@ -179,10 +185,11 @@ describe('configuration slice', () => {
       expect(newState).toEqual({...search, pipeline: 'mockPipeline'});
     });
 
-    it('does not overwrite pipeline value when only searchhub is passed as argument', () => {
+    it('does not overwrite other values when only searchhub is passed as argument', () => {
       const search = {
         pipeline: 'initPipeline',
         searchHub: 'initSearchHub',
+        locale: 'en-US',
       };
       const reducer = createReducer(search, (builder) =>
         builder.addCase(updateSearchConfiguration, (state, action) => {
@@ -194,6 +201,24 @@ describe('configuration slice', () => {
         updateSearchConfiguration({searchHub: 'mockSearchHub'})
       );
       expect(newState).toEqual({...search, searchHub: 'mockSearchHub'});
+    });
+
+    it('does not overwrite other values when only locale is passed as argument', () => {
+      const search = {
+        pipeline: 'initPipeline',
+        searchHub: 'initSearchHub',
+        locale: 'en-US',
+      };
+      const reducer = createReducer(search, (builder) =>
+        builder.addCase(updateSearchConfiguration, (state, action) => {
+          state.locale = action.payload.locale!;
+        })
+      );
+      const newState = reducer(
+        search,
+        updateSearchConfiguration({locale: 'fr-CA'})
+      );
+      expect(newState).toEqual({...search, locale: 'fr-CA'});
     });
   });
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -10,7 +10,6 @@ import {
   setOriginLevel2,
 } from './configuration-actions';
 import {platformUrl} from '../../api/platform-client';
-import {createReducer} from '../..';
 import {
   ConfigurationState,
   getConfigurationInitialState,
@@ -165,60 +164,6 @@ describe('configuration slice', () => {
           })
         )
       ).toEqual(expectedState);
-    });
-
-    it('does not overwrite other values when only pipeline is passed as argument', () => {
-      const search = {
-        pipeline: 'initPipeline',
-        searchHub: 'initSearchHub',
-        locale: 'en-US',
-      };
-      const reducer = createReducer(search, (builder) =>
-        builder.addCase(updateSearchConfiguration, (state, action) => {
-          state.pipeline = action.payload.pipeline!;
-        })
-      );
-      const newState = reducer(
-        search,
-        updateSearchConfiguration({pipeline: 'mockPipeline'})
-      );
-      expect(newState).toEqual({...search, pipeline: 'mockPipeline'});
-    });
-
-    it('does not overwrite other values when only searchhub is passed as argument', () => {
-      const search = {
-        pipeline: 'initPipeline',
-        searchHub: 'initSearchHub',
-        locale: 'en-US',
-      };
-      const reducer = createReducer(search, (builder) =>
-        builder.addCase(updateSearchConfiguration, (state, action) => {
-          state.searchHub = action.payload.searchHub!;
-        })
-      );
-      const newState = reducer(
-        search,
-        updateSearchConfiguration({searchHub: 'mockSearchHub'})
-      );
-      expect(newState).toEqual({...search, searchHub: 'mockSearchHub'});
-    });
-
-    it('does not overwrite other values when only locale is passed as argument', () => {
-      const search = {
-        pipeline: 'initPipeline',
-        searchHub: 'initSearchHub',
-        locale: 'en-US',
-      };
-      const reducer = createReducer(search, (builder) =>
-        builder.addCase(updateSearchConfiguration, (state, action) => {
-          state.locale = action.payload.locale!;
-        })
-      );
-      const newState = reducer(
-        search,
-        updateSearchConfiguration({locale: 'fr-CA'})
-      );
-      expect(newState).toEqual({...search, locale: 'fr-CA'});
     });
   });
 

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -36,6 +36,9 @@ export const configurationReducer = createReducer(
         if (action.payload.apiBaseUrl) {
           state.search.apiBaseUrl = action.payload.apiBaseUrl;
         }
+        if (action.payload.locale) {
+          state.search.locale = action.payload.locale;
+        }
       })
       .addCase(updateAnalyticsConfiguration, (state, action) => {
         if (action.payload.enabled !== undefined) {

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -24,6 +24,10 @@ export interface ConfigurationState {
      * By default, will append /rest/search/v2 to the platformUrl value.
      */
     apiBaseUrl: string;
+    /**
+     * The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+     */
+    locale: string;
   };
   /**
    * The global headless engine Usage Analytics API configuration.
@@ -72,6 +76,7 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
   platformUrl: platformUrl(),
   search: {
     apiBaseUrl: `${platformUrl()}${searchAPIEndpoint}`,
+    locale: 'en-US',
   },
   analytics: {
     enabled: true,

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -126,6 +126,7 @@ export const buildProductRecommendationsRequest = (
     accessToken: s.configuration.accessToken,
     organizationId: s.configuration.organizationId,
     url: s.configuration.search.apiBaseUrl,
+    locale: s.configuration.search.locale,
     ...(s.configuration.analytics.enabled && {
       visitorId: getVisitorID(),
     }),

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -135,6 +135,7 @@ export const buildQuerySuggestRequest = (
     url: s.configuration.search.apiBaseUrl,
     count: s.querySuggest[id]!.count,
     q: s.querySuggest[id]!.q,
+    locale: s.configuration.search.locale,
     actionsHistory: s.configuration.analytics.enabled
       ? historyStore.getHistory()
       : [],

--- a/packages/headless/src/features/redirection/redirection-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-actions.ts
@@ -63,6 +63,7 @@ export const buildPlanRequest = (state: RedirectionState): PlanRequest => {
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
     url: state.configuration.search.apiBaseUrl,
+    locale: state.configuration.search.locale,
     q: state.query.q,
     ...(state.context && {context: state.context.contextValues}),
     ...(state.pipeline && {pipeline: state.pipeline}),

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -25,6 +25,7 @@ export type SearchParameters = Omit<
   | 'searchHub'
   | 'pipeline'
   | 'context'
+  | 'locale'
 > &
   Partial<FacetParameters>;
 

--- a/packages/headless/src/features/search-parameters/search-parameter-schema.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-schema.ts
@@ -5,7 +5,6 @@ import {
   NumberValue,
   RecordValue,
 } from '@coveo/bueno';
-import {localeValidation} from '../configuration/configuration-actions';
 import {SearchParameters} from './search-parameter-actions';
 
 export const searchParametersDefinition: SchemaDefinition<Required<
@@ -13,7 +12,6 @@ export const searchParametersDefinition: SchemaDefinition<Required<
 >> = {
   q: new StringValue(),
   enableQuerySyntax: new BooleanValue(),
-  locale: localeValidation,
   aq: new StringValue(),
   cq: new StringValue(),
   firstResult: new NumberValue({min: 0}),

--- a/packages/headless/src/features/search-parameters/search-parameter-schema.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-schema.ts
@@ -5,6 +5,7 @@ import {
   NumberValue,
   RecordValue,
 } from '@coveo/bueno';
+import {localeValidation} from '../configuration/configuration-actions';
 import {SearchParameters} from './search-parameter-actions';
 
 export const searchParametersDefinition: SchemaDefinition<Required<
@@ -12,6 +13,7 @@ export const searchParametersDefinition: SchemaDefinition<Required<
 >> = {
   q: new StringValue(),
   enableQuerySyntax: new BooleanValue(),
+  locale: localeValidation,
   aq: new StringValue(),
   cq: new StringValue(),
   firstResult: new NumberValue({min: 0}),

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -266,6 +266,7 @@ export const buildSearchRequest = (
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
     url: state.configuration.search.apiBaseUrl,
+    locale: state.configuration.search.locale,
     debug: state.debug,
     ...(state.configuration.analytics.enabled && {
       visitorId: getVisitorID(),

--- a/packages/headless/src/test/mock-search-request.ts
+++ b/packages/headless/src/test/mock-search-request.ts
@@ -13,6 +13,7 @@ export function buildMockSearchRequest(
     facetOptions: buildMockFacetOptions(),
     firstResult: 0,
     numberOfResults: 10,
+    locale: 'en-US',
     q: '',
     cq: '',
     aq: '',


### PR DESCRIPTION
I've added support for a new query parameter called "locale".

https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestQueryParameters-locale

At the same time, I used that same parameter for the `analytics` parameter, by extracting the first part of the `locale`.

So: 

locale = search API parameter.
language = Analytics parameter

if locale == "en-US", then language = "en".
if locale == "fr-CA", then language = "fr".
And so on.

This can be configured with the global configuration option, under the `search` section.

https://coveord.atlassian.net/browse/KIT-447