### PR TITLE
docs(headless): removed redundant NumericFacetValueOption interface

### DIFF
--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
@@ -7,10 +7,7 @@ import {
   SchemaDefinition,
   StringValue,
 } from '@coveo/bueno';
-import {
-  FacetValueState,
-  facetValueStates,
-} from '../../../../features/facets/facet-api/value';
+import {facetValueStates} from '../../../../features/facets/facet-api/value';
 import {
   rangeFacetSortCriteria,
   RangeFacetSortCriterion,
@@ -24,31 +21,6 @@ import {
   injectionDepth,
   numberOfValues,
 } from '../../_common/facet-option-definitions';
-
-/**
- * The options defining a value to display in a `NumericFacet`.
- */
-export interface NumericFacetValueOption {
-  /**
-   * The start value of the range.
-   */
-  start: number;
-
-  /**
-   * The end value of the range.
-   */
-  end: number;
-
-  /**
-   * Whether to include the `end` value in the range.
-   */
-  endInclusive: boolean;
-
-  /**
-   * The current facet value state.
-   */
-  state: FacetValueState;
-}
 
 /**
  * The options defining a `NumericFacet`.
@@ -74,7 +46,7 @@ export interface NumericFacetOptions {
    *
    * @default []
    */
-  currentValues?: NumericFacetValueOption[];
+  currentValues?: NumericRangeRequest[];
 
   /**
    * A unique identifier for the controller.

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/interfaces/request.ts
@@ -2,6 +2,9 @@ import {BaseRangeFacetRequest} from '../../generic/interfaces/request';
 import {CurrentValues, Type} from '../../../facet-api/request';
 import {FacetValueState} from '../../../facet-api/value';
 
+/**
+ * The options defining a value to display in a `NumericFacet`.
+ */
 export interface NumericRangeRequest {
   /**
    * The start value of the range.


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-495

I missed [this comment](https://github.com/coveo/ui-kit/pull/575#discussion_r586704075) in a previous PR.