### PR TITLE
feat(headless): add isLoadingSuggestions to search box

### DIFF
--- a/packages/headless/src/controllers/search-box/headless-search-box.test.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.test.ts
@@ -135,6 +135,7 @@ describe('headless searchBox', () => {
         rawValue: completion.expression,
       })),
       isLoading: false,
+      isLoadingSuggestions: false,
     });
   });
 
@@ -267,5 +268,11 @@ describe('headless searchBox', () => {
       searchBox.submit();
       expect(engine.actions).toContainEqual(clearQuerySuggest({id}));
     });
+  });
+
+  it(`when querySuggest #isLoading state is true,
+  #state.isLoadingSuggestions is true`, () => {
+    state.querySuggest[id]!.isLoading = true;
+    expect(searchBox.state.isLoadingSuggestions).toBe(true);
   });
 });

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -111,7 +111,7 @@ export interface SearchBoxState {
   isLoading: boolean;
 
   /**
-   * Determins if a query suggest request is in progress.
+   * Determines if a query suggest request is in progress.
    */
   isLoadingSuggestions: boolean;
 }

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -109,6 +109,11 @@ export interface SearchBoxState {
    * Determines if a search is in progress.
    */
   isLoading: boolean;
+
+  /**
+   * Determins if a query suggest request is in progress.
+   */
+  isLoadingSuggestions: boolean;
 }
 
 export interface Suggestion {
@@ -207,16 +212,20 @@ export function buildSearchBox(
 
     get state() {
       const state = getState();
-      const querySuggestState = state.querySuggest[options.id];
+      const querySuggest = state.querySuggest[options.id];
       const suggestions = getSuggestions(
-        querySuggestState,
+        querySuggest,
         options.highlightOptions
       );
+      const isLoadingSuggestions = querySuggest
+        ? querySuggest.isLoading
+        : false;
 
       return {
         value: getValue(),
         suggestions,
         isLoading: state.search.isLoading,
+        isLoadingSuggestions,
       };
     },
   };

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
@@ -93,6 +93,7 @@ describe('headless standalone searchBox', () => {
       })),
       redirectTo: state.redirection.redirectTo,
       isLoading: false,
