### PR TITLE
feat(headless): expose logCustomEvent via loader function

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -374,6 +374,9 @@ const actionLoaderConfiguration: ActionLoaderConfiguration[] = [
   {
     initializer: 'loadClickAnalyticsActions',
   },
+  {
+    initializer: 'loadCustomAnalyticsActions',
+  },
 ];
 
 const controllers = controllerConfiguration.map((controller) =>

--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -375,7 +375,7 @@ const actionLoaderConfiguration: ActionLoaderConfiguration[] = [
     initializer: 'loadClickAnalyticsActions',
   },
   {
-    initializer: 'loadCustomAnalyticsActions',
+    initializer: 'loadGenericAnalyticsActions',
   },
 ];
 

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -80,11 +80,26 @@ export const logClickEvent = (p: ClickEventPayload) =>
     }
   )();
 
+export interface LogCustomEventActionCreatorPayload {
+  /**
+   * The event cause identifier of the custom action
+   */
+  evt: string;
+  /**
+   * The event type identifier of the custom action
+   */
+  type: string;
+  /**
+   * The event metadata.
+   * */
+  meta?: Record<string, unknown>;
+}
+
 /**
  * Logs a custom event.
  * @param p (CustomEventPayload) The custom event payload.
  */
-export const logCustomEvent = (p: CustomEventPayload) =>
+export const logCustomEvent = (p: LogCustomEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/custom',
     AnalyticsType.Custom,

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -45,11 +45,22 @@ const validateEvent = (p: {evt: string; type?: string}) =>
     type: new StringValue({required: false, emptyAllowed: false}),
   });
 
+export interface LogSearchEventActionCreatorPayload {
+  /**
+   * The identifier of the search action (e.g., `interfaceLoad`).
+   * */
+  evt: string;
+  /**
+   * The event metadata.
+   * */
+  meta?: Record<string, unknown>;
+}
+
 /**
  * Logs a search event.
  * @param p (SearchEventPayload) The search event payload.
  */
-export const logSearchEvent = (p: SearchEventPayload) =>
+export const logSearchEvent = (p: LogSearchEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/search',
     AnalyticsType.Search,
@@ -60,11 +71,23 @@ export const logSearchEvent = (p: SearchEventPayload) =>
     }
   )();
 
+export interface LogClickEventActionCreatorPayload {
+  /**
+   * The identifier of the click action (e.g., `documentOpen`).
+   * */
+  evt: string;
+
+  /**
+   * The result associated with the click event.
+   */
+  result: Result;
+}
+
 /**
  * Logs a click event.
  * @param p (ClickEventPayload) The click event payload.
  */
