### PR TITLE
feat(headless): added user actions controller

### DIFF
--- a/packages/headless/src/api/machine-learning/ml-api-client.test.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.test.ts
@@ -50,6 +50,24 @@ fdescribe('machine learning api client', () => {
       });
     });
 
+    it('should call the platform endpoint with debug=1 when debug is enabled', async () => {
+      state.debug = true;
+      const request = buildUserActionsRequest(state);
+      const url = `${platformUrl()}/rest/organizations/${
+        request.organizationId
+      }/machinelearning/user/actions`;
+
+      mockPlatformCall({
+        ok: true,
+        json: () => Promise.resolve('some content'),
+      });
+
+      await client.userActions(request);
+
+      const expectedUrl = `${url}?debug=1`;
+      expect(platformCallMock.mock.calls[0][0].url).toBe(expectedUrl);
+    });
+
     it('should return error response on failure', async () => {
       const request = buildUserActionsRequest(state);
 

--- a/packages/headless/src/api/machine-learning/ml-api-client.test.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.test.ts
@@ -1,0 +1,56 @@
+import pino from 'pino';
+import {MLAPIClient, MLAPIClientOptions} from './ml-api-client';
+import {
+  NoopPreprocessRequestMiddleware,
+  PlatformClient,
+  PlatformClientCallOptions,
+  platformUrl,
+} from '../platform-client';
+import {createMockUserProfileState} from '../../test/mock-user-profile-state';
+import {buildMockMLAPIClient} from '../../test/mock-ml-api-client';
+import {UserProfileAppState} from '../../state/user-profile-app-state';
+import {buildUserActionsRequest} from '../../features/user-profile/user-profile-actions';
+import {NoopPreprocessRequest} from '../preprocess-request';
+
+jest.mock('../platform-client');
+describe('machine learning api client', () => {
+  const mockOptions: MLAPIClientOptions = {
+    renewAccessToken: async () => 'newToken',
+    logger: pino({level: 'silent'}),
+  };
+  let client: MLAPIClient;
+  let state: UserProfileAppState;
+
+  beforeEach(() => {
+    client = buildMockMLAPIClient();
+    state = createMockUserProfileState();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`when calling MLAPIClient.userActions
+  should call PlatformClient.call with the right options`, () => {
+    const req = buildUserActionsRequest(state);
+    const url = `${platformUrl()}/rest/organizations/${
+      req.organizationId
+    }/machinelearning/user/actions`;
+    client.userActions(req);
+
+    const expectedRequest: PlatformClientCallOptions = {
+      accessToken: state.configuration.accessToken,
+      method: 'POST',
+      contentType: 'application/json',
+      url,
+      ...mockOptions,
+      requestParams: {
+        userId: state.userProfile.userId,
+      },
+      preprocessRequest: NoopPreprocessRequest,
+      deprecatedPreprocessRequest: NoopPreprocessRequestMiddleware,
+    };
+
+    expect(PlatformClient.call).toHaveBeenCalledWith(expectedRequest);
+  });
+});

--- a/packages/headless/src/api/machine-learning/ml-api-client.test.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.test.ts
@@ -1,25 +1,20 @@
-import pino from 'pino';
-import {MLAPIClient, MLAPIClientOptions} from './ml-api-client';
-import {
-  NoopPreprocessRequestMiddleware,
-  PlatformClient,
-  PlatformClientCallOptions,
-  platformUrl,
-} from '../platform-client';
+import {MLAPIClient} from './ml-api-client';
+import {PlatformClient, platformUrl} from '../platform-client';
 import {createMockUserProfileState} from '../../test/mock-user-profile-state';
 import {buildMockMLAPIClient} from '../../test/mock-ml-api-client';
 import {UserProfileAppState} from '../../state/user-profile-app-state';
 import {buildUserActionsRequest} from '../../features/user-profile/user-profile-actions';
-import {NoopPreprocessRequest} from '../preprocess-request';
 
-jest.mock('../platform-client');
-describe('machine learning api client', () => {
-  const mockOptions: MLAPIClientOptions = {
-    renewAccessToken: async () => 'newToken',
-    logger: pino({level: 'silent'}),
+fdescribe('machine learning api client', () => {
+  const mockPlatformCall = (mockResponse: unknown) => {
+    platformCallMock = jest.fn();
+    platformCallMock.mockReturnValue(mockResponse);
+    PlatformClient.call = platformCallMock;
   };
+
   let client: MLAPIClient;
   let state: UserProfileAppState;
+  let platformCallMock: jest.Mock;
 
   beforeEach(() => {
     client = buildMockMLAPIClient();
@@ -30,27 +25,78 @@ describe('machine learning api client', () => {
     jest.clearAllMocks();
   });
 
-  it(`when calling MLAPIClient.userActions
-  should call PlatformClient.call with the right options`, () => {
-    const req = buildUserActionsRequest(state);
-    const url = `${platformUrl()}/rest/organizations/${
-      req.organizationId
-    }/machinelearning/user/actions`;
-    client.userActions(req);
+  describe('userActions', () => {
+    it('should call the platform endpoint with the correct arguments', async () => {
+      const request = buildUserActionsRequest(state);
+      const url = `${platformUrl()}/rest/organizations/${
+        request.organizationId
+      }/machinelearning/user/actions`;
 
-    const expectedRequest: PlatformClientCallOptions = {
-      accessToken: state.configuration.accessToken,
-      method: 'POST',
-      contentType: 'application/json',
-      url,
-      ...mockOptions,
-      requestParams: {
-        userId: state.userProfile.userId,
-      },
-      preprocessRequest: NoopPreprocessRequest,
-      deprecatedPreprocessRequest: NoopPreprocessRequestMiddleware,
-    };
+      mockPlatformCall({
+        ok: true,
+        json: () => Promise.resolve('some content'),
+      });
 
-    expect(PlatformClient.call).toHaveBeenCalledWith(expectedRequest);
+      await client.userActions(request);
+
+      expect(platformCallMock).toBeCalled();
+      const mockRequest = platformCallMock.mock.calls[0][0];
+      expect(mockRequest).toMatchObject({
+        url,
+        accessToken: state.configuration.accessToken,
+        requestParams: {
+          objectId: state.userProfile.userId,
+        },
+      });
+    });
+
+    it('should return error response on failure', async () => {
+      const request = buildUserActionsRequest(state);
+
+      const expectedError = {
+        statusCode: 401,
+        message: 'Unauthorized',
+        type: 'authorization',
+      };
+
+      mockPlatformCall({
+        ok: false,
+        json: () => Promise.resolve(expectedError),
+      });
+
+      const response = await client.userActions(request);
+
+      expect(response).toMatchObject({
+        error: expectedError,
+      });
+    });
+
+    it('should return success response on success', async () => {
+      const request = buildUserActionsRequest(state);
+
+      const expectedBody = {
+        value: [
+          {
+            name: 'name',
+            time: '123456790',
+            value: 'value',
+          },
+        ],
+        debug: false,
+        internalExecutionLog: {},
+        executionTime: 123940,
+      };
+
+      mockPlatformCall({
+        ok: true,
+        json: () => Promise.resolve(expectedBody),
+      });
+
+      const response = await client.userActions(request);
+
+      expect(response).toMatchObject({
+        success: expectedBody,
+      });
+    });
   });
 });

--- a/packages/headless/src/api/machine-learning/ml-api-client.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.ts
@@ -14,7 +14,7 @@ export interface AsyncThunkMLRequestOptions<
   T extends Partial<UserProfileAppState>
 > {
   state: T;
-  rejectValue: MLAPIErrorWithStatusCode;
+  rejectValue: MLAPIErrorResponse;
   extra: {
     mlAPIClient: MLAPIClient;
     searchAPIClient: SearchAPIClient;
@@ -65,7 +65,7 @@ export class MLAPIClient {
     const body = await platformResponse.json();
     return platformResponse.ok
       ? {success: body as UserActionsSuccessContent}
-      : ({error: body} as MLAPIErrorResponse);
+      : {error: body as MLAPIErrorWithStatusCode};
   }
 }
 

--- a/packages/headless/src/api/machine-learning/ml-api-client.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.ts
@@ -56,7 +56,13 @@ export class MLAPIClient {
     req: UserActionsRequest
   ): Promise<MLAPIResponse<UserActionsSuccessContent>> {
     const platformResponse = await PlatformClient.call({
-      ...baseMLRequest(req, 'POST', 'application/json', '/user/actions'),
+      ...baseMLRequest(
+        req,
+        'POST',
+        'application/json',
+        '/user/actions',
+        req.debug
+      ),
       requestParams: pickNonBaseParams(req),
       ...this.options,
       ...this.defaultClientHooks,

--- a/packages/headless/src/api/machine-learning/ml-api-client.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-client.ts
@@ -1,0 +1,81 @@
+import {Logger} from 'pino';
+import {
+  NoopPreprocessRequestMiddleware,
+  PlatformClient,
+} from '../platform-client';
+import {BaseParam, baseMLRequest} from './ml-api-params';
+import {NoopPreprocessRequest} from '../preprocess-request';
+import {UserActionsRequest} from './user-profiles/user-actions-request';
+import {UserActionsSuccessContent} from './user-profiles/user-actions-response';
+import {UserProfileAppState} from '../../state/user-profile-app-state';
+import {SearchAPIClient} from '../search/search-api-client';
+
+export interface AsyncThunkMLRequestOptions<
+  T extends Partial<UserProfileAppState>
+> {
+  state: T;
+  rejectValue: MLAPIErrorWithStatusCode;
+  extra: {
+    mlAPIClient: MLAPIClient;
+    searchAPIClient: SearchAPIClient;
+  };
+}
+
+export interface MLAPIClientOptions {
+  renewAccessToken: () => Promise<string>;
+  logger: Logger;
+}
+
+export interface MLAPISuccessResponse<TContent> {
+  success: TContent;
+}
+
+export interface MLAPIErrorResponse {
+  error: MLAPIErrorWithStatusCode;
+}
+
+export interface MLAPIErrorWithStatusCode {
+  statusCode: number;
+  message: string;
+  type: string;
+}
+
+export type MLAPIResponse<TSuccessContent> =
+  | MLAPISuccessResponse<TSuccessContent>
+  | MLAPIErrorResponse;
+
+export class MLAPIClient {
+  private defaultClientHooks = {
+    preprocessRequest: NoopPreprocessRequest,
+    deprecatedPreprocessRequest: NoopPreprocessRequestMiddleware,
+  };
+
+  constructor(private options: MLAPIClientOptions) {}
+
+  async userActions(
+    req: UserActionsRequest
+  ): Promise<MLAPIResponse<UserActionsSuccessContent>> {
+    const platformResponse = await PlatformClient.call({
+      ...baseMLRequest(req, 'POST', 'application/json', '/user/actions'),
+      requestParams: pickNonBaseParams(req),
+      ...this.options,
+      ...this.defaultClientHooks,
+    });
+
+    const body = await platformResponse.json();
+    return platformResponse.ok
+      ? {success: body as UserActionsSuccessContent}
+      : ({error: body} as MLAPIErrorResponse);
+  }
+}
+
+function pickNonBaseParams<Params extends BaseParam>(req: Params) {
+  const {url, accessToken, organizationId, ...nonBase} = req;
+  return nonBase;
+}
+
+export const isErrorResponse = <T>(
+  r: MLAPIResponse<T>
+): r is {error: MLAPIErrorWithStatusCode} => {
+  return (r as {error: MLAPIErrorWithStatusCode}).error !== undefined;
+};

--- a/packages/headless/src/api/machine-learning/ml-api-params.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-params.ts
@@ -10,14 +10,19 @@ export interface BaseParam {
   organizationId: string;
 }
 
+export interface DebugParam {
+  debug: boolean;
+}
+
 export const baseMLRequest = (
   req: BaseParam,
   method: HttpMethods,
   contentType: HTTPContentType,
-  path: string
+  path: string,
+  debug: boolean
 ) => ({
   accessToken: req.accessToken,
   method,
   contentType,
-  url: `${req.url}${path}`,
+  url: `${req.url}${path}${debug ? '?debug=1' : ''}`,
 });

--- a/packages/headless/src/api/machine-learning/ml-api-params.ts
+++ b/packages/headless/src/api/machine-learning/ml-api-params.ts
@@ -1,0 +1,23 @@
+import {HTTPContentType, HttpMethods} from '../platform-client';
+
+export interface ObjectIdParam {
+  objectId?: string;
+}
+
+export interface BaseParam {
+  url: string;
+  accessToken: string;
+  organizationId: string;
+}
+
+export const baseMLRequest = (
+  req: BaseParam,
+  method: HttpMethods,
+  contentType: HTTPContentType,
+  path: string
+) => ({
+  accessToken: req.accessToken,
+  method,
+  contentType,
+  url: `${req.url}${path}`,
+});

--- a/packages/headless/src/api/machine-learning/user-profiles/user-actions-request.ts
+++ b/packages/headless/src/api/machine-learning/user-profiles/user-actions-request.ts
@@ -1,3 +1,3 @@
-import {BaseParam, ObjectIdParam} from '../ml-api-params';
+import {BaseParam, DebugParam, ObjectIdParam} from '../ml-api-params';
 
-export type UserActionsRequest = BaseParam & ObjectIdParam;
+export type UserActionsRequest = BaseParam & ObjectIdParam & DebugParam;

--- a/packages/headless/src/api/machine-learning/user-profiles/user-actions-request.ts
+++ b/packages/headless/src/api/machine-learning/user-profiles/user-actions-request.ts
@@ -1,0 +1,3 @@
+import {BaseParam, ObjectIdParam} from '../ml-api-params';
+
+export type UserActionsRequest = BaseParam & ObjectIdParam;

--- a/packages/headless/src/api/machine-learning/user-profiles/user-actions-response.ts
+++ b/packages/headless/src/api/machine-learning/user-profiles/user-actions-response.ts
@@ -1,0 +1,10 @@
+export interface UserActionsSuccessContent {
+  value: {
+    name: string;
+    time: string;
+    value: string;
+  }[];
+  debug: unknown;
+  internalExecutionLog: unknown;
+  executionTime: number;
+}

--- a/packages/headless/src/app/headless-engine.test.ts
+++ b/packages/headless/src/app/headless-engine.test.ts
@@ -9,6 +9,7 @@ import {AnalyticsClientSendEventHook} from 'coveo.analytics/dist/definitions/cli
 import pino from 'pino';
 import {validatePayloadAndThrow} from '../utils/validate-payload';
 import {buildMockSearchAPIClient} from '../test/mock-search-api-client';
+import {buildMockMLAPIClient} from '../test/mock-ml-api-client';
 
 describe('headless engine', () => {
   let options: HeadlessOptions<typeof searchAppReducers>;
@@ -21,6 +22,7 @@ describe('headless engine', () => {
       reducers: searchAppReducers,
       thunkExtraArguments: {
         searchAPIClient: buildMockSearchAPIClient(),
+        mlAPIClient: buildMockMLAPIClient(),
         analyticsClientMiddleware: {} as AnalyticsClientSendEventHook,
         logger: pino({level: 'silent'}),
         validatePayload: validatePayloadAndThrow,

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -17,6 +17,7 @@ import {
 } from '../features/configuration/configuration-actions';
 import {configureStore, Store, ThunkExtraArguments} from './store';
 import {SearchAPIClient} from '../api/search/search-api-client';
+import {MLAPIClient} from '../api/machine-learning/ml-api-client';
 import {debounce} from 'ts-debounce';
 import {SearchAppState} from '../state/search-app-state';
 import pino, {Logger, LogEvent, LevelWithSilent} from 'pino';
@@ -381,6 +382,10 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
           postprocessQuerySuggestResponseMiddleware:
             search?.preprocessQuerySuggestResponseMiddleware ||
             NoopPostprocessQuerySuggestResponseMiddleware,
+        }),
+        mlAPIClient: new MLAPIClient({
+          logger: this.logger,
+          renewAccessToken: () => this.renewAccessToken(),
         }),
         analyticsClientMiddleware: this.analyticsClientMiddleware(this.options),
         logger: this.logger,

--- a/packages/headless/src/app/store.ts
+++ b/packages/headless/src/app/store.ts
@@ -15,10 +15,12 @@ import {
 } from './logger-middlewares';
 import {validatePayloadAndThrow} from '../utils/validate-payload';
 import {PreprocessRequest} from '../api/preprocess-request';
+import {MLAPIClient} from '../api/machine-learning/ml-api-client';
 
 export interface ThunkExtraArguments {
   preprocessRequest?: PreprocessRequest;
   searchAPIClient: SearchAPIClient;
+  mlAPIClient: MLAPIClient;
   analyticsClientMiddleware: AnalyticsClientSendEventHook;
   logger: Logger;
   validatePayload: typeof validatePayloadAndThrow;

--- a/packages/headless/src/app/user-profile-app-reducers.ts
+++ b/packages/headless/src/app/user-profile-app-reducers.ts
@@ -1,0 +1,12 @@
+import {ReducersMapObject} from 'redux';
+import {configurationReducer} from '../features/configuration/configuration-slice';
+import {userProfileReducer} from '../features/user-profile/user-profile-slice';
+import {UserProfileAppState} from '../state/user-profile-app-state';
+
+/**
+ * Map of reducers that make up the UserActionsAppState.
+ */
+export const userProfileAppReducers: ReducersMapObject<UserProfileAppState> = {
+  configuration: configurationReducer,
+  userProfile: userProfileReducer,
+};

--- a/packages/headless/src/app/user-profile-app-reducers.ts
+++ b/packages/headless/src/app/user-profile-app-reducers.ts
@@ -1,5 +1,6 @@
 import {ReducersMapObject} from 'redux';
 import {configurationReducer} from '../features/configuration/configuration-slice';
+import {debugReducer} from '../features/debug/debug-slice';
 import {userProfileReducer} from '../features/user-profile/user-profile-slice';
 import {UserProfileAppState} from '../state/user-profile-app-state';
 
@@ -9,4 +10,5 @@ import {UserProfileAppState} from '../state/user-profile-app-state';
 export const userProfileAppReducers: ReducersMapObject<UserProfileAppState> = {
   configuration: configurationReducer,
   userProfile: userProfileReducer,
+  debug: debugReducer,
 };

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -277,3 +277,9 @@ export {
 } from './search-status/headless-search-status';
 
 export {ErrorPayload} from './controller/error-payload';
+
+export {
+  UserActionsProps,
+  UserActionsState,
+  buildUserActions,
+} from './user-actions/headless-user-actions';

--- a/packages/headless/src/controllers/user-actions/headless-user-actions.test.ts
+++ b/packages/headless/src/controllers/user-actions/headless-user-actions.test.ts
@@ -1,0 +1,31 @@
+import {executeGetUserActions} from '../../features/user-profile/user-profile-actions';
+import {UserProfileAppState} from '../../state/user-profile-app-state';
+import {
+  buildMockUserProfileAppEngine,
+  MockEngine,
+} from '../../test/mock-engine';
+import {buildUserActions, UserActions} from './headless-user-actions';
+
+describe('User Actions', () => {
+  const testId = 'mock-id-123';
+  let engine: MockEngine<UserProfileAppState>;
+  let userActions: UserActions;
+
+  beforeEach(() => {
+    engine = buildMockUserProfileAppEngine();
+    userActions = buildUserActions(engine, {options: {userId: testId}});
+  });
+
+  it('initializes', () => {
+    expect(userActions).toBeTruthy();
+  });
+
+  it('update dispatches a executeGetUserActions action', () => {
+    userActions.update();
+
+    const action = engine.actions.find(
+      (action) => action.type === executeGetUserActions.pending.type
+    );
+    expect(action).toBeTruthy;
+  });
+});

--- a/packages/headless/src/controllers/user-actions/headless-user-actions.ts
+++ b/packages/headless/src/controllers/user-actions/headless-user-actions.ts
@@ -1,0 +1,70 @@
+import {Schema, SchemaValues, StringValue} from '@coveo/bueno';
+import {Engine} from '../../app/headless-engine';
+import {
+  executeGetUserActions,
+  updateUserProfileUserId,
+} from '../../features/user-profile/user-profile-actions';
+import {buildController} from '../controller/headless-controller';
+import {UserProfileAppState} from '../../state/user-profile-app-state';
+
+const optionsSchema = new Schema({
+  /**
+   * The userId of the user whos actions we want to retrieve.
+   */
+  userId: new StringValue({
+    required: true,
+    emptyAllowed: false,
+  }),
+});
+
+export type UserActionsOptions = Required<SchemaValues<typeof optionsSchema>>;
+
+export interface UserActionsProps {
+  options: UserActionsOptions;
+}
+
+/**
+ * A scoped and simplified part of the headless state that is relevant to the `UserActions` controller.
+ */
+export type UserActionsState = UserActions['state'];
+
+/**
+ * The `UserActions` headless controller offers a high-level interface for designing a user actions controller.
+ */
+export type UserActions = ReturnType<typeof buildUserActions>;
+
+export function buildUserActions(
+  engine: Engine<UserProfileAppState>,
+  props: UserActionsProps
+) {
+  const controller = buildController(engine);
+  const {dispatch} = engine;
+
+  const options = optionsSchema.validate(props.options) as Required<
+    UserActionsOptions
+  >;
+
+  dispatch(updateUserProfileUserId(options));
+  dispatch(executeGetUserActions());
+
+  return {
+    ...controller,
+
+    /**
+     * Triggers a user actions fetch
+     */
+    update() {
+      dispatch(executeGetUserActions());
+    },
+
+    /**
+     * @returns The state of the `UserActions` controller.
+     */
+    get state() {
+      const state = engine.state;
+      return {
+        ...state.userProfile,
+      };
+    },
+  };
+}

--- a/packages/headless/src/controllers/user-actions/headless-user-actions.ts
+++ b/packages/headless/src/controllers/user-actions/headless-user-actions.ts
@@ -63,7 +63,7 @@ export function buildUserActions(
     get state() {
       const state = engine.state;
       return {
-        ...state.userProfile,
+        ...state.userProfile.userActions,
       };
     },
   };

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -1,11 +1,11 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {
-  renewAccessToken,
   updateBasicConfiguration,
   updateSearchConfiguration,
+  updateAnalyticsConfiguration,
+  renewAccessToken,
   disableAnalytics,
   enableAnalytics,
-  updateAnalyticsConfiguration,
   setOriginLevel2,
   setOriginLevel3,
 } from './configuration-actions';

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -282,3 +282,16 @@ export namespace ResultTemplatesHelpers {
   export const fieldMustMatch = fieldMustMatchAlias;
   export const fieldMustNotMatch = fieldMustNotMatchAlias;
 }
+
+import {
+  StateNeededByExecuteGetUserActions as StateNeededByExecuteGetUserActionsAlias,
+  ExecuteGetUserActionsThunkReturn as ExecuteGetUserActionsThunkReturnAlias,
+  updateUserProfileUserId as updateUserProfileUserIdAlias,
+  executeGetUserActions as executeGetUserActionsAlias,
+} from './user-profile/user-profile-actions';
+export namespace UserProfileActions {
+  export type StateNeededByExecuteGetUserActions = StateNeededByExecuteGetUserActionsAlias;
+  export type ExecuteGetUserActionsThunkReturn = ExecuteGetUserActionsThunkReturnAlias;
+  export const updateUserProfileUserId = updateUserProfileUserIdAlias;
+  export const executeGetUserActions = executeGetUserActionsAlias;
+}

--- a/packages/headless/src/features/user-profile/user-profile-actions.ts
+++ b/packages/headless/src/features/user-profile/user-profile-actions.ts
@@ -1,0 +1,197 @@
+import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
+import {
+  ConfigurationSection,
+  UserProfileSection,
+} from '../../state/state-sections';
+import {UserActionsRequest} from '../../api/machine-learning/user-profiles/user-actions-request';
+import {
+  AsyncThunkMLRequestOptions,
+  isErrorResponse,
+  MLAPIClient,
+} from '../../api/machine-learning/ml-api-client';
+import {UserActionsSuccessContent} from '../../api/machine-learning/user-profiles/user-actions-response';
+import {UserAction, UserActionType, ActionHistory} from './user-profile-state';
+import {Result} from '../../api/search/search/result';
+import {
+  isSuccessResponse,
+  SearchAPIClient,
+} from '../../api/search/search-api-client';
+import {StringValue} from '@coveo/bueno';
+import {validatePayload} from '../../utils/validate-payload';
+import {ThunkExtraArguments} from '../../app/store';
+import {UserProfileAppState} from '../../state/user-profile-app-state';
+
+export type StateNeededByExecuteGetUserActions = ConfigurationSection &
+  Partial<UserProfileSection>;
+
+export interface ExecuteGetUserActionsThunkReturn {
+  /** The retrieved user actions */
+  userActions: UserAction[];
+  /** The number of milliseconds it took to receive the response. */
+  duration: number;
+}
+
+export interface AsyncThunkOptions {
+  state: UserProfileAppState;
+  extra: ThunkExtraArguments;
+}
+
+export const updateUserProfileUserId = createAction(
+  'userProfile/updateUserProfileUserId',
+  (payload: {userId?: string}) =>
+    validatePayload(payload, {
+      userId: new StringValue({emptyAllowed: false, required: false}),
+    })
+);
+
+const fetchUserActionsFromAPI = async (
+  client: MLAPIClient,
+  state: StateNeededByExecuteGetUserActions
+) => {
+  const startedAt = new Date().getTime();
+  const response = await client.userActions(buildUserActionsRequest(state));
+  const duration = new Date().getTime() - startedAt;
+  return {response, duration};
+};
+
+const fetchDocumentsFromAPI = async (
+  client: SearchAPIClient,
+  state: StateNeededByExecuteGetUserActions,
+  documentURIs: string[]
+) => {
+  const response = await client.search(
+    buildDocumentFetchRequest(state, documentURIs)
+  );
+  return {response};
+};
+
+export const buildUserActionsRequest = (
+  state: StateNeededByExecuteGetUserActions
+): UserActionsRequest => {
+  return {
+    url: `${state.configuration.platformUrl}/rest/organizations/${state.configuration.organizationId}/machinelearning`,
+    accessToken: state.configuration.accessToken,
+    organizationId: state.configuration.organizationId,
+    objectId: state.userProfile?.userId,
+  };
+};
+
+const buildDocumentFetchRequest = (
+  state: StateNeededByExecuteGetUserActions,
+  documentURIs: string[]
+) => {
+  return {
+    accessToken: state.configuration.accessToken,
+    organizationId: state.configuration.organizationId,
+    url: state.configuration.search.apiBaseUrl,
+    aq: documentURIs.map((uri) => `@urihash==${uri}`).join(' OR '),
+    numberOfResults: documentURIs.length,
+  };
+};
+
+/**
+ * Get user actions
+ */
+export const executeGetUserActions = createAsyncThunk<
+  ExecuteGetUserActionsThunkReturn,
+  void,
+  AsyncThunkMLRequestOptions<StateNeededByExecuteGetUserActions>
+>(
+  'userProfile/getUserActions',
+  async (
+    _,
+    {getState, rejectWithValue, extra: {mlAPIClient, searchAPIClient}}
+  ) => {
+    const state = getState() as StateNeededByExecuteGetUserActions;
+    const fetched = await fetchUserActionsFromAPI(mlAPIClient, state);
+
+    if (isErrorResponse(fetched.response)) {
+      return rejectWithValue(fetched.response.error);
+    }
+
+    const actionHistory = parseResponse(fetched.response.success);
+    const userActions = await buildUserActions(
+      actionHistory,
+      state,
+      searchAPIClient
+    );
+
+    return {
+      userActions,
+      duration: fetched.duration,
+    };
+  }
+);
+
+const parseResponse = (
+  response: UserActionsSuccessContent
+): ActionHistory[] => {
+  return response.value.map((v) => {
+    return {
+      time: parseInt(v.time),
+      value: JSON.parse(v.value) as {[key: string]: string},
+      name: v.name as UserActionType,
+    };
+  });
+};
+
+const fetchDocuments = async (
+  state: StateNeededByExecuteGetUserActions,
+  client: SearchAPIClient,
+  uriHashes: string[]
+): Promise<{[urihash: string]: Result}> => {
+  if (uriHashes.length === 0) {
+    return Promise.resolve({});
+  }
+
+  try {
+    const fetched = await fetchDocumentsFromAPI(client, state, uriHashes);
+    if (isSuccessResponse(fetched.response)) {
+      const documentsDict = fetched.response.success.results.reduce(
+        (acc, result) => ({...acc, [result.raw.urihash]: result}),
+        {}
+      );
+      return documentsDict;
+    }
+  } catch (e) {
+    console.log(e.message);
+  }
+  return Promise.resolve({});
+};
+
+const buildUserActions = async (
+  actions: ActionHistory[],
+  state: StateNeededByExecuteGetUserActions,
+  searchAPIClient: SearchAPIClient
+): Promise<UserAction[]> => {
+  let documents = {} as {[urihash: string]: Result};
+
+  const uriHashes = actions
+    .filter(isClick)
+    .map((action) => action.value.uri_hash)
+    .filter((value, index, list) => list.indexOf(value) === index);
+
+  documents = await fetchDocuments(state, searchAPIClient, uriHashes);
+
+  return actions.map((action) => {
+    return new UserAction(
+      action.name,
+      new Date(action.time),
+      action.value,
+      isClickOrView(action) ? documents[action.value.uri_hash] : undefined,
+      isSearch(action) ? action.value.query_expression : undefined
+    );
+  });
+};
+
+const isClick = (action: ActionHistory) => {
+  return action.name === UserActionType.Click;
+};
+
+const isClickOrView = (action: ActionHistory) => {
+  return isClick(action) || action.name === UserActionType.PageView;
+};
+
+const isSearch = (action: ActionHistory) => {
+  return action.name === UserActionType.Search;
+};

--- a/packages/headless/src/features/user-profile/user-profile-actions.ts
+++ b/packages/headless/src/features/user-profile/user-profile-actions.ts
@@ -1,8 +1,6 @@
+import {StringValue} from '@coveo/bueno';
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
-import {
-  ConfigurationSection,
-  UserProfileSection,
-} from '../../state/state-sections';
+
 import {UserActionsRequest} from '../../api/machine-learning/user-profiles/user-actions-request';
 import {
   AsyncThunkMLRequestOptions,
@@ -16,13 +14,11 @@ import {
   isSuccessResponse,
   SearchAPIClient,
 } from '../../api/search/search-api-client';
-import {StringValue} from '@coveo/bueno';
 import {validatePayload} from '../../utils/validate-payload';
 import {ThunkExtraArguments} from '../../app/store';
 import {UserProfileAppState} from '../../state/user-profile-app-state';
 
-export type StateNeededByExecuteGetUserActions = ConfigurationSection &
-  Partial<UserProfileSection>;
+export type StateNeededByExecuteGetUserActions = UserProfileAppState;
 
 export interface ExecuteGetUserActionsThunkReturn {
   /** The retrieved user actions */
@@ -73,6 +69,7 @@ export const buildUserActionsRequest = (
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
     objectId: state.userProfile?.userId,
+    debug: state.debug,
   };
 };
 

--- a/packages/headless/src/features/user-profile/user-profile-actions.ts
+++ b/packages/headless/src/features/user-profile/user-profile-actions.ts
@@ -106,7 +106,7 @@ export const executeGetUserActions = createAsyncThunk<
     const fetched = await fetchUserActionsFromAPI(mlAPIClient, state);
 
     if (isErrorResponse(fetched.response)) {
-      return rejectWithValue(fetched.response.error);
+      return rejectWithValue(fetched.response);
     }
 
     const actionHistory = parseResponse(fetched.response.success);

--- a/packages/headless/src/features/user-profile/user-profile-slice.test.ts
+++ b/packages/headless/src/features/user-profile/user-profile-slice.test.ts
@@ -1,0 +1,89 @@
+import {Action} from '@reduxjs/toolkit';
+import {
+  executeGetUserActions,
+  updateUserProfileUserId,
+} from './user-profile-actions';
+import {userProfileReducer} from './user-profile-slice';
+import {
+  UserProfileState,
+  getUserProfileInitialState,
+  UserActionType,
+} from './user-profile-state';
+
+const rejectWithValue = (action: Action, payload: object) => ({
+  type: action.type,
+  meta: {
+    requestId: 'some request id',
+    rejectedWithValue: true,
+    requestStatus: 'rejected',
+    aborted: false,
+    condition: false,
+  },
+  payload,
+});
+
+describe('case assist slice', () => {
+  let state: UserProfileState;
+
+  beforeEach(() => {
+    state = getUserProfileInitialState();
+  });
+
+  it('initializes the state correctly', () => {
+    const finalState = userProfileReducer(undefined, {type: ''});
+
+    expect(finalState).toEqual(getUserProfileInitialState());
+  });
+
+  it('updateUserProfileUserId sets the value in the state', () => {
+    const testId = 'test-id-123';
+    const action = updateUserProfileUserId({
+      userId: testId,
+    });
+    const finalState = userProfileReducer(state, action);
+
+    expect(finalState.userId).toBe(testId);
+  });
+
+  it('executeGetUserActions.pending raises the loading flag', () => {
+    const action = executeGetUserActions.pending('some request id');
+    const finalState = userProfileReducer(state, action);
+
+    expect(finalState.userActions.isLoading).toBe(true);
+  });
+
+  it('executeGetUserActions.fulfilled updates userActions', () => {
+    const payload = {
+      userActions: [
+        {
+          type: UserActionType.Search,
+          timestamp: new Date(),
+          raw: {},
+        },
+      ],
+      duration: 0,
+    };
+    const action = executeGetUserActions.fulfilled(payload, 'some request id');
+    const finalState = userProfileReducer(state, action);
+
+    expect(finalState.userActions.isLoading).toBe(false);
+    expect(finalState.userActions.actions).toEqual(payload.userActions);
+    expect(finalState.userActions.error).toBeNull;
+  });
+
+  it('executeGetUserActions.rejected stores the error', () => {
+    const expectedError = {
+      statusCode: 400,
+      message: 'some value is missing',
+      type: 'invalid request',
+    };
+    const action = rejectWithValue(executeGetUserActions.rejected, {
+      error: expectedError,
+    });
+
+    const finalState = userProfileReducer(state, action);
+
+    expect(finalState.userActions.error).toEqual(expectedError);
+    expect(finalState.userActions.isLoading).toBe(false);
+  });
+});

--- a/packages/headless/src/features/user-profile/user-profile-slice.ts
+++ b/packages/headless/src/features/user-profile/user-profile-slice.ts
@@ -1,0 +1,38 @@
+import {createReducer} from '@reduxjs/toolkit';
+import {
+  executeGetUserActions,
+  updateUserProfileUserId,
+} from './user-profile-actions';
+import {
+  getUserProfileInitialState,
+  UserProfileState,
+} from './user-profile-state';
+
+function handleRejectedRequest(
+  state: UserProfileState,
+  action: ReturnType<typeof executeGetUserActions['rejected']>
+) {
+  state.userActions.error = action.payload ? action.payload : null;
+  state.userActions.isLoading = false;
+}
+
+export const userProfileReducer = createReducer(
+  getUserProfileInitialState(),
+  (builder) => {
+    builder.addCase(updateUserProfileUserId, (state, action) => {
+      if (action.payload.userId) {
+        state.userId = action.payload.userId;
+      }
+    });
+    builder.addCase(executeGetUserActions.rejected, handleRejectedRequest);
+    builder.addCase(executeGetUserActions.fulfilled, (state, action) => {
+      state.userActions.error = null;
+      state.userActions.actions = action.payload.userActions;
+      state.userActions.duration = action.payload.duration;
+      state.userActions.isLoading = false;
+    });
+    builder.addCase(executeGetUserActions.pending, (state) => {
+      state.userActions.isLoading = true;
+    });
+  }
+);

--- a/packages/headless/src/features/user-profile/user-profile-slice.ts
+++ b/packages/headless/src/features/user-profile/user-profile-slice.ts
@@ -8,11 +8,23 @@ import {
   UserProfileState,
 } from './user-profile-state';
 
-function handleRejectedRequest(
+type UserProfileAction = typeof executeGetUserActions;
+
+function handleFulfilledUserActionsRequest(
   state: UserProfileState,
-  action: ReturnType<typeof executeGetUserActions['rejected']>
+  action: ReturnType<UserProfileAction['fulfilled']>
 ) {
-  state.userActions.error = action.payload ? action.payload : null;
+  state.userActions.error = null;
+  state.userActions.actions = action.payload.userActions;
+  state.userActions.duration = action.payload.duration;
+  state.userActions.isLoading = false;
+}
+
+function handleRejectedUserActionsRequest(
+  state: UserProfileState,
+  action: ReturnType<UserProfileAction['rejected']>
+) {
+  state.userActions.error = action.payload ? action.payload.error : null;
   state.userActions.isLoading = false;
 }
 
@@ -24,13 +36,14 @@ export const userProfileReducer = createReducer(
         state.userId = action.payload.userId;
       }
     });
-    builder.addCase(executeGetUserActions.rejected, handleRejectedRequest);
-    builder.addCase(executeGetUserActions.fulfilled, (state, action) => {
-      state.userActions.error = null;
-      state.userActions.actions = action.payload.userActions;
-      state.userActions.duration = action.payload.duration;
-      state.userActions.isLoading = false;
-    });
+    builder.addCase(
+      executeGetUserActions.rejected,
+      handleRejectedUserActionsRequest
+    );
+    builder.addCase(
+      executeGetUserActions.fulfilled,
+      handleFulfilledUserActionsRequest
+    );
     builder.addCase(executeGetUserActions.pending, (state) => {
       state.userActions.isLoading = true;
     });

--- a/packages/headless/src/features/user-profile/user-profile-state.ts
+++ b/packages/headless/src/features/user-profile/user-profile-state.ts
@@ -1,0 +1,81 @@
+import {Result} from '../../api/search/search/result';
+import {MLAPIErrorWithStatusCode} from '../../api/machine-learning/ml-api-client';
+
+/**
+ * User Actions posible type.
+ */
+export enum UserActionType {
+  Search = 'SEARCH',
+  Click = 'CLICK',
+  PageView = 'VIEW',
+  Custom = 'CUSTOM',
+}
+
+/**
+ * Pased Action History item format.
+ */
+export interface ActionHistory {
+  /**
+   * Type of the action.
+   */
+  name: UserActionType;
+  /**
+   * When the action was done.
+   */
+  time: number;
+  /**
+   * Value associated to an actions.
+   */
+  value: {
+    [key: string]: string;
+  };
+}
+
+/**
+ * Represent an action that a user has made.
+ */
+export class UserAction {
+  constructor(
+    public type: UserActionType,
+    public timestamp: Date,
+    public raw: {
+      [key: string]: string | undefined;
+      query_expression?: string;
+      uri_hash?: string;
+      event_type?: string;
+      event_value?: string;
+      origin_level_1?: string;
+      cause?: string;
+      content_id_key?: string;
+      content_id_value?: string;
+    },
+    public document?: Result,
+    public query?: string
+  ) {}
+}
+
+export interface UserActionsState {
+  actions: UserAction[];
+  duration: number;
+  error: MLAPIErrorWithStatusCode | null;
+  isLoading: boolean;
+}
+
+export interface UserProfileState {
+  userId: string;
+  userActions: UserActionsState;
+  debug: boolean;
+}
+
+export function getUserProfileInitialState(): UserProfileState {
+  return {
+    userId: '',
+    userActions: {
+      actions: [],
+      duration: 0,
+      error: null,
+      isLoading: false,
+    },
+    debug: false,
+  };
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -18,11 +18,13 @@ export {
 } from './app/headless-engine';
 export {searchAppReducers} from './app/search-app-reducers';
 export {recommendationAppReducers} from './app/recommendation-app-reducers';
+export {userProfileAppReducers} from './app/user-profile-app-reducers';
 
 // State
 export {ProductRecommendationsAppState} from './state/product-recommendations-app-state';
 export {SearchParametersState, SearchAppState} from './state/search-app-state';
 export {RecommendationAppState} from './state/recommendation-app-state';
+export {UserProfileAppState} from './state/user-profile-app-state';
 
 // Controllers
 export * from './controllers/index';

--- a/packages/headless/src/state/state-sections.ts
+++ b/packages/headless/src/state/state-sections.ts
@@ -21,6 +21,7 @@ import {SearchState} from '../features/search/search-state';
 import {SortCriteriaState} from '../features/sort-criteria/sort-criteria-state';
 import {FacetOrderState} from '../features/facets/facet-order/facet-order-state';
 import {ResultPreviewState} from '../features/result-preview/result-preview-state';
+import {UserProfileState} from '../features/user-profile/user-profile-state';
 
 export interface QuerySection {
   /**
@@ -211,4 +212,11 @@ export interface ProductRecommendationsSection {
    * The information related to the product recommendations endpoint.
    */
   productRecommendations: ProductRecommendationsState;
+}
+
+export interface UserProfileSection {
+  /**
+   * The information the machine learning user actions endpoint
+   */
+  userProfile: UserProfileState;
 }

--- a/packages/headless/src/state/user-profile-app-state.ts
+++ b/packages/headless/src/state/user-profile-app-state.ts
@@ -1,0 +1,3 @@
+import {UserProfileSection, ConfigurationSection} from './state-sections';
+
+export type UserProfileAppState = ConfigurationSection & UserProfileSection;

--- a/packages/headless/src/state/user-profile-app-state.ts
+++ b/packages/headless/src/state/user-profile-app-state.ts
@@ -1,3 +1,9 @@
-import {UserProfileSection, ConfigurationSection} from './state-sections';
+import {
+  UserProfileSection,
+  ConfigurationSection,
+  DebugSection,
+} from './state-sections';
 
-export type UserProfileAppState = ConfigurationSection & UserProfileSection;
+export type UserProfileAppState = ConfigurationSection &
+  UserProfileSection &
+  DebugSection;

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -14,6 +14,8 @@ import {RecommendationAppState} from '../state/recommendation-app-state';
 import {createMockRecommendationState} from './mock-recommendation-state';
 import {ProductRecommendationsAppState} from '../state/product-recommendations-app-state';
 import {buildMockProductRecommendationsState} from './mock-product-recommendations-state';
+import {UserProfileAppState} from '../state/user-profile-app-state';
+import {createMockUserProfileState} from './mock-user-profile-state';
 import pino, {Logger} from 'pino';
 import {
   logActionErrorMiddleware,
@@ -33,7 +35,8 @@ type AsyncActionCreator<ThunkArg> = ActionCreatorWithPreparedPayload<
 export type AppState =
   | SearchAppState
   | RecommendationAppState
-  | ProductRecommendationsAppState;
+  | ProductRecommendationsAppState
+  | UserProfileAppState;
 
 export interface MockEngine<T extends AppState> extends Engine<T> {
   mockStore: MockStore;
@@ -64,6 +67,12 @@ export function buildMockProductRecommendationsAppEngine(
   config: Partial<Engine<ProductRecommendationsAppState>> = {}
 ): MockEngine<ProductRecommendationsAppState> {
   return buildMockEngine(config, buildMockProductRecommendationsState);
+}
+
+export function buildMockUserProfileAppEngine(
+  config: Partial<Engine<UserProfileAppState>> = {}
+): MockEngine<UserProfileAppState> {
+  return buildMockEngine(config, createMockUserProfileState);
 }
 
 function buildMockEngine<T extends AppState>(

--- a/packages/headless/src/test/mock-ml-api-client.ts
+++ b/packages/headless/src/test/mock-ml-api-client.ts
@@ -1,0 +1,13 @@
+import pino from 'pino';
+import {
+  MLAPIClient,
+  MLAPIClientOptions,
+} from '../api/machine-learning/ml-api-client';
+
+export function buildMockMLAPIClient(options?: Partial<MLAPIClientOptions>) {
+  return new MLAPIClient({
+    renewAccessToken: async () => '',
+    logger: pino({level: 'silent'}),
+    ...options,
+  });
+}

--- a/packages/headless/src/test/mock-user-profile-state.ts
+++ b/packages/headless/src/test/mock-user-profile-state.ts
@@ -1,0 +1,13 @@
+import {getConfigurationInitialState} from '../features/configuration/configuration-state';
+import {getUserProfileInitialState} from '../features/user-profile/user-profile-state';
+import {UserProfileAppState} from '../state/user-profile-app-state';
+
+export function createMockUserProfileState(
+  config: Partial<UserProfileAppState> = {}
+): UserProfileAppState {
+  return {
+    configuration: getConfigurationInitialState(),
+    userProfile: getUserProfileInitialState(),
+    ...config,
+  };
+}

--- a/packages/headless/src/test/mock-user-profile-state.ts
+++ b/packages/headless/src/test/mock-user-profile-state.ts
@@ -1,4 +1,5 @@
 import {getConfigurationInitialState} from '../features/configuration/configuration-state';
+import {getDebugInitialState} from '../features/debug/debug-state';
 import {getUserProfileInitialState} from '../features/user-profile/user-profile-state';
 import {UserProfileAppState} from '../state/user-profile-app-state';
 
@@ -8,6 +9,7 @@ export function createMockUserProfileState(
   return {
     configuration: getConfigurationInitialState(),
     userProfile: getUserProfileInitialState(),
+    debug: getDebugInitialState(),
     ...config,
   };
 }


### PR DESCRIPTION
[SFINT-3811](https://coveord.atlassian.net/browse/SFINT-3811)

This PR adds the headless controller required to get user actions data.
This includes:
- ML API client
- User profile feature
- User actions controller

In the future, the Personalization API should allow us to get the same user profile data and more so the ML client would likely be replaced when this new API is ready.