### PR TITLE
feat(atomic): add "state" classes on facet for display management

### DIFF
--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
@@ -1,4 +1,5 @@
 @import '../../../global/global.pcss';
+@import '../facet-common.pcss';
 @import '../facet-search/facet-search.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
 @import '../facet-value-link/facet-value-link.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State, Prop, VNode} from '@stencil/core';
+import {Component, h, State, Prop, VNode, Host} from '@stencil/core';
 import {
   Facet,
   buildFacet,
@@ -310,19 +310,21 @@ export class AtomicFacet
     }
 
     if (!this.facetState.values.length) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <FacetContainer>
-        {this.renderHeader()}
-        {!this.isCollapsed && [
-          this.renderSearchInput(),
-          shouldDisplaySearchResults(this.facetState.facetSearch)
-            ? [this.renderSearchResults(), this.renderMatches()]
-            : [this.renderValues(), this.renderShowMoreLess()],
-        ]}
-      </FacetContainer>
+      <Host class="with-values">
+        <FacetContainer>
+          {this.renderHeader()}
+          {!this.isCollapsed && [
+            this.renderSearchInput(),
+            shouldDisplaySearchResults(this.facetState.facetSearch)
+              ? [this.renderSearchResults(), this.renderMatches()]
+              : [this.renderValues(), this.renderShowMoreLess()],
+          ]}
+        </FacetContainer>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -310,11 +310,11 @@ export class AtomicFacet
     }
 
     if (!this.facetState.values.length) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <FacetContainer>
           {this.renderHeader()}
           {!this.isCollapsed && [

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.pcss
@@ -1,3 +1,4 @@
 @import '../../../global/global.pcss';
+@import '../facet-common.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
 @import '../facet-value-link/facet-value-link.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -275,11 +275,11 @@ export class AtomicNumericFacet
     }
 
     if (!this.valuesToRender.length) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <FacetContainer>
           {this.renderHeader()}
           {!this.isCollapsed && this.renderValues()}

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -1,4 +1,13 @@
-import {Component, h, State, Prop, VNode, Element, Listen} from '@stencil/core';
+import {
+  Component,
+  h,
+  State,
+  Prop,
+  VNode,
+  Element,
+  Listen,
+  Host,
+} from '@stencil/core';
 import {
   NumericFacet,
   buildNumericFacet,
@@ -266,14 +275,16 @@ export class AtomicNumericFacet
     }
 
     if (!this.valuesToRender.length) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <FacetContainer>
-        {this.renderHeader()}
-        {!this.isCollapsed && this.renderValues()}
-      </FacetContainer>
+      <Host class="with-values">
+        <FacetContainer>
+          {this.renderHeader()}
+          {!this.isCollapsed && this.renderValues()}
+        </FacetContainer>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets-v1/facet-common.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-common.pcss
@@ -1,3 +1,3 @@
-:host(.without-values) {
+:host(.atomic-without-values) {
   display: none;
 }

--- a/packages/atomic/src/components/facets-v1/facet-common.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-common.pcss
@@ -1,0 +1,3 @@
+:host(.without-values) {
+  display: none;
+}

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -372,11 +372,11 @@ export class AtomicCategoryFacet
       this.facetState.values.length === 0 &&
       this.facetState.parents.length === 0
     ) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <BaseFacet
           controller={new BaseFacetController(this)}
           label={this.strings[this.label]()}

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -1,4 +1,4 @@
-import {Component, h, Prop, State} from '@stencil/core';
+import {Component, h, Prop, State, Host} from '@stencil/core';
 import {
   CategoryFacetState,
   CategoryFacet,
@@ -372,28 +372,30 @@ export class AtomicCategoryFacet
       this.facetState.values.length === 0 &&
       this.facetState.parents.length === 0
     ) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <BaseFacet
-        controller={new BaseFacetController(this)}
-        label={this.strings[this.label]()}
-        hasActiveValues={this.facetState.hasActiveValues}
-      >
-        {this.facetSearch?.render()}
-        <div class="mt-1 text-lg lg:text-base">
-          {this.allCategoriesButton}
-          <div>{this.parents}</div>
-          <div class={this.parents.length ? 'pl-9' : 'pl-0'}>
-            <ul>{this.children}</ul>
-            <div class="flex flex-col items-start space-y-1">
-              {this.showLessButton}
-              {this.showMoreButton}
+      <Host class="with-values">
+        <BaseFacet
+          controller={new BaseFacetController(this)}
+          label={this.strings[this.label]()}
+          hasActiveValues={this.facetState.hasActiveValues}
+        >
+          {this.facetSearch?.render()}
+          <div class="mt-1 text-lg lg:text-base">
+            {this.allCategoriesButton}
+            <div>{this.parents}</div>
+            <div class={this.parents.length ? 'pl-9' : 'pl-0'}>
+              <ul>{this.children}</ul>
+              <div class="flex flex-col items-start space-y-1">
+                {this.showLessButton}
+                {this.showMoreButton}
+              </div>
             </div>
           </div>
-        </div>
-      </BaseFacet>
+        </BaseFacet>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -179,11 +179,11 @@ export class AtomicDateFacet implements InitializableComponent, BaseFacetState {
     }
 
     if (!this.facetState.hasActiveValues && this.totalNumberOfResults === 0) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <BaseFacet
           controller={new BaseFacetController(this)}
           label={this.strings[this.label]()}

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -1,4 +1,4 @@
-import {Component, Prop, State, h, Element} from '@stencil/core';
+import {Component, Prop, State, h, Element, Host} from '@stencil/core';
 import dayjs from 'dayjs';
 import {
   DateFacet,
@@ -179,18 +179,20 @@ export class AtomicDateFacet implements InitializableComponent, BaseFacetState {
     }
 
     if (!this.facetState.hasActiveValues && this.totalNumberOfResults === 0) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <BaseFacet
-        controller={new BaseFacetController(this)}
-        label={this.strings[this.label]()}
-        hasActiveValues={this.facetState.hasActiveValues}
-        clearAll={() => this.facet.deselectAll()}
-      >
-        <ul>{this.values}</ul>
-      </BaseFacet>
+      <Host class="with-values">
+        <BaseFacet
+          controller={new BaseFacetController(this)}
+          label={this.strings[this.label]()}
+          hasActiveValues={this.facetState.hasActiveValues}
+          clearAll={() => this.facet.deselectAll()}
+        >
+          <ul>{this.values}</ul>
+        </BaseFacet>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -240,11 +240,11 @@ export class AtomicFacet
     }
 
     if (this.facetState.values.length === 0) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <BaseFacet
           controller={new BaseFacetController(this)}
           label={this.strings[this.label]()}

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State, Prop} from '@stencil/core';
+import {Component, h, State, Prop, Host} from '@stencil/core';
 import {
   Facet,
   buildFacet,
@@ -240,25 +240,27 @@ export class AtomicFacet
     }
 
     if (this.facetState.values.length === 0) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <BaseFacet
