### PR TITLE
chore: shorten dependabot prefix to below 15 character limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "https://coveord.atlassian.net/browse/KIT-282"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: "https://coveord.atlassian.net/browse/KIT-282"
+      prefix: "KIT-282\n"
 


### PR DESCRIPTION
Reverting my change because there is a 15 character limit on the prefix:
https://github.com/coveo/ui-kit/runs/2555975457