### PR TITLE
feat(headless): expose updateSearchConfiguration via dedicated loader function

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -306,6 +306,9 @@ const actionLoaderConfiguration: ActionLoaderConfiguration[] = [
     initializer: 'loadConfigurationActions',
   },
   {
+    initializer: 'loadSearchConfigurationActions',
+  },
+  {
     initializer: 'loadContextActions',
   },
   {

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -47,21 +47,38 @@ export const updateBasicConfiguration = createAction(
     })
 );
 
+export interface UpdateSearchConfigurationActionCreatorPayload {
+  /**
+   * The Search API base URL to use (e.g., `https://platform.cloud.coveo.com/rest/search/v2`).
+   */
+  apiBaseUrl?: string;
+
+  /**
+   * The name of the query pipeline to use for the query (e.g., `External Search`).
+   */
+  pipeline?: string;
+
+  /**
+   * The first level of origin of the request, typically the identifier of the graphical search interface from which the request originates (e.g., `ExternalSearch`).
+   */
+  searchHub?: string;
+
+  /**
+   * The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+   */
+  locale?: string;
+}
+
 /**
  * Updates the search configuration.
  * @param apiBaseUrl (string) The Search API base URL to use (e.g., `https://platform.cloud.coveo.com/rest/search/v2`).
- * @param pipeline (string) The name of the query pipeline to use for the query (e.g., `External Search`). If not specified, the default query pipeline will be used.
+ * @param pipeline (string) The name of the query pipeline to use for the query (e.g., `External Search`).
  * @param searchHub (string) The first level of origin of the request, typically the identifier of the graphical search interface from which the request originates (e.g., `ExternalSearch`).
  * @param locale (string) The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
  */
 export const updateSearchConfiguration = createAction(
   'configuration/updateSearchConfiguration',
-  (payload: {
-    apiBaseUrl?: string;
-    pipeline?: string;
-    searchHub?: string;
-    locale?: string;
-  }) =>
+  (payload: UpdateSearchConfigurationActionCreatorPayload) =>
     validatePayload(payload, {
       apiBaseUrl: new StringValue({url: true, emptyAllowed: false}),
       pipeline: new StringValue({emptyAllowed: false}),

--- a/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
+++ b/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
@@ -1,0 +1,40 @@
+import {PayloadAction} from '@reduxjs/toolkit';
+import {Engine} from '../../app/headless-engine';
+import {configuration, pipeline, searchHub} from '../../app/reducers';
+import {
+  updateSearchConfiguration,
+  UpdateSearchConfigurationActionCreatorPayload,
+} from './configuration-actions';
+
+export {UpdateSearchConfigurationActionCreatorPayload};
+
+/**
+ * The search configuration action creators.
+ */
+export interface SearchConfigurationActionCreators {
+  /**
+   * Updates the search configuration.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  updateSearchConfiguration(
+    payload: UpdateSearchConfigurationActionCreatorPayload
+  ): PayloadAction<UpdateSearchConfigurationActionCreatorPayload>;
+}
+
+/**
+ * Loads the necessary reducers and returns possible action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadSearchConfigurationActions(
+  engine: Engine<object>
+): SearchConfigurationActionCreators {
+  engine.addReducers({configuration, pipeline, searchHub});
+
+  return {
+    updateSearchConfiguration,
+  };
+}

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -64,7 +64,7 @@ import {
   setOriginLevel3 as setOriginLevel3Alias,
 } from './configuration/configuration-actions';
 /**
- * @deprecated - This namespace will be removed. Please use `loadConfigurationActions` instead.
+ * @deprecated - This namespace will be removed. Please use `loadConfigurationActions` or `loadSearchConfigurationActions` instead.
  */
 export namespace ConfigurationActions {
   export const updateBasicConfiguration = updateBasicConfigurationAlias;
@@ -78,6 +78,7 @@ export namespace ConfigurationActions {
 }
 
 export * from './configuration/configuration-actions-loader';
+export * from './configuration/search-configuration-actions-loader';
 
 import {
   setContext as setContextAlias,


### PR DESCRIPTION
I did not want to group this action with `loadConfigurationActions`, because it is specific to the search app use-case. It loads reducers that may not be relevant to other cases (e.g. product recommendations do not use `pipeline`).

This PR exposes the action using a dedicated loader function.

https://coveord.atlassian.net/browse/KIT-663