### PR TITLE
test(atomic): improve date/numeric facet cypress flakiness

### DIFF
--- a/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
@@ -108,7 +108,7 @@ describe('Date Facet Test Suites', () => {
       });
 
       describe('When user clicks ClearAll facet button', () => {
-        function setupFacetWithTwoCheckboxesSelected() {
+        function setupFacetClearAll() {
           setupDateFacetWithCheckboxSelected();
           cy.wait(RouteAlias.analytics);
           selectClearAllFacetsButton(dateField, dateFacetComponent);
@@ -116,7 +116,7 @@ describe('Date Facet Test Suites', () => {
         }
 
         describe('verify rendering', () => {
-          before(setupFacetWithTwoCheckboxesSelected);
+          before(setupFacetClearAll);
           FacetAssertions.assertCheckboxDisplay(
             0,
             false,
@@ -132,7 +132,7 @@ describe('Date Facet Test Suites', () => {
         });
 
         describe('verify analytics', () => {
-          beforeEach(setupFacetWithTwoCheckboxesSelected);
+          beforeEach(setupFacetClearAll);
           FacetAssertions.assertAnalyticLogClearAllFacets();
         });
       });

--- a/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
@@ -53,6 +53,7 @@ describe('Date Facet Test Suites', () => {
         cy.wait(RouteAlias.search);
         cy.wait(RouteAlias.analytics);
         selectFacetValueAt(0, dateField, dateFacetComponent);
+        cy.wait(RouteAlias.search);
       }
 
       describe('verify rendering', () => {
@@ -81,69 +82,59 @@ describe('Date Facet Test Suites', () => {
           0
         );
       });
-    });
 
-    describe('When user deselects 1 date-facet checkbox', () => {
-      function setupDateFacetWithCheckboxDeSelected() {
-        setupDateFacet();
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, dateField, dateFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, dateField, dateFacetComponent);
-        cy.wait(RouteAlias.search);
-      }
+      describe('When user deselects 1 date-facet checkbox', () => {
+        function setupDateFacetWithCheckboxDeSelected() {
+          setupDateFacetWithCheckboxSelected();
+          cy.wait(RouteAlias.analytics);
+          selectFacetValueAt(0, dateField, dateFacetComponent);
+          cy.wait(RouteAlias.search);
+        }
 
-      describe('verify rendering', () => {
-        before(setupDateFacetWithCheckboxDeSelected);
-        FacetAssertions.assertCheckboxDisplay(
-          0,
-          false,
-          dateField,
-          dateFacetComponent
-        );
+        describe('verify rendering', () => {
+          before(setupDateFacetWithCheckboxDeSelected);
+          FacetAssertions.assertCheckboxDisplay(
+            0,
+            false,
+            dateField,
+            dateFacetComponent
+          );
+        });
+
+        describe('verify analytics', () => {
+          beforeEach(setupDateFacetWithCheckboxDeSelected);
+          FacetAssertions.assertAnalyticLogFacetDeselect(dateField);
+        });
       });
 
-      describe('verify analytics', () => {
-        beforeEach(setupDateFacetWithCheckboxDeSelected);
-        FacetAssertions.assertAnalyticLogFacetDeselect(dateField);
-      });
-    });
+      describe('When user clicks ClearAll facet button', () => {
+        function setupFacetWithTwoCheckboxesSelected() {
+          setupDateFacetWithCheckboxSelected();
+          cy.wait(RouteAlias.analytics);
+          selectClearAllFacetsButton(dateField, dateFacetComponent);
+          cy.wait(RouteAlias.search);
+        }
 
-    describe('When user clicks ClearAll facet button', () => {
-      function setupFacetWithTwoCheckboxesSelected() {
-        setupDateFacet();
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, dateField, dateFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(1, dateField, dateFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectClearAllFacetsButton(dateField, dateFacetComponent);
-        cy.wait(RouteAlias.search);
-      }
+        describe('verify rendering', () => {
+          before(setupFacetWithTwoCheckboxesSelected);
+          FacetAssertions.assertCheckboxDisplay(
+            0,
+            false,
+            dateField,
+            dateFacetComponent
+          );
+          FacetAssertions.assertCheckboxDisplay(
+            1,
+            false,
+            dateField,
+            dateFacetComponent
+          );
+        });
 
-      describe('verify rendering', () => {
-        before(setupFacetWithTwoCheckboxesSelected);
-        FacetAssertions.assertCheckboxDisplay(
-          0,
-          false,
-          dateField,
-          dateFacetComponent
-        );
-        FacetAssertions.assertCheckboxDisplay(
-          1,
-          false,
-          dateField,
-          dateFacetComponent
-        );
-      });
-
-      describe('verify analytics', () => {
-        beforeEach(setupFacetWithTwoCheckboxesSelected);
-        FacetAssertions.assertAnalyticLogClearAllFacets();
+        describe('verify analytics', () => {
+          beforeEach(setupFacetWithTwoCheckboxesSelected);
+          FacetAssertions.assertAnalyticLogClearAllFacets();
+        });
       });
     });
   });

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
@@ -60,6 +60,7 @@ describe('Numeric Facet Test Suites', () => {
         cy.wait(RouteAlias.search);
         cy.wait(RouteAlias.analytics);
         selectFacetValueAt(0, numericField, numericFacetComponent);
+        cy.wait(RouteAlias.search);
       }
 
       describe('verify rendering', () => {
@@ -92,68 +93,59 @@ describe('Numeric Facet Test Suites', () => {
           0
         );
       });
-    });
 
-    describe('When user deselects 1 numeric-facet checkbox', () => {
-      function setupNumericFacetWithCheckboxDeSelected() {
-        setupNumericFacet();
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, numericField, numericFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, numericField, numericFacetComponent);
-        cy.wait(RouteAlias.search);
-      }
+      describe('When user deselects 1 numeric-facet checkbox', () => {
+        function setupNumericFacetWithCheckboxDeSelected() {
+          setupDateFacetWithCheckboxSelected();
+          cy.wait(RouteAlias.analytics);
+          selectFacetValueAt(0, numericField, numericFacetComponent);
+          cy.wait(RouteAlias.search);
+        }
 
-      describe('verify rendering', () => {
-        before(setupNumericFacetWithCheckboxDeSelected);
-        FacetAssertions.assertCheckboxDisplay(
-          0,
-          false,
-          numericField,
-          numericFacetComponent
-        );
+        describe('verify rendering', () => {
+          before(setupNumericFacetWithCheckboxDeSelected);
+          FacetAssertions.assertCheckboxDisplay(
+            0,
+            false,
+            numericField,
+            numericFacetComponent
+          );
+        });
+
+        describe('verify analytics', () => {
+          beforeEach(setupNumericFacetWithCheckboxDeSelected);
+          FacetAssertions.assertAnalyticLogFacetDeselect(numericField);
+        });
       });
 
-      describe('verify analytics', () => {
-        beforeEach(setupNumericFacetWithCheckboxDeSelected);
-        FacetAssertions.assertAnalyticLogFacetDeselect(numericField);
-      });
-    });
+      describe('When user clicks ClearAll facet button', () => {
+        function setupFacetWithTwoCheckboxesSelected() {
+          setupDateFacetWithCheckboxSelected();
+          cy.wait(RouteAlias.analytics);
+          selectClearAllFacetsButton(numericField, numericFacetComponent);
+          cy.wait(RouteAlias.search);
+        }
 
-    describe('When user clicks ClearAll facet button', () => {
-      function setupFacetWithTwoCheckboxesSelected() {
-        setupNumericFacet();
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(0, numericField, numericFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectFacetValueAt(1, numericField, numericFacetComponent);
-        cy.wait(RouteAlias.search);
-        cy.wait(RouteAlias.analytics);
-        selectClearAllFacetsButton(numericField, numericFacetComponent);
-        cy.wait(RouteAlias.search);
-      }
-      describe('verify rendering', () => {
-        before(setupFacetWithTwoCheckboxesSelected);
-        FacetAssertions.assertCheckboxDisplay(
-          0,
-          false,
-          numericField,
-          numericFacetComponent
-        );
-        FacetAssertions.assertCheckboxDisplay(
-          1,
-          false,
-          numericField,
-          numericFacetComponent
-        );
-      });
+        describe('verify rendering', () => {
+          before(setupFacetWithTwoCheckboxesSelected);
+          FacetAssertions.assertCheckboxDisplay(
+            0,
+            false,
+            numericField,
+            numericFacetComponent
+          );
+          FacetAssertions.assertCheckboxDisplay(
+            1,
+            false,
+            numericField,
+            numericFacetComponent
+          );
+        });
 
-      describe('verify analytics', () => {
-        beforeEach(setupFacetWithTwoCheckboxesSelected);
-        FacetAssertions.assertAnalyticLogClearAllFacets();
+        describe('verify analytics', () => {
+          beforeEach(setupFacetWithTwoCheckboxesSelected);
+          FacetAssertions.assertAnalyticLogClearAllFacets();
+        });
       });
     });
   });

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
@@ -119,7 +119,7 @@ describe('Numeric Facet Test Suites', () => {
       });
 
       describe('When user clicks ClearAll facet button', () => {
-        function setupFacetWithTwoCheckboxesSelected() {
+        function setupFacetClearAll() {
           setupDateFacetWithCheckboxSelected();
           cy.wait(RouteAlias.analytics);
           selectClearAllFacetsButton(numericField, numericFacetComponent);
@@ -127,7 +127,7 @@ describe('Numeric Facet Test Suites', () => {
         }
 
         describe('verify rendering', () => {
-          before(setupFacetWithTwoCheckboxesSelected);
+          before(setupFacetClearAll);
           FacetAssertions.assertCheckboxDisplay(
             0,
             false,
@@ -143,7 +143,7 @@ describe('Numeric Facet Test Suites', () => {
         });
 
         describe('verify analytics', () => {
-          beforeEach(setupFacetWithTwoCheckboxesSelected);
+          beforeEach(setupFacetClearAll);
           FacetAssertions.assertAnalyticLogClearAllFacets();
         });
       });


### PR DESCRIPTION
> I'm seeing a specific kind of cypress test is intermittently failing on Jenkins. The test is checking that the correct UA event is sent after deselecting all facet values. Sometimes it's the numeric, sometimes it's the date facet. Any thoughts as to what might be causing these tests to error?

The structure and a missing wait was probably causing the intermittent test failure. Now it's similar to the facet/category-facet which don't appear as flaky

https://coveord.atlassian.net/browse/KIT-792