### PR TITLE
feat(atomic): added atomic-result-fields-list component

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -515,6 +515,8 @@ export namespace Components {
          */
         "format": string;
     }
+    interface AtomicResultFieldsListV1 {
+    }
     interface AtomicResultIcon {
         /**
           * Specifies the icon to display from the list of available icons.  By default, this will parse the `objecttype` and `filetype` fields to find a matching icon. If none are available, it will use the `custom` icon.
@@ -1049,6 +1051,12 @@ declare global {
         prototype: HTMLAtomicResultDateElement;
         new (): HTMLAtomicResultDateElement;
     };
+    interface HTMLAtomicResultFieldsListV1Element extends Components.AtomicResultFieldsListV1, HTMLStencilElement {
+    }
+    var HTMLAtomicResultFieldsListV1Element: {
+        prototype: HTMLAtomicResultFieldsListV1Element;
+        new (): HTMLAtomicResultFieldsListV1Element;
+    };
     interface HTMLAtomicResultIconElement extends Components.AtomicResultIcon, HTMLStencilElement {
     }
     var HTMLAtomicResultIconElement: {
@@ -1281,6 +1289,7 @@ declare global {
         "atomic-result": HTMLAtomicResultElement;
         "atomic-result-badge-v1": HTMLAtomicResultBadgeV1Element;
         "atomic-result-date": HTMLAtomicResultDateElement;
+        "atomic-result-fields-list-v1": HTMLAtomicResultFieldsListV1Element;
         "atomic-result-icon": HTMLAtomicResultIconElement;
         "atomic-result-icon-v1": HTMLAtomicResultIconV1Element;
         "atomic-result-image": HTMLAtomicResultImageElement;
@@ -1822,6 +1831,8 @@ declare namespace LocalJSX {
          */
         "format"?: string;
     }
