### PR TITLE
test(atomic): first cypress tests for facet v1

### DIFF
--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -62,7 +62,7 @@ export class TestFixture {
     });
 
     if (this.execFirstSearch) {
-      cy.wait(`@${this.interceptAliases.Search}`);
+      cy.wait(TestFixture.interceptAliases.Search);
     }
 
     this.aliases.forEach((alias) => alias(this));
@@ -70,11 +70,11 @@ export class TestFixture {
     return this;
   }
 
-  public get interceptAliases() {
+  public static get interceptAliases() {
     return {
-      UA: 'coveoAnalytics',
-      QuerySuggestions: 'coveoQuerySuggest',
-      Search: 'coveoSearch',
+      UA: '@coveoAnalytics',
+      QuerySuggestions: '@coveoQuerySuggest',
+      Search: '@coveoSearch',
     };
   }
 
@@ -88,17 +88,17 @@ export class TestFixture {
     cy.intercept({
       method: 'POST',
       path: '**/rest/ua/v15/analytics/*',
-    }).as(this.interceptAliases.UA);
+    }).as(TestFixture.interceptAliases.UA.substring(1));
 
     cy.intercept({
       method: 'POST',
       path: '**/rest/search/v2/querySuggest?*',
-    }).as(this.interceptAliases.QuerySuggestions);
+    }).as(TestFixture.interceptAliases.QuerySuggestions.substring(1));
 
     cy.intercept({
       method: 'POST',
       url: '**/rest/search/v2?*',
-    }).as(this.interceptAliases.Search);
+    }).as(TestFixture.interceptAliases.Search.substring(1));
   }
 }
 

--- a/packages/atomic/cypress/integration/facets-v1/facet/facet-actions.ts
+++ b/packages/atomic/cypress/integration/facets-v1/facet/facet-actions.ts
@@ -1,0 +1,13 @@
+import {TestFixture, addTag, TagProps} from '../../../fixtures/test-fixture';
+import {FacetSelectors} from './facet-selectors';
+
+export const defaultNumberOfValues = 8;
+export const label = 'The Authors';
+export const field = 'author';
+
+export const addFacet = (props: TagProps = {}) => (env: TestFixture) =>
+  addTag(env, 'atomic-facet-v1', props);
+
+export function selectIdleCheckboxValueAt(index: number) {
+  FacetSelectors.idleCheckboxValue().eq(index).click();
+}

