### PR TITLE
fix(atomic): add prop validation for Facets string literals

### DIFF
--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.tsx
@@ -31,6 +31,7 @@ import {
 } from '../facet-search/facet-search-utils';
 import {BaseFacet} from '../facet-common';
 import {FacetValueLabelHighlight} from '../facet-value-label-highlight/facet-value-label-highlight';
+import {Schema, StringValue} from '@coveo/bueno';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -119,7 +120,18 @@ export class AtomicFacet
   @Prop() public displayValuesAs: 'checkbox' | 'link' | 'box' = 'checkbox';
   // @Prop() public customSort?: string; TODO: add customSort to headless
 
+  private validateProps() {
+    new Schema({
+      displayValuesAs: new StringValue({
+        constrainTo: ['checkbox', 'link', 'box'],
+      }),
+    }).validate({
+      displayValuesAs: this.displayValuesAs,
+    });
+  }
+
   public initialize() {
+    this.validateProps();
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     const options: FacetOptions = {
       facetId: this.facetId,

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../formats/format-common';
 import {NumberInputType} from '../facet-number-input/number-input-type';
 import {FacetValueLabelHighlight} from '../facet-value-label-highlight/facet-value-label-highlight';
+import {Schema, StringValue} from '@coveo/bueno';
 
 interface NumericRangeWithLabel extends NumericRangeRequest {
   label?: string;
@@ -139,7 +140,18 @@ export class AtomicNumericFacet
    */
   @Prop() public displayValuesAs: 'checkbox' | 'link' = 'checkbox';
 
+  private validateProps() {
+    new Schema({
+      displayValuesAs: new StringValue({constrainTo: ['checkbox', 'link']}),
+      withInput: new StringValue({constrainTo: ['integer', 'decimal']}),
+    }).validate({
+      displayValuesAs: this.displayValuesAs,
+      withInput: this.withInput,
+    });
+  }
+
   public initialize() {
+    this.validateProps();
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     this.numberOfValues && this.initializeFacet();
     this.withInput && this.initializeFilter();

--- a/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
@@ -25,6 +25,7 @@ import {FacetValueLink} from '../facet-value-link/facet-value-link';
 import {FacetValueIconRating} from '../facet-value-icon-rating/facet-value-icon-rating';
 import {BaseFacet} from '../facet-common';
 import Star from '../../../images/star.svg';
+import {Schema, StringValue} from '@coveo/bueno';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -100,7 +101,16 @@ export class AtomicRatingFacet
    */
   @Prop() public icon = Star;
 
+  private validateProps() {
+    new Schema({
+      displayValuesAs: new StringValue({constrainTo: ['checkbox', 'link']}),
+    }).validate({
+      displayValuesAs: this.displayValuesAs,
+    });
+  }
+
   public initialize() {
+    this.validateProps();
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     this.initializeFacet();
   }


### PR DESCRIPTION
Stencil will accept any string, it won't automatically constrain the values. For props that aren't validated by headless controllers, we have to be careful and validate the string literals.

https://coveord.atlassian.net/browse/KIT-835