### PR TITLE
fix(headless): fix invalid field usage for sourceName click event

### DIFF
--- a/packages/headless/src/features/analytics/analytics-utils.test.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.test.ts
@@ -28,4 +28,20 @@ describe('analytics-utils', () => {
       partialDocumentInformation(result, createMockState()).documentAuthor
     ).toBe('unknown');
   });
+
+  it('should extract sourceName information from source field', () => {
+    const result = buildMockResult();
+    result.raw.source = 'mysource';
+    expect(
+      partialDocumentInformation(result, createMockState()).sourceName
+    ).toBe('mysource');
+  });
+
+  it('should extract sourceName information when there is no source field', () => {
+    const result = buildMockResult();
+    delete result.raw['source'];
+    expect(
+      partialDocumentInformation(result, createMockState()).sourceName
+    ).toBe('unknown');
+  });
 });

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -130,7 +130,7 @@ export const partialDocumentInformation = (
     documentUriHash: result.raw.urihash,
     documentUrl: result.clickUri,
     rankingModifier: result.rankingModifier || '',
-    sourceName: result.raw.sourcetype || '',
+    sourceName: getSourceName(result),
     queryPipeline: state.pipeline || getPipelineInitialState(),
   };
 };
@@ -181,6 +181,14 @@ function getDocumentAuthor(result: Result) {
   }
 
   return Array.isArray(author) ? author.join(';') : `${author}`;
+}
+
+function getSourceName(result: Result) {
+  const source = result.raw['source'];
+  if (isNullOrUndefined(source)) {
+    return 'unknown';
+  }
+  return source;
 }
 
 export const validateResultPayload = (result: Result) =>


### PR DESCRIPTION
First I thought we had an issue with the default fields to include that we request to the API, but I realized that in JSUI, we use the `source` field to map it to `sourceName` for click event payload in UA.

And `source` is correctly included in the default list of fields to include.

`sourceName` is also a mandatory parameter for UA, otherwise the event gets rejected.

https://coveord.atlassian.net/browse/KIT-713