### PR TITLE
docs(headless): document recursively referenced interfaces

### DIFF
--- a/packages/headless/doc-parser/src/extractor.test.ts
+++ b/packages/headless/doc-parser/src/extractor.test.ts
@@ -23,7 +23,7 @@ describe('#extractTypes', () => {
       members: [values],
     });
 
-    const {types} = extractTypes([state]);
+    const {types} = extractTypes([state], {});
 
     const expectedEntity = buildMockObjEntity({
       name: 'FacetValue',
@@ -44,7 +44,7 @@ describe('#extractTypes', () => {
 
     const state = buildMockObjEntity({name: 'state', members: [values]});
 
-    extractTypes([state]);
+    extractTypes([state], {});
 
     expect(values.members.length).toBe(0);
     expect(values.isTypeExtracted).toBe(true);
@@ -76,7 +76,7 @@ describe('#extractTypes', () => {
       members: [facetSearch],
     });
 
-    const {types} = extractTypes([state]);
+    const {types} = extractTypes([state], {});
 
     const expectedEntity1 = buildMockObjEntity({
       name: 'FacetSearchState',
@@ -110,7 +110,7 @@ describe('#extractTypes', () => {
       members: [numberOfResults],
     });
 
-    const {types} = extractTypes([state, facetSearch]);
+    const {types} = extractTypes([state, facetSearch], {});
     expect(types).toEqual([]);
   });
 
@@ -131,7 +131,7 @@ describe('#extractTypes', () => {
       params: [selection],
     });
 
-    const {types} = extractTypes([toggleSelect]);
+    const {types} = extractTypes([toggleSelect], {});
 
     const expected = buildMockObjEntity({
       name: 'FacetValue',
@@ -159,7 +159,7 @@ describe('#extractTypes', () => {
       returnType: facetValue,
     });
 
-    const {types} = extractTypes([getFacetValue]);
+    const {types} = extractTypes([getFacetValue], {});
 
     const expected = buildMockObjEntity({
       name: 'FacetValue',
@@ -167,5 +167,37 @@ describe('#extractTypes', () => {
     });
 
     expect(types).toEqual([expected]);
+  });
+
+  it("when objEntity has more than one reference and isn't a type heading, it extracts the type", () => {
+    const entity = buildMockObjEntity({
+      name: 'CategoryFacetValue',
+      type: 'CategoryFacetValue',
+      typeName: 'CategoryFacetValue',
+      members: [buildMockEntity({name: 'value', type: 'string'})],
+    });
+
+    const {types} = extractTypes([entity], {CategoryFacetValue: 2});
+
+    const expected = buildMockObjEntity({
+      name: 'CategoryFacetValue',
+      members: [buildMockEntity({name: 'value', type: 'string'})],
+    });
+
+    expect(types).toEqual([expected]);
+  });
+
+  it("when objEntity has more than one reference and is a type heading, it doesn't extract the type", () => {
+    const entity = buildMockObjEntity({
+      name: 'CategoryFacetValue',
+      type: 'CategoryFacetValue',
+      typeName: 'CategoryFacetValue',
+      members: [],
+      isTypeExtracted: true,
+    });
+
+    const {types} = extractTypes([entity], {CategoryFacetValue: 2});
+
+    expect(types).toEqual([]);
   });
 });

--- a/packages/headless/doc-parser/src/function-resolver.test.ts
+++ b/packages/headless/doc-parser/src/function-resolver.test.ts
@@ -11,6 +11,7 @@ import {
 import {buildMockFuncEntity} from '../mocks/mock-func-entity';
 import {buildMockObjEntity} from '../mocks/mock-obj-entity';
 import {resolveFunction} from './function-resolver';
+import {AnyEntity} from './entity';
 
 describe('#resolveFunction', () => {
   it('resolves function with a an interface return type', () => {
@@ -72,7 +73,7 @@ describe('#resolveFunction', () => {
     entry.addMember(requestInterface);
     entry.addMember(fn);
 
-    const result = resolveFunction(entry, fn, []);
+    const result = resolveFunction(entry, fn, [], {});
 
     const startProperty = buildMockEntity({name: 'start', type: 'number'});
     const optionsParam = buildMockObjEntity({
@@ -94,6 +95,183 @@ describe('#resolveFunction', () => {
       name: 'buildNumericRange',
       desc: 'Creates a `NumericRangeRequest`.',
       params: [optionsParam],
+      returnType,
+    });
+
+    expect(result).toEqual(funcEntity);
+  });
+
+  it('correctly resolves a function with a recursive return type', () => {
+    const entry = buildMockEntryPoint();
+
+    const fn = buildMockApiFunction({
+      name: 'getRootDirectory',
+      excerptTokens: [
+        buildContentExcerptToken('declare function getRootDirectory(): '),
+        buildReferenceExcerptToken(
+          'Directory',
+          '@some-package!~Directory:interface'
+        ),
+        buildContentExcerptToken(';'),
+      ],
+      returnTypeTokenRange: {startIndex: 1, endIndex: 2},
+    });
+
+    const directoryInterface = buildMockApiInterface({
+      name: 'Directory',
+      members: [
+        buildMockApiPropertySignature({
+          name: 'name',
+          excerptTokens: [
+            buildContentExcerptToken('name: '),
+            buildContentExcerptToken('string'),
+            buildContentExcerptToken(';'),
+          ],
+          propertyTypeTokenRange: {startIndex: 1, endIndex: 2},
+        }),
+        buildMockApiPropertySignature({
+          name: 'parent',
+          excerptTokens: [
+            buildContentExcerptToken('parent: '),
+            buildReferenceExcerptToken(
+              'Directory',
+              '@some-package!~Directory:interface'
+            ),
+            buildContentExcerptToken(';'),
+          ],
+          propertyTypeTokenRange: {
+            startIndex: 1,
+            endIndex: 2,
+          },
+        }),
+      ],
+    });
+
+    entry.addMember(directoryInterface);
+    entry.addMember(fn);
+
+    const result = resolveFunction(entry, fn, [], {});
+
+    const returnType = buildMockObjEntity({
+      name: 'Directory',
+      type: 'Directory',
+      typeName: 'Directory',
+      members: [
+        buildMockEntity({name: 'name', type: 'string'}),
+        buildMockObjEntity({
+          name: 'parent',
+          type: 'Directory',
+          typeName: 'Directory',
+          members: [],
+          isTypeExtracted: true,
+        }),
+      ],
+      isTypeExtracted: false,
+    });
+
+    const funcEntity = buildMockFuncEntity({
+      name: 'getRootDirectory',
+      returnType,
+    });
+
+    expect(result).toEqual(funcEntity);
+  });
+
+  it('correctly resolves a function with a recursive return type and parameter type', () => {
+    const entry = buildMockEntryPoint();
+
+    const fn = buildMockApiFunction({
+      name: 'deleteDirectory',
+      docComment: buildMockApiDocComment(`
+      /**
+       * Deletes a directory
+       * @param directory - The directory to delete
+      */
+      `),
+      excerptTokens: [
+        buildContentExcerptToken(
+          'declare function deleteDirectory(directory: '
+        ),
+        buildReferenceExcerptToken(
+          'Directory',
+          '@some-package!~Directory:interface'
+        ),
+        buildContentExcerptToken('): '),
+        buildReferenceExcerptToken(
+          'Directory',
+          '@some-package!~Directory:interface'
+        ),
+        buildContentExcerptToken(';'),
+      ],
+      returnTypeTokenRange: {startIndex: 3, endIndex: 4},
+      parameters: [
+        {
+          parameterName: 'directory',
+          parameterTypeTokenRange: {startIndex: 1, endIndex: 2},
+        },
+      ],
+    });
+
+    const directoryInterface = buildMockApiInterface({
+      name: 'Directory',
+      members: [
+        buildMockApiPropertySignature({
+          name: 'name',
+          excerptTokens: [
+            buildContentExcerptToken('name: '),
+            buildContentExcerptToken('string'),
+            buildContentExcerptToken(';'),
+          ],
+          propertyTypeTokenRange: {startIndex: 1, endIndex: 2},
+        }),
+        buildMockApiPropertySignature({
+          name: 'parent',
+          excerptTokens: [
+            buildContentExcerptToken('parent: '),
+            buildReferenceExcerptToken(
+              'Directory',
+              '@some-package!~Directory:interface'
+            ),
+            buildContentExcerptToken(';'),
+          ],
+          propertyTypeTokenRange: {
+            startIndex: 1,
+            endIndex: 2,
+          },
+        }),
+      ],
+    });
+
+    entry.addMember(directoryInterface);
+    entry.addMember(fn);
+
+    const result = resolveFunction(entry, fn, [], {});
+
+    const buildDirectoryObj = (name: string, members: AnyEntity[], desc = '') =>
+      buildMockObjEntity({
+        name,
+        desc,
+        type: 'Directory',
+        typeName: 'Directory',
+        members,
+        isTypeExtracted: members.length === 0,
+      });
+
+    const directoryParam = buildDirectoryObj(
+      'directory',
+      [
+        buildMockEntity({name: 'name', type: 'string'}),
+        buildDirectoryObj('parent', []),
+      ],
+      'The directory to delete'
+    );
+
+    const returnType = buildDirectoryObj('Directory', []);
+
+    const funcEntity = buildMockFuncEntity({
+      name: 'deleteDirectory',
+      desc: 'Deletes a directory',
+      params: [directoryParam],
       returnType,
     });
 

--- a/packages/headless/doc-parser/src/function-resolver.ts
+++ b/packages/headless/doc-parser/src/function-resolver.ts
@@ -22,7 +22,7 @@ export function resolveFunction(
   const returnTypeText = fn.returnTypeExcerpt.text;
   const returnTypeInterface = findApi(entry, returnTypeText) as ApiInterface;
 
-  const returnType = buildObjEntityFromInterface(
+  const returnType = resolveInterface(
     entry,
     returnTypeInterface,
     referencesCount
@@ -48,12 +48,4 @@ function resolveParams(
       ? buildParamEntity(p)
       : resolveParameter(entry, p, referencesCount);
   });
-}
-
-function buildObjEntityFromInterface(
-  entryPoint: ApiEntryPoint,
-  apiInterface: ApiInterface,
-  referencesCount: InterfaceReferencesCount
-) {
-  return resolveInterface(entryPoint, apiInterface, referencesCount);
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-440

This fix extracts every interface that is referenced more than once, which allows recursively referenced interfaces to be parsed.

For instance:
```ts
export interface CategoryFacetValue { // Will be extracted
  ...
  children: CategoryFacetValue[];
  ...
}
```
or
```ts
export interface FacetValue { // Will be extracted
  value: string;
  ...
}

export interface SomeInterface { // Not necessarily extracted
  facetValue: FacetValue;
}

export interface AnotherInterface { // Not necessarily extracted
  facetValue: FacetValue;
}
```

The doc generated after this change was compared to the doc generated before it, and only `CategoryFacet` was affected.