### PR TITLE
fix(headless): send originLevel3 to searchapi using referrer parameter

### DIFF
--- a/packages/headless/src/api/search/recommendation/recommendation-request.ts
+++ b/packages/headless/src/api/search/recommendation/recommendation-request.ts
@@ -6,7 +6,9 @@ import {
   FieldsToIncludeParam,
   PipelineParam,
   RecommendationParam,
+  ReferrerParam,
   SearchHubParam,
+  TabParam,
 } from '../search-api-params';
 
 export type RecommendationRequest = BaseParam &
@@ -17,4 +19,6 @@ export type RecommendationRequest = BaseParam &
   FieldsToIncludeParam &
   AdvancedQueryParam &
   ConstantQueryParam &
-  ActionsHistoryParam;
+  ActionsHistoryParam &
+  TabParam &
+  ReferrerParam;

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -35,6 +35,7 @@ import {buildMockSearchAPIClient} from '../../test/mock-search-api-client';
 import {NoopPreprocessRequest} from '../preprocess-request';
 import {Response} from 'cross-fetch';
 import {buildResultPreviewRequest} from '../../features/result-preview/result-preview-request-builder';
+import {buildMockAnalyticsConfiguration} from '../../test/mock-analytics-configuration';
 
 jest.mock('../platform-client');
 describe('search api client', () => {
@@ -376,7 +377,16 @@ describe('search api client', () => {
 
       it(`when calling SearchAPIClient.recommendations
       should call PlatformClient.call with the right options`, () => {
+        const originLevel2 = 'tab';
+        const originLevel3 = 'referrer';
+        const analytics = buildMockAnalyticsConfiguration({
+          originLevel2,
+          originLevel3,
+        });
+
         const recommendationState = createMockRecommendationState();
+        recommendationState.configuration.analytics = analytics;
+
         const req = buildRecommendationRequest(recommendationState);
 
         searchAPIClient.recommendations(req);
@@ -399,6 +409,8 @@ describe('search api client', () => {
             pipeline: recommendationState.pipeline,
             searchHub: recommendationState.searchHub,
             actionsHistory: expect.any(Array),
+            tab: originLevel2,
+            referrer: originLevel3,
           },
           preprocessRequest: NoopPreprocessRequest,
           deprecatedPreprocessRequest: NoopPreprocessRequestMiddleware,

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -56,6 +56,10 @@ export interface TabParam {
   tab: string;
 }
 
+export interface ReferrerParam {
+  referrer: string;
+}
+
 export interface RecommendationParam {
   recommendation: string;
 }

--- a/packages/headless/src/api/search/search/search-request.test.ts
+++ b/packages/headless/src/api/search/search/search-request.test.ts
@@ -143,4 +143,10 @@ describe('search request', () => {
     state.configuration.analytics.originLevel2 = originLevel2;
     expect(buildSearchRequest(state).tab).toBe(originLevel2);
   });
+
+  it('#searchRequest.referrer holds the #originLevel3', () => {
+    const originLevel3 = 'www.coveo.com';
+    state.configuration.analytics.originLevel3 = originLevel3;
+    expect(buildSearchRequest(state).referrer).toBe(originLevel3);
+  });
 });

--- a/packages/headless/src/api/search/search/search-request.ts
+++ b/packages/headless/src/api/search/search/search-request.ts
@@ -18,6 +18,7 @@ import {
   FirstResultParam,
   PipelineParam,
   QueryParam,
+  ReferrerParam,
   SearchHubParam,
   SortCriteriaParam,
   TabParam,
@@ -42,4 +43,5 @@ export type SearchRequest = BaseParam &
   DebugParam &
   LocaleParam &
   FoldingParam &
-  TabParam;
+  TabParam &
+  ReferrerParam;

--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -77,6 +77,7 @@ export const loadCollection = createAsyncThunk<
 
     const response = await searchAPIClient.search({
       tab: '',
+      referrer: '',
       accessToken,
       organizationId,
       url: apiBaseUrl,

--- a/packages/headless/src/features/recommendation/recommendation-actions.ts
+++ b/packages/headless/src/features/recommendation/recommendation-actions.ts
@@ -94,6 +94,8 @@ export const buildRecommendationRequest = (
   organizationId: s.configuration.organizationId,
   url: s.configuration.search.apiBaseUrl,
   recommendation: s.recommendation.id,
+  tab: s.configuration.analytics.originLevel2,
+  referrer: s.configuration.analytics.originLevel3,
   actionsHistory: s.configuration.analytics.enabled
     ? historyStore.getHistory()
     : [],

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -277,6 +277,7 @@ export const buildSearchRequest = (
     locale: state.configuration.search.locale,
     debug: state.debug,
     tab: state.configuration.analytics.originLevel2,
+    referrer: state.configuration.analytics.originLevel3,
     ...(state.configuration.analytics.enabled && {
       visitorId: getVisitorID(),
     }),


### PR DESCRIPTION
I made the change for both the search and recommendation requests. I also sent the originLevel2 (tab) in the recommendation request.
