### PR TITLE
chore: add loadFacetOptions function

### DIFF
--- a/packages/headless/src/features/facet-options/facet-options-actions-loader.ts
+++ b/packages/headless/src/features/facet-options/facet-options-actions-loader.ts
@@ -1,0 +1,40 @@
+import {PayloadAction} from '@reduxjs/toolkit';
+import {Engine} from '../../app/headless-engine';
+import {facetOptions} from '../../app/reducers';
+import {
+  updateFacetOptions,
+  UpdateFacetOptionsActionCreatorPayload,
+} from './facet-options-actions';
+
+export {UpdateFacetOptionsActionCreatorPayload};
+
+/**
+ * The facetOptions action creators.
+ */
+export interface FacetOptionsActionCreators {
+  /**
+   * Updates options that affect facet reordering. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#definitions-RestFacetOptions).
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  updateFacetOptions(
+    payload: UpdateFacetOptionsActionCreatorPayload
+  ): PayloadAction<UpdateFacetOptionsActionCreatorPayload>;
+}
+
+/**
+ * Loads the `facetOptions` reducer and returns possible action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadFacetOptionsActions(
+  engine: Engine<object>
+): FacetOptionsActionCreators {
+  engine.addReducers({facetOptions});
+
+  return {
+    updateFacetOptions,
+  };
+}

--- a/packages/headless/src/features/facet-options/facet-options-actions.ts
+++ b/packages/headless/src/features/facet-options/facet-options-actions.ts
@@ -2,13 +2,20 @@ import {createAction} from '@reduxjs/toolkit';
 import {validatePayload} from '../../utils/validate-payload';
 import {BooleanValue} from '@coveo/bueno';
 
+export interface UpdateFacetOptionsActionCreatorPayload {
+  /**
+   * Whether facets should be returned in the same order they were requested.
+   */
+  freezeFacetOrder?: boolean;
+}
+
 /**
  * Updates options that affect facet reordering. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#definitions-RestFacetOptions).
  * @param {Partial<FacetOptions>} facetOptions The options to update.
  */
 export const updateFacetOptions = createAction(
   'facetOptions/update',
-  (payload: {freezeFacetOrder?: boolean}) =>
+  (payload: UpdateFacetOptionsActionCreatorPayload) =>
     validatePayload(payload, {
       freezeFacetOrder: new BooleanValue({required: false}),
     })


### PR DESCRIPTION
Keeping `loadFacetOptions` internal, since the action was never exposed. I will refactor to use the load functions inside the controllers in a future PR. 

https://coveord.atlassian.net/browse/KIT-661