### PR TITLE
feat(atomic): gave opinionated style to visual section

### DIFF
--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-common.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-common.pcss
@@ -62,4 +62,18 @@
       display: none;
     }
   }
+
+  &.image-large,
+  &.image-small {
+    atomic-result-section-visual {
+      background-color: var(--atomic-neutral);
+      border-radius: 1rem;
+    }
+  }
+
+  &.image-icon {
+    atomic-result-section-visual {
+      border-radius: 0.25rem;
+    }
+  }
 }

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-common.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-common.pcss
@@ -67,13 +67,13 @@
   &.image-small {
     atomic-result-section-visual {
       background-color: var(--atomic-neutral);
-      border-radius: 1rem;
+      border-radius: var(--atomic-border-radius-xl);
     }
   }
 
   &.image-icon {
     atomic-result-section-visual {
-      border-radius: 0.25rem;
+      border-radius: var(--atomic-border-radius);
     }
   }
 }

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-row-mobile.pcss
@@ -134,8 +134,9 @@
       grid-template-rows: repeat(8, auto);
 
       atomic-result-section-visual {
+        aspect-ratio: 1 / 1;
         width: 100%;
-        height: 42vh;
+        height: auto;
         margin-right: 0;
         margin-bottom: 1rem;
       }

--- a/packages/atomic/src/themes/accessible.css
+++ b/packages/atomic/src/themes/accessible.css
@@ -34,5 +34,8 @@
   --atomic-text-lg: 1rem; /* 16px */
 
   /* Others */
+  /* TODO: Remove from v1 */
   --atomic-icon-size: 30px;
+  --atomic-border-radius: 0.25rem;
+  --atomic-border-radius-xl: 1rem;
 }

--- a/packages/atomic/src/themes/coveo.css
+++ b/packages/atomic/src/themes/coveo.css
@@ -36,4 +36,6 @@
   /* Others */
   /* TODO: Remove from v1 */
   --atomic-icon-size: 30px;
+  --atomic-border-radius: 0.25rem;
+  --atomic-border-radius-xl: 1rem;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-798

* The visual section is now always a 1:1 aspect ratio
* The visual section now has a light gray background color (same as the default badge background color), in case the image is transparent.
* The visual section now has a border radius

![image](https://user-images.githubusercontent.com/54454747/129275480-b8f6a59c-4817-4717-a880-7fc0744d807a.png)
