### PR TITLE
docs(headless): source code fixes for documentation extraction

### DIFF
--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
@@ -44,7 +44,7 @@ export interface FacetManagerState {
 }
 
 /**
- * Creates a `FacetManger` instance.
+ * Creates a `FacetManager` instance.
  *
  * @param engine - The headless engine.
  */

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -34,12 +34,12 @@ export {
   NumericFacetOptions,
 };
 
-export type NumericFacetProps = {
+export interface NumericFacetProps {
   /**
    * The options for the `NumericFacet` controller.
    */
   options: NumericFacetOptions;
-};
+}
 
 /**
  * The `NumericFacet` controller makes it possible to create a facet with numeric ranges.

--- a/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
@@ -4,8 +4,11 @@ import {
   BaseFacetValueRequest,
 } from '../../../facet-api/request';
 
-export const rangeFacetSortCriteria = ['ascending', 'descending'] as const;
-export type RangeFacetSortCriterion = typeof rangeFacetSortCriteria[number];
+export const rangeFacetSortCriteria: RangeFacetSortCriterion[] = [
+  'ascending',
+  'descending',
+];
+export type RangeFacetSortCriterion = 'ascending' | 'descending';
 
 export interface AutomaticRanges<T extends boolean> {
   /** Whether the index should automatically create range values.


### PR DESCRIPTION
Just a quick PR to fix some small issues I found while generating the documentation. I fixed a typo in FacetManager and made some last adjustments to NumericFacet that were missed during the initial flattening.

All Headless unit tests passed after my changes, and the documentation now parses correctly; let me know if there's any other check I need to do.