### PR TITLE
docs(headless): added automatic documentation for actions

### DIFF
--- a/packages/headless/dist/parsed_doc.json
+++ b/packages/headless/dist/parsed_doc.json
@@ -1,0 +1,180 @@
+{
+  "controllers": [ "Hidden for this PR" ],
+  "actions": [
+    {
+      "name": "AdvancedSearchQueriesActions",
+      "members": []
+    },
+    {
+      "name": "AnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "BreadcrumbActions",
+      "members": []
+    },
+    {
+      "name": "CategoryFacetAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "CategoryFacetSetActions",
+      "members": []
+    },
+    {
+      "name": "ConfigurationActions",
+      "members": []
+    },
+    {
+      "name": "ContextActions",
+      "members": []
+    },
+    {
+      "name": "DateFacetActions",
+      "members": []
+    },
+    {
+      "name": "DateFacetAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "DidYouMeanActions",
+      "members": []
+    },
+    {
+      "name": "DidYouMeanAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "FacetActions",
+      "members": []
+    },
+    {
+      "name": "FacetAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "FacetGenericAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "FieldActions",
+      "members": []
+    },
+    {
+      "name": "HistoryActions",
+      "members": []
+    },
+    {
+      "name": "HistoryAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "NumericFacetActions",
+      "members": []
+    },
+    {
+      "name": "NumericFacetAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "PaginationActions",
+      "members": []
+    },
+    {
+      "name": "PaginationAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "PipelineActions",
+      "members": []
+    },
+    {
+      "name": "ProductRecommendationAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "ProductRecommendationsActions",
+      "members": []
+    },
+    {
+      "name": "QueryActions",
+      "members": []
+    },
+    {
+      "name": "QueryAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "QuerySetActions",
+      "members": []
+    },
+    {
+      "name": "QuerySuggestActions",
+      "members": []
+    },
+    {
+      "name": "QuerySuggestAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "RecommendationActions",
+      "members": []
+    },
+    {
+      "name": "RecommendationAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "RedirectionActions",
+      "members": []
+    },
+    {
+      "name": "RedirectionAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "ResultAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "SearchActions",
+      "members": [
+        {
+          "actionKind": "asyncThunk",
+          "fullName": "search/executeSearch",
+          "desc": "Executes a search query.",
+          "parameter": {
+            "name": "analyticsAction",
+            "type": "SearchAction",
+            "desc": "The analytics action to log after a successful query.",
+            "isOptional": false,
+            "kind": "primitive"
+          }
+        },
+        {
+          "actionKind": "asyncThunk",
+          "fullName": "search/fetchMoreResults",
+          "desc": "Executes a search query and appends the results after the existing ones.",
+          "parameter": null
+        }
+      ]
+    },
+    {
+      "name": "SearchAnalyticsActions",
+      "members": []
+    },
+    {
+      "name": "SearchHubActions",
+      "members": []
+    },
+    {
+      "name": "SortCriterionActions",
+      "members": []
+    },
+    {
+      "name": "SortCriterionAnalyticsActions",
+      "members": []
+    }
+  ]
+}

--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -1,5 +1,6 @@
 import {ApiModel} from '@microsoft/api-extractor-model';
 import {writeFileSync} from 'fs';
+import {resolveActionNamespaces} from './src/actions-resolver';
 import {
   ControllerConfiguration,
   resolveController,
@@ -265,8 +266,11 @@ const controllers: ControllerConfiguration[] = [
   },
 ];
 
-const result = controllers.map((controller) =>
-  resolveController(entryPoint, controller)
-);
+const result = {
+  controllers: controllers.map((controller) =>
+    resolveController(entryPoint, controller)
+  ),
+  actions: resolveActionNamespaces(entryPoint),
+};
 
 writeFileSync('dist/parsed_doc.json', JSON.stringify(result, null, 2));

