### PR TITLE
feat(headless): added folding show more

### DIFF
--- a/packages/headless/src/api/search/search-api-client.ts
+++ b/packages/headless/src/api/search/search-api-client.ts
@@ -36,9 +36,12 @@ import {SearchThunkExtraArguments} from '../../app/headless-engine';
 
 export type AllSearchAPIResponse = Plan | Search | QuerySuggest;
 
-export interface AsyncThunkSearchOptions<T extends Partial<SearchAppState>> {
+export interface AsyncThunkSearchOptions<
+  T extends Partial<SearchAppState>,
+  E = SearchAPIErrorWithStatusCode
+> {
   state: T;
-  rejectValue: SearchAPIErrorWithStatusCode;
+  rejectValue: E;
   extra: SearchThunkExtraArguments;
 }
 

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -1,5 +1,4 @@
 import {Schema} from '@coveo/bueno';
-import {Result} from '../../api/search/search/result';
 import {Engine} from '../../app/headless-engine';
 import {search, configuration, folding} from '../../app/reducers';
 import {
@@ -87,7 +86,7 @@ export interface FoldedResultListState extends ResultListState {
   /**
    * The ordered list of results and collections.
    * */
-  results: (Collection | Result)[];
+  results: Collection[];
 }
 
 /**
@@ -139,10 +138,15 @@ export function buildFoldedResultList(
           const collectionId = result.raw[state.folding.fields.collection] as
             | string
             | undefined;
-          if (!collectionId) {
-            return result;
+          if (!collectionId || !state.folding.collections[collectionId]) {
+            return {
+              ...result,
+              moreResultsAvailable: false,
+              isLoadingMoreResults: false,
+              children: [],
+            };
           }
-          return state.folding.collections[collectionId] ?? result;
+          return state.folding.collections[collectionId];
         }),
       };
     },

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -72,7 +72,7 @@ export interface FoldedResultList extends ResultList {
   /**
    * Loads all the folded results for a given collection.
    */
-  loadAll(collection: string | Collection): void;
+  loadAll(collection: Collection): void;
   /**
    * The state of the `FoldedResultList` controller.
    */
@@ -125,9 +125,7 @@ export function buildFoldedResultList(
     loadAll: (collection) =>
       dispatch(
         loadAll(
-          typeof collection === 'string'
-            ? collection
-            : (collection.raw[engine.state.folding.fields.collection] as string)
+          collection.raw[engine.state.folding.fields.collection] as string
         )
       ),
 

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -1,4 +1,5 @@
 import {Schema} from '@coveo/bueno';
+import {Result} from '../../api/search/search/result';
 import {Engine} from '../../app/headless-engine';
 import {search, configuration, folding} from '../../app/reducers';
 import {
@@ -84,9 +85,9 @@ export interface FoldedResultList extends ResultList {
  * */
 export interface FoldedResultListState extends ResultListState {
   /**
-   * The hierarchical collections of results.
+   * The ordered list of results and collections.
    * */
-  results: Collection[];
+  results: (Collection | Result)[];
 }
 
 /**
@@ -134,7 +135,15 @@ export function buildFoldedResultList(
 
       return {
         ...controller.state,
-        results: state.folding.collections,
+        results: controller.state.results.map((result) => {
+          const collectionId = result.raw[state.folding.fields.collection] as
+            | string
+            | undefined;
+          if (!collectionId) {
+            return result;
+          }
+          return state.folding.collections[collectionId] ?? result;
+        }),
       };
     },
   };

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -3,7 +3,7 @@ import {Engine} from '../../app/headless-engine';
 import {search, configuration, folding} from '../../app/reducers';
 import {
   foldingOptionsSchemaDefinition,
-  loadAll,
+  loadCollection,
   registerFolding,
 } from '../../features/folding/folding-actions';
 import {Collection, FoldedResult} from '../../features/folding/folding-state';
@@ -72,7 +72,7 @@ export interface FoldedResultList extends ResultList {
   /**
    * Loads all the folded results for a given collection.
    */
-  loadAll(collection: Collection): void;
+  loadCollection(collection: Collection): void;
   /**
    * The state of the `FoldedResultList` controller.
    */
@@ -122,9 +122,9 @@ export function buildFoldedResultList(
   return {
     ...controller,
 
-    loadAll: (collection) =>
+    loadCollection: (collection) =>
       dispatch(
-        loadAll(
+        loadCollection(
           collection.raw[engine.state.folding.fields.collection] as string
         )
       ),

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -84,7 +84,7 @@ export interface FoldedResultList extends ResultList {
  * */
 export interface FoldedResultListState extends ResultListState {
   /**
-   * The ordered list of results and collections.
+   * The ordered list of collections.
    * */
   results: Collection[];
 }

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -3,9 +3,10 @@ import {Engine} from '../../app/headless-engine';
 import {search, configuration, folding} from '../../app/reducers';
 import {
   foldingOptionsSchemaDefinition,
+  loadAll,
   registerFolding,
 } from '../../features/folding/folding-actions';
-import {FoldedResult} from '../../features/folding/folding-state';
+import {Collection, FoldedResult} from '../../features/folding/folding-state';
 import {
   ConfigurationSection,
   FoldingSection,
@@ -20,7 +21,7 @@ import {
   ResultListState,
 } from '../result-list/headless-result-list';
 
-export {FoldedResult};
+export {Collection, FoldedResult};
 
 const optionsSchema = new Schema<Required<FoldingOptions>>(
   foldingOptionsSchemaDefinition
@@ -69,6 +70,10 @@ export interface FoldedResultListProps {
  */
 export interface FoldedResultList extends ResultList {
   /**
+   * Loads all the folded results for a given collection.
+   */
+  loadAll(collection: string | Collection): void;
+  /**
    * The state of the `FoldedResultList` controller.
    */
   state: FoldedResultListState;
@@ -81,7 +86,7 @@ export interface FoldedResultListState extends ResultListState {
   /**
    * The hierarchical collections of results.
    * */
-  results: FoldedResult[];
+  results: Collection[];
 }
 
 /**
@@ -116,6 +121,15 @@ export function buildFoldedResultList(
 
   return {
     ...controller,
+
+    loadAll: (collection) =>
+      dispatch(
+        loadAll(
+          typeof collection === 'string'
+            ? collection
+            : (collection.raw[engine.state.folding.fields.collection] as string)
+        )
+      ),
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -287,6 +287,7 @@ export {
 } from './quickview/headless-quickview';
 
 export {
+  Collection,
   FoldedResult,
   FoldedResultList,
   FoldingOptions,

--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -1,6 +1,17 @@
 import {NumberValue, SchemaDefinition, StringValue} from '@coveo/bueno';
-import {createAction} from '@reduxjs/toolkit';
+import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
+import {
+  AsyncThunkSearchOptions,
+  isErrorResponse,
+} from '../../api/search/search-api-client';
+import {SearchAPIErrorWithStatusCode} from '../../api/search/search-api-error-response';
+import {Result} from '../../api/search/search/result';
+import {ConfigurationSection, FoldingSection} from '../../state/state-sections';
 import {validatePayload} from '../../utils/validate-payload';
+
+export const collectionMoreResultsAvailableBuffer = 1;
+
+export type CollectionId = string;
 
 export interface RegisterFoldingActionCreatorPayload {
   /**
@@ -29,6 +40,16 @@ export interface RegisterFoldingActionCreatorPayload {
   numberOfFoldedResults?: number;
 }
 
+export interface LoadAllFulfilledReturn {
+  results: Result[];
+  collectionId: CollectionId;
+}
+
+export interface LoadAllRejectedReturn {
+  collectionId: CollectionId;
+  error: SearchAPIErrorWithStatusCode;
+}
+
 export const foldingOptionsSchemaDefinition: SchemaDefinition<Required<
   RegisterFoldingActionCreatorPayload
 >> = {
@@ -42,4 +63,42 @@ export const registerFolding = createAction(
   'folding/register',
   (payload: RegisterFoldingActionCreatorPayload) =>
     validatePayload(payload, foldingOptionsSchemaDefinition)
+);
+
+export const loadAll = createAsyncThunk<
+  LoadAllFulfilledReturn,
+  CollectionId,
+  AsyncThunkSearchOptions<
+    ConfigurationSection & FoldingSection,
+    LoadAllRejectedReturn
+  >
+>(
+  'folding/loadAll',
+  async (
+    collectionId: CollectionId,
+    {getState, rejectWithValue, extra: {searchAPIClient}}
+  ) => {
+    const {
+      folding: {fields},
+      configuration: {
+        accessToken,
+        organizationId,
+        search: {apiBaseUrl},
+      },
+    } = getState();
+
+    const response = await searchAPIClient.search({
+      accessToken,
+      organizationId,
+      url: apiBaseUrl,
+      aq: `@${fields.collection} = ${collectionId}`,
+      numberOfResults: 100,
+    });
+
+    if (isErrorResponse(response)) {
+      return rejectWithValue({collectionId, error: response.error});
+    }
+
+    return {collectionId, results: response.success.results};
+  }
 );

--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -40,12 +40,12 @@ export interface RegisterFoldingActionCreatorPayload {
   numberOfFoldedResults?: number;
 }
 
-export interface LoadAllFulfilledReturn {
+export interface LoadCollectionFulfilledReturn {
   results: Result[];
   collectionId: CollectionId;
 }
 
-export interface LoadAllRejectedReturn {
+export interface LoadCollectionRejectedReturn {
   collectionId: CollectionId;
   error: SearchAPIErrorWithStatusCode;
 }
@@ -65,15 +65,15 @@ export const registerFolding = createAction(
     validatePayload(payload, foldingOptionsSchemaDefinition)
 );
 
-export const loadAll = createAsyncThunk<
-  LoadAllFulfilledReturn,
+export const loadCollection = createAsyncThunk<
+  LoadCollectionFulfilledReturn,
   CollectionId,
   AsyncThunkSearchOptions<
     ConfigurationSection & FoldingSection,
-    LoadAllRejectedReturn
+    LoadCollectionRejectedReturn
   >
 >(
-  'folding/loadAll',
+  'folding/loadCollection',
   async (
     collectionId: CollectionId,
     {getState, rejectWithValue, extra: {searchAPIClient}}

--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -8,8 +8,7 @@ import {SearchAPIErrorWithStatusCode} from '../../api/search/search-api-error-re
 import {Result} from '../../api/search/search/result';
 import {ConfigurationSection, FoldingSection} from '../../state/state-sections';
 import {validatePayload} from '../../utils/validate-payload';
-
-export type CollectionId = string;
+import {CollectionId} from './folding-state';
 
 export interface RegisterFoldingActionCreatorPayload {
   /**

--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -9,8 +9,6 @@ import {Result} from '../../api/search/search/result';
 import {ConfigurationSection, FoldingSection} from '../../state/state-sections';
 import {validatePayload} from '../../utils/validate-payload';
 
-export const collectionMoreResultsAvailableBuffer = 1;
-
 export type CollectionId = string;
 
 export interface RegisterFoldingActionCreatorPayload {

--- a/packages/headless/src/features/folding/folding-slice.ts
+++ b/packages/headless/src/features/folding/folding-slice.ts
@@ -2,8 +2,13 @@ import {createReducer} from '@reduxjs/toolkit';
 import {Result} from '../../api/search/search/result';
 import {isArray, removeDuplicates} from '../../utils/utils';
 import {executeSearch, fetchMoreResults} from '../search/search-actions';
-import {registerFolding} from './folding-actions';
 import {
+  collectionMoreResultsAvailableBuffer,
+  loadAll,
+  registerFolding,
+} from './folding-actions';
+import {
+  Collection,
   FoldedResult,
   FoldingFields,
   getFoldingInitialState,
@@ -33,70 +38,113 @@ function areDefinedAndEqual<T>(
   return (value1 || value2) !== undefined && value1 === value2;
 }
 
-function flattenResultTree(result: ResultWithFolding): ResultWithFolding[] {
-  const results = [result];
-  if (result.parentResult) {
-    results.unshift(result.parentResult);
+function getFoldedResults(result: ResultWithFolding): ResultWithFolding[] {
+  if (!result.childResults) {
+    return [];
   }
-  if (result.childResults?.length) {
-    results.push(
-      ...result.childResults.flatMap((childResult) =>
-        flattenResultTree(childResult)
-      )
-    );
-  }
-  return results;
+  return result.childResults.flatMap((childResult) => [
+    childResult,
+    ...getFoldedResults(childResult),
+  ]);
 }
 
-function foldResult(
-  source: ResultWithFolding,
+function addChildren(
+  parent: ResultWithFolding,
   results: ResultWithFolding[],
   fields: FoldingFields
 ): FoldedResult {
-  const sourceChildValue = getChildField(source, fields);
+  const sourceChildValue = getChildField(parent, fields);
   return {
-    ...source,
+    ...parent,
     children: sourceChildValue
       ? results
           .filter((result) => {
             const isSameResultAsSource =
-              getChildField(result, fields) === getChildField(source, fields);
+              getChildField(result, fields) === getChildField(parent, fields);
             const isChildOfSource =
               getParentField(result, fields) === sourceChildValue;
             return isChildOfSource && !isSameResultAsSource;
           })
-          .map((result) => foldResult(result, results, fields))
+          .map((result) => addChildren(result, results, fields))
       : [],
   };
 }
 
-function createCollection(
+function createCollectionFromResults(
+  results: ResultWithFolding[],
+  fields: FoldingFields,
+  moreResultsAvailable: boolean
+): Collection | null {
+  const rootResult = results.find((result) => {
+    const hasNoParent = getParentField(result, fields) === undefined;
+    const isParentOfItself = areDefinedAndEqual(
+      getParentField(result, fields),
+      getChildField(result, fields)
+    );
+    return hasNoParent || isParentOfItself;
+  });
+
+  if (!rootResult) {
+    return null;
+  }
+
+  return {
+    ...addChildren(rootResult, results, fields),
+    moreResultsAvailable,
+    isLoadingMoreResults: false,
+  };
+}
+
+function createCollectionFromResult(
   relevantResult: ResultWithFolding,
-  fields: FoldingFields
-): FoldedResult {
-  const flattenedResults = removeDuplicates(
-    flattenResultTree(relevantResult),
+  fields: FoldingFields,
+  numberOfFoldedResults: number
+): Collection {
+  const foldedResults = getFoldedResults(relevantResult);
+
+  const moreResultsAvailable = foldedResults.length > numberOfFoldedResults;
+
+  const foldedResultsWithoutBuffer = moreResultsAvailable
+    ? foldedResults.slice(
+        0,
+        foldedResults.length - collectionMoreResultsAvailableBuffer
+      )
+    : foldedResults;
+
+  const parentResults = [relevantResult, ...foldedResults]
+    .filter((result) => result.parentResult)
+    .map((result) => result.parentResult!);
+
+  const resultsInCollection = removeDuplicates(
+    [relevantResult, ...foldedResultsWithoutBuffer, ...parentResults],
     (result) => result.uniqueId
   );
 
-  const topLevelResult =
-    flattenedResults.find((result) => {
-      const hasNoParent = getParentField(result, fields) === undefined;
-      const isParentOfItself = areDefinedAndEqual(
-        getParentField(result, fields),
-        getChildField(result, fields)
-      );
-      return hasNoParent || isParentOfItself;
-    }) ?? relevantResult;
+  const collection = createCollectionFromResults(
+    resultsInCollection,
+    fields,
+    moreResultsAvailable
+  );
 
-  return foldResult(topLevelResult, flattenedResults, fields);
+  if (collection) {
+    return collection;
+  }
+
+  return {
+    ...addChildren(relevantResult, resultsInCollection, fields),
+    moreResultsAvailable,
+    isLoadingMoreResults: false,
+  };
 }
 
 function createCollections(
   results: ResultWithFolding[],
-  fields: FoldingFields
-): FoldedResult[] {
-  return results.map((result) => createCollection(result, fields));
+  fields: FoldingFields,
+  numberOfFoldedResults: number
+) {
+  return results.map((result) =>
+    createCollectionFromResult(result, fields, numberOfFoldedResults)
+  );
 }
 
 export const foldingReducer = createReducer(
@@ -107,7 +155,8 @@ export const foldingReducer = createReducer(
         state.collections = state.enabled
           ? createCollections(
               payload.response.results as ResultWithFolding[],
-              state.fields
+              state.fields,
+              state.numberOfFoldedResults
             )
           : [];
       })
@@ -117,7 +166,8 @@ export const foldingReducer = createReducer(
               ...state.collections,
               ...createCollections(
                 payload.response.results as ResultWithFolding[],
-                state.fields
+                state.fields,
+                state.numberOfFoldedResults
               ),
             ]
           : [];
@@ -136,5 +186,40 @@ export const foldingReducer = createReducer(
               numberOfFoldedResults:
                 payload.numberOfFoldedResults ?? state.numberOfFoldedResults,
             }
+      )
+      .addCase(loadAll.pending, (state, {meta}) => {
+        const collectionId = meta.arg;
+
+        return {
+          ...state,
+          collections: state.collections.map((collection) =>
+            collection.raw[state.fields.collection] === collectionId
+              ? {...collection, isLoadingMoreResults: true}
+              : collection
+          ),
+        };
+      })
+      .addCase(loadAll.rejected, (state, {payload}) => ({
+        ...state,
+        collections: state.collections.map((collection) =>
+          collection.raw[state.fields.collection] === payload?.collectionId
+            ? {...collection, isLoadingMoreResults: false}
+            : collection
+        ),
+      }))
+      .addCase(
+        loadAll.fulfilled,
+        (state, {payload: {collectionId, results}}) => ({
+          ...state,
+          collections: state.collections.map((collection) =>
+            collection.raw[state.fields.collection] === collectionId
+              ? createCollectionFromResults(
+                  results as ResultWithFolding[],
+                  state.fields,
+                  false
+                ) ?? collection
+              : collection
+          ),
+        })
       )
 );

--- a/packages/headless/src/features/folding/folding-slice.ts
+++ b/packages/headless/src/features/folding/folding-slice.ts
@@ -4,7 +4,7 @@ import {isArray, removeDuplicates} from '../../utils/utils';
 import {executeSearch, fetchMoreResults} from '../search/search-actions';
 import {
   collectionMoreResultsAvailableBuffer,
-  loadAll,
+  loadCollection,
   registerFolding,
 } from './folding-actions';
 import {
@@ -167,7 +167,7 @@ export const foldingReducer = createReducer(
                 payload.numberOfFoldedResults ?? state.numberOfFoldedResults,
             }
       )
-      .addCase(loadAll.pending, (state, {meta}) => {
+      .addCase(loadCollection.pending, (state, {meta}) => {
         const collectionId = meta.arg;
 
         return {
@@ -179,7 +179,7 @@ export const foldingReducer = createReducer(
           ),
         };
       })
-      .addCase(loadAll.rejected, (state, {payload}) => ({
+      .addCase(loadCollection.rejected, (state, {payload}) => ({
         ...state,
         collections: state.collections.map((collection) =>
           collection.raw[state.fields.collection] === payload?.collectionId
@@ -188,7 +188,7 @@ export const foldingReducer = createReducer(
         ),
       }))
       .addCase(
-        loadAll.fulfilled,
+        loadCollection.fulfilled,
         (state, {payload: {collectionId, results}}) => ({
           ...state,
           collections: state.collections.map((collection) => {

--- a/packages/headless/src/features/folding/folding-state.ts
+++ b/packages/headless/src/features/folding/folding-state.ts
@@ -27,7 +27,7 @@ export interface FoldingFields {
 export interface FoldingState {
   enabled: boolean;
   fields: FoldingFields;
-  numberOfFoldedResults: number;
+  filterFieldRange: number;
   collections: Collection[];
 }
 
@@ -38,6 +38,6 @@ export const getFoldingInitialState: () => FoldingState = () => ({
     parent: 'foldingparent',
     child: 'foldingchild',
   },
-  numberOfFoldedResults: 2,
+  filterFieldRange: 3,
   collections: [],
 });

--- a/packages/headless/src/features/folding/folding-state.ts
+++ b/packages/headless/src/features/folding/folding-state.ts
@@ -1,5 +1,7 @@
 import {Result} from '../../api/search/search/result';
 
+export const collectionMoreResultsAvailableBuffer = 5;
+
 export type CollectionId = string;
 
 export interface FoldedResult extends Result {
@@ -40,6 +42,6 @@ export const getFoldingInitialState: () => FoldingState = () => ({
     parent: 'foldingparent',
     child: 'foldingchild',
   },
-  filterFieldRange: 3,
+  filterFieldRange: 2 + collectionMoreResultsAvailableBuffer,
   collections: {},
 });

--- a/packages/headless/src/features/folding/folding-state.ts
+++ b/packages/headless/src/features/folding/folding-state.ts
@@ -7,6 +7,17 @@ export interface FoldedResult extends Result {
   children: FoldedResult[];
 }
 
+export interface Collection extends FoldedResult {
+  /**
+   * Whether more results are available in the collection.
+   */
+  moreResultsAvailable: boolean;
+  /**
+   * Whether there is an ongoing query to add more results to the collection.
+   */
+  isLoadingMoreResults: boolean;
+}
+
 export interface FoldingFields {
   collection: string;
   parent: string;
@@ -17,7 +28,7 @@ export interface FoldingState {
   enabled: boolean;
   fields: FoldingFields;
   numberOfFoldedResults: number;
-  collections: FoldedResult[];
+  collections: Collection[];
 }
 
 export const getFoldingInitialState: () => FoldingState = () => ({

--- a/packages/headless/src/features/folding/folding-state.ts
+++ b/packages/headless/src/features/folding/folding-state.ts
@@ -1,5 +1,7 @@
 import {Result} from '../../api/search/search/result';
 
+export type CollectionId = string;
+
 export interface FoldedResult extends Result {
   /**
    * The children of this result sorted in the same order as the search results.
@@ -28,7 +30,7 @@ export interface FoldingState {
   enabled: boolean;
   fields: FoldingFields;
   filterFieldRange: number;
-  collections: Collection[];
+  collections: Record<CollectionId, Collection>;
 }
 
 export const getFoldingInitialState: () => FoldingState = () => ({
@@ -39,5 +41,5 @@ export const getFoldingInitialState: () => FoldingState = () => ({
     child: 'foldingchild',
   },
   filterFieldRange: 3,
-  collections: [],
+  collections: {},
 });

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -45,6 +45,7 @@ import {extractHistory} from '../history/history-state';
 import {sortFacets} from '../../utils/facet-utils';
 import {getSearchInitialState} from './search-state';
 import {logFetchMoreResults, logQueryError} from './search-analytics-actions';
+import {collectionMoreResultsAvailableBuffer} from '../folding/folding-actions';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -317,7 +318,9 @@ export const buildSearchRequest = (
       filterField: state.folding.fields.collection,
       childField: state.folding.fields.parent,
       parentField: state.folding.fields.child,
-      filterFieldRange: state.folding.numberOfFoldedResults,
+      filterFieldRange:
+        state.folding.numberOfFoldedResults +
+        collectionMoreResultsAvailableBuffer,
     }),
   };
 };

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -45,7 +45,6 @@ import {extractHistory} from '../history/history-state';
 import {sortFacets} from '../../utils/facet-utils';
 import {getSearchInitialState} from './search-state';
 import {logFetchMoreResults, logQueryError} from './search-analytics-actions';
-import {collectionMoreResultsAvailableBuffer} from '../folding/folding-actions';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -318,9 +317,7 @@ export const buildSearchRequest = (
       filterField: state.folding.fields.collection,
       childField: state.folding.fields.parent,
       parentField: state.folding.fields.child,
-      filterFieldRange:
-        state.folding.numberOfFoldedResults +
-        collectionMoreResultsAvailableBuffer,
+      filterFieldRange: state.folding.filterFieldRange,
     }),
   };
 };

--- a/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
+++ b/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
@@ -1,6 +1,7 @@
 import {Component, ContextType} from 'react';
 import {
   buildFoldedResultList,
+  Collection,
   FoldedResult,
   FoldedResultList as FoldedResultListController,
   FoldedResultListState,
@@ -31,7 +32,13 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
     this.setState(this.controller.state);
   }
 
-  private renderFoldedResult(result: FoldedResult) {
+  private isCollection(
+    result: Collection | FoldedResult
+  ): result is Collection {
+    return 'moreResultsAvailable' in result;
+  }
+
+  private renderFoldedResult(result: Collection | FoldedResult) {
     return (
       <li key={result.uniqueId}>
         <article>
@@ -43,6 +50,14 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
           <ul>
             {result.children.map((child) => this.renderFoldedResult(child))}
           </ul>
+          {this.isCollection(result) && result.moreResultsAvailable ? (
+            <button
+              disabled={result.isLoadingMoreResults}
+              onClick={() => this.controller.loadAll(result)}
+            >
+              Show more
+            </button>
+          ) : null}
         </article>
       </li>
     );

--- a/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
+++ b/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
@@ -1,11 +1,9 @@
 import {Component, ContextType} from 'react';
 import {
   buildFoldedResultList,
-  Collection,
   FoldedResult,
   FoldedResultList as FoldedResultListController,
   FoldedResultListState,
-  Result,
   Unsubscribe,
 } from '@coveo/headless';
 import {ResultLink} from '../result-list/result-link';
@@ -33,20 +31,8 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
     this.setState(this.controller.state);
   }
 
-  private isFoldedResult(
-    result: Collection | FoldedResult | Result
-  ): result is Collection | FoldedResult {
-    return 'children' in result;
-  }
-
-  private isCollection(
-    result: Collection | FoldedResult | Result
-  ): result is Collection {
-    return 'moreResultsAvailable' in result;
-  }
-
-  private renderFoldedResult(result: Collection | FoldedResult | Result) {
-    return (
+  private renderResults(results: FoldedResult[]) {
+    return results.map((result) => (
       <li key={result.uniqueId}>
         <article>
           <h3>
@@ -54,21 +40,10 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
             <ResultLink result={result}>{result.title}</ResultLink>
           </h3>
           <p>{result.excerpt}</p>
-          <ul>
-            {this.isFoldedResult(result) &&
-              result.children.map((child) => this.renderFoldedResult(child))}
-          </ul>
-          {this.isCollection(result) && result.moreResultsAvailable ? (
-            <button
-              disabled={result.isLoadingMoreResults}
-              onClick={() => this.controller.loadCollection(result)}
-            >
-              Show more
-            </button>
-          ) : null}
+          <ul>{this.renderResults(result.children)}</ul>
         </article>
       </li>
-    );
+    ));
   }
 
   render() {
@@ -83,7 +58,26 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
     return (
       <div>
         <ul style={{textAlign: 'left'}}>
-          {this.state.results.map((result) => this.renderFoldedResult(result))}
+          {this.state.results.map((result) => (
+            <li key={result.uniqueId}>
+              <article>
+                <h3>
+                  {/* Make sure to log analytics when the result link is clicked. */}
+                  <ResultLink result={result}>{result.title}</ResultLink>
+                </h3>
+                <p>{result.excerpt}</p>
+                <ul>{this.renderResults(result.children)}</ul>
+                {result.moreResultsAvailable && (
+                  <button
+                    disabled={result.isLoadingMoreResults}
+                    onClick={() => this.controller.loadCollection(result)}
+                  >
+                    Show more
+                  </button>
+                )}
+              </article>
+            </li>
+          ))}
         </ul>
       </div>
     );

--- a/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
+++ b/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.class.tsx
@@ -5,6 +5,7 @@ import {
   FoldedResult,
   FoldedResultList as FoldedResultListController,
   FoldedResultListState,
+  Result,
   Unsubscribe,
 } from '@coveo/headless';
 import {ResultLink} from '../result-list/result-link';
@@ -32,13 +33,19 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
     this.setState(this.controller.state);
   }
 
+  private isFoldedResult(
+    result: Collection | FoldedResult | Result
+  ): result is Collection | FoldedResult {
+    return 'children' in result;
+  }
+
   private isCollection(
-    result: Collection | FoldedResult
+    result: Collection | FoldedResult | Result
   ): result is Collection {
     return 'moreResultsAvailable' in result;
   }
 
-  private renderFoldedResult(result: Collection | FoldedResult) {
+  private renderFoldedResult(result: Collection | FoldedResult | Result) {
     return (
       <li key={result.uniqueId}>
         <article>
@@ -48,12 +55,13 @@ export class FoldedResultList extends Component<{}, FoldedResultListState> {
           </h3>
           <p>{result.excerpt}</p>
           <ul>
-            {result.children.map((child) => this.renderFoldedResult(child))}
+            {this.isFoldedResult(result) &&
+              result.children.map((child) => this.renderFoldedResult(child))}
           </ul>
           {this.isCollection(result) && result.moreResultsAvailable ? (
             <button
               disabled={result.isLoadingMoreResults}
-              onClick={() => this.controller.loadAll(result)}
+              onClick={() => this.controller.loadCollection(result)}
             >
               Show more
             </button>

--- a/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.fn.tsx
+++ b/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.fn.tsx
@@ -3,6 +3,7 @@ import {
   Collection,
   FoldedResult,
   FoldedResultList as HeadlessFoldedResultList,
+  Result,
 } from '@coveo/headless';
 import {ResultLink} from '../result-list/result-link';
 
@@ -18,13 +19,19 @@ export const FoldedResultList: FunctionComponent<FoldedResultListProps> = (
 
   useEffect(() => controller.subscribe(() => setState(controller.state)), []);
 
+  function isFoldedResult(
+    result: Collection | FoldedResult | Result
+  ): result is Collection | FoldedResult {
+    return 'children' in result;
+  }
+
   function isCollection(
-    result: Collection | FoldedResult
+    result: Collection | FoldedResult | Result
   ): result is Collection {
     return 'moreResultsAvailable' in result;
   }
 
-  function renderFoldedResult(result: Collection | FoldedResult) {
+  function renderFoldedResult(result: Collection | FoldedResult | Result) {
     return (
       <li key={result.uniqueId}>
         <article>
@@ -33,11 +40,14 @@ export const FoldedResultList: FunctionComponent<FoldedResultListProps> = (
             <ResultLink result={result}>{result.title}</ResultLink>
           </h3>
           <p>{result.excerpt}</p>
-          <ul>{result.children.map((child) => renderFoldedResult(child))}</ul>
+          <ul>
+            {isFoldedResult(result) &&
+              result.children.map((child) => renderFoldedResult(child))}
+          </ul>
           {isCollection(result) && result.moreResultsAvailable ? (
             <button
               disabled={result.isLoadingMoreResults}
-              onClick={() => controller.loadAll(result)}
+              onClick={() => controller.loadCollection(result)}
             >
               Show more
             </button>

--- a/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.fn.tsx
+++ b/packages/samples/headless-react/src/components/folded-result-list/folded-result-list.fn.tsx
@@ -1,9 +1,7 @@
 import {useEffect, useState, FunctionComponent} from 'react';
 import {
-  Collection,
   FoldedResult,
   FoldedResultList as HeadlessFoldedResultList,
-  Result,
 } from '@coveo/headless';
 import {ResultLink} from '../result-list/result-link';
 
@@ -19,20 +17,8 @@ export const FoldedResultList: FunctionComponent<FoldedResultListProps> = (
 
   useEffect(() => controller.subscribe(() => setState(controller.state)), []);
 
-  function isFoldedResult(
-    result: Collection | FoldedResult | Result
-  ): result is Collection | FoldedResult {
-    return 'children' in result;
-  }
-
-  function isCollection(
-    result: Collection | FoldedResult | Result
-  ): result is Collection {
-    return 'moreResultsAvailable' in result;
-  }
-
-  function renderFoldedResult(result: Collection | FoldedResult | Result) {
-    return (
+  function renderResults(results: FoldedResult[]) {
+    return results.map((result) => (
       <li key={result.uniqueId}>
         <article>
           <h3>
@@ -40,21 +26,10 @@ export const FoldedResultList: FunctionComponent<FoldedResultListProps> = (
             <ResultLink result={result}>{result.title}</ResultLink>
           </h3>
           <p>{result.excerpt}</p>
-          <ul>
-            {isFoldedResult(result) &&
-              result.children.map((child) => renderFoldedResult(child))}
-          </ul>
-          {isCollection(result) && result.moreResultsAvailable ? (
-            <button
-              disabled={result.isLoadingMoreResults}
-              onClick={() => controller.loadCollection(result)}
-            >
-              Show more
-            </button>
-          ) : null}
+          <ul>{renderResults(result.children)}</ul>
         </article>
       </li>
-    );
+    ));
   }
 
   if (!state.results.length) {
@@ -64,7 +39,26 @@ export const FoldedResultList: FunctionComponent<FoldedResultListProps> = (
   return (
     <div>
       <ul style={{textAlign: 'left'}}>
-        {state.results.map((result) => renderFoldedResult(result))}
+        {state.results.map((result) => (
+          <li key={result.uniqueId}>
+            <article>
+              <h3>
+                {/* Make sure to log analytics when the result link is clicked. */}
+                <ResultLink result={result}>{result.title}</ResultLink>
+              </h3>
+              <p>{result.excerpt}</p>
+              <ul>{renderResults(result.children)}</ul>
+              {result.moreResultsAvailable && (
+                <button
+                  disabled={result.isLoadingMoreResults}
+                  onClick={() => controller.loadCollection(result)}
+                >
+                  Show more
+                </button>
+              )}
+            </article>
+          </li>
+        ))}
       </ul>
     </div>
   );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-643

Follow-up to [this PR](https://github.com/coveo/ui-kit/pull/791).

[Here's a diagram](https://drive.google.com/drive/folders/14rJZ-FOXpjp14p_wiTblMro6woVWuUlu?usp=sharing) I made that attempts to demonstrate what the index and the Search API do in order to get folded results. It's not perfectly accurate and may have some small mistakes, but it gives context for this PR.

Unfortunately, while developing the "show more" functionality this time, I discovered other small issues that require discussion. As such, I haven't added unit tests yet. Additionally, the accumulation of these fixes made the folding reducer harder to read so I had to refactor it a bit.