### PR TITLE
feat(atomic): styling changes for printable uri

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -6,7 +6,7 @@ atomic-result-printable-uri button {
   color: var(--atomic-primary);
 }
 
-atomic-result-printable-uri span[part="result-printable-uri-list-separator"] svg {
+atomic-result-printable-uri svg {
   display: inline-block;
   width: 100%;
   height: 100%;

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -6,8 +6,11 @@ atomic-result-printable-uri button {
   color: var(--atomic-primary);
 }
 
-atomic-result-printable-uri li::after {
-  content: var(--atomic-separator);
+atomic-result-printable-uri span[part="result-printable-uri-list-separator"] svg {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  vertical-align: top;
 }
 
 atomic-result-printable-uri li:last-child::after {

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../utils/initialization-utils';
 import {Schema, NumberValue} from '@coveo/bueno';
 import {filterProtocol} from '../../../utils/xss-utils';
+import Arrow from '../../../images/arrow-right.svg';
 
 /**
  * The ResultUri component displays the URI, or path, to access a result.
@@ -17,6 +18,7 @@ import {filterProtocol} from '../../../utils/xss-utils';
  * @part result-printable-uri-list-element - A result printable uri list element
  * @part result-printable-uri-link - A result printable uri clickable link
  * @part result-printable-uri-list-ellipsis - The clickable ellipsis of a result uri
+ * @part result-printable-uri-list-separator - The visual separator between each part of the uri
  */
 @Component({
   tag: 'atomic-result-printable-uri',
@@ -54,12 +56,13 @@ export class AtomicResultPrintableUri {
     return (
       <li part="result-printable-uri-list-element">
         <button
-          part="result-printable-uri-list-ellipsis"
+          part="result-printable-uri-list-ellipsis align-middle"
           aria-label={this.strings.collapsedUriParts()}
           onClick={() => (this.listExpanded = true)}
         >
           ...
         </button>
+        {this.renderSeparator()}
       </li>
     );
   }
@@ -67,17 +70,32 @@ export class AtomicResultPrintableUri {
   private get allParents() {
     const parentsXml = parseXML(`${this.result.raw.parents}`);
     const parents = Array.from(parentsXml.getElementsByTagName('parent'));
-    return parents.map((parent) => {
+    return parents.map((parent, i) => {
       const name = parent.getAttribute('name');
       const uri = parent.getAttribute('uri')!;
       return (
         <li part="result-printable-uri-list-element">
-          <a part="result-printable-uri-link" href={filterProtocol(uri)}>
+          <a
+            part="result-printable-uri-link"
+            class="text-sm inline-block align-middle"
+            href={filterProtocol(uri)}
+          >
             {name}
           </a>
+          {i === parents.length - 1 ? null : this.renderSeparator()}
         </li>
       );
     });
+  }
+
+  private renderSeparator() {
+    return (
+      <span
+        part="result-printable-uri-list-separator"
+        class="w-3 h-3 inline-block mx-2 align-middle"
+        innerHTML={Arrow}
+      ></span>
+    );
   }
 
   private renderParents() {
@@ -100,7 +118,7 @@ export class AtomicResultPrintableUri {
   public render() {
     const parents = this.renderParents();
     if (parents.length) {
-      const parts = `result-printable-uri-list${
+      const parts = `result-printable-uri-list ${
         this.listExpanded ? ' result-printable-uri-list-expanded' : ''
       }`;
 
@@ -110,6 +128,7 @@ export class AtomicResultPrintableUri {
     return (
       <a
         part="result-printable-uri-link"
+        class="text-sm"
         href={filterProtocol(this.result.clickUri)}
       >
         <atomic-result-text field="printableUri"></atomic-result-text>

--- a/packages/atomic/src/images/arrow-right.svg
+++ b/packages/atomic/src/images/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.09619 10.5962L5.69239 6L1.09619 1.40381" stroke="#C5CACF" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/atomic/src/themes/default.css
+++ b/packages/atomic/src/themes/default.css
@@ -17,6 +17,5 @@
 
   /* Others */
   --atomic-font-family: Lato, Arial, Helvetica, sans-serif;
-  --atomic-separator: ' > ';
   --atomic-icon-size: 30px;
 }


### PR DESCRIPTION
* Smaller text for printable uri
* Use svg icon for separator
* Remove css var atomic-separator (used only for this component from what I can see)

![image](https://user-images.githubusercontent.com/1591893/114617786-9718f000-9c76-11eb-9ebd-c4264e19c256.png)


https://coveord.atlassian.net/browse/KIT-615