### PR TITLE
fix(headless): add wildcards in facet search initially query

### DIFF
--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
@@ -35,7 +35,7 @@ describe('FacetSearch slice', () => {
         facetId,
         captions: {},
         numberOfValues: 10,
-        query: '',
+        query: '**',
       });
     });
 

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
@@ -97,7 +97,7 @@ export function handleFacetSearchFulfilled<T extends FacetSearchResponse>(
 export const defaultFacetSearchOptions: FacetSearchRequestOptions = {
   captions: {},
   numberOfValues: 10,
-  query: '',
+  query: '**',
 };
 
 function buildFacetSearchOptions(


### PR DESCRIPTION
Consistent behaviour because updating a text with an empty string would set the query to `**`.
The issue was that for a hierarchical facet search, an empty string without wildcards returned no values, meanwhile it did for a specific facet search. I mentioned this bug to the API for v4.
https://coveord.atlassian.net/browse/KIT-601