### PR TITLE
fix(atomic): rating and rating range facet ranges end not inclusive

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -387,6 +387,10 @@ export namespace Components {
          */
         "maxValueInIndex": number;
         /**
+          * The minimum value of the field.
+         */
+        "minValueInIndex": number;
+        /**
           * The number of intervals to split the index for this facet.
          */
         "numberOfIntervals": number;
@@ -412,6 +416,10 @@ export namespace Components {
           * The maximum value of the field. This value is also used as the number of icons to be displayed.
          */
         "maxValueInIndex": number;
+        /**
+          * The minimum value of the field.
+         */
+        "minValueInIndex": number;
         /**
           * The number of intervals to split the index for this facet.
          */
@@ -1397,6 +1405,10 @@ declare namespace LocalJSX {
          */
         "maxValueInIndex"?: number;
         /**
+          * The minimum value of the field.
+         */
+        "minValueInIndex"?: number;
+        /**
           * The number of intervals to split the index for this facet.
          */
         "numberOfIntervals"?: number;
@@ -1422,6 +1434,10 @@ declare namespace LocalJSX {
           * The maximum value of the field. This value is also used as the number of icons to be displayed.
          */
         "maxValueInIndex"?: number;
+        /**
+          * The minimum value of the field.
+         */
+        "minValueInIndex"?: number;
         /**
           * The number of intervals to split the index for this facet.
          */

--- a/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
@@ -143,12 +143,12 @@ export class AtomicRatingFacet
 
   private generateCurrentValues() {
     const currentValues: NumericRangeRequest[] = [];
-    for (let i = 0; i < this.numberOfIntervals; i++) {
+    for (let i = 0; i <= this.numberOfIntervals; i++) {
       currentValues.push(
         buildNumericRange({
           start: Math.round(i * this.scaleFactor * 100) / 100,
           end: Math.round((i + 1) * this.scaleFactor * 100) / 100,
-          endInclusive: true,
+          endInclusive: false,
         })
       );
     }
@@ -190,7 +190,7 @@ export class AtomicRatingFacet
           >
             <FacetValueIconRating
               numberOfTotalIcons={this.maxValueInIndex}
-              numberOfActiveIcons={facetValue.end}
+              numberOfActiveIcons={facetValue.start}
               icon={this.icon}
             ></FacetValueIconRating>
           </FacetValueCheckbox>
@@ -206,7 +206,7 @@ export class AtomicRatingFacet
           >
             <FacetValueIconRating
               numberOfTotalIcons={this.maxValueInIndex}
-              numberOfActiveIcons={facetValue.end}
+              numberOfActiveIcons={facetValue.start}
               icon={this.icon}
             ></FacetValueIconRating>
           </FacetValueLink>

--- a/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.tsx
@@ -92,6 +92,10 @@ export class AtomicRatingFacet
    */
   @Prop() public maxValueInIndex = this.numberOfIntervals;
   /**
+   * The minimum value of the field.
+   */
+  @Prop() public minValueInIndex = 1;
+  /**
    * Whether to display the facet values as checkboxes (multiple selection) or links (single selection).
    * Possible values are 'checkbox' and 'link'.
    */
@@ -143,7 +147,7 @@ export class AtomicRatingFacet
 
   private generateCurrentValues() {
     const currentValues: NumericRangeRequest[] = [];
-    for (let i = 0; i <= this.numberOfIntervals; i++) {
+    for (let i = this.minValueInIndex; i <= this.numberOfIntervals; i++) {
       currentValues.push(
         buildNumericRange({
           start: Math.round(i * this.scaleFactor * 100) / 100,

--- a/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -126,10 +126,10 @@ export class AtomicRatingRangeFacet
 
   private generateCurrentValues() {
     const currentValues: NumericRangeRequest[] = [];
-    for (let i = 0; i < this.numberOfIntervals; i++) {
+    for (let i = 0; i <= this.numberOfIntervals; i++) {
       currentValues.push(
         buildNumericRange({
-          start: Math.round((i + 1) * this.scaleFactor * 100) / 100,
+          start: Math.round(i * this.scaleFactor * 100) / 100,
           end: Math.round(this.maxValueInIndex * 100) / 100,
           endInclusive: true,
         })
@@ -159,16 +159,12 @@ export class AtomicRatingRangeFacet
   }
 
   private renderLabelText(facetValue: NumericFacetValue) {
-    const textClasses =
-      'ml-1 flex items-center truncate group-hover:underline group-hover:text-primary';
     return (
       <span
         part="value-label"
-        class={
-          facetValue.state === 'selected'
-            ? textClasses + ' font-bold'
-            : textClasses
-        }
+        class={`ml-1 flex items-center truncate group-hover:underline group-hover:text-primary ${
+          facetValue.state === 'selected' ? 'font-bold' : ''
+        }`}
       >
         {facetValue.start === this.maxValueInIndex ? (
           <span>{this.bindings.i18n.t('only')}</span>

--- a/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -89,6 +89,10 @@ export class AtomicRatingRangeFacet
    */
   @Prop() public maxValueInIndex = this.numberOfIntervals;
   /**
+   * The minimum value of the field.
+   */
+  @Prop() public minValueInIndex = 1;
+  /**
    * The icon used to display the rating.
    */
   @Prop() public icon = Star;
@@ -126,7 +130,7 @@ export class AtomicRatingRangeFacet
 
   private generateCurrentValues() {
     const currentValues: NumericRangeRequest[] = [];
-    for (let i = 0; i <= this.numberOfIntervals; i++) {
+    for (let i = this.minValueInIndex; i <= this.numberOfIntervals; i++) {
       currentValues.push(
         buildNumericRange({
           start: Math.round(i * this.scaleFactor * 100) / 100,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-859

made `endInclusive: false` for the rating facet and updated the display of the number of icons to match the start of the interval instead of the end

rating range facet now starts from 0 instead of 1:
![Screen Shot 2021-07-28 at 10 49 00 AM](https://user-images.githubusercontent.com/83350303/127344406-e5fc585c-51ab-4fc0-b6e2-17aa56db1139.png)
