### PR TITLE
docs(headless): extract recommendation use-case reference

### DIFF
--- a/packages/headless/config/api-extractor/base.json
+++ b/packages/headless/config/api-extractor/base.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/index.d.ts",
+  "mainEntryPointFilePath": "",
   "bundledPackages": [ "redux", "@reduxjs/toolkit" ],
   "apiReport": {
     "enabled": false
   },
   "docModel": {
     "enabled": true,
-    "apiJsonFilePath": "<projectFolder>/temp/<unscopedPackageName>.api.json"
+    "apiJsonFilePath": ""
   },
   "dtsRollup": {
     "enabled": false

--- a/packages/headless/config/api-extractor/base.json
+++ b/packages/headless/config/api-extractor/base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/headless.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/temp/index.d.ts",
   "bundledPackages": [ "redux", "@reduxjs/toolkit" ],
   "apiReport": {
     "enabled": false

--- a/packages/headless/config/api-extractor/recommendation.json
+++ b/packages/headless/config/api-extractor/recommendation.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "mainEntryPointFilePath": "<projectFolder>/temp/recommendation.index.d.ts",
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/temp/recommendation.api.json"
+  }
+}

--- a/packages/headless/config/api-extractor/search.json
+++ b/packages/headless/config/api-extractor/search.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "mainEntryPointFilePath": "<projectFolder>/temp/index.d.ts",
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/temp/index.api.json"
+  }
+}

--- a/packages/headless/doc-parser/use-cases/recommendation.ts
+++ b/packages/headless/doc-parser/use-cases/recommendation.ts
@@ -1,0 +1,61 @@
+import {ActionLoaderConfiguration} from '../src/headless-export-resolvers/action-loader-resolver';
+import {ControllerConfiguration} from '../src/headless-export-resolvers/controller-resolver';
+import {EngineConfiguration} from '../src/headless-export-resolvers/engine-resolver';
+
+const controllers: ControllerConfiguration[] = [
+  {
+    initializer: 'buildRecommendationList',
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/recommendation-list/recommendation-list.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/recommendation-list/recommendation-list.fn.tsx',
+      ],
+    },
+  },
+  {
+    initializer: 'buildContext',
+    samplePaths: {
+      react_fn: [
+        'packages/samples/headless-react/src/components/context/context.ts',
+      ],
+    },
+  },
+];
+
+const actionLoaders: ActionLoaderConfiguration[] = [
+  {
+    initializer: 'loadConfigurationActions',
+  },
+  {
+    initializer: 'loadAdvancedSearchQueryActions',
+  },
+  {
+    initializer: 'loadContextActions',
+  },
+  {
+    initializer: 'loadFieldActions',
+  },
+  {
+    initializer: 'loadPipelineActions',
+  },
+  {
+    initializer: 'loadSearchHubActions',
+  },
+  {
+    initializer: 'loadDebugActions',
+  },
+  {
+    initializer: 'loadRecommendationActions',
+  },
+  {
+    initializer: 'loadClickAnalyticsActions',
+  },
+];
+
+const engine: EngineConfiguration = {
+  initializer: 'buildRecommendationEngine',
+};
+
+export const recommendationUseCase = {controllers, actionLoaders, engine};

--- a/packages/headless/doc-parser/use-cases/use-case-configuration.ts
+++ b/packages/headless/doc-parser/use-cases/use-case-configuration.ts
@@ -1,0 +1,9 @@
+import {ActionLoaderConfiguration} from '../src/headless-export-resolvers/action-loader-resolver';
+import {ControllerConfiguration} from '../src/headless-export-resolvers/controller-resolver';
+import {EngineConfiguration} from '../src/headless-export-resolvers/engine-resolver';
+
+export interface UseCaseConfiguration {
+  controllers: ControllerConfiguration[];
+  actionLoaders: ActionLoaderConfiguration[];
+  engine: EngineConfiguration;
+}

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -27,7 +27,7 @@
     "test:integration": "jest --testPathPattern=src/integration-tests",
     "npm:publish": "npm publish --access public",
     "doc:generate": "npm run doc:extract && npm run doc:parse",
