### PR TITLE
ci: added package names to conventional-graduate parameter

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,4 @@
 {
-  "packages": [
-    "packages/**"
-  ],
   "command": {
     "version": {
       "message": "[Version Bump]: publish %s\nlerna.json\nCHANGELOG.md\n**/CHANGELOG.md"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,7 @@
 {
+  "packages": [
+    "packages/**"
+  ],
   "command": {
     "version": {
       "message": "[Version Bump]: publish %s\nlerna.json\nCHANGELOG.md\n**/CHANGELOG.md"

--- a/packages/samples/atomic/package.json
+++ b/packages/samples/atomic/package.json
@@ -1,6 +1,5 @@
 {
   "name": "coveo-atomic-example-070-alpha33",
-  "version": "0.11.0",
   "description": "",
   "keywords": [],
   "author": "Coveo",

--- a/packages/samples/atomic/package.json
+++ b/packages/samples/atomic/package.json
@@ -1,5 +1,6 @@
 {
   "name": "coveo-atomic-example-070-alpha33",
+  "version": "0.11.0",
   "description": "",
   "keywords": [],
   "author": "Coveo",

--- a/packages/samples/atomic/package.json
+++ b/packages/samples/atomic/package.json
@@ -1,6 +1,6 @@
 {
+  "private": true,
   "name": "coveo-atomic-example-070-alpha33",
-  "version": "0.11.0",
   "description": "",
   "keywords": [],
   "author": "Coveo",

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -1,6 +1,5 @@
 {
   "name": "headless-react",
-  "version": "0.14.1",
   "dependencies": {
     "@coveo/headless": "^0.14.1",
     "@testing-library/jest-dom": "^5.11.9",

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -1,6 +1,6 @@
 {
+  "private": true,
   "name": "headless-react",
-  "version": "0.14.1",
   "dependencies": {
     "@coveo/headless": "^0.14.1",
     "@testing-library/jest-dom": "^5.11.9",

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "headless-react",
+  "version": "0.14.1",
   "dependencies": {
     "@coveo/headless": "^0.14.1",
     "@testing-library/jest-dom": "^5.11.9",

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -33,19 +33,10 @@ async function checkoutLatestMaster() {
   await exec('git pull origin master');
 }
 
-/**
- * @returns {Promise<string[]>}
- */
-async function getPackagesToBump() {
-  const {stdout} = await exec('git ls-files | grep -e "/package.json$"');
-  const packages = stdout.trim().split('\n').map(filePath => JSON.parse(readFileSync(filePath).toString()));
-  return packages.filter((npmPackage) => npmPackage.version && !npmPackage.private).map(({name}) => name)
-}
-
 async function bumpVersionAndPush() {
   try {
     await exec(
-      `npx lerna version --conventional-commits --conventional-graduate=${(await getPackagesToBump()).join(',')} --yes`
+      'npx lerna version --conventional-commits --conventional-graduate --yes'
     );
   } catch (e) {
     console.error(

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -1,5 +1,4 @@
 const {promisify} = require('util');
-const {readFileSync} = require('fs');
 const exec = promisify(require('child_process').exec);
 
 async function authenticateGitClient() {

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -35,7 +35,7 @@ async function checkoutLatestMaster() {
 async function bumpVersionAndPush() {
   try {
     await exec(
-      `npx lerna version --conventional-commits --conventional-graduate --yes`
+      `npx lerna version --conventional-commits --conventional-graduate --no-private --yes`
     );
   } catch (e) {
     console.error(

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -1,5 +1,4 @@
 const {promisify} = require('util');
-const {readFileSync} = require('fs');
 const exec = promisify(require('child_process').exec);
 
 async function authenticateGitClient() {
@@ -33,19 +32,10 @@ async function checkoutLatestMaster() {
   await exec('git pull origin master');
 }
 
-/**
- * @returns {Promise<string[]>}
- */
-async function getPackagesToBump() {
-  const {stdout} = await exec('git ls-files | grep -e "/package.json$"');
-  const packages = stdout.trim().split('\n').map(filePath => JSON.parse(readFileSync(filePath).toString()));
-  return packages.filter((npmPackage) => npmPackage.version && !npmPackage.private).map(({name}) => name)
-}
-
 async function bumpVersionAndPush() {
   try {
     await exec(
-      `npx lerna version --conventional-commits --conventional-graduate=${(await getPackagesToBump()).join(',')} --yes`
+      `npx lerna version --conventional-commits --conventional-graduate --yes`
     );
   } catch (e) {
     console.error(

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -1,4 +1,5 @@
 const {promisify} = require('util');
+const {readFileSync} = require('fs');
 const exec = promisify(require('child_process').exec);
 
 async function authenticateGitClient() {

--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -33,10 +33,19 @@ async function checkoutLatestMaster() {
   await exec('git pull origin master');
 }
 
+/**
+ * @returns {Promise<string[]>}
+ */
+async function getPackagesToBump() {
+  const {stdout} = await exec('git ls-files | grep -e "/package.json$"');
+  const packages = stdout.trim().split('\n').map(filePath => JSON.parse(readFileSync(filePath).toString()));
+  return packages.filter((npmPackage) => npmPackage.version && !npmPackage.private).map(({name}) => name)
+}
+
 async function bumpVersionAndPush() {
   try {
     await exec(
-      'npx lerna version --conventional-commits --conventional-graduate --yes'
+      `npx lerna version --conventional-commits --conventional-graduate=${(await getPackagesToBump()).join(',')} --yes`
     );
   } catch (e) {
     console.error(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-686

It looks like the CI is trying and failing to graduate every package due to some packages not having a version. It looks like previously it was only graduating packages with `-alpha`.