+      isLoadingSuggestions: false,
       analytics: {
         cause: '',
         metadata: null,

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -138,9 +138,7 @@ export interface FetchQuerySuggestionsThunkReturn
 export const fetchQuerySuggestions = createAsyncThunk<
   FetchQuerySuggestionsThunkReturn,
   FetchQuerySuggestionsActionCreatorPayload,
-  AsyncThunkSearchOptions<StateNeededByQuerySuggest> & {
-    rejectValue: FetchQuerySuggestionsActionCreatorPayload;
-  }
+  AsyncThunkSearchOptions<StateNeededByQuerySuggest>
 >(
   'querySuggest/fetch',
 
@@ -155,7 +153,7 @@ export const fetchQuerySuggestions = createAsyncThunk<
     );
 
     if (isErrorResponse(response)) {
-      return rejectWithValue({id, ...response.error});
+      return rejectWithValue(response.error);
     }
 
     return {

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -56,23 +56,19 @@ describe('querySuggest slice', () => {
     ).toEqual(expectedState);
   });
 
-  it('should handle selectQuerySuggestion on existing state', () => {
-    const expectedState = addToDefaultState({
-      completions: getCompletions(),
-      q: 'some expression',
+  describe('selectQuerySuggestion', () => {
+    it('when the id is valid, it updates the query to the passed expression', () => {
+      state[id]!.q = 'some previous query';
+      const action = selectQuerySuggestion({id, expression: 'some expression'});
+      const finalState = querySuggestReducer(state, action);
+
+      expect(finalState[id]?.q).toBe('some expression');
     });
 
-    const existingState = addToDefaultState({
-      completions: getCompletions(),
-      q: 'some previous query',
+    it('when the id is invalid, it does not throw', () => {
+      const action = selectQuerySuggestion({id: 'invalid id', expression: ''});
+      expect(() => querySuggestReducer(state, action)).not.toThrow();
     });
-
-    expect(
-      querySuggestReducer(
-        existingState,
-        selectQuerySuggestion({id, expression: 'some expression'})
-      )
-    ).toEqual(expectedState);
   });
 
   it('should handle clearQuerySuggest on existing state', () => {

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -9,7 +9,7 @@ import {
 import {buildMockQuerySuggest} from '../../test/mock-query-suggest';
 import {updateQuerySetQuery} from '../query-set/query-set-actions';
 import {QuerySuggestSet, QuerySuggestState} from './query-suggest-state';
-import {buildMockSearchApiErrorWithStateCode} from '../../test/mock-search-api-error-with-state-code';
+import {buildMockSearchApiErrorWithStatusCode} from '../../test/mock-search-api-error-with-status-code';
 
 describe('querySuggest slice', () => {
   let state: QuerySuggestSet;
@@ -178,6 +178,21 @@ describe('querySuggest slice', () => {
         expect(finalState[id]?.isLoading).toBe(false);
       });
 
+      it(`when fetchQuerySuggestions.fulfilled has the right request id,
+      it sets the error to null`, () => {
+        state[id] = buildMockQuerySuggest({
+          error: buildMockSearchApiErrorWithStatusCode(),
+          currentRequestId: 'the_right_id',
+        });
+
+        const finalState = querySuggestReducer(
+          state,
+          fetchQuerySuggestionsFulfilledAction
+        );
+
+        expect(finalState[id]?.error).toBe(null);
+      });
+
       it(`when fetchQuerySuggestions.fulfilled has the wrong request id
       should not update the completions`, () => {
         state[id]!.currentRequestId = 'the_wrong_id';
@@ -226,7 +241,7 @@ describe('querySuggest slice', () => {
 
       it('sets the error to the payload error', () => {
         const action = fetchQuerySuggestions.rejected(null, 'hello', {id});
-        action.payload = buildMockSearchApiErrorWithStateCode();
+        action.payload = buildMockSearchApiErrorWithStatusCode();
 
         const finalState = querySuggestReducer(state, action);
         expect(finalState[id]?.error).toEqual(action.payload);

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -8,7 +8,7 @@ import {
 } from './query-suggest-actions';
 import {buildMockQuerySuggest} from '../../test/mock-query-suggest';
 import {updateQuerySetQuery} from '../query-set/query-set-actions';
-import {QuerySuggestSet, QuerySuggestState} from './query-suggest-state';
+import {QuerySuggestSet} from './query-suggest-state';
 import {buildMockSearchApiErrorWithStatusCode} from '../../test/mock-search-api-error-with-status-code';
 
 describe('querySuggest slice', () => {
@@ -29,13 +29,6 @@ describe('querySuggest slice', () => {
     return completions;
   }
 
-  function addToDefaultState(
-    querySuggest: Partial<QuerySuggestState>
-  ): QuerySuggestSet {
-    const qs = buildMockQuerySuggest({id, ...querySuggest});
-    return {[id]: qs};
-  }
-
   beforeEach(() => {
     state = {
       [id]: buildMockQuerySuggest(),
@@ -47,13 +40,11 @@ describe('querySuggest slice', () => {
   });
 
   it('should handle registerQuerySuggest on initial state', () => {
-    const expectedState = addToDefaultState({q: 'test', count: 10});
-    expect(
-      querySuggestReducer(
-        undefined,
-        registerQuerySuggest({id, q: 'test', count: 10})
-      )
-    ).toEqual(expectedState);
+    const expectedState = buildMockQuerySuggest({id, q: 'test', count: 10});
+    const action = registerQuerySuggest({id, q: 'test', count: 10});
+    const finalState = querySuggestReducer(undefined, action);
+
+    expect(finalState[id]).toEqual(expectedState);
   });
 
   describe('selectQuerySuggestion', () => {
@@ -99,10 +90,8 @@ describe('querySuggest slice', () => {
     it(`when a query in the querySet is updated,
     does not update the query suggest query if the id is missing`, () => {
       const unknownId = '1';
-      const query = 'query';
-
-      const action = updateQuerySetQuery({id: unknownId, query});
-      const finalState = querySuggestReducer(addToDefaultState({}), action);
+      const action = updateQuerySetQuery({id: unknownId, query: 'query'});
+      const finalState = querySuggestReducer(state, action);
 
       expect(finalState[unknownId]).toBe(undefined);
     });
@@ -112,7 +101,7 @@ describe('querySuggest slice', () => {
       const query = 'query';
 
       const action = updateQuerySetQuery({id, query});
-      const finalState = querySuggestReducer(addToDefaultState({}), action);
+      const finalState = querySuggestReducer(state, action);
 
       expect(finalState[id]?.q).toBe(query);
     });

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -71,20 +71,28 @@ describe('querySuggest slice', () => {
     });
   });
 
-  it('should handle clearQuerySuggest on existing state', () => {
-    const expectedState = addToDefaultState({
-      completions: [],
-      q: '',
-      partialQueries: [],
+  describe('clearQuerySuggest', () => {
+    it('when the id is valid, it clears the query, completions and partialQueries', () => {
+      state[id] = buildMockQuerySuggest({
+        completions: getCompletions(),
+        q: 'some query',
+        partialQueries: ['s', 'so', 'som', 'some'],
+      });
+
+      const expectedState = buildMockQuerySuggest({
+        completions: [],
+        q: '',
+        partialQueries: [],
+      });
+
+      const finalState = querySuggestReducer(state, clearQuerySuggest({id}));
+      expect(finalState[id]).toEqual(expectedState);
     });
-    const existingState = addToDefaultState({
-      completions: getCompletions(),
-      q: 'some query',
-      partialQueries: ['s', 'so', 'som', 'some'],
+
+    it('when the id is invalid, it does not throw', () => {
+      const action = clearQuerySuggest({id: 'invalid id'});
+      expect(() => querySuggestReducer(state, action)).not.toThrow();
     });
-    expect(querySuggestReducer(existingState, clearQuerySuggest({id}))).toEqual(
-      expectedState
-    );
   });
 
   it(`when a query in the querySet is updated,

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -95,25 +95,27 @@ describe('querySuggest slice', () => {
     });
   });
 
-  it(`when a query in the querySet is updated,
-  does not update the query suggest query if the id is missing`, () => {
-    const unknownId = '1';
-    const query = 'query';
+  describe('updateQuerySetQuery', () => {
+    it(`when a query in the querySet is updated,
+    does not update the query suggest query if the id is missing`, () => {
+      const unknownId = '1';
+      const query = 'query';
 
-    const action = updateQuerySetQuery({id: unknownId, query});
-    const finalState = querySuggestReducer(addToDefaultState({}), action);
+      const action = updateQuerySetQuery({id: unknownId, query});
+      const finalState = querySuggestReducer(addToDefaultState({}), action);
 
-    expect(finalState[unknownId]).toBe(undefined);
-  });
+      expect(finalState[unknownId]).toBe(undefined);
+    });
 
-  it(`when a query in the querySet is updated,
-  it updates the query suggest query if the id exists`, () => {
-    const query = 'query';
+    it(`when a query in the querySet is updated,
+    it updates the query suggest query if the id exists`, () => {
+      const query = 'query';
 
-    const action = updateQuerySetQuery({id, query});
-    const finalState = querySuggestReducer(addToDefaultState({}), action);
+      const action = updateQuerySetQuery({id, query});
+      const finalState = querySuggestReducer(addToDefaultState({}), action);
 
-    expect(finalState[id]?.q).toBe(query);
+      expect(finalState[id]?.q).toBe(query);
+    });
   });
 
   describe('fetchQuerySuggestions', () => {

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -142,46 +142,60 @@ describe('querySuggest slice', () => {
       );
       fetchQuerySuggestionsFulfilledAction.meta.requestId = 'the_right_id';
 
-      it(`when fetchQuerySuggestions.fulfilled has the right request id
-      should update the completions`, () => {
-        const expectedState = addToDefaultState({
-          currentRequestId: 'the_right_id',
-          completions,
+      it('when fetchQuerySuggestions has an invalid id, it does not throw', () => {
+        const id = 'invalid id';
+        const action = fetchQuerySuggestions.fulfilled({completions, id}, '', {
+          id,
         });
 
-        const existingState = addToDefaultState({
+        expect(() => querySuggestReducer(state, action)).not.toThrow();
+      });
+
+      it(`when fetchQuerySuggestions.fulfilled has the right request id
+      should update the completions`, () => {
+        state[id]!.currentRequestId = 'the_right_id';
+
+        const finalState = querySuggestReducer(
+          state,
+          fetchQuerySuggestionsFulfilledAction
+        );
+
+        expect(finalState[id]?.completions).toEqual(completions);
+      });
+
+      it(`when fetchQuerySuggestions.fulfilled has the right request id,
+      it sets isLoading to false`, () => {
+        state[id] = buildMockQuerySuggest({
           currentRequestId: 'the_right_id',
+          isLoading: true,
         });
-        expect(
-          querySuggestReducer(
-            existingState,
-            fetchQuerySuggestionsFulfilledAction
-          )
-        ).toMatchObject(expectedState);
+
+        const finalState = querySuggestReducer(
+          state,
+          fetchQuerySuggestionsFulfilledAction
+        );
+
+        expect(finalState[id]?.isLoading).toBe(false);
       });
 
       it(`when fetchQuerySuggestions.fulfilled has the wrong request id
       should not update the completions`, () => {
-        const existingState = addToDefaultState({
-          currentRequestId: 'the_wrong_id',
-        });
+        state[id]!.currentRequestId = 'the_wrong_id';
 
         expect(
-          querySuggestReducer(
-            existingState,
-            fetchQuerySuggestionsFulfilledAction
-          )
-        ).toMatchObject(existingState);
+          querySuggestReducer(state, fetchQuerySuggestionsFulfilledAction)
+        ).toMatchObject(state);
       });
 
       it('should add the executed query to the list of partialQueries', () => {
         const q = 'test';
-        const existingState = addToDefaultState({
+        state[id] = buildMockQuerySuggest({
           q,
           currentRequestId: 'the_right_id',
         });
+
         const nextState = querySuggestReducer(
-          existingState,
+          state,
           fetchQuerySuggestionsFulfilledAction
         );
         expect(nextState[id]?.partialQueries).toEqual([q]);
@@ -189,12 +203,13 @@ describe('querySuggest slice', () => {
 
       it('should encode `;` characters in the list of partialQueries', () => {
         const q = ';';
-        const existingState = addToDefaultState({
+        state[id] = buildMockQuerySuggest({
           q,
           currentRequestId: 'the_right_id',
         });
+
         const nextState = querySuggestReducer(
-          existingState,
+          state,
           fetchQuerySuggestionsFulfilledAction
         );
         expect(nextState[id]?.partialQueries).toEqual([encodeURIComponent(q)]);

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -8,19 +8,16 @@ import {
 } from './query-suggest-actions';
 import {updateQuerySetQuery} from '../query-set/query-set-actions';
 import {
-  getQuerySuggestInitialState,
-  QuerySuggestSet,
+  getQuerySuggestSetInitialState,
+  QuerySuggestState,
 } from './query-suggest-state';
 
 export const querySuggestReducer = createReducer(
-  {} as QuerySuggestSet,
+  getQuerySuggestSetInitialState(),
   (builder) =>
     builder
       .addCase(registerQuerySuggest, (state, action) => {
-        state[action.payload.id] = {
-          ...getQuerySuggestInitialState(),
-          ...action.payload,
-        };
+        state[action.payload.id] = buildQuerySuggestState(action.payload);
       })
       .addCase(unregisterQuerySuggest, (state, action) => {
         delete state[action.payload.id];
@@ -61,3 +58,18 @@ export const querySuggestReducer = createReducer(
         state[id]!.q = expression;
       })
 );
+
+function buildQuerySuggestState(
+  config: Partial<QuerySuggestState>
+): QuerySuggestState {
+  return {
+    id: '',
+    completions: [],
+    count: 5,
+    q: '',
+    currentRequestId: '',
+    error: null,
+    partialQueries: [],
+    ...config,
+  };
+}

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -33,16 +33,23 @@ export const querySuggestReducer = createReducer(
         querySuggest.isLoading = true;
       })
       .addCase(fetchQuerySuggestions.fulfilled, (state, action) => {
-        const id = action.meta.arg.id;
-        if (action.meta.requestId === state[id]?.currentRequestId) {
-          const {q} = state[id]!;
-          if (q) {
-            state[id]!.partialQueries.push(
-              q.replace(/;/, encodeURIComponent(';'))
-            );
-          }
-          state[id]!.completions = action.payload.completions;
+        const querySuggest = state[action.meta.arg.id];
+
+        if (
+          !querySuggest ||
+          action.meta.requestId !== querySuggest.currentRequestId
+        ) {
+          return;
         }
+
+        const {q} = querySuggest;
+        if (q) {
+          querySuggest.partialQueries.push(
+            q.replace(/;/, encodeURIComponent(';'))
+          );
+        }
+        querySuggest.completions = action.payload.completions;
+        querySuggest.isLoading = false;
       })
       .addCase(fetchQuerySuggestions.rejected, (state, action) => {
         const querySuggest = state[action.meta.arg.id];

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -77,7 +77,13 @@ export const querySuggestReducer = createReducer(
       })
       .addCase(selectQuerySuggestion, (state, action) => {
         const {id, expression} = action.payload;
-        state[id]!.q = expression;
+        const querySuggest = state[id];
+
+        if (!querySuggest) {
+          return;
+        }
+
+        querySuggest.q = expression;
       })
 );
 

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -17,7 +17,7 @@ export const querySuggestReducer = createReducer(
   (builder) =>
     builder
       .addCase(registerQuerySuggest, (state, action) => {
-        state[action.payload.id] = buildQuerySuggestState(action.payload);
+        state[action.payload.id] = buildQuerySuggest(action.payload);
       })
       .addCase(unregisterQuerySuggest, (state, action) => {
         delete state[action.payload.id];
@@ -59,7 +59,7 @@ export const querySuggestReducer = createReducer(
       })
 );
 
-function buildQuerySuggestState(
+function buildQuerySuggest(
   config: Partial<QuerySuggestState>
 ): QuerySuggestState {
   return {
@@ -70,6 +70,7 @@ function buildQuerySuggestState(
     currentRequestId: '',
     error: null,
     partialQueries: [],
+    isLoading: false,
     ...config,
   };
 }

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -50,6 +50,7 @@ export const querySuggestReducer = createReducer(
         }
         querySuggest.completions = action.payload.completions;
         querySuggest.isLoading = false;
+        querySuggest.error = null;
       })
       .addCase(fetchQuerySuggestions.rejected, (state, action) => {
         const querySuggest = state[action.meta.arg.id];

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -70,10 +70,15 @@ export const querySuggestReducer = createReducer(
         }
       })
       .addCase(clearQuerySuggest, (state, action) => {
-        const {id} = action.payload;
-        state[id]!.q = '';
-        state[id]!.completions = [];
-        state[id]!.partialQueries = [];
+        const querySuggest = state[action.payload.id];
+
+        if (!querySuggest) {
+          return;
+        }
+
+        querySuggest.q = '';
+        querySuggest.completions = [];
+        querySuggest.partialQueries = [];
       })
       .addCase(selectQuerySuggestion, (state, action) => {
         const {id, expression} = action.payload;

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -23,7 +23,14 @@ export const querySuggestReducer = createReducer(
         delete state[action.payload.id];
       })
       .addCase(fetchQuerySuggestions.pending, (state, action) => {
-        state[action.meta.arg.id]!.currentRequestId = action.meta.requestId;
+        const querySuggest = state[action.meta.arg.id];
+
+        if (!querySuggest) {
+          return;
+        }
+
+        querySuggest.currentRequestId = action.meta.requestId;
+        querySuggest.isLoading = true;
       })
       .addCase(fetchQuerySuggestions.fulfilled, (state, action) => {
         const id = action.meta.arg.id;
@@ -38,7 +45,14 @@ export const querySuggestReducer = createReducer(
         }
       })
       .addCase(fetchQuerySuggestions.rejected, (state, action) => {
-        state[action.payload!.id]!.error = action.payload!;
+        const querySuggest = state[action.meta.arg.id];
+
+        if (!querySuggest) {
+          return;
+        }
+
+        querySuggest.error = action.payload || null;
+        querySuggest.isLoading = false;
       })
       .addCase(updateQuerySetQuery, (state, action) => {
         const {id, query} = action.payload;

--- a/packages/headless/src/features/query-suggest/query-suggest-state.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-state.ts
@@ -34,12 +34,4 @@ export interface QuerySuggestState {
 
 export type QuerySuggestSet = Record<string, QuerySuggestState | undefined>;
 
-export const getQuerySuggestInitialState: () => QuerySuggestState = () => ({
-  id: '',
-  completions: [],
-  count: 5,
-  q: '',
-  currentRequestId: '',
-  error: null,
-  partialQueries: [],
-});
+export const getQuerySuggestSetInitialState: () => QuerySuggestSet = () => ({});

--- a/packages/headless/src/features/query-suggest/query-suggest-state.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-state.ts
@@ -30,6 +30,10 @@ export interface QuerySuggestState {
    * The error returned by the Coveo platform while executing the query suggestion request, if any. `null` otherwise.
    */
   error: SearchAPIErrorWithStatusCode | null;
+  /**
+   * `true` if the query suggest request is currently being executed against the Coveo platform, `false` otherwise.
+   */
+  isLoading: boolean;
 }
 
 export type QuerySuggestSet = Record<string, QuerySuggestState | undefined>;

--- a/packages/headless/src/test/mock-query-suggest.ts
+++ b/packages/headless/src/test/mock-query-suggest.ts
@@ -11,6 +11,7 @@ export function buildMockQuerySuggest(
     completions: [],
     error: null,
     partialQueries: [],
+    isLoading: false,
     ...config,
   };
 }

--- a/packages/headless/src/test/mock-search-api-error-with-state-code.ts
+++ b/packages/headless/src/test/mock-search-api-error-with-state-code.ts
@@ -1,0 +1,12 @@
+import {SearchAPIErrorWithStatusCode} from '../api/search/search-api-error-response';
+
+export function buildMockSearchApiErrorWithStateCode(
+  config: Partial<SearchAPIErrorWithStatusCode> = {}
+): SearchAPIErrorWithStatusCode {
+  return {
+    message: '',
+    statusCode: 0,
+    type: '',
+    ...config,
+  };
+}

--- a/packages/headless/src/test/mock-search-api-error-with-status-code.ts
+++ b/packages/headless/src/test/mock-search-api-error-with-status-code.ts
@@ -1,6 +1,6 @@
 import {SearchAPIErrorWithStatusCode} from '../api/search/search-api-error-response';
 
-export function buildMockSearchApiErrorWithStateCode(
+export function buildMockSearchApiErrorWithStatusCode(
   config: Partial<SearchAPIErrorWithStatusCode> = {}
 ): SearchAPIErrorWithStatusCode {
   return {


### PR DESCRIPTION
This PR adds an `isLoadingSuggestions` property to the search box controller.
I also added defense in the query suggest slice against unregistered ids.