### PR TITLE
refactor: allow passing thunk arguments (API client) to core engine

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,11 @@
           {"ignoreRestSiblings": true}
         ],
         "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/ban-types": "off"
+        "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/no-empty-interface": [
+          "error",
+          {"allowSingleExtends": true}
+        ]
       }
     },
     {

--- a/packages/atomic/src/components/atomic-result/readme.md
+++ b/packages/atomic/src/components/atomic-result/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property               | Attribute | Description                    | Type                                                    | Default     |
-| ---------------------- | --------- | ------------------------------ | ------------------------------------------------------- | ----------- |
-| `content` _(required)_ | `content` | The result content to display. | `string`                                                | `undefined` |
-| `engine` _(required)_  | --        | The Headless Engine.           | `CoreEngine<SearchAppState, SearchThunkExtraArguments>` | `undefined` |
-| `result` _(required)_  | --        | The result item.               | `Result`                                                | `undefined` |
+| Property               | Attribute | Description                    | Type                     | Default     |
+| ---------------------- | --------- | ------------------------------ | ------------------------ | ----------- |
+| `content` _(required)_ | `content` | The result content to display. | `string`                 | `undefined` |
+| `engine` _(required)_  | --        | The Headless Engine.           | `Engine<SearchAppState>` | `undefined` |
+| `result` _(required)_  | --        | The result item.               | `Result`                 | `undefined` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-result/readme.md
+++ b/packages/atomic/src/components/atomic-result/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property               | Attribute | Description                    | Type                     | Default     |
-| ---------------------- | --------- | ------------------------------ | ------------------------ | ----------- |
-| `content` _(required)_ | `content` | The result content to display. | `string`                 | `undefined` |
-| `engine` _(required)_  | --        | The Headless Engine.           | `Engine<SearchAppState>` | `undefined` |
-| `result` _(required)_  | --        | The result item.               | `Result`                 | `undefined` |
+| Property               | Attribute | Description                    | Type                                                    | Default     |
+| ---------------------- | --------- | ------------------------------ | ------------------------------------------------------- | ----------- |
+| `content` _(required)_ | `content` | The result content to display. | `string`                                                | `undefined` |
+| `engine` _(required)_  | --        | The Headless Engine.           | `CoreEngine<SearchAppState, SearchThunkExtraArguments>` | `undefined` |
+| `result` _(required)_  | --        | The result item.               | `Result`                                                | `undefined` |
 
 
 ## Dependencies

--- a/packages/atomic/src/components/atomic-search-interface/readme.md
+++ b/packages/atomic/src/components/atomic-search-interface/readme.md
@@ -9,7 +9,7 @@
 
 | Property            | Attribute              | Description                                                            | Type                                                                                    | Default                    |
 | ------------------- | ---------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------- |
-| `engine`            | --                     | The search interface Headless engine.                                  | `CoreEngine<SearchAppState, SearchThunkExtraArguments> \| undefined`                    | `undefined`                |
+| `engine`            | --                     | The search interface Headless engine.                                  | `Engine<SearchAppState> \| undefined`                                                   | `undefined`                |
 | `i18n`              | --                     | The search interface i18next instance.                                 | `i18n`                                                                                  | `i18next.createInstance()` |
 | `language`          | `language`             | The search interface language.                                         | `string`                                                                                | `'en'`                     |
 | `logLevel`          | `log-level`            | The level of messages you want to be logged in the console.            | `"debug" \| "error" \| "fatal" \| "info" \| "silent" \| "trace" \| "warn" \| undefined` | `undefined`                |

--- a/packages/atomic/src/components/atomic-search-interface/readme.md
+++ b/packages/atomic/src/components/atomic-search-interface/readme.md
@@ -9,7 +9,7 @@
 
 | Property            | Attribute              | Description                                                            | Type                                                                                    | Default                    |
 | ------------------- | ---------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------- |
-| `engine`            | --                     | The search interface Headless engine.                                  | `Engine<SearchAppState> \| undefined`                                                   | `undefined`                |
+| `engine`            | --                     | The search interface Headless engine.                                  | `CoreEngine<SearchAppState, SearchThunkExtraArguments> \| undefined`                    | `undefined`                |
 | `i18n`              | --                     | The search interface i18next instance.                                 | `i18n`                                                                                  | `i18next.createInstance()` |
 | `language`          | `language`             | The search interface language.                                         | `string`                                                                                | `'en'`                     |
 | `logLevel`          | `log-level`            | The level of messages you want to be logged in the console.            | `"debug" \| "error" \| "fatal" \| "info" \| "silent" \| "trace" \| "warn" \| undefined` | `undefined`                |

--- a/packages/headless/src/api/search/search-api-client.ts
+++ b/packages/headless/src/api/search/search-api-client.ts
@@ -22,7 +22,6 @@ import {baseSearchRequest} from './search-api-params';
 import {RecommendationRequest} from './recommendation/recommendation-request';
 import {ProductRecommendationsRequest} from './product-recommendations/product-recommendations-request';
 import {Logger} from 'pino';
-import {ThunkExtraArguments} from '../../app/store';
 import {
   PostprocessFacetSearchResponseMiddleware,
   PostprocessQuerySuggestResponseMiddleware,
@@ -33,13 +32,14 @@ import {HtmlRequest} from './html/html-request';
 import {findEncoding} from './encoding-finder';
 import {TextDecoder} from 'web-encoding';
 import {BaseParam} from '../platform-service-params';
+import {SearchThunkExtraArguments} from '../../app/headless-engine';
 
 export type AllSearchAPIResponse = Plan | Search | QuerySuggest;
 
 export interface AsyncThunkSearchOptions<T extends Partial<SearchAppState>> {
   state: T;
   rejectValue: SearchAPIErrorWithStatusCode;
-  extra: ThunkExtraArguments;
+  extra: SearchThunkExtraArguments;
 }
 
 export interface SearchAPIClientOptions {

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -2,10 +2,9 @@ import {
   updateAnalyticsConfiguration,
   updateBasicConfiguration,
 } from '../features/configuration/configuration-actions';
-import {buildMockSearchAPIClient} from '../test/mock-search-api-client';
 import {buildMockStore} from '../test/mock-store';
+import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments';
 import {buildEngine, Engine, EngineOptions} from './engine';
-import {buildLogger} from './logger';
 import {searchAppReducers} from './search-app-reducers';
 import * as Store from './store';
 
@@ -16,9 +15,8 @@ describe('engine', () => {
   function initEngine() {
     jest.spyOn(Store, 'configureStore').mockReturnValue(buildMockStore());
 
-    const searchAPIClient = buildMockSearchAPIClient();
-    const logger = buildLogger({level: 'silent'});
-    engine = buildEngine(options, {searchAPIClient}, logger);
+    const thunkArguments = buildMockThunkExtraArguments();
+    engine = buildEngine(options, thunkArguments);
   }
 
   beforeEach(() => {

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -4,13 +4,13 @@ import {
 } from '../features/configuration/configuration-actions';
 import {buildMockStore} from '../test/mock-store';
 import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments';
-import {buildEngine, Engine, EngineOptions} from './engine';
+import {buildEngine, CoreEngine, EngineOptions} from './engine';
 import {searchAppReducers} from './search-app-reducers';
 import * as Store from './store';
 
 describe('engine', () => {
   let options: EngineOptions<typeof searchAppReducers>;
-  let engine: Engine;
+  let engine: CoreEngine;
 
   function initEngine() {
     jest.spyOn(Store, 'configureStore').mockReturnValue(buildMockStore());

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -24,7 +24,10 @@ type EngineDispatch<
   ExtraArguments extends ThunkExtraArguments
 > = ThunkDispatch<State, ExtraArguments, AnyAction> & Dispatch<AnyAction>;
 
-export interface Engine<State, ExtraArguments extends ThunkExtraArguments> {
+export interface Engine<
+  State extends object = {},
+  ExtraArguments extends ThunkExtraArguments = ThunkExtraArguments
+> {
   /**
    * Dispatches an action directly. This is the only way to trigger a state change.
    * Each headless controller dispatches its own actions.

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -24,7 +24,7 @@ type EngineDispatch<
   ExtraArguments extends ThunkExtraArguments
 > = ThunkDispatch<State, ExtraArguments, AnyAction> & Dispatch<AnyAction>;
 
-export interface Engine<
+export interface CoreEngine<
   State extends object = {},
   ExtraArguments extends ThunkExtraArguments = ThunkExtraArguments
 > {
@@ -112,7 +112,7 @@ export function buildEngine<
 >(
   options: EngineOptions<Reducers>,
   thunkExtraArguments: ExtraArguments
-): Engine<StateFromReducersMapObject<Reducers>, ExtraArguments> {
+): CoreEngine<StateFromReducersMapObject<Reducers>, ExtraArguments> {
   const engine = buildCoreEngine(options, thunkExtraArguments);
   const {
     accessToken,
@@ -143,7 +143,7 @@ function buildCoreEngine<
 >(
   options: EngineOptions<Reducers>,
   thunkExtraArguments: ExtraArguments
-): Engine<StateFromReducersMapObject<Reducers>, ExtraArguments> {
+): CoreEngine<StateFromReducersMapObject<Reducers>, ExtraArguments> {
   const {configuration, reducers} = options;
   const reducerManager = createReducerManager(reducers);
   const logger = thunkExtraArguments.logger;

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -25,7 +25,10 @@ type EngineDispatch<
 > = ThunkDispatch<State, ExtraArguments, AnyAction> & Dispatch<AnyAction>;
 
 export interface CoreEngine<
-  State extends object = {},
+  /**
+   * @deprecated For v1, restrict "State" generic by extending "object". e.g. State extends object = {}
+   */
+  State = {},
   ExtraArguments extends ThunkExtraArguments = ThunkExtraArguments
 > {
   /**

--- a/packages/headless/src/app/headless-engine.test.ts
+++ b/packages/headless/src/app/headless-engine.test.ts
@@ -1,13 +1,12 @@
-import {HeadlessEngine, HeadlessOptions} from './headless-engine';
+import {HeadlessEngine, HeadlessOptions, SearchEngine} from './headless-engine';
 import {updateSearchConfiguration} from '../features/configuration/configuration-actions';
 import * as Store from './store';
 import {searchAppReducers} from './search-app-reducers';
-import {Engine} from './engine';
 import {buildMockStore} from '../test/mock-store';
 
 describe('headless engine', () => {
   let options: HeadlessOptions<typeof searchAppReducers>;
-  let engine: Engine;
+  let engine: SearchEngine;
 
   beforeEach(() => {
     jest.spyOn(Store, 'configureStore').mockReturnValue(buildMockStore());

--- a/packages/headless/src/app/headless-engine.test.ts
+++ b/packages/headless/src/app/headless-engine.test.ts
@@ -1,4 +1,4 @@
-import {HeadlessEngine, HeadlessOptions, SearchEngine} from './headless-engine';
+import {HeadlessEngine, HeadlessOptions, Engine} from './headless-engine';
 import {updateSearchConfiguration} from '../features/configuration/configuration-actions';
 import * as Store from './store';
 import {searchAppReducers} from './search-app-reducers';
@@ -6,7 +6,7 @@ import {buildMockStore} from '../test/mock-store';
 
 describe('headless engine', () => {
   let options: HeadlessOptions<typeof searchAppReducers>;
-  let engine: SearchEngine;
+  let engine: Engine;
 
   beforeEach(() => {
     jest.spyOn(Store, 'configureStore').mockReturnValue(buildMockStore());

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -93,10 +93,8 @@ export interface HeadlessConfigurationOptions
   };
 }
 
-export type Engine<State extends object = SearchAppState> = CoreEngine<
-  State,
-  SearchThunkExtraArguments
->;
+export interface Engine<State extends object = SearchAppState>
+  extends CoreEngine<State, SearchThunkExtraArguments> {}
 
 export interface SearchThunkExtraArguments extends ThunkExtraArguments {
   searchAPIClient: SearchAPIClient;

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -92,7 +92,7 @@ export interface HeadlessConfigurationOptions
   };
 }
 
-export type SearchEngine<State extends object> = Engine<
+export type SearchEngine<State extends object = {}> = Engine<
   State,
   SearchThunkExtraArguments
 >;

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -96,7 +96,7 @@ export interface HeadlessConfigurationOptions
 /**
  * The engine for powering search experiences.
  */
-export interface Engine<State extends object = SearchAppState>
+export interface Engine<State = SearchAppState>
   extends CoreEngine<State, SearchThunkExtraArguments> {}
 
 export interface SearchThunkExtraArguments extends ThunkExtraArguments {

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -21,7 +21,7 @@ import {
   PostprocessQuerySuggestResponseMiddleware,
   PostprocessSearchResponseMiddleware,
 } from '../api/search/search-api-client-middleware';
-import {buildEngine, Engine, EngineOptions} from './engine';
+import {buildEngine, CoreEngine, EngineOptions} from './engine';
 import {
   engineConfigurationOptionDefinitions,
   EngineConfigurationOptions,
@@ -92,7 +92,7 @@ export interface HeadlessConfigurationOptions
   };
 }
 
-export type SearchEngine<State extends object = {}> = Engine<
+export type Engine<State extends object = {}> = CoreEngine<
   State,
   SearchThunkExtraArguments
 >;
@@ -107,9 +107,9 @@ export interface SearchThunkExtraArguments extends ThunkExtraArguments {
  * Every headless controller requires an instance of `Engine` as a parameter.
  */
 export class HeadlessEngine<Reducers extends ReducersMapObject>
-  implements SearchEngine<StateFromReducersMapObject<Reducers>> {
+  implements Engine<StateFromReducersMapObject<Reducers>> {
   public logger!: Logger;
-  private engine: SearchEngine<StateFromReducersMapObject<Reducers>>;
+  private engine: Engine<StateFromReducersMapObject<Reducers>>;
 
   constructor(private options: HeadlessOptions<Reducers>) {
     this.validateConfiguration(options);

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -31,6 +31,7 @@ import {
   buildThunkExtraArguments,
   ThunkExtraArguments,
 } from './thunk-extra-arguments';
+import {SearchAppState} from '../state/search-app-state';
 
 /**
  * The global headless engine options.
@@ -92,7 +93,7 @@ export interface HeadlessConfigurationOptions
   };
 }
 
-export type Engine<State extends object = {}> = CoreEngine<
+export type Engine<State extends object = SearchAppState> = CoreEngine<
   State,
   SearchThunkExtraArguments
 >;

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -93,6 +93,9 @@ export interface HeadlessConfigurationOptions
   };
 }
 
+/**
+ * The engine for powering search experiences.
+ */
 export interface Engine<State extends object = SearchAppState>
   extends CoreEngine<State, SearchThunkExtraArguments> {}
 

--- a/packages/headless/src/app/store.ts
+++ b/packages/headless/src/app/store.ts
@@ -5,24 +5,12 @@ import {
   Middleware,
   Reducer,
 } from '@reduxjs/toolkit';
-import {AnalyticsClientSendEventHook} from 'coveo.analytics';
-import {SearchAPIClient} from '../api/search/search-api-client';
 import {analyticsMiddleware} from './analytics-middleware';
-import {Logger} from 'pino';
 import {
   logActionErrorMiddleware,
   logActionMiddleware,
 } from './logger-middlewares';
-import {validatePayloadAndThrow} from '../utils/validate-payload';
-import {PreprocessRequest} from '../api/preprocess-request';
-
-export interface ThunkExtraArguments {
-  preprocessRequest?: PreprocessRequest;
-  searchAPIClient: SearchAPIClient;
-  analyticsClientMiddleware: AnalyticsClientSendEventHook;
-  logger: Logger;
-  validatePayload: typeof validatePayloadAndThrow;
-}
+import {ThunkExtraArguments} from './thunk-extra-arguments';
 
 interface ConfigureStoreOptions<Reducers extends ReducersMapObject> {
   reducer: Reducer;

--- a/packages/headless/src/app/thunk-extra-arguments.ts
+++ b/packages/headless/src/app/thunk-extra-arguments.ts
@@ -1,0 +1,41 @@
+import {AnalyticsClientSendEventHook} from 'coveo.analytics';
+import {Logger} from 'pino';
+import {PreprocessRequest} from '../api/preprocess-request';
+import {validatePayloadAndThrow} from '../utils/validate-payload';
+import {EngineConfigurationOptions} from './engine-configuration-options';
+import {NoopPreprocessRequest} from '../api/preprocess-request';
+
+export interface ThunkExtraArguments {
+  preprocessRequest?: PreprocessRequest;
+  analyticsClientMiddleware: AnalyticsClientSendEventHook;
+  logger: Logger;
+  validatePayload: typeof validatePayloadAndThrow;
+}
+
+export function buildThunkExtraArguments(
+  configuration: EngineConfigurationOptions,
+  logger: Logger
+): ThunkExtraArguments {
+  const analyticsClientMiddleware = getAnalyticsClientMiddleware(configuration);
+  const validatePayload = validatePayloadAndThrow;
+  const preprocessRequest = getPreprocessRequest(configuration);
+
+  return {
+    analyticsClientMiddleware,
+    validatePayload,
+    preprocessRequest,
+    logger,
+  };
+}
+
+function getAnalyticsClientMiddleware(
+  configuration: EngineConfigurationOptions
+): AnalyticsClientSendEventHook {
+  const {analytics} = configuration;
+  const NoopAnalyticsMiddleware = (_: string, p: any) => p;
+  return analytics?.analyticsClientMiddleware || NoopAnalyticsMiddleware;
+}
+
+function getPreprocessRequest(configuration: EngineConfigurationOptions) {
+  return configuration.preprocessRequest || NoopPreprocessRequest;
+}

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {BaseFacetValue} from '../../features/facets/facet-api/response';
 import {FacetValue} from '../../features/facets/facet-set/interfaces/response';

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {
   ContextPayload,

--- a/packages/headless/src/controllers/controller/headless-controller.ts
+++ b/packages/headless/src/controllers/controller/headless-controller.ts
@@ -1,5 +1,5 @@
 import {Unsubscribe} from '@reduxjs/toolkit';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 
 export interface Controller {
   /**
@@ -12,7 +12,9 @@ export interface Controller {
   readonly state: {};
 }
 
-export function buildController<T>(engine: Engine<T>): Controller {
+export function buildController<T extends object>(
+  engine: Engine<T>
+): Controller {
   let prevState = '{}';
 
   const hasStateChanged = (currentState: Record<string, unknown>): boolean => {

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {
   applyDidYouMeanCorrection,

--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {facetOptions, search} from '../../app/reducers';
 import {SearchSection} from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';

--- a/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
+++ b/packages/headless/src/controllers/facets/_common/facet-id-determinor.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../app/engine';
+import {Engine} from '../../../app/headless-engine';
 import {AllFacetSections} from '../../../features/facets/generic/interfaces/generic-facet-section';
 import {generateFacetId} from './facet-id-generator';
 

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../app/engine';
+import {Engine} from '../../../app/headless-engine';
 import {
   buildController,
   Controller,

--- a/packages/headless/src/controllers/facets/facet-search/category/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/facets/facet-search/category/headless-category-facet-search.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {
   registerCategoryFacetSearch,
   selectCategoryFacetSearchResult,

--- a/packages/headless/src/controllers/facets/facet-search/facet-search.ts
+++ b/packages/headless/src/controllers/facets/facet-search/facet-search.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../app/engine';
+import {Engine} from '../../../app/headless-engine';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
 import {executeSearch} from '../../../features/search/search-actions';
 import {logFacetSelect} from '../../../features/facets/facet-set/facet-set-analytics-actions';

--- a/packages/headless/src/controllers/facets/facet-search/specific/headless-facet-search.ts
+++ b/packages/headless/src/controllers/facets/facet-search/specific/headless-facet-search.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {
   registerFacetSearch,
   selectFacetSearchResult,

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -2,7 +2,7 @@ import {
   buildController,
   Controller,
 } from '../../controller/headless-controller';
-import {Engine} from '../../../app/engine';
+import {Engine} from '../../../app/headless-engine';
 import {
   registerFacet,
   deselectAllFacetValues,

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet-options.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet-options.ts
@@ -20,7 +20,7 @@ import {
   injectionDepth,
   numberOfValues,
 } from '../../_common/facet-option-definitions';
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {validateOptions} from '../../../../utils/validate-payload';
 import {
   ConfigurationSection,

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -2,7 +2,7 @@ import {
   DateFacetRequest,
   DateRangeRequest,
 } from '../../../../features/facets/range-facets/date-facet-set/interfaces/request';
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {DateFacetRegistrationOptions} from '../../../../features/facets/range-facets/date-facet-set/interfaces/options';
 import {
   DateFacetResponse,

--- a/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../app/engine';
+import {Engine} from '../../../app/headless-engine';
 import {buildController} from '../../controller/headless-controller';
 import {
   RangeFacetResponse,

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
@@ -22,7 +22,7 @@ import {
   numberOfValues,
 } from '../../_common/facet-option-definitions';
 import {validateOptions} from '../../../../utils/validate-payload';
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {
   ConfigurationSection,
   NumericFacetSection,

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../../../app/engine';
+import {Engine} from '../../../../app/headless-engine';
 import {
   NumericFacetRequest,
   NumericRangeRequest,

--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration, history} from '../../app/reducers';
 import {StateWithHistory} from '../../app/undoable';
 import {back, forward} from '../../features/history/history-actions';

--- a/packages/headless/src/controllers/history-manager/headless-history.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildHistoryManager} from './headless-history-manager';
 
 /**

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -1,5 +1,5 @@
 import {Schema, NumberValue} from '@coveo/bueno';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {
   updatePage,

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {
   getProductRecommendations as updateProductRecommendations,
   setProductRecommendationsSkus,

--- a/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/product-recommendations/headless-frequently-bought-together.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-frequently-bought-together.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema, SchemaValues, StringValue} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/product-recommendations/headless-frequently-viewed-together.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-frequently-viewed-together.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema, SchemaValues} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/product-recommendations/headless-popular-bought-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-popular-bought-recommendations.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema, SchemaValues} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/product-recommendations/headless-popular-viewed-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-popular-viewed-recommendations.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema, SchemaValues} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/product-recommendations/headless-user-interest-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-user-interest-recommendations.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {Schema, SchemaValues} from '@coveo/bueno';
 import {
   baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/query-error/headless-query-error.ts
+++ b/packages/headless/src/controllers/query-error/headless-query-error.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {search} from '../../app/reducers';
 import {SearchSection} from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';

--- a/packages/headless/src/controllers/query-summary/headless-query-summary.ts
+++ b/packages/headless/src/controllers/query-summary/headless-query-summary.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {pagination, search} from '../../app/reducers';
 import {PaginationSection, SearchSection} from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';

--- a/packages/headless/src/controllers/quickview/headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/headless-quickview.ts
@@ -1,5 +1,5 @@
 import {Result} from '../../api/search/search/result';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration, resultPreview} from '../../app/reducers';
 import {fetchResultContent} from '../../features/result-preview/result-preview-actions';
 import {logDocumentQuickview} from '../../features/result-preview/result-preview-analytics-actions';

--- a/packages/headless/src/controllers/recommendation/headless-recommendation.ts
+++ b/packages/headless/src/controllers/recommendation/headless-recommendation.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {
   getRecommendations,
   setRecommendationId,

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
@@ -7,7 +7,7 @@ import {QueryRankingExpression} from '../../api/search/search/query-ranking-expr
 import {Result} from '../../api/search/search/result';
 import {SearchResponseSuccessWithDebugInfo} from '../../api/search/search/search-response';
 import {SecurityIdentity} from '../../api/search/search/security-identity';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration, debug, search} from '../../app/reducers';
 import {
   AnalyticsType,

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.ts
@@ -1,5 +1,5 @@
 import {Result} from '../../api/search/search/result';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration} from '../../app/reducers';
 import {logDocumentOpen} from '../../features/result/result-analytics-actions';
 import {ConfigurationSection} from '../../state/state-sections';

--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {ConfigurationSection, SearchSection} from '../../state/state-sections';
 import {buildController, Controller} from '../controller/headless-controller';
 import {fetchMoreResults} from '../../features/search/search-actions';

--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
@@ -1,5 +1,5 @@
 import {NumberValue, Schema} from '@coveo/bueno';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration, pagination} from '../../app/reducers';
 import {
   registerNumberOfResults,

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -5,7 +5,7 @@ import {
   registerQuerySuggest,
   selectQuerySuggestion,
 } from '../../features/query-suggest/query-suggest-actions';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {updateQuery} from '../../features/query/query-actions';
 import {
   registerQuerySetQuery,

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -1,5 +1,5 @@
 import {RecordValue, Schema} from '@coveo/bueno';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {partitionIntoParentsAndValues} from '../../features/facets/category-facet-set/category-facet-utils';
 import {FacetValueRequest} from '../../features/facets/facet-set/interfaces/request';
 import {getDebugInitialState} from '../../features/debug/debug-state';

--- a/packages/headless/src/controllers/search-status/headless-search-status.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {SearchSection} from '../../state/state-sections';
 import {search} from '../../app/reducers';

--- a/packages/headless/src/controllers/sort/headless-sort.ts
+++ b/packages/headless/src/controllers/sort/headless-sort.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {
   registerSortCriterion,
   updateSortCriterion,

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {configuration, query, redirection} from '../../app/reducers';
 import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
 import {updateQuery} from '../../features/query/query-actions';

--- a/packages/headless/src/controllers/tab/headless-tab.ts
+++ b/packages/headless/src/controllers/tab/headless-tab.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {buildController, Controller} from '../controller/headless-controller';
 import {executeSearch} from '../../features/search/search-actions';
 import {logInterfaceChange} from '../../features/analytics/analytics-actions';

--- a/packages/headless/src/controllers/url-manager/headless-url-manager.ts
+++ b/packages/headless/src/controllers/url-manager/headless-url-manager.ts
@@ -1,5 +1,5 @@
 import {Schema, StringValue} from '@coveo/bueno';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {restoreSearchParameters} from '../../features/search-parameters/search-parameter-actions';
 import {SearchParametersState} from '../../state/search-app-state';
 import {validateInitialState} from '../../utils/validate-payload';

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -20,8 +20,8 @@ import {
 import {CoveoSearchPageClient, SearchPageClientProvider} from 'coveo.analytics';
 import {SearchEventResponse} from 'coveo.analytics/dist/definitions/events';
 import {AsyncThunkAction, createAsyncThunk} from '@reduxjs/toolkit';
-import {ThunkExtraArguments} from '../../app/store';
 import {requiredNonEmptyString} from '../../utils/validate-payload';
+import {ThunkExtraArguments} from '../../app/thunk-extra-arguments';
 
 export enum AnalyticsType {
   Search,

--- a/packages/headless/src/features/result-templates/result-templates-manager.ts
+++ b/packages/headless/src/features/result-templates/result-templates-manager.ts
@@ -7,7 +7,7 @@ import {
   SchemaValidationError,
   StringValue,
 } from '@coveo/bueno';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {registerFieldsToInclude} from '../fields/fields-actions';
 import {SearchAppState} from '../../state/search-app-state';
 
@@ -44,7 +44,10 @@ export interface ResultTemplatesManager<Content = unknown> {
  */
 export function buildResultTemplatesManager<
   Content = unknown,
-  State = SearchAppState
+  /**
+   * @deprecated The "State" generic is no longer needed and will be removed in the next major version. Please do not specify it.
+   */
+  State extends object = SearchAppState
 >(engine: Engine<State>): ResultTemplatesManager<Content> {
   const templates: Required<ResultTemplate<Content>>[] = [];
   const validateTemplates = (templates: ResultTemplate<Content>[]) => {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -13,8 +13,8 @@ export {
   HeadlessOptions,
   HeadlessConfigurationOptions,
   HeadlessEngine,
+  Engine,
 } from './app/headless-engine';
-export {Engine} from './app/engine';
 export {LogLevel} from './app/logger';
 
 export {searchAppReducers} from './app/search-app-reducers';

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -1,4 +1,4 @@
-import {Engine} from '../app/engine';
+import {Engine} from '../app/headless-engine';
 import {createMockState} from './mock-state';
 import configureStore, {MockStoreEnhanced} from 'redux-mock-store';
 import {

--- a/packages/headless/src/test/mock-thunk-extra-arguments.ts
+++ b/packages/headless/src/test/mock-thunk-extra-arguments.ts
@@ -1,0 +1,14 @@
+import {buildLogger} from '../app/logger';
+import {ThunkExtraArguments} from '../app/thunk-extra-arguments';
+
+export function buildMockThunkExtraArguments(
+  config: Partial<ThunkExtraArguments> = {}
+): ThunkExtraArguments {
+  return {
+    analyticsClientMiddleware: jest.fn(),
+    preprocessRequest: jest.fn(),
+    validatePayload: jest.fn(),
+    logger: buildLogger({level: 'silent'}),
+    ...config,
+  };
+}

--- a/packages/headless/src/utils/validate-payload.test.ts
+++ b/packages/headless/src/utils/validate-payload.test.ts
@@ -57,7 +57,7 @@ describe('validatePayloadAndThrow', () => {
 });
 
 describe('validateOptions', () => {
-  let engine: Engine<unknown>;
+  let engine: Engine<object>;
   const schema = new Schema({
     id: new NumberValue({max: 10}),
   });
@@ -86,7 +86,7 @@ describe('validateOptions', () => {
 });
 
 describe('validateInitialState', () => {
-  let engine: Engine<unknown>;
+  let engine: Engine<object>;
   const schema = new Schema({
     id: new NumberValue({max: 10}),
   });

--- a/packages/headless/src/utils/validate-payload.test.ts
+++ b/packages/headless/src/utils/validate-payload.test.ts
@@ -1,5 +1,5 @@
 import {NumberValue, Schema, SchemaValidationError} from '@coveo/bueno';
-import {Engine} from '../app/engine';
+import {Engine} from '../app/headless-engine';
 import {buildMockSearchAppEngine} from '../test';
 import {
   validatePayload,

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -69,7 +69,7 @@ export const validatePayload = <P>(
 };
 
 export const validateInitialState = <T extends object>(
-  engine: Engine,
+  engine: Engine<object>,
   schema: Schema<T>,
   obj: T | undefined,
   functionName: string
@@ -85,7 +85,7 @@ export const validateInitialState = <T extends object>(
 };
 
 export const validateOptions = <T extends object>(
-  engine: Engine,
+  engine: Engine<object>,
   schema: Schema<T>,
   obj: Partial<T> | undefined,
   functionName: string
@@ -101,7 +101,7 @@ export const validateOptions = <T extends object>(
 };
 
 const validateObject = <T extends object>(
-  engine: Engine,
+  engine: Engine<object>,
   schema: Schema<T>,
   obj: T | undefined,
   validationMessage: string,

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -6,7 +6,7 @@ import {
   StringValue,
 } from '@coveo/bueno';
 import {SerializedError} from '@reduxjs/toolkit';
-import {Engine} from '../app/engine';
+import {Engine} from '../app/headless-engine';
 
 export const requiredNonEmptyString = new StringValue({
   required: true,

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -69,7 +69,7 @@ export const validatePayload = <P>(
 };
 
 export const validateInitialState = <T extends object>(
-  engine: Engine<unknown>,
+  engine: Engine,
   schema: Schema<T>,
   obj: T | undefined,
   functionName: string
@@ -85,7 +85,7 @@ export const validateInitialState = <T extends object>(
 };
 
 export const validateOptions = <T extends object>(
-  engine: Engine<unknown>,
+  engine: Engine,
   schema: Schema<T>,
   obj: Partial<T> | undefined,
   functionName: string
@@ -101,7 +101,7 @@ export const validateOptions = <T extends object>(
 };
 
 const validateObject = <T extends object>(
-  engine: Engine<unknown>,
+  engine: Engine,
   schema: Schema<T>,
   obj: T | undefined,
   validationMessage: string,


### PR DESCRIPTION
With this PR, it is possible to specify the API client when creating an engine.