### PR TITLE
docs(headless): bug fix in doc parser

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -11,6 +11,17 @@ const entryPoint = apiPackage.entryPoints[0];
 
 const controllers: ControllerConfiguration[] = [
   {
+    initializer: 'buildFacet',
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/facet/facet.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/facet/facet.fn.tsx',
+      ],
+    },
+  },
+  {
     initializer: 'buildPager',
     samplePaths: {
       react_class: [

--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -91,6 +91,42 @@ describe('#extractTypes', () => {
     expect(types).toEqual([expectedEntity1, expectedEntity2]);
   });
 
+  it(`given Facet.facetSearch.select(value: SpecificFacetSearchResult) i.e. a function on an attribute,
+  it extracts #SpecificFacetSearchResult as type entities`, () => {
+    const displayValue = buildMockEntity({
+      name: 'displayValue',
+      type: 'string',
+    });
+
+    const value = buildMockObjEntity({
+      name: 'value',
+      type: 'SpecificFacetSearchResult',
+      typeName: 'SpecificFacetSearchResult',
+      members: [displayValue],
+    });
+
+    const select = buildMockFuncEntity({
+      name: 'select',
+      params: [value],
+    });
+
+    const facetSearch = buildMockObjEntity({
+      name: 'facetSearch',
+      type: 'FacetSearch',
+      typeName: 'FacetSearch',
+      members: [select],
+    });
+
+    const {types} = extractTypes([facetSearch]);
+
+    const expected = buildMockObjEntity({
+      name: 'SpecificFacetSearchResult',
+      members: [displayValue],
+    });
+
+    expect(types).toEqual([expected]);
+  });
+
   it(`when multiple entities have strictly members with primitive types,
   it does not extract anything`, () => {
     const numberOfResults = buildMockEntity({

--- a/packages/headless/doc-parser/src/extractor.ts
+++ b/packages/headless/doc-parser/src/extractor.ts
@@ -77,6 +77,7 @@ function extract(entity: ObjEntity, extraction: Extraction, level: Level) {
   }
 
   processObjectEntities(members, extraction, level);
+  processFunctionEntities(members, extraction);
 }
 
 function buildTypeEntity(originalEntity: ObjEntity, members: AnyEntity[]) {

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -90,12 +90,14 @@ function buildObjEntityFromProperty(
   entry: ApiEntryPoint,
   p: ApiPropertySignature
 ) {
-  const typeName = extractTypeName(p.propertyTypeExcerpt);
+  const {typeName, typeNameWithGenerics} = extractTypeName(
+    p.propertyTypeExcerpt
+  );
   const apiInterface = findApi(entry, typeName) as ApiInterface;
   const members = resolveInterfaceMembers(entry, apiInterface);
   const entity = buildEntityFromProperty(p);
 
-  return buildObjEntity({entity, members, typeName});
+  return buildObjEntity({entity, members, typeName: typeNameWithGenerics});
 }
 
 function buildEntityFromPropertyAndResolveTypeAlias(
@@ -104,7 +106,7 @@ function buildEntityFromPropertyAndResolveTypeAlias(
 ): Entity {
   const entity = buildEntityFromProperty(p);
   const alias = extractTypeName(p.propertyTypeExcerpt);
-  const typeAlias = findApi(entry, alias) as ApiTypeAlias;
+  const typeAlias = findApi(entry, alias.typeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
   return {...entity, type};
@@ -146,21 +148,28 @@ function buildEntityFromParamAndResolveTypeAlias(
 ): Entity {
   const entity = buildParamEntity(p);
   const alias = extractTypeName(p.parameterTypeExcerpt);
-  const typeAlias = findApi(entry, alias) as ApiTypeAlias;
+  const typeAlias = findApi(entry, alias.typeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
   return {...entity, type};
 }
 
 function buildObjEntityFromParam(entryPoint: ApiEntryPoint, p: Parameter) {
-  const typeName = extractTypeName(p.parameterTypeExcerpt);
+  const {typeName, typeNameWithGenerics} = extractTypeName(
+    p.parameterTypeExcerpt
+  );
   const apiInterface = findApi(entryPoint, typeName) as ApiInterface;
   const members = resolveInterfaceMembers(entryPoint, apiInterface);
   const entity = buildParamEntity(p);
 
-  return buildObjEntity({entity, members, typeName});
+  return buildObjEntity({entity, members, typeName: typeNameWithGenerics});
 }
 
 function extractTypeName(excerpt: Excerpt) {
-  return excerpt.spannedTokens[0].text;
+  const typeName = excerpt.spannedTokens[0].text;
+  const typeNameWithGenerics = excerpt.spannedTokens
+    .map((token) => token.text)
+    .join('')
+    .replace(/\[\]/, '');
+  return {typeName, typeNameWithGenerics};
 }

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -90,14 +90,13 @@ function buildObjEntityFromProperty(
   entry: ApiEntryPoint,
   p: ApiPropertySignature
 ) {
-  const {typeName, typeNameWithGenerics} = extractTypeName(
-    p.propertyTypeExcerpt
-  );
-  const apiInterface = findApi(entry, typeName) as ApiInterface;
+  const typeName = extractTypeName(p.propertyTypeExcerpt);
+  const searchableTypeName = extractSearchableTypeName(p.propertyTypeExcerpt);
+  const apiInterface = findApi(entry, searchableTypeName) as ApiInterface;
   const members = resolveInterfaceMembers(entry, apiInterface);
   const entity = buildEntityFromProperty(p);
 
-  return buildObjEntity({entity, members, typeName: typeNameWithGenerics});
+  return buildObjEntity({entity, members, typeName});
 }
 
 function buildEntityFromPropertyAndResolveTypeAlias(
@@ -105,8 +104,8 @@ function buildEntityFromPropertyAndResolveTypeAlias(
   p: ApiPropertySignature
 ): Entity {
   const entity = buildEntityFromProperty(p);
-  const alias = extractTypeName(p.propertyTypeExcerpt);
-  const typeAlias = findApi(entry, alias.typeName) as ApiTypeAlias;
+  const searchableTypeName = extractSearchableTypeName(p.propertyTypeExcerpt);
+  const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
   return {...entity, type};
@@ -147,29 +146,27 @@ function buildEntityFromParamAndResolveTypeAlias(
   p: Parameter
 ): Entity {
   const entity = buildParamEntity(p);
-  const alias = extractTypeName(p.parameterTypeExcerpt);
-  const typeAlias = findApi(entry, alias.typeName) as ApiTypeAlias;
+  const searchableTypeName = extractSearchableTypeName(p.parameterTypeExcerpt);
+  const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
   return {...entity, type};
 }
 
 function buildObjEntityFromParam(entryPoint: ApiEntryPoint, p: Parameter) {
-  const {typeName, typeNameWithGenerics} = extractTypeName(
-    p.parameterTypeExcerpt
-  );
-  const apiInterface = findApi(entryPoint, typeName) as ApiInterface;
+  const typeName = extractTypeName(p.parameterTypeExcerpt);
+  const searchableTypeName = extractSearchableTypeName(p.parameterTypeExcerpt);
+  const apiInterface = findApi(entryPoint, searchableTypeName) as ApiInterface;
   const members = resolveInterfaceMembers(entryPoint, apiInterface);
   const entity = buildParamEntity(p);
 
-  return buildObjEntity({entity, members, typeName: typeNameWithGenerics});
+  return buildObjEntity({entity, members, typeName});
 }
 
 function extractTypeName(excerpt: Excerpt) {
-  const typeName = excerpt.spannedTokens[0].text;
-  const typeNameWithGenerics = excerpt.spannedTokens
-    .map((token) => token.text)
-    .join('')
-    .replace(/\[\]/, '');
-  return {typeName, typeNameWithGenerics};
+  return excerpt.text.replace(/\[\]/, '');
+}
+
+function extractSearchableTypeName(excerpt: Excerpt) {
+  return excerpt.spannedTokens[0].text;
 }


### PR DESCRIPTION
Two fixes here. First, functions within objects weren't having their types extracted; that's fixed in extractor.ts. Then, I realized that the typeName being extracted didn't include the generics. Turns out you _can't_ include them when using the `findApi` method, but we do still need to display them on the docs site, so I adjusted interface-resolver.ts so that both type names (with and without generics) are extracted.

If you run the parser, you should notice that `SpecificFacetSearchResult` is extracted from the `facetSearch.select` method and that `FacetManagerPayload<T>` now includes the `<T>`, neither of which happened before.