### PR TITLE
fix(controller): do not use spread for base controller

### DIFF
--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -286,7 +286,7 @@ export function buildBreadcrumbManager(
   }
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       return {

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -71,7 +71,7 @@ export function buildContext(engine: Engine<object>): Context {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       return {

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -78,7 +78,7 @@ export function buildDidYouMean(engine: Engine<object>): DidYouMean {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
+++ b/packages/headless/src/controllers/facet-manager/headless-facet-manager.ts
@@ -59,7 +59,7 @@ export function buildFacetManager(engine: Engine<object>): FacetManager {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     sort<T>(facets: FacetManagerPayload<T>[]) {
       return sortFacets(facets, this.state.facetIds);

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -265,7 +265,7 @@ export function buildCategoryFacet(
   const {state, ...restOfFacetSearch} = facetSearch;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
     facetSearch: restOfFacetSearch,
 
     toggleSelect: (selection: CategoryFacetValue) =>

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -286,7 +286,7 @@ export function buildFacet(engine: Engine<object>, props: FacetProps): Facet {
   const {state, ...restOfFacetSearch} = facetSearch;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     facetSearch: restOfFacetSearch,
 

--- a/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/headless-range-facet.ts
@@ -42,7 +42,7 @@ export function buildRangeFacet<
   const dispatch = engine.dispatch;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     toggleSelect: (selection: RangeFacetValue) =>
       dispatch(executeToggleRangeFacetSelect({facetId, selection})),

--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -54,7 +54,7 @@ export function buildHistoryManager(engine: Engine<object>): HistoryManager {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
     get state() {
       return getState().history;
     },

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -180,7 +180,7 @@ export function buildPager(
   };
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const currentPage = getCurrentPage();

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
@@ -103,7 +103,7 @@ export const buildBaseProductRecommendationsList = (
     );
   }
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     setSkus(skus: string[]) {
       dispatch(setProductRecommendationsSkus({skus: skus}));

--- a/packages/headless/src/controllers/query-error/headless-query-error.ts
+++ b/packages/headless/src/controllers/query-error/headless-query-error.ts
@@ -44,7 +44,7 @@ export function buildQueryError(engine: Engine<object>): QueryError {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       return {

--- a/packages/headless/src/controllers/query-summary/headless-query-summary.ts
+++ b/packages/headless/src/controllers/query-summary/headless-query-summary.ts
@@ -80,7 +80,7 @@ export function buildQuerySummary(engine: Engine<object>): QuerySummary {
   };
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/quickview/headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/headless-quickview.ts
@@ -77,7 +77,7 @@ export function buildQuickview(
   const uniqueId = result.uniqueId;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     fetchResultContent() {
       dispatch(fetchResultContent({uniqueId}));

--- a/packages/headless/src/controllers/recommendation/headless-recommendation.ts
+++ b/packages/headless/src/controllers/recommendation/headless-recommendation.ts
@@ -99,7 +99,7 @@ export function buildRecommendationList(
   }
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     refresh() {
       dispatch(getRecommendations());

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
@@ -211,8 +211,6 @@ export function buildRelevanceInspector(
   }
 
   return {
-    ...controller,
-
     get state() {
       const state = getState();
       const isEnabled = state.debug;
@@ -285,7 +283,7 @@ export function buildRelevanceInspector(
       const getState = () => this.state;
 
       const unsubscribeStateListener = {
-        ...controller,
+        subscribe: controller.subscribe,
         get state() {
           return getState();
         },

--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -151,7 +151,7 @@ export function buildResultList(
   };
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
@@ -100,7 +100,7 @@ export function buildResultsPerPage(
   }
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       return {

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -179,7 +179,7 @@ export function buildSearchBox(
   };
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     updateText(value: string) {
       dispatch(updateQuerySetQuery({id, query: value}));

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -82,7 +82,7 @@ export function buildSearchParameterManager(
   dispatch(restoreSearchParameters(props.initialState.parameters));
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/search-status/headless-search-status.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.ts
@@ -51,7 +51,7 @@ export function buildSearchStatus(engine: Engine<object>): SearchStatus {
   const getState = () => engine.state;
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/sort/headless-sort.ts
+++ b/packages/headless/src/controllers/sort/headless-sort.ts
@@ -115,7 +115,7 @@ export function buildSort(engine: Engine<object>, props: SortProps = {}): Sort {
   }
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     sortBy(criterion: SortCriterion | SortCriterion[]) {
       dispatch(updateSortCriterion(criterion));

--- a/packages/headless/src/controllers/tab/headless-tab.ts
+++ b/packages/headless/src/controllers/tab/headless-tab.ts
@@ -116,7 +116,7 @@ export function buildTab(engine: Engine<object>, props: TabProps): Tab {
   }
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     select() {
       dispatch(updateAdvancedSearchQueries({cq: options.expression}));

--- a/packages/headless/src/controllers/url-manager/headless-url-manager.ts
+++ b/packages/headless/src/controllers/url-manager/headless-url-manager.ts
@@ -87,7 +87,7 @@ export function buildUrlManager(
   });
 
   return {
-    ...controller,
+    subscribe: controller.subscribe,
 
     get state() {
       return {


### PR DESCRIPTION
This fixes an issue where, sometimes, with specific code optimization, the "spread" operator gets replaced by a method that copies the properties without its getter.
This effectively makes `state` completely stateless and only return its first value instead of returning the new state

We found this issue when hackathoning, and I can confirm just this change fixed our build! (when npm link-ing this version)

I checked every file in there, and all of them already defines `get state()`, so only `subscribe` was needed :shrug: 

See the JIRA for much more details :)

[KIT-657]

https://coveord.atlassian.net/browse/KIT-657

[KIT-657]: https://coveord.atlassian.net/browse/KIT-657