### PR TITLE
fix(headless): fix create engine logger before validation

### DIFF
--- a/packages/headless/src/app/headless-engine.test.ts
+++ b/packages/headless/src/app/headless-engine.test.ts
@@ -22,7 +22,9 @@ describe('headless engine', () => {
 
   it('should thrown an error if the engine is constructed with invalid options', () => {
     options.configuration.organizationId = (123 as unknown) as string;
-    expect(() => new HeadlessEngine(options)).toThrow();
+    expect(() => new HeadlessEngine(options)).toThrow(
+      /The following properties are invalid/
+    );
   });
 
   it(`when there is a search param in the configuration

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -99,9 +99,8 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
   private engine: Engine<StateFromReducersMapObject<Reducers>>;
 
   constructor(private options: HeadlessOptions<Reducers>) {
-    this.validateConfiguration(options);
-
     this.logger = buildLogger(options.loggerOptions);
+    this.validateConfiguration(options);
     const searchAPIClient = this.createSearchAPIClient();
     this.engine = buildEngine(options, {searchAPIClient}, this.logger);
 


### PR DESCRIPTION
`this.logger` is called inside `this.validateConfiguration` when there's an error in the config.

Net result before fix: Engine creation fails (that's ok, it's invalid) but you can't see a nice log message that explains why.

https://coveord.atlassian.net/browse/KIT-646