### PR TITLE
ci: added version to deployment package name

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -49,7 +49,7 @@
       "id": "deploy-headless-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/headless/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/headless/v$[VERSION]",
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
@@ -63,7 +63,7 @@
       "id": "deploy-atomic-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/atomic/v$[VERSION]",
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,8 @@ node('linux && docker') {
 
       stage('Deployment pipeline upload') {
         lerna = readJSON file: 'lerna.json'
-        prereleaseVersion = lerna.version
-        version = prereleaseVersion.split('-alpha')[0]
-        sh "deployment-package package create --with-deploy --resolve COMMIT_HASH=${commitHash} --resolve VERSION=${version} --resolve PRERELEASE=${prereleaseVersion}  || true"
+        version = lerna.version
+        sh "deployment-package package create --with-deploy --version ${version} --resolve COMMIT_HASH=${commitHash} --resolve VERSION=${version}  || true"
       }
     }
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-714

~~Also removed the now unnecessary `PRERELEASE` variable.~~