### PR TITLE
feat(headless): add buildHistoryManager controller; deprecate buildHistory

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -11,6 +11,10 @@ const entryPoint = apiPackage.entryPoints[0];
 
 const controllers: ControllerConfiguration[] = [
   {
+    initializer: 'buildHistoryManager',
+    samplePaths: {},
+  },
+  {
     initializer: 'buildFacet',
     samplePaths: {
       react_class: [

--- a/packages/headless/src/controllers/history/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history/headless-history-manager.ts
@@ -1,0 +1,66 @@
+import {Engine} from '../../app/headless-engine';
+import {StateWithHistory} from '../../app/undoable';
+import {back, forward} from '../../features/history/history-actions';
+import {
+  logNavigateBackward,
+  logNavigateForward,
+} from '../../features/history/history-analytics-actions';
+import {HistoryState} from '../../features/history/history-state';
+import {executeSearch} from '../../features/search/search-actions';
+import {buildController, Controller} from '../controller/headless-controller';
+
+/**
+ * The `HistoryManager` controller is in charge of allowing navigating back and forward in the search interface history.
+ */
+export interface HistoryManager extends Controller {
+  /**
+   * Move backward in the interface history.
+   */
+  back(): void;
+
+  /**
+   * Move forward in the interface history.
+   */
+  forward(): void;
+
+  /**
+   * The state relevant to the `HistoryManager` controller.
+   * */
+  state: HistoryManagerState;
+}
+
+export type HistoryManagerState = StateWithHistory<HistoryState>;
+
+/**
+ * Creates a `HistoryManager` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @returns A `HistoryManager` controller instance.
+ */
+export function buildHistoryManager(engine: Engine): HistoryManager {
+  const controller = buildController(engine);
+  const {dispatch} = engine;
+
+  return {
+    ...controller,
+    get state() {
+      return engine.state.history;
+    },
+
+    async back() {
+      if (!this.state.past.length || !this.state.present) {
+        return;
+      }
+      await dispatch(back());
+      dispatch(executeSearch(logNavigateBackward()));
+    },
+
+    async forward() {
+      if (!this.state.future.length || !this.state.present) {
+        return;
+      }
+      await dispatch(forward());
+      dispatch(executeSearch(logNavigateForward()));
+    },
+  };
+}

--- a/packages/headless/src/controllers/history/headless-history.ts
+++ b/packages/headless/src/controllers/history/headless-history.ts
@@ -1,49 +1,31 @@
 import {Engine} from '../../app/headless-engine';
-import {buildController} from '../controller/headless-controller';
-import {back, forward} from '../../features/history/history-actions';
-import {executeSearch} from '../../features/search/search-actions';
-import {
-  logNavigateBackward,
-  logNavigateForward,
-} from '../../features/history/history-analytics-actions';
+import {buildHistoryManager} from './headless-history-manager';
 
 /**
  * The `History` controller is in charge of allowing navigating back and forward in the search interface history.
+ *
+ * @deprecated The `History` type alias will be removed in a future release. Please use `HistoryManager` instead.
  */
 export type History = ReturnType<typeof buildHistory>;
-/** The state relevant to the `History` controller.*/
+
+/**
+ * The state relevant to the `History` controller.
+ *
+ * @deprecated The `HistoryState` type alias will be removed in a future release. Please use `HistoryManagerState` instead.
+ * */
 export type HistoryState = History['state'];
 
+/**
+ * Creates a `History` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @returns A `History` controller instance.
+ *
+ * @deprecated The `buildHistory` controller will be removed in a future release. Please use `buildHistoryManager` instead.
+ */
 export const buildHistory = (engine: Engine) => {
-  const controller = buildController(engine);
-  const {dispatch} = engine;
-
-  return {
-    ...controller,
-    get state() {
-      return engine.state.history;
-    },
-
-    /**
-     * Move backward in the interface history.
-     */
-    async back() {
-      if (!this.state.past.length || !this.state.present) {
-        return;
-      }
-      await dispatch(back());
-      dispatch(executeSearch(logNavigateBackward()));
-    },
-
-    /**
-     * Move forward in the interface history.
-     */
-    async forward() {
-      if (!this.state.future.length || !this.state.present) {
-        return;
-      }
-      await dispatch(forward());
-      dispatch(executeSearch(logNavigateForward()));
-    },
-  };
+  engine.logger.error(
+    'The "buildHistory" controller will be removed in a future release. Please use "buildHistoryManager" instead.'
+  );
+  return buildHistoryManager(engine);
 };

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -75,6 +75,12 @@ export {
 export {History, HistoryState, buildHistory} from './history/headless-history';
 
 export {
+  HistoryManager,
+  HistoryManagerState,
+  buildHistoryManager,
+} from './history/headless-history-manager';
+
+export {
   PagerInitialState,
   PagerOptions,
   PagerProps,


### PR DESCRIPTION
This is a draft PR.

**Challenges**
I encountered a few difficulties in documenting the `buildHistoryManager` controller.

1. The returned `History` type is extracted by api-extractor as `History_2`. I suspect this is because it conflicts with the browser interface that is used to interact with the browser's history. Resolving the correct `History` interface requires adding a hack to the parser which I am not excited to do.

2. The `HistoryState` interface in the controller file has the same name as an internal interface, but a different shape. The tooling ignores imported type aliases. We could rename the internal interface to `HistorySliceState`, but this breaks the pattern and does not solve issue 1 above.

**Proposed Solution**

Deprecate the `buildHistory` controller and not document it in our reference docs. Expose a new controller `buildHistoryManager` which otherwise has the same functionality, and that will be shown in our docs.


https://coveord.atlassian.net/browse/KIT-466