### PR TITLE
feat: add loadSearchActions

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -1,15 +1,19 @@
 import {ApiModel} from '@microsoft/api-extractor-model';
 import {writeFileSync} from 'fs';
 import {
+  ActionLoaderConfiguration,
+  resolveActionLoader,
+} from './src/headless-export-resolvers/action-loader-resolver';
+import {
   ControllerConfiguration,
   resolveController,
-} from './src/controller-resolver';
+} from './src/headless-export-resolvers/controller-resolver';
 
 const apiModel = new ApiModel();
 const apiPackage = apiModel.loadPackage('temp/headless.api.json');
 const entryPoint = apiPackage.entryPoints[0];
 
-const controllers: ControllerConfiguration[] = [
+const controllerConfiguration: ControllerConfiguration[] = [
   {
     initializer: 'buildHistoryManager',
     samplePaths: {
@@ -276,8 +280,19 @@ const controllers: ControllerConfiguration[] = [
   },
 ];
 
-const result = controllers.map((controller) =>
+const actionLoaderConfiguration: ActionLoaderConfiguration[] = [
+  {
+    initializer: 'loadSearchActions',
+  },
+];
+
+const controllers = controllerConfiguration.map((controller) =>
   resolveController(entryPoint, controller)
 );
+const actionLoaders = actionLoaderConfiguration.map((loader) =>
+  resolveActionLoader(entryPoint, loader)
+);
+
+const result = {controllers, actionLoaders};
 
 writeFileSync('dist/parsed_doc.json', JSON.stringify(result, null, 2));

--- a/packages/headless/doc-parser/src/headless-export-resolvers/action-loader-resolver.ts
+++ b/packages/headless/doc-parser/src/headless-export-resolvers/action-loader-resolver.ts
@@ -1,0 +1,19 @@
+import {ApiEntryPoint} from '@microsoft/api-extractor-model';
+import {FuncEntity} from '../entity';
+import {resolveInitializer} from './initializer-resolver';
+
+export interface ActionLoaderConfiguration {
+  initializer: string;
+}
+
+interface ActionLoader {
+  initializer: FuncEntity;
+}
+
+export function resolveActionLoader(
+  entry: ApiEntryPoint,
+  config: ActionLoaderConfiguration
+): ActionLoader {
+  const initializer = resolveInitializer(entry, config.initializer);
+  return {initializer};
+}

--- a/packages/headless/doc-parser/src/headless-export-resolvers/controller-resolver.ts
+++ b/packages/headless/doc-parser/src/headless-export-resolvers/controller-resolver.ts
@@ -1,18 +1,14 @@
-import {
-  ApiEntryPoint,
-  ApiFunction,
-  ApiItem,
-  ApiItemKind,
-} from '@microsoft/api-extractor-model';
-import {findApi} from './api-finder';
-import {FuncEntity, ObjEntity} from './entity';
-import {resolveFunction} from './function-resolver';
+import {ApiEntryPoint, ApiFunction} from '@microsoft/api-extractor-model';
+import {findApi} from '../api-finder';
+import {FuncEntity, ObjEntity} from '../entity';
+import {resolveFunction} from '../function-resolver';
 import {
   resolveCodeSamplePaths,
   SamplePaths,
   CodeSampleInfo,
-} from './code-sample-resolver';
-import {extractControllerTypes} from './controller-type-extractor';
+} from '../code-sample-resolver';
+import {extractControllerTypes} from '../controller-type-extractor';
+import {resolveInitializer} from './initializer-resolver';
 
 export interface ControllerConfiguration {
   initializer: string;
@@ -31,7 +27,7 @@ export function resolveController(
   entry: ApiEntryPoint,
   config: ControllerConfiguration
 ): Controller {
-  const initializer = resolveControllerInitializer(entry, config.initializer);
+  const initializer = resolveInitializer(entry, config.initializer);
   const utils = (config.utils || []).map((util) => resolveUtility(entry, util));
   const extractedTypes = extractControllerTypes(initializer, utils);
   const codeSampleInfo = resolveCodeSamplePaths(config.samplePaths);
@@ -39,23 +35,7 @@ export function resolveController(
   return {initializer, extractedTypes, utils, codeSampleInfo};
 }
 
-function resolveControllerInitializer(entry: ApiEntryPoint, name: string) {
-  const fn = findApi(entry, name);
-
-  if (!isFunction(fn)) {
-    throw new Error(
-      `controller initializer "${name}" must be a function. Instead found: ${fn.kind}`
-    );
-  }
-
-  return resolveFunction(entry, fn, [0]);
-}
-
 function resolveUtility(entry: ApiEntryPoint, name: string) {
   const fn = findApi(entry, name) as ApiFunction;
   return resolveFunction(entry, fn, []);
-}
-
-function isFunction(item: ApiItem): item is ApiFunction {
-  return item.kind === ApiItemKind.Function;
 }

--- a/packages/headless/doc-parser/src/headless-export-resolvers/initializer-resolver.ts
+++ b/packages/headless/doc-parser/src/headless-export-resolvers/initializer-resolver.ts
@@ -1,0 +1,24 @@
+import {
+  ApiEntryPoint,
+  ApiFunction,
+  ApiItem,
+  ApiItemKind,
+} from '@microsoft/api-extractor-model';
+import {findApi} from '../api-finder';
+import {resolveFunction} from '../function-resolver';
+
+export function resolveInitializer(entry: ApiEntryPoint, name: string) {
+  const fn = findApi(entry, name);
+
+  if (!isFunction(fn)) {
+    throw new Error(
+      `initializer "${name}" must be a function. Instead found: ${fn.kind}`
+    );
+  }
+
+  return resolveFunction(entry, fn, [0]);
+}
+
+function isFunction(item: ApiItem): item is ApiFunction {
+  return item.kind === ApiItemKind.Function;
+}

--- a/packages/headless/doc-parser/src/interface-resolver.test.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.test.ts
@@ -330,6 +330,48 @@ describe('#resolveInterfaceMembers', () => {
     expect(result).toEqual([func]);
   });
 
+  it('resolves a method with a type alias return type', () => {
+    const entry = buildMockEntryPoint();
+    const searchActions = buildMockApiInterface({name: 'ISearchActions'});
+
+    const docComment = buildMockApiDocComment(
+      '/**\n * Fetches more results.\n *\n * @returns A dispatchable object.\n */\n'
+    );
+
+    const fetchMoreResults = buildMockApiMethodSignature({
+      name: 'fetchMoreResults',
+      docComment,
+      excerptTokens: [
+        buildContentExcerptToken('fetchMoreResults(): '),
+        buildReferenceExcerptToken(
+          'AsyncThunkAction',
+          '@coveo/headless!AsyncThunkAction:type'
+        ),
+        buildContentExcerptToken(';'),
+      ],
+      returnTypeTokenRange: {startIndex: 1, endIndex: 2},
+    });
+
+    searchActions.addMember(fetchMoreResults);
+    entry.addMember(searchActions);
+
+    const result = resolveInterfaceMembers(entry, searchActions, []);
+
+    const returnType = buildMockEntity({
+      name: 'returnType',
+      type: 'AsyncThunkAction',
+      desc: 'A dispatchable object.',
+    });
+
+    const func = buildMockFuncEntity({
+      desc: 'Fetches more results.',
+      name: 'fetchMoreResults',
+      returnType,
+    });
+
+    expect(result).toEqual([func]);
+  });
+
   it('resolves a call signature with primitive types', () => {
     const entryPoint = buildMockEntryPoint();
     const unsubscribeInterface = buildMockApiInterface({name: 'Unsubscribe'});

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -15,7 +15,7 @@ import {
 } from '@microsoft/api-extractor-model';
 import {DocComment} from '@microsoft/tsdoc';
 import {findApi} from './api-finder';
-import {AnyEntity, EntityWithTypeAlias} from './entity';
+import {AnyEntity, Entity, EntityWithTypeAlias} from './entity';
 import {
   buildEntity,
   buildFuncEntity,
@@ -164,11 +164,7 @@ function buildEntityFromPropertyAndResolveTypeAlias(
   p: ApiPropertySignature
 ): EntityWithTypeAlias {
   const entity = buildEntityFromProperty(p);
-  const searchableTypeName = extractSearchableTypeName(p.propertyTypeExcerpt);
-  const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
-  const type = typeAlias.typeExcerpt.text;
-
-  return {...entity, kind: 'primitive-with-type-alias', type};
+  return tryToResolveTypeAlias(entry, entity, p.propertyTypeExcerpt);
 }
 
 function isIndexSignature(m: ApiItem): m is ApiIndexSignature {
@@ -258,7 +254,7 @@ export function resolveParameter(
   const type = p.parameterTypeExcerpt.text;
 
   if (isTypeAlias(typeExcerpt)) {
-    return buildEntityFromParamAndResolveTypeAlias(entry, p);
+    return buildEntityFromParamWithTypeAlias(entry, p);
   }
 
   if (isUnionType(type)) {
@@ -272,14 +268,28 @@ export function resolveParameter(
   return buildParamEntity(p);
 }
 
-function buildEntityFromParamAndResolveTypeAlias(
+function buildEntityFromParamWithTypeAlias(
   entry: ApiEntryPoint,
   p: Parameter
 ): EntityWithTypeAlias {
   const entity = buildParamEntity(p);
-  const searchableTypeName = extractSearchableTypeName(p.parameterTypeExcerpt);
-  const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
-  const type = typeAlias.typeExcerpt.text;
+  return tryToResolveTypeAlias(entry, entity, p.parameterTypeExcerpt);
+}
+
+function tryToResolveTypeAlias(
+  entry: ApiEntryPoint,
+  entity: Entity,
+  typeExcerpt: Excerpt
+): EntityWithTypeAlias {
+  const searchableTypeName = extractSearchableTypeName(typeExcerpt);
+  let type: string;
+
+  try {
+    const typeAlias = findApi(entry, searchableTypeName) as ApiTypeAlias;
+    type = typeAlias.typeExcerpt.text;
+  } catch {
+    type = typeExcerpt.text;
+  }
 
   return {...entity, kind: 'primitive-with-type-alias', type};
 }

--- a/packages/headless/doc-parser/src/interface-resolver.ts
+++ b/packages/headless/doc-parser/src/interface-resolver.ts
@@ -224,6 +224,10 @@ function resolveMethodReturnType(
     return buildReturnTypeEntity(m);
   }
 
+  if (isTypeAlias(typeExcerpt)) {
+    return buildReturnTypeEntity(m);
+  }
+
   if (isReference(typeExcerpt)) {
     return buildObjEntityFromReturnType(entry, m, ancestorNames);
   }

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -220,6 +220,8 @@ export namespace SearchActions {
   export const fetchMoreResults = fetchMoreResultsAlias;
 }
 
+export * from './search/search-actions-loader';
+
 import {setSearchHub as setSearchHubAlias} from './search-hub/search-hub-actions';
 export namespace SearchHubActions {
   export const setSearchHub = setSearchHubAlias;

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -11,14 +11,22 @@ import {
 } from './search-actions';
 
 /**
- * The search actions that can be created.
+ * The search action creators.
  */
 export interface SearchActionCreators {
   /**
    * Creates an action that executes a search query.
    *
-   * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadAnalyticsSearchActions` for possible values.
+   * @example
    *
+   * ```js
+   * const {logInterfaceLoad} = loadAnalyticsSearchActions(engine);
+   * const {executeSearch} = loadSearchActions(engine);
+   *
+   * engine.dispatch(executeSearch(interfaceLoad()));
+   * ```
+   *
+   * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadAnalyticsSearchActions` for possible values.
    * @returns A dispatchable action.
    */
   executeSearch(
@@ -42,12 +50,12 @@ export interface SearchActionCreators {
 }
 
 /**
- * Loads the `search` reducer and returns possible search actions that can be created.
+ * Loads the `search` reducer and returns possible search action creators.
  *
  * @param engine - The headless engine.
- * @returns An object holding the search actions that can be created.
+ * @returns An object holding the search action creators.
  */
-export function loadSearchActionCreators(
+export function loadSearchActions(
   engine: Engine<object>
 ): SearchActionCreators {
   engine.addReducers({search});

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -10,10 +10,15 @@ import {
   StateNeededByExecuteSearch,
 } from './search-actions';
 
+/**
+ * The search actions.
+ */
 export interface ISearchActions {
   /**
    * Executes a search query.
    * @param analyticsAction - The analytics action to log after a successful query.
+   *
+   * @returns A dispatchable action object.
    */
   executeSearch(
     analyticsAction: SearchAction
@@ -25,6 +30,8 @@ export interface ISearchActions {
 
   /**
    * Fetches more results.
+   *
+   * @returns A dispatchable action object.
    */
   fetchMoreResults(): AsyncThunkAction<
     ExecuteSearchThunkReturn,
@@ -33,6 +40,12 @@ export interface ISearchActions {
   >;
 }
 
+/**
+ * Loads the `search` reducer and returns the possible search actions.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the search actions.
+ */
 export function loadSearchActions(engine: Engine<object>): ISearchActions {
   engine.addReducers({search});
   return {

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -15,7 +15,8 @@ import {
  */
 export interface ISearchActions {
   /**
-   * Executes a search query.
+   * Creates an action that executes a search query.
+   *
    * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadAnalyticsSearchActions` for possible values.
    *
    * @returns A dispatchable action.
@@ -29,7 +30,7 @@ export interface ISearchActions {
   >;
 
   /**
-   * Fetches more results.
+   * Creates an action that fetches more results.
    *
    * @returns A dispatchable action.
    */
@@ -41,7 +42,7 @@ export interface ISearchActions {
 }
 
 /**
- * Loads the `search` reducer and returns the possible search actions.
+ * Loads the `search` reducer and returns possible search actions.
  *
  * @param engine - The headless engine.
  * @returns An object holding the search actions.

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -16,12 +16,12 @@ import {
 export interface ISearchActions {
   /**
    * Executes a search query.
-   * @param analyticsAction - The analytics action to log after a successful query.
+   * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadAnalyticsSearchActions` for possible values.
    *
    * @returns A dispatchable action.
    */
   executeSearch(
-    analyticsAction: SearchAction
+    analyticsSearchAction: SearchAction
   ): AsyncThunkAction<
     ExecuteSearchThunkReturn,
     SearchAction,

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -1,6 +1,6 @@
 import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {AsyncThunkSearchOptions} from '../../api/search/search-api-client';
-import {Engine} from '../../app/engine';
+import {Engine} from '../../app/headless-engine';
 import {search} from '../../app/reducers';
 import {SearchAction} from '../analytics/analytics-utils';
 import {
@@ -11,9 +11,9 @@ import {
 } from './search-actions';
 
 /**
- * The search actions.
+ * The search actions that can be created.
  */
-export interface ISearchActions {
+export interface SearchActionCreators {
   /**
    * Creates an action that executes a search query.
    *
@@ -42,12 +42,14 @@ export interface ISearchActions {
 }
 
 /**
- * Loads the `search` reducer and returns possible search actions.
+ * Loads the `search` reducer and returns possible search actions that can be created.
  *
  * @param engine - The headless engine.
- * @returns An object holding the search actions.
+ * @returns An object holding the search actions that can be created.
  */
-export function loadSearchActions(engine: Engine<object>): ISearchActions {
+export function loadSearchActionCreators(
+  engine: Engine<object>
+): SearchActionCreators {
   engine.addReducers({search});
   return {
     executeSearch,

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -18,7 +18,7 @@ export interface ISearchActions {
    * Executes a search query.
    * @param analyticsAction - The analytics action to log after a successful query.
    *
-   * @returns A dispatchable action object.
+   * @returns A dispatchable action.
    */
   executeSearch(
     analyticsAction: SearchAction
@@ -31,7 +31,7 @@ export interface ISearchActions {
   /**
    * Fetches more results.
    *
-   * @returns A dispatchable action object.
+   * @returns A dispatchable action.
    */
   fetchMoreResults(): AsyncThunkAction<
     ExecuteSearchThunkReturn,

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -1,0 +1,42 @@
+import {AsyncThunkAction} from '@reduxjs/toolkit';
+import {AsyncThunkSearchOptions} from '../../api/search/search-api-client';
+import {Engine} from '../../app/engine';
+import {search} from '../../app/reducers';
+import {SearchAction} from '../analytics/analytics-utils';
+import {
+  executeSearch,
+  ExecuteSearchThunkReturn,
+  fetchMoreResults,
+  StateNeededByExecuteSearch,
+} from './search-actions';
+
+export interface ISearchActions {
+  /**
+   * Executes a search query.
+   * @param analyticsAction - The analytics action to log after a successful query.
+   */
+  executeSearch(
+    analyticsAction: SearchAction
+  ): AsyncThunkAction<
+    ExecuteSearchThunkReturn,
+    SearchAction,
+    AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+  >;
+
+  /**
+   * Fetches more results.
+   */
+  fetchMoreResults(): AsyncThunkAction<
+    ExecuteSearchThunkReturn,
+    void,
+    AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+  >;
+}
+
+export function loadSearchActions(engine: Engine<object>): ISearchActions {
+  engine.addReducers({search});
+  return {
+    executeSearch,
+    fetchMoreResults,
+  };
+}


### PR DESCRIPTION
This PR is a PoC show-casing a way to retrieve actions in headless v1.

Rather than exporting namespaces, headless would provide a series of `load<featureName>Actions` functions that take one parameter: the engine. The function would attach the necessary reducers, and return an object containing the actions relevant to the feature.


Usage:

```
const {interfaceLoad} = loadAnalyticsSearchActions(engine);
const {executeSearch} = loadSearchActions(engine);

engine.dispatch(executeSearch(interfaceLoad()));
```


The PoC also documents the `load` function. Since it is similar to a controller function, it was possible to reuse the existing code with only minor tweaks.

<details>
<summary>JSON output  for <code>loadSearchActions</code></summary>

```json
"actionLoaders": [
    {
      "initializer": {
        "kind": "function",
        "name": "loadSearchActions",
        "params": [
          {
            "kind": "primitive",
            "name": "engine",
            "isOptional": false,
            "desc": "The headless engine.",
            "type": "Engine<object>"
          }
        ],
        "returnType": {
          "kind": "object",
          "name": "ISearchActions",
          "isOptional": false,
          "type": "ISearchActions",
          "desc": "The search actions.",
          "members": [
            {
              "kind": "function",
              "name": "executeSearch",
              "params": [
                {
                  "kind": "primitive-with-type-alias",
                  "name": "analyticsAction",
                  "isOptional": false,
                  "desc": "The analytics action to log after a successful query.",
                  "type": "SearchAction"
                }
              ],
              "returnType": {
                "kind": "primitive",
                "name": "returnType",
                "type": "AsyncThunkAction<ExecuteSearchThunkReturn, SearchAction, AsyncThunkSearchOptions<StateNeededByExecuteSearch>>",
                "isOptional": false,
                "desc": "A dispatchable action object."
              },
              "desc": "Executes a search query."
            },
            {
              "kind": "function",
              "name": "fetchMoreResults",
              "params": [],
              "returnType": {
                "kind": "primitive",
                "name": "returnType",
                "type": "AsyncThunkAction<ExecuteSearchThunkReturn, void, AsyncThunkSearchOptions<StateNeededByExecuteSearch>>",
                "isOptional": false,
                "desc": "A dispatchable action object."
              },
              "desc": "Fetches more results."
            }
          ],
          "isTypeExtracted": false,
          "typeName": "ISearchActions"
        },
        "desc": "Loads necessary reducers and returns the search actions."
      }
    }
  ]
```
</details>


I grouped controllers and actionLoaders together, so this would require a small change to the doc-gen code. Open to other structures too.

