### PR TITLE
fix(headless): use cq as originLevel2 if defined

### DIFF
--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -18,6 +18,7 @@ import {
   RecommendationSection,
   SearchHubSection,
   SearchSection,
+  AdvancedSearchQueriesSection,
 } from '../../state/state-sections';
 import {ContextPayload} from '../../features/context/context-state';
 import {PreprocessRequest} from '../preprocess-request';
@@ -36,7 +37,8 @@ export type StateNeededByAnalyticsProvider = ConfigurationSection &
       QuerySection &
       ContextSection &
       RecommendationSection &
-      SectionNeededForFacetMetadata
+      SectionNeededForFacetMetadata &
+      AdvancedSearchQueriesSection
   >;
 
 export class AnalyticsProvider implements SearchPageClientProvider {
@@ -84,12 +86,8 @@ export class AnalyticsProvider implements SearchPageClientProvider {
   }
 
   public getOriginLevel2() {
-    // TODO: When tab implemented;
-    // Configurable on headless engine, optionally
-    // Need to use tabs as originLevel2, in priority if they exists/available.
-    // Otherwise, use configured originLevel2 on the engine.
-    // Ultimate fallback should be `default`;
-    return this.state.configuration.analytics.originLevel2 || 'default';
+    const {advancedSearchQueries, configuration} = this.state;
+    return advancedSearchQueries?.cq || configuration.analytics.originLevel2;
   }
 
   public getOriginLevel3() {

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -32,39 +32,41 @@ export interface ConfigurationState {
   /**
    * The global headless engine Usage Analytics API configuration.
    */
-  analytics: {
-    /**
-     * Specifies if analytics tracking should be enabled. By default analytics events are tracked.
-     */
-    enabled: boolean;
-    /**
-     * The Analytics API base URL to use.
-     * By default, will append /rest/ua to the platformUrl value.
-     */
-    apiBaseUrl: string;
-    /**
-     * Origin level 2 is a usage analytics event metadata whose value should typically be the name/identifier of the tab from which the usage analytics event originates.
-     *
-     * When logging a Search usage analytics event, originLevel2 should always be set to the same value as the corresponding tab (parameter) Search API query parameter so Coveo Machine Learning models function properly, and usage analytics reports and dashboards are coherent.
-     *
-     * This value is optional, and will automatically try to resolve itself from the tab search parameter.
-     */
-    originLevel2: string;
+  analytics: AnalyticsConfiguration;
+}
 
-    /**
-     * Origin level 3 is a usage analytics event metadata whose value should typically be the URL of the page that linked to the search interface that’s making the request.
-     *
-     * When logging a Search usage analytics event, originLevel3 should always be set to the same value as the corresponding referrer Search API query parameter so usage analytics reports and dashboards are coherent.
-     *
-     * This value is optional, and will automatically try to resolve itself from the referrer search parameter.
-     */
-    originLevel3: string;
-    /**
-     * Optional analytics runtime environment, this is needed for analytics to work correctly if you're running outside of a browser.
-     * See https://github.com/coveo/coveo.analytics.js for more info
-     */
-    runtimeEnvironment?: IRuntimeEnvironment;
-  };
+export interface AnalyticsConfiguration {
+  /**
+   * Specifies if analytics tracking should be enabled. By default analytics events are tracked.
+   */
+  enabled: boolean;
+  /**
+   * The Analytics API base URL to use.
+   * By default, will append /rest/ua to the platformUrl value.
+   */
+  apiBaseUrl: string;
+  /**
+   * Origin level 2 is a usage analytics event metadata whose value should typically be the name/identifier of the tab from which the usage analytics event originates.
+   *
+   * When logging a Search usage analytics event, originLevel2 should always be set to the same value as the corresponding tab (parameter) Search API query parameter so Coveo Machine Learning models function properly, and usage analytics reports and dashboards are coherent.
+   *
+   * This value is optional, and will automatically try to resolve itself from the tab search parameter.
+   */
+  originLevel2: string;
+
+  /**
+   * Origin level 3 is a usage analytics event metadata whose value should typically be the URL of the page that linked to the search interface that’s making the request.
+   *
+   * When logging a Search usage analytics event, originLevel3 should always be set to the same value as the corresponding referrer Search API query parameter so usage analytics reports and dashboards are coherent.
+   *
+   * This value is optional, and will automatically try to resolve itself from the referrer search parameter.
+   */
+  originLevel3: string;
+  /**
+   * Optional analytics runtime environment, this is needed for analytics to work correctly if you're running outside of a browser.
+   * See https://github.com/coveo/coveo.analytics.js for more info
+   */
+  runtimeEnvironment?: IRuntimeEnvironment;
 }
 
 export const searchAPIEndpoint = '/rest/search/v2';

--- a/packages/headless/src/test/mock-analytics-configuration.ts
+++ b/packages/headless/src/test/mock-analytics-configuration.ts
@@ -1,0 +1,13 @@
+import {AnalyticsConfiguration} from '../features/configuration/configuration-state';
+
+export function buildMockAnalyticsConfiguration(
+  config: Partial<AnalyticsConfiguration> = {}
+): AnalyticsConfiguration {
+  return {
+    apiBaseUrl: '',
+    enabled: false,
+    originLevel2: '',
+    originLevel3: '',
+    ...config,
+  };
+}


### PR DESCRIPTION
The headless tab controller does not expose an `id` prop. The tab expression is used as the identifier to determine which tab is active. This differs from the JSUI, which allows configuring a tab id, and sends the value as the `originLevel2`. If no tab id is configured, `default` is sent, regardless of the actual tab expression.

Rather than introduce a required prop, or an optional prop with a randomly generated value, I chose to send the tab expression as the originLevel2. If the tab expression is empty, as with the "All Content" tab, then the default originLevel2 value is sent, which is `default`.

https://coveord.atlassian.net/browse/KIT-407