### PR TITLE
fix(atomic): fix text overflow on Category Facet

### DIFF
--- a/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets-v1/category-facet-search-result/category-facet-search-result.tsx
@@ -84,7 +84,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
         </div>
         <div
           part="search-result-path"
-          class="flex text-neutral-dark mt-1 group-focus:text-primary group-hover:text-primary"
+          class="flex w-full text-neutral-dark mt-1 group-focus:text-primary group-hover:text-primary"
         >
           {renderPath(localizedPath)}
         </div>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-895

Just had to set a width to the parent element to fix the overflow.

![Screen Shot 2021-08-11 at 1 23 41 PM](https://user-images.githubusercontent.com/83350303/129075337-115bd8a2-85ef-431e-a1b8-400a3cdfa648.png)