--- a/packages/headless/doc-parser/src/actions-resolver.ts
+++ b/packages/headless/doc-parser/src/actions-resolver.ts
@@ -1,0 +1,87 @@
+import {
+  ApiEntryPoint,
+  ApiItemKind,
+  ApiVariable,
+} from '@microsoft/api-extractor-model';
+import {DocNode, DocParamBlock} from '@microsoft/tsdoc';
+import {AnyEntity, Entity} from './entity';
+import {emitAsTsDoc} from './tsdoc-emitter';
+
+interface ActionsNamespace {
+  name: string;
+  members: Action[];
+}
+
+enum ActionKind {
+  Action = 'action',
+  AsyncAction = 'asyncThunk',
+  AnalyticsAction = 'analyticsAction',
+}
+
+interface Action {
+  desc: string;
+  fullName: string;
+  parameter: AnyEntity | null;
+  actionKind: ActionKind;
+}
+
+export function resolveActionNamespaces(
+  entry: ApiEntryPoint
+): ActionsNamespace[] {
+  return entry.members
+    .filter(
+      (member) =>
+        member.kind === ApiItemKind.Namespace &&
+        member.displayName.endsWith('Actions')
+    )
+    .map((namespace) => ({
+      name: namespace.displayName,
+      members: namespace.members
+        .filter((member) => member.kind === ApiItemKind.Variable)
+        .map((action) => resolveAction(action as ApiVariable))
+        .filter((action) => action) as Action[],
+    }));
+}
+
+function resolveAction(variable: ApiVariable): Action | null {
+  const tokens = variable.excerpt.tokens.map(({text}) => text);
+
+  if (tokens[1] === 'AsyncThunkDefinition') {
+    const actionNameToken = tokens[2];
+    const [, actionName] = /"([^"]*)"/.exec(actionNameToken)!;
+    const parameterTypeName = tokens[4].trim() === ',' ? tokens[5] : null;
+
+    return {
+      actionKind: ActionKind.AsyncAction,
+      fullName: actionName,
+      desc: variable.tsdocComment
+        ? emitAsTsDoc(
+            (variable.tsdocComment.summarySection
+              .nodes as unknown) as readonly DocNode[]
+          )
+        : '',
+      parameter: parameterTypeName
+        ? resolveActionParameter(
+            parameterTypeName,
+            (variable.tsdocComment?.params?.blocks[0] ??
+              null) as DocParamBlock | null
+          )
+        : null,
+    };
+  }
+
+  return null;
+}
+
+function resolveActionParameter(
+  parameterTypeName: string,
+  parameterDoc: DocParamBlock | null
+): Entity {
+  return {
+    name: parameterDoc?.parameterName ?? parameterTypeName,
+    type: parameterTypeName,
+    desc: parameterDoc ? emitAsTsDoc(parameterDoc.content.nodes) : '',
+    isOptional: false,
+    kind: 'primitive',
+  };
+}

