### PR TITLE
test(atomic): fix date/numeric facet cypress url test

### DIFF
--- a/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/date-facet/date-facet.cypress.ts
@@ -310,11 +310,10 @@ describe('Date Facet Test Suites', () => {
       );
     });
     FacetAssertions.assertAnalyticLogFacetInInterfaceLoadEvent(dateField);
-    FacetAssertions.assertCheckboxDisplay(
-      0,
-      true,
+    FacetAssertions.assertNumberOfSelectedCheckboxValues(
       dateField,
-      dateFacetComponent
+      dateFacetComponent,
+      1
     );
   });
 });

--- a/packages/atomic/cypress/integration/facets/facet/facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet-assertions.ts
@@ -300,3 +300,20 @@ export function assertRenderPlaceHolder(
     FacetSelector.facetPlaceHolder(field, type).should('be.visible');
   });
 }
+
+export function assertNumberOfSelectedCheckboxValues(
+  field = facetField,
+  type = facetComponent,
+  value: number
+) {
+  it(`should display ${value} number of selected checkbox values`, () => {
+    if (value > 0) {
+      FacetSelector.selectedCheckboxValue(field, type)
+        .its('length')
+        .should('eq', value);
+      return;
+    }
+
+    FacetSelector.selectedCheckboxValue(field, type).should('not.exist');
+  });
+}

--- a/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
@@ -25,6 +25,10 @@ export const FacetSelector = {
     FacetSelector.shadow(field, type).find('[part="show-less"]'),
   facetClearAllFilter: (field = facetField, type = facetComponent) =>
     FacetSelector.shadow(field, type).find('[part="clear-button"]'),
+  selectedCheckboxValue: (field = facetField, type = facetComponent) =>
+    FacetSelector.shadow(field, type).find(
+      '[part="value"] button[aria-checked="true"]'
+    ),
   facetValueAtIndex: (
     index: number,
     field = facetField,

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
@@ -329,11 +329,10 @@ describe('Numeric Facet Test Suites', () => {
       );
     });
     FacetAssertions.assertAnalyticLogFacetInInterfaceLoadEvent(numericField);
-    FacetAssertions.assertCheckboxDisplay(
-      0,
-      true,
+    FacetAssertions.assertNumberOfSelectedCheckboxValues(
       numericField,
-      numericFacetComponent
+      numericFacetComponent,
+      1
     );
   });
 });


### PR DESCRIPTION
We have to be careful with tests with hardcoded value that rely on new data not being added, such as this new document, which bumped the position to 2

![Screen Shot 2021-07-02 at 11 16 50 AM](https://user-images.githubusercontent.com/4923043/124296656-34721a80-db28-11eb-8204-4a25c2016485.png)


https://coveord.atlassian.net/browse/KIT-792