-export const logClickEvent = (p: ClickEventPayload) =>
+export const logClickEvent = (p: LogClickEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/click',
     AnalyticsType.Click,

--- a/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
@@ -1,0 +1,44 @@
+import {AsyncThunkAction} from '@reduxjs/toolkit';
+import {StateNeededByAnalyticsProvider} from '../../api/analytics/analytics';
+import {Engine} from '../../app/headless-engine';
+import {AnalyticsType, AsyncThunkAnalyticsOptions} from './analytics-utils';
+import {logCustomEvent, CustomEventPayload} from './analytics-actions';
+
+export {CustomEventPayload};
+
+/**
+ * The custom analytics action creators.
+ */
+export interface CustomAnalyticsActionCreators {
+  /**
+   * Creates a custom analytics event.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  logCustomEvent(
+    payload: CustomEventPayload
+  ): AsyncThunkAction<
+    {
+      analyticsType: AnalyticsType.Custom;
+    },
+    void,
+    AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
+  >;
+}
+
+/**
+ * Returns possible custom analytics action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadCustomAnalyticsActions(
+  engine: Engine<object>
+): CustomAnalyticsActionCreators {
+  engine.addReducers({});
+
+  return {
+    logCustomEvent,
+  };
+}

--- a/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
@@ -3,16 +3,56 @@ import {StateNeededByAnalyticsProvider} from '../../api/analytics/analytics';
 import {Engine} from '../../app/headless-engine';
 import {AnalyticsType, AsyncThunkAnalyticsOptions} from './analytics-utils';
 import {
+  logSearchEvent,
+  LogSearchEventActionCreatorPayload,
+  logClickEvent,
+  LogClickEventActionCreatorPayload,
   logCustomEvent,
   LogCustomEventActionCreatorPayload,
 } from './analytics-actions';
 
-export {LogCustomEventActionCreatorPayload};
+export {
+  LogSearchEventActionCreatorPayload,
+  LogClickEventActionCreatorPayload,
+  LogCustomEventActionCreatorPayload,
+};
 
 /**
  * The custom analytics action creators.
  */
 export interface CustomAnalyticsActionCreators {
+  /**
+   * Creates a search analytics event.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  logSearchEvent(
+    payload: LogSearchEventActionCreatorPayload
+  ): AsyncThunkAction<
+    {
+      analyticsType: AnalyticsType.Search;
+    },
+    void,
+    AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
+  >;
+
+  /**
+   * Creates a click analytics event.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  logClickEvent(
+    payload: LogSearchEventActionCreatorPayload
+  ): AsyncThunkAction<
+    {
+      analyticsType: AnalyticsType.Click;
+    },
+    void,
+    AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
+  >;
+
   /**
    * Creates a custom analytics event.
    *
@@ -42,6 +82,8 @@ export function loadCustomAnalyticsActions(
   engine.addReducers({});
 
   return {
+    logSearchEvent,
+    logClickEvent,
     logCustomEvent,
   };
 }

--- a/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/custom-analytics-actions-loader.ts
@@ -2,9 +2,12 @@ import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {StateNeededByAnalyticsProvider} from '../../api/analytics/analytics';
 import {Engine} from '../../app/headless-engine';
 import {AnalyticsType, AsyncThunkAnalyticsOptions} from './analytics-utils';
-import {logCustomEvent, CustomEventPayload} from './analytics-actions';
+import {
+  logCustomEvent,
+  LogCustomEventActionCreatorPayload,
+} from './analytics-actions';
 
-export {CustomEventPayload};
+export {LogCustomEventActionCreatorPayload};
 
 /**
  * The custom analytics action creators.
@@ -17,7 +20,7 @@ export interface CustomAnalyticsActionCreators {
    * @returns A dispatchable action.
    */
   logCustomEvent(
-    payload: CustomEventPayload
+    payload: LogCustomEventActionCreatorPayload
   ): AsyncThunkAction<
     {
       analyticsType: AnalyticsType.Custom;

--- a/packages/headless/src/features/analytics/generic-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/generic-analytics-actions-loader.ts
@@ -18,9 +18,9 @@ export {
 };
 
 /**
- * The custom analytics action creators.
+ * The generic analytics action creators.
  */
-export interface CustomAnalyticsActionCreators {
+export interface GenericAnalyticsActionCreators {
   /**
    * Creates a search analytics event.
    *
@@ -71,14 +71,14 @@ export interface CustomAnalyticsActionCreators {
 }
 
 /**
- * Returns possible custom analytics action creators.
+ * Returns possible generic analytics action creators.
  *
  * @param engine - The headless engine.
  * @returns An object holding the action creators.
  */
-export function loadCustomAnalyticsActions(
+export function loadGenericAnalyticsActions(
   engine: Engine<object>
-): CustomAnalyticsActionCreators {
+): GenericAnalyticsActionCreators {
   engine.addReducers({});
 
   return {

--- a/packages/headless/src/features/analytics/index.ts
+++ b/packages/headless/src/features/analytics/index.ts
@@ -187,4 +187,4 @@ export namespace SearchAnalyticsActions {
 
 export * from './search-analytics-actions-loader';
 export * from './click-analytics-actions-loader';
-export * from './custom-analytics-actions-loader';
+export * from './generic-analytics-actions-loader';

--- a/packages/headless/src/features/analytics/index.ts
+++ b/packages/headless/src/features/analytics/index.ts
@@ -187,3 +187,4 @@ export namespace SearchAnalyticsActions {
 
 export * from './search-analytics-actions-loader';
 export * from './click-analytics-actions-loader';
+export * from './custom-analytics-actions-loader';


### PR DESCRIPTION
While refactoring to expose analytics actions via loader functions, I left out certain lower level actions like `logClickEvent` and `logSearchEvent` since there are higher level actions that can be used instead (if there is a need to expose the low-level action, please let me know).

On the other hand, `logCustomEvent` would be useful to a dev wanting to send additional information, This PR exposes the action using the new loader function approach.