-        controller={new BaseFacetController(this)}
-        label={this.strings[this.label]()}
-        hasActiveValues={this.facetState.hasActiveValues}
-        clearAll={() => this.facet.deselectAll()}
-      >
-        {this.facetState.canShowMoreValues && this.facetSearch?.render()}
-        <div class="mt-1">
-          <ul>{this.values}</ul>
-          <div class="flex flex-col items-start space-y-1">
-            {this.showLessButton}
-            {this.showMoreButton}
+      <Host class="with-values">
+        <BaseFacet
+          controller={new BaseFacetController(this)}
+          label={this.strings[this.label]()}
+          hasActiveValues={this.facetState.hasActiveValues}
+          clearAll={() => this.facet.deselectAll()}
+        >
+          {this.facetState.canShowMoreValues && this.facetSearch?.render()}
+          <div class="mt-1">
+            <ul>{this.values}</ul>
+            <div class="flex flex-col items-start space-y-1">
+              {this.showLessButton}
+              {this.showMoreButton}
+            </div>
           </div>
-        </div>
-      </BaseFacet>
+        </BaseFacet>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -182,11 +182,11 @@ export class AtomicNumericFacet
     }
 
     if (!this.facetState.hasActiveValues && this.totalNumberOfResults === 0) {
-      return <Host class="without-values"></Host>;
+      return <Host class="atomic-without-values"></Host>;
     }
 
     return (
-      <Host class="with-values">
+      <Host class="atomic-with-values">
         <BaseFacet
           controller={new BaseFacetController(this)}
           label={this.strings[this.label]()}

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -1,4 +1,4 @@
-import {Component, Element, h, Prop, State} from '@stencil/core';
+import {Component, Element, h, Prop, State, Host} from '@stencil/core';
 import {
   NumericFacet,
   buildNumericFacet,
@@ -182,18 +182,20 @@ export class AtomicNumericFacet
     }
 
     if (!this.facetState.hasActiveValues && this.totalNumberOfResults === 0) {
-      return;
+      return <Host class="without-values"></Host>;
     }
 
     return (
-      <BaseFacet
-        controller={new BaseFacetController(this)}
-        label={this.strings[this.label]()}
-        hasActiveValues={this.facetState.hasActiveValues}
-        clearAll={() => this.facet.deselectAll()}
-      >
-        <ul>{this.values}</ul>
-      </BaseFacet>
+      <Host class="with-values">
+        <BaseFacet
+          controller={new BaseFacetController(this)}
+          label={this.strings[this.label]()}
+          hasActiveValues={this.facetState.hasActiveValues}
+          clearAll={() => this.facet.deselectAll()}
+        >
+          <ul>{this.values}</ul>
+        </BaseFacet>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/facets/base-facet/base-facet.pcss
+++ b/packages/atomic/src/components/facets/base-facet/base-facet.pcss
@@ -1,4 +1,4 @@
-:host(.without-values) {
+:host(.atomic-without-values) {
   display: none;
 }
 

--- a/packages/atomic/src/components/facets/base-facet/base-facet.pcss
+++ b/packages/atomic/src/components/facets/base-facet/base-facet.pcss
@@ -1,3 +1,7 @@
+:host(.without-values) {
+  display: none;
+}
+
 .value-count {
   @apply text-neutral-dark ml-1.5;
 }

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -121,7 +121,7 @@
           flex-wrap: wrap;
         }
 
-        atomic-facet-manager > .with-values {
+        atomic-facet-manager > .atomic-with-values {
           margin: 0 10px 0 0;
         }
 

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -31,7 +31,6 @@
         grid-template-rows: 22px 50px 22px 1fr;
         column-gap: 20px;
         display: grid;
-        margin: 0 auto;
       }
 
       .header {
@@ -122,16 +121,13 @@
           flex-wrap: wrap;
         }
 
+        atomic-facet-manager > .with-values {
+          margin: 0 10px 0 0;
+        }
+
         .results-container {
           grid-row: 5 / auto;
           margin-top: 0;
-        }
-
-        atomic-facet,
-        atomic-numeric-facet,
-        atomic-date-facet,
-        atomic-category-facet {
-          margin: 0 10px 0 0;
         }
 
         atomic-search-box {


### PR DESCRIPTION
OOTB sets display:none on facets when they have no values.
This will allow implementation to hide a section of their UI when no facets are visible.

A downside is the class name, I did prepend atomic so it's not affect by a customer's css
https://coveord.atlassian.net/browse/KIT-746