### PR TITLE
docs: export as ProductRecommendation interface instead of Product type

### DIFF
--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -1,4 +1,4 @@
-export type Product = {
+export interface ProductRecommendation {
   /**
    * The SKU of the product.
    */
@@ -67,6 +67,4 @@ export type Product = {
    * From the `ec_rating` field.
    */
   rating?: number;
-};
-
-export type ProductRecommendation = Product;
+}

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -204,8 +204,6 @@ export {
   buildStandaloneSearchBox,
 } from './standalone-search-box/headless-standalone-search-box';
 
-export {Product} from './product-recommendations/headless-base-product-recommendations';
-
 export {
   FrequentlyBoughtTogetherListOptions,
   FrequentlyBoughtTogetherListProps,
@@ -218,6 +216,7 @@ export {
   CartRecommendationsListOptions,
   CartRecommendationsListProps,
   CartRecommendationsListState,
+  ProductRecommendation,
   CartRecommendationsList,
   buildCartRecommendationsList,
 } from './product-recommendations/headless-cart-recommendations';

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
@@ -19,8 +19,6 @@ import {
 } from '@coveo/bueno';
 import {validateOptions} from '../../utils/validate-payload';
 
-export {Product} from '../../api/search/search/product';
-
 export const baseProductRecommendationsOptionsSchema = {
   skus: new ArrayValue<string>({
     required: false,

--- a/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
@@ -10,11 +10,11 @@ import {
 } from './headless-base-product-recommendations';
 import {validateOptions} from '../../utils/validate-payload';
 import {Controller} from '../controller/headless-controller';
-import {Product} from '../../api/search/search/product';
+import {ProductRecommendation} from '../../api/search/search/product-recommendation';
 import {CartRecommendationsListOptions} from './headless-cart-recommendations-options';
 import {ErrorPayload} from '../controller/error-payload';
 
-export {CartRecommendationsListOptions};
+export {CartRecommendationsListOptions, ProductRecommendation};
 
 const optionsSchema = new Schema({
   ...baseProductRecommendationsOptionsSchema,
@@ -57,7 +57,7 @@ export interface CartRecommendationsListState {
   /**
    * The products recommended by the Coveo platform.
    */
-  recommendations: Product[];
+  recommendations: ProductRecommendation[];
 
   /**
    * The error returned by the Coveo platform while executing the cart recommendation request, if any. `null` otherwise.

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -17,7 +17,7 @@ import {
 import {ArrayValue, NumberValue, StringValue} from '@coveo/bueno';
 import {getVisitorID, historyStore} from '../../api/analytics/analytics';
 import {ProductRecommendationsRequest} from '../../api/search/product-recommendations/product-recommendations-request';
-import {ProductRecommendation} from '../../api/search/search/product';
+import {ProductRecommendation} from '../../api/search/search/product-recommendation';
 import {Result} from '../../api/search/search/result';
 import {logProductRecommendations} from './product-recommendations-analytics.actions';
 import {SearchAction} from '../analytics/analytics-utils';

--- a/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
@@ -1,5 +1,5 @@
 import {buildMockProductRecommendations} from '../../test/mock-product-recommendations';
-import {buildMockProductRecommendation} from '../../test/mock-product';
+import {buildMockProductRecommendation} from '../../test/mock-product-recommendation';
 import {
   getProductRecommendations,
   setProductRecommendationsSkus,

--- a/packages/headless/src/features/product-recommendations/product-recommendations-state.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-state.ts
@@ -1,6 +1,6 @@
 import {SearchAPIErrorWithStatusCode} from '../../api/search/search-api-error-response';
 
-import {ProductRecommendation} from '../../api/search/search/product';
+import {ProductRecommendation} from '../../api/search/search/product-recommendation';
 
 export type ProductRecommendationsState = {
   id: string;

--- a/packages/headless/src/test/mock-product-recommendation.ts
+++ b/packages/headless/src/test/mock-product-recommendation.ts
@@ -1,4 +1,4 @@
-import {ProductRecommendation} from '../api/search/search/product';
+import {ProductRecommendation} from '../api/search/search/product-recommendation';
 
 export function buildMockProductRecommendation(
   config: Partial<ProductRecommendation> = {}


### PR DESCRIPTION
I changed the type from an alias to an interface to allow the tool to pick it up and resolve it. I used the opportunity to export the longer `ProductRecommendation` since I felt `Product` was too vague.

https://coveord.atlassian.net/browse/KIT-527