### PR TITLE
docs(headless): resolve union types in properties as primitives

### DIFF
--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -107,15 +107,16 @@ function resolvePropertySignature(
   ancestorNames: string[]
 ) {
   const typeExcerpt = p.propertyTypeExcerpt.spannedTokens[0];
+  const typeName = extractTypeName(p.propertyTypeExcerpt);
   if (isRecordType(typeExcerpt)) {
     return buildEntityFromProperty(p);
   }
 
-  if (isTypeAlias(typeExcerpt)) {
+  if (isTypeAlias(typeExcerpt) && !typeName.includes('|')) {
     return buildEntityFromPropertyAndResolveTypeAlias(entry, p);
   }
 
-  if (isReference(typeExcerpt)) {
+  if (isReference(typeExcerpt) && !typeName.includes('|')) {
     return buildObjEntityFromProperty(entry, p, ancestorNames);
   }
 

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -112,11 +112,15 @@ function resolvePropertySignature(
     return buildEntityFromProperty(p);
   }
 
-  if (isTypeAlias(typeExcerpt) && !typeName.includes('|')) {
+  if (isUnionType(typeName)) {
+    return buildEntityFromProperty(p);
+  }
+
+  if (isTypeAlias(typeExcerpt)) {
     return buildEntityFromPropertyAndResolveTypeAlias(entry, p);
   }
 
-  if (isReference(typeExcerpt) && !typeName.includes('|')) {
+  if (isReference(typeExcerpt)) {
     return buildObjEntityFromProperty(entry, p, ancestorNames);
   }
 
@@ -299,4 +303,8 @@ function isRecordType(token: ExcerptToken) {
 
 function isReference(token: ExcerptToken) {
   return token.kind === ExcerptTokenKind.Reference;
+}
+
+function isUnionType(typeName: string) {
+  return typeName.includes('|');
 }


### PR DESCRIPTION
This is a quick, _temporary_ fix to the parser that prevents it from trying to resolve the first object in a union type.

Properly resolving union types is going to be a much bigger refactor, so Sami and I decided to hold off on that for now. But, the parser was already attempting to resolve (and then extract) the first type in a union if it was an object, and it wasn't working properly. It's better to have missing docs than incorrect docs, so this fix just makes the parser resolve union types on properties as primitives.

(As discussed with Sami, I didn't make the same temporary fix for methods because there were no instances of union types occurring there. If we run into one before the bigger refactor, we'll make another temporary fix then.)