--- a/packages/atomic/cypress/integration/facets-v1/facet/facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets-v1/facet/facet-assertions.ts
@@ -1,0 +1,155 @@
+import {TestFixture} from '../../../fixtures/test-fixture';
+import {doSortAlphanumeric} from '../../../utils/componentUtils';
+import {ComponentErrorSelectors} from '../../component-error-selectors';
+import {facetComponent, FacetSelectors} from './facet-selectors';
+
+function should(should: boolean) {
+  return should ? 'should' : 'should not';
+}
+
+export function assertAccessibility() {
+  it('should pass accessibility tests', () => {
+    cy.checkA11y(facetComponent);
+  });
+}
+
+export function assertContainsComponentError(display: boolean) {
+  it(`${should(display)} display an error component`, () => {
+    FacetSelectors.shadow()
+      .find(ComponentErrorSelectors.component)
+      .should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertDisplayFacet(display: boolean) {
+  it(`${should(display)} display the facet`, () => {
+    FacetSelectors.wrapper().should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertDisplayPlaceholder(display: boolean) {
+  it(`${should(display)} display the placeholder`, () => {
+    FacetSelectors.placeholder().should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertNumberOfSelectedCheckboxValues(value: number) {
+  it(`should display ${value} number of selected checkbox values`, () => {
+    if (value > 0) {
+      FacetSelectors.selectedCheckboxValue().its('length').should('eq', value);
+      return;
+    }
+
+    FacetSelectors.selectedCheckboxValue().should('not.exist');
+  });
+}
+
+export function assertNumberOfIdleCheckboxValues(value: number) {
+  it(`should display ${value} number of idle checkbox values`, () => {
+    if (value > 0) {
+      FacetSelectors.idleCheckboxValue().its('length').should('eq', value);
+      return;
+    }
+
+    FacetSelectors.idleCheckboxValue().should('not.exist');
+  });
+}
+
+export function assertDisplayShowMoreButton(display: boolean) {
+  it(`${should(display)} display a "Show more" button`, () => {
+    FacetSelectors.showMoreButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayShowLessButton(display: boolean) {
+  it(`${should(display)} display a "Show less" button`, () => {
+    FacetSelectors.showLessButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayClearButton(display: boolean) {
+  it(`${should(display)} display a "Clear filter" button`, () => {
+    FacetSelectors.clearButton().should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertLabelContains(label: string) {
+  it(`should have the label ${label}`, () => {
+    FacetSelectors.labelButton().contains(label);
+  });
+}
+
+export function assertDisplaySearchInput(display: boolean) {
+  it(`${should(display)} display a the facet search input`, () => {
+    FacetSelectors.searchInput().should(display ? 'be.visible' : 'not.exist');
+  });
+}
+
+export function assertLogFacetSelect(field: string, index: number) {
+  it('should log the facet select results to UA ', () => {
+    cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'facetSelect');
+      expect(analyticsBody.customData).to.have.property('facetField', field);
+      expect(analyticsBody.facetState[0]).to.have.property('state', 'selected');
+      expect(analyticsBody.facetState[0]).to.have.property('field', field);
+
+      FacetSelectors.facetValueLabelAtIndex(index)
+        .invoke('text')
+        .then((txt: string) => {
+          expect(analyticsBody.customData).to.have.property('facetValue', txt);
+        });
+    });
+  });
+}
+
+export function assertLogClearFacetValues(field: string) {
+  it('should log the facet clear all to UA', () => {
+    cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'facetClearAll');
+      expect(analyticsBody.customData).to.have.property('facetField', field);
+    });
+  });
+}
+
+export function assertValuesSortedAlphanumerically() {
+  it('values should be ordered alphanumerically', () => {
+    FacetSelectors.valueLabel().as('facetAllValuesLabel');
+    cy.getTextOfAllElements('@facetAllValuesLabel').then((originalValues) => {
+      expect(originalValues).to.eql(doSortAlphanumeric(originalValues));
+    });
+  });
+}
+
+export function assertLogFacetShowMore(field: string) {
+  it('should log the facet show more results to UA', () => {
+    cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('eventType', 'facet');
+      expect(analyticsBody).to.have.property(
+        'eventValue',
+        'showMoreFacetResults'
+      );
+      expect(analyticsBody.customData).to.have.property('facetField', field);
+    });
+  });
+}
+
+export function assertLogFacetShowLess(field: string) {
+  it('should log the facet show less results to UA', () => {
+    cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
+      const analyticsBody = intercept.request.body;
+      expect(analyticsBody).to.have.property('eventType', 'facet');
+      expect(analyticsBody).to.have.property(
+        'eventValue',
+        'showLessFacetResults'
+      );
+      expect(analyticsBody.customData).to.have.property('facetField', field);
+    });
+  });
+}

--- a/packages/atomic/cypress/integration/facets-v1/facet/facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets-v1/facet/facet-selectors.ts
@@ -1,0 +1,23 @@
+export const facetComponent = 'atomic-facet-v1';
+export const FacetSelectors = {
+  shadow: () => cy.get(facetComponent).shadow(),
+  wrapper: () => FacetSelectors.shadow().find('[part="facet"]'),
+  placeholder: () => FacetSelectors.shadow().find('[part="placeholder"]'),
+  selectedCheckboxValue: () =>
+    FacetSelectors.shadow().find(
+      '[part="value-checkbox"][aria-checked="true"]'
+    ),
+  idleCheckboxValue: () =>
+    FacetSelectors.shadow().find(
+      '[part="value-checkbox"][aria-checked="false"]'
+    ),
+  showMoreButton: () => FacetSelectors.shadow().find('[part="show-more"]'),
+  showLessButton: () => FacetSelectors.shadow().find('[part="show-less"]'),
+  clearButton: () => FacetSelectors.shadow().find('[part="clear-button"]'),
+  labelButton: () => FacetSelectors.shadow().find('[part="label-button"]'),
+  searchInput: () => FacetSelectors.shadow().find('[part="search-input"]'),
+  valueLabel: () => FacetSelectors.shadow().find('[part="value-label"]'),
+  valueCount: () => FacetSelectors.shadow().find('[part="value-count"]'),
+  facetValueLabelAtIndex: (index: number) =>
+    FacetSelectors.valueLabel().eq(index),
+};

--- a/packages/atomic/cypress/integration/facets-v1/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets-v1/facet/facet.cypress.ts
@@ -92,7 +92,7 @@ describe('Facet v1 Test Suites', () => {
           describe('verify rendering', () => {
             before(setupClearCheckboxValues);
 
-            FacetAssertions.assertDisplayClearButton(true);
+            FacetAssertions.assertDisplayClearButton(false);
             FacetAssertions.assertNumberOfSelectedCheckboxValues(0);
             FacetAssertions.assertNumberOfIdleCheckboxValues(
               defaultNumberOfValues

--- a/packages/atomic/cypress/integration/facets-v1/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets-v1/facet/facet.cypress.ts
@@ -1,0 +1,182 @@
+import {TestFixture} from '../../../fixtures/test-fixture';
+import {FacetSelectors} from './facet-selectors';
+import {
+  addFacet,
+  field,
+  label,
+  defaultNumberOfValues,
+  selectIdleCheckboxValueAt,
+} from './facet-actions';
+import * as FacetAssertions from './facet-assertions';
+
+describe('Facet v1 Test Suites', () => {
+  describe('with checkbox values', () => {
+    function setupWithCheckboxValues() {
+      new TestFixture().with(addFacet({field, label})).init();
+      cy.wait(TestFixture.interceptAliases.UA);
+    }
+
+    describe('verify rendering', () => {
+      before(setupWithCheckboxValues);
+
+      FacetAssertions.assertAccessibility();
+      FacetAssertions.assertContainsComponentError(false);
+      FacetAssertions.assertDisplayFacet(true);
+      FacetAssertions.assertDisplayPlaceholder(false);
+      FacetAssertions.assertNumberOfSelectedCheckboxValues(0);
+      FacetAssertions.assertNumberOfIdleCheckboxValues(defaultNumberOfValues);
+      FacetAssertions.assertDisplayShowMoreButton(true);
+      FacetAssertions.assertDisplayShowLessButton(false);
+      FacetAssertions.assertLabelContains(label);
+      FacetAssertions.assertDisplayClearButton(false);
+      FacetAssertions.assertDisplaySearchInput(true);
+    });
+
+    describe('when selecting a value', () => {
+      const selectionIndex = 2;
+      function setupSelectCheckboxValue() {
+        setupWithCheckboxValues();
+        selectIdleCheckboxValueAt(selectionIndex);
+        cy.wait(TestFixture.interceptAliases.Search);
+      }
+
+      describe('verify rendering', () => {
+        before(setupSelectCheckboxValue);
+
+        FacetAssertions.assertAccessibility();
+        FacetAssertions.assertDisplayClearButton(true);
+        FacetAssertions.assertNumberOfSelectedCheckboxValues(1);
+        FacetAssertions.assertNumberOfIdleCheckboxValues(
+          defaultNumberOfValues - 1
+        );
+      });
+
+      describe('verify analytics', () => {
+        before(setupSelectCheckboxValue);
+        FacetAssertions.assertLogFacetSelect(field, selectionIndex);
+      });
+
+      describe('when selecting a second value', () => {
+        const secondSelectionIndex = 0;
+        function setupSelectSecondCheckboxValue() {
+          setupSelectCheckboxValue();
+          cy.wait(TestFixture.interceptAliases.UA);
+          selectIdleCheckboxValueAt(secondSelectionIndex);
+          cy.wait(TestFixture.interceptAliases.Search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupSelectSecondCheckboxValue);
+
+          FacetAssertions.assertDisplayClearButton(true);
+          FacetAssertions.assertNumberOfSelectedCheckboxValues(2);
+          FacetAssertions.assertNumberOfIdleCheckboxValues(
+            defaultNumberOfValues - 2
+          );
+        });
+
+        describe('verify analytics', () => {
+          before(setupSelectSecondCheckboxValue);
+
+          FacetAssertions.assertLogFacetSelect(field, secondSelectionIndex);
+        });
+
+        describe('when selecting the "Clear" button', () => {
+          function setupClearCheckboxValues() {
+            setupSelectSecondCheckboxValue();
+            cy.wait(TestFixture.interceptAliases.UA);
+            FacetSelectors.clearButton().click();
+            cy.wait(TestFixture.interceptAliases.Search);
+          }
+
+          describe('verify rendering', () => {
+            before(setupClearCheckboxValues);
+
+            FacetAssertions.assertDisplayClearButton(true);
+            FacetAssertions.assertNumberOfSelectedCheckboxValues(0);
+            FacetAssertions.assertNumberOfIdleCheckboxValues(
+              defaultNumberOfValues
+            );
+          });
+          describe('verify analytics', () => {
+            before(setupClearCheckboxValues);
+
+            FacetAssertions.assertLogClearFacetValues(field);
+          });
+        });
+      });
+    });
+
+    describe('when selecting the "Show more" button', () => {
+      function setupSelectShowMore() {
+        setupWithCheckboxValues();
+        FacetSelectors.showMoreButton().click();
+        cy.wait(TestFixture.interceptAliases.Search);
+      }
+
+      describe('verify rendering', () => {
+        before(setupSelectShowMore);
+
+        FacetAssertions.assertDisplayShowMoreButton(true);
+        FacetAssertions.assertDisplayShowLessButton(true);
+        FacetAssertions.assertValuesSortedAlphanumerically();
+        FacetAssertions.assertNumberOfIdleCheckboxValues(
+          defaultNumberOfValues * 2
+        );
+      });
+
+      describe('verify analytics', () => {
+        before(setupSelectShowMore);
+
+        FacetAssertions.assertLogFacetShowMore(field);
+      });
+
+      describe('when selecting the "Show less" button', () => {
+        function setupSelectShowLess() {
+          setupSelectShowMore();
+          cy.wait(TestFixture.interceptAliases.UA);
+          FacetSelectors.showLessButton().click();
+          cy.wait(TestFixture.interceptAliases.Search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupSelectShowLess);
+
+          FacetAssertions.assertDisplayShowMoreButton(true);
+          FacetAssertions.assertDisplayShowLessButton(false);
+          FacetAssertions.assertNumberOfIdleCheckboxValues(
+            defaultNumberOfValues
+          );
+        });
+
+        describe('verify analytics', () => {
+          before(setupSelectShowLess);
+
+          FacetAssertions.assertLogFacetShowLess(field);
+        });
+      });
+    });
+  });
+
+  describe.skip('with link values', () => {});
+
+  describe.skip('with box values', () => {});
+
+  describe.skip('when being collapsed', () => {});
+
+  describe.skip('with custom #numberOfValues', () => {});
+
+  describe.skip('with custom #sortCriteria, alphanumeric', () => {});
+
+  describe.skip('with custom #sortCriteria, occurrences', () => {});
+
+  describe.skip('with #withSearch to false', () => {});
+
+  describe.skip('when no search has yet been executed', () => {});
+
+  describe.skip('with an invalid option', () => {});
+
+  describe.skip('when field returns no results', () => {});
+
+  describe.skip('with a selected path in the URL', () => {});
+});

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -37,6 +37,7 @@ import {BaseFacet} from '../facet-common';
  * An `atomic-facet` displays a facet of the results for the current query. In mobile browsers, this is rendered as a button that opens a facet modal.
  *
  * @part facet - The wrapper for the entire facet.
+ * @part placeholder - The placeholder shown before the first search is executed.
  *
  * @part label-button - The button that displays the label and allows to expand/collapse the facet.
  * @part label-button-icon - The label button icon.

--- a/packages/atomic/src/themes/default.css
+++ b/packages/atomic/src/themes/default.css
@@ -8,7 +8,7 @@
 
   /* Secondary colors */
   --atomic-secondary: #1565c0;
-  --atomic-secondary-light: #5e92f3;
+  --atomic-secondary-light: #286ef0;
   --atomic-secondary-dark: #003c8f;
   --atomic-on-secondary: #ffffff;
 


### PR DESCRIPTION
Heavily inspired and copied from the "legacy" facets tests, like the components, they will be removed for Atomic v1.
That's the first of a few PR covering tests, you can still see empty describe blocks
https://coveord.atlassian.net/browse/KIT-725