### PR TITLE
chore: improve release pipeline speed

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -106,9 +106,6 @@
         "job_name": "ui-kit-production-release",
         "prd": {
           "disabled": false
-        },
-        "extra_parameters": {
-          "COMMIT_HASH": "$[COMMIT_HASH]"
         }
       }
     }

--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -53,9 +53,6 @@
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
-        },
-        "prd": {
-          "directory": "proda/StaticCDN/headless/v$[HEADLESS_MINOR_VERSION]"
         }
       }
     },
@@ -67,9 +64,6 @@
         "source": "packages/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
-        },
-        "prd": {
-          "directory": "proda/StaticCDN/headless/v$[HEADLESS_MAJOR_VERSION]"
         }
       }
     },
@@ -81,9 +75,6 @@
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
-        },
-        "prd": {
-          "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]"
         }
       }
     },
@@ -95,9 +86,6 @@
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
-        },
-        "prd": {
-          "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]"
         }
       }
     },

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 node('linux && docker') {
   checkout scm
-  def commitHash = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
   def tag = sh(script: "git tag --contains", returnStdout: true).trim()
   def isBump = !!tag
   def isMaster = env.BRANCH_NAME == 'master'
@@ -100,7 +99,6 @@ node('linux && docker') {
         (atomicMinor, atomicMajor) = (atomic.version =~ semanticVersionRegex)[0]
         
         sh "deployment-package package create --with-deploy \
-        --resolve COMMIT_HASH=${commitHash} \
         --resolve HEADLESS_MINOR_VERSION=${headlessMinor} \
         --resolve HEADLESS_MAJOR_VERSION=${headlessMajor} \
         --resolve ATOMIC_MINOR_VERSION=${atomicMinor} \

--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -6,14 +6,6 @@ node('linux && docker') {
       sh "git checkout ${params.COMMIT_HASH}"
     }
 
-    stage('Setup') {
-      sh 'npm run setup'
-    }
-
-    stage('Build') {
-      sh 'npm run build'
-    }
-
     stage('Npm publish') {
       withCredentials([
       string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {

--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -2,10 +2,7 @@ node('linux && docker') {
   checkout scm
 
   withDockerContainer(image: 'node:14', args: '-u=root') {
-    stage('Checkout') {
-      sh "git checkout ${params.COMMIT_HASH}"
-    }
-
+    
     stage('Npm publish') {
       withCredentials([
       string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {

--- a/JenkinsfileQARelease
+++ b/JenkinsfileQARelease
@@ -2,6 +2,7 @@ node('linux && docker') {
   checkout scm
 
   withDockerContainer(image: 'node:14', args: '-u=root') {
+    
     stage('Npm publish') {
       withCredentials([
       string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {

--- a/JenkinsfileQARelease
+++ b/JenkinsfileQARelease
@@ -2,14 +2,6 @@ node('linux && docker') {
   checkout scm
 
   withDockerContainer(image: 'node:14', args: '-u=root') {
-    stage('Setup') {
-      sh 'npm run setup'
-    }
-
-    stage('Build') {
-      sh 'npm run build'
-    }
-
     stage('Npm publish') {
       withCredentials([
       string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {


### PR DESCRIPTION
~I initially was looking to speed up the pipeline with this jira by removing the build step in qa. After understanding the deployment config though, I realized it was needed to upload files to the CDN.~

I noticeed that the prd directory override path was equal to the default path though, so I removed it to tidy up the config.

I also removed the setup and build steps from QA and Prod because they do not seem to be needed. I crossed out my earlier observations because the s3 upload happens before the Jenkins job runs. This should speed up the pipeline by ~15-20 min.

Ref: https://tools-docs.dep.cloud.coveo.com/deployment-package/_static/schema_doc.html#phases_s3_prd

https://coveord.atlassian.net/browse/KIT-818