### PR TITLE
fix(atomic): made table refresh when sort or filters are changed

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -126,10 +126,14 @@ export class AtomicResultList implements InitializableComponent {
     return this.resultTemplatesManager.selectTemplate(result) || '';
   }
 
+  private getId(result: Result) {
+    return result.uniqueId + this.resultListState.searchUid;
+  }
+
   private buildListResults() {
     return this.resultListState.results.map((result) => (
       <atomic-result-v1
-        key={`${result.raw.permanentid}${this.resultListState.searchUid}`}
+        key={this.getId(result)}
         result={result}
         engine={this.bindings.engine}
         display={this.display}
@@ -162,9 +166,9 @@ export class AtomicResultList implements InitializableComponent {
         </thead>
         <tbody>
           {this.resultListState.results.map((result) => (
-            <tr>
+            <tr key={this.getId(result)}>
               {fieldColumns.map((column) => (
-                <td>
+                <td key={column.getAttribute('label')! + this.getId(result)}>
                   <atomic-table-cell-v1
                     result={result}
                     content={column.innerHTML}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-899

For some reason, I didn't think stencil supported or needed `key` :facepalm: