### PR TITLE
chore(headless): add case-assist sub-module

### DIFF
--- a/packages/headless/case-assist/package.json
+++ b/packages/headless/case-assist/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "case-assist",
+  "version": "1.0.0",
+  "description": "",
+  "main": "../dist/case-assist/headless-case-assist.esm.js",
+  "types": "../dist/case-assist.index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -11,7 +11,8 @@
   "license": "Apache-2.0",
   "version": "0.10.0-alpha.12",
   "files": [
-    "dist/"
+    "dist/",
+    "case-assist/"
   ],
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -55,6 +55,26 @@ const nodeConfig = {
   onwarn: onWarn,
 };
 
+const caseAssistEsm = {
+  input: 'src/case-assist.index.ts',
+  output: [
+    {file: 'dist/case-assist/headless-case-assist.esm.js', format: 'es'},
+  ],
+  plugins: [
+    resolve({modulesOnly: true}),
+    commonjs({
+      // https://github.com/pinojs/pino/issues/688
+      ignore: ['pino-pretty'],
+    }),
+    typescript(),
+    replace(),
+  ],
+  external: ['cross-fetch', 'web-encoding'],
+  onwarn: onWarn,
+};
+
+
+
 const browserConfig = {
   input: 'src/index.ts',
   output: [
@@ -111,6 +131,6 @@ const typeDefinitions = {
   plugins: [dts()]
 }
 
-const config = isProduction ? [nodeConfig, typeDefinitions, browserConfig] : [browserConfig];
+const config = isProduction ? [nodeConfig, typeDefinitions, browserConfig, caseAssistEsm] : [browserConfig];
 
 export default config;

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -1,0 +1,3 @@
+export function hello() {
+  return 'hello world';
+}


### PR DESCRIPTION
As headless supports more apis, there is need to organize the exports so that developers know what set of controllers and actions go together to build a cohesive interface.

It feels like the natural division is by use-case/api. There is more than one way to deliver this, but the approach in this draft PR is to create sub-modules within the headless package. Some benefits include:

1. There is only one @coveo/headless dependency that developers need to install.
2. It is easier to share code internally.

One disadvantage is it might become difficult to know what goes with what internally, but I think we can manage this by using directories and conventions.


To access different sub-modules, the developer would type:

```
import {buildCaseAssistEngine} from '@coveo/headless/case-assist'
```

**Note**: The PR is just a PoC to show what is needed to achieve the approach, and gather feedback.



https://coveord.atlassian.net/browse/KIT-605