### PR TITLE
ci(headless,atomic): fixed build version in prod

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -1,6 +1,7 @@
 {
   "product": "ui-kit",
   "team_name": "searchui",
+  "development_workflow": "gitflow",
   "general": {
     "aws_regions": {
       "sequential": ["us-east-1"]
@@ -9,9 +10,12 @@
       "sequential": ["dev", "qa", "prd"]
     },
     "team_jenkins": "searchuibuilds",
-    "start_environment_automatically": false,
+    "start_environment_automatically": true,
     "notifications": {
       "slack_channels": ["#searchuibuilds"]
+    },
+    "prd": {
+      "start_environment_automatically": false
     }
   },
   "ordered_phases": [
@@ -23,6 +27,9 @@
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
+        },
+        "qa": {
+          "directory": "proda/StaticCDN/headless/beta"
         }
       }
     },
@@ -34,6 +41,9 @@
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
+        },
+        "qa": {
+          "directory": "proda/StaticCDN/atomic/beta"
         }
       }
     },
@@ -41,13 +51,13 @@
       "id": "deploy-headless-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/headless/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/headless/v$[VERSION]",
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
         },
-        "prd": {
-          "directory": "proda/StaticCDN/headless/v$[VERSION]"
+        "qa": {
+          "disabled": true
         }
       }
     },
@@ -55,13 +65,23 @@
       "id": "deploy-atomic-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/atomic/v$[VERSION]",
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
         },
-        "prd": {
-          "directory": "proda/StaticCDN/atomic/v$[VERSION]"
+        "qa": {
+          "disabled": true
+        }
+      }
+    },
+    {
+      "id": "wait-for-dev-deployment-request",
+      "manual": {
+        "disabled": true,
+        "message": "Deploy v${VERSION} → v${RELEASE_VERSION}?",
+        "dev": {
+          "disabled": false
         }
       }
     },
@@ -70,7 +90,7 @@
       "team_jenkins": {
         "disabled": true,
         "job_name": "ui-kit-qa-release",
-        "qa": {
+        "dev": {
           "disabled": false
         }
       }

--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -27,9 +27,6 @@
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
-        },
-        "qa": {
-          "directory": "proda/StaticCDN/headless/beta"
         }
       }
     },
@@ -41,9 +38,6 @@
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
-        },
-        "qa": {
-          "directory": "proda/StaticCDN/atomic/beta"
         }
       }
     },
@@ -55,9 +49,6 @@
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
-        },
-        "qa": {
-          "disabled": true
         }
       }
     },
@@ -69,9 +60,6 @@
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
-        },
-        "qa": {
-          "disabled": true
         }
       }
     },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ node('linux && docker') {
           deployment-package package create
             --with-deploy
             --package-name ui-kit/v${version}
-            --target-environment ${isRelease ? 'prd' : 'dev'}
+            --target-environment ${isRelease ? 'qa' : 'dev'}
             --resolve COMMIT_HASH=${commitHash}
             --resolve VERSION=${version}
             --resolve RELEASE_VERSION=${releaseVersion}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-551

The build version in prod was wrong because the version uploaded to prod was not the newly bumped version.

To fix the issue, I changed the workflow in the deployment pipeline to "gitflow", which allows the "qa" and "prd" environments to run only on release (non-alpha) bump commits.

# Steps by environment before VS after

## Before

|#|dev (on alpha bump)        |qa (on dev approval)        |prd (on QA approval)          |
|-|---------------------------|----------------------------|------------------------------|
|1|Run tests                  |Upload alpha builds in qa S3|Upload alpha builds to prod S3|
|2|Publish alpha builds to NPM|Create release bump commit  |Publish release builds to NPM |
|3|Upload dev builds to S3    |Publish beta builds to NPM  |Notify doc repo of change     |
|4|[Wait for dev approval]    |[Wait for QA approval]      |                              |
|5|Start qa environment       |Start prd environment       |                              |

## After

|#|dev (on alpha bump)          |qa (on release bump)          |prd (on QA approval)            |
|-|-----------------------------|------------------------------|--------------------------------|
|1|Run tests                    |Run tests                     |Upload release builds to prod S3|
|2|Publish alpha builds to NPM  |Upload release builds to qa S3|Publish release builds to NPM   |
|3|Upload alpha builds to dev S3|[Wait for QA approval]        |Notify doc repo of change       |
|4|[Wait for manual approval]   |Start prd environment         |                                |
|5|Create release bump commit   |                              |                                |
|6|Publish beta builds to NPM   |                              |                                |