### PR TITLE
fix(headless): make ec_thumbnails array

### DIFF
--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -48,7 +48,7 @@ export interface ProductRecommendation {
    *
    * From the `ec_thumbnails` field.
    */
-  ec_thumbnails?: string;
+  ec_thumbnails?: string[];
   /**
    * Additional product images in URL format.
    *

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -137,7 +137,7 @@ const mapResultToProductResult = (
     ec_category: result.raw.ec_category as string,
     ec_price,
     ec_shortdesc: result.raw.ec_shortdesc as string,
-    ec_thumbnails: result.raw.ec_thumbnails as string,
+    ec_thumbnails: result.raw.ec_thumbnails as string[],
     ec_images: result.raw.ec_images as string[],
     ec_promo_price:
       ec_promo_price === undefined ||


### PR DESCRIPTION
According to the data standard, `ec_thumbnails` should be an array and not a string.

[COM-1014]

[COM-1014]: https://coveord.atlassian.net/browse/COM-1014