+    interface AtomicResultFieldsListV1 {
+    }
     interface AtomicResultIcon {
         /**
           * Specifies the icon to display from the list of available icons.  By default, this will parse the `objecttype` and `filetype` fields to find a matching icon. If none are available, it will use the `custom` icon.
@@ -2178,6 +2189,7 @@ declare namespace LocalJSX {
         "atomic-result": AtomicResult;
         "atomic-result-badge-v1": AtomicResultBadgeV1;
         "atomic-result-date": AtomicResultDate;
+        "atomic-result-fields-list-v1": AtomicResultFieldsListV1;
         "atomic-result-icon": AtomicResultIcon;
         "atomic-result-icon-v1": AtomicResultIconV1;
         "atomic-result-image": AtomicResultImage;
@@ -2250,6 +2262,7 @@ declare module "@stencil/core" {
             "atomic-result": LocalJSX.AtomicResult & JSXBase.HTMLAttributes<HTMLAtomicResultElement>;
             "atomic-result-badge-v1": LocalJSX.AtomicResultBadgeV1 & JSXBase.HTMLAttributes<HTMLAtomicResultBadgeV1Element>;
             "atomic-result-date": LocalJSX.AtomicResultDate & JSXBase.HTMLAttributes<HTMLAtomicResultDateElement>;
+            "atomic-result-fields-list-v1": LocalJSX.AtomicResultFieldsListV1 & JSXBase.HTMLAttributes<HTMLAtomicResultFieldsListV1Element>;
             "atomic-result-icon": LocalJSX.AtomicResultIcon & JSXBase.HTMLAttributes<HTMLAtomicResultIconElement>;
             "atomic-result-icon-v1": LocalJSX.AtomicResultIconV1 & JSXBase.HTMLAttributes<HTMLAtomicResultIconV1Element>;
             "atomic-result-image": LocalJSX.AtomicResultImage & JSXBase.HTMLAttributes<HTMLAtomicResultImageElement>;

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-desktop.pcss
@@ -69,8 +69,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 2.25rem;
+      line-height: 2rem;
+      margin-top: 1.75rem;
+      max-height: 4rem;
     }
   }
 
@@ -131,8 +132,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1.75rem;
+      line-height: 1.75rem;
+      margin-top: 1.375rem;
+      max-height: 3.5rem;
     }
   }
 
@@ -193,8 +195,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1.25rem;
+      line-height: 1.625rem;
+      margin-top: 0.9375rem;
+      max-height: 3.25rem;
     }
   }
 

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-mobile.pcss
@@ -56,8 +56,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1.25rem;
+      line-height: 1.5rem;
+      margin-top: 1rem;
+      max-height: 3rem;
     }
   }
 
@@ -105,8 +106,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 1rem;
+      line-height: 1.5rem;
+      margin-top: 0.75rem;
+      max-height: 3rem;
     }
   }
 
@@ -154,8 +156,9 @@
 
     atomic-result-section-bottom-metadata {
       font-size: 0.75rem;
-      line-height: 1rem;
-      margin-top: 0.75rem;
+      line-height: 1.5rem;
+      margin-top: 0.5rem;
+      max-height: 3rem;
     }
   }
 

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-row-desktop.pcss
@@ -30,9 +30,15 @@
       line-height: 1.5rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 1.75rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 1.25rem;
+      font-size: 0.75rem;
+      line-height: 2rem;
+      max-height: 4rem;
     }
   }
 
@@ -61,9 +67,15 @@
       line-height: 1.25rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 1.25rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 0.875rem;
+      font-size: 0.75rem;
+      line-height: 1.75rem;
+      max-height: 3.5rem;
     }
   }
 
@@ -92,9 +104,15 @@
       line-height: 1.25rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 1rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 0.6875rem;
+      font-size: 0.75rem;
+      line-height: 1.625rem;
+      max-height: 3.25rem;
     }
   }
 
@@ -192,10 +210,5 @@
     font-size: 1.5rem;
     line-height: 2rem;
     margin-top: 0.5rem;
-  }
-
-  atomic-result-section-bottom-metadata {
-    font-size: 0.75rem;
-    line-height: 1rem;
   }
 }

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-row-mobile.pcss
@@ -30,9 +30,15 @@
       line-height: 1.25rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 1.25rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 0.75rem;
+      font-size: 0.75rem;
+      line-height: 2rem;
+      max-height: 4rem;
     }
   }
 
@@ -61,9 +67,15 @@
       line-height: 1.25rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 1rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 0.625rem;
+      font-size: 0.75rem;
+      line-height: 1.75rem;
+      max-height: 3.5rem;
     }
   }
 
@@ -92,9 +104,15 @@
       line-height: 1.25rem;
     }
 
-    atomic-result-section-bottom-metadata,
     atomic-result-section-excerpt {
       margin-top: 0.75rem;
+    }
+
+    atomic-result-section-bottom-metadata {
+      margin-top: 0.4375rem;
+      font-size: 0.75rem;
+      line-height: 1.625rem;
+      max-height: 3.25rem;
     }
   }
 
@@ -201,10 +219,5 @@
     font-size: 1.5rem;
     line-height: 2rem;
     margin-top: 0.5rem;
-  }
-
-  atomic-result-section-bottom-metadata {
-    font-size: 0.75rem;
-    line-height: 1rem;
   }
 }

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.pcss
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.pcss
@@ -1,0 +1,24 @@
+@import '../../../global/global.pcss';
+
+atomic-result-fields-list-v1 {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  height: 100%;
+
+  > * {
+    &::after {
+      display: block;
+      content: ' ';
+      width: 1px;
+      height: 1rem;
+      margin: 0 1rem;
+      background-color: var(--atomic-neutral);
+      vertical-align: middle;
+    }
+
+    &.hide-divider::after {
+      visibility: hidden;
+    }
+  }
+}

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.tsx
@@ -1,0 +1,113 @@
+import {Component, h, Element, Host} from '@stencil/core';
+
+/**
+ * The `atomic-result-fields-list` element selectively renders its children to ensure they fit the parent element and adds dividers between them.
+ */
+@Component({
+  tag: 'atomic-result-fields-list-v1',
+  styleUrl: 'atomic-result-fields-list.pcss',
+  shadow: false,
+})
+export class AtomicResultFieldsList {
+  private resizeObserver!: ResizeObserver;
+
+  private updatingChildren = false;
+  private rows: number[] = [];
+
+  @Element() private host!: HTMLElement;
+
+  public connectedCallback() {
+    this.resizeObserver = new ResizeObserver(() => this.update());
+    this.resizeObserver.observe(this.host.parentElement!);
+  }
+
+  public disconnectedCallback() {
+    this.resizeObserver.disconnect();
+  }
+
+  public componentWasRendered() {
+    this.update();
+  }
+
+  public update() {
+    if (this.updatingChildren) {
+      return;
+    }
+    this.updatingChildren = true;
+    this.showDividers();
+    this.showChildren();
+    this.hideChildrenToFit();
+    this.hideDividersAtEndOfRows();
+    this.updatingChildren = false;
+  }
+
+  private get children() {
+    return Array.from(this.host.children) as HTMLElement[];
+  }
+
+  private get isOverflowing() {
+    return (
+      this.host.scrollWidth > this.host.clientWidth ||
+      this.host.scrollHeight > this.host.clientHeight
+    );
+  }
+
+  private getSortedChildrenBySize() {
+    return this.children.sort((a, b) => a.offsetWidth - b.offsetWidth);
+  }
+
+  private hide(element: HTMLElement) {
+    element.style.display = 'none';
+  }
+
+  private show(element: HTMLElement) {
+    element.style.display = '';
+  }
+
+  private isChildHidden(element: HTMLElement) {
+    return element.style.display === 'none';
+  }
+
+  private setHideDivider(element: HTMLElement, hideDivider: boolean) {
+    element.classList.toggle('hide-divider', hideDivider);
+  }
+
+  private showChildren() {
+    this.children.forEach((child) => this.show(child));
+  }
+
+  private showDividers() {
+    this.children.forEach((child) => this.setHideDivider(child, false));
+  }
+
+  private hideChildrenToFit() {
+    const children = this.getSortedChildrenBySize();
+    for (let i = children.length - 1; this.isOverflowing && i >= 0; i--) {
+      this.hide(children[i]);
+    }
+  }
+
+  private hideDividersAtEndOfRows() {
+    this.rows = [];
+    let previousChild: HTMLElement | null = null;
+    this.children
+      .filter((child) => !this.isChildHidden(child))
+      .forEach((child) => {
+        const row = child.offsetTop;
+        if (this.rows.indexOf(row) === -1) {
+          this.rows.push(row);
+          if (previousChild) {
+            this.setHideDivider(previousChild, true);
+          }
+        }
+        previousChild = child;
+      });
+    if (previousChild) {
+      this.setHideDivider(previousChild, true);
+    }
+  }
+
+  render() {
+    return <Host></Host>;
+  }
+}

--- a/packages/atomic/src/pages/v1.html
+++ b/packages/atomic/src/pages/v1.html
@@ -284,8 +284,9 @@
             <template>
               <style>
                 .field {
+                  display: inline-flex;
                   white-space: nowrap;
-                  margin-right: 0.5rem;
+                  align-items: center;
                 }
 
                 .field-label {
@@ -341,30 +342,32 @@
                 ><atomic-result-text field="excerpt"></atomic-result-text
               ></atomic-result-section-excerpt>
               <atomic-result-section-bottom-metadata>
-                <atomic-field-condition class="field" if-defined="author">
-                  <atomic-text value="author" class="field-label"></atomic-text>
-                  <atomic-result-text field="author"></atomic-result-text>
-                </atomic-field-condition>
+                <atomic-result-fields-list-v1>
+                  <atomic-field-condition class="field" if-defined="author">
+                    <span class="field-label"><atomic-text value="author"></atomic-text>:</span>
+                    <atomic-result-text field="author"></atomic-result-text>
+                  </atomic-field-condition>
 
-                <atomic-field-condition class="field" if-defined="source">
-                  <atomic-text value="source" class="field-label"></atomic-text>
-                  <atomic-result-text field="source"></atomic-result-text>
-                </atomic-field-condition>
+                  <atomic-field-condition class="field" if-defined="source">
+                    <span class="field-label"><atomic-text value="source"></atomic-text>:</span>
+                    <atomic-result-text field="source"></atomic-result-text>
+                  </atomic-field-condition>
 
-                <atomic-field-condition class="field" if-defined="language">
-                  <atomic-text value="language" class="field-label"></atomic-text>
-                  <atomic-result-text field="language"></atomic-result-text>
-                </atomic-field-condition>
+                  <atomic-field-condition class="field" if-defined="language">
+                    <span class="field-label"><atomic-text value="language"></atomic-text>:</span>
+                    <atomic-result-text field="language"></atomic-result-text>
+                  </atomic-field-condition>
 
-                <atomic-field-condition class="field" if-defined="filetype">
-                  <atomic-text value="fileType" class="field-label"></atomic-text>
-                  <atomic-result-text field="filetype"></atomic-result-text>
-                </atomic-field-condition>
+                  <atomic-field-condition class="field" if-defined="filetype">
+                    <span class="field-label"><atomic-text value="fileType"></atomic-text>:</span>
+                    <atomic-result-text field="filetype"></atomic-result-text>
+                  </atomic-field-condition>
 
-                <span class="field">
-                  <span class="field-label">Date</span>
-                  <atomic-result-date></atomic-result-date>
-                </span>
+                  <span class="field">
+                    <span class="field-label">Date:</span>
+                    <atomic-result-date></atomic-result-date>
+                  </span>
+                </atomic-result-fields-list-v1>
               </atomic-result-section-bottom-metadata>
               <atomic-table-element-v1 label="Description">
                 <atomic-result-link field="title"></atomic-result-link>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-884

* [Design](https://www.figma.com/file/BWSlnVeORhILh79Z2gSf1U/Atomic-v1?node-id=430%3A80)
* [Live test](http://kit-884.herokuapp.com/)

The purpose of this component is to display as many fields as possible without exceeding its parent's boundaries. Additionally, this component adds a divider between each field.

In the future, a `display-show-more` option could be added that adds a "Show more" button.

<details>
<summary>Image</summary>

![image](https://user-images.githubusercontent.com/54454747/128918482-2bd792d8-19cb-4078-bb8b-0b042ef44c81.png)
</details>

You can test it [here](http://kit-884.herokuapp.com/).