### PR TITLE
feat(atomic): rework hover & focus effects on facet elements

### DIFF
--- a/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
+++ b/packages/atomic/src/components/atomic-breadcrumb-manager/atomic-breadcrumb-manager.tsx
@@ -83,7 +83,7 @@ export class AtomicBreadcrumbManager implements InitializableComponent {
           this.breadcrumbManager.deselectBreadcrumb(breadcrumbValue)
         }
       >
-        <span class="ellipsed">{value}</span>
+        <span class="truncate">{value}</span>
         <div
           role="button"
           class="w-2.5 ml-1.5 flex-shrink-0 self-center"

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -130,7 +130,7 @@ export class AtomicSearchBox {
       <button
         type="button"
         part="submit-button"
-        class={`submit-button h-full border-0 focus:outline-none bg-primary p-0 ${roundedClasses}`}
+        class={`submit-button h-full border-0 focus:outline-none focus:bg-primary-light hover:bg-primary-light bg-primary p-0 ${roundedClasses}`}
         aria-label={this.strings.search()}
         onClick={() => this.searchBox.submit()}
       >
@@ -178,7 +178,7 @@ export class AtomicSearchBox {
         onKeyDown={(e) => this.combobox.onInputKeydown(e)}
         type="text"
         class={
-          'search-input mx-2 my-0 text-base placeholder-on-background outline-none flex-grow flex-row items-center '
+          'search-input bg-background mx-2 my-0 text-base placeholder-on-background outline-none flex-grow flex-row items-center '
         }
         placeholder={this.placeholder}
         value={this.searchBoxState.value}

--- a/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
@@ -9,7 +9,7 @@
 }
 
 .parent-button {
-  @apply relative flex items-center focus:outline-none hover:text-primary-light hover:bg-neutral-light focus:text-primary-light focus:bg-neutral-light;
+  @apply relative flex items-center focus:outline-none hover:text-primary hover:bg-neutral-light focus:text-primary focus:bg-neutral-light;
 }
 
 .parent-active {

--- a/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
@@ -2,11 +2,10 @@
 @import '../facet-common.pcss';
 @import '../facet-search/facet-search.pcss';
 @import '../facet-show-more-less/facet-show-more-less.pcss';
-@import '../category-facet-search-result/category-facet-search-result.pcss';
 
 .parent-button,
 .parent-active {
-  @apply w-full py-2.5 text-left text-on-background pl-6;
+  @apply w-full py-2.5 pr-2 pl-7 text-left text-on-background;
 }
 
 .parent-button {
@@ -18,5 +17,5 @@
 }
 
 .back-arrow {
-  @apply fill-current h-5 w-5 absolute left-0;
+  @apply fill-current h-5 w-5 absolute left-1;
 }

--- a/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.pcss
@@ -2,7 +2,6 @@
 @import '../facet-common.pcss';
 @import '../facet-search/facet-search.pcss';
 @import '../facet-show-more-less/facet-show-more-less.pcss';
-@import '../facet-value-link/facet-value-link.pcss';
 @import '../category-facet-search-result/category-facet-search-result.pcss';
 
 .parent-button,
@@ -11,7 +10,7 @@
 }
 
 .parent-button {
-  @apply relative flex items-center focus:outline-none hover:text-primary-light hover:underline focus:text-primary-light focus:underline;
+  @apply relative flex items-center focus:outline-none hover:text-primary-light hover:bg-neutral-light focus:text-primary-light focus:bg-neutral-light;
 }
 
 .parent-active {

--- a/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-category-facet/atomic-category-facet.tsx
@@ -234,7 +234,7 @@ export class AtomicCategoryFacet
             part="back-arrow"
             class="back-arrow"
           />
-          <span class="ellipsed">{allCategories}</span>
+          <span class="truncate">{allCategories}</span>
         </button>
       </li>
     );
@@ -265,7 +265,7 @@ export class AtomicCategoryFacet
             part="back-arrow"
             class="back-arrow"
           />
-          <span class="ellipsed">{displayValue}</span>
+          <span class="truncate">{displayValue}</span>
         </button>
       </li>
     );

--- a/packages/atomic/src/components/facets-v1/atomic-color-facet/atomic-color-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-color-facet/atomic-color-facet.pcss
@@ -10,7 +10,7 @@
  * @prop --atomic-facet-color-boxes-gap: Gap value for facet values for the Color Facet , when the display is 'box'
  */
 .box-color-container {
-  @apply grid;
+  @apply grid px-2;
   grid-template-columns: repeat(var(--atomic-facet-color-boxes-per-row, 3), minmax(0, 1fr));
   gap: var(--atomic-facet-color-boxes-gap, 0.5rem);
 }

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
@@ -2,6 +2,6 @@
 @import '../facet-common.pcss';
 @import '../facet-search/facet-search.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
-@import '../facet-value-link/facet-value-link.pcss';
 @import '../facet-value-box/facet-value-box.pcss';
+
 @import '../facet-show-more-less/facet-show-more-less.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-facet/atomic-facet.pcss
@@ -3,5 +3,4 @@
 @import '../facet-search/facet-search.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
 @import '../facet-value-box/facet-value-box.pcss';
-
 @import '../facet-show-more-less/facet-show-more-less.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-numeric-facet/atomic-numeric-facet.pcss
@@ -1,4 +1,3 @@
 @import '../../../global/global.pcss';
 @import '../facet-common.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
-@import '../facet-value-link/facet-value-link.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-facet/atomic-rating-facet.pcss
@@ -1,5 +1,4 @@
 @import '../../../global/global.pcss';
 @import '../facet-common.pcss';
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
-@import '../facet-value-link/facet-value-link.pcss';
 @import '../facet-value-icon-rating/facet-value-icon-rating.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.pcss
