### PR TITLE
feat(headless): expose synchronize method on search parameter manager

### DIFF
--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -1,4 +1,5 @@
 import {restoreSearchParameters} from '../../features/search-parameters/search-parameter-actions';
+import {initialSearchParameterSelector} from '../../features/search-parameters/search-parameter-selectors';
 import {buildMockSearchAppEngine, MockSearchEngine} from '../../test';
 import {buildMockCategoryFacetRequest} from '../../test/mock-category-facet-request';
 import {buildMockCategoryFacetSlice} from '../../test/mock-category-facet-slice';
@@ -322,5 +323,19 @@ describe('search parameter manager', () => {
     const unavailableKeys = allKeys.filter((key) => !(key in stateParams));
 
     expect(unavailableKeys).toEqual([]);
+  });
+
+  it('calling #synchronize with partial search parameters dispatches #restoreSearchParameters with non-specified parameters set to their initial values', () => {
+    const params = {q: 'a'};
+    manager.synchronize(params);
+
+    const initialParameters = initialSearchParameterSelector(engine.state);
+
+    const action = restoreSearchParameters({
+      ...initialParameters,
+      ...params,
+    });
+
+    expect(engine.actions).toContainEqual(action);
   });
 });

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -327,13 +327,10 @@ describe('search parameter manager', () => {
   });
 
   describe('#synchronize', () => {
-    const params = {q: 'a'};
-
-    beforeEach(() => {
-      manager.synchronize(params);
-    });
-
     it('given partial search parameters, it dispatches #restoreSearchParameters with non-specified parameters set to their initial values', () => {
+      const params = {q: 'a'};
+      manager.synchronize(params);
+
       const initialParameters = initialSearchParameterSelector(engine.state);
       const action = restoreSearchParameters({
         ...initialParameters,
@@ -344,7 +341,33 @@ describe('search parameter manager', () => {
     });
 
     it('executes a search', () => {
+      manager.synchronize({q: 'a'});
       expect(engine.findAsyncAction(executeSearch.pending)).toBeTruthy();
+    });
+
+    it(`when only the order of facet values changes,
+    calling #synchronize does not execute a search`, () => {
+      const value1 = 'Kafka';
+      const value2 = 'Cervantes';
+
+      const facetValue1 = buildMockFacetValueRequest({
+        value: value1,
+        state: 'selected',
+      });
+      const facetValue2 = buildMockFacetValueRequest({
+        value: value2,
+        state: 'selected',
+      });
+
+      engine.state.facetSet = {
+        author: buildMockFacetRequest({
+          currentValues: [facetValue1, facetValue2],
+        }),
+      };
+
+      manager.synchronize({f: {author: [value2, value1]}});
+
+      expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
     });
   });
 });

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -1,5 +1,6 @@
 import {restoreSearchParameters} from '../../features/search-parameters/search-parameter-actions';
 import {initialSearchParameterSelector} from '../../features/search-parameters/search-parameter-selectors';
+import {executeSearch} from '../../features/search/search-actions';
 import {buildMockSearchAppEngine, MockSearchEngine} from '../../test';
 import {buildMockCategoryFacetRequest} from '../../test/mock-category-facet-request';
 import {buildMockCategoryFacetSlice} from '../../test/mock-category-facet-slice';
@@ -325,17 +326,25 @@ describe('search parameter manager', () => {
     expect(unavailableKeys).toEqual([]);
   });
 
-  it('calling #synchronize with partial search parameters dispatches #restoreSearchParameters with non-specified parameters set to their initial values', () => {
+  describe('#synchronize', () => {
     const params = {q: 'a'};
-    manager.synchronize(params);
 
-    const initialParameters = initialSearchParameterSelector(engine.state);
-
-    const action = restoreSearchParameters({
-      ...initialParameters,
-      ...params,
+    beforeEach(() => {
+      manager.synchronize(params);
     });
 
-    expect(engine.actions).toContainEqual(action);
+    it('given partial search parameters, it dispatches #restoreSearchParameters with non-specified parameters set to their initial values', () => {
+      const initialParameters = initialSearchParameterSelector(engine.state);
+      const action = restoreSearchParameters({
+        ...initialParameters,
+        ...params,
+      });
+
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('executes a search', () => {
+      expect(engine.findAsyncAction(executeSearch.pending)).toBeTruthy();
+    });
   });
 });

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -18,6 +18,7 @@ import {SearchEngine} from '../../app/search-engine/search-engine';
 import {initialSearchParameterSelector} from '../../features/search-parameters/search-parameter-selectors';
 import {executeSearch} from '../../features/search/search-actions';
 import {logParametersChange} from '../../features/search-parameters/search-parameter-analytics-actions';
+import {deepEqualAnyOrder} from '../../utils/compare-utils';
 
 export {SearchParameters};
 
@@ -94,11 +95,13 @@ export function buildSearchParameterManager(
     ...controller,
 
     synchronize(parameters: SearchParameters) {
-      const oldParams = enrichParameters(
-        engine,
-        getActiveSearchParameters(engine)
-      );
+      const activeParams = getActiveSearchParameters(engine);
+      const oldParams = enrichParameters(engine, activeParams);
       const newParams = enrichParameters(engine, parameters);
+
+      if (deepEqualAnyOrder(oldParams, newParams)) {
+        return;
+      }
 
       dispatch(restoreSearchParameters(newParams));
       dispatch(executeSearch(logParametersChange(oldParams, newParams)));

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -15,6 +15,7 @@ import {validateInitialState} from '../../utils/validate-payload';
 import {buildController, Controller} from '../controller/headless-controller';
 import {RangeValueRequest} from '../../features/facets/range-facets/generic/interfaces/range-facet';
 import {SearchEngine} from '../../app/search-engine/search-engine';
+import {initialSearchParameterSelector} from '../../features/search-parameters/search-parameter-selectors';
 
 export {SearchParameters};
 
@@ -45,6 +46,13 @@ const initialStateSchema = new Schema<
  * The `SearchParameterManager` controller allows restoring parameters that affect the results from e.g. a url.
  * */
 export interface SearchParameterManager extends Controller {
+  /**
+   * Updates the search parameters in state with the passed parameters. Unspecified keys are reset to their initial values.
+   *
+   * @param parameters - The search parameters
+   */
+  synchronize(parameters: SearchParameters): void;
+
   /**
    * The state relevant to the `SearchParameterManager` controller.
    * */
@@ -83,6 +91,15 @@ export function buildSearchParameterManager(
 
   return {
     ...controller,
+
+    synchronize(parameters: SearchParameters) {
+      const enrichedParams: Required<SearchParameters> = {
+        ...initialSearchParameterSelector(engine.state),
+        ...parameters,
+      };
+
+      dispatch(restoreSearchParameters(enrichedParams));
+    },
 
     get state() {
       const state = getState();

--- a/packages/headless/src/controllers/url-manager/headless-url-manager.test.ts
+++ b/packages/headless/src/controllers/url-manager/headless-url-manager.test.ts
@@ -85,7 +85,7 @@ describe('url manager', () => {
 
     it(`when removing a parameter
     should restore the right parameters and execute a search`, () => {
-      initUrlManager('q=test');
+      engine.state.query.q = 'test';
       manager.synchronize('');
 
       testLatestRestoreSearchParameters(
@@ -96,7 +96,7 @@ describe('url manager', () => {
 
     it(`when the fragment is unchanged
     should not execute a search`, () => {
-      initUrlManager('q=test');
+      engine.state.query.q = 'test';
       manager.synchronize('q=test');
 
       expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
@@ -104,7 +104,7 @@ describe('url manager', () => {
 
     it(`when a parameter's value changes
     should restore the right parameters and execute a search`, () => {
-      initUrlManager('q=books');
+      engine.state.query.q = 'books';
       manager.synchronize('q=movies');
 
       testLatestRestoreSearchParameters({
@@ -112,30 +112,6 @@ describe('url manager', () => {
         q: 'movies',
       });
       testExecuteSearch();
-    });
-
-    it(`when a different parameters order changes
-    should not execute a search`, () => {
-      initUrlManager('q=books&sortCriteria=author ascending');
-      manager.synchronize('sortCriteria=author ascending&q=books');
-
-      expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
-    });
-
-    it(`when repetitive parameters order changes
-    should not execute a search`, () => {
-      initUrlManager('f[author]=Cervantes&f[writer]=Kafka');
-      manager.synchronize('f[writer]=Kafka&f[author]=Cervantes');
-
-      expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
-    });
-
-    it(`when a parameter's values order changes
-    should not execute a search`, () => {
-      initUrlManager('f[author]=Kafka,Cervantes');
-      manager.synchronize('f[author]=Cervantes,Kafka');
-
-      expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
     });
   });
 });

--- a/packages/headless/src/controllers/url-manager/headless-url-manager.ts
+++ b/packages/headless/src/controllers/url-manager/headless-url-manager.ts
@@ -108,12 +108,9 @@ export function buildUrlManager(
 
     synchronize(fragment: string) {
       const newFragment = decodeFragment(fragment);
-      if (areFragmentsEquivalent(previousFragment, newFragment)) {
-        return;
-      }
       previousFragment = newFragment;
 
-      const parameters = deserializeFragment(fragment);
+      const parameters = deserializeFragment(newFragment);
       searchParameterManager.synchronize(parameters);
     },
   };


### PR DESCRIPTION
This PR refactors the `synchronize` parameter to the SearchParameterManager to make it available to devs creating custom url formats.