### PR TITLE
chore: load reducers dynamically

### DIFF
--- a/packages/headless/src/app/frequently-bought-together-app-reducers.ts
+++ b/packages/headless/src/app/frequently-bought-together-app-reducers.ts
@@ -1,18 +1,20 @@
 import {ReducersMapObject} from 'redux';
-import {configurationReducer} from '../features/configuration/configuration-slice';
-import {contextReducer} from '../features/context/context-slice';
-import {versionReducer} from '../features/debug/version-slice';
-import {productRecommendationsReducer} from '../features/product-recommendations/product-recommendations-slice';
-import {searchHubReducer} from '../features/search-hub/search-hub-slice';
 import {ProductRecommendationsAppState} from '../state/product-recommendations-app-state';
+import {
+  configuration,
+  productRecommendations,
+  context,
+  searchHub,
+  version,
+} from './reducers';
 
 /**
  * Map of reducers that make up the ProductRecommendationsAppState.
  */
 export const productRecommendationsAppReducers: ReducersMapObject<ProductRecommendationsAppState> = {
-  configuration: configurationReducer,
-  productRecommendations: productRecommendationsReducer,
-  context: contextReducer,
-  searchHub: searchHubReducer,
-  version: versionReducer,
+  configuration,
+  productRecommendations,
+  context,
+  searchHub,
+  version,
 };

--- a/packages/headless/src/app/recommendation-app-reducers.ts
+++ b/packages/headless/src/app/recommendation-app-reducers.ts
@@ -1,26 +1,28 @@
 import {ReducersMapObject} from 'redux';
-import {advancedSearchQueriesReducer} from '../features/advanced-search-queries/advanced-search-queries-slice';
-import {configurationReducer} from '../features/configuration/configuration-slice';
-import {contextReducer} from '../features/context/context-slice';
-import {debugReducer} from '../features/debug/debug-slice';
-import {versionReducer} from '../features/debug/version-slice';
-import {fieldsReducer} from '../features/fields/fields-slice';
-import {pipelineReducer} from '../features/pipeline/pipeline-slice';
-import {recommendationReducer} from '../features/recommendation/recommendation-slice';
-import {searchHubReducer} from '../features/search-hub/search-hub-slice';
 import {RecommendationAppState} from '../state/recommendation-app-state';
+import {
+  configuration,
+  advancedSearchQueries,
+  fields,
+  context,
+  pipeline,
+  searchHub,
+  debug,
+  recommendation,
+  version,
+} from './reducers';
 
 /**
  * Map of reducers that make up the RecommendationAppState.
  */
 export const recommendationAppReducers: ReducersMapObject<RecommendationAppState> = {
-  configuration: configurationReducer,
-  advancedSearchQueries: advancedSearchQueriesReducer,
-  fields: fieldsReducer,
-  context: contextReducer,
-  pipeline: pipelineReducer,
-  searchHub: searchHubReducer,
-  debug: debugReducer,
-  recommendation: recommendationReducer,
-  version: versionReducer,
+  configuration,
+  advancedSearchQueries,
+  fields,
+  context,
+  pipeline,
+  searchHub,
+  debug,
+  recommendation,
+  version,
 };

--- a/packages/headless/src/app/reducers.ts
+++ b/packages/headless/src/app/reducers.ts
@@ -1,11 +1,69 @@
+import {advancedSearchQueriesReducer} from '../features/advanced-search-queries/advanced-search-queries-slice';
 import {configurationReducer} from '../features/configuration/configuration-slice';
+import {contextReducer} from '../features/context/context-slice';
+import {debugReducer} from '../features/debug/debug-slice';
+import {versionReducer} from '../features/debug/version-slice';
+import {didYouMeanReducer} from '../features/did-you-mean/did-you-mean-slice';
+import {facetOptionsReducer} from '../features/facet-options/facet-options-slice';
+import {categoryFacetSetReducer} from '../features/facets/category-facet-set/category-facet-set-slice';
+import {facetOrderReducer} from '../features/facets/facet-order/facet-order-slice';
+import {categoryFacetSearchSetReducer} from '../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {specificFacetSearchSetReducer} from '../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {facetSetReducer} from '../features/facets/facet-set/facet-set-slice';
+import {dateFacetSetReducer} from '../features/facets/range-facets/date-facet-set/date-facet-set-slice';
+import {numericFacetSetReducer} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice';
+import {fieldsReducer} from '../features/fields/fields-slice';
+import {redo, snapshot, undo} from '../features/history/history-actions';
+import {historyReducer} from '../features/history/history-slice';
 import {paginationReducer} from '../features/pagination/pagination-slice';
