### PR TITLE
feat(headless,atomic): added error when losing connection

### DIFF
--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../utils/initialization-utils';
 
 // TODO: Get type from Headless once the API provides more streamlined errors.
+const disconnectedException = 'Disconnected';
 const noEndpointsException = 'NoEndpointsException';
 const invalidTokenException = 'InvalidTokenException';
 
@@ -33,6 +34,8 @@ export class AtomicQueryError implements InitializableComponent {
   @BindStateToI18n()
   @State()
   private strings = {
+    disconnectedTitle: () => this.bindings.i18n.t('disconnected'),
+    disconnectedDesc: () => this.bindings.i18n.t('checkYourConnection'),
     noEndpointsTitle: () => this.bindings.i18n.t('noEndpoints'),
     noEndpointsDesc: () => this.bindings.i18n.t('addSources'),
     invalidTokenTitle: () => this.bindings.i18n.t('cannotAccess'),
@@ -77,6 +80,8 @@ export class AtomicQueryError implements InitializableComponent {
 
   private get title() {
     switch (this.queryErrorState.error!.type) {
+      case disconnectedException:
+        return this.strings.disconnectedTitle();
       case noEndpointsException:
         return this.strings.noEndpointsTitle();
       case invalidTokenException:
@@ -88,6 +93,8 @@ export class AtomicQueryError implements InitializableComponent {
 
   private get description() {
     switch (this.queryErrorState.error!.type) {
+      case disconnectedException:
+        return this.strings.disconnectedDesc();
       case noEndpointsException:
         return this.strings.noEndpointsDesc();
       case invalidTokenException:

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -660,6 +660,14 @@
     "en": "Collapsed URI parts",
     "fr": "Segments d'URI réduits"
   },
+  "disconnected": {
+    "en": "Could not connect.",
+    "fr": "Impossible de se connecter."
+  },
+  "checkYourConnection": {
+    "en": "Your query could not be sent. You may have lost your internet connection.",
+    "fr": "Votre requête n'a pas plus être envoyée. Peut-être que vous avez perdu votre connexion internet."
+  },
   "noEndpoints": {
     "en": "The Coveo Organization has no registered endpoints.",
     "fr": "L'organisation Coveo n'a pas de point de terminaison unique."

--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -3,6 +3,7 @@ import {
   PlatformClient,
   NoopPreprocessRequestMiddleware,
   PlatformClientCallOptions,
+  PlatformClientErrorResponse,
 } from './platform-client';
 import pino from 'pino';
 import * as BackOff from 'exponential-backoff';
@@ -230,5 +231,15 @@ describe('PlatformClient call', () => {
       expect(error).toBe(abortError);
       done();
     }
+  });
+
+  it('should return Disconnected when unable to fetch', async (done) => {
+    const fetchError = new TypeError('Failed to fetch');
+    fetchError.name = 'TypeError';
+    mockFetch.mockRejectedValue(fetchError);
+
+    const result = await platformCall();
+    expect(result).toEqual(PlatformClientErrorResponse.Disconnected);
+    done();
   });
 });

--- a/packages/headless/src/api/search/search-api-error-response.ts
+++ b/packages/headless/src/api/search/search-api-error-response.ts
@@ -9,3 +9,11 @@ export interface SearchAPIErrorWithStatusCode {
 export interface SearchAPIErrorWithExceptionInBody {
   exception: QueryException;
 }
+
+export function buildDisconnectedError(): SearchAPIErrorWithStatusCode {
+  return {
+    statusCode: 0,
+    type: 'Disconnected',
+    message: 'Could not connect',
+  };
+}

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
@@ -1,5 +1,9 @@
 import {buildMockCaseAssistAPIClient} from '../../../test/mock-case-assist-api-client';
-import {PlatformClient} from '../../platform-client';
+import {
+  PlatformClient,
+  PlatformClientErrorResponse,
+} from '../../platform-client';
+import {buildDisconnectedError} from '../../search/search-api-error-response';
 import {CaseAssistAPIClient} from './case-assist-api-client';
 import {GetCaseClassificationsRequest} from './get-case-classifications/get-case-classifications-request';
 import {GetDocumentSuggestionsRequest} from './get-document-suggestions/get-document-suggestions-request';
@@ -144,6 +148,18 @@ describe('case assist api client', () => {
         success: expectedBody,
       });
     });
+
+    it(`without an internet connection
+    should return an error`, async (done) => {
+      PlatformClient.call = () =>
+        Promise.resolve(PlatformClientErrorResponse.Disconnected);
+
+      const response = await client.getCaseClassifications(
+        buildGetCaseClassificationsRequest()
+      );
+      expect(response).toEqual({error: buildDisconnectedError()});
+      done();
+    });
   });
 
   describe('getDocumentSuggestions', () => {
@@ -270,6 +286,18 @@ describe('case assist api client', () => {
       expect(response).toMatchObject({
         success: expectedBody,
       });
+    });
+
+    it(`without an internet connection
+    should return an error`, async (done) => {
+      PlatformClient.call = () =>
+        Promise.resolve(PlatformClientErrorResponse.Disconnected);
+
+      const response = await client.getDocumentSuggestions(
+        buildGetDocumentSuggestionsRequest()
+      );
+      expect(response).toEqual({error: buildDisconnectedError()});
+      done();
     });
   });
 });

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.ts
@@ -2,8 +2,10 @@ import {Logger} from 'pino';
 import {
   NoopPreprocessRequestMiddleware,
   PlatformClient,
+  PlatformClientErrorResponse,
 } from '../../platform-client';
 import {PreprocessRequest} from '../../preprocess-request';
+import {buildDisconnectedError} from '../../search/search-api-error-response';
 import {
   buildGetCaseClassificationsRequest,
   GetCaseClassificationsRequest,
@@ -81,6 +83,12 @@ export class CaseAssistAPIClient {
       ...this.defaultClientHooks,
     });
 
+    if (response === PlatformClientErrorResponse.Disconnected) {
+      return {
+        error: buildDisconnectedError(),
+      };
+    }
+
     const body = await response.json();
     return response.ok
       ? {success: body as GetCaseClassificationsResponse}
@@ -103,6 +111,12 @@ export class CaseAssistAPIClient {
       ...this.options,
       ...this.defaultClientHooks,
     });
+
+    if (response === PlatformClientErrorResponse.Disconnected) {
+      return {
+        error: buildDisconnectedError(),
+      };
+    }
 
     const body = await response.json();
     return response.ok


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-637

When we don't have an internet connection, `fetch` throws an error. Unfortunately, headless didn't have a way to handle the lack of a `Response` already, so I picked the smallest fix I could think of.