### PR TITLE
ci: update ci to only upload major and minor versions

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -46,30 +46,58 @@
       }
     },
     {
-      "id": "deploy-headless-to-s3-version",
+      "id": "deploy-headless-minor-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/headless/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/headless/v$[MINOR]",
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
         },
         "prd": {
-          "directory": "proda/StaticCDN/headless/v$[VERSION]"
+          "directory": "proda/StaticCDN/headless/v$[MINOR]"
         }
       }
     },
     {
-      "id": "deploy-atomic-to-s3-version",
+      "id": "deploy-headless-major-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[PRERELEASE]",
+        "directory": "proda/StaticCDN/headless/v$[MAJOR]",
+        "source": "packages/headless/dist/browser",
+        "parameters": {
+          "acl": "public-read"
+        },
+        "prd": {
+          "directory": "proda/StaticCDN/headless/v$[MAJOR]"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-minor-to-s3-version",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[MINOR]",
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
         },
         "prd": {
-          "directory": "proda/StaticCDN/atomic/v$[VERSION]"
+          "directory": "proda/StaticCDN/atomic/v$[MINOR]"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-major-to-s3-version",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[MAJOR]",
+        "source": "packages/atomic/dist/atomic",
+        "parameters": {
+          "acl": "public-read"
+        },
+        "prd": {
+          "directory": "proda/StaticCDN/atomic/v$[MAJOR]"
         }
       }
     },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,9 @@ node('linux && docker') {
 
       stage('Deployment pipeline upload') {
         lerna = readJSON file: 'lerna.json'
-        prereleaseVersion = lerna.version
-        version = prereleaseVersion.split('-alpha')[0]
-        sh "deployment-package package create --with-deploy --resolve COMMIT_HASH=${commitHash} --resolve VERSION=${version} --resolve PRERELEASE=${prereleaseVersion}  || true"
+        version = lerna.version
+        (minor, major) = (version =~ /^([^\.]*)\.[^\.]*/)[0]
+        sh "deployment-package package create --with-deploy --resolve COMMIT_HASH=${commitHash} --resolve MINORVERSION=${minor} --resolve MAJORVERSION=${major} || true"
       }
     }
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-724

With this PR, the CDN would no longer contain every patch version, it would only contain major and minor versions.

E.g.:
https://staticdev.cloud.coveo.com/atomic/latest/atomic.esm.js
https://staticdev.cloud.coveo.com/atomic/v0/atomic.esm.js
https://staticdev.cloud.coveo.com/atomic/v0.23/atomic.esm.js
https://staticdev.cloud.coveo.com/atomic/v0.22/atomic.esm.js
https://staticdev.cloud.coveo.com/atomic/v0.21/atomic.esm.js

Yay or nay?