### PR TITLE
fix(atomic): merge i18n resource bundle on language change

### DIFF
--- a/packages/atomic/cypress/integration/search-interface.cypress.ts
+++ b/packages/atomic/cypress/integration/search-interface.cypress.ts
@@ -1,0 +1,67 @@
+import {setUpPage} from '../utils/setupComponent';
+import {i18n} from 'i18next';
+
+type SearchInterface = HTMLElement & {
+  language: string;
+  i18n: i18n;
+};
+
+describe('Search Interface Component', () => {
+  beforeEach(() => {
+    setUpPage('<atomic-query-summary>', true);
+  });
+
+  const getSearchInterface = (
+    cb: (searchInterface: SearchInterface) => void
+  ) => {
+    cy.get('atomic-search-interface').then(($el) => {
+      cb(
+        $el.get(0) as HTMLElement & {
+          language: string;
+          i18n: i18n;
+        }
+      );
+    });
+  };
+
+  const setLanguage = (lang: string) => {
+    getSearchInterface((searchInterface) => {
+      searchInterface.language = lang;
+    });
+  };
+
+  const setTranslation = (lang: string, key: string, value: string) => {
+    getSearchInterface((searchInterface) => {
+      searchInterface.i18n.addResource(lang, 'translation', key, value);
+    });
+  };
+
+  it('should support changing language', () => {
+    setLanguage('fr');
+    cy.get('atomic-query-summary')
+      .shadow()
+      .invoke('text')
+      .should('contain', 'Résultats');
+
+    setLanguage('en');
+    cy.get('atomic-query-summary')
+      .shadow()
+      .invoke('text')
+      .should('contain', 'Results');
+  });
+
+  it('should support changing a translation value without overriding other strings', () => {
+    setTranslation('fr', 'showingResultsOf_plural', 'patate');
+    setLanguage('fr');
+
+    cy.get('atomic-query-summary')
+      .shadow()
+      .invoke('text')
+      .should('contain', 'patate');
+
+    cy.get('atomic-query-summary')
+      .shadow()
+      .invoke('text')
+      .should('contain', 'seconde');
+  });
+});

--- a/packages/atomic/cypress/tsconfig.json
+++ b/packages/atomic/cypress/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "strict": true,
     "baseUrl": "../node_modules",

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -107,7 +107,20 @@ export class AtomicSearchInterface {
 
   @Watch('language')
   public updateLanguage() {
-    this.i18n.changeLanguage(this.language);
+    new Backend(this.i18n.services, this.i18nBackendOptions).read(
+      this.language,
+      'translation',
+      (_, data) => {
+        this.i18n.addResourceBundle(
+          this.language,
+          'translation',
+          data,
+          true,
+          false
+        );
+        this.i18n.changeLanguage(this.language);
+      }
+    );
   }
 
   public disconnectedCallback() {
@@ -193,9 +206,7 @@ export class AtomicSearchInterface {
       debug: this.logLevel === 'debug',
       lng: this.language,
       fallbackLng: ['en'],
-      backend: {
-        loadPath: `${getAssetPath('./lang/')}{{lng}}.json`,
-      } as BackendOptions,
+      backend: this.i18nBackendOptions,
     });
   }
 
@@ -262,5 +273,11 @@ export class AtomicSearchInterface {
       ),
       <slot></slot>,
     ];
+  }
+
+  private get i18nBackendOptions(): BackendOptions {
+    return {
+      loadPath: `${getAssetPath('./lang/')}{{lng}}.json`,
+    };
   }
 }


### PR DESCRIPTION
Problem was: 
Using a backend, which serves local assets from stencil asset folder works as long as you don't any any "custom local resource".

As soon as you call something like this in your search page: 

```
searchInterface.i18n.addResource('fr', 'translation', 'sortBy', 'patate');

searchInterface.language = 'fr';
```

Then the end result will be that `sortBy` will be translated to `patate`, but all the other strings in the interface will appear in the fallback language (`en`), since i18n will only look at "local" resources for translation as soon as you add at least one, and won't automatically merge with those available in the backend (the various JSON translation files we have).

This PR changes it so that whenever someone change the language with `searchInterface.language = 'foo'`, we use the backend to read all available translation for that language, call `this.i18n.addResourceBundle` with `deep=true` (3rd param) and `overwrite=false` (4th param), which essentially merge everything without overwriting any user provided values.


https://coveord.atlassian.net/browse/KIT-596