### PR TITLE
docs(headless): breadcrumb manager interface fix

### DIFF
--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -40,7 +40,7 @@ export interface BreadcrumbManager extends Controller {
   /**
    * Deselects all facet values.
    */
-  deselectAll: () => void;
+  deselectAll(): void;
 
   /**
    * Deselects a facet breadcrumb value or category facet breadcrumb.


### PR DESCRIPTION
Another quick fix that I stumbled across when running the parsed doc through the docs site generator, this time on the BreadcrumbManager flattened interface