### PR TITLE
fix(headless): set hasResults to false when hasError is true

### DIFF
--- a/packages/headless/src/controllers/search-status/headless-search-status.test.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.test.ts
@@ -32,6 +32,17 @@ describe('SearchStatus', () => {
     expect(buildSearchStatus(engine).state.hasResults).toBe(true);
   });
 
+  it('returns right state "hasResults" when there is an error', () => {
+    engine.state.search.results = [buildMockResult()];
+    engine.state.search.error = {
+      message: 'unknown',
+      statusCode: 0,
+      type: 'unknown',
+    };
+
+    expect(buildSearchStatus(engine).state.hasResults).toBe(false);
+  });
+
   it('returns right state "firstSearchExecuted"', () => {
     expect(buildSearchStatus(engine).state.firstSearchExecuted).toBe(false);
 

--- a/packages/headless/src/controllers/search-status/headless-search-status.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.ts
@@ -56,11 +56,12 @@ export function buildSearchStatus(engine: SearchEngine): SearchStatus {
 
     get state() {
       const state = getState();
+      const hasError = state.search.error !== null;
 
       return {
-        hasError: state.search.error !== null,
+        hasError,
         isLoading: state.search.isLoading,
-        hasResults: !!state.search.results.length,
+        hasResults: !hasError && !!state.search.results.length,
         firstSearchExecuted: firstSearchExecutedSelector(state),
       };
     },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-833

https://discuss.coveo.com/t/pager-is-still-visible-when-error-raised/6191

A few things:
- I don't think changing the `handleRejectedSearch` of the search-slice method to always reset the response is the way to go. Sometimes it might reject because of an aborted request and in that case, we don't want our results to disappear.
- Modifying the search state controller only should fix the issue, I could go a step further and add a condition in the render method of the 2 components but I think it's a bit overkill here 😄 
