### PR TITLE
fix(atomic): fix facet search scrolling & focus issues

### DIFF
--- a/packages/atomic/cypress/integration/facets/category-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet-assertions.ts
@@ -1,0 +1,255 @@
+import {doSortAlphanumeric, doSortOccurences} from '../../utils/componentUtils';
+import {RouteAlias} from '../../utils/setupComponent';
+import {ComponentErrorSelectors} from '../component-error-selectors';
+import {ResultListSelectors} from '../result-list-selectors';
+import {
+  hierarchicalField,
+  CategoryFacetSelectors,
+  categoryFacetComponent,
+  BreadcrumbSelectors,
+} from './category-facet-selectors';
+
+function should(should: boolean) {
+  return should ? 'should' : 'should not';
+}
+
+export function assertAccessibility() {
+  it('should pass accessibility tests', () => {
+    cy.checkA11y(categoryFacetComponent);
+  });
+}
+
+export function assertNumberOfChildValues(value: number) {
+  it('should display the right number of child values', () => {
+    if (value > 0) {
+      CategoryFacetSelectors.childValue().its('length').should('eq', value);
+      return;
+    }
+
+    CategoryFacetSelectors.childValue().should('not.exist');
+  });
+}
+
+export function assertNumberOfParentValues(value: number) {
+  it('should display the right number of parent values', () => {
+    CategoryFacetSelectors.activeParentValue().should(
+      value > 0 ? 'be.visible' : 'not.exist'
+    );
+
+    if (value <= 1) {
+      CategoryFacetSelectors.parentValue().should('not.exist');
+      return;
+    }
+
+    CategoryFacetSelectors.parentValue()
+      .its('length')
+      .should('eq', value - 1);
+  });
+}
+
+export function assertLabelContains(label: string) {
+  it('should have the correct label', () => {
+    CategoryFacetSelectors.label().contains(label);
+  });
+}
+
+export function assertDisplayShowMoreButton(display: boolean) {
+  it(`${should(display)} display a "Show more" button`, () => {
+    CategoryFacetSelectors.showMoreButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayShowLessButton(display: boolean) {
+  it(`${should(display)} display a "Show less" button`, () => {
+    CategoryFacetSelectors.showLessButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayClearButton(display: boolean) {
+  it(`${should(display)} display a "All Categories" button`, () => {
+    CategoryFacetSelectors.clearButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplaySearch(display: boolean) {
+  it(`${should(display)} display a the facet search`, () => {
+    CategoryFacetSelectors.searchInput().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+    CategoryFacetSelectors.searchResults().should(
+      display ? 'exist' : 'not.exist'
+    );
+  });
+}
+
+export function assertContainsComponentError(display: boolean) {
+  it(`${should(display)} display an error component`, () => {
+    CategoryFacetSelectors.shadow()
+      .find(ComponentErrorSelectors.component)
+      .should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertDisplayFacet(display: boolean) {
+  it(`${should(display)} display the facet`, () => {
+    CategoryFacetSelectors.wrapper().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayPlaceholder(display: boolean) {
+  it(`${should(display)} display the placeholder`, () => {
+    CategoryFacetSelectors.placeholder().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertPathInBreadcrumb(path: string[]) {
+  const ellipsedPath =
+    path.length > 3 ? path.slice(0, 1).concat(['...'], path.slice(-2)) : path;
+  it('should display the selected path in the breadcrumbs', () => {
+    BreadcrumbSelectors.breadcrumbButton()
+      .first()
+      .contains(ellipsedPath.join(' / '));
+  });
+}
+
+export function assertPathInUrl(path: string[]) {
+  it('should display the selected path in the url', () => {
+    const categoryFacetListInUrl = path.join(',');
+    const urlHash = `#cf[${hierarchicalField}]=${encodeURI(
+      categoryFacetListInUrl
+    )}`;
+    cy.url().should('include', urlHash);
+  });
+}
+
+export function assertNoBreadcrumb() {
+  it('should not have any breadcrumb', () => {
+    BreadcrumbSelectors.breadcrumbButton().should('not.exist');
+  });
+}
+
+export function assertNoPathInUrl() {
+  it('should not display a selected path in the url', () => {
+    cy.url().should('not.include', '#cf');
+  });
+}
+
+export function assertLogFacetSelect(path: string[]) {
+  it('should log the facet selection to UA', () => {
+    cy.wait(RouteAlias.analytics).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'facetSelect');
+      expect(analyticsBody.customData).to.have.property(
+        'facetValue',
+        path.join(';')
+      );
+      expect(analyticsBody.customData).to.have.property(
+        'facetField',
+        hierarchicalField
+      );
+
+      expect(analyticsBody.facetState[0]).to.have.property('state', 'selected');
+      expect(analyticsBody.facetState[0]).to.have.property(
+        'field',
+        hierarchicalField
+      );
+      expect(analyticsBody.facetState[0]).to.have.property(
+        'facetType',
+        'hierarchical'
+      );
+    });
+  });
+}
+
+export function assertLogFacetShowMore() {
+  it('should log the facet show more results to UA', () => {
+    cy.wait(RouteAlias.analytics).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('eventType', 'facet');
+      expect(analyticsBody).to.have.property(
+        'eventValue',
+        'showMoreFacetResults'
+      );
+      expect(analyticsBody.customData).to.have.property(
+        'facetField',
+        hierarchicalField
+      );
+    });
+  });
+}
+
+export function assertLogClearFacetValues() {
+  it('should log the facet clear all to UA', () => {
+    cy.wait(RouteAlias.analytics).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'facetClearAll');
+      expect(analyticsBody.customData).to.have.property(
+        'facetField',
+        hierarchicalField
+      );
+    });
+  });
+}
+
+export function assertLogFacetShowLess() {
+  it('should log the facet show less results to UA', () => {
+    cy.wait(RouteAlias.analytics).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('eventType', 'facet');
+      expect(analyticsBody).to.have.property(
+        'eventValue',
+        'showLessFacetResults'
+      );
+      expect(analyticsBody.customData).to.have.property(
+        'facetField',
+        hierarchicalField
+      );
+    });
+  });
+}
+
+export function assertValuesSortedByOccurences() {
+  it('values should be ordered by occurences', () => {
+    CategoryFacetSelectors.valueCount().as('categoryFacetAllValuesCount');
+    cy.getTextOfAllElements('@categoryFacetAllValuesCount').then(
+      (originalValues) => {
+        expect(originalValues).to.eql(doSortOccurences(originalValues));
+      }
+    );
+  });
+}
+
+export function assertValuesSortedAlphanumerically() {
+  it('values should be ordered alphanumerically', () => {
+    CategoryFacetSelectors.valueLabel().as('categoryFacetAllValuesLabel');
+    cy.getTextOfAllElements('@categoryFacetAllValuesLabel').then(
+      (originalValues) => {
+        expect(originalValues).to.eql(doSortAlphanumeric(originalValues));
+      }
+    );
+  });
+}
+
+export function assertFirstChildContains(value: string) {
+  it('first child value should contain the proper value', () => {
+    CategoryFacetSelectors.childValue().first().contains(value);
+  });
+}
+
+export function assertNumberOfSearchResults(numberOfResults: number) {
+  it('should have the correct number of search results', () => {
+    cy.get(ResultListSelectors.component)
+      .find(ResultListSelectors.result)
+      .should('have.length', numberOfResults);
+  });
+}

--- a/packages/atomic/cypress/integration/facets/category-facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet-selectors.ts
@@ -1,0 +1,45 @@
+// TODO: move breadcrumb selectors out
+export const breadcrumbComponent = 'atomic-breadcrumb-manager';
+export const BreadcrumbSelectors = {
+  shadow: () => cy.get(breadcrumbComponent).shadow(),
+  breadcrumbButton: () =>
+    BreadcrumbSelectors.shadow().find('[part="breadcrumb"]'),
+};
+
+export const categoryFacetComponent = 'atomic-category-facet';
+export const CategoryFacetSelectors = {
+  shadow: () => cy.get(categoryFacetComponent).shadow(),
+  wrapper: () => CategoryFacetSelectors.shadow().find('[part="facet"]'),
+  label: () => CategoryFacetSelectors.shadow().find('[part="label"]'),
+  placeholder: () =>
+    CategoryFacetSelectors.shadow().find('[part="placeholder"]'),
+  clearButton: () =>
+    CategoryFacetSelectors.shadow().find('[part="clear-button"]'),
+  valueLabel: () =>
+    CategoryFacetSelectors.shadow().find('[part="value-label"]'),
+  valueCount: () =>
+    CategoryFacetSelectors.shadow().find('[part="value-count"]'),
+  childValue: () => CategoryFacetSelectors.shadow().find('[part="child"]'),
+  parentValue: () => CategoryFacetSelectors.shadow().find('[part="parent"]'),
+  activeParentValue: () =>
+    CategoryFacetSelectors.shadow().find('[part="active-parent"]'),
+  showMoreButton: () =>
+    CategoryFacetSelectors.shadow().find('[part="show-more"]'),
+  showLessButton: () =>
+    CategoryFacetSelectors.shadow().find('[part="show-less"]'),
+  searchInput: () =>
+    CategoryFacetSelectors.shadow().find('[part="search-input"]'),
+  searchResults: () =>
+    CategoryFacetSelectors.shadow().find('[part="search-results"]'),
+};
+
+export const canadaHierarchy = [
+  'North America',
+  'Canada',
+  'Quebec',
+  'Montreal',
+];
+export const canadaHierarchyIndex = [0, 1, 0, 4];
+export const togoHierarchy = ['Africa', 'Togo', 'Lome'];
+export const hierarchicalField = 'geographicalhierarchy';
+export const defaultNumberOfValues = 5;

--- a/packages/atomic/cypress/integration/facets/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet.cypress.ts
@@ -1,617 +1,372 @@
+import {buildTestUrl, RouteAlias, setUpPage} from '../../utils/setupComponent';
 import {
-  setUpPage,
-  shouldRenderErrorComponent,
-  injectComponent,
-} from '../../utils/setupComponent';
-import {
-  FacetSelectors,
-  createAliasShadow,
-  createAliasFacetUL,
-  FacetAlias,
-  BreadcrumbSelectors,
-} from './facet-selectors';
-import {
-  validateFacetComponentLoaded,
-  validateFacetComponentVisible,
-  validateFacetNumberofValueEqual,
-  assertNonZeroFacetCount,
-  assertClickShowMore,
-  assertShowMoreUA,
-  assertClickShowLess,
-  assertShowLessUA,
-  typeQueryAndWaitUA,
-  assertHightlightedText,
-} from './facet-utils';
-import {doSortAlphanumeric} from '../../utils/componentUtils';
-import {ResultListSelectors} from '../result-list-selectors';
+  canadaHierarchy,
+  canadaHierarchyIndex,
+  CategoryFacetSelectors,
+  hierarchicalField,
+  defaultNumberOfValues,
+  togoHierarchy,
+} from './category-facet-selectors';
+import * as CategoryFacetAssertions from './category-facet-assertions';
 
-const categoryFacetProp = {
-  field: 'geographicalhierarchy',
-  label: 'Atlas',
-  defaultCategoryLabel: 'All Categories',
-  numberOfValue: 5,
-  numberOfFacetValueAfterExpand: 7,
-};
-
-const canadaHierarchy = ['North America', 'Canada', 'British Columbia'];
-function setupCategoryFacet(field: string, label: string, option?: {}) {
-  setUpPage(`
-    <atomic-breadcrumb-manager></atomic-breadcrumb-manager>     
-    <atomic-category-facet field="${field}" label="${label}" ${option}></atomic-category-facet>
-    <atomic-result-list></atomic-result-list>`);
+interface CategoryFacetSetupOptions {
+  field: string;
+  attributes: string;
+  executeFirstSearch: boolean;
+  withResultList: boolean;
 }
 
-function assertClearAllTitleAndTotalParents(
-  clearAllTitle: string,
-  totalParents: number
-) {
-  cy.get(FacetAlias.facetShadow)
-    .find(FacetSelectors.clearAllButton)
-    .should('contain.text', clearAllTitle);
-  cy.get(FacetAlias.facetShadow)
-    .find('[part*="parent"]')
-    .its('length')
-    .should('eq', totalParents);
+// TODO: adapt new setup
+function setupCategoryFacet(options: Partial<CategoryFacetSetupOptions> = {}) {
+  const setupOptions: CategoryFacetSetupOptions = {
+    attributes: '',
+    executeFirstSearch: true,
+    field: hierarchicalField,
+    withResultList: false,
+    ...options,
+  };
+  setUpPage(
+    `<atomic-breadcrumb-manager></atomic-breadcrumb-manager>     
+    <atomic-category-facet field="${setupOptions.field}" label="Atlas" ${
+      setupOptions.attributes
+    }></atomic-category-facet>
+    ${
+      setupOptions.withResultList && '<atomic-result-list></atomic-result-list>'
+    }`,
+    setupOptions.executeFirstSearch
+  );
 }
 
-function assertTotalChildrentMoreThan(value: number) {
-  cy.get(FacetAlias.facetShadow)
-    .find('[part="child"]')
-    .its('length')
-    .should('be.gt', value);
+function selectChildValueAt(index: number) {
+  CategoryFacetSelectors.childValue().eq(index).click();
 }
 
-function clickOnCategoryFacetWithValue(value: string) {
-  cy.get(FacetAlias.facetUL)
-    .find(FacetSelectors.categoryFacetNextLevelButton)
-    .contains(value)
-    .click();
-}
+describe('Category Facet Test Suites', () => {
+  describe('with default settings', () => {
+    function setupWithDefaultSettings() {
+      setupCategoryFacet();
+      cy.wait(RouteAlias.search);
+    }
 
-describe('Category Facet with default setting', () => {
-  beforeEach(() => {
-    setupCategoryFacet(categoryFacetProp.field, categoryFacetProp.label);
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoSearch');
-    cy.wait('@coveoAnalytics');
-  });
+    describe('verify rendering', () => {
+      before(setupWithDefaultSettings);
 
-  it('Should load, pass accessibility test, have correct label, facetCount and no facetSearch', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-    cy.get(FacetAlias.facetShadow)
-      .find(FacetSelectors.facetSearchbox)
-      .should('not.exist');
-  });
+      CategoryFacetAssertions.assertAccessibility();
+      CategoryFacetAssertions.assertContainsComponentError(false);
+      CategoryFacetAssertions.assertDisplayFacet(true);
+      CategoryFacetAssertions.assertDisplayPlaceholder(false);
+      CategoryFacetAssertions.assertNumberOfChildValues(defaultNumberOfValues);
+      CategoryFacetAssertions.assertNumberOfParentValues(0);
+      CategoryFacetAssertions.assertDisplayShowMoreButton(true);
+      CategoryFacetAssertions.assertDisplayShowLessButton(false);
+      CategoryFacetAssertions.assertDisplaySearch(false);
+      CategoryFacetAssertions.assertDisplayClearButton(false);
+      CategoryFacetAssertions.assertLabelContains('Atlas');
+      CategoryFacetAssertions.assertValuesSortedByOccurences();
+    });
 
-  it('Should contain ShowMore buttons but should not contain "All Categories" button', () => {
-    cy.get(FacetAlias.facetShadow)
-      .find(FacetSelectors.clearAllButton)
-      .should('not.exist');
-    cy.get(FacetAlias.facetShadow)
-      .find(FacetSelectors.showMoreButton)
-      .should('be.visible');
-  });
-
-  it('Should not display facetValue in Alphanumeric order', () => {
-    cy.getTextOfAllElements(FacetAlias.facetAllValueLabel).then(
-      (originalValues) => {
-        expect(originalValues).not.to.eql(doSortAlphanumeric(originalValues));
+    describe('when selecting a value to go deeper one level (2nd level of the dataset)', () => {
+      function setupGoDeeperOneLevel() {
+        setupWithDefaultSettings();
+        cy.wait(RouteAlias.analytics);
+        selectChildValueAt(canadaHierarchyIndex[0]);
+        cy.wait(RouteAlias.search);
       }
-    );
-  });
 
-  describe('When user clicks on Arrow to go to next level', () => {
-    beforeEach(() => {
-      clickOnCategoryFacetWithValue(canadaHierarchy[0]);
-      cy.wait('@coveoSearch');
-      cy.get(FacetAlias.facetShadow)
-        .find(FacetSelectors.clearAllButton)
-        .as('categoryClearAllButton');
-    });
+      const selectedPath = canadaHierarchy.slice(0, 1);
 
-    it('Should display its parent and default Category Label should display', () => {
-      assertClearAllTitleAndTotalParents(
-        categoryFacetProp.defaultCategoryLabel,
-        1
-      );
-    });
+      describe('verify rendering', () => {
+        before(setupGoDeeperOneLevel);
 
-    it('Should contain more than 1 child on second level', () => {
-      assertTotalChildrentMoreThan(1);
-    });
+        CategoryFacetAssertions.assertAccessibility();
+        CategoryFacetAssertions.assertDisplayClearButton(true);
+        CategoryFacetAssertions.assertNumberOfChildValues(
+          defaultNumberOfValues
+        );
+        CategoryFacetAssertions.assertNumberOfParentValues(1);
+        CategoryFacetAssertions.assertDisplayShowMoreButton(true);
+        CategoryFacetAssertions.assertDisplayShowLessButton(false);
+        CategoryFacetAssertions.assertPathInBreadcrumb(selectedPath);
+        CategoryFacetAssertions.assertPathInUrl(selectedPath);
+      });
 
-    it('Should log UA', () => {
-      cy.wait('@coveoAnalytics').then((intercept: any) => {
-        const analyticsBody = intercept.request.body;
-        expect(analyticsBody).to.have.property('actionCause', 'facetSelect');
-        expect(analyticsBody.customData).to.have.property(
-          'facetValue',
-          canadaHierarchy[0]
-        );
-        expect(analyticsBody.customData).to.have.property(
-          'facetField',
-          categoryFacetProp.field
-        );
-        expect(analyticsBody.facetState[0]).to.have.property(
-          'state',
-          'selected'
-        );
-        expect(analyticsBody.facetState[0]).to.have.property(
-          'field',
-          categoryFacetProp.field
-        );
-        expect(analyticsBody.facetState[0]).to.have.property(
-          'facetType',
-          'hierarchical'
-        );
+      describe('verify analytics', () => {
+        before(setupGoDeeperOneLevel);
+        CategoryFacetAssertions.assertLogFacetSelect(selectedPath);
+      });
+
+      describe('when selecting the "Show more" button', () => {
+        function setupShowMore() {
+          setupGoDeeperOneLevel();
+          cy.wait(RouteAlias.analytics);
+          CategoryFacetSelectors.showMoreButton().click();
+          cy.wait(RouteAlias.search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupShowMore);
+          CategoryFacetAssertions.assertNumberOfChildValues(10);
+          CategoryFacetAssertions.assertDisplayShowLessButton(true);
+        });
+
+        describe('verify analytics', () => {
+          before(setupShowMore);
+          CategoryFacetAssertions.assertLogFacetShowMore();
+        });
+
+        describe('when selecting the "Show less" button', () => {
+          function setupShowLess() {
+            setupShowMore();
+            cy.wait(RouteAlias.analytics);
+            CategoryFacetSelectors.showLessButton().click();
+            cy.wait(RouteAlias.search);
+            cy.wait(200); // flakiness prevention
+          }
+
+          describe('verify rendering', () => {
+            before(setupShowLess);
+            CategoryFacetAssertions.assertNumberOfChildValues(5);
+            CategoryFacetAssertions.assertDisplayShowLessButton(false);
+          });
+
+          describe('verify analytics', () => {
+            before(setupShowLess);
+            CategoryFacetAssertions.assertLogFacetShowLess();
+          });
+        });
+      });
+
+      describe('when selecting the "All categories" button', () => {
+        function setupClear() {
+          setupGoDeeperOneLevel();
+          cy.wait(RouteAlias.analytics);
+          CategoryFacetSelectors.clearButton().click();
+          cy.wait(RouteAlias.search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupClear);
+          CategoryFacetAssertions.assertDisplayClearButton(false);
+          CategoryFacetAssertions.assertNumberOfParentValues(0);
+          CategoryFacetAssertions.assertNoBreadcrumb();
+          CategoryFacetAssertions.assertNoPathInUrl();
+        });
+
+        describe('verify analytics', () => {
+          before(setupClear);
+          CategoryFacetAssertions.assertLogClearFacetValues();
+        });
       });
     });
 
-    it('Should trigger breadcrumb and display correctly', () => {
-      cy.get(BreadcrumbSelectors.breadcrumb)
-        .shadow()
-        .find('[part="breadcrumb"]')
-        .should('be.visible')
-        .contains(canadaHierarchy[0]);
-    });
+    describe('when selecting values subsequently to go deeper three level (last level of the dataset)', () => {
+      function setupGoDeeperLastLevel() {
+        setupWithDefaultSettings();
+        cy.wait(RouteAlias.analytics);
+        selectChildValueAt(canadaHierarchyIndex[0]);
+        cy.wait(RouteAlias.analytics);
+        selectChildValueAt(canadaHierarchyIndex[1]);
+        cy.wait(RouteAlias.analytics);
+        selectChildValueAt(canadaHierarchyIndex[2]);
+        cy.wait(RouteAlias.analytics);
+        selectChildValueAt(canadaHierarchyIndex[3]);
+        cy.wait(RouteAlias.search);
+      }
 
-    describe('When user click on "All Categories" button', () => {
-      beforeEach(() => {
-        cy.get('@categoryClearAllButton').click();
-        cy.wait('@coveoAnalytics');
+      describe('verify rendering', () => {
+        before(setupGoDeeperLastLevel);
+        CategoryFacetAssertions.assertDisplayClearButton(true);
+        CategoryFacetAssertions.assertNumberOfParentValues(4);
+        CategoryFacetAssertions.assertNumberOfChildValues(0);
+        CategoryFacetAssertions.assertDisplayShowMoreButton(false);
+        CategoryFacetAssertions.assertDisplayShowLessButton(false);
+        CategoryFacetAssertions.assertPathInBreadcrumb(canadaHierarchy);
+        CategoryFacetAssertions.assertPathInUrl(canadaHierarchy);
       });
 
-      it('Should go back to the first parent level', () => {
-        cy.get('@categoryClearAllButton').should('not.exist');
-        assertNonZeroFacetCount();
+      describe('verify analytics', () => {
+        before(setupGoDeeperLastLevel);
+        CategoryFacetAssertions.assertLogFacetSelect(canadaHierarchy);
       });
 
-      it('Should log UA correctly', () => {
-        cy.wait('@coveoAnalytics').then((intercept: any) => {
-          const analyticsBody = intercept.request.body;
-          expect(analyticsBody).to.have.property(
-            'actionCause',
-            'facetClearAll'
+      describe('when selecting the first parent button', () => {
+        function setupSelectFirstParent() {
+          setupGoDeeperLastLevel();
+          cy.wait(RouteAlias.analytics);
+          CategoryFacetSelectors.parentValue().first().click();
+          cy.wait(RouteAlias.search);
+        }
+
+        const selectedPath = canadaHierarchy.slice(0, 1);
+
+        describe('verify rendering', () => {
+          before(setupSelectFirstParent);
+          CategoryFacetAssertions.assertDisplayClearButton(true);
+          CategoryFacetAssertions.assertNumberOfParentValues(1);
+          CategoryFacetAssertions.assertNumberOfChildValues(
+            defaultNumberOfValues
           );
-          expect(analyticsBody.customData).to.have.property(
-            'facetField',
-            categoryFacetProp.field
-          );
+          CategoryFacetAssertions.assertDisplayShowMoreButton(true);
+          CategoryFacetAssertions.assertDisplayShowLessButton(false);
+          CategoryFacetAssertions.assertPathInBreadcrumb(selectedPath);
+          CategoryFacetAssertions.assertPathInUrl(selectedPath);
+        });
+
+        describe('verify analytics', () => {
+          before(setupSelectFirstParent);
+          CategoryFacetAssertions.assertLogFacetSelect(selectedPath);
         });
       });
     });
 
-    describe('When user clicks ShowMore button', () => {
-      it('Should expand list of childrens on same level', () => {
-        assertClickShowMore(categoryFacetProp.numberOfValue);
+    describe('when selecting the "Show more" button', () => {
+      function setupShowMore() {
+        setupWithDefaultSettings();
+        cy.wait(RouteAlias.analytics);
+        CategoryFacetSelectors.showMoreButton().click();
+        cy.wait(RouteAlias.search);
+      }
+
+      describe('verify rendering', () => {
+        before(setupShowMore);
+        CategoryFacetAssertions.assertNumberOfChildValues(7);
+        CategoryFacetAssertions.assertDisplayShowLessButton(true);
+        CategoryFacetAssertions.assertDisplayShowMoreButton(false);
       });
 
-      it('Should log UA correctly', () => {
-        cy.wait('@coveoAnalytics');
-        assertShowMoreUA(categoryFacetProp.field);
+      describe('verify analytics', () => {
+        before(setupShowMore);
+        CategoryFacetAssertions.assertLogFacetShowMore();
       });
 
-      describe('When user click ShowLess button', () => {
-        it('Should collapse the list and hide ShowLess button', () => {
-          assertClickShowLess(categoryFacetProp.numberOfValue * 2);
+      describe('when selecting the "Show less" button', () => {
+        function setupShowLess() {
+          setupShowMore();
+          cy.wait(RouteAlias.analytics);
+          CategoryFacetSelectors.showLessButton().click();
+          cy.wait(RouteAlias.search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupShowLess);
+          CategoryFacetAssertions.assertNumberOfChildValues(5);
+          CategoryFacetAssertions.assertDisplayShowLessButton(false);
+          CategoryFacetAssertions.assertDisplayShowMoreButton(true);
         });
 
-        it('Should log UA correctly', () => {
-          cy.wait('@coveoAnalytics');
-          assertShowLessUA(categoryFacetProp.field);
+        describe('verify analytics', () => {
+          before(setupShowLess);
+          CategoryFacetAssertions.assertLogFacetShowLess();
         });
       });
     });
   });
 
-  describe('When user goes to last child on level 3', () => {
-    beforeEach(() => {
-      clickOnCategoryFacetWithValue(canadaHierarchy[0]);
-      cy.wait('@coveoSearch');
-      cy.wait('@coveoAnalytics');
-      clickOnCategoryFacetWithValue(canadaHierarchy[1]);
-      cy.wait('@coveoSearch');
-      cy.wait('@coveoAnalytics');
-      clickOnCategoryFacetWithValue(canadaHierarchy[2]);
-      cy.wait('@coveoSearch');
-    });
+  describe('with custom #numberOfValues', () => {
+    const numberOfValues = 2;
+    function setupCustomNumberOfValues() {
+      setupCategoryFacet({attributes: `number-of-values="${numberOfValues}"`});
+      cy.wait(RouteAlias.search);
+    }
 
-    it('Should have correct 3 parents level up and default Category Label', () => {
-      assertClearAllTitleAndTotalParents(
-        categoryFacetProp.defaultCategoryLabel,
-        3
-      );
-    });
+    before(setupCustomNumberOfValues);
 
-    it('Should log UA correctly', () => {
-      cy.wait('@coveoAnalytics').then((intercept: any) => {
-        const analyticsBody = intercept.request.body;
-        expect(analyticsBody).to.have.property('actionCause', 'facetSelect');
-        expect(analyticsBody.customData).to.have.property(
-          'facetField',
-          categoryFacetProp.field
-        );
-        expect(analyticsBody.customData).to.have.property(
-          'facetValue',
-          canadaHierarchy.join(';')
-        );
+    CategoryFacetAssertions.assertNumberOfChildValues(numberOfValues);
+
+    describe('when selecting a value to go deeper one level (2nd level of the dataset)', () => {
+      before(() => {
+        setupCustomNumberOfValues();
+        selectChildValueAt(0);
+        cy.wait(RouteAlias.search);
       });
-    });
 
-    it('Should not contain any other level', () => {
-      cy.get(FacetAlias.facetShadow).find('[part="child"]').should('not.exist');
-    });
-
-    it('Last level should not be a button', () => {
-      cy.get(FacetAlias.facetShadow)
-        .find('[part*="parent"]')
-        .last()
-        .find('button')
-        .should('not.exist');
-    });
-
-    it('Should display correctly in URL hash', () => {
-      const categoryFacetListInUrl = canadaHierarchy.join(',');
-      const urlHash = `#cf[${categoryFacetProp.field}]=${encodeURI(
-        categoryFacetListInUrl
-      )}`;
-      cy.url().should('include', urlHash);
-    });
-
-    it('Should trigger breadcrumb and display correctly', () => {
-      const text = canadaHierarchy.join(' / ');
-      cy.get(BreadcrumbSelectors.breadcrumb)
-        .shadow()
-        .find('[part="breadcrumb"]')
-        .should('be.visible')
-        .contains(text);
+      CategoryFacetAssertions.assertNumberOfChildValues(numberOfValues);
     });
   });
 
-  describe('When user clicks ShowMore button', () => {
-    it('Should expand list of facetValue and dislay ShowLess button', () => {
-      assertClickShowMore(
-        categoryFacetProp.numberOfValue,
-        categoryFacetProp.numberOfFacetValueAfterExpand
-      );
+  describe('with custom #sortCriteria, alphanumeric', () => {
+    before(() => {
+      setupCategoryFacet({attributes: 'sort-criteria="alphanumeric"'});
     });
-
-    it('Should log UA correctly', () => {
-      assertShowMoreUA(categoryFacetProp.field);
-    });
+    CategoryFacetAssertions.assertValuesSortedAlphanumerically();
   });
 
-  describe('When user clicks ShowLess button', () => {
-    it('Should collapse the facet list and hide button ShowLess', () => {
-      assertClickShowLess(
-        categoryFacetProp.numberOfFacetValueAfterExpand,
-        categoryFacetProp.numberOfValue
-      );
-    });
-
-    it('Should log UA correctly', () => {
-      assertShowLessUA(categoryFacetProp.field);
-    });
-  });
-});
-
-describe('Category Facet with custom numberOfValues', () => {
-  const numberOfValues = 6;
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      `number-of-values=${numberOfValues}`
-    );
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
-  });
-
-  it('Should load, pass accessibility test and have correct label and facetCount', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-
-  it('Should contain custom numberOfValues', () => {
-    validateFacetNumberofValueEqual(numberOfValues);
-  });
-});
-
-describe('Category Facet with facetSearchEnable', () => {
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      'enable-facet-search=true'
-    );
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
-    cy.get(FacetAlias.facetShadow)
-      .find(FacetSelectors.facetSearchbox)
-      .as('facetSearchbox');
-  });
-
-  it('Should load, pass accessibility test, have correct label, and facetCount', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-
-  it('Should have facet searchbox', () => {
-    cy.get(FacetAlias.facetShadow)
-      .find(FacetSelectors.facetSearchbox)
-      .should('be.visible');
-  });
-
-  describe('When user interacts with category facet searchbox', () => {
-    it('Should display suggestion when click on searchbox', () => {
-      cy.get('@facetSearchbox').click();
-      cy.get(FacetAlias.facetShadow)
-        .find('ul[part="search-results"]')
-        .should('be.visible');
-    });
-
-    it.skip('Should highlight recommendation correctly when entering a query', () => {
-      const query = 'Ca';
-      typeQueryAndWaitUA('@facetSearchbox', query);
-      assertHightlightedText(query);
-    });
-  });
-
-  describe('When user types "Quebec" on category facet searchbox', () => {
-    const query = 'Quebec';
-    beforeEach(() => {
-      typeQueryAndWaitUA('@facetSearchbox', query);
-    });
-
-    it('Should display search results with parentPath correctly', () => {
-      cy.get(FacetAlias.facetShadow)
-        .find(
-          'ul[part="search-results"] li[part="search-result"] div:nth-child(2)'
+  // TODO: enable with new setup
+  describe.skip('with a selected path in the URL', () => {
+    before(() => {
+      setupCategoryFacet({
+        withResultList: true,
+      });
+      cy.visit(
+        buildTestUrl(
+          `cf[geographicalhierarchy]=${togoHierarchy.slice(0, 2).join(',')}`
         )
-        .as('parentPaths');
-      cy.getTextOfAllElements('@parentPaths').then((parentPathLabels) => {
-        expect(parentPathLabels[0]).to.equal('inNorth America/Canada');
-        expect(parentPathLabels[1]).to.equal('inNorth America/Canada/Quebec');
+      );
+      cy.wait(RouteAlias.search);
+    });
+
+    CategoryFacetAssertions.assertDisplayClearButton(true);
+    CategoryFacetAssertions.assertNumberOfParentValues(2);
+    CategoryFacetAssertions.assertNumberOfSearchResults(1);
+    CategoryFacetAssertions.assertFirstChildContains(togoHierarchy[2]);
+  });
+
+  describe('with #basePath & #filterByBasePath set to true (default)', () => {
+    before(() => {
+      setupCategoryFacet({
+        attributes: `base-path="${togoHierarchy.slice(0, 2).join(',')}"`,
+        withResultList: true,
       });
     });
 
-    it('Should trigger new filter when selected result from dropdown box', () => {
-      cy.get(FacetAlias.facetShadow)
-        .find('ul[part="search-results"] li:nth-child(1)')
-        .click();
-      cy.get(FacetAlias.facetShadow)
-        .find('[part*="parent"]')
-        .last()
-        .should('contain.text', query);
-    });
+    CategoryFacetAssertions.assertNumberOfSearchResults(1);
+    CategoryFacetAssertions.assertFirstChildContains(togoHierarchy[2]);
+    CategoryFacetAssertions.assertDisplayClearButton(false);
+    CategoryFacetAssertions.assertNumberOfParentValues(0);
+  });
 
-    it.skip('Should log UA when selected result from dropdown box', () => {
-      cy.get(FacetAlias.facetShadow)
-        .find('ul[part="search-results"] li:nth-child(1)')
-        .click();
-      //TODO: enable it when UA for facetSearch works properly
-      cy.wait('@coveoAnalytics').then((intercept) => {
-        const analyticsBody = intercept.request.body;
-        expect(analyticsBody).to.have.property('actionCause', 'facetSelect');
+  describe('with #basePath & #filterByBasePath set to false', () => {
+    before(() => {
+      setupCategoryFacet({
+        attributes: `base-path="${togoHierarchy
+          .slice(0, 2)
+          .join(',')}" filter-by-base-path="false"`,
+        withResultList: true,
       });
     });
-  });
-});
 
-describe('Category Facet with custom delimiting character', () => {
-  const delimitingCharacter = '|';
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      `delimiting-character="${delimitingCharacter}"`
-    );
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
+    CategoryFacetAssertions.assertNumberOfSearchResults(10);
   });
 
-  it('Should load, pass accessibility test, have correct label, and facetCount', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-  //temporary checking like this before setting up the source
-  it('Should send custom delimiting character to api', () => {
-    cy.wait('@coveoSearch').then((intercept) => {
-      const firstRequestBodyFacets = (intercept.request.body.facets as any)[0];
-
-      expect(firstRequestBodyFacets).to.have.property(
-        'delimitingCharacter',
-        delimitingCharacter
-      );
-    });
-  });
-});
-
-describe('Category Facet with custom sortCriteria', () => {
-  const customSort = 'alphanumeric';
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      `sort-criteria=${customSort}`
-    );
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
-  });
-
-  it('Should load, pass accessibility test, have correct label, and facetCount', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-
-  it('Should display facetValue in correct sort order', () => {
-    cy.getTextOfAllElements(FacetAlias.facetAllValueLabel).then(
-      (originalValues) => {
-        expect(originalValues).to.eql(doSortAlphanumeric(originalValues));
-      }
-    );
-  });
-});
-
-describe('Category Facet with invalid option', () => {
-  describe('Facet with invalid field', () => {
-    it('Should render an error when field is invalid', () => {
-      setupCategoryFacet('@test', categoryFacetProp.label);
-      shouldRenderErrorComponent(FacetSelectors.categoryFacet);
+  describe('when no search has yet been executed', () => {
+    before(() => {
+      setupCategoryFacet({executeFirstSearch: false});
     });
 
-    it('Should not render when field returns no result', () => {
-      setupCategoryFacet('test', categoryFacetProp.label);
-      validateFacetComponentVisible(
-        categoryFacetProp.label,
-        FacetSelectors.categoryFacet
-      );
-    });
+    CategoryFacetAssertions.assertDisplayPlaceholder(true);
   });
 
-  describe('Facet with invalid numberOfValues', () => {
-    it('Should render an error when the prop is not in the list of numberOfValues', () => {
-      setupCategoryFacet(
-        categoryFacetProp.field,
-        categoryFacetProp.label,
-        'number-of-values=-5'
-      );
-      shouldRenderErrorComponent(FacetSelectors.categoryFacet);
+  describe('with an invalid option', () => {
+    before(() => {
+      setupCategoryFacet({attributes: 'sort-criteria="notasortcriteria"'});
     });
 
-    it('Should render an error when the prop is not a number ', () => {
-      setupCategoryFacet(
-        categoryFacetProp.field,
-        categoryFacetProp.label,
-        'number-of-values="here"'
-      );
-      shouldRenderErrorComponent(FacetSelectors.categoryFacet);
+    CategoryFacetAssertions.assertContainsComponentError(true);
+  });
+
+  describe('when field returns no results', () => {
+    before(() => {
+      setupCategoryFacet({field: 'notanactualfield'});
     });
+
+    CategoryFacetAssertions.assertDisplayFacet(false);
   });
 
-  describe('Facet with invalid sort criteria', () => {
-    it('Should render an error when the prop is not in the list of sortCriteria', () => {
-      setupCategoryFacet(
-        categoryFacetProp.field,
-        categoryFacetProp.label,
-        'sort-criteria=test'
-      );
-      shouldRenderErrorComponent(FacetSelectors.categoryFacet);
+  // See category-facet-search.cypress.ts for more facet search tests
+  describe('with #enableFacetSearch set to true', () => {
+    before(() => {
+      setupCategoryFacet({attributes: 'enable-facet-search'});
     });
-  });
-});
-
-describe('When URL contains a selected path of category facet', () => {
-  it('Category Facet should load with correct path', () => {
-    cy.visit(
-      'http://localhost:3333/pages/test.html#cf[geographicalhierarchy]=North%20America,Canada,Alberta'
-    );
-    injectComponent(`
-    <atomic-breadcrumb-manager></atomic-breadcrumb-manager>
-    <atomic-category-facet field="${categoryFacetProp.field}" label="${categoryFacetProp.label}"></atomic-category-facet>`);
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    assertClearAllTitleAndTotalParents(
-      categoryFacetProp.defaultCategoryLabel,
-      3
-    );
-    cy.get(FacetAlias.facetShadow)
-      .find('[part*="parent"]')
-      .last()
-      .contains('Alberta');
-  });
-});
-
-describe('Category Facet with custom basePath and default filterByBasePath', () => {
-  const basePath = 'North America;Canada;Alberta';
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      `base-path="${basePath}"`
-    );
-    cy.wait('@coveoSearch');
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
-  });
-
-  it('Category facet should load properly', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-
-  it('Should contains Canada country, but not contain Europe continent', () => {
-    cy.getTextOfAllElements(FacetAlias.facetAllValueLabel).then((labels) => {
-      expect(labels).not.to.include('Europe');
-      expect(labels).to.include('Calgary');
-    });
-  });
-
-  it('Results should be filtered and contain only 3 documents', () => {
-    cy.get(ResultListSelectors.component)
-      .find(ResultListSelectors.result)
-      .should('have.length', 3);
-  });
-});
-
-describe('Category Facet with custom basePath and custom filterByBasePath', () => {
-  const basePath = 'North America;Canada;Alberta';
-  beforeEach(() => {
-    setupCategoryFacet(
-      categoryFacetProp.field,
-      categoryFacetProp.label,
-      `base-path="${basePath}" filter-by-base-path="false"`
-    );
-    cy.wait('@coveoSearch');
-    createAliasShadow(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    createAliasFacetUL(categoryFacetProp.field, FacetSelectors.categoryFacet);
-    cy.wait('@coveoAnalytics');
-  });
-
-  it('Category facet should load properly', () => {
-    validateFacetComponentLoaded(
-      categoryFacetProp.label,
-      FacetSelectors.categoryFacet
-    );
-  });
-
-  it('Results should be filtered and contain more than 3 documents', () => {
-    cy.get(ResultListSelectors.component)
-      .find(ResultListSelectors.result)
-      .should('have.length.greaterThan', 3);
-  });
-});
-
-describe('when no first search has yet been executed', () => {
-  beforeEach(() => {
-    setUpPage(
-      ` <atomic-category-facet field="${categoryFacetProp.field}"></atomic-category-facet>`,
-      false
-    );
-  });
-
-  it('should render a placeholder', () => {
-    cy.get(FacetSelectors.categoryFacet)
-      .shadow()
-      .find('[part="placeholder"]')
-      .should('be.visible');
+    CategoryFacetAssertions.assertDisplaySearch(true);
   });
 });

--- a/packages/atomic/cypress/utils/componentUtils.ts
+++ b/packages/atomic/cypress/utils/componentUtils.ts
@@ -8,6 +8,14 @@ export function doSortAlphanumeric(originalValues: string[]) {
     .sort((first, second) => first.localeCompare(second));
 }
 
+export function doSortOccurences(originalValues: string[]) {
+  return originalValues
+    .concat()
+    .sort((first, second) =>
+      second.localeCompare(first, 'en', {numeric: true})
+    );
+}
+
 export const aliasNoAtSignBuilder = (alaisWithAtSign: IAlias) => {
   const alaisNoAtSign = Object.assign({}, alaisWithAtSign);
   Object.keys(alaisNoAtSign).forEach((key: string) => {

--- a/packages/atomic/cypress/utils/setupComponent.ts
+++ b/packages/atomic/cypress/utils/setupComponent.ts
@@ -20,21 +20,27 @@ export function injectComponent(
 export const searchEndpoint =
   'https://platform.cloud.coveo.com/rest/search/v2?organizationId=searchuisamples';
 
+export const RouteAlias = {
+  analytics: '@coveoAnalytics',
+  querySuggest: '@coveoQuerySuggest',
+  search: '@coveoSearch',
+};
+
 export function setupIntercept() {
   cy.intercept({
     method: 'POST',
     path: '**/rest/ua/v15/analytics/*',
-  }).as('coveoAnalytics');
+  }).as(RouteAlias.analytics.substring(1));
 
   cy.intercept({
     method: 'POST',
     path: '**/rest/search/v2/querySuggest?*',
-  }).as('coveoQuerySuggest');
+  }).as(RouteAlias.querySuggest.substring(1));
 
   cy.intercept({
     method: 'POST',
     url: searchEndpoint,
-  }).as('coveoSearch');
+  }).as(RouteAlias.search.substring(1));
 }
 
 // TODO: rename to setupPage (typo)

--- a/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
@@ -80,7 +80,7 @@ export class AtomicBreadcrumbManager implements InitializableComponent {
     return (
       <button
         part="breadcrumb"
-        class="inline-grid grid-flow-col"
+        class="inline-grid grid-flow-col text-on-background-variant hover:text-primary-variant"
         aria-label={this.strings.breadcrumb({value})}
         title={value}
         onClick={() =>
@@ -118,11 +118,7 @@ export class AtomicBreadcrumbManager implements InitializableComponent {
   }
 
   private getBreadcrumbValueWrapper(children: VNode[]) {
-    return (
-      <li class="mr-3 text-on-background-variant hover:text-primary-variant">
-        {children}
-      </li>
-    );
+    return <li class="mr-3">{children}</li>;
   }
 
   private getBreadcrumbValues(

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -135,7 +135,7 @@ export class AtomicSearchBox {
       <button
         type="button"
         part="submit-button"
-        class={`submit-button h-full bg-transparent border-0 focus:outline-none bg-primary p-0 ${roundedClasses}`}
+        class={`submit-button h-full border-0 focus:outline-none bg-primary p-0 ${roundedClasses}`}
         aria-label={this.strings.search()}
         onClick={() => this.searchBox.submit()}
       >

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -41,6 +41,8 @@ const PATH_MAX_LENGTH = 3;
  * The `atomic-category-facet` displays a facet of values in a hierarchical fashion. In mobile browsers, this is rendered as a button which opens a facet modal.
  *
  * @part facet - The wrapper for the entire facet
+ * @part label - The label of the facet
+ * @part modal-button - The button to open the facet modal (mobile only)
  * @part close-button - The button to close the facet when displayed modally (mobile only)
  * @part clear-button - The button that resets the actively selected facet values
  *
@@ -194,7 +196,7 @@ export class AtomicCategoryFacet
 
   private buildActiveParent(parent: CategoryFacetValue) {
     return (
-      <div part="parent active-parent" class="value-button font-bold ml-6">
+      <div part="active-parent" class="value-button font-bold ml-6">
         <span part="value-label" class="ellipsed">
           {parent.value}
         </span>

--- a/packages/atomic/src/components/facets/atomic-category-facet/readme.md
+++ b/packages/atomic/src/components/facets/atomic-category-facet/readme.md
@@ -30,6 +30,8 @@ A hierarchical category facet component. It is displayed as a facet in desktop b
 | `"clear-button"`              | The button that resets the actively selected facet values          |
 | `"close-button"`              | The button to close the facet when displayed modally (mobile only) |
 | `"facet"`                     | The wrapper for the entire facet                                   |
+| `"label"`                     | The label of the facet                                             |
+| `"modal-button"`              | The button to open the facet modal (mobile only)                   |
 | `"parent"`                    | A parent element                                                   |
 | `"placeholder"`               | The placeholder shown before the first search is executed.         |
 | `"search-icon"`               | The magnifier icon of the input                                    |

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -31,6 +31,8 @@ import {FacetPlaceholder} from '../atomic-facet-placeholder/atomic-facet-placeho
  * The `atomic-date-facet` component displays facet values as date ranges. In mobile browsers, this is rendered as a button that opens a facet modal.
  *
  * @part facet - The wrapper for the entire facet
+ * @part label - The label of the facet
+ * @part modal-button - The button to open the facet modal (mobile only)
  * @part close-button - The button to close the facet when displayed modally (mobile only)
  * @part clear-button - The button that resets the actively selected facet values
  *

--- a/packages/atomic/src/components/facets/atomic-date-facet/readme.md
+++ b/packages/atomic/src/components/facets/atomic-date-facet/readme.md
@@ -24,6 +24,8 @@ a button which opens a facet modal in mobile browsers.
 | `"clear-button"` | The button that resets the actively selected facet values          |
 | `"close-button"` | The button to close the facet when displayed modally (mobile only) |
 | `"facet"`        | The wrapper for the entire facet                                   |
+| `"label"`        | The label of the facet                                             |
+| `"modal-button"` | The button to open the facet modal (mobile only)                   |
 | `"placeholder"`  | The placeholder shown before the first search is executed.         |
 | `"value"`        | A single facet value                                               |
 | `"value-count"`  | The facet value count                                              |

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -36,6 +36,8 @@ import {FacetPlaceholder} from '../atomic-facet-placeholder/atomic-facet-placeho
  * An `atomic-facet` displays a facet of the results for the current query. In mobile browsers, this is rendered as a button which opens a facet modal.
  *
  * @part facet - The wrapper for the entire facet
+ * @part label - The label of the facet
+ * @part modal-button - The button to open the facet modal (mobile only)
  * @part close-button - The button to close the facet when displayed modally (mobile only)
  * @part clear-button - The button that resets the actively selected facet values
  *

--- a/packages/atomic/src/components/facets/atomic-facet/readme.md
+++ b/packages/atomic/src/components/facets/atomic-facet/readme.md
@@ -26,6 +26,8 @@ A facet component. It is displayed as a facet in desktop browsers and as a butto
 | `"clear-button"`              | The button that resets the actively selected facet values          |
 | `"close-button"`              | The button to close the facet when displayed modally (mobile only) |
 | `"facet"`                     | The wrapper for the entire facet                                   |
+| `"label"`                     | The label of the facet                                             |
+| `"modal-button"`              | The button to open the facet modal (mobile only)                   |
 | `"placeholder"`               | The placeholder shown before the first search is executed.         |
 | `"search-icon"`               | The magnifier icon of the input                                    |
 | `"search-input"`              | The search input                                                   |

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -30,6 +30,8 @@ import {FacetPlaceholder} from '../atomic-facet-placeholder/atomic-facet-placeho
  * The `atomic-numeric-facet` component displays values as numeric ranges. In mobile browsers, this is rendered as a button which opens a facet modal.
  *
  * @part facet - The wrapper for the entire facet
+ * @part label - The label of the facet
+ * @part modal-button - The button to open the facet modal (mobile only)
  * @part close-button - The button to close the facet when displayed modally (mobile only)
  * @part clear-button - The button that resets the actively selected facet values
  *

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/readme.md
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/readme.md
@@ -23,6 +23,8 @@ It is displayed as a regular facet in desktop browsers and as a button which ope
 | `"clear-button"` | The button that resets the actively selected facet values          |
 | `"close-button"` | The button to close the facet when displayed modally (mobile only) |
 | `"facet"`        | The wrapper for the entire facet                                   |
+| `"label"`        | The label of the facet                                             |
+| `"modal-button"` | The button to open the facet modal (mobile only)                   |
 | `"placeholder"`  | The placeholder shown before the first search is executed.         |
 | `"value"`        | A single facet value                                               |
 | `"value-count"`  | The facet value count                                              |

--- a/packages/atomic/src/components/facets/base-facet/base-facet.tsx
+++ b/packages/atomic/src/components/facets/base-facet/base-facet.tsx
@@ -61,6 +61,7 @@ export const BaseFacet: FunctionalComponent<BaseFacetProps> = (
     <div class="facet mb-4" part="facet">
       <button
         title={props.label}
+        part="modal-button"
         class={`rounded-3xl text-left border-solid bg-background px-4 h-9 outline-none focus:outline-none lg:hidden cursor-pointer ellipsed w-full ${
           props.hasActiveValues
             ? 'border-2 border-primary text-primary'
@@ -78,6 +79,7 @@ export const BaseFacet: FunctionalComponent<BaseFacetProps> = (
         <div class="flex flex-row items-center pb-2 mb-2 border-b border-solid border-divider">
           <span
             title={props.label}
+            part="label"
             class="font-semibold text-on-background-variant text-base lg:text-sm ellipsed w-full"
           >
             {props.label}

--- a/packages/atomic/src/components/facets/facet-search/facet-search.pcss
+++ b/packages/atomic/src/components/facets/facet-search/facet-search.pcss
@@ -3,7 +3,7 @@
 }
 
 .search-results {
-  @apply z-10 absolute w-full bg-background border-divider-t-0 empty:border-none rounded-b overflow-y-scroll left-0;
+  @apply z-10 absolute w-full bg-background border-divider-t-0 empty:border-none rounded-b overflow-y-auto left-0;
   max-height: var(--atomic-facet-search-max-height, 250px);
   top: var(--atomic-facet-search-height, 30px);
 }

--- a/packages/atomic/src/components/facets/facet-search/facet-search.tsx
+++ b/packages/atomic/src/components/facets/facet-search/facet-search.tsx
@@ -105,9 +105,10 @@ export class FacetSearch {
   }
 
   private onValuesScroll() {
+    const scrollPixelBuffer = 50;
     const scrollEndReached =
       this.valuesRef.scrollTop + this.valuesRef.clientHeight >=
-      this.valuesRef.scrollHeight;
+      this.valuesRef.scrollHeight - scrollPixelBuffer;
 
     if (this.facetSearchState.moreValuesAvailable && scrollEndReached) {
       this.facetSearchController.showMoreResults();

--- a/packages/atomic/src/components/facets/facet-search/facet-search.tsx
+++ b/packages/atomic/src/components/facets/facet-search/facet-search.tsx
@@ -89,6 +89,7 @@ export class FacetSearch {
 
   private triggerSearch() {
     this.facetSearchController.search();
+    this.scrollTop();
   }
 
   private onChange(value: string) {
@@ -112,7 +113,11 @@ export class FacetSearch {
     this.text = '';
   }
 
-  private onValuesScroll() {
+  private scrollTop() {
+    this.valuesRef.scrollTo({top: 0});
+  }
+
+  private onScroll() {
     const scrollPixelBuffer = 50;
     const scrollEndReached =
       this.valuesRef.scrollTop + this.valuesRef.clientHeight >=
@@ -203,7 +208,7 @@ export class FacetSearch {
         part="search-results"
         class={'search-results ' + (showResults ? 'block' : 'hidden')}
         ref={(el) => (this.valuesRef = el as HTMLElement)}
-        onScroll={() => this.onValuesScroll()}
+        onScroll={() => this.onScroll()}
       >
         {this.resultList}
       </ul>

--- a/packages/atomic/src/components/facets/facet-search/facet-search.tsx
+++ b/packages/atomic/src/components/facets/facet-search/facet-search.tsx
@@ -148,25 +148,6 @@ export class FacetSearch {
     );
   }
 
-  // TODO: remove show more
-  private get showMoreSearchResults() {
-    if (!this.facetSearchState.moreValuesAvailable) {
-      return null;
-    }
-
-    return (
-      <li class="search-result text-primary">
-        <button
-          onClick={() => this.facetSearchController.showMoreResults()}
-          onMouseDown={(e) => e.preventDefault()}
-          value={FacetSearch.ShowMoreResultsValue}
-        >
-          {this.strings.showMore()}
-        </button>
-      </li>
-    );
-  }
-
   private get resultList() {
     return this.facetSearchResults.map((searchResult, index) => (
       <li part="search-result" class="search-result">
@@ -192,7 +173,6 @@ export class FacetSearch {
         ref={(el) => (this.valuesRef = el as HTMLElement)}
       >
         {this.resultList}
-        {this.showMoreSearchResults}
       </ul>
     );
   }

--- a/packages/atomic/src/components/facets/facet-search/facet-search.tsx
+++ b/packages/atomic/src/components/facets/facet-search/facet-search.tsx
@@ -11,7 +11,6 @@ type FacetSearchResult = CategoryFacetSearchResult;
 
 export interface FacetSearchStrings extends ComboboxStrings {
   placeholder: () => string;
-  showMore: () => string;
 }
 
 export interface FacetSearchComponent {
@@ -105,6 +104,16 @@ export class FacetSearch {
     }
   }
 
+  private onValuesScroll() {
+    const scrollEndReached =
+      this.valuesRef.scrollTop + this.valuesRef.clientHeight >=
+      this.valuesRef.scrollHeight;
+
+    if (this.facetSearchState.moreValuesAvailable && scrollEndReached) {
+      this.facetSearchController.showMoreResults();
+    }
+  }
+
   private get clearButton() {
     if (this.component.facetSearchQuery === '') {
       return;
@@ -171,6 +180,7 @@ export class FacetSearch {
         part="search-results"
         class={'search-results ' + (showResults ? 'block' : 'hidden')}
         ref={(el) => (this.valuesRef = el as HTMLElement)}
+        onScroll={() => this.onValuesScroll()}
       >
         {this.resultList}
       </ul>

--- a/packages/atomic/src/utils/combobox.tsx
+++ b/packages/atomic/src/utils/combobox.tsx
@@ -96,6 +96,10 @@ export class Combobox {
     return !!this.listbox.childElementCount;
   }
 
+  private scrollActiveDescendantIntoView() {
+    this.activeDescendantElement?.scrollIntoView(false);
+  }
+
   private focusNextValue() {
     if (!this.hasValues) {
       return;
@@ -103,6 +107,7 @@ export class Combobox {
 
     this.updateActiveDescendantElement(this.nextOfFirstValue);
     this.updateAccessibilityAttributes();
+    this.scrollActiveDescendantIntoView();
   }
 
   private get firstValue() {
@@ -124,6 +129,7 @@ export class Combobox {
 
     this.updateActiveDescendantElement(this.previousOrLastValue);
     this.updateAccessibilityAttributes();
+    this.scrollActiveDescendantIntoView();
   }
 
   private get lastValue() {

--- a/packages/atomic/src/utils/combobox.tsx
+++ b/packages/atomic/src/utils/combobox.tsx
@@ -26,6 +26,8 @@ export class Combobox {
   public onInputChange(e: Event) {
     const value = (e.target as HTMLInputElement).value;
     this.options.onChange(value);
+    this.updateActiveDescendant();
+    this.listbox.scrollTo({top: 0});
   }
 
   public onInputKeyup(e: KeyboardEvent) {

--- a/packages/atomic/src/utils/combobox.tsx
+++ b/packages/atomic/src/utils/combobox.tsx
@@ -27,7 +27,6 @@ export class Combobox {
     const value = (e.target as HTMLInputElement).value;
     this.options.onChange(value);
     this.updateActiveDescendant();
-    this.listbox.scrollTo({top: 0});
   }
 
   public onInputKeyup(e: KeyboardEvent) {
@@ -99,7 +98,9 @@ export class Combobox {
   }
 
   private scrollActiveDescendantIntoView() {
-    this.activeDescendantElement?.scrollIntoView(false);
+    this.activeDescendantElement?.scrollIntoView({
+      block: 'nearest',
+    });
   }
 
   private focusNextValue() {

--- a/packages/atomic/src/utils/initialization-utils.spec.ts
+++ b/packages/atomic/src/utils/initialization-utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AtomicStore,
   BindStateToController,
   InitializableComponent,
   InitializeBindings,
@@ -8,6 +9,7 @@ import {newSpecPage, SpecPage} from '@stencil/core/testing';
 import {AtomicSearchInterface} from '../components/atomic-search-interface/atomic-search-interface';
 import i18next from 'i18next';
 import {AtomicSearchBox} from '../components/atomic-search-box/atomic-search-box';
+import {createStore} from '@stencil/store';
 
 describe('InitializeBindings decorator', () => {
   it(`when using the decorator with a property other than bindings 
@@ -90,6 +92,7 @@ describe('InitializeBindings decorator', () => {
           state: TestUtils.createMockState(),
         }),
         i18n: i18next,
+        store: createStore<AtomicStore>({facets: {}}),
       };
       InitializeBindings()(component, 'bindings');
       component.initialize!();
@@ -110,6 +113,7 @@ describe('BindStateToController decorator', () => {
           state: TestUtils.createMockState(),
         }),
         i18n: i18next,
+        store: createStore<AtomicStore>({facets: {}}),
       },
       error: {} as Error,
     };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-629

(When I mean search & search box here, it's for the facet, not the atomic-search-box search)

**To recap:**
- Removed "show more button" in the facet search results
- We show more depending on the scroll position, the more we go down in the list, the more we fetch (like JSUI)
- The selected element is now always shown in scroll view when using the keyboard
- The selected element is reset when changing the query
- The query is now cleared when leaving the search box (like JSUI)
- We don't trigger a new search when selecting an element
- We hide the result when it's querying (loading) I'M NOT A SUPER FAN OF THIS ONE, [see my other comment](https://github.com/coveo/ui-kit/pull/730/files#r617012250)