### PR TITLE
feat(atomic): added support for grid results on mobile

### DIFF
--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -98,28 +98,57 @@ atomic-result-list {
 
   .list-root.display-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(272px, 1fr));
     justify-content: space-evenly;
 
-    &.density-comfortable {
-      padding: 2rem 0.75rem;
-      grid-row-gap: 4rem;
-      grid-column-gap: 1.5rem;
+    @screen desktop-only {
+      grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+
+      &.density-comfortable {
+        padding: 2rem 0.75rem;
+        grid-row-gap: 4rem;
+        grid-column-gap: 1.5rem;
+      }
+
+      &.density-normal,
+      &.density-compact {
+        padding: 1.5rem 0.75rem;
+        grid-row-gap: 3rem;
+        grid-column-gap: 1.5rem;
+      }
+
+      &.image-large {
+        grid-template-columns: repeat(auto-fill, 20.625rem);
+      }
+
+      &.image-small {
+        grid-template-columns: repeat(auto-fill, 15.5rem);
+      }
     }
 
-    &.density-normal,
-    &.density-compact {
-      padding: 1.5rem 0.75rem;
-      grid-row-gap: 3rem;
-      grid-column-gap: 1.5rem;
-    }
+    @screen mobile-only {
+      padding: 2rem;
+      &.image-large {
+        @apply atomic-list-with-dividers;
+        grid-template-columns: auto;
+      }
+      &.image-small {
+        grid-template-columns: repeat(auto-fill, 9.5rem);
+      }
+      &.image-icon,
+      &.image-none {
+        grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+      }
+      &.image-small,
+      &.image-icon,
+      &.image-none {
+        @apply atomic-list-with-cards;
+        grid-column-gap: 2.5rem;
+        grid-row-gap: 2.5rem;
 
-    &.image-large {
-      grid-template-columns: repeat(auto-fill, 20.625rem);
-    }
-
-    &.image-small {
-      grid-template-columns: repeat(auto-fill, 15.5rem);
+        atomic-result {
+          margin: -1rem;
+        }
+      }
     }
   }
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
@@ -1,4 +1,4 @@
-.cell-result-desktop {
+.cell-result-mobile {
   grid-template-areas:
     'badges'
     'visual'
@@ -13,21 +13,8 @@
 
   /* == Density styles == */
   &.density-comfortable {
-    &.image-large,
-    &.image-small {
-      atomic-result-section-visual {
-        margin: 0 auto 2rem auto;
-      }
-    }
-
-    &.image-icon {
-      atomic-result-section-badges {
-        margin-bottom: 2rem;
-      }
-    }
-
     atomic-result-section-visual {
-      margin-bottom: 0.5rem;
+      margin-bottom: 1rem;
     }
 
     atomic-result-section-badges {
@@ -40,14 +27,14 @@
     atomic-result-section-actions {
       font-size: 0.875rem;
       line-height: 1.25rem;
-      margin-top: 2.25rem;
-      height: 2.5rem;
+      margin-top: 1.25rem;
+      height: 2rem;
     }
 
     atomic-result-section-title {
-      font-size: 1.5rem;
-      line-height: 2rem;
-      height: 4rem;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      height: 3rem;
     }
 
     atomic-result-section-title-metadata {
@@ -62,34 +49,21 @@
     }
 
     atomic-result-section-excerpt {
-      font-size: 1rem;
-      line-height: 1.5rem;
-      margin-top: 2.25rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      margin-top: 1.25rem;
     }
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
       line-height: 1rem;
-      margin-top: 2.25rem;
+      margin-top: 1.25rem;
     }
   }
 
   &.density-normal {
-    &.image-large,
-    &.image-small {
-      atomic-result-section-visual {
-        margin: 0 auto 1.5rem auto;
-      }
-    }
-
-    &.image-icon {
-      atomic-result-section-badges {
-        margin-bottom: 1.5rem;
-      }
-    }
-
     atomic-result-section-visual {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.75rem;
     }
 
     atomic-result-section-badges {
@@ -100,14 +74,14 @@
     }
 
     atomic-result-section-actions {
-      font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1.75rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      margin-top: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      font-size: 1.125rem;
+      font-size: 1rem;
       line-height: 1.5rem;
       height: 3rem;
     }
@@ -126,30 +100,17 @@
     atomic-result-section-excerpt {
       font-size: 0.875rem;
       line-height: 1.25rem;
-      margin-top: 1.75rem;
+      margin-top: 1rem;
     }
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
       line-height: 1rem;
-      margin-top: 1.75rem;
+      margin-top: 1rem;
     }
   }
 
   &.density-compact {
-    &.image-large,
-    &.image-small {
-      atomic-result-section-visual {
-        margin: 0 auto 1rem auto;
-      }
-    }
-
-    &.image-icon {
-      atomic-result-section-badges {
-        margin-bottom: 1rem;
-      }
-    }
-
     atomic-result-section-visual {
       margin-bottom: 0.5rem;
     }
@@ -162,14 +123,14 @@
     }
 
     atomic-result-section-actions {
-      font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1.25rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      margin-top: 0.75rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      font-size: 1.125rem;
+      font-size: 1rem;
       line-height: 1.5rem;
       height: 3rem;
     }
@@ -188,32 +149,21 @@
     atomic-result-section-excerpt {
       font-size: 0.875rem;
       line-height: 1.25rem;
-      margin-top: 1.25rem;
+      margin-top: 0.75rem;
     }
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
       line-height: 1rem;
-      margin-top: 1.25rem;
+      margin-top: 0.75rem;
     }
   }
 
   /* == Image styles == */
