### PR TITLE
ci: cleaned untracked changes before bumping version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,10 +57,11 @@ node('linux && docker') {
     if (!isBump) {
       withDockerContainer(image: 'node:14', args: '-u=root') {
         stage('Commit bumped version') {
-            withCredentials([
-            usernameColonPassword(credentialsId: 'github-commit-token', variable: 'GH_CREDENTIALS')]) {
-              sh 'npm run bump:version'
-            }
+          sh 'git clean -dfX'
+          withCredentials([
+          usernameColonPassword(credentialsId: 'github-commit-token', variable: 'GH_CREDENTIALS')]) {
+            sh 'npm run bump:version'
+          }
         }
       }
       return


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-700

Lerna was trying to bump the version of atomic-loader because it doesn't have `"private": true`. However, we can't add `"private": true` to it because it's generated by Stencil.

Instead of trying to exclude it manually, I made the CI clean untracked changes before bumping the version, which should delete atomic-loader.

Before:
![image](https://user-images.githubusercontent.com/54454747/120033090-20874600-bfc9-11eb-807f-16f4bbf602b7.png)