### PR TITLE
docs: filter duplicate inherited members

### DIFF
--- a/packages/headless/doc-parser/src/interface-resolver.test.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.test.ts
@@ -698,6 +698,56 @@ describe('#resolveInterfaceMembers', () => {
     expect(result).toEqual([expected]);
   });
 
+  it(`an interface extends two interfaces,
+  both inherited interfaces have a property with the same name,
+  it only keeps one inherited instance`, () => {
+    const entry = buildMockEntryPoint();
+    const standaloneSearchBox = buildMockApiInterface({
+      name: 'StandaloneSearchBox',
+      excerptTokens: [
+        buildContentExcerptToken('interface StandaloneSearchBox extends '),
+        buildReferenceExcerptToken('SearchBox', ''),
+        buildContentExcerptToken(', '),
+        buildReferenceExcerptToken('Controller', ''),
+        buildContentExcerptToken(' '),
+      ],
+      extendsTokenRanges: [
+        {startIndex: 1, endIndex: 3},
+        {startIndex: 3, endIndex: 5},
+      ],
+    });
+
+    const createValueMemeber = () =>
+      buildMockApiPropertySignature({
+        name: 'value',
+        excerptTokens: [
+          buildContentExcerptToken('value: '),
+          buildContentExcerptToken('string'),
+          buildContentExcerptToken(';'),
+        ],
+        propertyTypeTokenRange: {startIndex: 1, endIndex: 2},
+      });
+
+    const searchBox = buildMockApiInterface({
+      name: 'SearchBox',
+      members: [createValueMemeber()],
+    });
+
+    const controller = buildMockApiInterface({
+      name: 'Controller',
+      members: [createValueMemeber()],
+    });
+
+    entry.addMember(standaloneSearchBox);
+    entry.addMember(searchBox);
+    entry.addMember(controller);
+
+    const result = resolveInterfaceMembers(entry, standaloneSearchBox, []);
+    const valueEntity = buildMockEntity({name: 'value', type: 'string'});
+
+    expect(result).toEqual([valueEntity]);
+  });
+
   // Allowing members to be parsed twice gives a chance for the extractor to set `isTypeExtracted` to true.
   // Source: https://github.com/coveo/ui-kit/pull/567#discussion_r586461134
   it(`an interface has a property of its own type,

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -52,7 +52,12 @@ function filterOverridesAndCombine(
 ) {
   const memberNames = new Set();
   members.forEach((m) => memberNames.add(m.name));
-  const filtered = inheritedMembers.filter((m) => !memberNames.has(m.name));
+
+  const filtered = inheritedMembers.filter((m) => {
+    const shouldKeep = !memberNames.has(m.name);
+    memberNames.add(m.name);
+    return shouldKeep;
+  });
 
   return members.concat(filtered);
 }

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -12,7 +12,6 @@ import {
 } from '../../state/state-sections';
 import {randomID} from '../../utils/utils';
 import {validateOptions} from '../../utils/validate-payload';
-import {Controller} from '../controller/headless-controller';
 import {
   buildSearchBox,
   SearchBox,
@@ -34,7 +33,7 @@ export interface StandaloneSearchBoxProps {
  * The `StandaloneSearchBox` headless controller offers a high-level interface for designing a common search box UI controller.
  * Meant to be used for a search box that will redirect instead of executing a query.
  */
-export interface StandaloneSearchBox extends SearchBox, Controller {
+export interface StandaloneSearchBox extends SearchBox {
   /**
    * Triggers a redirection.
    */


### PR DESCRIPTION
The parser was only filtering members that already existed at the top-level interface. This PR adjusts the logic to filter duplicates among inherited interfaces.

Example:

```
interface A extends B, C {}
```

If `B` and `C` both have the member `bar`, it will now only be included once as a member of A.

Once this PR is merged, I will start a ui-kit release and we will publish docs shortly afterward.