### PR TITLE
chore: configure dependabot commit-message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "https://coveord.atlassian.net/browse/KIT-282"
 


### PR DESCRIPTION
The intent behind this change is to be able to merge dependabot PRs directly, without needing to adjust the commit message [Ref](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#commit-message).

https://coveord.atlassian.net/browse/KIT-675