### PR TITLE
fix(atomic): unsubscribe controllers after delay, if element is still removed from the DOM

### DIFF
--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -71,7 +71,7 @@ export class AtomicFacet
   public facet!: Facet;
   public searchStatus!: SearchStatus;
 
-  @BindStateToController('facet', {subscribeOnConnectedCallback: true})
+  @BindStateToController('facet')
   @State()
   public facetState!: FacetState;
   @BindStateToController('searchStatus')

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -77,7 +77,7 @@ export class AtomicCategoryFacet
   public facet!: CategoryFacet;
   public searchStatus!: SearchStatus;
 
-  @BindStateToController('facet', {subscribeOnConnectedCallback: true})
+  @BindStateToController('facet')
   @State()
   public facetState!: CategoryFacetState;
   @BindStateToController('searchStatus')

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -54,7 +54,7 @@ export class AtomicDateFacet implements InitializableComponent, BaseFacetState {
   private facet!: DateFacet;
   public searchStatus!: SearchStatus;
 
-  @BindStateToController('facet', {subscribeOnConnectedCallback: true})
+  @BindStateToController('facet')
   @State()
   private facetState!: DateFacetState;
   @State() public error!: Error;

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -69,7 +69,7 @@ export class AtomicFacet
   public searchStatus!: SearchStatus;
   private facetSearch?: FacetSearch;
 
-  @BindStateToController('facet', {subscribeOnConnectedCallback: true})
+  @BindStateToController('facet')
   @State()
   public facetState!: FacetState;
   @BindStateToController('searchStatus')

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -55,7 +55,7 @@ export class AtomicNumericFacet
   private facet!: NumericFacet;
   public searchStatus!: SearchStatus;
 
-  @BindStateToController('facet', {subscribeOnConnectedCallback: true})
+  @BindStateToController('facet')
   @State()
   private facetState!: NumericFacetState;
   @BindStateToController('searchStatus')

--- a/packages/atomic/src/utils/initialization-utils.spec.ts
+++ b/packages/atomic/src/utils/initialization-utils.spec.ts
@@ -192,18 +192,5 @@ describe('BindStateToController decorator', () => {
 
       expect(controller.subscribe).toHaveBeenCalledTimes(1);
     });
-
-    it(`when "subscribeOnConnectedCallback" is true
-    should resubscribe to the controller`, () => {
-      spyOn(controller, 'subscribe');
-      BindStateToController('controller', {subscribeOnConnectedCallback: true})(
-        component,
-        'controllerState'
-      );
-      component.initialize!();
-      component.connectedCallback!();
-
-      expect(controller.subscribe).toHaveBeenCalledTimes(2);
-    });
   });
 });

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -209,12 +209,8 @@ export function BindStateToController(
       });
     };
 
-    const disconnectUnsubscribeDelay = 100;
     component.disconnectedCallback = function () {
-      setTimeout(() => {
-        const isStillInDOM = document.contains(getElement(this));
-        !isStillInDOM && unsubscribeController();
-      }, disconnectUnsubscribeDelay);
+      !getElement(this).isConnected && unsubscribeController();
       disconnectedCallback && disconnectedCallback.call(this);
     };
   };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-732

😩    That one was a bit of a pain to find.

Basically an intermittent race condition problem:
- The facet manager reorders facets from the DOM
- That causes them to disconnect & reconnect from the DOM from a web component's perspective
- I previously implemented an `unsubscribe` on `disconnectedCallback` and a  _re_`subscribe` on `connectedCallback`
- Sometimes it did not appear to resubscribe correctly and the facet remained frozen as it was not getting Headless updates anymore
- What I've done instead is remove that implementation and on `disconnectedCallback` I added a delay that checks if the component still exists and only unsubcribes then, moving components in the DOM won't cause any issues.