### PR TITLE
feat(atomic): v0 reponsive style

### DIFF
--- a/packages/atomic/src/index.html
+++ b/packages/atomic/src/index.html
@@ -53,10 +53,9 @@
       }
 
       atomic-search-interface {
-        /* TODO: adjust according to breakpoints */
         grid-template-columns: 1fr minmax(150px, 300px) minmax(500px, 950px) 1fr;
         grid-template-rows: 22px 50px 22px 1fr;
-        gap: 20px;
+        column-gap: 20px;
         display: grid;
         margin: 0 auto;
       }
@@ -76,11 +75,13 @@
       atomic-facet-manager {
         grid-column: 2 / auto;
         grid-row: 4 / auto;
+        margin-top: 15px;
       }
 
       .results-container {
         grid-column: 3 / auto;
         grid-row: 4 / auto;
+        margin-top: 15px;
       }
 
       .side-by-side-container {
@@ -104,6 +105,68 @@
 
       atomic-breadcrumb-manager {
         margin: 10px 0;
+      }
+
+      @media only screen and (max-width: 1024px) {
+        atomic-search-interface {
+          grid-template-rows: 16px 50px 16px auto 1fr;
+          grid-template-columns: minmax(0, 100%);
+        }
+
+        atomic-facet-manager,
+        .header,
+        atomic-search-box,
+        .results-container {
+          grid-column: 1 / auto;
+        }
+
+        atomic-breadcrumb-manager,
+        atomic-query-summary,
+        atomic-no-results,
+        atomic-did-you-mean,
+        atomic-query-error,
+        atomic-sort-dropdown,
+        atomic-facet-manager {
+          padding: 0 15px;
+        }
+
+        atomic-atomic-breadcrumb-manager,
+        atomic-query-summary,
+        atomic-no-results,
+        atomic-query-error,
+        atomic-sort-dropdown {
+          margin-bottom: 10px;
+        }
+
+        atomic-facet-manager {
+          grid-row: 4 / auto;
+          display: flex;
+        }
+
+        .results-container {
+          grid-row: 5 / auto;
+          margin-top: 0;
+        }
+
+        atomic-facet,
+        atomic-numeric-facet,
+        atomic-date-facet,
+        atomic-category-facet {
+          margin: 0 10px 0 0;
+        }
+
+        atomic-search-box {
+          justify-self: center;
+          min-width: 80%;
+          max-width: 80%;
+        }
+      }
+
+      @media only screen and (max-width: 640px) {
+        .side-by-side-container {
+          flex-direction: column;
+          align-items: flex-start;
+        }
       }
 
       :root {

--- a/packages/atomic/src/templates/default.html
+++ b/packages/atomic/src/templates/default.html
@@ -63,7 +63,7 @@
   }
 
   atomic-result-printable-uri {
-    line-height: 20px;
+    line-height: 1.25rem;
   }
 </style>
 <div class="template-container">

--- a/packages/atomic/src/templates/default.html
+++ b/packages/atomic/src/templates/default.html
@@ -17,16 +17,18 @@
   .content-container {
     width: 100%;
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     margin-left: 15px;
     gap: 15px;
   }
 
   .fields-container {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .fields-container > atomic-field-condition {
-    margin-right: 15px;
+    margin: 0 15px 10px 0;
     background: var(--atomic-background-variant);
     padding: 4px 8px;
     font-size: 0.8rem;
@@ -58,6 +60,10 @@
 
   .template-container b {
     font-weight: var(--atomic-font-bold);
+  }
+
+  atomic-result-printable-uri {
+    line-height: 20px;
   }
 </style>
 <div class="template-container">


### PR DESCRIPTION
Very incomplete, but for v0 it should be "good enough" I guess.

I did all of that only in index.html/default.html, but for v1 we will obviously need to revisit how we want to do responsiveness, especially if we want to move components around/reorder them completely when the screen size changes.

It's not like the mockups on figma, because this would have required much more important changes for all facets + facet manager + a way to move re-order components in the page with JS.

![image](https://user-images.githubusercontent.com/1591893/116286308-0e618000-a75d-11eb-8853-cfb4a2ca68b7.png)



https://coveord.atlassian.net/browse/KIT-644