### PR TITLE
test(atomic): Add more cypress tests for sort & pager components

### DIFF
--- a/packages/atomic/cypress/integration/facet-standard.cypress.ts
+++ b/packages/atomic/cypress/integration/facet-standard.cypress.ts
@@ -94,7 +94,7 @@ describe('Standard Facet', () => {
       );
     });
 
-    it('Should reflect selected facetValue on URL', async () => {
+    it('Should reflect selected facetValue on URL', () => {
       cy.get('@firstFacetValue')
         .click()
         .find('label span:nth-child(1)')

--- a/packages/atomic/cypress/integration/facet-utils.ts
+++ b/packages/atomic/cypress/integration/facet-utils.ts
@@ -52,7 +52,7 @@ export async function assertSortCriteria(
     '@coveoSearch',
     requestBodyOrder
   );
-  const firstRequestBodyFacets = requestBody.facets[0];
+  const firstRequestBodyFacets = (requestBody.facets as any)[0];
 
   expect(firstRequestBodyFacets).to.have.property('sortCriteria', sortOption);
 }

--- a/packages/atomic/cypress/integration/pager.cypress.ts
+++ b/packages/atomic/cypress/integration/pager.cypress.ts
@@ -122,6 +122,15 @@ describe('Pager Test Suites', () => {
       cy.get('@pagerLi').get(PagerSelectors.buttonPrevious).should('not.exist');
     });
 
+    it('should load without navigation buttons when user goes to page 2', () => {
+      setupPager('enable-navigation-buttons=false');
+      createAliasLi();
+      cy.get('@pagerLi').find('button').contains('2').click();
+      checkPagerSelected('2', true);
+      cy.get('@pagerLi').get(PagerSelectors.buttonNext).should('not.exist');
+      cy.get('@pagerLi').get(PagerSelectors.buttonPrevious).should('not.exist');
+    });
+
     it('should load without navigation buttons when prop is "false"_string', () => {
       setupPager('enable-navigation-buttons="false"');
       createAliasLi();

--- a/packages/atomic/cypress/integration/sort-dropdown.cypress.ts
+++ b/packages/atomic/cypress/integration/sort-dropdown.cypress.ts
@@ -75,11 +75,17 @@ describe('Sort Dropdown Component', () => {
 });
 
 describe('When sort with invalid criteria option', () => {
-  it('Should render an error when <atomic-sort-criteria> is invalid', () => {
+  it('Should render an error when <atomic-sort-dropdown> has no child', () => {
     setUpPage(`
         <atomic-sort-dropdown>
-          <atomic-sort-criteria</atomic-sort-criteria>
         </atomic-sort-dropdown>
+      `);
+    shouldRenderErrorComponent(sortDropdown);
+  });
+
+  it.skip('Should render an error when "<atomic-sort-dropdown" is missing', () => {
+    setUpPage(`
+    <atomic-sort-criteria caption="Relevance" criteria="${criteria[0]}"></atomic-sort-criteria>
       `);
     shouldRenderErrorComponent(sortDropdown);
   });

--- a/packages/atomic/cypress/integration/sort-dropdown.cypress.ts
+++ b/packages/atomic/cypress/integration/sort-dropdown.cypress.ts
@@ -6,41 +6,40 @@ const criteria = [
   'relevancy',
   'date descending',
   'size ascending, date descending',
+  'qre',
 ];
+
+function selectOption(value: string) {
+  return cy.get(sortDropdown).shadow().find('select').select(value);
+}
 
 describe('Sort Dropdown Component', () => {
   function setup(attributes = '') {
     setUpPage(`
       <atomic-sort-dropdown ${attributes}>
-        <atomic-sort-criteria caption="relevance" criteria="${criteria[0]}"></atomic-sort-criteria>
-        <atomic-sort-criteria caption="mostRecent" criteria="${criteria[1]}"></atomic-sort-criteria>
-        <atomic-sort-criteria caption="mostRecent" criteria="${criteria[2]}"></atomic-sort-criteria>
+        <atomic-sort-criteria caption="Relevance" criteria="${criteria[0]}"></atomic-sort-criteria>
+        <atomic-sort-criteria caption="Most Recent" criteria="${criteria[1]}"></atomic-sort-criteria>
+        <atomic-sort-criteria caption="Size Date" criteria="${criteria[2]}"></atomic-sort-criteria>
+        <atomic-sort-criteria caption="QRE" criteria="${criteria[3]}"></atomic-sort-criteria>
       </atomic-sort-dropdown>
     `);
-    cy.wait(500);
   }
-
-  function selectOption(value: string) {
-    return cy.get(sortDropdown).shadow().find('select').select(value);
-  }
-
-  it('should load', () => {
+  beforeEach(() => {
     setup();
+  });
+  it('should load', () => {
     cy.get(sortDropdown).should('be.visible');
   });
 
   it('passes automated accessibility', () => {
-    setup();
     cy.checkA11y(sortDropdown);
   });
 
   it('should display a label', () => {
-    setup();
     cy.get(sortDropdown).shadow().find('label').should('exist');
   });
 
   it('should display the localized string for the option innerHTML', () => {
-    setup();
     cy.get(sortDropdown)
       .shadow()
       .find('option[value="relevancy"]')
@@ -48,7 +47,6 @@ describe('Sort Dropdown Component', () => {
   });
 
   it('should execute a query with the correct sort order on selection', async () => {
-    setup();
     selectOption(criteria[1]);
 
     const request = await getApiRequestBodyAt('@coveoSearch', 1);
@@ -56,7 +54,6 @@ describe('Sort Dropdown Component', () => {
   });
 
   it('should log the right analytics on selection', async () => {
-    setup();
     selectOption(criteria[1]);
 
     const analytics = await getAnalyticsAt('@coveoAnalytics', 1);
@@ -70,14 +67,42 @@ describe('Sort Dropdown Component', () => {
     );
   });
 
-  it(`when a criteria is not valid
-    should render an error`, () => {
+  it('Should reflect selected sort on URL', () => {
+    selectOption(criteria[1]);
+    const urlHash = `sortCriteria=${encodeURIComponent(criteria[1])}`;
+    cy.url().should('include', urlHash);
+  });
+});
+
+describe('When sort with invalid criteria option', () => {
+  it('Should render an error when <atomic-sort-criteria> is invalid', () => {
     setUpPage(`
-      <atomic-sort-dropdown>
-        <atomic-sort-criteria</atomic-sort-criteria>
-      </atomic-sort-dropdown>
-    `);
-    cy.wait(500);
+        <atomic-sort-dropdown>
+          <atomic-sort-criteria</atomic-sort-criteria>
+        </atomic-sort-dropdown>
+      `);
     shouldRenderErrorComponent(sortDropdown);
   });
+
+  it('Should render an error when criteria is missing', () => {
+    setUpPage(`
+        <atomic-sort-dropdown>
+          <atomic-sort-criteria label="Sort"></atomic-sort-criteria>
+        </atomic-sort-dropdown>
+      `);
+    shouldRenderErrorComponent(sortDropdown);
+  });
+
+  it('Should render an error when criteria contains invalid character', () => {
+    setUpPage(`
+        <atomic-sort-dropdown>
+          <atomic-sort-criteria criteria="size ascending; date ascending"></atomic-sort-criteria>
+        </atomic-sort-dropdown>
+      `);
+    shouldRenderErrorComponent(sortDropdown);
+  });
+});
+
+describe('When sort has no label', () => {
+  it('Should display default label');
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-507
Sort
- Add check for URL
- Add check for sort with field QRE generated correctly
- Add more check for invalid sort-criteria field

Pager
- Add check for 'disable-navigation' button when go to page 2

Facet
- Remove async when function is not async/await