### PR TITLE
feat(atomic): added atomic-size-condition component

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -582,6 +582,16 @@ export namespace Components {
          */
         "searchHub": string;
     }
+    interface AtomicSizeCondition {
+        "maximumHeightExclusive"?: string;
+        "maximumHeightInclusive"?: string;
+        "maximumWidthExclusive"?: string;
+        "maximumWidthInclusive"?: string;
+        "minimumHeightExclusive"?: string;
+        "minimumHeightInclusive"?: string;
+        "minimumWidthExclusive"?: string;
+        "minimumWidthInclusive"?: string;
+    }
     interface AtomicSortDropdown {
     }
     interface AtomicSortExpression {
@@ -918,6 +928,12 @@ declare global {
         prototype: HTMLAtomicSearchInterfaceElement;
         new (): HTMLAtomicSearchInterfaceElement;
     };
+    interface HTMLAtomicSizeConditionElement extends Components.AtomicSizeCondition, HTMLStencilElement {
+    }
+    var HTMLAtomicSizeConditionElement: {
+        prototype: HTMLAtomicSizeConditionElement;
+        new (): HTMLAtomicSizeConditionElement;
+    };
     interface HTMLAtomicSortDropdownElement extends Components.AtomicSortDropdown, HTMLStencilElement {
     }
     var HTMLAtomicSortDropdownElement: {
@@ -992,6 +1008,7 @@ declare global {
         "atomic-results-per-page": HTMLAtomicResultsPerPageElement;
         "atomic-search-box": HTMLAtomicSearchBoxElement;
         "atomic-search-interface": HTMLAtomicSearchInterfaceElement;
+        "atomic-size-condition": HTMLAtomicSizeConditionElement;
         "atomic-sort-dropdown": HTMLAtomicSortDropdownElement;
         "atomic-sort-expression": HTMLAtomicSortExpressionElement;
         "atomic-text": HTMLAtomicTextElement;
@@ -1558,6 +1575,16 @@ declare namespace LocalJSX {
          */
         "searchHub"?: string;
     }
+    interface AtomicSizeCondition {
+        "maximumHeightExclusive"?: string;
+        "maximumHeightInclusive"?: string;
+        "maximumWidthExclusive"?: string;
+        "maximumWidthInclusive"?: string;
+        "minimumHeightExclusive"?: string;
+        "minimumHeightInclusive"?: string;
+        "minimumWidthExclusive"?: string;
+        "minimumWidthInclusive"?: string;
+    }
     interface AtomicSortDropdown {
     }
     interface AtomicSortExpression {
@@ -1648,6 +1675,7 @@ declare namespace LocalJSX {
         "atomic-results-per-page": AtomicResultsPerPage;
         "atomic-search-box": AtomicSearchBox;
         "atomic-search-interface": AtomicSearchInterface;
+        "atomic-size-condition": AtomicSizeCondition;
         "atomic-sort-dropdown": AtomicSortDropdown;
         "atomic-sort-expression": AtomicSortExpression;
         "atomic-text": AtomicText;
@@ -1707,6 +1735,7 @@ declare module "@stencil/core" {
             "atomic-results-per-page": LocalJSX.AtomicResultsPerPage & JSXBase.HTMLAttributes<HTMLAtomicResultsPerPageElement>;
             "atomic-search-box": LocalJSX.AtomicSearchBox & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxElement>;
             "atomic-search-interface": LocalJSX.AtomicSearchInterface & JSXBase.HTMLAttributes<HTMLAtomicSearchInterfaceElement>;
+            "atomic-size-condition": LocalJSX.AtomicSizeCondition & JSXBase.HTMLAttributes<HTMLAtomicSizeConditionElement>;
             "atomic-sort-dropdown": LocalJSX.AtomicSortDropdown & JSXBase.HTMLAttributes<HTMLAtomicSortDropdownElement>;
             "atomic-sort-expression": LocalJSX.AtomicSortExpression & JSXBase.HTMLAttributes<HTMLAtomicSortExpressionElement>;
             "atomic-text": LocalJSX.AtomicText & JSXBase.HTMLAttributes<HTMLAtomicTextElement>;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -583,13 +583,37 @@ export namespace Components {
         "searchHub": string;
     }
     interface AtomicSizeCondition {
+        /**
+          * The maximum height (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumHeightExclusive"?: string;
+        /**
+          * The maximum height (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumHeightInclusive"?: string;
+        /**
+          * The maximum width (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumWidthExclusive"?: string;
+        /**
+          * The maximum width (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumWidthInclusive"?: string;
+        /**
+          * The minimum height (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumHeightExclusive"?: string;
+        /**
+          * The minimum height (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumHeightInclusive"?: string;
+        /**
+          * The minimum width (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumWidthExclusive"?: string;
+        /**
+          * The minimum width (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumWidthInclusive"?: string;
     }
     interface AtomicSortDropdown {
@@ -1576,13 +1600,37 @@ declare namespace LocalJSX {
         "searchHub"?: string;
     }
     interface AtomicSizeCondition {
+        /**
+          * The maximum height (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumHeightExclusive"?: string;
+        /**
+          * The maximum height (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumHeightInclusive"?: string;
+        /**
+          * The maximum width (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumWidthExclusive"?: string;
+        /**
+          * The maximum width (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "maximumWidthInclusive"?: string;
+        /**
+          * The minimum height (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumHeightExclusive"?: string;
+        /**
+          * The minimum height (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumHeightInclusive"?: string;
+        /**
+          * The minimum width (exclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumWidthExclusive"?: string;
+        /**
+          * The minimum width (inclusively) required to display children.  E.g.: `3rem`, `500px` or `30vw`.
+         */
         "minimumWidthInclusive"?: string;
     }
     interface AtomicSortDropdown {

--- a/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.pcss
@@ -1,0 +1,6 @@
+:host {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: block;
+}

--- a/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.tsx
@@ -1,0 +1,150 @@
+import {Element, Component, Prop, State} from '@stencil/core';
+
+type Criterion = (width: number, height: number) => boolean;
+
+/**
+ * Displays children only if their parent meets the defined size constraints.
+ */
+@Component({
+  tag: 'atomic-size-condition',
+  styleUrl: 'atomic-size-condition.pcss',
+  shadow: false,
+})
+export class AtomicSizeCondition {
+  private resizeObserver!: ResizeObserver;
+
+  @Element() private host!: HTMLElement;
+
+  @State() private shouldRender!: boolean;
+
+  /**
+   * The minimum width (exclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public minimumWidthExclusive?: string;
+  /**
+   * The minimum width (inclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public minimumWidthInclusive?: string;
+  /**
+   * The maximum width (exclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public maximumWidthExclusive?: string;
+  /**
+   * The maximum width (inclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public maximumWidthInclusive?: string;
+  /**
+   * The minimum height (exclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public minimumHeightExclusive?: string;
+  /**
+   * The minimum height (inclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public minimumHeightInclusive?: string;
+  /**
+   * The maximum height (exclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public maximumHeightExclusive?: string;
+  /**
+   * The maximum height (inclusively) required to display children.
+   *
+   * E.g.: `3rem`, `500px` or `30vw`.
+   */
+  @Prop() public maximumHeightInclusive?: string;
+
+  constructor() {
+    this.shouldRender = this.elementMeetsCriteria;
+  }
+
+  public componentDidLoad() {
+    this.resizeObserver = new ResizeObserver(
+      () => (this.shouldRender = this.elementMeetsCriteria)
+    );
+    this.resizeObserver.observe(this.parent);
+  }
+
+  public componentDidUnLoad() {
+    this.resizeObserver.disconnect();
+  }
+
+  public componentDidRender() {
+    this.host.style.display = this.shouldRender ? '' : 'none';
+  }
+
+  private convertToPixels(size: string) {
+    const temporaryElement = document.createElement('div');
+    temporaryElement.style.position = 'absolute';
+    temporaryElement.style.width = size;
+    this.parent.appendChild(temporaryElement);
+    const {offsetWidth} = temporaryElement;
+    temporaryElement.remove();
+    return offsetWidth;
+  }
+
+  private get parent() {
+    return this.host.parentElement!;
+  }
+
+  private get criteria() {
+    const criteria: Criterion[] = [];
+    this.minimumWidthExclusive &&
+      criteria.push(
+        (width) => width > this.convertToPixels(this.minimumWidthExclusive!)
+      );
+    this.minimumWidthInclusive &&
+      criteria.push(
+        (width) => width >= this.convertToPixels(this.minimumWidthInclusive!)
+      );
+    this.maximumWidthExclusive &&
+      criteria.push(
+        (width) => width < this.convertToPixels(this.maximumWidthExclusive!)
+      );
+    this.maximumWidthInclusive &&
+      criteria.push(
+        (width) => width <= this.convertToPixels(this.maximumWidthInclusive!)
+      );
+    this.minimumHeightExclusive &&
+      criteria.push(
+        (_, height) =>
+          height > this.convertToPixels(this.minimumHeightExclusive!)
+      );
+    this.minimumHeightInclusive &&
+      criteria.push(
+        (_, height) =>
+          height >= this.convertToPixels(this.minimumHeightInclusive!)
+      );
+    this.maximumHeightExclusive &&
+      criteria.push(
+        (_, height) =>
+          height < this.convertToPixels(this.maximumHeightExclusive!)
+      );
+    this.maximumHeightInclusive &&
+      criteria.push(
+        (_, height) =>
+          height <= this.convertToPixels(this.maximumHeightInclusive!)
+      );
+    return criteria;
+  }
+
+  private get elementMeetsCriteria() {
+    const {offsetWidth, offsetHeight} = this.parent;
+    const indexOfInvalidatedCriterion = this.criteria.findIndex(
+      (criterion) => !criterion(offsetWidth, offsetHeight)
+    );
+    return indexOfInvalidatedCriterion === -1;
+  }
+}

--- a/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-size-condition/atomic-size-condition.tsx
@@ -70,14 +70,14 @@ export class AtomicSizeCondition {
     this.shouldRender = this.elementMeetsCriteria;
   }
 
-  public componentDidLoad() {
+  public connectedCallback() {
     this.resizeObserver = new ResizeObserver(
       () => (this.shouldRender = this.elementMeetsCriteria)
     );
     this.resizeObserver.observe(this.parent);
   }
 
-  public componentDidUnLoad() {
+  public disconnectedCallback() {
     this.resizeObserver.disconnect();
   }
 

--- a/packages/atomic/src/pages/v1.html
+++ b/packages/atomic/src/pages/v1.html
@@ -231,13 +231,19 @@
                   font-weight: bold;
                   margin-right: 0.25rem;
                 }
+
+                .thumbnail {
+                  display: block;
+                  width: 100%;
+                  height: 100%;
+                }
               </style>
               <atomic-result-section-visual>
                 <atomic-size-condition maximum-width-inclusive="3rem">
                   <atomic-result-icon></atomic-result-icon>
                 </atomic-size-condition>
                 <atomic-size-condition minimum-width-exclusive="3rem">
-                  <img src="https://picsum.photos/350" class="block w-full h-full" />
+                  <img src="https://picsum.photos/350" class="thumbnail" />
                 </atomic-size-condition>
               </atomic-result-section-visual>
               <atomic-result-section-badges>

--- a/packages/atomic/src/pages/v1.html
+++ b/packages/atomic/src/pages/v1.html
@@ -232,7 +232,14 @@
                   margin-right: 0.25rem;
                 }
               </style>
-              <atomic-result-section-visual><atomic-result-icon></atomic-result-icon></atomic-result-section-visual>
+              <atomic-result-section-visual>
+                <atomic-size-condition maximum-width-inclusive="3rem">
+                  <atomic-result-icon></atomic-result-icon>
+                </atomic-size-condition>
+                <atomic-size-condition minimum-width-exclusive="3rem">
+                  <img src="https://picsum.photos/350" class="block w-full h-full" />
+                </atomic-size-condition>
+              </atomic-result-section-visual>
               <atomic-result-section-badges>
                 <atomic-field-condition must-match-sourcetype="Salesforce">
                   <span class="badge"> Salesforce </span>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-839

* [Design doc](https://docs.google.com/document/d/1NkSlX-w8p6BlrXICPWD-oM5Z7sMjgD9XOES-ldObrzY/view#heading=h.xbn6j3r37uiw)

![image](https://user-images.githubusercontent.com/54454747/127053942-31e05279-3fef-4e34-bb1e-b68f56a21f9e.png)

Usage example:
```html
<atomic-size-condition maximum-width-inclusive="3rem">
  <atomic-result-icon></atomic-result-icon>
</atomic-size-condition>
<atomic-size-condition minimum-width-exclusive="3rem">
  <img src="https://picsum.photos/350" class="block w-full h-full" />
</atomic-size-condition>
```

If you prefer, I can rebase this towards `master`.