### PR TITLE
fix(headless): fix Redirect Triggers

### DIFF
--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
@@ -70,6 +70,26 @@ describe('RedirectionTrigger', () => {
     const listener = jest.fn();
     beforeEach(() => {
       redirectionTrigger.subscribe(listener);
+      const [firstListener] = registeredListeners();
+      firstListener();
+    });
+
+    it('it does not call the listener', () => {
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('it does not dispatch #logTriggerRedirect', () => {
+      expect(getLogTriggerRedirectAction()).toBeFalsy();
+    });
+  });
+
+  describe('when the #engine.state.triggers.redirectTo is updated to the empty string', () => {
+    const listener = jest.fn();
+    beforeEach(() => {
+      redirectionTrigger.subscribe(listener);
+      engine.state.triggers.redirectTo = '';
+      const [firstListener] = registeredListeners();
+      firstListener();
     });
 
     it('it does not call the listener', () => {
@@ -85,7 +105,6 @@ describe('RedirectionTrigger', () => {
     const listener = jest.fn();
     beforeEach(() => {
       redirectionTrigger.subscribe(listener);
-
       engine.state.triggers.redirectTo = 'https://www.coveo.com';
       const [firstListener] = registeredListeners();
       firstListener();

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
@@ -47,36 +47,56 @@ describe('RedirectionTrigger', () => {
     expect(redirectionTrigger.subscribe).toBeTruthy();
   });
 
-  it('when the #engine.state.triggers.redirectTo is already initialized, it does not call #onRedirect and does not dispatch #logTriggerRedirect', () => {
+  describe('when the #engine.state.triggers.redirectTo is already initialized', () => {
     const listener = jest.fn();
-    const state = createMockState();
-    state.triggers.redirectTo = 'https://www.google.com';
-    engine = buildMockSearchAppEngine({state});
-    initRedirectTrigger();
+    beforeEach(() => {
+      const state = createMockState();
+      state.triggers.redirectTo = 'https://www.google.com';
+      engine = buildMockSearchAppEngine({state});
+      initRedirectTrigger();
+      redirectionTrigger.subscribe(listener);
+    });
 
-    redirectionTrigger.subscribe(listener);
+    it('it does not call the listener', () => {
+      expect(listener).toHaveBeenCalledTimes(0);
+    });
 
-    expect(listener).toHaveBeenCalledTimes(0);
-    expect(getLogTriggerRedirectAction()).toBeFalsy();
+    it('it does not dispatch #logTriggerRedirect', () => {
+      expect(getLogTriggerRedirectAction()).toBeFalsy();
+    });
   });
 
-  it('when the #engine.state.triggers.redirectTo is not updated, it does not call #onRedirect and does not dispatch #logTriggerRedirect', () => {
+  describe('when the #engine.state.triggers.redirectTo is not updated', () => {
     const listener = jest.fn();
-    redirectionTrigger.subscribe(listener);
+    beforeEach(() => {
+      redirectionTrigger.subscribe(listener);
+    });
 
-    expect(listener).not.toHaveBeenCalled();
-    expect(getLogTriggerRedirectAction()).toBeFalsy();
+    it('it does not call the listener', () => {
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('it does not dispatch #logTriggerRedirect', () => {
+      expect(getLogTriggerRedirectAction()).toBeFalsy();
+    });
   });
 
-  it('when the #engine.state.triggers.redirectTo is updated, it calls #onRedirect and dispatches #logTriggerRedirect', () => {
+  describe('when the #engine.state.triggers.redirectTo is updated', () => {
     const listener = jest.fn();
-    redirectionTrigger.subscribe(listener);
+    beforeEach(() => {
+      redirectionTrigger.subscribe(listener);
 
-    engine.state.triggers.redirectTo = 'https://www.coveo.com';
-    const [firstListener] = registeredListeners();
-    firstListener();
+      engine.state.triggers.redirectTo = 'https://www.coveo.com';
+      const [firstListener] = registeredListeners();
+      firstListener();
+    });
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(getLogTriggerRedirectAction()).toBeTruthy();
+    it('it calls the listener', () => {
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('it dispatches #logTriggerRedirect', () => {
+      expect(getLogTriggerRedirectAction()).toBeTruthy();
+    });
   });
 });

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
@@ -7,7 +7,7 @@ import {
   MockSearchEngine,
 } from '../../test/mock-engine';
 import {triggers} from '../../app/reducers';
-import {logTriggerRedirect} from '../../features/redirection/redirection-analytics-actions';
+import {logTriggerRedirect} from '../../features/triggers/trigger-analytics-actions';
 import {createMockState} from '../../test/mock-state';
 
 describe('RedirectionTrigger', () => {

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.test.ts
@@ -6,7 +6,7 @@ import {
   buildMockSearchAppEngine,
   MockSearchEngine,
 } from '../../test/mock-engine';
-import {triggers, configuration} from '../../app/reducers';
+import {triggers} from '../../app/reducers';
 import {logTriggerRedirect} from '../../features/redirection/redirection-analytics-actions';
 import {createMockState} from '../../test/mock-state';
 
@@ -40,7 +40,6 @@ describe('RedirectionTrigger', () => {
   it('it adds the correct reducers to the engine', () => {
     expect(engine.addReducers).toHaveBeenCalledWith({
       triggers,
-      configuration,
     });
   });
 

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
@@ -22,7 +22,7 @@ export interface RedirectionTriggerState {
   /**
    * The url used for the redirection.
    */
-  redirectTo: string | null;
+  redirectTo: string;
 }
 
 /**
@@ -43,7 +43,7 @@ export function buildRedirectionTrigger(
 
   const getState = () => engine.state;
 
-  let previousRedirectTo: string | null = getState().triggers.redirectTo;
+  let previousRedirectTo: string = getState().triggers.redirectTo;
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
@@ -1,5 +1,5 @@
-import {ConfigurationSection, TriggerSection} from '../../state/state-sections';
-import {configuration, triggers} from '../../app/reducers';
+import {TriggerSection} from '../../state/state-sections';
+import {triggers} from '../../app/reducers';
 import {buildController, Controller} from '../controller/headless-controller';
 import {loadReducerError} from '../../utils/errors';
 import {logTriggerRedirect} from '../../features/redirection/redirection-analytics-actions';
@@ -72,7 +72,7 @@ export function buildRedirectionTrigger(
 
 function loadRedirectionReducers(
   engine: SearchEngine
-): engine is SearchEngine<TriggerSection & ConfigurationSection> {
-  engine.addReducers({configuration, triggers});
+): engine is SearchEngine<TriggerSection> {
+  engine.addReducers({triggers});
   return true;
 }

--- a/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-redirection-trigger.ts
@@ -2,7 +2,7 @@ import {TriggerSection} from '../../state/state-sections';
 import {triggers} from '../../app/reducers';
 import {buildController, Controller} from '../controller/headless-controller';
 import {loadReducerError} from '../../utils/errors';
-import {logTriggerRedirect} from '../../features/redirection/redirection-analytics-actions';
+import {logTriggerRedirect} from '../../features/triggers/trigger-analytics-actions';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 
 /**

--- a/packages/headless/src/features/redirection/redirection-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-actions.ts
@@ -5,7 +5,7 @@ import {
 } from '../../api/search/search-api-client';
 import {ExecutionPlan} from '../../api/search/plan/plan-endpoint';
 import {StringValue} from '@coveo/bueno';
-import {logTriggerRedirect} from './redirection-analytics-actions';
+import {logRedirection} from './redirection-analytics-actions';
 import {
   ConfigurationSection,
   ContextSection,
@@ -58,7 +58,7 @@ export const checkForRedirection = createAsyncThunk<
 
     const planRedirection = new ExecutionPlan(response.success).redirectionUrl;
     if (planRedirection) {
-      dispatch(logTriggerRedirect());
+      dispatch(logRedirection());
     }
 
     return planRedirection || payload.defaultRedirectionUrl;

--- a/packages/headless/src/features/redirection/redirection-analytics-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-analytics-actions.ts
@@ -1,15 +1,14 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
 /**
- * Log trigger redirection
+ * Log redirection
  */
-export const logTriggerRedirect = makeAnalyticsAction(
-  'analytics/trigger/redirection',
+export const logRedirection = makeAnalyticsAction(
+  'analytics/redirection',
   AnalyticsType.Search,
   (client, state) => {
     if (state.redirection && state.redirection.redirectTo !== null) {
       return client.logTriggerRedirect({
-        //shouldn't this be state.triggers.redirectTo? make another action?
         redirectedTo: state.redirection.redirectTo,
       });
     }

--- a/packages/headless/src/features/redirection/redirection-analytics-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-analytics-actions.ts
@@ -7,7 +7,7 @@ export const logRedirection = makeAnalyticsAction(
   'analytics/redirection',
   AnalyticsType.Search,
   (client, state) => {
-    if (state.redirection && state.redirection.redirectTo !== null) {
+    if (state.redirection?.redirectTo) {
       return client.logTriggerRedirect({
         redirectedTo: state.redirection.redirectTo,
       });

--- a/packages/headless/src/features/redirection/redirection-analytics-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-analytics-actions.ts
@@ -9,6 +9,7 @@ export const logTriggerRedirect = makeAnalyticsAction(
   (client, state) => {
     if (state.redirection && state.redirection.redirectTo !== null) {
       return client.logTriggerRedirect({
+        //shouldn't this be state.triggers.redirectTo? make another action?
         redirectedTo: state.redirection.redirectTo,
       });
     }

--- a/packages/headless/src/features/redirection/redirection-slice.test.ts
+++ b/packages/headless/src/features/redirection/redirection-slice.test.ts
@@ -1,7 +1,7 @@
 import {redirectionReducer} from './redirection-slice';
 import {checkForRedirection} from './redirection-actions';
 import {Trigger} from '../../api/search/trigger';
-import {logTriggerRedirect} from './redirection-analytics-actions';
+import {logRedirection} from './redirection-analytics-actions';
 import {
   getRedirectionInitialState,
   RedirectionState,
@@ -75,10 +75,8 @@ describe('redirection slice', () => {
     return response;
   }
 
-  function getLogTriggerRedirectAction() {
-    return engine.actions.find(
-      (a) => a.type === logTriggerRedirect.pending.type
-    );
+  function getlogRedirectionAction() {
+    return engine.actions.find((a) => a.type === logRedirection.pending.type);
   }
 
   it(`when the plan endpoint doesn't return a redirection trigger
@@ -89,9 +87,9 @@ describe('redirection slice', () => {
   });
 
   it(`when the plan endpoint doesn't return a redirection trigger
-  should not dispatch a logTriggerRedirect action`, async (done) => {
+  should not dispatch a logRedirection action`, async (done) => {
     await mockPlan();
-    expect(getLogTriggerRedirectAction()).toBeFalsy();
+    expect(getlogRedirectionAction()).toBeFalsy();
     done();
   });
 
@@ -102,18 +100,18 @@ describe('redirection slice', () => {
       content: 'https://www.coveo.com',
     });
     expect(response.payload).toBe('https://www.coveo.com');
-    expect(getLogTriggerRedirectAction()).toBeTruthy();
+    expect(getlogRedirectionAction()).toBeTruthy();
     done();
   });
 
   it(`when the plan endpoint returns a redirection trigger
-  should dispatch a logTriggerRedirect action`, async (done) => {
+  should dispatch a logRedirection action`, async (done) => {
     const response = await mockPlan({
       type: 'redirect',
       content: 'https://www.coveo.com',
     });
     expect(response.payload).toBe('https://www.coveo.com');
-    expect(getLogTriggerRedirectAction()).toBeTruthy();
+    expect(getlogRedirectionAction()).toBeTruthy();
     done();
   });
 });

--- a/packages/headless/src/features/triggers/trigger-analytics-actions.ts
+++ b/packages/headless/src/features/triggers/trigger-analytics-actions.ts
@@ -13,3 +13,19 @@ export const logQueryTrigger = makeAnalyticsAction(
     return;
   }
 );
+
+/**
+ * Log trigger redirection
+ */
+export const logTriggerRedirect = makeAnalyticsAction(
+  'analytics/trigger/redirect',
+  AnalyticsType.Search,
+  (client, state) => {
+    if (state.triggers?.redirectTo) {
+      return client.logTriggerRedirect({
+        redirectedTo: state.triggers.redirectTo,
+      });
+    }
+    return;
+  }
+);

--- a/packages/headless/src/features/triggers/triggers-state.ts
+++ b/packages/headless/src/features/triggers/triggers-state.ts
@@ -2,7 +2,7 @@ export interface TriggerState {
   /**
    * The URL to redirect the user to after receiving a redirection trigger.
    */
-  redirectTo: string | null;
+  redirectTo: string;
 
   /**
    * The new query to perform a search with after receiving a query trigger.
@@ -11,6 +11,6 @@ export interface TriggerState {
 }
 
 export const getTriggerInitialState: () => TriggerState = () => ({
-  redirectTo: null,
+  redirectTo: '',
   query: '',
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-802

List of fixes:
- Changed `triggers.state.redirectTo: string | null` to `triggers.state.redirectTo: string`
- Added empty string test case
- Reformatted Controller test
- Question about logTriggerRedirect Action