### PR TITLE
feat(atomic): remove atomic-result-excerpt component from DOM when empty

### DIFF
--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.pcss
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.pcss
@@ -1,9 +1,2 @@
 @import "tailwindcss/base";
 @import "tailwindcss/utilities";
-
-/**
- * @prop --atomic-query-summary-highlight-color: Color of the highlight
- */
-strong {
-  color: var(--atomic-query-summary-highlight-color, black);
-}

--- a/packages/atomic/src/components/atomic-query-summary/readme.md
+++ b/packages/atomic/src/components/atomic-query-summary/readme.md
@@ -24,13 +24,6 @@
 | `"results"`     | The results container                   |
 
 
-## CSS Custom Properties
-
-| Name                                     | Description            |
-| ---------------------------------------- | ---------------------- |
-| `--atomic-query-summary-highlight-color` | Color of the highlight |
-
-
 ## Dependencies
 
 ### Depends on

--- a/packages/atomic/src/components/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/atomic-result/atomic-result.tsx
@@ -7,7 +7,7 @@ import {bindLogDocumentOpenOnResult} from '../../utils/result-utils';
   shadow: true,
 })
 export class AtomicResult {
-  @Element() host!: HTMLDivElement;
+  @Element() host!: HTMLElement;
   @Prop() result!: Result;
   @Prop() engine!: Engine;
   @Prop() content!: string;
@@ -18,7 +18,7 @@ export class AtomicResult {
     this.unbindLogDocumentOpen = bindLogDocumentOpenOnResult(
       this.engine,
       this.result,
-      this.host
+      this.host.shadowRoot!
     );
   }
 

--- a/packages/atomic/src/components/result-template-components/atomic-result-excerpt/atomic-result-excerpt.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-excerpt/atomic-result-excerpt.tsx
@@ -1,4 +1,6 @@
-import {Component, h} from '@stencil/core';
+import {Result} from '@coveo/headless';
+import {Component, h, Element} from '@stencil/core';
+import {ResultContext} from '../result-template-decorators';
 
 /**
  * The ResultExcerpt component renders an excerpt of its associated result and highlights the keywords from the query.
@@ -8,7 +10,15 @@ import {Component, h} from '@stencil/core';
   shadow: false,
 })
 export class AtomicResultExcerpt {
-  render() {
+  @ResultContext() private result!: Result;
+  @Element() host!: HTMLElement;
+
+  public render() {
+    if (!this.result.excerpt || this.result.excerpt.trim() === '') {
+      this.host.remove();
+      return;
+    }
+
     return (
       <atomic-result-value
         value="excerpt"

--- a/packages/atomic/src/components/result-template-components/atomic-result-value/atomic-result-value.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-value/atomic-result-value.tsx
@@ -12,7 +12,7 @@ import {ResultContext} from '../result-template-decorators';
 export class AtomicResultValue {
   @ResultContext() private result!: Result;
 
-  @Element() host!: HTMLDivElement;
+  @Element() host!: HTMLElement;
 
   /**
    * Which result value should the component render

--- a/packages/atomic/src/templates/default.html
+++ b/packages/atomic/src/templates/default.html
@@ -28,7 +28,10 @@
 
   .fields-container {
     display: flex;
-    justify-content: space-between;
+  }
+
+  .fields-container > atomic-field-condition {
+    margin-right: 15px;
   }
 </style>
 <div class="template-container">

--- a/packages/atomic/src/utils/result-utils.ts
+++ b/packages/atomic/src/utils/result-utils.ts
@@ -11,7 +11,7 @@ import {buildInteractiveResult, Engine, Result} from '@coveo/headless';
 export function bindLogDocumentOpenOnResult(
   engine: Engine,
   result: Result,
-  resultElement: Element,
+  resultElement: Element | ShadowRoot,
   selector?: string
 ) {
   const interactiveResult = buildInteractiveResult(engine, {


### PR DESCRIPTION
Was already the case for other components like field condition & result value... not sure if it's necessary for result link
https://coveord.atlassian.net/browse/KIT-474