### PR TITLE
docs(headless): extract default values for controller options

### DIFF
--- a/packages/headless/doc-parser/src/entity-builder.test.ts
+++ b/packages/headless/doc-parser/src/entity-builder.test.ts
@@ -18,6 +18,23 @@ describe('#buildEntity', () => {
     expect(entity.desc).toBe('The number of pages to display in the pager.');
   });
 
+  it(`when a docComment contains an @defaultValue tag,
+  it sets the defaultValue to the default`, () => {
+    const parser = new TSDocParser();
+    const {docComment} = parser.parseString(
+      '/**\n * The number of pages to display in the pager.\n *\n * @defaultValue `5`\n */\n'
+    );
+
+    const entity = buildEntity({
+      name: 'numberOfPages',
+      type: 'number',
+      isOptional: true,
+      comment: docComment,
+    });
+
+    expect(entity.defaultValue).toBe('`5`');
+  });
+
   it(`when a docComment contains a summary and a non-standard tag (e.g. @default),
   it ignores the non-standard tag`, () => {
     const parser = new TSDocParser();

--- a/packages/headless/doc-parser/src/entity.ts
+++ b/packages/headless/doc-parser/src/entity.ts
@@ -29,7 +29,9 @@ export interface Entity
     Name,
     Description,
     Type,
-    Optional {}
+    Optional {
+  defaultValue?: string;
+}
 
 export interface EntityWithTypeAlias
   extends Kind<'primitive-with-type-alias'>,

--- a/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
@@ -5,7 +5,7 @@ export interface FacetSearchRequestOptions {
   /** A dictionary that maps index field values to facet value display names. */
   captions: Record<string, string>;
   /** The maximum number of values to fetch.
-   * @default 10
+   * @defaultValue `10`
    */
   numberOfValues: number;
   /** The string to match.*/

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-options.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-options.ts
@@ -24,14 +24,14 @@ export interface CategoryFacetOptions {
   /**
    * The base path shared by all values for the facet.
    *
-   * @default []
+   * @defaultValue `[]`
    */
   basePath?: string[];
 
   /**
    * The character that specifies the hierarchical dependency.
    *
-   * @default ";"
+   * @defaultValue `;`
    */
   delimitingCharacter?: string;
 
@@ -48,14 +48,14 @@ export interface CategoryFacetOptions {
   /**
    * Whether to use basePath as a filter for the results.
    *
-   * @default true
+   * @defaultValue `true`
    */
   filterByBasePath?: boolean;
 
   /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    *
-   * @default true
+   * @defaultValue `true`
    */
   filterFacetCount?: boolean;
 
@@ -64,23 +64,25 @@ export interface CategoryFacetOptions {
    *
    * Note: A high injectionDepth may negatively impact the facet request performance.
    *
-   * @default 1000
-   * @minimum 0
+   * Minimum: `0`
+   *
+   * @defaultValue `1000`
    * */
   injectionDepth?: number;
 
   /**
    * The number of values to request for this facet. Also determines the number of additional values to request each time this facet is expanded, and the number of values to display when this facet is collapsed.
    *
-   * @default 5
-   * @minimum 1
+   * Minimum: `1`
+   *
+   * @defaultValue `5`
    */
   numberOfValues?: number;
 
   /**
    * The criterion to use for sorting returned facet values.
    *
-   * @default "occurences"
+   * @defaultValue `occurences`
    */
   sortCriteria?: CategoryFacetSortCriterion;
 }
@@ -94,7 +96,7 @@ export interface CategoryFacetSearchOptions {
   /**
    * The maximum number of values to fetch.
    *
-   * @default 10
+   * @defaultValue `10`
    */
   numberOfValues?: number;
 

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -22,7 +22,7 @@ export interface FacetOptions {
   /**
    * The character that separates values of a multi-value field.
    *
-   * @default ">"
+   * @defaultValue `>`
    */
   delimitingCharacter?: string;
 
@@ -39,7 +39,7 @@ export interface FacetOptions {
   /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    *
-   * @default true
+   * @defaultValue `true`
    */
   filterFacetCount?: boolean;
 
@@ -48,23 +48,25 @@ export interface FacetOptions {
    *
    * Note: A high injectionDepth may negatively impact the facet request performance.
    *
-   * @default 1000
-   * @minimum 0
+   * Minimum: `0`
+   *
+   * @defaultValue `1000`
    * */
   injectionDepth?: number;
 
   /**
    * The number of values to request for this facet. Also determines the number of additional values to request each time this facet is expanded, and the number of values to display when this facet is collapsed.
    *
-   * @default 8
-   * @minimum 1
+   * Minimum: `1`
+   *
+   * @defaultValue `8`
    */
   numberOfValues?: number;
 
   /**
    * The criterion to use for sorting returned facet values.
    *
-   * @default "automatic"
+   * @defaultValue `automatic`
    */
   sortCriteria?: FacetSortCriterion;
 }
@@ -78,7 +80,7 @@ export interface FacetSearchOptions {
   /**
    * The maximum number of values to fetch.
    *
-   * @default 10
+   * @defaultValue `10`
    */
   numberOfValues?: number;
 

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/date-range.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/date-range.ts
@@ -23,14 +23,14 @@ export interface DateRangeOptions {
   /**
    * Whether to include the end value in the range.
    *
-   * @default false
+   * @defaultValue `false`
    */
   endInclusive?: boolean;
 
   /**
    * The current facet value state.
    *
-   * @default "idle"
+   * @defaultValue `idle`
    */
   state?: FacetValueState;
 
@@ -42,7 +42,7 @@ export interface DateRangeOptions {
   /**
    * If `true`, the date will be returned unshifted. If `false`, the date will be adjusted to UTC time.
    *
-   * @default false
+   * @defaultValue `false`
    */
   useLocalTime?: boolean;
 }

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet-options.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet-options.ts
@@ -40,7 +40,7 @@ export interface DateFacetOptions {
    * If `generateAutomaticRanges` is false, values must be specified.
    * If `generateAutomaticRanges` is true, automatic ranges are going to be appended after the specified values.
    *
-   * @default []
+   * @defaultValue `[]`
    */
   currentValues?: DateRangeRequest[];
 
@@ -53,7 +53,7 @@ export interface DateFacetOptions {
   /**
    * Whether to exclude folded result parents when estimating the result count for each facet value.
    *
-   * @default true
+   * @defaultValue `true`
    */
   filterFacetCount?: boolean;
 
@@ -62,8 +62,9 @@ export interface DateFacetOptions {
    *
    * Note: A high injectionDepth may negatively impact the facet request performance.
    *
-   * @default 1000
-   * @minimum 0
+   * Minimum: `0`
+   *
+   * @defaultValue `1000`
    */
   injectionDepth?: number;
 
@@ -71,15 +72,16 @@ export interface DateFacetOptions {
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time this facet is expanded, and the number of values to display when this facet is collapsed.
    *
-   * @minimum 1
-   * @default 8
+   * Minimum: `1`
+   *
+   * @defaultValue `8`
    */
   numberOfValues?: number;
 
   /**
    * The sort criterion to apply to the returned facet values.
    *
-   * @default "ascending"
+   * @defaultValue `ascending`
    */
   sortCriteria?: RangeFacetSortCriterion;
 }

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
@@ -44,7 +44,7 @@ export interface NumericFacetOptions {
    * If `generateAutomaticRanges` is false, values must be specified.
    * If `generateAutomaticRanges` is true, automatic ranges are going to be appended after the specified values.
    *
-   * @default []
+   * @defaultValue `[]`
    */
   currentValues?: NumericRangeRequest[];
 
@@ -57,7 +57,7 @@ export interface NumericFacetOptions {
   /**
    * Whether to exclude folded result parents when estimating the result count for each facet value.
    *
-   * @default true
+   * @defaultValue `true`
    */
   filterFacetCount?: boolean;
 
@@ -66,8 +66,9 @@ export interface NumericFacetOptions {
    *
    * Note: A high injectionDepth may negatively impact the facet request performance.
    *
-   * @default 1000
-   * @minimum 0
+   * Minimum: `0`
+   *
+   * @defaultValue `1000`
    */
   injectionDepth?: number;
 
@@ -75,15 +76,16 @@ export interface NumericFacetOptions {
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time this facet is expanded, and the number of values to display when this facet is collapsed.
    *
-   * @minimum 1
-   * @default 8
+   * Minimum: `1`
+   *
+   * @defaultValue `8`
    */
   numberOfValues?: number;
 
   /**
    * The sort criterion to apply to the returned facet values.
    *
-   * @default "ascending"
+   * @defaultValue `ascending`
    */
   sortCriteria?: RangeFacetSortCriterion;
 }

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/numeric-range.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/numeric-range.ts
@@ -15,14 +15,14 @@ export interface NumericRangeOptions {
   /**
    * Whether to include the `end` value in the range.
    *
-   * @default false
+   * @defaultValue `false`
    */
   endInclusive?: boolean;
 
   /**
    * The current facet value state.
    *
-   * @default "idle"
+   * @defaultValue `idle`
    */
   state?: FacetValueState;
 }

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -39,7 +39,7 @@ export interface PagerOptions {
   /**
    * The number of pages to display in the pager.
    *
-   * @default 5
+   * @defaultValue `5`
    * */
   numberOfPages?: number;
 }

--- a/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations-options.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations-options.ts
@@ -6,7 +6,7 @@ export interface CartRecommendationsListOptions {
   /**
    * The maximum number of recommendations, from 1 to 50.
    *
-   * @default 5
+   * @defaultValue `5`
    */
   maxNumberOfRecommendations?: number;
   /**

--- a/packages/headless/src/controllers/recommendation/headless-recommendation.ts
+++ b/packages/headless/src/controllers/recommendation/headless-recommendation.ts
@@ -25,7 +25,7 @@ export interface RecommendationListOptions {
   /**
    * The Recommendation identifier used by the Coveo platform to retrieve recommended documents.
    *
-   * @default "Recommendation".
+   * @defaultValue `Recommendation`
    */
   id?: string;
 }

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.ts
@@ -12,7 +12,7 @@ export interface InteractiveResultOptions {
   /**
    * The amount of time to wait before selecting the result after calling `beginDelayedSelect`.
    *
-   * @default 1000
+   * @defaultValue `1000`
    */
   selectionDelay?: number;
 }

--- a/packages/headless/src/controllers/search-box/headless-search-box-options.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box-options.ts
@@ -18,7 +18,7 @@ export interface SearchBoxOptions {
   /**
    * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
    *
-   * @default false
+   * @defaultValue `false`
    */
   enableQuerySyntax?: boolean;
 
@@ -32,7 +32,7 @@ export interface SearchBoxOptions {
    *
    * Using the value `0` disables the query suggest feature.
    *
-   * @default 5
+   * @defaultValue `5`
    */
   numberOfSuggestions?: number;
 }

--- a/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
@@ -26,18 +26,18 @@ export interface CategoryFacetRequest
     Delimitable,
     Type<'hierarchical'>,
     SortCriteria<CategoryFacetSortCriterion> {
-  /** @default 5 */
+  /** @defaultValue `5` */
   numberOfValues: number;
-  /** @default ";" */
+  /** @defaultValue `;` */
   delimitingCharacter: string;
-  /** @default "occurrences" */
+  /** @defaultValue `occurrences` */
   sortCriteria: CategoryFacetSortCriterion;
   /** The base path shared by all values for the facet.
-   * @default []
+   * @defaultValue `[]`
    */
   basePath: string[];
   /** Whether to use basePath as a filter for the results.
-   * @default true
+   * @defaultValue `true`
    */
   filterByBasePath: boolean;
 }

--- a/packages/headless/src/features/facets/facet-api/request.ts
+++ b/packages/headless/src/features/facets/facet-api/request.ts
@@ -9,61 +9,62 @@ export interface BaseFacetRequest {
   /** The field whose values you want to display in the facet.*/
   field: string;
   /** Whether to exclude folded result parents when estimating the result count for each facet value.
-   * @default true
+   * @defaultValue `true`
    */
   filterFacetCount: boolean;
   /** The maximum number of results to scan in the index to ensure that the facet lists all potential facet values.
    *
    * Note: A high injectionDepth may negatively impact the facet request performance.
    *
-   * @default 1000
-   * @minimum 0
+   * Minimum: `0`
+   *
+   * @defaultValue `1000`
    */
   injectionDepth: number;
   /**
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time this facet is expanded, and the number of values to display when this facet is collapsed.
-   * @minimum 1
-   * @default 8
+   * Minimum: `1`
+   * @defaultValue `8`
    */
   numberOfValues: number;
   /** Whether to prevent Coveo ML from automatically selecting values.
-   * @default false
+   * @defaultValue `false`
    */
   preventAutoSelect: boolean;
 }
 
 export interface BaseFacetValueRequest {
   /** The current facet value state.
-   * @default "idle"
+   * @defaultValue `idle`
    */
   state: FacetValueState;
 }
 
 export interface CurrentValues<T> {
   /** The values displayed by the facet in the search interface at the moment of the request.
-   * @default []
+   * @defaultValue `[]`
    */
   currentValues: T[];
 }
 
 export interface Freezable {
   /** Setting this to true is ensures that the facet does not move around while the end-user is interacting with it in the search interface.
-   * @default false
+   * @defaultValue `false`
    */
   freezeCurrentValues: boolean;
 }
 
 export interface Delimitable {
   /** The character that specifies the hierarchical dependency.
-   * @default ">"
+   * @defaultValue `>`
    */
   delimitingCharacter: string;
 }
 
 export interface Expandable {
   /** Whether the facet is expanded in the search interface at the moment of the request.
-   * @default false
+   * @defaultValue `false`
    */
   isFieldExpanded: boolean;
 }

--- a/packages/headless/src/features/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/request.ts
@@ -33,6 +33,6 @@ export interface FacetRequest
     Delimitable,
     Type<'specific'>,
     SortCriteria<FacetSortCriterion> {
-  /** @default "automatic" */
+  /** @defaultValue `automatic` */
   sortCriteria: FacetSortCriterion;
 }

--- a/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
@@ -25,7 +25,7 @@ export interface RangeRequest<T extends string | number>
   /** The end value of the range.*/
   end: T;
   /** Whether to include the `end` value in the range.
-   * @default false
+   * @defaultValue `false`
    */
   endInclusive: boolean;
 }
@@ -34,6 +34,6 @@ export interface BaseRangeFacetRequest
   extends BaseFacetRequest,
     AutomaticRanges<boolean>,
     SortCriteria<RangeFacetSortCriterion> {
-  /** @default "ascending" */
+  /** @defaultValue `ascending` */
   sortCriteria: RangeFacetSortCriterion;
 }

--- a/packages/headless/src/features/recommendation/recommendation-state.ts
+++ b/packages/headless/src/features/recommendation/recommendation-state.ts
@@ -13,7 +13,7 @@ export const getRecommendationInitialState = (): RecommendationState => ({
 export interface RecommendationState {
   /**
    * Specifies the ID of the recommendation interface.
-   * @default Recommendation
+   * @defaultValue `Recommendation`
    */
   id: string;
   /**


### PR DESCRIPTION
The goal was to extract default values for controller options but also minimums/maximums. As it turns out, the API extractor tool doesn't handle custom tags like `@default` and `@minimum`. Fortunately, it does properly parse the `@defaultValue` tag.

So, I switched all `@default` tags to `@defaultValue` and added code backticks around the values so that the parser can parse them. I also removed the `@minimum` tags (there were no maximums) and incorporated them into the summary. If custom tags are implemented in the API extractor tool at a later date (it seems to be in progress now), we can move min/max back into a tagged annotation and extract them then.