-  &.image-large {
-    atomic-result-section-visual {
-      width: 20.625rem;
-      height: 20.625rem;
-    }
-
-    atomic-result-section-badges {
-      margin-bottom: 1rem;
-    }
-  }
-
   &.image-small {
     atomic-result-section-visual {
-      width: 15.5rem;
-      height: 15.5rem;
+      width: 9.5rem;
+      height: 9.5rem;
     }
   }
 
@@ -231,6 +181,11 @@
   }
 
   /* == Common styles == */
+  atomic-result-section-badges,
+  atomic-result-section-actions {
+    overflow-x: auto;
+  }
+
   atomic-result-section-badges.empty {
     display: block;
   }

--- a/packages/atomic/src/components/atomic-result/atomic-result.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result.pcss
@@ -3,6 +3,7 @@
 @import './atomic-result-row-desktop.pcss';
 @import './atomic-result-row-mobile.pcss';
 @import './atomic-result-cell-desktop.pcss';
+@import './atomic-result-cell-mobile.pcss';
 
 :host {
   @apply font-sans font-normal;
@@ -20,8 +21,23 @@
     }
   }
   &.display-grid {
-    @screen desktop-only {
-      @apply cell-result-desktop;
+    &.image-large {
+      @screen desktop-only {
+        @apply cell-result-desktop;
+      }
+      @screen mobile-only {
+        @apply row-result-mobile;
+      }
+    }
+    &.image-small,
+    &.image-icon,
+    &.image-none {
+      @screen desktop-only {
+        @apply cell-result-desktop;
+      }
+      @screen mobile-only {
+        @apply cell-result-mobile;
+      }
     }
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.pcss
@@ -8,6 +8,7 @@ atomic-result-icon {
   > svg {
     width: 100%;
     height: auto;
+    aspect-ratio: 1 / 1;
   }
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-876

Results with a large image on mobile will show the same style as list results with a large image on mobile.

Other changes in this PR include:
* Fixing some minor margin issues on the desktop grid layout
* Making icons keep a 1:1 aspect ratio

Previews with normal density:

<details>
<summary>Image size: small</summary>

![image](https://user-images.githubusercontent.com/54454747/128225853-31b134fc-2c84-453a-8a6d-13429afab596.png)
</details>

<details>
<summary>Image size: icon</summary>

![image](https://user-images.githubusercontent.com/54454747/128225941-ea07fdf4-4de2-4bee-9e75-24b914e00061.png)
</details>

<details>
<summary>Image size: none</summary>

![image](https://user-images.githubusercontent.com/54454747/128225979-1fbbf82f-015e-4aea-8d32-acddcca2367a.png)
</details>