### PR TITLE
fix(atomic): prevent result template  text elements from overflowing

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -22,10 +22,6 @@ atomic-result-printable-uri li:last-child::after {
   content: none;
 }
 
-atomic-result-printable-uri atomic-result-text {
-  overflow-wrap: anywhere;
-}
-
 .result-printable-uri-separator {
   display: inline-block;
   margin: 0 0.5rem;

--- a/packages/atomic/src/templates/default.html
+++ b/packages/atomic/src/templates/default.html
@@ -65,6 +65,13 @@
   atomic-result-printable-uri {
     line-height: 1.25rem;
   }
+
+  atomic-result-link,
+  atomic-result-printable-uri,
+  atomic-result-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 </style>
 <div class="template-container">
   <div>


### PR DESCRIPTION

![Screen Shot 2021-05-05 at 5 10 10 PM](https://user-images.githubusercontent.com/4923043/117210016-26707980-adc5-11eb-8def-bcf5f31cdd9d.png)
https://coveord.atlassian.net/browse/KIT-649