### PR TITLE
docs: ✏️ add homepage links to packages

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/atomic",
   "version": "0.41.0",
   "description": "A web-component library for building modern UIs interfacing with the Coveo platform",
+  "homepage": "https://github.com/coveo/ui-kit/tree/master/packages/atomic",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -2,7 +2,12 @@
   "name": "@coveo/atomic",
   "version": "0.41.0",
   "description": "A web-component library for building modern UIs interfacing with the Coveo platform",
-  "homepage": "https://github.com/coveo/ui-kit/tree/master/packages/atomic",
+  "homepage": "https://docs.coveo.com/en/atomic/latest/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coveo/ui-kit.git",
+    "directory": "packages/atomic"
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@coveo/bueno",
   "private": false,
+  "homepage": "https://github.com/coveo/ui-kit/tree/master/packages/bueno",
   "main": "./dist/bueno.js",
   "module": "./dist/bueno.esm.js",
   "browser": {

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -18,7 +18,6 @@
   "files": [
     "dist/"
   ],
-
   "scripts": {
     "start": "rollup -c -w",
     "build": "npm run clean && npm run build:prod",

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@coveo/bueno",
   "private": false,
-  "homepage": "https://github.com/coveo/ui-kit/tree/master/packages/bueno",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coveo/ui-kit.git",
+    "directory": "packages/bueno"
+  },
   "main": "./dist/bueno.js",
   "module": "./dist/bueno.esm.js",
   "browser": {
@@ -14,6 +18,7 @@
   "files": [
     "dist/"
   ],
+
   "scripts": {
     "start": "rollup -c -w",
     "build": "npm run clean && npm run build:prod",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@coveo/headless",
   "private": false,
-  "homePage": "https://github.com/coveo/ui-kit/tree/master/packages/headless",
+  "homepage": "https://docs.coveo.com/en/headless/latest/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coveo/ui-kit.git",
+    "directory": "packages/headless"
+  },
   "main": "./dist/headless.js",
   "module": "./dist/headless.esm.js",
   "browser": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@coveo/headless",
   "private": false,
+  "homePage": "https://github.com/coveo/ui-kit/tree/master/packages/headless",
   "main": "./dist/headless.js",
   "module": "./dist/headless.esm.js",
   "browser": {


### PR DESCRIPTION
Added a link to the repos in each package.json files to make it nicer for NPM users.

One choice I took was to link to the leaf package instead of the root one, but both are valid IMO.

Having `homepage` filled out will provide a link to the repo, as shown for example in `@coveo/cra-template`
![image](https://user-images.githubusercontent.com/12366410/125672287-9e524e39-fcf7-47f4-ad1a-8c2aa3496d87.png)
