### PR TITLE
chore(quantic): migrate quantic to search engine

### DIFF
--- a/packages/quantic/coveo.d.ts
+++ b/packages/quantic/coveo.d.ts
@@ -14,8 +14,8 @@ declare global {
           element: LightningElement;
           initialized: boolean;
         }[];
-        config: HeadlessTypes.SearchEngineConfiguration;
-        engine: HeadlessTypes.SearchEngine;
+        config: any;
+        engine: Promise<HeadlessTypes.SearchEngine>;
       };
     };
   }

--- a/packages/quantic/coveo.d.ts
+++ b/packages/quantic/coveo.d.ts
@@ -14,8 +14,8 @@ declare global {
           element: LightningElement;
           initialized: boolean;
         }[];
-        config: HeadlessConfigurationOptions;
-        engine: HeadlessTypes.HeadlessEngine;
+        config: HeadlessTypes.SearchEngineConfiguration;
+        engine: HeadlessTypes.SearchEngine;
       };
     };
   }

--- a/packages/quantic/coveo.d.ts
+++ b/packages/quantic/coveo.d.ts
@@ -14,9 +14,16 @@ declare global {
           element: LightningElement;
           initialized: boolean;
         }[];
-        config: any;
+        config: Deferred<HeadlessTypes.SearchEngineConfiguration>;
         engine: Promise<HeadlessTypes.SearchEngine>;
       };
     };
   }
+}
+
+class Deferred<T> {
+  promise: Promise<T>;
+  isResolved: boolean;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -29,7 +29,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
@@ -28,7 +28,7 @@ export default class QuanticDateFacet extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -29,7 +29,7 @@ export default class QuanticFacet extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
@@ -10,7 +10,6 @@ import { CoveoHeadlessStub } from '../../testUtils/coveoHeadlessStub';
 import {Deferred} from '../../quanticUtils/quanticUtils';
 
 describe('c/quanticHeadlessLoader', () => {
-  const dispatchMock = jest.fn();
   const testConfig = {
     organizationId: 'testOrganization',
     accessToken: 'bogus-token-xxxxx-xxxxx',
@@ -122,9 +121,7 @@ describe('c/quanticHeadlessLoader', () => {
         window.coveoHeadless = {
           [testId]: {
             components: [],
-            engine: {
-              dispatch: dispatchMock
-            }
+            engine: CoveoHeadlessStub.buildSearchEngine()
           }
         }
       });
@@ -164,9 +161,7 @@ describe('c/quanticHeadlessLoader', () => {
         window.coveoHeadless = {
           [testId]: {
             components: [],
-            engine: Promise.resolve({
-              dispatch: dispatchMock
-            }),
+            engine: Promise.resolve(CoveoHeadlessStub.buildSearchEngine()),
             config: new Deferred()
           }
         }
@@ -188,7 +183,7 @@ describe('c/quanticHeadlessLoader', () => {
   
           assertComponentIsSetInitialized(testElement, testId);
           jest.runAllTimers();
-          expect(dispatchMock).not.toBeCalled();
+          expect(window.coveoHeadless[testId].engine.executeFirstSearch).not.toBeCalled();
         });
       });
 
@@ -209,7 +204,7 @@ describe('c/quanticHeadlessLoader', () => {
           assertComponentIsSetInitialized(testElement, testId);
           jest.runAllTimers();
           await window.coveoHeadless.engine;
-          expect(dispatchMock).toBeCalled();
+          expect(window.coveoHeadless[testId].engine.executeFirstSearch).toBeCalled();
         });
       });
     });
@@ -229,7 +224,7 @@ describe('c/quanticHeadlessLoader', () => {
       it('should init the engine return a promise that resolves to that instance', async () => {
         const engine = await getHeadlessEngine(testId);
 
-        expect(engine).toEqual(CoveoHeadlessStub.buildSearchEngine());
+        expect(engine).toBeTruthy();
       });
     });
 
@@ -294,7 +289,7 @@ describe('c/quanticHeadlessLoader', () => {
         await initializeWithHeadless(testElement, testId, initialize);
         const engine = await window.coveoHeadless[testId].engine;
 
-        expect(engine).toEqual(CoveoHeadlessStub.buildSearchEngine());
+        expect(engine).toBeTruthy();
         expect(initialize).toHaveBeenCalled();
         assertComponentIsSetInitialized(testElement, testId);
       });

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
@@ -178,12 +178,13 @@ describe('c/quanticHeadlessLoader', () => {
           ];
         });
 
-        it('should set the component to initialized', () => {
+        it('should set the component to initialized', async () => {
           setComponentInitialized(testElement, testId);
   
           assertComponentIsSetInitialized(testElement, testId);
           jest.runAllTimers();
-          expect(window.coveoHeadless[testId].engine.executeFirstSearch).not.toBeCalled();
+          const engine = await window.coveoHeadless[testId].engine;
+          expect(engine.executeFirstSearch).not.toBeCalled();
         });
       });
 
@@ -204,7 +205,8 @@ describe('c/quanticHeadlessLoader', () => {
           assertComponentIsSetInitialized(testElement, testId);
           jest.runAllTimers();
           await window.coveoHeadless.engine;
-          expect(window.coveoHeadless[testId].engine.executeFirstSearch).toBeCalled();
+          const engine = await window.coveoHeadless[testId].engine;
+          expect(engine.executeFirstSearch).toBeCalled();
         });
       });
     });

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/__tests__/headlessLoader.test.js
@@ -6,7 +6,7 @@ import {
   getHeadlessEngine,
   initializeWithHeadless
 } from '../quanticHeadlessLoader';
