### PR TITLE
doc(quantic): explain how to push in readme

### DIFF
--- a/packages/quantic/README.md
+++ b/packages/quantic/README.md
@@ -50,9 +50,15 @@ Start the server.
 - You can also run this command from the command line. `sfdx force:lightning:lwc:start`
 - View the server at http://localhost:3333/.
 
+## Use Quantic From Source
+
+After you have cloned the repository and have run `npm install`, run the following commands:
+
+- `npm run copy:staticresources`
+- `sfdx force:source:deploy -m LightningComponentBundle`
+
 ## Other useful commands
 
-- Deploy source code to your salesforce organization: `sfdx force:source:deploy -m LightningComponentBundle`.
 - `-m LightningComponentBundle` can be changed for different types of "resources". To know which name, check the related `meta.xml` file for each type of resource.
 - Create new web components. In VS Code, press Command + Shift P, enter sfdx, and select SFDX: Create Lightning Web Component.
 


### PR DESCRIPTION
@tedre191 I noticed just a few lines below that there was already a command to supposedly export to a SF org, but it did not mention the copy:staticresources, so it was likely wrong. So I removed it and created a new section as we had discussed.

Also, I thought I could reuse some paragraphs I had written elsewhere (https://github.com/coveo/ui-kit/compare/DOC-8874) about what is Quantic and when to use it, but I realized that it really depends on it being available as an unmanaged package, so I can't really use it here, and I think it's best that I just wait until it is indeed available as an unmanaged package.

Let me know if that all makes sense, and thank you :D