-    "doc:extract": "api-extractor run --local --verbose",
+    "doc:extract": "node ./scripts/extract-documentation.js",
     "doc:parse": "ts-node --project ./doc-parser/tsconfig.build.json ./doc-parser/doc-parser.ts"
   },
   "dependencies": {

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -197,12 +197,19 @@ const dev = [
 // Api-extractor cannot resolve import() types, so we use dts to create a file that api-extractor
 // can consume. When the api-extractor limitation is resolved, this step will not be necessary.
 // [https://github.com/microsoft/rushstack/issues/1050]
-const typeDefinitions = {
-  input: "./dist/definitions/index.d.ts",
-  output: [{file: "temp/headless.d.ts", format: "es"}],
-  plugins: [dts()]
+const typeDefinitions = [
+  buildTypeDefinitionConfiguration('index.d.ts'),
+  buildTypeDefinitionConfiguration('recommendation.index.d.ts'),
+];
+
+function buildTypeDefinitionConfiguration(entryFileName) {
+  return {
+    input: `./dist/definitions/${entryFileName}`,
+    output: [{file: `temp/${entryFileName}`, format: "es"}],
+    plugins: [dts()]
+  }
 }
 
-const config = isProduction ? [...nodejs, typeDefinitions, ...browser] : dev;
+const config = isProduction ? [...nodejs, ...typeDefinitions, ...browser] : dev;
 
 export default config;

--- a/packages/headless/scripts/extract-documentation.js
+++ b/packages/headless/scripts/extract-documentation.js
@@ -1,14 +1,14 @@
 const {promisify} = require('util');
-const {} = require('path');
+const {readdirSync} = require('fs')
 const exec = promisify(require('child_process').exec);
 
-const configFiles = [
-  'search.json',
-  'recommendation.json'
-]
+const dir = './config/api-extractor';
 
 async function main() {
-  const jobs = configFiles.map(file => exec(`api-extractor run -l -c ./config/api-extractor/${file}`))
+  const paths = readdirSync(dir).filter(file => file !== 'base.json').map(file => `${dir}/${file}`);
+  console.log('extracting documentation using', paths);
+  
+  const jobs = paths.map(path => exec(`api-extractor run -l -c ${path}`))
   await Promise.all(jobs);
 }
 

--- a/packages/headless/scripts/extract-documentation.js
+++ b/packages/headless/scripts/extract-documentation.js
@@ -1,0 +1,15 @@
+const {promisify} = require('util');
+const {} = require('path');
+const exec = promisify(require('child_process').exec);
+
+const configFiles = [
+  'search.json',
+  'recommendation.json'
+]
+
+async function main() {
+  const jobs = configFiles.map(file => exec(`api-extractor run -l -c ./config/api-extractor/${file}`))
+  await Promise.all(jobs);
+}
+
+main();

--- a/packages/headless/src/features/recommendation/recommendation-click-analytics-actions-loader.ts
+++ b/packages/headless/src/features/recommendation/recommendation-click-analytics-actions-loader.ts
@@ -15,7 +15,7 @@ export interface ClickAnalyticsActionCreators {
   /**
    * The event to log when a recommendation is selected.
    *
-   * @param result - The selected recommendation.
+   * @param recommendation - The selected recommendation.
    * @returns A dispatchable action.
    */
   logRecommendationOpen(

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -1,5 +1,13 @@
 export {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 
+export {
+  RecommendationEngine,
+  RecommendationEngineOptions,
+  RecommendationEngineConfiguration,
+  buildRecommendationEngine,
+  getSampleRecommendationEngineConfiguration,
+} from './app/recommendation-engine/recommendation-engine';
+
 export {CoreEngine, ExternalEngineOptions} from './app/engine';
 export {
   EngineConfiguration,
@@ -8,14 +16,6 @@ export {
 } from './app/engine-configuration';
 export {LoggerOptions} from './app/logger';
 export {LogLevel} from './app/logger';
-
-export {
-  RecommendationEngine,
-  RecommendationEngineOptions,
-  RecommendationEngineConfiguration,
-  buildRecommendationEngine,
-  getSampleRecommendationEngineConfiguration,
-} from './app/recommendation-engine/recommendation-engine';
 
 // Actions
 export * from './features/configuration/configuration-actions-loader';

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -11,6 +11,7 @@ export {
 // Actions
 export * from './features/configuration/configuration-actions-loader';
 export * from './features/advanced-search-queries/advanced-search-queries-actions-loader';
+export * from './features/context/context-actions-loader';
 export * from './features/fields/fields-actions-loader';
 export * from './features/pipeline/pipeline-actions-loader';
 export * from './features/search-hub/search-hub-actions-loader';

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -1,4 +1,13 @@
-export {Unsubscribe} from '@reduxjs/toolkit';
+export {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+
+export {CoreEngine, ExternalEngineOptions} from './app/engine';
+export {
+  EngineConfiguration,
+  AnalyticsConfiguration,
+  AnalyticsRuntimeEnvironment,
+} from './app/engine-configuration';
+export {LoggerOptions} from './app/logger';
+export {LogLevel} from './app/logger';
 
 export {
   RecommendationEngine,
@@ -21,6 +30,11 @@ export * from './features/recommendation/recommendation-click-analytics-actions-
 
 // Controllers
 export {
+  Controller,
+  buildController,
+} from './controllers/controller/headless-controller';
+
+export {
   RecommendationListOptions,
   RecommendationListProps,
   RecommendationListState,
@@ -36,4 +50,7 @@ export {
   buildContext,
 } from './controllers/context/headless-context';
 
+// Miscellaneous
 export {Result} from './api/search/search/result';
+export {HighlightKeyword} from './utils/highlight';
+export {Raw} from './api/search/search/raw';


### PR DESCRIPTION
This PR adjusts the doc extraction and parsing to support `n` use-cases and extracts the recommendation use-case.
I will open a sister branch for product-recommendation,

https://coveord.atlassian.net/browse/KIT-809