### PR TITLE
chore: mark case-assist package private to resolve lerna version bump error

### DIFF
--- a/packages/headless/case-assist/package.json
+++ b/packages/headless/case-assist/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "case-assist",
   "description": "Headless Case Assist Module",
   "main": "../dist/case-assist/headless.js",

--- a/packages/headless/contributors/adding-a-sub-package.md
+++ b/packages/headless/contributors/adding-a-sub-package.md
@@ -8,13 +8,14 @@ Headless provides exports through multiple sub packages. A sub-package groups to
 1. Create an entry file for your sub-package inside the `src` directory (e.g. case-assist.ts).
 2. Configure nodejs and browser bundles inside `rollup.config.js` for your entry file.
 3. Create a new directory with the name of your sub-package at the project root.
-4. Inside the new directory, add a `package.json` file and fill in the paths to your bundled files and type definitions.
+4. Inside the new directory, add a `package.json` file. Add the paths to your bundled files and type definitions. Mark the package `private` so that `lerna` does not bump it's version.
 5. Add the directory name to the `files` array in the project root `package.json` file.
 
 ```json
 pkg/case-assist/package.json
 
 {
+  "private": true,
   "name": "case-assist",
   "description": "Headless Case Assist Module",
   "main": "../dist/case-assist/headless.js",

--- a/packages/headless/contributors/adding-a-sub-package.md
+++ b/packages/headless/contributors/adding-a-sub-package.md
@@ -8,7 +8,7 @@ Headless provides exports through multiple sub packages. A sub-package groups to
 1. Create an entry file for your sub-package inside the `src` directory (e.g. case-assist.ts).
 2. Configure nodejs and browser bundles inside `rollup.config.js` for your entry file.
 3. Create a new directory with the name of your sub-package at the project root.
-4. Inside the new directory, add a `package.json` file. Add the paths to your bundled files and type definitions. Mark the package `private` so that `lerna` does not bump it's version.
+4. Inside the new directory, add a `package.json` file. Add the paths to your bundled files and type definitions. Mark the package `private` to prevent `lerna` from bumping it's version.
 5. Add the directory name to the `files` array in the project root `package.json` file.
 
 ```json


### PR DESCRIPTION
Lerna version bump throws an error when it detects a package.json with no version field that is not private.

```
lerna ERR! ENOVERSION A version field is required in case-assist's package.json file.
lerna ERR! ENOVERSION If you wish to keep the package unversioned, it must be made private.
```

https://coveord.atlassian.net/browse/KIT-639