### PR TITLE
feat(atomic): scroll to top of the "scrollContainer" when interacting with Pager

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -503,6 +503,10 @@ export namespace Components {
          */
         "reflectStateInUrl": boolean;
         /**
+          * The CSS selector for the container where the interface will scroll back to.
+         */
+        "scrollContainer": string;
+        /**
           * The search interface [search hub](https://docs.coveo.com/en/1342/).
          */
         "searchHub": string;
@@ -1127,6 +1131,7 @@ declare namespace LocalJSX {
           * Specifies how many page buttons to display in the pager.
          */
         "numberOfPages"?: number;
+        "onAtomic/scrollToTop"?: (event: CustomEvent<any>) => void;
     }
     interface AtomicQueryError {
     }
@@ -1309,6 +1314,10 @@ declare namespace LocalJSX {
           * Whether the state should be reflected in the URL parameters.
          */
         "reflectStateInUrl"?: boolean;
+        /**
+          * The CSS selector for the container where the interface will scroll back to.
+         */
+        "scrollContainer"?: string;
         /**
           * The search interface [search hub](https://docs.coveo.com/en/1342/).
          */

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -1,4 +1,4 @@
-import {Component, h, Prop, State} from '@stencil/core';
+import {Component, h, Prop, State, Event, EventEmitter} from '@stencil/core';
 import {
   Pager,
   PagerState,
@@ -52,6 +52,11 @@ export class AtomicPager implements InitializableComponent {
   };
   @State() error!: Error;
 
+  @Event({
+    eventName: 'atomic/scrollToTop',
+  })
+  private scrollToTopEvent!: EventEmitter;
+
   /**
    * Specifies how many page buttons to display in the pager.
    */
@@ -62,6 +67,10 @@ export class AtomicPager implements InitializableComponent {
     this.pager = buildPager(this.bindings.engine, {
       options: {numberOfPages: this.numberOfPages},
     });
+  }
+
+  private scrollToTop() {
+    this.scrollToTopEvent.emit();
   }
 
   private buildButton(options: {
@@ -82,7 +91,10 @@ export class AtomicPager implements InitializableComponent {
           }`}
           disabled={options.disabled}
           aria-label={options.ariaLabel}
-          onClick={options.callback}
+          onClick={() => {
+            options.callback();
+            this.scrollToTop();
+          }}
         >
           <span class="fill-current" innerHTML={options.icon}></span>
         </button>
@@ -134,6 +146,7 @@ export class AtomicPager implements InitializableComponent {
           aria-label={this.strings.pageNumber(page)}
           onClick={() => {
             this.pager.selectPage(page);
+            this.scrollToTop();
           }}
         >
           {page.toLocaleString(this.bindings.i18n.language)}

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -158,9 +158,15 @@ export class AtomicSearchInterface {
 
   @Listen('atomic/scrollToTop')
   public scrollToTop() {
-    document
-      .querySelector(this.scrollContainer)
-      ?.scrollIntoView({behavior: 'smooth'});
+    const scrollContainerElement = document.querySelector(this.scrollContainer);
+    if (!scrollContainerElement) {
+      this.bindings.engine.logger.warn(
+        `Could not find the scroll container with the selector "${this.scrollContainer}". This will prevent UX interactions that require a scroll from working correctly. Please check the CSS selector in the scrollContainer option`
+      );
+      return;
+    }
+
+    scrollContainerElement.scrollIntoView({behavior: 'smooth'});
   }
 
   /**

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -88,6 +88,11 @@ export class AtomicSearchInterface {
    */
   @Prop() public reflectStateInUrl = true;
 
+  /**
+   * The CSS selector for the container where the interface will scroll back to.
+   */
+  @Prop() public scrollContainer = 'atomic-search-interface';
+
   public constructor() {
     setCoveoGlobal();
   }
@@ -149,6 +154,13 @@ export class AtomicSearchInterface {
     }
 
     this.hangingComponentsInitialization.push(event);
+  }
+
+  @Listen('atomic/scrollToTop')
+  public scrollToTop() {
+    document
+      .querySelector(this.scrollContainer)
+      ?.scrollIntoView({behavior: 'smooth'});
   }
 
   /**


### PR DESCRIPTION
I believe using an event here is a clean solution, since the "scrollContainer" (the element to which you want to scroll back to) has only to be defined on the atomic-search-interface. Then many component can emit that same event and make the page scroll. The pagination is a no brainer, but for other element such as clicking facet values, or changing result per page.

Another solution is to emit the event when the page change (looking at the pagination state)

https://coveord.atlassian.net/browse/KIT-747