### PR TITLE
chore(atomic): switch locales keys to kebab-case

### DIFF
--- a/packages/atomic/README.md
+++ b/packages/atomic/README.md
@@ -86,11 +86,11 @@ npm run cypress:test
 
 ## Utilities
 
-### The InitializeBindings, BindStateToController & BindStateToI18n decorators
+### The InitializeBindings & BindStateToController decorators
 
 The `InitializeBindings` is an utility that automatically fetches the `bindings` from the parent `atomic-search-interface` component. This decorator should be applied to the `bindings` property directly.
 
-_Important_ In order for a component using this decorator to render properly, it should have an internal state bound to one of the property from `bindings`. This is possible by using either the `BindStateToController` or the `BindStateToI18n` decorator.
+_Important_ In order for a component using this decorator to render properly, it should have an internal state bound to one of the property from `bindings`. This is possible by using either the `BindStateToController`decorator.
 
 Here is a complete example using all these decorators:
 
@@ -107,16 +107,6 @@ export class AtomicComponent {
   @BindStateToController('controller')
   @State()
   private controllerState!: ControllerState;
-
-  // Will automically update the strings on initialization and when the locale changes
-  @BindStateToI18n()
-  @State()
-  private strings = {
-    value: () =>
-      this.bindings.i18n.t('value', {
-        /* options */
-      }),
-  };
 
   // Method called after bindings are defined, where controllers should be initialized
   public initialize() {

--- a/packages/atomic/cypress/integration/search-interface.cypress.ts
+++ b/packages/atomic/cypress/integration/search-interface.cypress.ts
@@ -49,7 +49,7 @@ describe('Search Interface Component', () => {
     });
 
     it('should support changing a translation value without overriding other strings', () => {
-      setTranslation('fr', 'showingResultsOf_plural', 'patate');
+      setTranslation('fr', 'showing-results-of_plural', 'patate');
       setLanguage('fr');
 
       cy.get('atomic-query-summary')

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -325,6 +325,28 @@ export namespace Components {
          */
         "enableDuration": boolean;
     }
+    interface AtomicRatingFacet {
+        /**
+          * Whether to display the facet values as checkboxes (multiple selection) or links (single selection). Possible values are 'checkbox' and 'link'.
+         */
+        "displayValuesAs": 'checkbox' | 'link';
+        /**
+          * Specifies a unique identifier for the facet.
+         */
+        "facetId"?: string;
+        /**
+          * The field whose values you want to display in the facet.
+         */
+        "field": string;
+        /**
+          * The non-localized label for the facet.
+         */
+        "label": string;
+        /**
+          * The number of stars to request for this facet.
+         */
+        "numberOfStars": number;
+    }
     interface AtomicRelevanceInspector {
         /**
           * The Atomic interface bindings, namely the headless search engine and i18n instances.
@@ -699,6 +721,12 @@ declare global {
         prototype: HTMLAtomicQuerySummaryElement;
         new (): HTMLAtomicQuerySummaryElement;
     };
+    interface HTMLAtomicRatingFacetElement extends Components.AtomicRatingFacet, HTMLStencilElement {
+    }
+    var HTMLAtomicRatingFacetElement: {
+        prototype: HTMLAtomicRatingFacetElement;
+        new (): HTMLAtomicRatingFacetElement;
+    };
     interface HTMLAtomicRelevanceInspectorElement extends Components.AtomicRelevanceInspector, HTMLStencilElement {
     }
     var HTMLAtomicRelevanceInspectorElement: {
@@ -849,6 +877,7 @@ declare global {
         "atomic-pager": HTMLAtomicPagerElement;
         "atomic-query-error": HTMLAtomicQueryErrorElement;
         "atomic-query-summary": HTMLAtomicQuerySummaryElement;
+        "atomic-rating-facet": HTMLAtomicRatingFacetElement;
         "atomic-relevance-inspector": HTMLAtomicRelevanceInspectorElement;
         "atomic-result": HTMLAtomicResultElement;
         "atomic-result-date": HTMLAtomicResultDateElement;
@@ -1189,6 +1218,28 @@ declare namespace LocalJSX {
          */
         "enableDuration"?: boolean;
     }
+    interface AtomicRatingFacet {
+        /**
+          * Whether to display the facet values as checkboxes (multiple selection) or links (single selection). Possible values are 'checkbox' and 'link'.
+         */
+        "displayValuesAs"?: 'checkbox' | 'link';
+        /**
+          * Specifies a unique identifier for the facet.
+         */
+        "facetId"?: string;
+        /**
+          * The field whose values you want to display in the facet.
+         */
+        "field": string;
+        /**
+          * The non-localized label for the facet.
+         */
+        "label"?: string;
+        /**
+          * The number of stars to request for this facet.
+         */
+        "numberOfStars"?: number;
+    }
     interface AtomicRelevanceInspector {
         /**
           * The Atomic interface bindings, namely the headless search engine and i18n instances.
@@ -1435,6 +1486,7 @@ declare namespace LocalJSX {
         "atomic-pager": AtomicPager;
         "atomic-query-error": AtomicQueryError;
         "atomic-query-summary": AtomicQuerySummary;
+        "atomic-rating-facet": AtomicRatingFacet;
         "atomic-relevance-inspector": AtomicRelevanceInspector;
         "atomic-result": AtomicResult;
         "atomic-result-date": AtomicResultDate;
@@ -1485,6 +1537,7 @@ declare module "@stencil/core" {
             "atomic-pager": LocalJSX.AtomicPager & JSXBase.HTMLAttributes<HTMLAtomicPagerElement>;
             "atomic-query-error": LocalJSX.AtomicQueryError & JSXBase.HTMLAttributes<HTMLAtomicQueryErrorElement>;
             "atomic-query-summary": LocalJSX.AtomicQuerySummary & JSXBase.HTMLAttributes<HTMLAtomicQuerySummaryElement>;
+            "atomic-rating-facet": LocalJSX.AtomicRatingFacet & JSXBase.HTMLAttributes<HTMLAtomicRatingFacetElement>;
             "atomic-relevance-inspector": LocalJSX.AtomicRelevanceInspector & JSXBase.HTMLAttributes<HTMLAtomicRelevanceInspectorElement>;
             "atomic-result": LocalJSX.AtomicResult & JSXBase.HTMLAttributes<HTMLAtomicResultElement>;
             "atomic-result-date": LocalJSX.AtomicResultDate & JSXBase.HTMLAttributes<HTMLAtomicResultDateElement>;

--- a/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
@@ -41,11 +41,11 @@ export class AtomicBreadcrumbManager implements InitializableComponent {
   private breadcrumbManager!: BreadcrumbManager;
   private strings = {
     breadcrumb: (label: string) =>
-      this.bindings.i18n.t('removeFilterOn', {value: label}),
-    clearAllFilters: () => this.bindings.i18n.t('clearAllFilters'),
-    nMore: (value: number) => this.bindings.i18n.t('nMore', {value}),
+      this.bindings.i18n.t('remove-filter-on', {value: label}),
+    clearAllFilters: () => this.bindings.i18n.t('clear-all-filters'),
+    nMore: (value: number) => this.bindings.i18n.t('n-more', {value}),
     showNMoreFilters: (value: number) =>
-      this.bindings.i18n.t('showNMoreFilters', {value}),
+      this.bindings.i18n.t('show-n-more-filters', {value}),
     to: (start: string, end: string) =>
       this.bindings.i18n.t('to', {start, end}),
   };

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -3,7 +3,6 @@ import {DidYouMean, DidYouMeanState, buildDidYouMean} from '@coveo/headless';
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializableComponent,
   InitializeBindings,
 } from '../../utils/initialization-utils';
@@ -30,11 +29,9 @@ export class AtomicDidYouMean implements InitializableComponent {
   @State()
   private didYouMeanState!: DidYouMeanState;
   @State() public error!: Error;
-  @BindStateToI18n()
-  @State()
   private strings = {
     withQuery: (
-      key: 'noResultsFor' | 'queryAutoCorrectedTo' | 'didYouMean',
+      key: 'no-results-for' | 'query-auto-corrected-to' | 'did-you-mean',
       query: string
     ) =>
       this.bindings.i18n.t(key, {
@@ -53,11 +50,11 @@ export class AtomicDidYouMean implements InitializableComponent {
 
   private renderAutomaticallyCorrected() {
     const noResults = this.strings.withQuery(
-      'noResultsFor',
+      'no-results-for',
       this.didYouMeanState.originalQuery
     );
     const queryAutoCorrectedTo = this.strings.withQuery(
-      'queryAutoCorrectedTo',
+      'query-auto-corrected-to',
       this.didYouMeanState.wasCorrectedTo
     );
     return [
@@ -76,7 +73,7 @@ export class AtomicDidYouMean implements InitializableComponent {
 
   private renderCorrection() {
     const didYouMean = this.strings.withQuery(
-      'didYouMean',
+      'did-you-mean',
       this.didYouMeanState.queryCorrection.correctedQuery
     );
     return (

--- a/packages/atomic/src/components/atomic-no-results/atomic-no-results.tsx
+++ b/packages/atomic/src/components/atomic-no-results/atomic-no-results.tsx
@@ -10,7 +10,6 @@ import {Component, h, Prop, State} from '@stencil/core';
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializeBindings,
 } from '../../utils/initialization-utils';
 
@@ -38,14 +37,13 @@ export class AtomicNoResults {
   @BindStateToController('history')
   @State()
   private historyState!: HistoryManagerState;
-  @BindStateToI18n()
-  @State()
   private strings = {
-    cancelLastAction: () => this.bindings.i18n.t('cancelLastAction'),
-    searchTips: () => this.bindings.i18n.t('searchTips'),
-    checkSpelling: () => this.bindings.i18n.t('checkSpelling'),
-    tryUsingFewerKeywords: () => this.bindings.i18n.t('tryUsingFewerKeywords'),
-    selectFewerFilters: () => this.bindings.i18n.t('selectFewerFilters'),
+    cancelLastAction: () => this.bindings.i18n.t('cancel-last-action'),
+    searchTips: () => this.bindings.i18n.t('search-tips'),
+    checkSpelling: () => this.bindings.i18n.t('check-spelling'),
+    tryUsingFewerKeywords: () =>
+      this.bindings.i18n.t('try-using-fewer-keywords'),
+    selectFewerFilters: () => this.bindings.i18n.t('select-fewer-filters'),
   };
   @State() public error!: Error;
 

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -10,7 +10,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializableComponent,
   InitializeBindings,
 } from '../../utils/initialization-utils';
@@ -42,13 +41,11 @@ export class AtomicPager implements InitializableComponent {
   @BindStateToController('searchStatus')
   @State()
   private searchStatusState!: SearchStatusState;
-  @BindStateToI18n()
-  @State()
   private strings = {
     pagination: () => this.bindings.i18n.t('pagination'),
     previous: () => this.bindings.i18n.t('previous'),
     next: () => this.bindings.i18n.t('next'),
-    pageNumber: (page: number) => this.bindings.i18n.t('pageNumber', {page}),
+    pageNumber: (page: number) => this.bindings.i18n.t('page-number', {page}),
   };
   @State() error!: Error;
 

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
@@ -3,7 +3,6 @@ import {QueryError, QueryErrorState, buildQueryError} from '@coveo/headless';
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializableComponent,
   InitializeBindings,
 } from '../../utils/initialization-utils';
@@ -32,22 +31,20 @@ export class AtomicQueryError implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
   public queryError!: QueryError;
 
-  @BindStateToI18n()
-  @State()
   private strings = {
     disconnectedTitle: () => this.bindings.i18n.t('disconnected'),
-    disconnectedDesc: () => this.bindings.i18n.t('checkYourConnection'),
-    noEndpointsTitle: () => this.bindings.i18n.t('noEndpoints'),
-    noEndpointsDesc: () => this.bindings.i18n.t('addSources'),
-    invalidTokenTitle: () => this.bindings.i18n.t('cannotAccess'),
-    invalidTokenDesc: () => this.bindings.i18n.t('invalidToken'),
-    genericErrorTitle: () => this.bindings.i18n.t('somethingWentWrong'),
-    genericErrorDesc: () => this.bindings.i18n.t('ifProblemPersists'),
-    helpLink: () => this.bindings.i18n.t('coveoOnlineHelp'),
-    moreInfo: () => this.bindings.i18n.t('moreInfo'),
-    organizationIsPaused: () => this.bindings.i18n.t('organizationIsPaused'),
+    disconnectedDesc: () => this.bindings.i18n.t('check-your-connection'),
+    noEndpointsTitle: () => this.bindings.i18n.t('no-endpoints'),
+    noEndpointsDesc: () => this.bindings.i18n.t('add-sources'),
+    invalidTokenTitle: () => this.bindings.i18n.t('cannot-access'),
+    invalidTokenDesc: () => this.bindings.i18n.t('invalid-token'),
+    genericErrorTitle: () => this.bindings.i18n.t('something-went-wrong'),
+    genericErrorDesc: () => this.bindings.i18n.t('if-problem-persists'),
+    helpLink: () => this.bindings.i18n.t('coveo-online-help'),
+    moreInfo: () => this.bindings.i18n.t('more-info'),
+    organizationIsPaused: () => this.bindings.i18n.t('organization-is-paused'),
     organizationWillResume: () =>
-      this.bindings.i18n.t('organizationWillResume'),
+      this.bindings.i18n.t('organization-will-resume'),
   };
   @BindStateToController('queryError')
   @State()

--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.tsx
@@ -35,7 +35,7 @@ export class AtomicQuerySummary implements InitializableComponent {
   @State()
   private querySummaryState!: QuerySummaryState;
   private strings = {
-    inSeconds: (count: number) => this.bindings.i18n.t('inSeconds', {count}),
+    inSeconds: (count: number) => this.bindings.i18n.t('in-seconds', {count}),
   };
   @State() public error!: Error;
 
@@ -65,11 +65,11 @@ export class AtomicQuerySummary implements InitializableComponent {
 
   private renderNoResults() {
     const content = this.querySummaryState.hasQuery
-      ? this.bindings.i18n.t('noResultsFor', {
+      ? this.bindings.i18n.t('no-results-for', {
           interpolation: {escapeValue: false},
           query: this.wrapHighlight(escape(this.querySummaryState.query)),
         })
-      : this.bindings.i18n.t('noResults');
+      : this.bindings.i18n.t('no-results');
     return <span part="no-results" innerHTML={content}></span>;
   }
 
@@ -93,8 +93,11 @@ export class AtomicQuerySummary implements InitializableComponent {
 
   private renderHasResults() {
     const content = this.querySummaryState.hasQuery
-      ? this.bindings.i18n.t('showingResultsOfWithQuery', this.resultOfOptions)
-      : this.bindings.i18n.t('showingResultsOf', this.resultOfOptions);
+      ? this.bindings.i18n.t(
+          'showing-results-of-with-query',
+          this.resultOfOptions
+        )
+      : this.bindings.i18n.t('showing-results-of', this.resultOfOptions);
 
     return <span part="results" innerHTML={content}></span>;
   }

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.tsx
@@ -12,7 +12,6 @@ import {
   BindStateToController,
   InitializableComponent,
   InitializeBindings,
-  BindStateToI18n,
 } from '../../utils/initialization-utils';
 
 /**
@@ -40,12 +39,10 @@ export class AtomicResultsPerPage implements InitializableComponent {
   @BindStateToController('searchStatus')
   @State()
   private searchStatusState!: SearchStatusState;
-  @BindStateToI18n()
-  @State()
   private strings = {
-    resultsPerPage: () => this.bindings.i18n.t('resultsPerPage'),
+    resultsPerPage: () => this.bindings.i18n.t('results-per-page'),
     displayResultsPerPage: (results: number) =>
-      this.bindings.i18n.t('displayResultsPerPage', {results}),
+      this.bindings.i18n.t('display-results-per-page', {results}),
   };
   @State() public error!: Error;
 

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -3,7 +3,6 @@ import {SearchBox, SearchBoxState, buildSearchBox} from '@coveo/headless';
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializeBindings,
 } from '../../utils/initialization-utils';
 import {randomID} from '../../utils/utils';
@@ -30,13 +29,11 @@ import SearchIcon from 'coveo-styleguide/resources/icons/svg/search.svg';
 export class AtomicSearchBox {
   @InitializeBindings() public bindings!: Bindings;
 
-  @BindStateToI18n()
-  @State()
   public strings: ComboboxStrings = {
     clear: () => this.bindings.i18n.t('clear'),
     search: () => this.bindings.i18n.t('search'),
-    searchBox: () => this.bindings.i18n.t('searchBox'),
-    querySuggestionList: () => this.bindings.i18n.t('querySuggestionList'),
+    searchBox: () => this.bindings.i18n.t('search-box'),
+    querySuggestionList: () => this.bindings.i18n.t('query-suggestion-list'),
   };
   /**
    * The maximum number of suggestions to display.

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   I18nState,
   InitializableComponent,
   InitializeBindings,
@@ -53,8 +52,8 @@ export class AtomicSortDropdown implements InitializableComponent {
   @BindStateToController('searchStatus')
   @State()
   private searchStatusState!: SearchStatusState;
-  @BindStateToI18n() @State() private strings: I18nState = {
-    sortBy: () => this.bindings.i18n.t('sortBy'),
+  private strings: I18nState = {
+    sortBy: () => this.bindings.i18n.t('sort-by'),
   };
   @State() public error!: Error;
 

--- a/packages/atomic/src/components/atomic-text/atomic-text.tsx
+++ b/packages/atomic/src/components/atomic-text/atomic-text.tsx
@@ -3,7 +3,6 @@ import {
   InitializableComponent,
   Bindings,
   InitializeBindings,
-  BindStateToI18n,
 } from '../../utils/initialization-utils';
 
 /**
@@ -16,7 +15,7 @@ import {
 export class AtomicText implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
 
-  @BindStateToI18n() @State() private strings = {
+  private strings = {
     value: () =>
       this.bindings.i18n.t(this.value, {
         count: this.count,

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -91,7 +91,7 @@ export class AtomicFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The field whose values you want to display in the facet.
    */

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -108,7 +108,7 @@ export class AtomicNumericFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The field whose values you want to display in the facet.
    */

--- a/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
@@ -74,7 +74,7 @@ export class AtomicRatingFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The field whose values you want to display in the facet.
    */

--- a/packages/atomic/src/components/facets-v1/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -65,7 +65,7 @@ export class AtomicTimeframeFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The field whose values you want to display in the facet.
    */

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -13,12 +13,12 @@ export const FacetHeader: FunctionalComponent<{
   onClearFilters(): void;
 }> = (props) => {
   const label = props.i18n.t(props.label);
-  const expandFacet = props.i18n.t('expandFacet', {label});
-  const collapseFacet = props.i18n.t('collapseFacet', {label});
-  const clearFilters = props.i18n.t('clearFilters', {
+  const expandFacet = props.i18n.t('expand-facet', {label});
+  const collapseFacet = props.i18n.t('collapse-facet', {label});
+  const clearFilters = props.i18n.t('clear-filters', {
     count: props.numberOfSelectedValues,
   });
-  const clearFiltersForFacet = props.i18n.t('clearFiltersForFacet', {
+  const clearFiltersForFacet = props.i18n.t('clear-filters-for-facet', {
     count: props.numberOfSelectedValues,
     label,
   });

--- a/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
@@ -56,11 +56,11 @@ export class FacetNumberInput {
   render() {
     const label = this.bindings.i18n.t(this.label);
     const minPlaceholder = this.bindings.i18n.t('min');
-    const minAria = this.bindings.i18n.t('numberInputMinimum', {label});
+    const minAria = this.bindings.i18n.t('number-input-minimum', {label});
     const maxPlaceholder = this.bindings.i18n.t('max');
-    const maxAria = this.bindings.i18n.t('numberInputMaximum', {label});
+    const maxAria = this.bindings.i18n.t('number-input-maximum', {label});
     const apply = this.bindings.i18n.t('apply');
-    const applyAria = this.bindings.i18n.t('numberInputApply', {label});
+    const applyAria = this.bindings.i18n.t('number-input-apply', {label});
 
     const commonClasses = 'text-base rounded p-2.5 border border-neutral-light';
     const inputClasses = `${commonClasses} placeholder-neutral-dark min-w-0 mr-1`;

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
@@ -16,7 +16,7 @@ export const FacetSearchInput: FunctionalComponent<FacetSearchInputProps> = (
 ) => {
   const label = props.i18n.t(props.label);
   const search = props.i18n.t('search');
-  const facetSearch = props.i18n.t('facetSearch', {label});
+  const facetSearch = props.i18n.t('facet-search', {label});
   const clear = props.i18n.t('clear');
   let inputRef: HTMLInputElement | undefined;
 

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
@@ -10,7 +10,7 @@ interface FacetSearchMatchesProps {
 }
 
 function matchesFound(
-  key: 'moreMatchesFor' | 'noMatchesFoundFor',
+  key: 'more-matches-for' | 'no-matches-found-for',
   query: string,
   i18n: i18n
 ) {
@@ -30,7 +30,11 @@ export const FacetSearchMatches: FunctionalComponent<FacetSearchMatchesProps> = 
       <div
         part="no-matches"
         class="ellipsed p-3 bg-neutral-light text-neutral-dark text-sm"
-        innerHTML={matchesFound('noMatchesFoundFor', props.query, props.i18n)}
+        innerHTML={matchesFound(
+          'no-matches-found-for',
+          props.query,
+          props.i18n
+        )}
       ></div>
     );
   }
@@ -40,7 +44,7 @@ export const FacetSearchMatches: FunctionalComponent<FacetSearchMatchesProps> = 
       <div
         part="more-matches"
         class="ellipsed mt-3 text-neutral-dark text-sm"
-        innerHTML={matchesFound('moreMatchesFor', props.query, props.i18n)}
+        innerHTML={matchesFound('more-matches-for', props.query, props.i18n)}
       ></div>
     );
   }

--- a/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
@@ -16,12 +16,12 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
   props
 ) => {
   const label = props.i18n.t(props.label);
-  const showMore = props.i18n.t('showMore');
-  const showMoreFacetValues = props.i18n.t('showMoreFacetValues', {
+  const showMore = props.i18n.t('show-more');
+  const showMoreFacetValues = props.i18n.t('show-more-facet-values', {
     label,
   });
-  const showLess = props.i18n.t('showLess');
-  const showLessFacetValues = props.i18n.t('showLessFacetValues', {
+  const showLess = props.i18n.t('show-less');
+  const showLessFacetValues = props.i18n.t('show-less-facet-values', {
     label,
   });
   const btnClasses =

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
@@ -4,7 +4,7 @@ import {highlightSearchResult} from '../facet-search/facet-search-utils';
 
 export const FacetValueBox: FunctionalComponent<FacetValueProps> = (props) => {
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
-  const ariaLabel = props.i18n.t('facetValue', {
+  const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
     count: props.numberOfResults,
   });

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
@@ -8,7 +8,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
 ) => {
   const id = randomID('facet-value-');
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
-  const ariaLabel = props.i18n.t('facetValue', {
+  const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
     count: props.numberOfResults,
   });

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
@@ -4,7 +4,7 @@ import {highlightSearchResult} from '../facet-search/facet-search-utils';
 
 export const FacetValueLink: FunctionalComponent<FacetValueProps> = (props) => {
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
-  const ariaLabel = props.i18n.t('facetValue', {
+  const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
     count: props.numberOfResults,
   });

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -114,7 +114,7 @@ export class AtomicCategoryFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The character that separates values of a multi-value field.
    */

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -14,7 +14,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
@@ -87,19 +86,17 @@ export class AtomicCategoryFacet
 
   private facetSearch?: FacetSearch;
 
-  @BindStateToI18n()
-  @State()
   public strings: FacetSearchStrings = {
     clear: () => this.bindings.i18n.t('clear'),
     placeholder: () => this.bindings.i18n.t('search'),
     searchBox: () =>
-      this.bindings.i18n.t('facetSearch', {label: this.strings[this.label]()}),
-    querySuggestionList: () => this.bindings.i18n.t('querySuggestionList'),
-    showMore: () => this.bindings.i18n.t('showMore'),
-    showLess: () => this.bindings.i18n.t('showLess'),
-    noValuesFound: () => this.bindings.i18n.t('noValuesFound'),
-    facetValue: (variables) => this.bindings.i18n.t('facetValue', variables),
-    allCategories: () => this.bindings.i18n.t('allCategories'),
+      this.bindings.i18n.t('facet-search', {label: this.strings[this.label]()}),
+    querySuggestionList: () => this.bindings.i18n.t('query-suggestion-list'),
+    showMore: () => this.bindings.i18n.t('show-more'),
+    showLess: () => this.bindings.i18n.t('show-less'),
+    noValuesFound: () => this.bindings.i18n.t('no-values-found'),
+    facetValue: (variables) => this.bindings.i18n.t('facet-value', variables),
+    allCategories: () => this.bindings.i18n.t('all-categories'),
     pathPrefix: () => this.bindings.i18n.t('in'),
     under: (variables) => this.bindings.i18n.t('under', variables),
   };

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -80,7 +80,7 @@ export class AtomicDateFacet implements InitializableComponent, BaseFacetState {
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The format that the date will be displayed in. See https://day.js.org/docs/en/display/format for formatting details.
    */

--- a/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-date-facet/atomic-date-facet.tsx
@@ -15,7 +15,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   I18nState,
   InitializableComponent,
   InitializeBindings,
@@ -62,11 +61,9 @@ export class AtomicDateFacet implements InitializableComponent, BaseFacetState {
   @State()
   private searchStatusState!: SearchStatusState;
 
-  @BindStateToI18n()
-  @State()
   public strings: I18nState = {
     clear: () => this.bindings.i18n.t('clear'),
-    facetValue: (variables) => this.bindings.i18n.t('facetValue', variables),
+    facetValue: (variables) => this.bindings.i18n.t('facet-value', variables),
     to: (variables) => this.bindings.i18n.t('to', variables),
   };
 

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -14,7 +14,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
@@ -77,18 +76,16 @@ export class AtomicFacet
   private searchStatusState!: SearchStatusState;
   @State() public error!: Error;
 
-  @BindStateToI18n()
-  @State()
   public strings: FacetSearchStrings = {
     clear: () => this.bindings.i18n.t('clear'),
     searchBox: () =>
-      this.bindings.i18n.t('facetSearch', {label: this.strings[this.label]()}),
+      this.bindings.i18n.t('facet-search', {label: this.strings[this.label]()}),
     placeholder: () => this.bindings.i18n.t('search'),
-    querySuggestionList: () => this.bindings.i18n.t('querySuggestionList'),
-    showMore: () => this.bindings.i18n.t('showMore'),
-    showLess: () => this.bindings.i18n.t('showLess'),
-    noValuesFound: () => this.bindings.i18n.t('noValuesFound'),
-    facetValue: (variables) => this.bindings.i18n.t('facetValue', variables),
+    querySuggestionList: () => this.bindings.i18n.t('query-suggestion-list'),
+    showMore: () => this.bindings.i18n.t('show-more'),
+    showLess: () => this.bindings.i18n.t('show-less'),
+    noValuesFound: () => this.bindings.i18n.t('no-values-found'),
+    facetValue: (variables) => this.bindings.i18n.t('facet-value', variables),
   };
 
   @State() public isExpanded = false;

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -101,7 +101,7 @@ export class AtomicFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The character that separates values of a multi-value field.
    */

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -14,7 +14,6 @@ import {
 import {
   Bindings,
   BindStateToController,
-  BindStateToI18n,
   I18nState,
   InitializableComponent,
   InitializeBindings,
@@ -63,11 +62,10 @@ export class AtomicNumericFacet
   private searchStatusState!: SearchStatusState;
   @State() public error!: Error;
 
-  @BindStateToI18n()
   @State()
   public strings: I18nState = {
     clear: () => this.bindings.i18n.t('clear'),
-    facetValue: (variables) => this.bindings.i18n.t('facetValue', variables),
+    facetValue: (variables) => this.bindings.i18n.t('facet-value', variables),
     to: (variables) => this.bindings.i18n.t('to', variables),
   };
 

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -82,7 +82,7 @@ export class AtomicNumericFacet
   /**
    * The non-localized label for the facet.
    */
-  @Prop() public label = 'noLabel';
+  @Prop() public label = 'no-label';
   /**
    * The number of values to request for this facet, when there are no manual ranges.
    */

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.tsx
@@ -47,7 +47,7 @@ export class AtomicResultValue {
         ) : (
           <atomic-result-text
             field="title"
-            default="noTitle"
+            default="no-title"
           ></atomic-result-text>
         )}
       </a>

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
@@ -4,7 +4,6 @@ import {ResultContext} from '../result-template-decorators';
 import {parseXML} from '../../../utils/utils';
 import {
   Bindings,
-  BindStateToI18n,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
 import {Schema, NumberValue} from '@coveo/bueno';
@@ -30,10 +29,8 @@ export class AtomicResultPrintableUri {
   @ResultContext() private result!: Result;
 
   @State() listExpanded = false;
-  @BindStateToI18n()
-  @State()
   private strings = {
-    collapsedUriParts: () => this.bindings.i18n.t('collapsedUriParts'),
+    collapsedUriParts: () => this.bindings.i18n.t('collapsed-uri-parts'),
   };
   @State() error!: Error;
 

--- a/packages/atomic/src/components/result-template-components/atomic-result-quickview/atomic-result-quickview.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-quickview/atomic-result-quickview.tsx
@@ -32,9 +32,8 @@ export class AtomicResultQuickview implements InitializableComponent {
   @State()
   private quickviewState!: QuickviewState;
 
-  @State()
   private strings = {
-    previewResult: () => this.bindings.i18n.t('previewResult'),
+    previewResult: () => this.bindings.i18n.t('preview-result'),
   };
 
   @State() private isModalOpen = false;

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -24,7 +24,7 @@
     "zh-cn": "搜索",
     "zh-tw": "搜尋"
   },
-  "noTitle": {
+  "no-title": {
     "en": "No title",
     "fr": "Pas de titre",
     "cs": "Žádný název",
@@ -49,27 +49,27 @@
     "zh-cn": "无标题",
     "zh-tw": "無標題"
   },
-  "searchBox": {
+  "search-box": {
     "en": "Insert a query. Press enter to send.",
     "fr": "Insérer une requête. Appuyez sur Entrée pour envoyer."
   },
-  "facetSearch": {
+  "facet-search": {
     "en": "Search for values in the {{label}} facet",
     "fr": "Rechercher des valeurs dans la facette {{label}}"
   },
-  "facetValue": {
+  "facet-value": {
     "en": "Inclusion filter on {{value}}; {{count}} result",
     "fr": "Filtre d'inclusion sur {{value}}; {{count}} résultat"
   },
-  "facetValue_plural": {
+  "facet-value_plural": {
     "en": "Inclusion filter on {{value}}; {{count}} results",
     "fr": "Filtre d'inclusion sur {{value}}; {{count}} résultats"
   },
-  "removeFilterOn": {
+  "remove-filter-on": {
     "en": "Remove inclusion filter on {{value}}",
     "fr": "Enlever le filtre d'inclusion sur {{value}}"
   },
-  "querySuggestionList": {
+  "query-suggestion-list": {
     "en": "Search suggestions. Select one to search.",
     "fr": ""
   },
@@ -77,11 +77,11 @@
     "en": "Clear",
     "fr": "Effacer"
   },
-  "allCategories": {
+  "all-categories": {
     "en": "All Categories",
     "fr": "Toutes les catégories"
   },
-  "showMore": {
+  "show-more": {
     "en": "Show more",
     "fr": "Voir plus de résultats",
     "cs": "Zobrazit více",
@@ -106,7 +106,7 @@
     "zh-cn": "显示较多的值",
     "zh-tw": "顯示較多的值"
   },
-  "showLess": {
+  "show-less": {
     "en": "Show less",
     "fr": "Voir moins de résultats",
     "cs": "Zobrazit méně",
@@ -131,11 +131,11 @@
     "zh-cn": "显示较少的值",
     "zh-tw": "顯示較少的值"
   },
-  "showLessFacetValues": {
+  "show-less-facet-values": {
     "en": "Show fewer values for the {{label}} facet",
     "fr": "Afficher moins de valeurs pour la facette {{label}}"
   },
-  "showMoreFacetValues": {
+  "show-more-facet-values": {
     "en": "Show more values for the {{label}} facet",
     "fr": "Afficher plus de valeurs pour la facette {{label}}"
   },
@@ -193,15 +193,15 @@
     "zh-cn": "上一页",
     "zh-tw": "上一頁"
   },
-  "pageNumber": {
+  "page-number": {
     "en": "Page {{page}}",
     "fr": "Page {{page}}"
   },
-  "noValuesFound": {
+  "no-values-found": {
     "en": "No values found.",
     "fr": "Aucune valeur trouvée."
   },
-  "resultsPerPage": {
+  "results-per-page": {
     "en": "Results per page",
     "fr": "Résultats par page",
     "cs": "Počet výsledků na stránce",
@@ -226,11 +226,11 @@
     "zh-cn": "每一页的结果",
     "zh-tw": "每頁的結果數"
   },
-  "displayResultsPerPage": {
+  "display-results-per-page": {
     "en": "Display {{results}} results per page",
     "fr": "Afficher {{results}} résultats par page"
   },
-  "sortBy": {
+  "sort-by": {
     "en": "Sort by",
     "fr": "Trier par",
     "cs": "Seřadit podle",
@@ -280,35 +280,35 @@
     "zh-cn": "关联",
     "zh-tw": "關聯"
   },
-  "mostRecent": {
+  "most-recent": {
     "en": "Most recent",
     "fr": "Plus récents"
   },
-  "clearFilters": {
+  "clear-filters": {
     "en": "Clear filter",
     "fr": "Enlever le filtre"
   },
-  "clearFilters_plural": {
+  "clear-filters_plural": {
     "en": "Clear {{count}} filters",
     "fr": "Enlever {{count}} filtres"
   },
-  "clearFiltersForFacet": {
+  "clear-filters-for-facet": {
     "en": "Clear {{count}} filter for the {{label}} facet",
     "fr": "Enlever {{count}} filtre pour la facette {{label}}"
   },
-  "clearFiltersForFacet_plural": {
+  "clear-filters-for-facet_plural": {
     "en": "Clear {{count}} filters for the {{label}} facet",
     "fr": "Enlever {{count}} filtres pour la facette {{label}}"
   },
-  "collapseFacet": {
+  "collapse-facet": {
     "en": "Collapse the {{label}} facet",
     "fr": "Réduire la facette {{label}}"
   },
-  "expandFacet": {
+  "expand-facet": {
     "en": "Expand the {{label}} facet",
     "fr": "Agrandir la facette {{label}}"
   },
-  "showingResultsOf": {
+  "showing-results-of": {
     "en": "Result {{first}} of {{total}}",
     "fr": "Résultat {{first}} de {{total}}",
     "cs": "Výsledek {{first}} ze {{total}}",
@@ -333,7 +333,7 @@
     "zh-cn": "结果数 {{first}}，总数 {{total}}",
     "zh-tw": "結果數 {{first}}，總數 {{total}}"
   },
-  "showingResultsOf_plural": {
+  "showing-results-of_plural": {
     "en": "Results {{first}}-{{last}} of {{total}}",
     "fr": "Résultats {{first}}-{{last}} de {{total}}",
     "cs": "Výsledky {{first}}–{{last}} ze {{total}}",
@@ -358,7 +358,7 @@
     "zh-cn": "结果数 {{first}}-{{last}}，总数 {{total}}",
     "zh-tw": "結果數 {{first}}-{{last}}，總數 {{total}}"
   },
-  "showingResultsOfWithQuery": {
+  "showing-results-of-with-query": {
     "en": "Result {{first}} of {{total}} for {{query}}",
     "fr": "Résultat {{first}} de {{total}} pour {{query}}",
     "cs": "Výsledek {{first}} ze {{total}} za {{query}}",
@@ -383,7 +383,7 @@
     "zh-cn": "结果数 {{first}}，总数 {{total}}, 搜索 {{query}}",
     "zh-tw": "结果数 {{first}}，总数 {{total}}, 搜索 {{query}}"
   },
-  "showingResultsOfWithQuery_plural": {
+  "showing-results-of-with-query_plural": {
     "en": "Results {{first}}-{{last}} of {{total}} for {{query}}",
     "fr": "Résultats {{first}}-{{last}} de {{total}} pour {{query}}",
     "cs": "Výsledky {{first}}–{{last}} ze {{total}} za {{query}}",
@@ -408,7 +408,7 @@
     "zh-cn": "结果数 {{first}}-{{last}}，总数 {{total}}, 搜索 {{query}}",
     "zh-tw": "结果数 {{first}}-{{last}}，总数 {{total}}, 搜索 {{query}}"
   },
-  "inSeconds": {
+  "in-seconds": {
     "en": "in {{count}} second",
     "fr": "en {{count}} seconde",
     "cs": "za dobu: {{count}}",
@@ -433,7 +433,7 @@
     "zh-cn": "用时 {{count}} 秒",
     "zh-tw": "用時 {{count}} 秒"
   },
-  "inSeconds_plural": {
+  "in-seconds_plural": {
     "en": "in {{count}} seconds",
     "fr": "en {{count}} secondes",
     "cs": "za dobu: {{count}}",
@@ -458,7 +458,7 @@
     "zh-cn": "用时 {{count}} 秒",
     "zh-tw": "用時 {{count}} 秒"
   },
-  "noResultsFor": {
+  "no-results-for": {
     "en": "No results for {{query}}",
     "fr": "Aucun résultat pour {{query}}",
     "cs": "Pro dotaz {{query}} nebyly nalezeny žádné výsledky",
@@ -483,20 +483,20 @@
     "zh-cn": "没有找到与 {{query}} 相关的结果",
     "zh-tw": "沒有找到與 {{query}} 相關的結果"
   },
-  "noResults": {
+  "no-results": {
     "en": "No results",
     "fr": "Aucun résultat",
     "es-es": "No hay resultados"
   },
-  "moreMatchesFor": {
+  "more-matches-for": {
     "en": "More matches for {{query}}",
     "fr": "Plus de résultats pour {{query}}"
   },
-  "noMatchesFoundFor": {
+  "no-matches-found-for": {
     "en": "No matches found for {{query}}",
     "fr": "Aucun résultat pour {{query}}"
   },
-  "cancelLastAction": {
+  "cancel-last-action": {
     "en": "Cancel last action",
     "fr": "Annuler la dernière action",
     "cs": "Zrušit poslední akci",
@@ -521,7 +521,7 @@
     "zh-cn": "取消最后一个动作",
     "zh-tw": "取消最後一個動作"
   },
-  "searchTips": {
+  "search-tips": {
     "en": "Search tips",
     "fr": "Conseils de recherche",
     "cs": "Tipy pro hledání",
@@ -546,7 +546,7 @@
     "zh-cn": "搜索提示",
     "zh-tw": "搜尋提示"
   },
-  "checkSpelling": {
+  "check-spelling": {
     "en": "Check the spelling of your keywords.",
     "fr": "Vérifiez l'orthographe de vos mots-clés.",
     "cs": "Zkontrolujte pravopis klíčových slov.",
@@ -571,7 +571,7 @@
     "zh-cn": "检查关键字的拼写。",
     "zh-tw": "檢查關鍵字的拼寫。"
   },
-  "tryUsingFewerKeywords": {
+  "try-using-fewer-keywords": {
     "en": "Try using fewer, different or more general keywords.",
     "fr": "Essayez d'utiliser moins ou différents mots-clés.",
     "cs": "Zkuste použít méně, více či jiná obecná klíčová slova.",
@@ -596,7 +596,7 @@
     "zh-cn": "尝试使用更少、更常用或不同的关键字。",
     "zh-tw": "嘗試使用更少、更常用或不同的關鍵字。"
   },
-  "selectFewerFilters": {
+  "select-fewer-filters": {
     "en": "Select fewer filters to broaden your search.",
     "fr": "Sélectionner moins de filtres pour élargir votre recherche.",
     "cs": "Chcete-li rozšířit hledání, vyberte méně filtrů.",
@@ -646,7 +646,7 @@
     "zh-cn": "作者",
     "zh-tw": "作者"
   },
-  "fileType": {
+  "file-type": {
     "en": "File type",
     "fr": "Type de fichier",
     "cs": "Typ souboru",
@@ -700,7 +700,7 @@
     "en": "Source",
     "fr": "Source"
   },
-  "collapsedUriParts": {
+  "collapsed-uri-parts": {
     "en": "Collapsed URI parts",
     "fr": "Segments d'URI réduits"
   },
@@ -708,31 +708,31 @@
     "en": "Could not connect.",
     "fr": "Impossible de se connecter."
   },
-  "checkYourConnection": {
+  "check-your-connection": {
     "en": "Your query couldn't be sent. Verify your internet connection.",
     "fr": "Votre requête n'a pas plus être envoyée. Peut-être que vous avez perdu votre connexion internet."
   },
-  "noEndpoints": {
+  "no-endpoints": {
     "en": "The Coveo Organization has no registered endpoints.",
     "fr": "L'organisation Coveo n'a pas de point de terminaison unique."
   },
-  "invalidToken": {
+  "invalid-token": {
     "en": "The token is invalid.",
     "fr": "Le jeton d'identification est invalide."
   },
-  "addSources": {
+  "add-sources": {
     "en": "You will need to add sources in your index, or wait for the created sources to finish indexing.",
     "fr": "Vous devrez ajouter des sources à votre index, ou attendre la fin de l'indexation des sources créées."
   },
-  "coveoOnlineHelp": {
+  "coveo-online-help": {
     "en": "Coveo Online Help",
     "fr": "Aide en ligne Coveo"
   },
-  "cannotAccess": {
+  "cannot-access": {
     "en": "The Coveo Organization cannot be accessed.",
     "fr": "L'organisation Coveo est inaccessible."
   },
-  "somethingWentWrong": {
+  "something-went-wrong": {
     "en": "Something went wrong.",
     "fr": "Une erreur s'est produite.",
     "cs": "Na serveru došlo k chybě.",
@@ -757,7 +757,7 @@
     "zh-cn": "服务器出现了错误。",
     "zh-tw": "伺服器出現了錯誤。"
   },
-  "ifProblemPersists": {
+  "if-problem-persists": {
     "en": "If the problem persists contact the administrator.",
     "fr": "Si le problème persiste, contactez l'administrateur.",
     "cs": "Pokud problém přetrvává, spojte se se správcem.",
@@ -782,7 +782,7 @@
     "zh-cn": "如果问题仍然存在，请联系管理员。",
     "zh-tw": "如果問題仍然存在，請連絡管理員。"
   },
-  "moreInfo": {
+  "more-info": {
     "en": "More Information",
     "fr": "Plus d'information",
     "cs": "Více informací",
@@ -807,7 +807,7 @@
     "zh-cn": "更多信息",
     "zh-tw": "更多資訊"
   },
-  "clearAllFilters": {
+  "clear-all-filters": {
     "en": "Clear All Filters",
     "fr": "Enlever tous les filtres",
     "cs": "Vymazat všechny filtry",
@@ -832,7 +832,7 @@
     "zh-cn": "清除所有筛选条件",
     "zh-tw": "清除所有篩選條件"
   },
-  "nMore": {
+  "n-more": {
     "en": "{{value}} more...",
     "fr": "{{value}} de plus...",
     "cs": "počet dalších: {{value}}",
@@ -857,11 +857,11 @@
     "zh-cn": "{{value}} 更多...",
     "zh-tw": "{{value}} 更多..."
   },
-  "showNMoreFilters": {
+  "show-n-more-filters": {
     "en": "Show {{value}} more filters",
     "fr": "Montrer {{value}} filtres de plus"
   },
-  "queryAutoCorrectedTo": {
+  "query-auto-corrected-to": {
     "en": "Query was automatically corrected to {{query}}",
     "fr": "La requête a été corrigée automatiquement à {{query}}",
     "cs": "Dotaz byl automaticky opraven na {{query}}",
@@ -886,7 +886,7 @@
     "zh-cn": "查询自动更正为 {{query}}",
     "zh-tw": "查詢自動校正為 {{query}}"
   },
-  "didYouMean": {
+  "did-you-mean": {
     "en": "Did you mean: {{query}}",
     "fr": "Vouliez-vous dire : {{query}}",
     "cs": "Měli jste na mysli: {{query}}",
@@ -911,7 +911,7 @@
     "zh-cn": "您要找的是不是： {{query}}",
     "zh-tw": "您要找的是不是： {{query}}"
   },
-  "noLabel": {
+  "no-label": {
     "en": "No label",
     "fr": "Sans titre"
   },
@@ -931,15 +931,15 @@
     "en": "Apply",
     "fr": "Filtrer"
   },
-  "numberInputMinimum": {
+  "number-input-minimum": {
     "en": "Enter a minimum numerical value for the {{label}} facet",
     "fr": "Entrez une valeur numérique minimale pour la facette {{label}}"
   },
-  "numberInputMaximum": {
+  "number-input-maximum": {
     "en": "Enter a maximum numerical value for the {{label}} facet",
     "fr": "Entrez une valeur numérique maximale pour la facette {{label}}"
   },
-  "numberInputApply": {
+  "number-input-apply": {
     "en": "Apply custom numerical values for the {{label}} facet",
     "fr": "Appliquer les filtres numériques manuels pour la facette {{label}}"
   },
@@ -951,15 +951,15 @@
     "en": "{{child}} under {{parent}}",
     "fr": "{{child}} sous {{parent}}"
   },
-  "previewResult": {
+  "preview-result": {
     "en": "Preview the result",
     "fr": "Prévisualiser le résultat"
   },
-  "organizationIsPaused": {
+  "organization-is-paused": {
     "en": "Your Coveo organization is paused due to inactivity and search is currently unavailable.",
     "fr": "Votre organisation Coveo est en pause pour cause d'inactivité et la recherche est présentement non disponible."
   },
-  "organizationWillResume": {
+  "organization-will-resume": {
     "en": "Your organization is resuming and will be available shortly.",
     "fr": "Votre organisation redeviendra active et sera bientôt disponible."
   },

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -77,7 +77,7 @@ export interface InitializableComponent extends ComponentInterface {
  * Once a component is bound, the `initialize` method is called, if defined.
  *
  * In order for a component using this decorator to render properly, it should have an internal state bound to one of the property from `bindings`.
- * This is possible by using either the `BindStateToController` or the `BindStateToI18n` decorator.
+ * This is possible by using the `BindStateToController` decorator.
  *
  * For more information and examples, view the "Utilities" section of the readme.
  */
@@ -229,12 +229,3 @@ export function BindStateToController(
 }
 
 export type I18nState = Record<string, (variables?: TOptions) => string>;
-
-/**
- * TODO: remove this method once no component calls it
- * @deprecated This binding method is not needed anymore and should be removed.
- */
-export function BindStateToI18n() {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return (_component: InitializableComponent, _stateProperty: string) => {};
-}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-817

https://www.i18next.com/overview/configuration-options

Explored the i18next options and plugin features, could not find a clean way to use keys in a case insensitive manner. Example:
`this.bindings.i18n.t('helloworld')` would return the string with the key `helloWorld`. Only solution would have been to make all keys lowercase (not super readable) and override the `t()` method to set the key to lowercase characters.

I then decided to switch the keys to lowercase kebab case instead. This is still readable and less subject to errors by customers updating strings.

Also removed the deprecated BindStateToI18n