### PR TITLE
feat(headless): made facet manager's sort results include every payload

### DIFF
--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.test.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.test.ts
@@ -44,12 +44,12 @@ describe('facet manager', () => {
       return {facetId, payload};
     }
 
-    it('when the facetId does not exist, it returns an empty array', () => {
+    it('when the facetId does not exist, it still returns it', () => {
       const facet1 = buildFacetManagerPayload('1', 'a');
 
       const facets = [facet1];
       const sortedFacets = facetManager.sort(facets);
-      expect(sortedFacets.length).toBe(0);
+      expect(sortedFacets).toEqual([facet1]);
     });
 
     it('when the facetId exists, it returns the facet payload', () => {
@@ -78,7 +78,7 @@ describe('facet manager', () => {
       expect(facetManager.sort(facets)).toEqual([facet2, facet1]);
     });
 
-    it('when one facetId exists but another does not, it returns only the facetId that exists', () => {
+    it('when one facetId exists but another does not, it returns the facetId that exists first', () => {
       const facet1 = buildFacetManagerPayload('1', 'a');
       const facet2 = buildFacetManagerPayload('2', 'b');
 
@@ -89,7 +89,7 @@ describe('facet manager', () => {
         buildMockFacetResponse({facetId: '3'}),
       ];
 
-      expect(facetManager.sort(facets)).toEqual([facet2]);
+      expect(facetManager.sort(facets)).toEqual([facet2, facet1]);
     });
   });
 });

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -323,18 +323,7 @@ const buildFetchMoreRequest = (
 };
 
 function getFacets(state: StateNeededByExecuteSearch) {
-  return [...getFacetsInOrder(state), ...getRemainingUnorderedFacets(state)];
-}
-
-function getFacetsInOrder(state: StateNeededByExecuteSearch) {
   return sortFacets(getAllFacets(state), state.facetOrder ?? []);
-}
-
-function getRemainingUnorderedFacets(state: StateNeededByExecuteSearch) {
-  const facetOrder = state.facetOrder ?? [];
-  return getAllFacets(state).filter(
-    (f) => facetOrder.indexOf(f.facetId) === -1
-  );
 }
 
 function getAllFacets(state: StateNeededByExecuteSearch) {

--- a/packages/headless/src/utils/facet-utils.ts
+++ b/packages/headless/src/utils/facet-utils.ts
@@ -5,7 +5,14 @@ export function sortFacets<T extends {facetId: string}>(
   const payloadMap: Record<string, T> = {};
   facets.forEach((f) => (payloadMap[f.facetId] = f));
 
-  return sortOrder
-    .map((id) => payloadMap[id])
-    .filter((payload) => payload !== undefined);
+  const sortedFacets: T[] = [];
+  sortOrder.forEach((facetId) => {
+    if (facetId in payloadMap) {
+      sortedFacets.push(payloadMap[facetId]);
+      delete payloadMap[facetId];
+    }
+  });
+  const remainingFacets = Object.values(payloadMap);
+
+  return [...sortedFacets, ...remainingFacets];
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-476

For instance, say you sorted `[facetA, facetB, facetC]` and only `facetB` was part of the last search response, then only `[facetB]` would be returned. With this change, `[facetB, facetA, facetC]` would be returned.