### PR TITLE
docs: extract complex types from controller options and initialState

### DIFF
--- a/packages/headless/doc-parser/src/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/controller-resolver.ts
@@ -61,19 +61,32 @@ function isFunction(item: ApiItem): item is ApiFunction {
 }
 
 function extractTypesFrom(initializer: FuncEntity, utils: FuncEntity[]) {
-  const instanceTypes = extractTypesFromInitializerInstance(initializer);
+  const initializerTypes = extractedTypesFromInitializer(initializer);
   const utilTypes = extractTypes(utils).types;
-  const types = instanceTypes.concat(utilTypes);
+  const types = initializerTypes.concat(utilTypes);
 
   return removeDuplicates(types);
 }
 
-function extractTypesFromInitializerInstance(entity: FuncEntity) {
-  const {returnType} = entity;
+function extractedTypesFromInitializer(initializer: FuncEntity) {
+  const propTypes = extractTypesFromInitializerProps(initializer);
+  const instanceTypes = extractTypesFromInitializerInstance(initializer);
 
-  if (typeof returnType === 'string') {
-    return [];
+  return propTypes.concat(instanceTypes);
+}
+
+function extractTypesFromInitializerProps(initializer: FuncEntity) {
+  const propsParameter = initializer.params[1];
+
+  if (propsParameter && isObjectEntity(propsParameter)) {
+    return extractTypes(propsParameter.members).types;
   }
+
+  return [];
+}
+
+function extractTypesFromInitializerInstance(initializer: FuncEntity) {
+  const {returnType} = initializer;
 
   if (isObjectEntity(returnType)) {
     return extractTypes(returnType.members).types;

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -101,12 +101,8 @@ function getSummary(comment: DocComment | undefined) {
     const nodes = removeBlockTagNodes(comment.summarySection.nodes);
     return emitAsTsDoc(nodes);
   } catch (e) {
-    console.log(
-      'failed to get summary for comment:\n',
-      comment.emitAsTsdoc(),
-      e
-    );
-    return '';
+    const message = `failed to get summary for comment:\n\n${comment.emitAsTsdoc()}\n${e}`;
+    throw new Error(message);
   }
 }
 

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
@@ -7,12 +7,12 @@ import {FacetValueState} from '../../../facet-api/value';
  */
 export interface DateRangeRequest {
   /**
-   * The start value of the range, formatted as YYYY/MM/DD@HH:mm:ss.
+   * The start value of the range, formatted as `YYYY/MM/DD@HH:mm:ss`.
    */
   start: string;
 
   /**
-   * The end value of the range, formatted as YYYY/MM/DD@HH:mm:ss.
+   * The end value of the range, formatted as `YYYY/MM/DD@HH:mm:ss`.
    */
   end: string;
 

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/response.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/response.ts
@@ -8,12 +8,12 @@ export interface DateFacetValue {
   numberOfResults: number;
 
   /**
-   * The starting value for the date range, formatted as YYYY/MM/DD@HH:mm:ss.
+   * The starting value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss`.
    */
   start: string;
 
   /**
-   * The ending value for the date range, formatted as YYYY/MM/DD@HH:mm:ss.
+   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss`.
    */
   end: string;
 


### PR DESCRIPTION
Certain controllers have deeply nested option interfaces. e.g.

```
SearchBoxOptions {
    highlightOptions: SuggestionHighlightingOptions
}

interface SuggestionHighlightingOptions {
   notMatchDelimiters?: Delimiters;
   exactMatchDelimiters?: Delimiters;
   correctionDelimiters?: Delimiters;
}

interface Delimiters {
    open: string;
    close: string;
}
```

This PR adjusts the parser to extract types from controller options and initialState. In the above example, it would extract `SuggestionHighlightingOptions` and `Delimiters`.