### PR TITLE
feat(productrecommendations): allow adding additional fields

### DIFF
--- a/packages/atomic/src/components/atomic-frequently-bought-together/atomic-frequently-bought-together.tsx
+++ b/packages/atomic/src/components/atomic-frequently-bought-together/atomic-frequently-bought-together.tsx
@@ -61,7 +61,7 @@ export class AtomicProductRecommendations {
         FREQUENTLY BOUGHT TOGETHER:
         <ul>
           {this.state.recommendations.map((p) => (
-            <li>{p.name}</li>
+            <li>{p.ec_name}</li>
           ))}
         </ul>
       </div>

--- a/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
+++ b/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
@@ -2,6 +2,7 @@ import {
   ActionsHistoryParam,
   BaseParam,
   ContextParam,
+  FieldsToIncludeParam,
   LocaleParam,
   MachineLearningParam,
   NumberOfResultsParam,
@@ -11,6 +12,7 @@ import {
 } from '../search-api-params';
 
 export type ProductRecommendationsRequest = BaseParam &
+  FieldsToIncludeParam &
   NumberOfResultsParam &
   MachineLearningParam &
   RecommendationParam &

--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -73,8 +73,60 @@ export interface ProductRecommendation {
    * An object containing the requested additional fields for the product.
    */
   additionalFields: Record<string, unknown>;
+
+  // Deprecated fields
+
+  /**
+   * @deprecated Use `permanentid` instead.
+   */
+  sku?: string;
+  /**
+   * @deprecated Use `ec_name` instead.
+   */
+  name?: string;
+  /**
+   * @deprecated Use `clickUri` instead.
+   */
+  link?: string;
+  /**
+   * @deprecated Use `ec_brand` instead.
+   */
+  brand?: string;
+  /**
+   * @deprecated Use `ec_category` instead.
+   */
+  category?: string;
+  /**
+   * @deprecated Use `ec_price` instead.
+   */
+  price?: number;
+  /**
+   * @deprecated Use `ec_shortdesc` instead.
+   */
+  shortDescription?: string;
+  /**
+   * @deprecated Use `ec_thumbnails` instead.
+   */
+  thumbnailUrl?: string;
+  /**
+   * @deprecated Use `ec_images` instead.
+   */
+  imageUrls?: string[];
+  /**
+   * @deprecated Use `ec_promo_price` instead.
+   */
+  promoPrice?: number;
+  /**
+   * @deprecated Use `ec_in_stock` instead.
+   */
+  inStock?: boolean;
+  /**
+   * @deprecated Use `ec_rating` instead.
+   */
+  rating?: number;
 }
 
+// Change this list when changing the fields exposed by `ProductRecommendation`
 export const ProductRecommendationDefaultFields: string[] = [
   'permanentid',
   'ec_name',

--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -2,69 +2,89 @@ export interface ProductRecommendation {
   /**
    * The SKU of the product.
    */
-  sku: string;
+  permanentid: string;
+  /**
+   * A direct link to the product in URL format.
+   */
+  clickUri: string;
   /**
    * Name of the product.
    *
    * From the `ec_name` field.
    */
-  name: string;
-  /**
-   * A direct link to the product in URL format.
-   */
-  link: string;
+  ec_name?: string;
   /**
    * Product brand.
    *
    * From the `ec_brand` field.
    */
-  brand?: string;
+  ec_brand?: string;
   /**
    * Category of the product (e.g., `"Electronics"`, `"Electronics|Televisions"`, or `"Electronics|Televisions|4K Televisions"`)
    *
    * From the `ec_category` field.
    */
-  category?: string;
+  ec_category?: string;
   /**
    * Base price of the product or variant.
    *
    * From the `ec_price` field.
    */
-  price?: number;
-  /**
-   * Short description of the product.
-   *
-   * From the `ec_shortdesc` field.
-   */
-  shortDescription?: string;
-  /**
-   * Product image in URL format.
-   *
-   * From the `ec_thumbnail` field.
-   */
-  thumbnailUrl?: string;
-  /**
-   * Additional product images in URL format.
-   *
-   * From the `ec_images` field.
-   */
-  imageUrls?: string[];
+  ec_price?: number;
   /**
    * Promotional price of product or variant.
    *
    * From the `ec_promo_price` field.
    */
-  promoPrice?: number;
+  ec_promo_price?: number;
+  /**
+   * Short description of the product.
+   *
+   * From the `ec_shortdesc` field.
+   */
+  ec_shortdesc?: string;
+  /**
+   * Product images in URL format.
+   *
+   * From the `ec_thumbnails` field.
+   */
+  ec_thumbnails?: string;
+  /**
+   * Additional product images in URL format.
+   *
+   * From the `ec_images` field.
+   */
+  ec_images?: string[];
+
   /**
    * Availability of the product (i.e., whether the product is in stock).
    *
    * From the `ec_in_stock` field.
    */
-  inStock?: boolean;
+  ec_in_stock?: boolean;
   /**
    * A rating based system from 0-10.
    *
    * From the `ec_rating` field.
    */
-  rating?: number;
+  ec_rating?: number;
+
+  /**
+   * An object containing the requested additional fields for the product.
+   */
+  additionalFields: Record<string, unknown>;
 }
+
+export const ProductRecommendationDefaultFields: string[] = [
+  'permanentid',
+  'ec_name',
+  'ec_brand',
+  'ec_category',
+  'ec_price',
+  'ec_promo_price',
+  'ec_shortdesc',
+  'ec_thumbnails',
+  'ec_images',
+  'ec_in_stock',
+  'ec_rating',
+];

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.test.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.test.ts
@@ -12,6 +12,7 @@ import {buildMockProductRecommendationsState} from '../../test/mock-product-reco
 import {Action} from 'redux';
 import {
   getProductRecommendations,
+  setProductRecommendationsAdditionalFields,
   setProductRecommendationsMaxNumberOfRecommendations,
   setProductRecommendationsRecommenderId,
   setProductRecommendationsSkus,
@@ -56,6 +57,13 @@ describe('headless product-recommendations', () => {
       options: {...baseOptions, maxNumberOfRecommendations: 10},
     });
     expectContainAction(setProductRecommendationsMaxNumberOfRecommendations);
+  });
+
+  it('when options.additionalFields is set to a non empty value, it dispatches #setProductRecommendationsAdditionalFields', () => {
+    productRecommendations = buildBaseProductRecommendationsList(engine, {
+      options: {...baseOptions, additionalFields: ['bloup']},
+    });
+    expectContainAction(setProductRecommendationsAdditionalFields);
   });
 
   it('when options.skus is set to a one item array, it dispatches #setProductRecommendationsSkus', () => {

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
@@ -4,6 +4,7 @@ import {
   setProductRecommendationsSkus,
   setProductRecommendationsMaxNumberOfRecommendations,
   setProductRecommendationsRecommenderId,
+  setProductRecommendationsAdditionalFields,
 } from '../../features/product-recommendations/product-recommendations-actions';
 import {
   ConfigurationSection,
@@ -20,6 +21,10 @@ import {
 import {validateOptions} from '../../utils/validate-payload';
 
 export const baseProductRecommendationsOptionsSchema = {
+  additionalFields: new ArrayValue<string>({
+    required: false,
+    each: new StringValue({emptyAllowed: false}),
+  }),
   skus: new ArrayValue<string>({
     required: false,
     each: new StringValue({emptyAllowed: false}),
@@ -75,6 +80,13 @@ export const buildBaseProductRecommendationsList = (
       number: options.maxNumberOfRecommendations,
     })
   );
+  if (options.additionalFields) {
+    dispatch(
+      setProductRecommendationsAdditionalFields({
+        additionalFields: options.additionalFields,
+      })
+    );
+  }
   if (options.skus) {
     dispatch(
       setProductRecommendationsSkus({

--- a/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations-options.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations-options.ts
@@ -9,4 +9,8 @@ export interface CartRecommendationsListOptions {
    * @default 5
    */
   maxNumberOfRecommendations?: number;
+  /**
+   * Additional fields to fetch in the results.
+   */
+  additionalFields?: string[];
 }

--- a/packages/headless/src/controllers/product-recommendations/headless-frequently-bought-together.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-frequently-bought-together.ts
@@ -14,6 +14,7 @@ const optionsSchema = new Schema({
   sku: new StringValue({required: true, emptyAllowed: false}),
   maxNumberOfRecommendations:
     baseProductRecommendationsOptionsSchema.maxNumberOfRecommendations,
+  additionalFields: baseProductRecommendationsOptionsSchema.additionalFields,
 });
 
 export type FrequentlyBoughtTogetherListOptions = SchemaValues<
@@ -43,6 +44,7 @@ export const buildFrequentlyBoughtTogetherList = (
     ...props,
     options: {
       maxNumberOfRecommendations: options.maxNumberOfRecommendations,
+      additionalFields: options.additionalFields,
       skus: [options.sku],
       id: 'frequentBought',
     },

--- a/packages/headless/src/controllers/product-recommendations/headless-popular-bought-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-popular-bought-recommendations.ts
@@ -13,6 +13,7 @@ import {validateOptions} from '../../utils/validate-payload';
 const optionsSchema = new Schema({
   maxNumberOfRecommendations:
     baseProductRecommendationsOptionsSchema.maxNumberOfRecommendations,
+  additionalFields: baseProductRecommendationsOptionsSchema.additionalFields,
 });
 
 export type PopularBoughtRecommendationsListOptions = SchemaValues<

--- a/packages/headless/src/controllers/product-recommendations/headless-popular-viewed-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-popular-viewed-recommendations.ts
@@ -13,6 +13,7 @@ import {validateOptions} from '../../utils/validate-payload';
 const optionsSchema = new Schema({
   maxNumberOfRecommendations:
     baseProductRecommendationsOptionsSchema.maxNumberOfRecommendations,
+  additionalFields: baseProductRecommendationsOptionsSchema.additionalFields,
 });
 
 export type PopularViewedRecommendationsListOptions = SchemaValues<

--- a/packages/headless/src/controllers/product-recommendations/headless-user-interest-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-user-interest-recommendations.ts
@@ -13,6 +13,7 @@ import {validateOptions} from '../../utils/validate-payload';
 const optionsSchema = new Schema({
   maxNumberOfRecommendations:
     baseProductRecommendationsOptionsSchema.maxNumberOfRecommendations,
+  additionalFields: baseProductRecommendationsOptionsSchema.additionalFields,
 });
 
 export type UserInterestRecommendationsListOptions = SchemaValues<

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -17,7 +17,10 @@ import {
 import {ArrayValue, NumberValue, StringValue} from '@coveo/bueno';
 import {getVisitorID, historyStore} from '../../api/analytics/analytics';
 import {ProductRecommendationsRequest} from '../../api/search/product-recommendations/product-recommendations-request';
-import {ProductRecommendation} from '../../api/search/search/product-recommendation';
+import {
+  ProductRecommendation,
+  ProductRecommendationDefaultFields,
+} from '../../api/search/search/product-recommendation';
 import {Result} from '../../api/search/search/result';
 import {logProductRecommendations} from './product-recommendations-analytics.actions';
 import {SearchAction} from '../analytics/analytics-utils';
@@ -69,6 +72,17 @@ export const setProductRecommendationsCategoryFilter = createAction(
     })
 );
 
+export const setProductRecommendationsAdditionalFields = createAction(
+  'productrecommendations/setAdditionalFields',
+  (payload: {additionalFields: string[]}) =>
+    validatePayload(payload, {
+      additionalFields: new ArrayValue({
+        required: true,
+        each: new StringValue({emptyAllowed: false}),
+      }),
+    })
+);
+
 export const setProductRecommendationsMaxNumberOfRecommendations = createAction(
   'productrecommendations/setMaxNumberOfRecommendations',
   (payload: {number: number}) =>
@@ -94,7 +108,11 @@ export const getProductRecommendations = createAsyncThunk<
       return rejectWithValue(fetched.error);
     }
     return {
-      recommendations: fetched.success.results.map(mapResultToProductResult),
+      recommendations: fetched.success.results.map((result) =>
+        mapResultToProductResult(result, {
+          additionalFields: state.productRecommendations.additionalFields || [],
+        })
+      ),
       analyticsAction: logProductRecommendations(),
       searchUid: fetched.success.searchUid,
       duration,
@@ -102,28 +120,39 @@ export const getProductRecommendations = createAsyncThunk<
   }
 );
 
-const mapResultToProductResult = (result: Result): ProductRecommendation => {
-  const price = result.raw.ec_price as number | undefined;
-  const promoPrice = result.raw.ec_promo_price as number | undefined;
-  const inStock = result.raw.ec_in_stock as string | undefined;
+const mapResultToProductResult = (
+  result: Result,
+  {additionalFields}: {additionalFields: string[]}
+): ProductRecommendation => {
+  const ec_price = result.raw.ec_price as number | undefined;
+  const ec_promo_price = result.raw.ec_promo_price as number | undefined;
+  const ec_in_stock = result.raw.ec_in_stock as string | undefined;
 
   return {
-    sku: result.raw.permanentid!,
-    name: result.raw.ec_name as string,
-    link: result.clickUri,
-    brand: result.raw.ec_brand as string,
-    category: result.raw.ec_category as string,
-    price,
-    shortDescription: result.raw.ec_shortdesc as string,
-    thumbnailUrl: result.raw.ec_thumbnail as string,
-    imageUrls: result.raw.ec_images as string[],
-    promoPrice:
-      promoPrice === undefined || (price !== undefined && promoPrice >= price)
+    permanentid: result.raw.permanentid!,
+    clickUri: result.clickUri,
+    ec_name: result.raw.ec_name as string,
+    ec_brand: result.raw.ec_brand as string,
+    ec_category: result.raw.ec_category as string,
+    ec_price,
+    ec_shortdesc: result.raw.ec_shortdesc as string,
+    ec_thumbnails: result.raw.ec_thumbnails as string,
+    ec_images: result.raw.ec_images as string[],
+    ec_promo_price:
+      ec_promo_price === undefined ||
+      (ec_price !== undefined && ec_promo_price >= ec_price)
         ? undefined
-        : promoPrice,
-    inStock:
-      inStock === undefined ? undefined : inStock.toLowerCase() === 'yes',
-    rating: result.raw.ec_rating as number,
+        : ec_promo_price,
+    ec_in_stock:
+      ec_in_stock === undefined
+        ? undefined
+        : ec_in_stock.toLowerCase() === 'yes' ||
+          ec_in_stock.toLowerCase() === 'true',
+    ec_rating: result.raw.ec_rating as number,
+    additionalFields: additionalFields.reduce(
+      (all, field) => ({...all, [field]: result.raw[field]}),
+      {}
+    ),
   };
 };
 
@@ -140,6 +169,10 @@ export const buildProductRecommendationsRequest = (
     }),
     recommendation: s.productRecommendations.id,
     numberOfResults: s.productRecommendations.maxNumberOfRecommendations,
+    fieldsToInclude: [
+      ...ProductRecommendationDefaultFields,
+      ...(s.productRecommendations.additionalFields || []),
+    ],
     mlParameters: {
       ...(s.productRecommendations.skus &&
         s.productRecommendations.skus.length > 0 && {

--- a/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-slice.test.ts
@@ -2,6 +2,7 @@ import {buildMockProductRecommendations} from '../../test/mock-product-recommend
 import {buildMockProductRecommendation} from '../../test/mock-product-recommendation';
 import {
   getProductRecommendations,
+  setProductRecommendationsAdditionalFields,
   setProductRecommendationsSkus,
 } from './product-recommendations-actions';
 import {productRecommendationsReducer} from './product-recommendations-slice';
@@ -10,7 +11,7 @@ import {
   ProductRecommendationsState,
 } from './product-recommendations-state';
 
-describe('frequently-bought-together slice', () => {
+describe('product-recommendations-slice', () => {
   let state: ProductRecommendationsState;
   beforeEach(() => {
     state = getProductRecommendationsInitialState();
@@ -28,6 +29,17 @@ describe('frequently-bought-together slice', () => {
         setProductRecommendationsSkus({skus: ['foo']})
       ).skus
     ).toEqual(['foo']);
+  });
+
+  it('should allow to set the additional fields', () => {
+    expect(
+      productRecommendationsReducer(
+        state,
+        setProductRecommendationsAdditionalFields({
+          additionalFields: ['somefield'],
+        })
+      ).additionalFields
+    ).toEqual(['somefield']);
   });
 
   it('when a getProductRecommendations fulfilled is received, it updates the state to the received payload', () => {

--- a/packages/headless/src/features/product-recommendations/product-recommendations-slice.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-slice.ts
@@ -5,6 +5,7 @@ import {
   setProductRecommendationsBrandFilter,
   setProductRecommendationsCategoryFilter,
   setProductRecommendationsMaxNumberOfRecommendations,
+  setProductRecommendationsAdditionalFields,
   setProductRecommendationsRecommenderId,
 } from './product-recommendations-actions';
 import {getProductRecommendationsInitialState} from './product-recommendations-state';
@@ -32,6 +33,9 @@ export const productRecommendationsReducer = createReducer(
           state.maxNumberOfRecommendations = action.payload.number;
         }
       )
+      .addCase(setProductRecommendationsAdditionalFields, (state, action) => {
+        state.additionalFields = action.payload.additionalFields;
+      })
       .addCase(getProductRecommendations.rejected, (state, action) => {
         state.error = action.payload ? action.payload : null;
         state.isLoading = false;

--- a/packages/headless/src/features/product-recommendations/product-recommendations-state.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-state.ts
@@ -10,6 +10,7 @@ export type ProductRecommendationsState = {
     brand: string;
     category: string;
   };
+  additionalFields: string[];
   recommendations: ProductRecommendation[];
   error: SearchAPIErrorWithStatusCode | null;
   isLoading: boolean;
@@ -25,6 +26,7 @@ export const getProductRecommendationsInitialState = (): ProductRecommendationsS
     brand: '',
     category: '',
   },
+  additionalFields: [],
   recommendations: [],
   error: null,
   isLoading: false,

--- a/packages/headless/src/test/mock-product-recommendation.ts
+++ b/packages/headless/src/test/mock-product-recommendation.ts
@@ -4,9 +4,10 @@ export function buildMockProductRecommendation(
   config: Partial<ProductRecommendation> = {}
 ): ProductRecommendation {
   return {
-    sku: '',
-    name: '',
-    link: '',
+    permanentid: '',
+    clickUri: '',
+    ec_name: '',
+    additionalFields: {},
     ...config,
   };
 }


### PR DESCRIPTION
And rename the product recommendations fields

The core of the discussion is here: https://discuss.coveo.com/t/product-recommendations-mapping-filtering-out-fields/5400

Basically, we want to allow retrieving other fields than the Commerce Standard Fields, but also make it clear that they are not from the standard.

So you can now request "additionalFields" which will be returned in the "additionalFields" object.

We also renamed the properties so that they match what fields they come from. It was more confusing than helping, really.

[COM-918]

[COM-918]: https://coveord.atlassian.net/browse/COM-918