### PR TITLE
feat(atomic): styling default page search box alignment with results

### DIFF
--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -52,23 +52,35 @@
         margin: 0;
       }
 
-      .interface-container {
-        width: 100%;
-        max-width: 1250px;
-        margin: 0 auto;
-        display: grid;
-        grid-template-columns: 25% 1fr;
+      atomic-search-interface {
+        grid-template-columns: 10% 1fr 3fr 10%;
+        grid-template-rows: 22px 50px 22px 1fr;
         gap: 20px;
+        display: grid;
+        margin: 0 auto;
       }
 
-      .search-box-container {
+      .header {
         background-color: var(--atomic-background-variant);
-        padding: 22px 50px;
+        grid-column: 1 / span 4;
+        grid-row: 1 / span 3;
       }
 
-      .footer-item {
-        grid-column-start: 2;
-        grid-row-start: 3;
+      atomic-search-box {
+        grid-column: 3 / auto;
+        grid-row: 2 / auto;
+        max-width: 1250px;
+      }
+
+      atomic-facet-manager {
+        grid-column: 2 / auto;
+        grid-row: 4 / auto;
+      }
+
+      .results-container {
+        grid-column: 3 / auto;
+        grid-row: 4 / auto;
+        max-width: 1250px;
       }
 
       .side-by-side-container {
@@ -77,13 +89,12 @@
         align-items: center;
       }
 
-      atomic-facet-manager {
-        padding-top: 13px;
+      .footer-item {
+        margin: 30px 0;
       }
 
-      atomic-search-box {
-        margin: auto;
-        max-width: 1250px;
+      atomic-facet-manager {
+        padding-top: 13px;
       }
 
       atomic-result-list {
@@ -103,40 +114,34 @@
 
   <body>
     <atomic-search-interface id="search">
-      <div class="search-box-container">
-        <atomic-search-box></atomic-search-box>
-      </div>
-      <div class="interface-container">
-        <atomic-facet-manager>
-          <atomic-facet field="author" label="Authors"></atomic-facet>
-          <atomic-numeric-facet field="size" label="File sizes">
-            <atomic-numeric-range start="0" end="10"></atomic-numeric-range>
-            <atomic-numeric-range start="10" end="20"></atomic-numeric-range>
-            <atomic-numeric-range start="20" end="30"></atomic-numeric-range>
-            <atomic-numeric-range start="30" end="40"></atomic-numeric-range>
-            <atomic-numeric-range start="40" end="50"></atomic-numeric-range>
-          </atomic-numeric-facet>
-          <atomic-date-facet field="date" label="Date"></atomic-date-facet>
-          <atomic-category-facet
-            field="geographicalhierarchy"
-            label="World Atlas"
-            enable-facet-search
-          ></atomic-category-facet>
-        </atomic-facet-manager>
-        <div class="results-container">
-          <atomic-breadcrumb-manager></atomic-breadcrumb-manager>
-          <atomic-did-you-mean></atomic-did-you-mean>
-          <atomic-query-error></atomic-query-error>
-          <div class="side-by-side-container">
-            <atomic-query-summary></atomic-query-summary>
-            <atomic-sort-dropdown>
-              <atomic-sort-expression caption="relevance" expression="relevancy"></atomic-sort-expression>
-              <atomic-sort-expression caption="mostRecent" expression="date descending"></atomic-sort-expression>
-            </atomic-sort-dropdown>
-          </div>
-          <atomic-no-results></atomic-no-results>
-          <atomic-result-list></atomic-result-list>
+      <div class="header"></div>
+      <atomic-search-box></atomic-search-box>
+      <atomic-facet-manager>
+        <atomic-facet field="author" label="Authors"></atomic-facet>
+        <atomic-numeric-facet field="size" label="File sizes">
+          <atomic-numeric-range start="0" end="10"></atomic-numeric-range>
+          <atomic-numeric-range start="10" end="20"></atomic-numeric-range>
+          <atomic-numeric-range start="20" end="30"></atomic-numeric-range>
+          <atomic-numeric-range start="30" end="40"></atomic-numeric-range>
+          <atomic-numeric-range start="40" end="50"></atomic-numeric-range>
+        </atomic-numeric-facet>
+        <atomic-date-facet field="date" label="Date"></atomic-date-facet>
+        <atomic-category-facet field="geographicalhierarchy" label="World Atlas" enable-facet-search="">
+        </atomic-category-facet>
+      </atomic-facet-manager>
+      <div class="results-container">
+        <atomic-breadcrumb-manager></atomic-breadcrumb-manager>
+        <atomic-did-you-mean></atomic-did-you-mean>
+        <atomic-query-error></atomic-query-error>
+        <div class="side-by-side-container">
+          <atomic-query-summary></atomic-query-summary>
+          <atomic-sort-dropdown>
+            <atomic-sort-expression caption="relevance" expression="relevancy"></atomic-sort-expression>
+            <atomic-sort-expression caption="mostRecent" expression="date descending"></atomic-sort-expression>
+          </atomic-sort-dropdown>
         </div>
+        <atomic-no-results></atomic-no-results>
+        <atomic-result-list></atomic-result-list>
         <div class="footer-item side-by-side-container">
           <atomic-pager></atomic-pager>
           <atomic-results-per-page></atomic-results-per-page>

--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -69,7 +69,7 @@
       atomic-search-box {
         grid-column: 3 / auto;
         grid-row: 2 / auto;
-        max-width: 1250px;
+        max-width: 650px;
       }
 
       atomic-facet-manager {


### PR DESCRIPTION
Did some tweaks to the grid to get the search box correctly aligned with search results + gray header (previously added)

![image](https://user-images.githubusercontent.com/1591893/114768408-cdb63f80-9d36-11eb-8861-67e857ea69b9.png)


https://coveord.atlassian.net/browse/KIT-619