### PR TITLE
ci: removed `private` from samples `package.json`

### DIFF
--- a/packages/samples/atomic/package.json
+++ b/packages/samples/atomic/package.json
@@ -1,6 +1,6 @@
 {
-  "private": true,
   "name": "coveo-atomic-example-070-alpha33",
+  "version": "0.15.0",
   "description": "",
   "keywords": [],
   "author": "Coveo",
@@ -9,6 +9,9 @@
     "url": "https://github.com/codesandbox-app/static-template/issues"
   },
   "homepage": "https://github.com/codesandbox-app/static-template#readme",
+  "scripts": {
+    "prepublishOnly": "exit 1"
+  },
   "devDependencies": {
     "serve": "^11.2.0"
   }

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -1,6 +1,6 @@
 {
-  "private": true,
   "name": "headless-react",
+  "version": "0.15.0",
   "dependencies": {
     "@coveo/headless": "^0.14.1",
     "@testing-library/jest-dom": "^5.11.9",

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -2,7 +2,7 @@
   "name": "headless-react",
   "version": "0.15.0",
   "dependencies": {
-    "@coveo/headless": "^0.14.1",
+    "@coveo/headless": "^0.15.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^13.1.8",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-705

Packages with `"private": true` don't get a version bump, which was intended. However, when their versions aren't bumped, their dependencies neither.

`--no-private` is still necessary to exclude sub-packages with no dependencies like `case-assist`.