+import {pipelineReducer} from '../features/pipeline/pipeline-slice';
+import {productRecommendationsReducer} from '../features/product-recommendations/product-recommendations-slice';
+import {querySetReducer} from '../features/query-set/query-set-slice';
+import {querySuggestReducer} from '../features/query-suggest/query-suggest-slice';
+import {queryReducer} from '../features/query/query-slice';
+import {recommendationReducer} from '../features/recommendation/recommendation-slice';
+import {redirectionReducer} from '../features/redirection/redirection-slice';
+import {resultPreviewReducer} from '../features/result-preview/result-preview-slice';
+import {searchHubReducer} from '../features/search-hub/search-hub-slice';
 import {searchReducer} from '../features/search/search-slice';
+import {sortCriteriaReducer} from '../features/sort-criteria/sort-criteria-slice';
+import {undoable} from './undoable';
 
 export const configuration = configurationReducer;
 export const pagination = paginationReducer;
 export const facetSet = facetSetReducer;
 export const facetSearchSet = specificFacetSearchSetReducer;
 export const search = searchReducer;
+
+export const dateFacetSet = dateFacetSetReducer;
+export const facetOrder = facetOrderReducer;
+export const numericFacetSet = numericFacetSetReducer;
+export const categoryFacetSet = categoryFacetSetReducer;
+export const facetOptions = facetOptionsReducer;
+export const categoryFacetSearchSet = categoryFacetSearchSetReducer;
+export const query = queryReducer;
+export const advancedSearchQueries = advancedSearchQueriesReducer;
+export const querySet = querySetReducer;
+export const redirection = redirectionReducer;
+export const querySuggest = querySuggestReducer;
+export const sortCriteria = sortCriteriaReducer;
+export const context = contextReducer;
+export const didYouMean = didYouMeanReducer;
+export const fields = fieldsReducer;
+export const pipeline = pipelineReducer;
+export const searchHub = searchHubReducer;
+export const debug = debugReducer;
+export const resultPreview = resultPreviewReducer;
+export const version = versionReducer;
+
+export const history = undoable({
+  actionTypes: {
+    redo: redo.type,
+    undo: undo.type,
+    snapshot: snapshot.type,
+  },
+  reducer: historyReducer,
+});
+
+export const recommendation = recommendationReducer;
+export const productRecommendations = productRecommendationsReducer;

--- a/packages/headless/src/app/search-app-reducers.ts
+++ b/packages/headless/src/app/search-app-reducers.ts
@@ -1,69 +1,63 @@
 import {ReducersMapObject} from '@reduxjs/toolkit';
 import {SearchAppState} from '../state/search-app-state';
