### PR TITLE
chore(headless): dynamically load reducers

### DIFF
--- a/packages/headless/src/app/headless-engine.test.ts
+++ b/packages/headless/src/app/headless-engine.test.ts
@@ -9,6 +9,7 @@ import {AnalyticsClientSendEventHook} from 'coveo.analytics/dist/definitions/cli
 import pino from 'pino';
 import {validatePayloadAndThrow} from '../utils/validate-payload';
 import {buildMockSearchAPIClient} from '../test/mock-search-api-client';
+import {combineReducers} from '@reduxjs/toolkit';
 
 describe('headless engine', () => {
   let options: HeadlessOptions<typeof searchAppReducers>;
@@ -18,7 +19,7 @@ describe('headless engine', () => {
 
   beforeEach(() => {
     store = storeConfig.configureStore({
-      reducers: searchAppReducers,
+      reducer: combineReducers(searchAppReducers),
       thunkExtraArguments: {
         searchAPIClient: buildMockSearchAPIClient(),
         analyticsClientMiddleware: {} as AnalyticsClientSendEventHook,

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -292,8 +292,8 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
   }
 
   public addReducers(reducers: ReducersMapObject) {
-    const reducer = this.reducerManager.combine(reducers);
-    this.reduxStore.replaceReducer(reducer);
+    this.reducerManager.add(reducers);
+    this.reduxStore.replaceReducer(this.reducerManager.reducer);
   }
 
   private validateConfiguration(options: HeadlessOptions<Reducers>) {

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -438,11 +438,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
   }
 
   get store() {
-    const replaceReducer = () =>
-      this.logger.warn(
-        'Please use the "addReducers" method on the engine instead.'
-      );
-    return {...this.reduxStore, replaceReducer};
+    return this.reduxStore;
   }
 
   get dispatch(): EngineDispatch<StateFromReducersMapObject<Reducers>> {

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -293,7 +293,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
 
   public addReducers(reducers: ReducersMapObject) {
     this.reducerManager.add(reducers);
-    this.reduxStore.replaceReducer(this.reducerManager.reducer);
+    this.reduxStore.replaceReducer(this.reducerManager.combinedReducer);
   }
 
   private validateConfiguration(options: HeadlessOptions<Reducers>) {
@@ -381,7 +381,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
       this.options.configuration.preprocessRequest || NoopPreprocessRequest;
     this.reduxStore = configureStore({
       preloadedState: this.options.preloadedState,
-      reducer: this.reducerManager.reducer,
+      reducer: this.reducerManager.combinedReducer,
       middlewares: this.options.middlewares,
       thunkExtraArguments: {
         searchAPIClient: new SearchAPIClient({

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -250,7 +250,7 @@ export interface Engine<State = SearchAppState> {
   /**
    * Adds the specified reducers to the store.
    */
-  addReducers(reducerMap: ReducersMapObject): void;
+  addReducers(reducers: ReducersMapObject): void;
 }
 
 /**
@@ -267,7 +267,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
   constructor(private options: HeadlessOptions<Reducers>) {
     this.initLogger();
     this.validateConfiguration(options);
-    this.initReducerManger();
+    this.initReducerManager();
     this.initStore();
 
     this.reduxStore.dispatch(
@@ -371,7 +371,7 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
     });
   }
 
-  private initReducerManger() {
+  private initReducerManager() {
     this.reducerManager = createReducerManager(this.options.reducers);
   }
 

--- a/packages/headless/src/app/reducer-manager.test.ts
+++ b/packages/headless/src/app/reducer-manager.test.ts
@@ -7,7 +7,7 @@ describe('ReducerManager', () => {
     const manager = createReducerManager({});
     manager.add({pagination});
 
-    const state = manager.reducer(undefined, {type: ''});
+    const state = manager.combinedReducer(undefined, {type: ''});
     expect(state).toEqual({pagination: getPaginationInitialState()});
   });
 
@@ -15,7 +15,7 @@ describe('ReducerManager', () => {
     const manager = createReducerManager({pagination});
     manager.add({pagination: search});
 
-    const state = manager.reducer(undefined, {type: ''});
+    const state = manager.combinedReducer(undefined, {type: ''});
     expect(state).toEqual({pagination: getPaginationInitialState()});
   });
 });

--- a/packages/headless/src/app/reducer-manager.test.ts
+++ b/packages/headless/src/app/reducer-manager.test.ts
@@ -1,0 +1,21 @@
+import {getPaginationInitialState} from '../features/pagination/pagination-state';
+import {createReducerManager} from './reducer-manager';
+import {pagination, search} from './reducers';
+
+describe('ReducerManager', () => {
+  it('when a key does not exist, #add stores the key-reducer pair', () => {
+    const manager = createReducerManager({});
+    manager.add({pagination});
+
+    const state = manager.reducer(undefined, {type: ''});
+    expect(state).toEqual({pagination: getPaginationInitialState()});
+  });
+
+  it('when a key exists, calling #add with the same key does not overwrite the existing reducer', () => {
+    const manager = createReducerManager({pagination});
+    manager.add({pagination: search});
+
+    const state = manager.reducer(undefined, {type: ''});
+    expect(state).toEqual({pagination: getPaginationInitialState()});
+  });
+});

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -1,7 +1,7 @@
 import {combineReducers, ReducersMapObject, Reducer} from '@reduxjs/toolkit';
 
 export interface ReducerManager {
-  reducer: Reducer;
+  combinedReducer: Reducer;
   add: (newReducers: ReducersMapObject) => void;
 }
 
@@ -11,7 +11,7 @@ export function createReducerManager(
   const reducers = {...initialReducers};
 
   return {
-    get reducer() {
+    combinedReducer() {
       return combineReducers(reducers);
     },
 

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -11,7 +11,7 @@ export function createReducerManager(
   const reducers = {...initialReducers};
 
   return {
-    combinedReducer() {
+    get combinedReducer() {
       return combineReducers(reducers);
     },
 

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -1,0 +1,23 @@
+import {combineReducers, ReducersMapObject, Reducer} from '@reduxjs/toolkit';
+
+export interface ReducerManager {
+  reducer: Reducer;
+  combine: (newReducers: ReducersMapObject) => Reducer;
+}
+
+export function createReducerManager(
+  initialReducers: ReducersMapObject
+): ReducerManager {
+  let reducers = {...initialReducers};
+
+  return {
+    get reducer() {
+      return combineReducers(reducers);
+    },
+
+    combine(newReducers: ReducersMapObject) {
+      reducers = {...newReducers, ...reducers};
+      return this.reducer;
+    },
+  };
+}

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -2,22 +2,23 @@ import {combineReducers, ReducersMapObject, Reducer} from '@reduxjs/toolkit';
 
 export interface ReducerManager {
   reducer: Reducer;
-  combine: (newReducers: ReducersMapObject) => Reducer;
+  add: (newReducers: ReducersMapObject) => void;
 }
 
 export function createReducerManager(
   initialReducers: ReducersMapObject
 ): ReducerManager {
-  let reducers = {...initialReducers};
+  const reducers = {...initialReducers};
 
   return {
     get reducer() {
       return combineReducers(reducers);
     },
 
-    combine(newReducers: ReducersMapObject) {
-      reducers = {...newReducers, ...reducers};
-      return this.reducer;
+    add(newReducers: ReducersMapObject) {
+      Object.keys(newReducers)
+        .filter((key) => !(key in reducers))
+        .forEach((key) => (reducers[key] = newReducers[key]));
     },
   };
 }

--- a/packages/headless/src/app/reducers.ts
+++ b/packages/headless/src/app/reducers.ts
@@ -1,6 +1,11 @@
 import {configurationReducer} from '../features/configuration/configuration-slice';
+import {specificFacetSearchSetReducer} from '../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
+import {facetSetReducer} from '../features/facets/facet-set/facet-set-slice';
 import {paginationReducer} from '../features/pagination/pagination-slice';
+import {searchReducer} from '../features/search/search-slice';
 
 export const configuration = configurationReducer;
-
 export const pagination = paginationReducer;
+export const facetSet = facetSetReducer;
+export const facetSearchSet = specificFacetSearchSetReducer;
+export const search = searchReducer;

--- a/packages/headless/src/app/reducers.ts
+++ b/packages/headless/src/app/reducers.ts
@@ -1,0 +1,6 @@
+import {configurationReducer} from '../features/configuration/configuration-slice';
+import {paginationReducer} from '../features/pagination/pagination-slice';
+
+export const configuration = configurationReducer;
+
+export const pagination = paginationReducer;

--- a/packages/headless/src/app/store.ts
+++ b/packages/headless/src/app/store.ts
@@ -1,9 +1,9 @@
 import {
   configureStore as configureStoreToolkit,
   ReducersMapObject,
-  combineReducers,
   StateFromReducersMapObject,
   Middleware,
+  Reducer,
 } from '@reduxjs/toolkit';
 import {AnalyticsClientSendEventHook} from 'coveo.analytics';
 import {SearchAPIClient} from '../api/search/search-api-client';
@@ -25,20 +25,20 @@ export interface ThunkExtraArguments {
 }
 
 interface ConfigureStoreOptions<Reducers extends ReducersMapObject> {
-  reducers: Reducers;
+  reducer: Reducer;
   preloadedState?: StateFromReducersMapObject<Reducers>;
   middlewares?: Middleware[];
   thunkExtraArguments: ThunkExtraArguments;
 }
 
 export function configureStore<Reducers extends ReducersMapObject>({
-  reducers,
+  reducer,
   preloadedState,
   middlewares = [],
   thunkExtraArguments,
 }: ConfigureStoreOptions<Reducers>) {
   return configureStoreToolkit({
-    reducer: combineReducers(reducers),
+    reducer,
     preloadedState,
     devTools: {
       stateSanitizer: (state) =>

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -20,6 +20,12 @@ import {SearchAppState} from '../../../state/search-app-state';
 import * as FacetIdDeterminor from '../_common/facet-id-determinor';
 import {buildMockFacetSearch} from '../../../test/mock-facet-search';
 import * as FacetSearch from '../facet-search/specific/headless-facet-search';
+import {
+  configuration,
+  facetSearchSet,
+  facetSet,
+  search,
+} from '../../../app/reducers';
 
 describe('facet', () => {
   const facetId = '1';
@@ -54,6 +60,15 @@ describe('facet', () => {
 
   it('renders', () => {
     expect(facet).toBeTruthy();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      facetSet,
+      configuration,
+      facetSearchSet,
+      search,
+    });
   });
 
   it('exposes a #subscribe method', () => {

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -48,6 +48,7 @@ import {
   facetSet,
   search,
 } from '../../../app/reducers';
+import {failedToLoadReducers} from '../../../utils/errors';
 
 export {FacetOptions, FacetSearchOptions, FacetValueState};
 
@@ -234,7 +235,7 @@ export interface FacetValue {
  * */
 export function buildFacet(engine: Engine<unknown>, props: FacetProps): Facet {
   if (!loadFacetReducers(engine)) {
-    throw new Error();
+    throw failedToLoadReducers;
   }
 
   const {dispatch} = engine;

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -48,7 +48,7 @@ import {
   facetSet,
   search,
 } from '../../../app/reducers';
-import {failedToLoadReducers} from '../../../utils/errors';
+import {loadReducerError} from '../../../utils/errors';
 
 export {FacetOptions, FacetSearchOptions, FacetValueState};
 
@@ -235,7 +235,7 @@ export interface FacetValue {
  * */
 export function buildFacet(engine: Engine<unknown>, props: FacetProps): Facet {
   if (!loadFacetReducers(engine)) {
-    throw failedToLoadReducers;
+    throw loadReducerError;
   }
 
   const {dispatch} = engine;

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -42,6 +42,12 @@ import {
 } from './headless-facet-options';
 import {determineFacetId} from '../_common/facet-id-determinor';
 import {FacetValueState} from '../../../features/facets/facet-api/value';
+import {
+  configuration,
+  facetSearchSet,
+  facetSet,
+  search,
+} from '../../../app/reducers';
 
 export {FacetOptions, FacetSearchOptions, FacetValueState};
 
@@ -226,12 +232,11 @@ export interface FacetValue {
  * @param props - The configurable `Facet` properties.
  * @returns A `Facet` controller instance.
  * */
-export function buildFacet(
-  engine: Engine<
-    FacetSection & ConfigurationSection & FacetSearchSection & SearchSection
-  >,
-  props: FacetProps
-): Facet {
+export function buildFacet(engine: Engine<unknown>, props: FacetProps): Facet {
+  if (!loadFacetReducers(engine)) {
+    throw new Error();
+  }
+
   const {dispatch} = engine;
   const controller = buildController(engine);
 
@@ -267,6 +272,8 @@ export function buildFacet(
 
     return initialNumberOfValues < currentValues.length && hasIdleValues;
   };
+
+  const getIsLoading = () => engine.state.search.isLoading;
 
   dispatch(registerFacet(options));
   const facetSearch = createFacetSearch();
@@ -330,7 +337,7 @@ export function buildFacet(
       const request = getRequest();
       const response = getResponse();
 
-      const isLoading = engine.state.search.isLoading;
+      const isLoading = getIsLoading();
       const sortCriterion = request.sortCriteria;
       const values = response ? response.values : [];
       const hasActiveValues = values.some(
@@ -350,4 +357,13 @@ export function buildFacet(
       };
     },
   };
+}
+
+function loadFacetReducers(
+  engine: Engine<unknown>
+): engine is Engine<
+  FacetSection & ConfigurationSection & FacetSearchSection & SearchSection
+> {
+  engine.addReducers({facetSet, configuration, facetSearchSet, search});
+  return true;
 }

--- a/packages/headless/src/controllers/pager/headless-pager.test.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../features/pagination/pagination-actions';
 import {executeSearch} from '../../features/search/search-actions';
 import {SearchAppState} from '../../state/search-app-state';
+import {pagination, configuration} from '../../app/reducers';
 
 describe('Pager', () => {
   let engine: MockEngine<SearchAppState>;
@@ -43,6 +44,13 @@ describe('Pager', () => {
 
   it('initializes', () => {
     expect(pager).toBeTruthy();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      pagination,
+      configuration,
+    });
   });
 
   it('exposes a #subscribe method', () => {

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -28,7 +28,7 @@ import {
   validateOptions,
 } from '../../utils/validate-payload';
 import {configuration, pagination} from '../../app/reducers';
-import {failedToLoadReducers} from '../../utils/errors';
+import {loadReducerError} from '../../utils/errors';
 
 export interface PagerInitialState {
   /**
@@ -142,7 +142,7 @@ export function buildPager(
   props: PagerProps = {}
 ): Pager {
   if (!loadPagerReducers(engine)) {
-    throw failedToLoadReducers;
+    throw loadReducerError;
   }
 
   const controller = buildController(engine);

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -140,7 +140,7 @@ export function buildPager(
   engine: Engine<unknown>,
   props: PagerProps = {}
 ): Pager {
-  if (!loadPagination(engine)) {
+  if (!loadPagerReducers(engine)) {
     throw new Error();
   }
 
@@ -217,7 +217,7 @@ export function buildPager(
   };
 }
 
-function loadPagination(
+function loadPagerReducers(
   engine: Engine<unknown>
 ): engine is Engine<PaginationSection & ConfigurationSection> {
   engine.addReducers({configuration, pagination});

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -27,6 +27,7 @@ import {
   validateInitialState,
   validateOptions,
 } from '../../utils/validate-payload';
+import {configuration, pagination} from '../../app/reducers';
 
 export interface PagerInitialState {
   /**
@@ -136,9 +137,13 @@ export interface PagerState {
  * @returns A `Pager` controller instance.
  * */
 export function buildPager(
-  engine: Engine<PaginationSection & ConfigurationSection>,
+  engine: Engine<unknown>,
   props: PagerProps = {}
 ): Pager {
+  if (!loadPagination(engine)) {
+    throw new Error();
+  }
+
   const controller = buildController(engine);
   const {dispatch} = engine;
 
@@ -210,4 +215,11 @@ export function buildPager(
       return page === this.state.currentPage;
     },
   };
+}
+
+function loadPagination(
+  engine: Engine<unknown>
+): engine is Engine<PaginationSection & ConfigurationSection> {
+  engine.addReducers({configuration, pagination});
+  return true;
 }

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -28,6 +28,7 @@ import {
   validateOptions,
 } from '../../utils/validate-payload';
 import {configuration, pagination} from '../../app/reducers';
+import {failedToLoadReducers} from '../../utils/errors';
 
 export interface PagerInitialState {
   /**
@@ -141,7 +142,7 @@ export function buildPager(
   props: PagerProps = {}
 ): Pager {
   if (!loadPagerReducers(engine)) {
-    throw new Error();
+    throw failedToLoadReducers;
   }
 
   const controller = buildController(engine);

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -93,6 +93,7 @@ function buildMockEngine<T extends AppState>(
     ...config,
     renewAccessToken: mockRenewAccessToken,
     logger,
+    addReducers: jest.fn(),
   };
 }
 

--- a/packages/headless/src/utils/errors.ts
+++ b/packages/headless/src/utils/errors.ts
@@ -1,1 +1,1 @@
-export const failedToLoadReducers = new Error('Failed to load reducers.');
+export const loadReducerError = new Error('Failed to load reducers.');

--- a/packages/headless/src/utils/errors.ts
+++ b/packages/headless/src/utils/errors.ts
@@ -1,0 +1,1 @@
+export const failedToLoadReducers = new Error('Failed to load reducers.');


### PR DESCRIPTION
The goal of this PR is to simplify Headless configuration. Rather than asking a developer to specify reducers, they would be added dynamically when instantiating a controller. Some benefits of the approach are:

- Less configuration for Typescript users. The `reducers` option when instantiating an engine would eventually become optional.
- Reduces the chance of errors for javascript users. The state of the engine argument on controllers can be empty.
- Smaller bundles. Only the instantiated controllers and their corresponding reducers will be included in the bundle. At the moment, all the reducers in `searchAppReducers` are included, whether or not the feature set is being used.


Inspiration: https://redux.js.org/recipes/code-splitting#using-a-reducer-manager
