### PR TITLE
feat(headless): improve standalone search box experience

### DIFF
--- a/packages/atomic/cypress/integration/search-engine.cypress.ts
+++ b/packages/atomic/cypress/integration/search-engine.cypress.ts
@@ -32,7 +32,7 @@ describe('search engine tests', () => {
 
     cy.wait(RouteAlias.analytics).then(({request}) => {
       const analyticsBody = request.body;
-      expect(analyticsBody).to.have.property('actionCause', 'interfaceLoad');
+      expect(analyticsBody).to.have.property('actionCause', 'searchFromLink');
     });
   });
 });

--- a/packages/atomic/cypress/integration/search-engine.cypress.ts
+++ b/packages/atomic/cypress/integration/search-engine.cypress.ts
@@ -1,0 +1,22 @@
+import {
+  buildSearchEngine,
+  getSampleSearchEngineConfiguration,
+} from '@coveo/headless';
+import {RouteAlias, setupIntercept} from '../utils/setupComponent';
+
+describe('search engine tests', () => {
+  it('calling #executeFirstSearch logs an interfaceLoad analytics event', () => {
+    const engine = buildSearchEngine({
+      configuration: getSampleSearchEngineConfiguration(),
+    });
+
+    setupIntercept();
+
+    engine.executeFirstSearch();
+
+    cy.wait(RouteAlias.analytics).then(({request}) => {
+      const analyticsBody = request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'interfaceLoad');
+    });
+  });
+});

--- a/packages/atomic/cypress/integration/search-engine.cypress.ts
+++ b/packages/atomic/cypress/integration/search-engine.cypress.ts
@@ -32,7 +32,7 @@ describe('search engine tests', () => {
 
     cy.wait(RouteAlias.analytics).then(({request}) => {
       const analyticsBody = request.body;
-      expect(analyticsBody).to.have.property('actionCause', 'searchFromLink');
+      expect(analyticsBody).to.have.property('actionCause', 'interfaceLoad');
     });
   });
 });

--- a/packages/atomic/cypress/integration/search-engine.cypress.ts
+++ b/packages/atomic/cypress/integration/search-engine.cypress.ts
@@ -1,22 +1,38 @@
 import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