@@ -1,4 +1,3 @@
 @import '../../../global/global.pcss';
 @import '../facet-common.pcss';
-@import '../facet-value-link/facet-value-link.pcss';
 @import '../facet-value-icon-rating/facet-value-icon-rating.pcss';

--- a/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -166,7 +166,7 @@ export class AtomicRatingRangeFacet
     return (
       <span
         part="value-label"
-        class={`ml-1 flex items-center truncate group-hover:underline group-hover:text-primary ${
+        class={`ml-1 flex items-center truncate group-focus:text-primary-light group-hover:text-primary-light ${
           facetValue.state === 'selected' ? 'font-bold' : ''
         }`}
       >

--- a/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets-v1/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -166,7 +166,7 @@ export class AtomicRatingRangeFacet
     return (
       <span
         part="value-label"
-        class={`ml-1 flex items-center truncate group-focus:text-primary-light group-hover:text-primary-light ${
+        class={`ml-1 flex items-center truncate group-focus:text-primary group-hover:text-primary ${
           facetValue.state === 'selected' ? 'font-bold' : ''
         }`}
       >

--- a/packages/atomic/src/components/facets-v1/atomic-timeframe-facet/atomic-timeframe-facet.pcss
+++ b/packages/atomic/src/components/facets-v1/atomic-timeframe-facet/atomic-timeframe-facet.pcss
@@ -1,3 +1,2 @@
 @import '../../../global/global.pcss';
 @import '../facet-common.pcss';
-@import '../facet-value-link/facet-value-link.pcss';

--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.pcss
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.pcss
@@ -1,6 +1,0 @@
-.search-result:hover .value-label,
-.search-result:focus .value-label,
-.search-result:hover .search-result-path,
-.search-result:focus .search-result-path {
-  @apply text-primary;
-}

--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
@@ -67,7 +67,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
       <button
         part="search-result"
         onClick={() => onClick()}
-        class="search-result w-full flex flex-col py-2.5 text-on-background truncate focus:outline-none"
+        class="search-result w-full flex flex-col px-2 py-2.5 text-on-background truncate focus:outline-none group rounded focus:bg-neutral-light hover:bg-neutral-light"
         aria-label={ariaLabel}
       >
         <div class="w-full flex">
@@ -82,7 +82,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
         </div>
         <div
           part="search-result-path"
-          class="search-result-path flex text-neutral-dark mt-1"
+          class="flex text-neutral-dark mt-1 group-focus:text-primary-light group-hover:text-primary-light"
         >
           {renderPath(localizedPath)}
         </div>

--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
@@ -48,14 +48,14 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
 
   function renderPath(path: string[]) {
     if (!path.length) {
-      return <span class="ellipsed">{`${inLabel} ${allCategories}`}</span>;
+      return <span class="truncate">{`${inLabel} ${allCategories}`}</span>;
     }
 
     return [
       <span class="mr-0.5">{inLabel}</span>,
       ellipsedPath(path).map((value, index) => [
         index > 0 && <span class="mx-0.5">{SEPARATOR}</span>,
-        <span class={value === ELLIPSIS ? '' : 'ellipsed flex-1 max-w-max'}>
+        <span class={value === ELLIPSIS ? '' : 'truncate flex-1 max-w-max'}>
           {value}
         </span>,
       ]),
@@ -67,7 +67,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
       <button
         part="search-result"
         onClick={() => onClick()}
-        class="search-result w-full flex flex-col py-2.5 text-on-background ellipsed focus:outline-none"
+        class="search-result w-full flex flex-col py-2.5 text-on-background truncate focus:outline-none"
         aria-label={ariaLabel}
       >
         <div class="w-full flex">

--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
@@ -82,7 +82,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
         </div>
         <div
           part="search-result-path"
-          class="flex text-neutral-dark mt-1 group-focus:text-primary-light group-hover:text-primary-light"
+          class="flex text-neutral-dark mt-1 group-focus:text-primary group-hover:text-primary"
         >
           {renderPath(localizedPath)}
         </div>

--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
@@ -76,10 +76,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
             isSelected={false}
             searchQuery={searchQuery}
           ></FacetValueLabelHighlight>
-          <span
-            part="value-count"
-            class="ml-1.5 text-neutral-dark with-parentheses"
-          >
+          <span part="value-count" class="value-count">
             {count}
           </span>
         </div>

--- a/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.pcss
@@ -1,5 +1,5 @@
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
 
 .color-checkbox-list-item:hover label .value-label {
-  @apply text-primary-light underline;
+  @apply text-primary-light;
 }

--- a/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.pcss
@@ -1,5 +1,6 @@
 @import '../facet-value-checkbox/facet-value-checkbox.pcss';
 
-.color-checkbox-list-item:hover label .value-label {
-  @apply text-primary-light;
+.value-checkbox:focus,
+.value-checkbox:hover {
+  @apply ring-1 ring-primary-light ring-offset-2;
 }

--- a/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.tsx
@@ -17,37 +17,19 @@ export const ColorFacetCheckbox: FunctionalComponent<FacetValueProps> = (
     ?.toString();
 
   return (
-    <li
-      key={props.displayValue}
-      class="flex items-center color-checkbox-list-item"
-    >
-      <div
-        class={
-          props.isSelected
-            ? 'border-2 border-primary-light rounded relative right-0.5'
-            : ''
-        }
-      >
-        <button
-          id={id}
-          role="checkbox"
-          part={`value-${partValue}`}
-          onClick={() => props.onClick()}
-          aria-checked={props.isSelected.toString()}
-          class="value-checkbox m-0.5 flex justify-center rounded focus:outline-none focus:border-primary-light bg-neutral-dark"
-          aria-label={ariaLabel}
-        ></button>
-      </div>
-      <label
-        htmlFor={id}
-        part="value-checkbox-label"
-        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer truncate"
-      >
+    <li key={props.displayValue} class="relative flex items-center">
+      <button
+        id={id}
+        role="checkbox"
+        part={`value-${partValue}`}
+        onClick={() => props.onClick()}
+        aria-checked={props.isSelected.toString()}
+        class={`value-checkbox ${props.isSelected ? 'ring-primary' : ''}`}
+        aria-label={ariaLabel}
+      ></button>
+      <label htmlFor={id} part="value-checkbox-label">
         {children}
-        <span
-          part="value-count"
-          class="ml-1.5 text-neutral-dark with-parentheses"
-        >
+        <span part="value-count" class="value-count">
           {count}
         </span>
       </label>

--- a/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/color-facet-checkbox/color-facet-checkbox.tsx
@@ -41,7 +41,7 @@ export const ColorFacetCheckbox: FunctionalComponent<FacetValueProps> = (
       <label
         htmlFor={id}
         part="value-checkbox-label"
-        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer ellipsed"
+        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer truncate"
       >
         {children}
         <span

--- a/packages/atomic/src/components/facets-v1/facet-common.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-common.pcss
@@ -1,3 +1,7 @@
 :host(.atomic-without-values) {
   display: none;
 }
+
+.value-count {
+  @apply ml-1.5 text-neutral-dark with-parentheses;
+}

--- a/packages/atomic/src/components/facets-v1/facet-container/facet-container.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-container/facet-container.tsx
@@ -1,7 +1,7 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
 export const FacetContainer: FunctionalComponent = (_, children) => (
-  <div class="bg-background border border-neutral rounded-lg p-6" part="facet">
+  <div class="bg-background border border-neutral rounded-lg p-4" part="facet">
     {children}
   </div>
 );

--- a/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
@@ -67,7 +67,7 @@ export class FacetDateInput {
     const applyAria = this.bindings.i18n.t('date-input-apply', {label});
 
     const commonClasses =
-      'rounded border border-neutral p-2.5 hover:border-primary-light focus:border-primary focus:outline-none';
+      'rounded border border-neutral p-2.5 bg-background hover:border-primary-light focus:border-primary focus:outline-none';
     const inputClasses = `${commonClasses}`;
     const labelClasses = 'text-neutral-dark self-center';
 
@@ -125,7 +125,7 @@ export class FacetDateInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} col-span-2 bg-background text-primary hover:text-primary-light`}
+          class={`${commonClasses} col-span-2 text-primary hover:text-primary-light`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
@@ -66,7 +66,8 @@ export class FacetDateInput {
     const apply = this.bindings.i18n.t('apply');
     const applyAria = this.bindings.i18n.t('date-input-apply', {label});
 
-    const commonClasses = 'rounded border border-neutral p-2.5';
+    const commonClasses =
+      'rounded border border-neutral p-2.5 hover:border-primary-light focus:border-primary focus:outline-none';
     const inputClasses = `${commonClasses}`;
     const labelClasses = 'text-neutral-dark self-center';
 
@@ -124,7 +125,7 @@ export class FacetDateInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} col-span-2 bg-background text-primary`}
+          class={`${commonClasses} col-span-2 bg-background text-primary hover:text-primary-light`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
@@ -125,7 +125,7 @@ export class FacetDateInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} col-span-2 text-primary hover:text-primary-light`}
+          class={`${commonClasses} col-span-2 text-primary hover:text-primary`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-date-input/facet-date-input.tsx
@@ -72,7 +72,7 @@ export class FacetDateInput {
 
     return (
       <form
-        class="grid gap-2 grid-cols-min-1fr mt-4"
+        class="grid gap-2 grid-cols-min-1fr mt-4 px-2"
         onSubmit={(e) => {
           e.preventDefault();
           this.apply();

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -26,7 +26,7 @@ export const FacetHeader: FunctionalComponent<{
   return [
     <button
       part="label-button"
-      class="flex justify-between w-full py-1 text-on-background text-lg hover:text-primary"
+      class="flex justify-between w-full py-1 px-2 text-on-background text-lg hover:text-primary"
       title={props.isCollapsed ? expandFacet : collapseFacet}
       onClick={() => props.onToggleCollapse()}
       aria-expanded={(!props.isCollapsed).toString()}
@@ -41,7 +41,7 @@ export const FacetHeader: FunctionalComponent<{
     props.onClearFilters && props.numberOfSelectedValues > 0 && (
       <button
         part="clear-button"
-        class="flex items-baseline w-full p-1 text-sm text-primary hover:text-primary-light focus:text-primary-light"
+        class="flex items-baseline p-2 text-sm text-primary rounded hover:text-primary-light focus:text-primary-light hover:bg-neutral-light focus:bg-neutral-light"
         title={clearFiltersForFacet}
         onClick={() => props.onClearFilters!()}
       >

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -26,7 +26,7 @@ export const FacetHeader: FunctionalComponent<{
   return [
     <button
       part="label-button"
-      class="flex justify-between w-full py-1 px-2 text-on-background text-lg hover:text-primary"
+      class="flex justify-between w-full py-1 px-2 text-on-background text-lg hover:text-primary focus:text-primary"
       title={props.isCollapsed ? expandFacet : collapseFacet}
       onClick={() => props.onToggleCollapse()}
       aria-expanded={(!props.isCollapsed).toString()}

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -41,7 +41,7 @@ export const FacetHeader: FunctionalComponent<{
     props.onClearFilters && props.numberOfSelectedValues > 0 && (
       <button
         part="clear-button"
-        class="flex items-baseline p-2 text-sm text-primary rounded hover:text-primary-light focus:text-primary-light hover:bg-neutral-light focus:bg-neutral-light"
+        class="flex items-baseline p-2 text-sm text-primary rounded hover:text-primary focus:text-primary hover:bg-neutral-light focus:bg-neutral-light"
         title={clearFiltersForFacet}
         onClick={() => props.onClearFilters!()}
       >

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -31,7 +31,7 @@ export const FacetHeader: FunctionalComponent<{
       onClick={() => props.onToggleCollapse()}
       aria-expanded={(!props.isCollapsed).toString()}
     >
-      <span class="ellipsed">{label}</span>
+      <span class="truncate">{label}</span>
       <span
         part="label-button-icon"
         class="fill-current w-3 h-2 self-center flex-shrink-0 ml-4"

--- a/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-header/facet-header.tsx
@@ -41,7 +41,7 @@ export const FacetHeader: FunctionalComponent<{
     props.onClearFilters && props.numberOfSelectedValues > 0 && (
       <button
         part="clear-button"
-        class="flex items-baseline w-full p-1 text-sm link"
+        class="flex items-baseline w-full p-1 text-sm text-primary hover:text-primary-light focus:text-primary-light"
         title={clearFiltersForFacet}
         onClick={() => props.onClearFilters!()}
       >

--- a/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
@@ -104,7 +104,7 @@ export class FacetNumberInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} text-primary hover:text-primary-light flex-none`}
+          class={`${commonClasses} text-primary hover:text-primary flex-none`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
@@ -55,7 +55,7 @@ export class FacetNumberInput {
     const applyAria = this.bindings.i18n.t('number-input-apply', {label});
 
     const commonClasses =
-      'rounded p-2.5 border border-neutral hover:border-primary-light focus:border-primary focus:outline-none';
+      'rounded p-2.5 border border-neutral bg-background hover:border-primary-light focus:border-primary focus:outline-none';
     const inputClasses = `${commonClasses} placeholder-neutral-dark min-w-0 mr-1`;
 
     const step = this.type === 'integer' ? '1' : 'any';
@@ -104,7 +104,7 @@ export class FacetNumberInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} bg-background text-primary  hover:text-primary-light flex-none`}
+          class={`${commonClasses} text-primary hover:text-primary-light flex-none`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
@@ -54,7 +54,8 @@ export class FacetNumberInput {
     const apply = this.bindings.i18n.t('apply');
     const applyAria = this.bindings.i18n.t('number-input-apply', {label});
 
-    const commonClasses = 'rounded p-2.5 border border-neutral';
+    const commonClasses =
+      'rounded p-2.5 border border-neutral hover:border-primary-light focus:border-primary focus:outline-none';
     const inputClasses = `${commonClasses} placeholder-neutral-dark min-w-0 mr-1`;
 
     const step = this.type === 'integer' ? '1' : 'any';
@@ -103,7 +104,7 @@ export class FacetNumberInput {
         <button
           type="submit"
           part="input-apply-button"
-          class={`${commonClasses} bg-background text-primary flex-none`}
+          class={`${commonClasses} bg-background text-primary  hover:text-primary-light flex-none`}
           aria-label={applyAria}
         >
           {apply}

--- a/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-number-input/facet-number-input.tsx
@@ -61,7 +61,7 @@ export class FacetNumberInput {
 
     return (
       <form
-        class="flex flex-row mt-4"
+        class="flex flex-row mt-4 px-2"
         onSubmit={(e) => {
           e.preventDefault();
           this.apply();

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
@@ -21,37 +21,39 @@ export const FacetSearchInput: FunctionalComponent<FacetSearchInputProps> = (
   let inputRef: HTMLInputElement | undefined;
 
   return (
-    <div class="relative h-10 w-full mt-3">
-      <input
-        part="search-input"
-        class="w-full h-full border border-neutral rounded px-9 placeholder-neutral-dark text-sm focus:border-primary focus:outline-none"
-        type="text"
-        placeholder={search}
-        aria-label={facetSearch}
-        value={props.query}
-        onInput={(e) => props.onChange((e.target as HTMLInputElement).value)}
-        ref={(ref) => (inputRef = ref)}
-      ></input>
-      <div class="input-ring w-full h-full absolute inset-0 pointer-events-none rounded opacity-40"></div>
-      <div
-        part="search-icon"
-        class="search-icon pointer-events-none absolute inline-flex justify-center items-center left-0 w-9 h-full text-on-background"
-      >
-        <div class="fill-current" innerHTML={SearchIcon}></div>
-      </div>
-      {props.query !== '' && (
-        <button
-          title={clear}
-          part="search-clear-button"
-          class="search-clear-button absolute border border-transparent inline-flex justify-center items-center right-0 w-9 h-full text-on-background rounded focus:text-primary hover:text-primary"
-          onClick={() => {
-            props.onClear();
-            inputRef!.focus();
-          }}
+    <div class="px-2 mt-3">
+      <div class="relative h-10">
+        <input
+          part="search-input"
+          class="w-full h-full border border-neutral rounded px-9 placeholder-neutral-dark text-sm focus:border-primary focus:outline-none"
+          type="text"
+          placeholder={search}
+          aria-label={facetSearch}
+          value={props.query}
+          onInput={(e) => props.onChange((e.target as HTMLInputElement).value)}
+          ref={(ref) => (inputRef = ref)}
+        ></input>
+        <div class="input-ring w-full h-full absolute inset-0 pointer-events-none rounded opacity-40"></div>
+        <div
+          part="search-icon"
+          class="search-icon pointer-events-none absolute inline-flex justify-center items-center left-0 w-9 h-full text-on-background"
         >
-          <div class="fill-current" innerHTML={CloseIcon}></div>
-        </button>
-      )}
+          <div class="fill-current" innerHTML={SearchIcon}></div>
+        </div>
+        {props.query !== '' && (
+          <button
+            title={clear}
+            part="search-clear-button"
+            class="search-clear-button absolute border border-transparent inline-flex justify-center items-center right-0 w-9 h-full text-on-background rounded focus:text-primary hover:text-primary"
+            onClick={() => {
+              props.onClear();
+              inputRef!.focus();
+            }}
+          >
+            <div class="fill-current" innerHTML={CloseIcon}></div>
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
@@ -25,7 +25,7 @@ export const FacetSearchInput: FunctionalComponent<FacetSearchInputProps> = (
       <div class="relative h-10">
         <input
           part="search-input"
-          class="w-full h-full border border-neutral rounded px-9 placeholder-neutral-dark text-sm hover:border-primary-light focus:border-primary focus:outline-none group"
+          class="w-full h-full border border-neutral bg-background rounded px-9 placeholder-neutral-dark text-sm hover:border-primary-light focus:border-primary focus:outline-none group"
           type="text"
           placeholder={search}
           aria-label={facetSearch}

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-input.tsx
@@ -25,15 +25,15 @@ export const FacetSearchInput: FunctionalComponent<FacetSearchInputProps> = (
       <div class="relative h-10">
         <input
           part="search-input"
-          class="w-full h-full border border-neutral rounded px-9 placeholder-neutral-dark text-sm focus:border-primary focus:outline-none"
+          class="w-full h-full border border-neutral rounded px-9 placeholder-neutral-dark text-sm hover:border-primary-light focus:border-primary focus:outline-none group"
           type="text"
           placeholder={search}
           aria-label={facetSearch}
           value={props.query}
           onInput={(e) => props.onChange((e.target as HTMLInputElement).value)}
           ref={(ref) => (inputRef = ref)}
-        ></input>
-        <div class="input-ring w-full h-full absolute inset-0 pointer-events-none rounded opacity-40"></div>
+        />
+        <div class="input-ring invisible ring-2 w-full h-full absolute inset-0 pointer-events-none rounded opacity-40 ring-primary"></div>
         <div
           part="search-icon"
           class="search-icon pointer-events-none absolute inline-flex justify-center items-center left-0 w-9 h-full text-on-background"

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
@@ -29,7 +29,7 @@ export const FacetSearchMatches: FunctionalComponent<FacetSearchMatchesProps> = 
     return (
       <div
         part="no-matches"
-        class="ellipsed p-3 bg-neutral-light text-neutral-dark text-sm"
+        class="truncate p-3 bg-neutral-light text-neutral-dark text-sm"
         innerHTML={matchesFound(
           'no-matches-found-for',
           props.query,
@@ -43,7 +43,7 @@ export const FacetSearchMatches: FunctionalComponent<FacetSearchMatchesProps> = 
     return (
       <div
         part="more-matches"
-        class="ellipsed mt-3 text-neutral-dark text-sm"
+        class="truncate mt-3 text-neutral-dark text-sm"
         innerHTML={matchesFound('more-matches-for', props.query, props.i18n)}
       ></div>
     );

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search-matches.tsx
@@ -27,25 +27,29 @@ export const FacetSearchMatches: FunctionalComponent<FacetSearchMatchesProps> = 
 ) => {
   if (!props.numberOfMatches) {
     return (
-      <div
-        part="no-matches"
-        class="truncate p-3 bg-neutral-light text-neutral-dark text-sm"
-        innerHTML={matchesFound(
-          'no-matches-found-for',
-          props.query,
-          props.i18n
-        )}
-      ></div>
+      <div class="px-2">
+        <div
+          part="no-matches"
+          class="truncate p-3 bg-neutral-light text-neutral-dark text-sm rounded"
+          innerHTML={matchesFound(
+            'no-matches-found-for',
+            props.query,
+            props.i18n
+          )}
+        ></div>
+      </div>
     );
   }
 
   if (props.hasMoreMatches) {
     return (
-      <div
-        part="more-matches"
-        class="truncate mt-3 text-neutral-dark text-sm"
-        innerHTML={matchesFound('more-matches-for', props.query, props.i18n)}
-      ></div>
+      <div class="px-2">
+        <div
+          part="more-matches"
+          class="truncate mt-3 text-neutral-dark text-sm"
+          innerHTML={matchesFound('more-matches-for', props.query, props.i18n)}
+        ></div>
+      </div>
     );
   }
 };

--- a/packages/atomic/src/components/facets-v1/facet-search/facet-search.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-search/facet-search.pcss
@@ -2,12 +2,12 @@ input[type='text']:focus ~ .search-icon {
   @apply text-primary;
 }
 
-/**
- * @prop --atomic-facet-search-ring-color: Color of the input's outline ring
- */
+input[type='text']:hover ~ .search-icon {
+  @apply text-primary-light;
+}
+
 input[type='text']:focus ~ .input-ring {
-  --tw-ring-color: var(--atomic-facet-search-ring-color, var(--atomic-primary));
-  @apply ring-2;
+  @apply visible;
 }
 
 /**

--- a/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
@@ -25,7 +25,7 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
     label,
   });
   const btnClasses =
-    'flex items-baseline text-left p-2 text-sm mt-2 text-primary rounded hover:text-primary-light focus:text-primary-light hover:bg-neutral-light focus:bg-neutral-ligh';
+    'flex items-baseline text-left p-2 text-sm mt-2 text-primary rounded hover:text-primary focus:text-primary hover:bg-neutral-light focus:bg-neutral-ligh';
   const iconClasses = 'fill-current w-2 h-2 mr-1';
   return [
     props.canShowLessValues && (

--- a/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
@@ -25,7 +25,7 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
     label,
   });
   const btnClasses =
-    'w-full flex items-baseline text-left py-2 text-sm mt-2 link';
+    'w-full flex items-baseline text-left py-2 text-sm mt-2 text-primary hover:text-primary-light focus:text-primary-light';
   const iconClasses = 'fill-current w-2 h-2 mr-1';
   return [
     props.canShowLessValues && (

--- a/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-show-more-less/facet-show-more-less.tsx
@@ -25,7 +25,7 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
     label,
   });
   const btnClasses =
-    'w-full flex items-baseline text-left py-2 text-sm mt-2 text-primary hover:text-primary-light focus:text-primary-light';
+    'flex items-baseline text-left p-2 text-sm mt-2 text-primary rounded hover:text-primary-light focus:text-primary-light hover:bg-neutral-light focus:bg-neutral-ligh';
   const iconClasses = 'fill-current w-2 h-2 mr-1';
   return [
     props.canShowLessValues && (

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
@@ -7,3 +7,7 @@
   grid-template-columns: repeat(var(--atomic-facet-boxes-per-row, 4), minmax(0, 1fr));
   gap: var(--atomic-facet-boxes-gap, 0.5rem);
 }
+
+.value-box .value-label {
+  @apply w-full;
+}

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
@@ -7,8 +7,3 @@
   grid-template-columns: repeat(var(--atomic-facet-boxes-per-row, 4), minmax(0, 1fr));
   gap: var(--atomic-facet-boxes-gap, 0.5rem);
 }
-
-.value-box:hover .value-label,
-.value-box:focus .value-label {
-  @apply text-primary-light underline;
-}

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.pcss
@@ -3,7 +3,7 @@
  * @prop --atomic-facet-boxes-gap: Gap value for facet values, when the display is 'box'
  */
 .box-container {
-  @apply grid;
+  @apply grid px-2;
   grid-template-columns: repeat(var(--atomic-facet-boxes-per-row, 4), minmax(0, 1fr));
   gap: var(--atomic-facet-boxes-gap, 0.5rem);
 }

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
@@ -26,7 +26,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
         <span
           title={count}
           part="value-count"
-          class="text-neutral-dark ellipsed with-parentheses w-full text-sm mt-1"
+          class="text-neutral-dark truncate with-parentheses w-full text-sm mt-1"
         >
           {count}
         </span>

--- a/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-box/facet-value-box.tsx
@@ -16,7 +16,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
       <button
         part="value-box"
         onClick={() => props.onClick()}
-        class={`value-box box-border w-full h-full flex flex-col items-center rounded text-on-background hover:border-primary-light focus:border-primary-light focus:outline-none p-2 ${
+        class={`value-box box-border w-full h-full flex flex-col items-center rounded text-on-background hover:border-primary-light focus:border-primary-light focus:outline-none p-2 group focus:bg-neutral-light hover:bg-neutral-light ${
           props.isSelected ? 'border-primary border-2' : 'border border-neutral'
         }`}
         aria-pressed={props.isSelected.toString()}

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
@@ -29,5 +29,5 @@
 }
 
 .value-checkbox:focus + label .value-label {
-  @apply text-primary-light;
+  @apply text-primary;
 }

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
@@ -5,11 +5,11 @@
   width: var(--atomic-facet-checkbox-size, 16px);
   height: var(--atomic-facet-checkbox-size, 16px);
 
-  @apply absolute flex justify-center rounded focus:outline-none focus:border-primary-light bg-neutral-dark;
+  @apply absolute left-2 flex justify-center rounded focus:outline-none focus:border-primary-light;
 }
 
 .value-checkbox + label {
-  @apply w-full flex items-center pl-7 py-2.5 text-on-background cursor-pointer truncate hover:bg-neutral-light group;
+  @apply w-full flex pl-8 pr-2 py-2.5 text-on-background cursor-pointer truncate hover:bg-neutral-light group;
 }
 
 /**

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
@@ -18,8 +18,10 @@
   margin-top: 15%;
 }
 
-.value-checkbox:focus + label .value-label,
-.value-checkbox:hover + label .value-label,
-.value-checkbox + label:hover .value-label {
-  @apply text-primary-light underline;
+.value-checkbox:focus + label {
+  @apply bg-neutral-light;
+}
+
+.value-checkbox:focus + label .value-label {
+  @apply text-primary-light;
 }

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.pcss
@@ -4,6 +4,12 @@
 .value-checkbox {
   width: var(--atomic-facet-checkbox-size, 16px);
   height: var(--atomic-facet-checkbox-size, 16px);
+
+  @apply absolute flex justify-center rounded focus:outline-none focus:border-primary-light bg-neutral-dark;
+}
+
+.value-checkbox + label {
+  @apply w-full flex items-center pl-7 py-2.5 text-on-background cursor-pointer truncate hover:bg-neutral-light group;
 }
 
 /**

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
@@ -31,7 +31,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
       <label
         htmlFor={id}
         part="value-checkbox-label"
-        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer ellipsed"
+        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer truncate"
       >
         {children}
         <span

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
@@ -21,23 +21,16 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
         part="value-checkbox"
         onClick={() => props.onClick()}
         aria-checked={props.isSelected.toString()}
-        class={`value-checkbox absolute flex justify-center rounded focus:outline-none focus:border-primary-light ${
+        class={`value-checkbox ${
           props.isSelected
             ? 'selected bg-primary'
             : 'border border-neutral-dark'
         }`}
         aria-label={ariaLabel}
       ></button>
-      <label
-        htmlFor={id}
-        part="value-checkbox-label"
-        class="w-full flex items-center pl-6 py-2.5 text-on-background cursor-pointer truncate hover:bg-neutral-light group"
-      >
+      <label htmlFor={id} part="value-checkbox-label">
         {children}
-        <span
-          part="value-count"
-          class="ml-1.5 text-neutral-dark with-parentheses"
-        >
+        <span part="value-count" class="value-count">
           {count}
         </span>
       </label>

--- a/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-checkbox/facet-value-checkbox.tsx
@@ -14,14 +14,14 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
   });
 
   return (
-    <li key={props.displayValue} class="flex items-center">
+    <li key={props.displayValue} class="relative flex items-center">
       <button
         id={id}
         role="checkbox"
         part="value-checkbox"
         onClick={() => props.onClick()}
         aria-checked={props.isSelected.toString()}
-        class={`value-checkbox flex justify-center rounded focus:outline-none focus:border-primary-light ${
+        class={`value-checkbox absolute flex justify-center rounded focus:outline-none focus:border-primary-light ${
           props.isSelected
             ? 'selected bg-primary'
             : 'border border-neutral-dark'
@@ -31,7 +31,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
       <label
         htmlFor={id}
         part="value-checkbox-label"
-        class="w-full flex items-center pl-2 py-2.5 text-on-background cursor-pointer truncate"
+        class="w-full flex items-center pl-6 py-2.5 text-on-background cursor-pointer truncate hover:bg-neutral-light group"
       >
         {children}
         <span

--- a/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
@@ -14,7 +14,7 @@ export const FacetValueLabelHighlight: FunctionalComponent<FacetValueLabelHighli
     <span
       title={props.displayValue}
       part="value-label"
-      class={`value-label w-full truncate group-hover:text-primary-light group-focus:text-primary-light ${
+      class={`value-label truncate group-hover:text-primary-light group-focus:text-primary-light ${
         props.isSelected ? 'font-bold' : ''
       }`}
       innerHTML={highlightSearchResult(props.displayValue, props.searchQuery)}

--- a/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
@@ -14,7 +14,7 @@ export const FacetValueLabelHighlight: FunctionalComponent<FacetValueLabelHighli
     <span
       title={props.displayValue}
       part="value-label"
-      class={`value-label w-full truncate ${
+      class={`value-label w-full truncate group-hover:text-primary-light group-focus:text-primary-light ${
         props.isSelected ? 'font-bold' : ''
       }`}
       innerHTML={highlightSearchResult(props.displayValue, props.searchQuery)}

--- a/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
@@ -14,7 +14,7 @@ export const FacetValueLabelHighlight: FunctionalComponent<FacetValueLabelHighli
     <span
       title={props.displayValue}
       part="value-label"
-      class={`value-label truncate group-hover:text-primary-light group-focus:text-primary-light ${
+      class={`value-label truncate group-hover:text-primary group-focus:text-primary ${
         props.isSelected ? 'font-bold' : ''
       }`}
       innerHTML={highlightSearchResult(props.displayValue, props.searchQuery)}

--- a/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-label-highlight/facet-value-label-highlight.tsx
@@ -14,7 +14,7 @@ export const FacetValueLabelHighlight: FunctionalComponent<FacetValueLabelHighli
     <span
       title={props.displayValue}
       part="value-label"
-      class={`value-label w-full ellipsed ${
+      class={`value-label w-full truncate ${
         props.isSelected ? 'font-bold' : ''
       }`}
       innerHTML={highlightSearchResult(props.displayValue, props.searchQuery)}

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.pcss
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.pcss
@@ -1,4 +1,0 @@
-.value-link:hover .value-label,
-.value-link:focus .value-label {
-  @apply text-primary-light underline;
-}

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
@@ -16,7 +16,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
       <button
         part="value-link"
         onClick={() => props.onClick()}
-        class="value-link w-full flex items-center py-2.5 text-on-background truncate focus:outline-none"
+        class="value-link w-full flex items-center py-2.5 text-left text-on-background truncate focus:outline-none group focus:bg-neutral-light hover:bg-neutral-light"
         aria-pressed={props.isSelected.toString()}
         aria-label={ariaLabel}
       >

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
@@ -16,7 +16,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
       <button
         part="value-link"
         onClick={() => props.onClick()}
-        class="value-link w-full flex items-center py-2.5 text-on-background ellipsed focus:outline-none"
+        class="value-link w-full flex items-center py-2.5 text-on-background truncate focus:outline-none"
         aria-pressed={props.isSelected.toString()}
         aria-label={ariaLabel}
       >

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
@@ -21,10 +21,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
         aria-label={ariaLabel}
       >
         {children}
-        <span
-          part="value-count"
-          class="ml-1.5 text-neutral-dark with-parentheses"
-        >
+        <span part="value-count" class="value-count">
           {count}
         </span>
       </button>

--- a/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets-v1/facet-value-link/facet-value-link.tsx
@@ -16,7 +16,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
       <button
         part="value-link"
         onClick={() => props.onClick()}
-        class="value-link w-full flex items-center py-2.5 text-left text-on-background truncate focus:outline-none group focus:bg-neutral-light hover:bg-neutral-light"
+        class="value-link w-full flex items-center px-2 py-2.5 text-left text-on-background truncate focus:outline-none group focus:bg-neutral-light hover:bg-neutral-light rounded"
         aria-pressed={props.isSelected.toString()}
         aria-label={ariaLabel}
       >

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -189,7 +189,7 @@ export class AtomicCategoryFacet
         onClick={() => this.facet.toggleSelect(parent)}
       >
         <div innerHTML={LeftArrow} class="facet-arrow mr-1.5" />
-        <span class="ellipsed">{parent.value}</span>
+        <span class="truncate">{parent.value}</span>
       </button>
     );
   }
@@ -197,7 +197,7 @@ export class AtomicCategoryFacet
   private buildActiveParent(parent: CategoryFacetValue) {
     return (
       <div part="active-parent" class="value-button font-bold ml-6">
-        <span part="value-label" class="ellipsed">
+        <span part="value-label" class="truncate">
           {parent.value}
         </span>
         <span part="value-count" class="value-count">
@@ -220,7 +220,7 @@ export class AtomicCategoryFacet
           onClick={() => this.facet.toggleSelect(item)}
           aria-label={this.strings.facetValue(item)}
         >
-          <span part="value-label" class="ellipsed">
+          <span part="value-label" class="truncate">
             {item.value}
           </span>
           <span part="value-count" class="value-count">
@@ -307,7 +307,7 @@ export class AtomicCategoryFacet
   private renderPath(path: string[]) {
     if (!path.length) {
       return (
-        <span class="ellipsed">{`${this.strings.pathPrefix()} ${this.strings.allCategories()}`}</span>
+        <span class="truncate">{`${this.strings.pathPrefix()} ${this.strings.allCategories()}`}</span>
       );
     }
 
@@ -315,7 +315,7 @@ export class AtomicCategoryFacet
       <span class="mr-1">{this.strings.pathPrefix()}</span>,
       this.ellipsedPath(path).map((part, index) => [
         index > 0 && <span>{SEPARATOR}</span>,
-        <span class={part === ELLIPSIS ? '' : 'ellipsed flex-1 max-w-max'}>
+        <span class={part === ELLIPSIS ? '' : 'truncate flex-1 max-w-max'}>
           {part}
         </span>,
       ]),
@@ -327,7 +327,7 @@ export class AtomicCategoryFacet
       <div class="flex items-baseline" aria-hidden="true">
         <span
           part="value-label"
-          class="ellipsed font-bold"
+          class="truncate font-bold"
           innerHTML={FacetSearch.highlightSearchResult(
             searchResult.displayValue,
             this.facetState.facetSearch.query

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -199,7 +199,7 @@ export class AtomicFacet
       <div class="flex items-baseline" aria-hidden="true">
         <span
           part="value-label"
-          class="ellipsed font-bold"
+          class="truncate font-bold"
           innerHTML={FacetSearch.highlightSearchResult(
             searchResult.displayValue,
             this.facetState.facetSearch.query

--- a/packages/atomic/src/components/facets/base-facet/base-facet.tsx
+++ b/packages/atomic/src/components/facets/base-facet/base-facet.tsx
@@ -61,7 +61,7 @@ export const BaseFacet: FunctionalComponent<BaseFacetProps> = (
     <button
       title={props.label}
       part="modal-button"
-      class={`rounded-lg text-left border-solid bg-background px-4 h-9 outline-none focus:outline-none lg:hidden cursor-pointer ellipsed w-full ${
+      class={`rounded-lg text-left border-solid bg-background px-4 h-9 outline-none focus:outline-none lg:hidden cursor-pointer truncate w-full ${
         props.hasActiveValues
           ? 'border-2 border-primary text-primary'
           : 'border border-neutral text-on-background'
@@ -89,7 +89,7 @@ export const BaseFacet: FunctionalComponent<BaseFacetProps> = (
           <span
             title={props.label}
             part="label"
-            class="font-bold text-on-background ellipsed w-full"
+            class="font-bold text-on-background truncate w-full"
           >
             {props.label}
           </span>

--- a/packages/atomic/src/components/facets/facet-value/facet-value.tsx
+++ b/packages/atomic/src/components/facets/facet-value/facet-value.tsx
@@ -23,10 +23,10 @@ export const FacetValue: FunctionalComponent<FacetValueProps> = (props) => {
       ></button>
       <label
         htmlFor={id}
-        class="w-full flex pl-3 text-on-background cursor-pointer ellipsed text-lg lg:text-base py-1.5"
+        class="w-full flex pl-3 text-on-background cursor-pointer truncate text-lg lg:text-base py-1.5"
         title={props.label}
       >
-        <span part="value-label" class="ellipsed">
+        <span part="value-label" class="truncate">
           {props.label}
         </span>
         <span part="value-count" class="value-count">

--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -11,10 +11,6 @@
     border: none;
   }
 
-  .ellipsed {
-    @apply whitespace-nowrap overflow-ellipsis overflow-hidden;
-  }
-
   .with-parentheses::before {
     content: '(';
   }

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -51,7 +51,8 @@ module.exports = {
   },
   variants: {
     extend: {
-      textColor: ['visited'],
+      textColor: ['visited', 'group-focus'],
+      backgroundColor: ['group-focus'],
     },
   },
   plugins: [],


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-874
Mockups https://www.figma.com/file/BWSlnVeORhILh79Z2gSf1U/Atomic-v1?node-id=1069%3A130058
Screenshot:
![Screen Shot 2021-08-04 at 11 31 25 AM](https://user-images.githubusercontent.com/4923043/128209852-e9e5cf11-8179-4042-9f0a-8749a8f7ee48.png)

- Replace custom ellipsed class by Tailwind's truncate
- Make focus/hover show pale gray background
- Add padding to the values
- other various refactors