### PR TITLE
ci: readd setup stage to prod release

### DIFF
--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -2,6 +2,9 @@ node('linux && docker') {
   checkout scm
 
   withDockerContainer(image: 'node:14', args: '-u=root') {
+    stage('Setup') {
+      sh 'npm run setup'
+    }
     
     stage('Npm publish') {
       withCredentials([


### PR DESCRIPTION
I removed certain stages [as part of this PR](https://github.com/coveo/ui-kit/commit/6cde8a706ef18802539246bdfa99490b035f8df6#diff-29ea4805c4f5fd924d77d3fa0966f6c9d70d8c95cb8c4d66300150269e0f7354L9-L11) to speed up the pipeline. However, the `setup` stage is needed in prod since the publish script imports certain dependencies. 

https://coveord.atlassian.net/browse/KIT-879