### PR TITLE
refactor(headless): place enable/disable analytics on core engine

### DIFF
--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -50,6 +50,26 @@ describe('engine', () => {
     expect(analytics.originLevel3).toBe(originLevel3);
   });
 
+  it('calling #enableAnalytics sets #analytics.enabled to true', () => {
+    options.configuration.analytics = {enabled: false};
+    initEngine();
+
+    engine.enableAnalytics();
+
+    const {analytics} = engine.state.configuration;
+    expect(analytics.enabled).toBe(true);
+  });
+
+  it('calling #disableAnalytics sets #analytics.enabled to false', () => {
+    options.configuration.analytics = {enabled: true};
+    initEngine();
+
+    engine.disableAnalytics();
+
+    const {analytics} = engine.state.configuration;
+    expect(analytics.enabled).toBe(false);
+  });
+
   it(`when renewAccessToken is not defined in the config
   renewAccessToken should return an empty string`, async (done) => {
     expect(await engine.renewAccessToken()).toBe('');

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -9,6 +9,8 @@ import {
 } from '@reduxjs/toolkit';
 import {debounce} from 'ts-debounce';
 import {
+  disableAnalytics,
+  enableAnalytics,
   updateAnalyticsConfiguration,
   updateBasicConfiguration,
 } from '../features/configuration/configuration-actions';
@@ -73,6 +75,14 @@ export interface CoreEngine<
    * Adds the specified reducers to the store.
    */
   addReducers(reducers: ReducersMapObject): void;
+  /**
+   * Enable analytics tracking
+   */
+  enableAnalytics(): void;
+  /**
+   * Disable analytics tracking
+   */
+  disableAnalytics(): void;
 }
 
 export interface EngineOptions<Reducers extends ReducersMapObject> {
@@ -170,6 +180,14 @@ function buildCoreEngine<
     dispatch: store.dispatch,
 
     subscribe: store.subscribe,
+
+    enableAnalytics() {
+      store.dispatch(enableAnalytics());
+    },
+
+    disableAnalytics() {
+      store.dispatch(disableAnalytics());
+    },
 
     get state() {
       return store.getState();

--- a/packages/headless/src/app/headless-engine.ts
+++ b/packages/headless/src/app/headless-engine.ts
@@ -1,8 +1,6 @@
 import {ReducersMapObject, StateFromReducersMapObject} from '@reduxjs/toolkit';
 import {
   updateSearchConfiguration,
-  disableAnalytics,
-  enableAnalytics,
   localeValidation,
 } from '../features/configuration/configuration-actions';
 import {SearchAPIClient} from '../api/search/search-api-client';
@@ -219,14 +217,14 @@ export class HeadlessEngine<Reducers extends ReducersMapObject>
    * Enable analytics tracking
    */
   public enableAnalytics() {
-    this.dispatch(enableAnalytics());
+    this.engine.enableAnalytics();
   }
 
   /**
    * Disable analytics tracking
    */
   public disableAnalytics() {
-    this.dispatch(disableAnalytics());
+    this.engine.disableAnalytics();
   }
 
   get store() {


### PR DESCRIPTION
This refactor places the analytics methods on the `CoreEngine` interface so that they are able to all use-cases extending it. 


https://coveord.atlassian.net/browse/KIT-695