--- a/packages/headless/doc-parser/tsconfig.json
+++ b/packages/headless/doc-parser/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../tsconfig.json",
+  
   "compilerOptions": {
     "outDir": "build",
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "lib": ["es2019"]
   },
   "exclude": [
     "./**/*.test.ts"

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -26,7 +26,7 @@
     "npm:publish": "npm publish --access public",
     "doc:generate": "npm run doc:extract && npm run doc:parse",
     "doc:extract": "api-extractor run --local --verbose",
-    "doc:parse": "ts-node --project ./doc-parser/tsconfig.build.json ./doc-parser/doc-parser.ts"
+    "doc:parse": "ts-node --project ./doc-parser/tsconfig.json ./doc-parser/doc-parser.ts"
   },
   "dependencies": {
     "@coveo/bueno": "^0.8.0",

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -32,19 +32,19 @@ export type SearchAction = AsyncThunkAction<
   {analyticsType: AnalyticsType.Search},
   void | {},
   AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
->;
+> & {name: string};
 
 export type CustomAction = AsyncThunkAction<
   {analyticsType: AnalyticsType.Custom},
   {},
   {}
->;
+> & {name: string};
 
 export type ClickAction = AsyncThunkAction<
   {analyticsType: AnalyticsType.Click},
   {},
   {}
->;
+> & {name: string};
 
 const searchPageState = (getState: () => unknown) =>
   getState() as SearchAppState;

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -196,18 +196,26 @@ export namespace RedirectionActions {
   export const buildPlanRequest = buildPlanRequestAlias;
 }
 
+export {
+  StateNeededByExecuteSearch,
+  ExecuteSearchThunkReturn,
+} from './search/search-actions';
+
 import {
-  StateNeededByExecuteSearch as StateNeededByExecuteSearchAlias,
-  ExecuteSearchThunkReturn as ExecuteSearchThunkReturnAlias,
-  executeSearch as executeSearchAlias,
   buildSearchRequest as buildSearchRequestAlias,
+  executeSearch as executeSearchAlias,
   fetchMoreResults as fetchMoreResultsAlias,
 } from './search/search-actions';
 export namespace SearchActions {
-  export type StateNeededByExecuteSearch = StateNeededByExecuteSearchAlias;
-  export type ExecuteSearchThunkReturn = ExecuteSearchThunkReturnAlias;
-  export const executeSearch = executeSearchAlias;
   export const buildSearchRequest = buildSearchRequestAlias;
+  /**
+   * Executes a search query.
+   * @param analyticsAction - The analytics action to log after a successful query.
+   */
+  export const executeSearch = executeSearchAlias;
+  /**
+   * Executes a search query and appends the results after the existing ones.
+   */
   export const fetchMoreResults = fetchMoreResultsAlias;
 }
 
@@ -282,3 +290,5 @@ export namespace ResultTemplatesHelpers {
   export const fieldMustMatch = fieldMustMatchAlias;
   export const fieldMustNotMatch = fieldMustNotMatchAlias;
 }
+
+export {SearchAction} from './analytics/analytics-utils';

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -44,6 +44,7 @@ import {extractHistory} from '../history/history-state';
 import {sortFacets} from '../../utils/facet-utils';
 import {getSearchInitialState} from './search-state';
 import {logFetchMoreResults, logQueryError} from './search-analytics-actions';
+import {AsyncThunkDefinition} from '../../utils/action';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -94,18 +95,16 @@ const fetchFromAPI = async (
 
 /**
  * Executes a search query.
- * @param analyticsAction (SearchAction) The analytics action to log after a successful query.
+ * @param analyticsAction - The analytics action to log after a successful query.
  */
-export const executeSearch = createAsyncThunk<
+export const executeSearch: AsyncThunkDefinition<
+  'search/executeSearch',
   ExecuteSearchThunkReturn,
   SearchAction,
   AsyncThunkSearchOptions<StateNeededByExecuteSearch>
->(
+> = createAsyncThunk(
   'search/executeSearch',
-  async (
-    analyticsAction: SearchAction,
-    {getState, dispatch, rejectWithValue, extra}
-  ) => {
+  async (analyticsAction, {getState, dispatch, rejectWithValue, extra}) => {
     const state = getState();
     addEntryInActionsHistory(state);
     const fetched = await fetchFromAPI(
@@ -158,7 +157,7 @@ export const executeSearch = createAsyncThunk<
     );
     dispatch(snapshot(extractHistory(getState())));
 
-    return {
+    return <ExecuteSearchThunkReturn>{
       ...retried,
       response: {
         ...retried.response.success,
@@ -170,11 +169,15 @@ export const executeSearch = createAsyncThunk<
   }
 );
 
-export const fetchMoreResults = createAsyncThunk<
+/**
+ * Executes a search query and appends the results after the existing ones.
+ */
+export const fetchMoreResults: AsyncThunkDefinition<
+  'search/fetchMoreResults',
   ExecuteSearchThunkReturn,
   void,
   AsyncThunkSearchOptions<StateNeededByExecuteSearch>
->(
+> = createAsyncThunk(
   'search/fetchMoreResults',
   async (
     _,
@@ -194,7 +197,7 @@ export const fetchMoreResults = createAsyncThunk<
 
     dispatch(snapshot(extractHistory(state)));
 
-    return {
+    return <ExecuteSearchThunkReturn>{
       ...fetched,
       response: fetched.response.success,
       automaticallyCorrected: false,

--- a/packages/headless/src/utils/action.ts
+++ b/packages/headless/src/utils/action.ts
@@ -1,0 +1,11 @@
+import {AsyncThunk} from '@reduxjs/toolkit';
+
+export type AsyncThunkDefinition<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  BaseActionType extends string,
+  ReturnType,
+  ArgumentType,
+  Context
+> = AsyncThunk<ReturnType, ArgumentType, Context> & {
+  typePrefix: BaseActionType | string;
+};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-543

This isn't meant to be merged, this is only here to highlight the major issues with automatically document actions and discuss solutions. Assume that most of the code in this PR is there for demonstrative purpose and will be refactored.

Currently, in this PR, every action namespace is parsed and no samples are included. I will explore attaching samples after this PR since this is getting very big.