### PR TITLE
docs: store actionloaders under #actions key

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -25,7 +25,7 @@ interface UseCase {
 interface ResolvedUseCase {
   name: string;
   controllers: Controller[];
-  actionLoaders: ActionLoader[];
+  actions: ActionLoader[];
   engine: Engine;
 }
 
@@ -51,13 +51,13 @@ function resolveUseCase(useCase: UseCase): ResolvedUseCase {
   const controllers = config.controllers.map((controller) =>
     resolveController(entryPoint, controller)
   );
-  const actionLoaders = config.actionLoaders.map((loader) =>
+  const actions = config.actionLoaders.map((loader) =>
     resolveActionLoader(entryPoint, loader)
   );
 
   const engine = resolveEngine(entryPoint, config.engine);
 
-  return {name, controllers, actionLoaders, engine};
+  return {name, controllers, actions, engine};
 }
 
 const resolved = useCases.map(resolveUseCase);


### PR DESCRIPTION
@dlutzCoveo is saying that it would be simpler for the doc scripts if the action loaders where stored under a key called `actions`, so I made the adjustment.

https://coveord.atlassian.net/browse/KIT-813