+  loadSearchAnalyticsActions,
+  SearchEngine,
 } from '@coveo/headless';
 import {RouteAlias, setupIntercept} from '../utils/setupComponent';
 
 describe('search engine tests', () => {
-  it('calling #executeFirstSearch logs an interfaceLoad analytics event', () => {
-    const engine = buildSearchEngine({
+  let engine: SearchEngine;
+
+  beforeEach(() => {
+    engine = buildSearchEngine({
       configuration: getSampleSearchEngineConfiguration(),
     });
 
     setupIntercept();
+  });
 
+  it('calling #executeFirstSearch with no arguments logs an interfaceLoad analytics event', () => {
     engine.executeFirstSearch();
 
     cy.wait(RouteAlias.analytics).then(({request}) => {
       const analyticsBody = request.body;
       expect(analyticsBody).to.have.property('actionCause', 'interfaceLoad');
+    });
+  });
+
+  it('calling #executeFirstSearch with an analytics action logs the passed action', () => {
+    const {logSearchFromLink} = loadSearchAnalyticsActions(engine);
+    engine.executeFirstSearch(logSearchFromLink());
+
+    cy.wait(RouteAlias.analytics).then(({request}) => {
+      const analyticsBody = request.body;
+      expect(analyticsBody).to.have.property('actionCause', 'searchFromLink');
     });
   });
 });

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -6,14 +6,14 @@
   "packages": {
     "": {
       "name": "@coveo/headless",
-      "version": "1.3.0",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.31.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
-        "coveo.analytics": "^2.18.27",
+        "coveo.analytics": "^2.18.29",
         "cross-fetch": "^3.0.6",
         "dayjs": "^1.9.6",
         "exponential-backoff": "^3.1.0",
@@ -2852,9 +2852,10 @@
       "dev": true
     },
     "node_modules/coveo.analytics": {
-      "version": "2.18.27",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.27.tgz",
-      "integrity": "sha512-a/hDpfQ9rhE5Fyh0kh3oYYpt6/y1QAPTRfP+jp1te/3U45wS/jYCQjom1LWzkllYspYIjvl51boqEMr9XimUXA==",
+      "version": "2.18.29",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.29.tgz",
+      "integrity": "sha512-3JcruDMvIoDmI4MUGR2/sHVYkqAu2pAhjGChpZqtY6V9/U23sLFEmb5DRjoAtjbjORyv8ZlTkliuZtraShNdEg==",
+      "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.13.3",
         "cross-fetch": "^3.1.4"
@@ -12348,9 +12349,9 @@
       "dev": true
     },
     "coveo.analytics": {
-      "version": "2.18.27",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.27.tgz",
-      "integrity": "sha512-a/hDpfQ9rhE5Fyh0kh3oYYpt6/y1QAPTRfP+jp1te/3U45wS/jYCQjom1LWzkllYspYIjvl51boqEMr9XimUXA==",
+      "version": "2.18.29",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.29.tgz",
+      "integrity": "sha512-3JcruDMvIoDmI4MUGR2/sHVYkqAu2pAhjGChpZqtY6V9/U23sLFEmb5DRjoAtjbjORyv8ZlTkliuZtraShNdEg==",
       "requires": {
         "@react-native-async-storage/async-storage": "^1.13.3",
         "cross-fetch": "^3.1.4"

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -35,7 +35,7 @@
     "@reduxjs/toolkit": "^1.5.0",
     "@types/pino": "^6.3.4",
     "@types/redux-mock-store": "^1.0.2",
-    "coveo.analytics": "^2.18.27",
+    "coveo.analytics": "^2.18.29",
     "cross-fetch": "^3.0.6",
     "dayjs": "^1.9.6",
     "exponential-backoff": "^3.1.0",

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -28,6 +28,7 @@ import {logInterfaceLoad} from '../../features/analytics/analytics-actions';
 import {firstSearchExecutedSelector} from '../../features/search/search-selectors';
 import {SearchAppState} from '../../state/search-app-state';
 import {SearchThunkExtraArguments} from '../search-thunk-extra-arguments';
+import {SearchAction} from '../../features/analytics/analytics-utils';
 
 export {
   SearchEngineConfiguration,
@@ -47,8 +48,10 @@ export interface SearchEngine<State extends object = {}>
   extends CoreEngine<State & SearchEngineState, SearchThunkExtraArguments> {
   /**
    * Executes the first search.
+   *
+   * @param analyticsEvent - The analytics event to log in association with the first search. If unspecified, `logInterfaceLoad` will be used.
    */
-  executeFirstSearch(): void;
+  executeFirstSearch(analyticsEvent?: SearchAction): void;
 }
 
 /**
@@ -99,14 +102,14 @@ export function buildSearchEngine(options: SearchEngineOptions): SearchEngine {
       return engine.state;
     },
 
-    executeFirstSearch() {
+    executeFirstSearch(analyticsEvent = logInterfaceLoad()) {
       const firstSearchExecuted = firstSearchExecutedSelector(engine.state);
 
       if (firstSearchExecuted) {
         return;
       }
 
-      const action = executeSearch(logInterfaceLoad());
+      const action = executeSearch(analyticsEvent);
       engine.dispatch(action);
     },
   };

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
@@ -12,9 +12,17 @@ import {
   MockSearchEngine,
 } from '../../test/mock-engine';
 import {SearchAppState} from '../../state/search-app-state';
-import {registerQuerySetQuery} from '../../features/query-set/query-set-actions';
+import {
+  registerQuerySetQuery,
+  updateQuerySetQuery,
+} from '../../features/query-set/query-set-actions';
 import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
-import {configuration, query, redirection} from '../../app/reducers';
+import {
+  configuration,
+  query,
+  redirection,
+  querySuggest,
+} from '../../app/reducers';
 
 describe('headless standalone searchBox', () => {
   const id = 'search-box-123';
@@ -51,6 +59,7 @@ describe('headless standalone searchBox', () => {
       redirection,
       configuration,
       query,
+      querySuggest,
     });
   });
 
@@ -84,6 +93,32 @@ describe('headless standalone searchBox', () => {
       })),
       redirectTo: state.redirection.redirectTo,
       isLoading: false,
+      analytics: {
+        cause: '',
+        metadata: null,
+      },
+    });
+  });
+
+  describe('#updateText', () => {
+    const query = 'a';
+
+    beforeEach(() => {
+      searchBox.updateText(query);
+    });
+
+    it('sets the analytics cause to "searchFromLink"', () => {
+      searchBox.updateText('');
+
+      expect(searchBox.state.analytics).toEqual({
+        cause: 'searchFromLink',
+        metadata: null,
+      });
+    });
+
+    it('dispatches #updateQuerySetQuery', () => {
+      const action = updateQuerySetQuery({id, query});
+      expect(engine.actions).toContainEqual(action);
     });
   });
 
@@ -95,6 +130,20 @@ describe('headless standalone searchBox', () => {
       expect(engine.actions).toContainEqual(
         selectQuerySuggestion({id, expression})
       );
+    });
+
+    it('sets #state.analytics to the correct data', () => {
+      searchBox.selectSuggestion('a');
+
+      expect(searchBox.state.analytics).toEqual({
+        cause: 'omniboxFromLink',
+        metadata: {
+          partialQueries: [],
+          partialQuery: undefined,
+          suggestionRanking: -1,
+          suggestions: [],
+        },
+      });
     });
 
     it('calls #submit', () => {

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -1,11 +1,19 @@
-import {configuration, query, redirection} from '../../app/reducers';
+import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
+import {
+  configuration,
+  query,
+  redirection,
+  querySuggest,
+} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
+import {buildOmniboxSuggestionMetadata} from '../../features/query-suggest/query-suggest-analytics-actions';
 import {updateQuery} from '../../features/query/query-actions';
 import {checkForRedirection} from '../../features/redirection/redirection-actions';
 import {
   ConfigurationSection,
   QuerySection,
+  QuerySuggestionSection,
   RedirectionSection,
 } from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';
@@ -46,10 +54,35 @@ export interface StandaloneSearchBox extends SearchBox {
 
 export interface StandaloneSearchBoxState extends SearchBoxState {
   /**
+   * The analytics data to send when performing the first query on the search page the user is redirected to.
+   */
+  analytics: StandaloneSearchBoxAnalyticsData;
+
+  /**
    * The Url to redirect to.
    */
   redirectTo: string | null;
 }
+
+interface InitialData {
+  cause: '';
+  metadata: null;
+}
+
+interface SearchFromLinkData {
+  cause: 'searchFromLink';
+  metadata: null;
+}
+
+interface OmniboxFromLinkData {
+  cause: 'omniboxFromLink';
+  metadata: OmniboxSuggestionsMetadata;
+}
+
+type StandaloneSearchBoxAnalyticsData =
+  | InitialData
+  | SearchFromLinkData
+  | OmniboxFromLinkData;
 
 /**
  * Creates a `StandaloneSearchBox` instance.
@@ -86,10 +119,21 @@ export function buildStandaloneSearchBox(
 
   const searchBox = buildSearchBox(engine, {options});
 
+  let analytics: StandaloneSearchBoxAnalyticsData = {
+    cause: '',
+    metadata: null,
+  };
+
   return {
     ...searchBox,
 
+    updateText(value: string) {
+      analytics = buildSearchFromLinkData();
+      searchBox.updateText(value);
+    },
+
     selectSuggestion(value: string) {
+      analytics = buildOmniboxFromLinkData(getState(), id, value);
       dispatch(selectQuerySuggestion({id, expression: value}));
       this.submit();
     },
@@ -111,6 +155,7 @@ export function buildStandaloneSearchBox(
       return {
         ...searchBox.state,
         redirectTo: state.redirection.redirectTo,
+        analytics,
       };
     },
   };
@@ -119,8 +164,29 @@ export function buildStandaloneSearchBox(
 function loadStandaloneSearchBoxReducers(
   engine: SearchEngine
 ): engine is SearchEngine<
-  RedirectionSection & ConfigurationSection & QuerySection
+  RedirectionSection &
+    ConfigurationSection &
+    QuerySection &
+    QuerySuggestionSection
 > {
-  engine.addReducers({redirection, configuration, query});
+  engine.addReducers({redirection, configuration, query, querySuggest});
   return true;
+}
+
+function buildSearchFromLinkData(): SearchFromLinkData {
+  return {
+    cause: 'searchFromLink',
+    metadata: null,
+  };
+}
+
+function buildOmniboxFromLinkData(
+  state: QuerySuggestionSection,
+  id: string,
+  suggestion: string
+): OmniboxFromLinkData {
+  return {
+    cause: 'omniboxFromLink',
+    metadata: buildOmniboxSuggestionMetadata(state, {id, suggestion}),
+  };
 }

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -1,4 +1,3 @@
-import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
 import {
   configuration,
   query,
@@ -7,7 +6,10 @@ import {
 } from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {selectQuerySuggestion} from '../../features/query-suggest/query-suggest-actions';
-import {buildOmniboxSuggestionMetadata} from '../../features/query-suggest/query-suggest-analytics-actions';
+import {
+  buildOmniboxSuggestionMetadata,
+  OmniboxSuggestionMetadata,
+} from '../../features/query-suggest/query-suggest-analytics-actions';
 import {updateQuery} from '../../features/query/query-actions';
 import {checkForRedirection} from '../../features/redirection/redirection-actions';
 import {
@@ -76,7 +78,7 @@ interface SearchFromLinkData {
 
 interface OmniboxFromLinkData {
   cause: 'omniboxFromLink';
-  metadata: OmniboxSuggestionsMetadata;
+  metadata: OmniboxSuggestionMetadata;
 }
 
 type StandaloneSearchBoxAnalyticsData =

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -13,6 +13,7 @@ import {
   partialDocumentInformation,
   validateResultPayload,
 } from './analytics-utils';
+import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
 
 export interface SearchEventPayload {
   /** The identifier of the search action (e.g., `interfaceLoad`). */
@@ -154,3 +155,22 @@ export const logInterfaceChange = makeAnalyticsAction(
         getAdvancedSearchQueriesInitialState().cq,
     })
 );
+
+/**
+ * Logs an interface load event.
+ */
+export const logSearchFromLink = makeAnalyticsAction(
+  'analytics/interface/searchFromLink',
+  AnalyticsType.Search,
+  (client) => client.logInterfaceLoad()
+);
+
+/**
+ * Logs an interface load event.
+ */
+export const logOmniboxFromLink = (metadata: OmniboxSuggestionsMetadata) =>
+  makeAnalyticsAction(
+    'analytics/interface/omniboxFromLink',
+    AnalyticsType.Search,
+    (client) => client.logOmniboxFromLink(metadata)
+  )();

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -159,7 +159,7 @@ export const logInterfaceChange = makeAnalyticsAction(
 export const logSearchFromLink = makeAnalyticsAction(
   'analytics/interface/searchFromLink',
   AnalyticsType.Search,
-  (client) => client.logInterfaceLoad()
+  (client) => client.logSearchFromLink()
 );
 
 export const logOmniboxFromLink = (metadata: OmniboxSuggestionMetadata) =>

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -13,7 +13,7 @@ import {
   partialDocumentInformation,
   validateResultPayload,
 } from './analytics-utils';
-import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
+import {OmniboxSuggestionMetadata} from '../query-suggest/query-suggest-analytics-actions';
 
 export interface SearchEventPayload {
   /** The identifier of the search action (e.g., `interfaceLoad`). */
@@ -156,19 +156,13 @@ export const logInterfaceChange = makeAnalyticsAction(
     })
 );
 
-/**
- * Logs an interface load event.
- */
 export const logSearchFromLink = makeAnalyticsAction(
   'analytics/interface/searchFromLink',
   AnalyticsType.Search,
   (client) => client.logInterfaceLoad()
 );
 
-/**
- * Logs an interface load event.
- */
-export const logOmniboxFromLink = (metadata: OmniboxSuggestionsMetadata) =>
+export const logOmniboxFromLink = (metadata: OmniboxSuggestionMetadata) =>
   makeAnalyticsAction(
     'analytics/interface/omniboxFromLink',
     AnalyticsType.Search,

--- a/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
@@ -1,7 +1,12 @@
 import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {StateNeededByAnalyticsProvider} from '../../api/analytics/analytics';
 import {logClearBreadcrumbs} from '../facets/generic/facet-generic-analytics-actions';
-import {logInterfaceChange, logInterfaceLoad} from './analytics-actions';
+import {
+  logInterfaceChange,
+  logInterfaceLoad,
+  logSearchFromLink,
+  logOmniboxFromLink,
+} from './analytics-actions';
 import {AnalyticsType, AsyncThunkAnalyticsOptions} from './analytics-utils';
 import {logDidYouMeanClick} from '../did-you-mean/did-you-mean-analytics-actions';
 import {
@@ -55,6 +60,7 @@ import {
 } from '../question-answering/question-answering-analytics-actions';
 import {QuestionAnsweringDocumentIdActionCreatorPayload} from '../question-answering/question-answering-document-id';
 import {SearchEngine} from '../../app/search-engine/search-engine';
+import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
 
 export {
   LogCategoryFacetBreadcrumbActionCreatorPayload,
@@ -89,6 +95,34 @@ export interface SearchAnalyticsActionCreators {
    * @returns A dispatchable action.
    */
   logInterfaceLoad(): AsyncThunkAction<
+    {
+      analyticsType: AnalyticsType.Search;
+    },
+    void,
+    AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
+  >;
+
+  /**
+   * The event to log when a search interface loads for the first time, for a user who performed a search using a standalone search box.
+   *
+   * @returns A dispatchable action.
+   */
+  logSearchFromLink(): AsyncThunkAction<
+    {
+      analyticsType: AnalyticsType.Search;
+    },
+    void,
+    AsyncThunkAnalyticsOptions<StateNeededByAnalyticsProvider>
+  >;
+
+  /**
+   * The event to log when a search interface loads for the first time, for a user who selected a query suggestion from a standalone search box.
+   *
+   * @returns A dispatchable action.
+   */
+  logOmniboxFromLink(
+    metadata: OmniboxSuggestionsMetadata
+  ): AsyncThunkAction<
     {
       analyticsType: AnalyticsType.Search;
     },
@@ -501,6 +535,8 @@ export function loadSearchAnalyticsActions(
   return {
     logClearBreadcrumbs,
     logInterfaceLoad,
+    logSearchFromLink,
+    logOmniboxFromLink,
     logInterfaceChange,
     logDidYouMeanClick,
     logCategoryFacetBreadcrumb,

--- a/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
@@ -48,6 +48,7 @@ import {logSearchboxSubmit} from '../query/query-analytics-actions';
 import {
   logQuerySuggestionClick,
   LogQuerySuggestionClickActionCreatorPayload,
+  OmniboxSuggestionMetadata,
 } from '../query-suggest/query-suggest-analytics-actions';
 import {logResultsSort} from '../sort-criteria/sort-criteria-analytics-actions';
 import {
@@ -60,7 +61,6 @@ import {
 } from '../question-answering/question-answering-analytics-actions';
 import {QuestionAnsweringDocumentIdActionCreatorPayload} from '../question-answering/question-answering-document-id';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
 
 export {
   LogCategoryFacetBreadcrumbActionCreatorPayload,
@@ -118,10 +118,11 @@ export interface SearchAnalyticsActionCreators {
   /**
    * The event to log when a search interface loads for the first time, for a user who selected a query suggestion from a standalone search box.
    *
+   * @param metadata - The metadata of the clicked query suggestion that triggered the redirect.
    * @returns A dispatchable action.
    */
   logOmniboxFromLink(
-    metadata: OmniboxSuggestionsMetadata
+    metadata: OmniboxSuggestionMetadata
   ): AsyncThunkAction<
     {
       analyticsType: AnalyticsType.Search;

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -26,7 +26,7 @@ export const logQuerySuggestionClick = (
     }
   )();
 
-function buildOmniboxSuggestionMetadata(
+export function buildOmniboxSuggestionMetadata(
   state: Partial<SearchAppState>,
   payload: LogQuerySuggestionClickActionCreatorPayload
 ): OmniboxSuggestionsMetadata {
@@ -35,7 +35,7 @@ function buildOmniboxSuggestionMetadata(
 
   if (!querySuggest) {
     throw new Error(
-      `Unable to log querySuggest click to analytics because no querysuggest with id "${id}" was found.`
+      `Unable to determine the query suggest analytics metadata to send because no query suggest with id "${id}" was found. Please check the sent #id.`
     );
   }
 

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -1,4 +1,5 @@
 import {OmniboxSuggestionsMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
+import {SearchAppState} from '../../state/search-app-state';
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
 export interface LogQuerySuggestionClickActionCreatorPayload {
@@ -20,23 +21,33 @@ export const logQuerySuggestionClick = (
     'analytics/querySuggest',
     AnalyticsType.Search,
     (client, state) => {
-      const {id, suggestion} = payload;
-      const querySuggest = state.querySuggest && state.querySuggest[id];
-      if (querySuggest !== null && querySuggest !== undefined) {
-        const suggestions = querySuggest.completions.map(
-          (completion) => completion.expression
-        );
-
-        const payload: OmniboxSuggestionsMetadata = {
-          suggestionRanking: suggestions.indexOf(suggestion),
-          partialQuery:
-            querySuggest.partialQueries[querySuggest.partialQueries.length - 1],
-          partialQueries: querySuggest.partialQueries,
-          suggestions,
-        };
-        return client.logOmniboxAnalytics(payload);
-      }
-
-      return;
+      const metadata = buildOmniboxSuggestionMetadata(state, payload);
+      return client.logOmniboxAnalytics(metadata);
     }
   )();
+
+function buildOmniboxSuggestionMetadata(
+  state: Partial<SearchAppState>,
+  payload: LogQuerySuggestionClickActionCreatorPayload
+): OmniboxSuggestionsMetadata {
+  const {id, suggestion} = payload;
+  const querySuggest = state.querySuggest && state.querySuggest[id];
+
+  if (!querySuggest) {
+    throw new Error(
+      `Unable to log querySuggest click to analytics because no querysuggest with id "${id}" was found.`
+    );
+  }
+
+  const suggestions = querySuggest.completions.map(
+    (completion) => completion.expression
+  );
+
+  return {
+    suggestionRanking: suggestions.indexOf(suggestion),
+    partialQuery:
+      querySuggest.partialQueries[querySuggest.partialQueries.length - 1],
+    partialQueries: querySuggest.partialQueries,
+    suggestions,
+  };
+}

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -26,10 +26,12 @@ export const logQuerySuggestionClick = (
     }
   )();
 
+export type OmniboxSuggestionMetadata = OmniboxSuggestionsMetadata;
+
 export function buildOmniboxSuggestionMetadata(
   state: Partial<SearchAppState>,
   payload: LogQuerySuggestionClickActionCreatorPayload
-): OmniboxSuggestionsMetadata {
+): OmniboxSuggestionMetadata {
   const {id, suggestion} = payload;
   const querySuggest = state.querySuggest && state.querySuggest[id];
 


### PR DESCRIPTION
This PR tries to make it easier to implement the standalone search box use-case using headless:

1. The `logSearchFromLink` and `logOmniboxFromLink` actions are now available.
2. The `executeFirstSearch` accepts a search action, allowing a developer specify the analytics event associated with the first search.
3. The standalone search box controller provides the analytics cause and metadata.

I will create a doc article too, since developers will still need to manage the plumbing between the standalone page and the actual search page. Once available, we can link to it inside the reference,