### PR TITLE
fix(headless): clear response/results when search contains an error

### DIFF
--- a/packages/headless/src/controllers/search-status/headless-search-status.test.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.test.ts
@@ -32,17 +32,6 @@ describe('SearchStatus', () => {
     expect(buildSearchStatus(engine).state.hasResults).toBe(true);
   });
 
-  it('returns right state "hasResults" when there is an error', () => {
-    engine.state.search.results = [buildMockResult()];
-    engine.state.search.error = {
-      message: 'unknown',
-      statusCode: 0,
-      type: 'unknown',
-    };
-
-    expect(buildSearchStatus(engine).state.hasResults).toBe(false);
-  });
-
   it('returns right state "firstSearchExecuted"', () => {
     expect(buildSearchStatus(engine).state.firstSearchExecuted).toBe(false);
 

--- a/packages/headless/src/controllers/search-status/headless-search-status.ts
+++ b/packages/headless/src/controllers/search-status/headless-search-status.ts
@@ -56,12 +56,11 @@ export function buildSearchStatus(engine: SearchEngine): SearchStatus {
 
     get state() {
       const state = getState();
-      const hasError = state.search.error !== null;
 
       return {
-        hasError,
+        hasError: state.search.error !== null,
         isLoading: state.search.isLoading,
-        hasResults: !hasError && !!state.search.results.length,
+        hasResults: !!state.search.results.length,
         firstSearchExecuted: firstSearchExecutedSelector(state),
       };
     },

--- a/packages/headless/src/features/search/search-slice.test.ts
+++ b/packages/headless/src/features/search/search-slice.test.ts
@@ -15,6 +15,7 @@ import {Result} from '../../api/search/search/result';
 import {applyDidYouMeanCorrection} from '../did-you-mean/did-you-mean-actions';
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 import {Response} from 'cross-fetch';
+import {buildMockSearchState} from '../../test/mock-search-state';
 
 jest.mock('../../api/platform-client');
 
@@ -117,26 +118,65 @@ describe('search-slice', () => {
     });
   });
 
-  it('when a executeSearch rejected is received, set the error', () => {
-    const err = {
-      message: 'message',
-      statusCode: 500,
-      type: 'type',
-    };
-    const action = {type: 'search/executeSearch/rejected', payload: err};
-    const finalState = searchReducer(state, action);
-    expect(finalState.error).toEqual(err);
-  });
+  describe('handles rejected searches correctly', () => {
+    const results = [buildMockResult()];
+    const initialMockState = () =>
+      buildMockSearchState({
+        results,
+        response: buildMockSearchResponse({results}),
+      });
 
-  it('when a fetchMoreResults rejected is received, set the error', () => {
-    const err = {
-      message: 'message',
-      statusCode: 500,
-      type: 'type',
-    };
-    const action = {type: 'search/fetchMoreResults/rejected', payload: err};
-    const finalState = searchReducer(state, action);
-    expect(finalState.error).toEqual(err);
+    beforeEach(() => (state = initialMockState()));
+
+    it('when a executeSearch rejected is received with an error', () => {
+      const err = {
+        message: 'message',
+        statusCode: 500,
+        type: 'type',
+      };
+      const action = {type: 'search/executeSearch/rejected', payload: err};
+      const finalState = searchReducer(state, action);
+
+      expect(finalState.response).toEqual(getSearchInitialState().response);
+      expect(finalState.results).toEqual([]);
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.error).toEqual(err);
+    });
+
+    it('when a fetchMoreResults rejected is received with an error', () => {
+      const err = {
+        message: 'message',
+        statusCode: 500,
+        type: 'type',
+      };
+      const action = {type: 'search/fetchMoreResults/rejected', payload: err};
+      const finalState = searchReducer(state, action);
+
+      expect(finalState.response).toEqual(getSearchInitialState().response);
+      expect(finalState.results).toEqual([]);
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.error).toEqual(err);
+    });
+
+    it('when a executeSearch rejected is received without an error', () => {
+      const action = {type: 'search/executeSearch/rejected', payload: null};
+      const finalState = searchReducer(state, action);
+
+      expect(finalState.response).toEqual(initialMockState().response);
+      expect(finalState.results).toEqual(initialMockState().results);
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.error).toEqual(null);
+    });
+
+    it('when a fetchMoreResults rejected is received without an error', () => {
+      const action = {type: 'search/fetchMoreResults/rejected', payload: null};
+      const finalState = searchReducer(state, action);
+
+      expect(finalState.response).toEqual(initialMockState().response);
+      expect(finalState.results).toEqual(initialMockState().results);
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.error).toEqual(null);
+    });
   });
 
   it('when a executeSearch fulfilled is received, set the error to null', () => {

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -8,7 +8,13 @@ function handleRejectedSearch(
   state: SearchState,
   action: ReturnType<SearchAction['rejected']>
 ) {
-  state.error = action.payload ? action.payload : null;
+  const hasError = action.payload ? action.payload : null;
+  if (hasError) {
+    state.response = getSearchInitialState().response;
+    state.results = [];
+  }
+
+  state.error = hasError;
   state.isLoading = false;
 }
 
@@ -30,8 +36,12 @@ function handlePendingSearch(state: SearchState) {
 export const searchReducer = createReducer(
   getSearchInitialState(),
   (builder) => {
-    builder.addCase(executeSearch.rejected, handleRejectedSearch);
-    builder.addCase(fetchMoreResults.rejected, handleRejectedSearch);
+    builder.addCase(executeSearch.rejected, (state, action) =>
+      handleRejectedSearch(state, action)
+    );
+    builder.addCase(fetchMoreResults.rejected, (state, action) =>
+      handleRejectedSearch(state, action)
+    );
     builder.addCase(executeSearch.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);
       state.results = action.payload.response.results;

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -8,13 +8,13 @@ function handleRejectedSearch(
   state: SearchState,
   action: ReturnType<SearchAction['rejected']>
 ) {
-  const hasError = action.payload ? action.payload : null;
-  if (hasError) {
+  const error = action.payload ?? null;
+  if (error) {
     state.response = getSearchInitialState().response;
     state.results = [];
   }
 
-  state.error = hasError;
+  state.error = error;
   state.isLoading = false;
 }
 


### PR DESCRIPTION
Moved from the controller's level to the slice's level
https://coveord.atlassian.net/browse/KIT-833