-import {queryReducer} from '../features/query/query-slice';
-import {configurationReducer} from '../features/configuration/configuration-slice';
-import {redirectionReducer} from '../features/redirection/redirection-slice';
-import {querySuggestReducer} from '../features/query-suggest/query-suggest-slice';
-import {querySetReducer} from '../features/query-set/query-set-slice';
-import {searchReducer} from '../features/search/search-slice';
-import {paginationReducer} from '../features/pagination/pagination-slice';
-import {sortCriteriaReducer} from '../features/sort-criteria/sort-criteria-slice';
-import {facetSetReducer} from '../features/facets/facet-set/facet-set-slice';
-import {contextReducer} from '../features/context/context-slice';
-import {undoable} from './undoable';
-import {historyReducer} from '../features/history/history-slice';
-import {didYouMeanReducer} from '../features/did-you-mean/did-you-mean-slice';
-import {specificFacetSearchSetReducer} from '../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
-import {fieldsReducer} from '../features/fields/fields-slice';
-import {pipelineReducer} from '../features/pipeline/pipeline-slice';
-import {dateFacetSetReducer} from '../features/facets/range-facets/date-facet-set/date-facet-set-slice';
-import {numericFacetSetReducer} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice';
-import {searchHubReducer} from '../features/search-hub/search-hub-slice';
-import {categoryFacetSetReducer} from '../features/facets/category-facet-set/category-facet-set-slice';
-import {categoryFacetSearchSetReducer} from '../features/facets/facet-search-set/category/category-facet-search-set-slice';
-import {facetOptionsReducer} from '../features/facet-options/facet-options-slice';
-import {advancedSearchQueriesReducer} from '../features/advanced-search-queries/advanced-search-queries-slice';
-import {debugReducer} from '../features/debug/debug-slice';
-import {facetOrderReducer} from '../features/facets/facet-order/facet-order-slice';
-import {redo, snapshot, undo} from '../features/history/history-actions';
-import {resultPreviewReducer} from '../features/result-preview/result-preview-slice';
-import {versionReducer} from '../features/debug/version-slice';
+
+import {
+  configuration,
+  facetSet,
+  dateFacetSet,
+  facetOrder,
+  numericFacetSet,
+  categoryFacetSet,
+  facetSearchSet,
+  facetOptions,
+  categoryFacetSearchSet,
+  query,
+  advancedSearchQueries,
+  querySet,
+  pagination,
+  redirection,
+  querySuggest,
+  search,
+  sortCriteria,
+  context,
+  history,
+  didYouMean,
+  fields,
+  pipeline,
+  searchHub,
+  debug,
+  resultPreview,
+  version,
+} from './reducers';
 
 /**
  * Map of reducers that make up the SearchAppState.
  */
 export const searchAppReducers: ReducersMapObject<SearchAppState> = {
-  configuration: configurationReducer,
-  facetSet: facetSetReducer,
-  dateFacetSet: dateFacetSetReducer,
-  facetOrder: facetOrderReducer,
-  numericFacetSet: numericFacetSetReducer,
-  categoryFacetSet: categoryFacetSetReducer,
-  facetSearchSet: specificFacetSearchSetReducer,
-  facetOptions: facetOptionsReducer,
-  categoryFacetSearchSet: categoryFacetSearchSetReducer,
-  query: queryReducer,
-  advancedSearchQueries: advancedSearchQueriesReducer,
-  querySet: querySetReducer,
-  pagination: paginationReducer,
-  redirection: redirectionReducer,
-  querySuggest: querySuggestReducer,
-  search: searchReducer,
-  sortCriteria: sortCriteriaReducer,
-  context: contextReducer,
-  history: undoable({
-    actionTypes: {
-      redo: redo.type,
-      undo: undo.type,
-      snapshot: snapshot.type,
-    },
-    reducer: historyReducer,
-  }),
-  didYouMean: didYouMeanReducer,
-  fields: fieldsReducer,
-  pipeline: pipelineReducer,
-  searchHub: searchHubReducer,
-  debug: debugReducer,
-  resultPreview: resultPreviewReducer,
-  version: versionReducer,
+  configuration,
+  facetSet,
+  dateFacetSet,
+  facetOrder,
+  numericFacetSet,
+  categoryFacetSet,
+  facetSearchSet,
+  facetOptions,
+  categoryFacetSearchSet,
+  query,
+  advancedSearchQueries,
+  querySet,
+  pagination,
+  redirection,
+  querySuggest,
+  search,
+  sortCriteria,
+  context,
+  history,
+  didYouMean,
+  fields,
+  pipeline,
+  searchHub,
+  debug,
+  resultPreview,
+  version,
 };

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.test.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.test.ts
@@ -38,6 +38,14 @@ import {
 import {toggleSelectDateFacetValue} from '../../features/facets/range-facets/date-facet-set/date-facet-actions';
 import {toggleSelectNumericFacetValue} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
 import {deselectAllCategoryFacetValues} from '../../features/facets/category-facet-set/category-facet-set-actions';
+import {
+  configuration,
+  search,
+  facetSet,
+  numericFacetSet,
+  dateFacetSet,
+  categoryFacetSet,
+} from '../../app/reducers';
 
 describe('headless breadcrumb manager', () => {
   const facetId = 'abc123';
@@ -53,6 +61,17 @@ describe('headless breadcrumb manager', () => {
   beforeEach(() => {
     state = createMockState();
     initController();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      configuration,
+      search,
+      facetSet,
+      numericFacetSet,
+      dateFacetSet,
+      categoryFacetSet,
+    });
   });
 
   describe('facet breadcrumbs', () => {

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -173,7 +173,7 @@ export interface BreadcrumbValue<T extends BaseFacetValue> {
  * @returns A `BreadcrumbManager` controller instance.
  */
 export function buildBreadcrumbManager(
-  engine: Engine<unknown>
+  engine: Engine<object>
 ): BreadcrumbManager {
   if (!loadBreadcrumbManagerReducers(engine)) {
     throw loadReducerError;
@@ -312,7 +312,7 @@ export function buildBreadcrumbManager(
 }
 
 function loadBreadcrumbManagerReducers(
-  engine: Engine<unknown>
+  engine: Engine<object>
 ): engine is Engine<
   ConfigurationSection &
     SearchSection &

--- a/packages/headless/src/controllers/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/context/headless-context.test.ts
@@ -7,6 +7,7 @@ import {
   removeContext,
 } from '../../features/context/context-actions';
 import {SearchAppState} from '../../state/search-app-state';
+import {contextReducer} from '../../features/context/context-slice';
 
 describe('Context', () => {
   let context: Context;
@@ -24,6 +25,12 @@ describe('Context', () => {
 
   it('initializes properly', () => {
     expect(context.state.values).toEqual({});
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      context: contextReducer,
+    });
   });
 
   it('setContext dispatches #setContext', () => {

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -69,14 +69,14 @@ export function buildContext(engine: Engine<unknown>): Context {
   const controller = buildController(engine);
   const {dispatch} = engine;
 
-  const getContext = () => engine.state.context;
+  const getContextState = () => engine.state.context;
 
   return {
     ...controller,
 
     get state() {
       return {
-        values: getContext().contextValues,
+        values: getContextState().contextValues,
       };
     },
 

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -68,15 +68,14 @@ export function buildContext(engine: Engine<unknown>): Context {
 
   const controller = buildController(engine);
   const {dispatch} = engine;
-
-  const getContextState = () => engine.state.context;
+  const getState = () => engine.state;
 
   return {
     ...controller,
 
     get state() {
       return {
-        values: getContextState().contextValues,
+        values: getState().context.contextValues,
       };
     },
 

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -61,7 +61,7 @@ export interface ContextState {
  * @param engine - The headless engine.
  * @returns A `Context` controller instance.
  */
-export function buildContext(engine: Engine<unknown>): Context {
+export function buildContext(engine: Engine<object>): Context {
   if (!loadContextReducers(engine)) {
     throw loadReducerError;
   }
@@ -94,7 +94,7 @@ export function buildContext(engine: Engine<unknown>): Context {
 }
 
 function loadContextReducers(
-  engine: Engine<unknown>
+  engine: Engine<object>
 ): engine is Engine<ContextSection> {
   engine.addReducers({context});
   return true;

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.test.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.test.ts
@@ -1,23 +1,41 @@
-import {buildDidYouMean} from './headless-did-you-mean';
-import {buildMockSearchAppEngine} from '../../test/mock-engine';
+import {buildDidYouMean, DidYouMean} from './headless-did-you-mean';
+import {buildMockSearchAppEngine, MockEngine} from '../../test/mock-engine';
 import {
   applyDidYouMeanCorrection,
   enableDidYouMean,
 } from '../../features/did-you-mean/did-you-mean-actions';
+import {configuration, didYouMean} from '../../app/reducers';
+import {SearchAppState} from '../../state/search-app-state';
 
 describe('did you mean', () => {
-  it('should enable did you mean', () => {
-    const e = buildMockSearchAppEngine();
+  let dym: DidYouMean;
+  let engine: MockEngine<SearchAppState>;
 
-    buildDidYouMean(e);
-    expect(e.actions).toContainEqual(enableDidYouMean());
+  function initDidYouMean() {
+    dym = buildDidYouMean(engine);
+  }
+
+  beforeEach(() => {
+    engine = buildMockSearchAppEngine();
+    initDidYouMean();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      configuration,
+      didYouMean,
+    });
+  });
+
+  it('should enable did you mean', () => {
+    expect(engine.actions).toContainEqual(enableDidYouMean());
   });
 
   it('should allow to update query correction', () => {
-    const e = buildMockSearchAppEngine();
-    e.state.didYouMean.queryCorrection.correctedQuery = 'bar';
+    engine.state.didYouMean.queryCorrection.correctedQuery = 'bar';
+    initDidYouMean();
 
-    buildDidYouMean(e).applyCorrection();
-    expect(e.actions).toContainEqual(applyDidYouMeanCorrection('bar'));
+    dym.applyCorrection();
+    expect(engine.actions).toContainEqual(applyDidYouMeanCorrection('bar'));
   });
 });

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -62,7 +62,7 @@ export interface DidYouMeanState {
  *
  * @param engine - The headless engine.
  */
-export function buildDidYouMean(engine: Engine<unknown>): DidYouMean {
+export function buildDidYouMean(engine: Engine<object>): DidYouMean {
   if (!loadDidYouMeanReducers(engine)) {
     throw loadReducerError;
   }
@@ -100,7 +100,7 @@ export function buildDidYouMean(engine: Engine<unknown>): DidYouMean {
 }
 
 function loadDidYouMeanReducers(
-  engine: Engine<unknown>
+  engine: Engine<object>
 ): engine is Engine<ConfigurationSection & DidYouMeanSection> {
   engine.addReducers({configuration, didYouMean});
   return true;

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -72,21 +72,21 @@ export function buildDidYouMean(engine: Engine<unknown>): DidYouMean {
 
   dispatch(enableDidYouMean());
 
-  const getDidYouMeanState = () => engine.state.didYouMean;
+  const getState = () => engine.state;
 
   return {
     ...controller,
 
     get state() {
-      const state = getDidYouMeanState();
+      const state = getState();
 
       return {
-        wasCorrectedTo: state.wasCorrectedTo,
-        wasAutomaticallyCorrected: state.wasAutomaticallyCorrected,
-        queryCorrection: state.queryCorrection,
+        wasCorrectedTo: state.didYouMean.wasCorrectedTo,
+        wasAutomaticallyCorrected: state.didYouMean.wasAutomaticallyCorrected,
+        queryCorrection: state.didYouMean.queryCorrection,
         hasQueryCorrection:
-          state.queryCorrection.correctedQuery !== '' ||
-          state.wasCorrectedTo !== '',
+          state.didYouMean.queryCorrection.correctedQuery !== '' ||
+          state.didYouMean.wasCorrectedTo !== '',
       };
     },
 

--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.test.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.test.ts
@@ -1,3 +1,4 @@
+import {facetOptions, search} from '../../app/reducers';
 import {SearchAppState} from '../../state/search-app-state';
 import {buildMockSearchAppEngine, MockEngine} from '../../test';
 import {buildMockFacetResponse} from '../../test/mock-facet-response';
@@ -18,6 +19,13 @@ describe('facet manager', () => {
 
   it('exposes a #subscribe method', () => {
     expect(facetManager.subscribe).toBeTruthy();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      search,
+      facetOptions,
+    });
   });
 
   it('when #response.facets is empty, #state.facetIds returns an empty array', () => {

--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
@@ -1,5 +1,7 @@
 import {Engine} from '../../app/headless-engine';
+import {facetOptions, search} from '../../app/reducers';
 import {SearchSection} from '../../state/state-sections';
+import {loadReducerError} from '../../utils/errors';
 import {sortFacets} from '../../utils/facet-utils';
 import {buildController, Controller} from '../controller/headless-controller';
 
@@ -48,8 +50,13 @@ export interface FacetManagerState {
  *
  * @param engine - The headless engine.
  */
-export function buildFacetManager(engine: Engine<SearchSection>): FacetManager {
+export function buildFacetManager(engine: Engine<unknown>): FacetManager {
+  if (!loadFacetManagerReducers(engine)) {
+    throw loadReducerError;
+  }
+
   const controller = buildController(engine);
+  const getState = () => engine.state;
 
   return {
     ...controller,
@@ -59,10 +66,17 @@ export function buildFacetManager(engine: Engine<SearchSection>): FacetManager {
     },
 
     get state() {
-      const facets = engine.state.search.response.facets;
+      const facets = getState().search.response.facets;
       const facetIds = facets.map((f) => f.facetId);
 
       return {facetIds};
     },
   };
+}
+
+function loadFacetManagerReducers(
+  engine: Engine<unknown>
+): engine is Engine<SearchSection> {
+  engine.addReducers({search, facetOptions});
+  return true;
 }

--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
@@ -50,7 +50,7 @@ export interface FacetManagerState {
  *
  * @param engine - The headless engine.
  */
-export function buildFacetManager(engine: Engine<unknown>): FacetManager {
+export function buildFacetManager(engine: Engine<object>): FacetManager {
   if (!loadFacetManagerReducers(engine)) {
     throw loadReducerError;
   }
@@ -75,7 +75,7 @@ export function buildFacetManager(engine: Engine<unknown>): FacetManager {
 }
 
 function loadFacetManagerReducers(
-  engine: Engine<unknown>
+  engine: Engine<object>
 ): engine is Engine<SearchSection> {
   engine.addReducers({search, facetOptions});
   return true;


### PR DESCRIPTION
Since this PR was getting large, I will split the changes across a few PRs.
This one converts: `breadcrumbManager`, `context`, `didYouMean` and `facetManager`.