### PR TITLE
fix(atomic): fix query suggestions whitespace

### DIFF
--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -205,9 +205,10 @@ export class AtomicSearchBox {
           part="suggestion"
           id={id}
           class="suggestion h-9 px-2 cursor-pointer text-left text-sm bg-transparent border-none shadow-none flex flex-row items-center"
-          innerHTML={suggestion.highlightedValue}
           value={index}
-        />
+        >
+          <pre class="font-sans" innerHTML={suggestion.highlightedValue}></pre>
+        </li>
       );
     });
   }


### PR DESCRIPTION
Other possible solution, with no `pre` tag: 

```
suggestion.highlightedValue.replace(/\s/g, '&nbsp;')
```
https://coveord.atlassian.net/browse/KIT-593