-import { CoveoHeadlessStub, MockEngine } from '../../testUtils/coveoHeadlessStub';
+import { CoveoHeadlessStub } from '../../testUtils/coveoHeadlessStub';
 import {Deferred} from '../../quanticUtils/quanticUtils';
 
 describe('c/quanticHeadlessLoader', () => {
@@ -229,7 +229,7 @@ describe('c/quanticHeadlessLoader', () => {
       it('should init the engine return a promise that resolves to that instance', async () => {
         const engine = await getHeadlessEngine(testId);
 
-        expect(engine).toBeInstanceOf(MockEngine);
+        expect(engine).toEqual(CoveoHeadlessStub.buildSearchEngine());
       });
     });
 
@@ -294,7 +294,7 @@ describe('c/quanticHeadlessLoader', () => {
         await initializeWithHeadless(testElement, testId, initialize);
         const engine = await window.coveoHeadless[testId].engine;
 
-        expect(engine).toBeInstanceOf(MockEngine);
+        expect(engine).toEqual(CoveoHeadlessStub.buildSearchEngine());
         expect(initialize).toHaveBeenCalled();
         assertComponentIsSetInitialized(testElement, testId);
       });

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
@@ -35,11 +35,7 @@ const cancelInitialSearch = (engineId) => {
  */
 const executeInitialSearch = (engineId) => {
   window.coveoHeadless[engineId].engine.then((engine) => {
-    engine.dispatch(
-      CoveoHeadless.SearchActions.executeSearch(
-        CoveoHeadless.AnalyticsActions.logInterfaceLoad()
-      )
-    );
+    engine.executeFirstSearch();
   });
 };
 
@@ -107,11 +103,7 @@ async function initEngine(engineId) {
       throw new Error('Engine configuration has not been set.');
     }
     const configuration = await window.coveoHeadless[engineId].config.promise;
-
-    return new CoveoHeadless.HeadlessEngine({
-      configuration,
-      reducers: CoveoHeadless.searchAppReducers,
-    });
+    return CoveoHeadless.buildSearchEngine({configuration})
   } catch (error) {
     throw new Error('Fatal error: unable to initialize Coveo Headless: ' + error);
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -28,7 +28,7 @@ export default class QuanticNumericFacet extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
@@ -26,7 +26,7 @@ export default class QuanticPager extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -7,7 +7,7 @@ export default class QuanticResultLink extends LightningElement {
   /** @type {string} */
   @api engineId;
 
-  /** @type {import("coveo").Engine} */
+  /** @type {import("coveo").SearchEngine} */
   engine;
 
   connectedCallback() {
@@ -19,7 +19,7 @@ export default class QuanticResultLink extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {
@@ -34,7 +34,7 @@ export default class QuanticResultLink extends LightningElement {
   /**
    * Binds the logging of document
    * @returns An unbind function for the events
-   * @param {import("coveo").Engine} engine An instance of an Headless Engine
+   * @param {import("coveo").SearchEngine} engine An instance of an Headless Engine
    * @param {import("coveo").Result} result The result object
    * @param {import("lwc").ShadowRootTheGoodPart} resultElement Parent result element
    * @param {string} selector Optional. Css selector that selects all links to the document. Default: "a" tags with the clickUri as "href" parameter.

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -23,7 +23,7 @@ export default class QuanticResultList extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
@@ -23,7 +23,7 @@ export default class QuanticResultsPerPage extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
@@ -46,7 +46,7 @@ export default class QuanticSearchBox extends LightningElement {
   getSuggestionElements = () => this.template.querySelectorAll('.slds-listbox__option');
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
@@ -21,7 +21,7 @@ export default class QuanticSort extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
@@ -21,7 +21,7 @@ export default class QuanticSummary extends LightningElement {
   }
 
   /**
-   * @param {import("coveo").Engine} engine
+   * @param {import("coveo").SearchEngine} engine
    */
   @api
   initialize(engine) {

--- a/packages/quantic/force-app/main/default/lwc/testUtils/coveoHeadlessStub.js
+++ b/packages/quantic/force-app/main/default/lwc/testUtils/coveoHeadlessStub.js
@@ -1,6 +1,6 @@
 function buildSearchEngine() {
   return {
-    executeFirstSearch() {}
+    executeFirstSearch: jest.fn(() => {})
   }
 }
 

--- a/packages/quantic/force-app/main/default/lwc/testUtils/coveoHeadlessStub.js
+++ b/packages/quantic/force-app/main/default/lwc/testUtils/coveoHeadlessStub.js
@@ -1,15 +1,7 @@
-export class MockEngine {
-  static getSampleConfiguration() {
-    return {}
+function buildSearchEngine() {
+  return {
+    executeFirstSearch() {}
   }
 }
 
-export const CoveoHeadlessStub = {
-  HeadlessEngine: MockEngine,
-  SearchActions: {
-    executeSearch: () => {}
-  },
-  AnalyticsActions: {
-    logInterfaceLoad: () => {}
-  }
-}
+export const CoveoHeadlessStub = {buildSearchEngine}


### PR DESCRIPTION
The `HeadlessEngine` class is deprecated, in favor of engines dedicated to each use-case. This PR refactors to use `buildSearchEngine`.

https://coveord.atlassian.net/browse/KIT-726