### PR TITLE
docs: label primitive entities holding a type alias

### DIFF
--- a/packages/headless/doc-parser/mocks/mock-entity-with-type-alias.ts
+++ b/packages/headless/doc-parser/mocks/mock-entity-with-type-alias.ts
@@ -1,0 +1,14 @@
+import {EntityWithTypeAlias} from '../src/entity';
+
+export function buildMockEntityWithTypeAlias(
+  config: Partial<EntityWithTypeAlias> = {}
+): EntityWithTypeAlias {
+  return {
+    kind: 'primitive-with-type-alias',
+    desc: '',
+    isOptional: false,
+    name: '',
+    type: '',
+    ...config,
+  };
+}

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -1,4 +1,8 @@
-type EntityKind = 'primitive' | 'object' | 'function';
+type EntityKind =
+  | 'primitive'
+  | 'primitive-with-type-alias'
+  | 'object'
+  | 'function';
 
 interface Kind<T extends EntityKind> {
   kind: T;
@@ -27,6 +31,13 @@ export interface Entity
     Type,
     Optional {}
 
+export interface EntityWithTypeAlias
+  extends Kind<'primitive-with-type-alias'>,
+    Name,
+    Description,
+    Type,
+    Optional {}
+
 export interface ObjEntity
   extends Kind<'object'>,
     Name,
@@ -43,7 +54,7 @@ export interface FuncEntity extends Kind<'function'>, Name, Description {
   returnType: AnyEntity;
 }
 
-export type AnyEntity = Entity | ObjEntity | FuncEntity;
+export type AnyEntity = Entity | EntityWithTypeAlias | ObjEntity | FuncEntity;
 
 interface UnknownEntity {
   kind: EntityKind;

--- a/packages/headless/doc-parser/src/interface-resolver.test.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.test.ts
@@ -6,6 +6,7 @@ import {buildMockApiMethodSignature} from '../mocks/mock-api-method-signature';
 import {buildMockApiPropertySignature} from '../mocks/mock-api-property-signature';
 import {buildMockApiTypeAlias} from '../mocks/mock-api-type-alias';
 import {buildMockEntity} from '../mocks/mock-entity';
+import {buildMockEntityWithTypeAlias} from '../mocks/mock-entity-with-type-alias';
 import {buildMockEntryPoint} from '../mocks/mock-entry-point';
 import {
   buildContentExcerptToken,
@@ -415,7 +416,7 @@ describe('#resolveInterfaceMembers', () => {
     entry.addMember(typeAlias);
 
     const result = resolveInterfaceMembers(entry, apiInterface, []);
-    const entity = buildMockEntity({
+    const entity = buildMockEntityWithTypeAlias({
       name: 'state',
       type: "'idle' | 'selected'",
     });
@@ -567,7 +568,7 @@ describe('#resolveInterfaceMembers', () => {
 
     const result = resolveInterfaceMembers(entry, context, []);
 
-    const param = buildMockEntity({
+    const param = buildMockEntityWithTypeAlias({
       name: 'contextValue',
       type: 'string | string[]',
       desc: 'The context value to add.',

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -15,7 +15,7 @@ import {
 } from '@microsoft/api-extractor-model';
 import {DocComment} from '@microsoft/tsdoc';
 import {findApi} from './api-finder';
-import {AnyEntity, Entity} from './entity';
+import {AnyEntity, EntityWithTypeAlias} from './entity';
 import {
   buildEntity,
   buildFuncEntity,
@@ -154,13 +154,13 @@ function buildObjEntityFromProperty(
 function buildEntityFromPropertyAndResolveTypeAlias(
   entry: ApiEntryPoint,
   p: ApiPropertySignature
-): Entity {
+): EntityWithTypeAlias {
   const entity = buildEntityFromProperty(p);
   const searchableTypeName = extractSearchableTypeName(p.propertyTypeExcerpt);
   const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
-  return {...entity, type};
+  return {...entity, kind: 'primitive-with-type-alias', type};
 }
 
 function isIndexSignature(m: ApiItem): m is ApiIndexSignature {
@@ -263,13 +263,13 @@ export function resolveParameter(
 function buildEntityFromParamAndResolveTypeAlias(
   entry: ApiEntryPoint,
   p: Parameter
-): Entity {
+): EntityWithTypeAlias {
   const entity = buildParamEntity(p);
   const searchableTypeName = extractSearchableTypeName(p.parameterTypeExcerpt);
   const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
   const type = typeAlias.typeExcerpt.text;
 
-  return {...entity, type};
+  return {...entity, kind: 'primitive-with-type-alias', type};
 }
 
 function buildObjEntityFromParam(


### PR DESCRIPTION
The intent behind the change is to help the doc-generation scripts render attributes when their type is a resolved type alias.
@kaitlynkatz, I will wait for your confirmation before merging.

https://coveord.atlassian.net/browse/KIT-526