### PR TITLE
fix(headless): prevent facet search race conditions

### DIFF
--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
@@ -31,14 +31,18 @@ export const categoryFacetSearchSetReducer = createReducer(
       })
       .addCase(executeFacetSearch.pending, (state, action) => {
         const facetId = action.meta.arg;
-        handleFacetSearchPending(state, facetId);
+        handleFacetSearchPending(state, facetId, action.meta.requestId);
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {
         const facetId = action.meta.arg;
         handleFacetSearchRejected(state, facetId);
       })
       .addCase(executeFacetSearch.fulfilled, (state, action) => {
-        handleFacetSearchFulfilled(state, action.payload);
+        handleFacetSearchFulfilled(
+          state,
+          action.payload,
+          action.meta.requestId
+        );
       })
       .addCase(clearFacetSearch, (state, {payload: {facetId}}) => {
         handleFacetSearchClear(state, {facetId}, buildEmptyResponse);

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
@@ -155,10 +155,10 @@ describe('FacetSearch slice', () => {
       expect(state[facetId].response).toEqual(buildEmptyResponse());
     });
 
-    it('when the id is registered, it updates the requestId to an undefined value', () => {
+    it('when the id is registered, it updates the requestId to an empty string', () => {
       state[facetId] = buildMockFacetSearch();
       handleFacetSearchClear(state, {facetId}, buildEmptyResponse);
-      expect(state[facetId].requestId).toBeUndefined();
+      expect(state[facetId].requestId).toBe('');
     });
 
     it('when the id is registered, it sets isLoading state to false', () => {

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.test.ts
@@ -80,16 +80,24 @@ describe('FacetSearch slice', () => {
   });
 
   describe('#handleFacetSearchPending', () => {
+    const requestId = 'unique_id';
     it('when the id is unregistered, it does nothing', () => {
-      handleFacetSearchPending(state, facetId);
+      handleFacetSearchPending(state, facetId, requestId);
       expect(state[facetId]).toBe(undefined);
     });
 
     it('when the id is registered, it sets the isLoading state to true', () => {
       state[facetId] = buildMockFacetSearch();
 
-      handleFacetSearchPending(state, facetId);
+      handleFacetSearchPending(state, facetId, requestId);
       expect(state[facetId].isLoading).toBe(true);
+    });
+
+    it('sets the requestId in the state', () => {
+      state[facetId] = buildMockFacetSearch();
+
+      handleFacetSearchPending(state, facetId, requestId);
+      expect(state[facetId].requestId).toBe(requestId);
     });
   });
 
@@ -107,27 +115,35 @@ describe('FacetSearch slice', () => {
   });
 
   describe('#handleFacetSearchFulfilled', () => {
-    it('when the id is registered, it updates the facetSearch response', () => {
-      state[facetId] = buildMockFacetSearch();
+    const requestId = 'unique_id';
+
+    it('when the id is registered & the requestId matches, it updates the facetSearch response', () => {
+      state[facetId] = buildMockFacetSearch({requestId});
 
       const values = [buildMockFacetSearchResult()];
       const response = buildMockFacetSearchResponse({values});
 
-      handleFacetSearchFulfilled(state, {facetId, response});
+      handleFacetSearchFulfilled(state, {facetId, response}, requestId);
       expect(state[facetId].response).toEqual(response);
     });
 
-    it('when the id is registered, it sets isLoading state to false', () => {
-      state[facetId] = buildMockFacetSearch({isLoading: true});
+    it('when the id is registered & the requestId matches, it sets isLoading state to false', () => {
+      state[facetId] = buildMockFacetSearch({isLoading: true, requestId});
       const response = buildMockFacetSearchResponse();
 
-      handleFacetSearchFulfilled(state, {facetId, response});
+      handleFacetSearchFulfilled(state, {facetId, response}, requestId);
       expect(state[facetId].isLoading).toBe(false);
     });
 
     it('when the id is unregistered, it does nothing', () => {
       const response = buildMockFacetSearchResponse();
-      handleFacetSearchFulfilled(state, {facetId, response});
+      handleFacetSearchFulfilled(state, {facetId, response}, requestId);
+      expect(state[facetId]).toBe(undefined);
+    });
+
+    it('when the requestId does not match, it does nothing', () => {
+      const response = buildMockFacetSearchResponse();
+      handleFacetSearchFulfilled(state, {facetId, response}, requestId);
       expect(state[facetId]).toBe(undefined);
     });
   });
@@ -137,6 +153,12 @@ describe('FacetSearch slice', () => {
       state[facetId] = buildMockFacetSearch();
       handleFacetSearchClear(state, {facetId}, buildEmptyResponse);
       expect(state[facetId].response).toEqual(buildEmptyResponse());
+    });
+
+    it('when the id is registered, it updates the requestId to an undefined value', () => {
+      state[facetId] = buildMockFacetSearch();
+      handleFacetSearchClear(state, {facetId}, buildEmptyResponse);
+      expect(state[facetId].requestId).toBeUndefined();
     });
 
     it('when the id is registered, it sets isLoading state to false', () => {

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
@@ -21,7 +21,7 @@ export type FacetSearchState<T extends FacetSearchResponse> = {
   /**
    * The unique identifier of the current request.
    */
-  requestId?: string;
+  requestId: string;
 };
 
 export type FacetSearchSetState<T extends FacetSearchResponse> = Record<
@@ -49,6 +49,7 @@ export function handleFacetSearchRegistration<T extends FacetSearchResponse>(
     isLoading,
     response,
     initialNumberOfValues: options.numberOfValues,
+    requestId: '',
   };
 }
 
@@ -126,7 +127,7 @@ export function handleFacetSearchClear<T extends FacetSearchResponse>(
     return;
   }
 
-  search.requestId = undefined;
+  search.requestId = '';
   search.isLoading = false;
   search.response = buildEmptyResponse();
   search.options.numberOfValues = search.initialNumberOfValues;

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
@@ -18,6 +18,10 @@ export type FacetSearchState<T extends FacetSearchResponse> = {
   /** The initial maximum number of values to fetch.
    */
   initialNumberOfValues: number;
+  /**
+   * The unique identifier of the current request.
+   */
+  requestId?: string;
 };
 
 export type FacetSearchSetState<T extends FacetSearchResponse> = Record<
@@ -64,7 +68,8 @@ export function handleFacetSearchUpdate<T extends FacetSearchResponse>(
 
 export function handleFacetSearchPending<T extends FacetSearchResponse>(
   state: FacetSearchSetState<T>,
-  facetId: string
+  facetId: string,
+  requestId: string
 ) {
   const search = state[facetId];
 
@@ -72,6 +77,7 @@ export function handleFacetSearchPending<T extends FacetSearchResponse>(
     return;
   }
 
+  search.requestId = requestId;
   search.isLoading = true;
 }
 
@@ -90,7 +96,8 @@ export function handleFacetSearchRejected<T extends FacetSearchResponse>(
 
 export function handleFacetSearchFulfilled<T extends FacetSearchResponse>(
   state: FacetSearchSetState<T>,
-  payload: {facetId: string; response: T}
+  payload: {facetId: string; response: T},
+  requestId: string
 ) {
   const {facetId, response} = payload;
   const search = state[facetId];
@@ -98,6 +105,11 @@ export function handleFacetSearchFulfilled<T extends FacetSearchResponse>(
   if (!search) {
     return;
   }
+
+  if (search.requestId !== requestId) {
+    return;
+  }
+
   search.isLoading = false;
   search.response = response;
 }
@@ -114,6 +126,7 @@ export function handleFacetSearchClear<T extends FacetSearchResponse>(
     return;
   }
 
+  search.requestId = undefined;
   search.isLoading = false;
   search.response = buildEmptyResponse();
   search.options.numberOfValues = search.initialNumberOfValues;

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
@@ -31,14 +31,18 @@ export const specificFacetSearchSetReducer = createReducer(
       })
       .addCase(executeFacetSearch.pending, (state, action) => {
         const facetId = action.meta.arg;
-        handleFacetSearchPending(state, facetId);
+        handleFacetSearchPending(state, facetId, action.meta.requestId);
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {
         const facetId = action.meta.arg;
         handleFacetSearchRejected(state, facetId);
       })
       .addCase(executeFacetSearch.fulfilled, (state, action) => {
-        handleFacetSearchFulfilled(state, action.payload);
+        handleFacetSearchFulfilled(
+          state,
+          action.payload,
+          action.meta.requestId
+        );
       })
       .addCase(clearFacetSearch, (state, {payload}) => {
         handleFacetSearchClear(state, payload, buildEmptyResponse);

--- a/packages/headless/src/test/mock-category-facet-search.ts
+++ b/packages/headless/src/test/mock-category-facet-search.ts
@@ -10,6 +10,7 @@ export function buildMockCategoryFacetSearch(
     isLoading: false,
     response: buildMockCategoryFacetSearchResponse(),
     initialNumberOfValues: buildMockFacetSearchRequestOptions().numberOfValues,
+    requestId: '',
     ...config,
   };
 }

--- a/packages/headless/src/test/mock-facet-search.ts
+++ b/packages/headless/src/test/mock-facet-search.ts
@@ -10,6 +10,7 @@ export function buildMockFacetSearch(
     isLoading: false,
     response: buildMockFacetSearchResponse(),
     initialNumberOfValues: 0,
+    requestId: '',
     ...config,
   };
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-655

We have potential race condition problems for all Search API requests except the /search endpoint, which is the only one with an abort mechanism.

I’m focusing here on an issue with the /facetSearch & /querySuggest endpoints. Both are used in set slices and usually called often (on keypress). This means that technically multiple requests could be happening simultaneously and resolving different results for different slices, that’s good. The problems are:
- Both those slices also have “clear” actions, which empty the results. If a request fulfills after the clear has been dispatched, it will fill up the results again.
- If the API happens to be slower on a first request but not a second, we could see the wrong results appear.

The solution is to leverage the meta identifier “requestId” & only fill the results if the “fullfiled” action has the same “requestId” as the latest “pending” action.

Using an abort controller is not a viable solution for this issue, since we are not calling fetch and overriding a previous query when we are clearing results & we could abort a request from another set.

If this is good, I will add the requestId for query suggest too 😄 