### PR TITLE
chore(headless): share request parameters

### DIFF
--- a/packages/headless/src/api/platform-service-params.ts
+++ b/packages/headless/src/api/platform-service-params.ts
@@ -1,0 +1,25 @@
+export interface BaseParam {
+  url: string;
+  accessToken: string;
+  organizationId: string;
+}
+
+export interface ContextParam {
+  context?: Record<string, string | string[]>;
+}
+
+export interface DebugParam {
+  debug?: boolean;
+}
+
+export interface LocaleParam {
+  locale?: string;
+}
+
+export interface NumberOfResultsParam {
+  numberOfResults?: number;
+}
+
+export interface VisitorIDParam {
+  visitorId?: string;
+}

--- a/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
@@ -1,4 +1,4 @@
-import {BaseParam} from '../../search-api-params';
+import {BaseParam} from '../../../platform-service-params';
 import {SearchRequest} from '../../search/search-request';
 
 export interface FacetSearchRequestOptions {

--- a/packages/headless/src/api/search/facet-search/facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/facet-search-request.ts
@@ -1,6 +1,6 @@
 import {SpecificFacetSearchRequest} from './specific-facet-search/specific-facet-search-request';
 import {CategoryFacetSearchRequest} from './category-facet-search/category-facet-search-request';
-import {BaseParam} from '../search-api-params';
+import {BaseParam} from '../../platform-service-params';
 
 export type FacetSearchRequest = BaseParam &
   (SpecificFacetSearchRequest | CategoryFacetSearchRequest);

--- a/packages/headless/src/api/search/html/html-request.ts
+++ b/packages/headless/src/api/search/html/html-request.ts
@@ -1,4 +1,4 @@
-import {BaseParam} from '../search-api-params';
+import {BaseParam} from '../../platform-service-params';
 
 export interface HtmlRequestOptions {
   uniqueId: string;

--- a/packages/headless/src/api/search/plan/plan-request.ts
+++ b/packages/headless/src/api/search/plan/plan-request.ts
@@ -2,10 +2,8 @@ import {
   BaseParam,
   ContextParam,
   LocaleParam,
-  PipelineParam,
-  QueryParam,
-  SearchHubParam,
-} from '../search-api-params';
+} from '../../platform-service-params';
+import {PipelineParam, QueryParam, SearchHubParam} from '../search-api-params';
 
 export type PlanRequest = BaseParam &
   SearchHubParam &

--- a/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
+++ b/packages/headless/src/api/search/product-recommendations/product-recommendations-request.ts
@@ -1,14 +1,16 @@
 import {
-  ActionsHistoryParam,
   BaseParam,
   ContextParam,
-  FieldsToIncludeParam,
   LocaleParam,
-  MachineLearningParam,
   NumberOfResultsParam,
+  VisitorIDParam,
+} from '../../platform-service-params';
+import {
+  ActionsHistoryParam,
+  FieldsToIncludeParam,
+  MachineLearningParam,
   RecommendationParam,
   SearchHubParam,
-  VisitorIDParam,
 } from '../search-api-params';
 
 export type ProductRecommendationsRequest = BaseParam &

--- a/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
+++ b/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
@@ -1,8 +1,10 @@
 import {
-  ActionsHistoryParam,
   BaseParam,
   ContextParam,
   LocaleParam,
+} from '../../platform-service-params';
+import {
+  ActionsHistoryParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,

--- a/packages/headless/src/api/search/recommendation/recommendation-request.ts
+++ b/packages/headless/src/api/search/recommendation/recommendation-request.ts
@@ -1,9 +1,8 @@
+import {BaseParam, ContextParam} from '../../platform-service-params';
 import {
   ActionsHistoryParam,
   AdvancedQueryParam,
-  BaseParam,
   ConstantQueryParam,
-  ContextParam,
   FieldsToIncludeParam,
   PipelineParam,
   RecommendationParam,

--- a/packages/headless/src/api/search/search-api-client.ts
+++ b/packages/headless/src/api/search/search-api-client.ts
@@ -18,7 +18,7 @@ import {PlanRequest} from './plan/plan-request';
 import {QuerySuggestRequest} from './query-suggest/query-suggest-request';
 import {FacetSearchRequest} from './facet-search/facet-search-request';
 import {SearchAppState} from '../../state/search-app-state';
-import {BaseParam, baseSearchRequest} from './search-api-params';
+import {baseSearchRequest} from './search-api-params';
 import {RecommendationRequest} from './recommendation/recommendation-request';
 import {ProductRecommendationsRequest} from './product-recommendations/product-recommendations-request';
 import {Logger} from 'pino';
@@ -32,6 +32,7 @@ import {PreprocessRequest} from '../preprocess-request';
 import {HtmlRequest} from './html/html-request';
 import {findEncoding} from './encoding-finder';
 import {TextDecoder} from 'web-encoding';
+import {BaseParam} from '../platform-service-params';
 
 export type AllSearchAPIResponse = Plan | Search | QuerySuggest;
 

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -2,16 +2,7 @@ import {history} from 'coveo.analytics';
 import {FacetOptions} from '../../features/facet-options/facet-options';
 import {AnyFacetRequest} from '../../features/facets/generic/interfaces/generic-facet-request';
 import {HTTPContentType, HttpMethods} from '../platform-client';
-
-export interface BaseParam {
-  url: string;
-  accessToken: string;
-  organizationId: string;
-}
-
-export interface ContextParam {
-  context?: Record<string, string | string[]>;
-}
+import {BaseParam} from '../platform-service-params';
 
 export interface QueryParam {
   q?: string;
@@ -31,10 +22,6 @@ export interface AdvancedQueryParam {
 
 export interface ConstantQueryParam {
   cq?: string;
-}
-
-export interface NumberOfResultsParam {
-  numberOfResults?: number;
 }
 
 export interface SortCriteriaParam {
@@ -61,10 +48,6 @@ export interface FieldsToIncludeParam {
   fieldsToInclude?: string[];
 }
 
-export interface VisitorIDParam {
-  visitorId?: string;
-}
-
 export interface FacetOptionsParam {
   facetOptions?: FacetOptions;
 }
@@ -75,14 +58,6 @@ export interface RecommendationParam {
 
 export interface MachineLearningParam {
   mlParameters: MachineLearningECommerceParameters;
-}
-
-export interface DebugParam {
-  debug?: boolean;
-}
-
-export interface LocaleParam {
-  locale?: string;
 }
 
 export interface MachineLearningECommerceParameters {

--- a/packages/headless/src/api/search/search/search-request.ts
+++ b/packages/headless/src/api/search/search/search-request.ts
@@ -1,22 +1,24 @@
 import {
-  AdvancedQueryParam,
   BaseParam,
-  ConstantQueryParam,
   ContextParam,
+  DebugParam,
+  LocaleParam,
+  NumberOfResultsParam,
+  VisitorIDParam,
+} from '../../platform-service-params';
+import {
+  AdvancedQueryParam,
+  ConstantQueryParam,
   EnableDidYouMeanParam,
   EnableQuerySyntaxParam,
   FacetOptionsParam,
   FacetsParam,
   FieldsToIncludeParam,
   FirstResultParam,
-  NumberOfResultsParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,
   SortCriteriaParam,
-  VisitorIDParam,
-  DebugParam,
-  LocaleParam,
 } from '../search-api-params';
 
 export type SearchRequest = BaseParam &


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-3836

For the Case Assist, we'll need to add a CaseAssistAPIClient. In order to invoke this client, we'll need to pass some request parameters that are already defined for the SearchAPIClient.

In order to better share request parameters between the different API clients, this PR moves the common request parameters into the `platform-service-params.ts` file.
