### PR TITLE
docs(headless): handle multi-paragraph descriptions

### DIFF
--- a/packages/headless/doc-parser/src/tsdoc-emitter.test.ts
+++ b/packages/headless/doc-parser/src/tsdoc-emitter.test.ts
@@ -17,4 +17,14 @@ describe('#emitAsTsDoc', () => {
     const result = emitAsTsDoc(ast.docComment.summarySection.nodes);
     expect(result).toBe('Creates a `Pager`.');
   });
+
+  it('when the summary has multiple paragraphs, it inserts newlines between them but not at the end', () => {
+    const parser = new TSDocParser();
+    const ast = parser.parseString(
+      '/**\n * Creates a `Pager`.\n *\n * Note: test note.\n */\n'
+    );
+
+    const result = emitAsTsDoc(ast.docComment.summarySection.nodes);
+    expect(result).toBe('Creates a `Pager`.\n\nNote: test note.');
+  });
 });

--- a/packages/headless/doc-parser/src/tsdoc-emitter.ts
+++ b/packages/headless/doc-parser/src/tsdoc-emitter.ts
@@ -8,7 +8,7 @@ import {
 } from '@microsoft/tsdoc';
 
 export function emitAsTsDoc(nodes: readonly DocNode[]) {
-  return nodes.map(emitNode).join('').trimRight();
+  return nodes.map(emitNode).join('').trim();
 }
 
 function emitNode(node: DocNode): string {

--- a/packages/headless/doc-parser/src/tsdoc-emitter.ts
+++ b/packages/headless/doc-parser/src/tsdoc-emitter.ts
@@ -8,13 +8,13 @@ import {
 } from '@microsoft/tsdoc';
 
 export function emitAsTsDoc(nodes: readonly DocNode[]) {
-  return nodes.map(emitNode).join('');
+  return nodes.map(emitNode).join('').trimRight();
 }
 
 function emitNode(node: DocNode): string {
   if (isParagraph(node)) {
     const trimmed = DocNodeTransforms.trimSpacesInParagraph(node);
-    return emitAsTsDoc(trimmed.nodes);
+    return emitAsTsDoc(trimmed.nodes) + '\n\n';
   }
 
   if (isPlainText(node)) {


### PR DESCRIPTION
Previously, descriptions were stripped of all their leading/trailing whitespace, which included removing newlines between paragraphs. The code I've added re-inserts newlines between paragraphs, allowing for proper display on the docs site.