### PR TITLE
feat(atomic): added atomic-format-* support to atomic-result-number

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -588,7 +588,7 @@ export namespace Components {
     }
     interface AtomicResultNumberV1 {
         /**
-          * The result field which the component should use. This will look for the fields in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
          */
         "field": string;
     }
@@ -1947,7 +1947,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultNumberV1 {
         /**
-          * The result field which the component should use. This will look for the fields in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
          */
         "field": string;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -586,6 +586,12 @@ export namespace Components {
          */
         "minimumSignificantDigits"?: number;
     }
+    interface AtomicResultNumberV1 {
+        /**
+          * The result field which the component should use. This will look for the fields in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+         */
+        "field": string;
+    }
     interface AtomicResultPrice {
         /**
           * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB — see the [Current currency & funds code list](http://www.currency-iso.org/en/home/tables/table-a1.html).
@@ -1127,6 +1133,12 @@ declare global {
         prototype: HTMLAtomicResultNumberElement;
         new (): HTMLAtomicResultNumberElement;
     };
+    interface HTMLAtomicResultNumberV1Element extends Components.AtomicResultNumberV1, HTMLStencilElement {
+    }
+    var HTMLAtomicResultNumberV1Element: {
+        prototype: HTMLAtomicResultNumberV1Element;
+        new (): HTMLAtomicResultNumberV1Element;
+    };
     interface HTMLAtomicResultPriceElement extends Components.AtomicResultPrice, HTMLStencilElement {
     }
     var HTMLAtomicResultPriceElement: {
@@ -1327,6 +1339,7 @@ declare global {
         "atomic-result-list-placeholder": HTMLAtomicResultListPlaceholderElement;
         "atomic-result-list-v1": HTMLAtomicResultListV1Element;
         "atomic-result-number": HTMLAtomicResultNumberElement;
+        "atomic-result-number-v1": HTMLAtomicResultNumberV1Element;
         "atomic-result-price": HTMLAtomicResultPriceElement;
         "atomic-result-printable-uri": HTMLAtomicResultPrintableUriElement;
         "atomic-result-quickview": HTMLAtomicResultQuickviewElement;
@@ -1932,6 +1945,12 @@ declare namespace LocalJSX {
          */
         "minimumSignificantDigits"?: number;
     }
+    interface AtomicResultNumberV1 {
+        /**
+          * The result field which the component should use. This will look for the fields in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+         */
+        "field": string;
+    }
     interface AtomicResultPrice {
         /**
           * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB — see the [Current currency & funds code list](http://www.currency-iso.org/en/home/tables/table-a1.html).
@@ -2245,6 +2264,7 @@ declare namespace LocalJSX {
         "atomic-result-list-placeholder": AtomicResultListPlaceholder;
         "atomic-result-list-v1": AtomicResultListV1;
         "atomic-result-number": AtomicResultNumber;
+        "atomic-result-number-v1": AtomicResultNumberV1;
         "atomic-result-price": AtomicResultPrice;
         "atomic-result-printable-uri": AtomicResultPrintableUri;
         "atomic-result-quickview": AtomicResultQuickview;
@@ -2320,6 +2340,7 @@ declare module "@stencil/core" {
             "atomic-result-list-placeholder": LocalJSX.AtomicResultListPlaceholder & JSXBase.HTMLAttributes<HTMLAtomicResultListPlaceholderElement>;
             "atomic-result-list-v1": LocalJSX.AtomicResultListV1 & JSXBase.HTMLAttributes<HTMLAtomicResultListV1Element>;
             "atomic-result-number": LocalJSX.AtomicResultNumber & JSXBase.HTMLAttributes<HTMLAtomicResultNumberElement>;
+            "atomic-result-number-v1": LocalJSX.AtomicResultNumberV1 & JSXBase.HTMLAttributes<HTMLAtomicResultNumberV1Element>;
             "atomic-result-price": LocalJSX.AtomicResultPrice & JSXBase.HTMLAttributes<HTMLAtomicResultPriceElement>;
             "atomic-result-printable-uri": LocalJSX.AtomicResultPrintableUri & JSXBase.HTMLAttributes<HTMLAtomicResultPrintableUriElement>;
             "atomic-result-quickview": LocalJSX.AtomicResultQuickview & JSXBase.HTMLAttributes<HTMLAtomicResultQuickviewElement>;

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
@@ -1,0 +1,76 @@
+import {Component, Prop, Element, State, Listen} from '@stencil/core';
+import {Result, ResultTemplatesHelpers} from '@coveo/headless';
+import {ResultContext} from '../../result-template-components/result-template-decorators';
+import {
+  Bindings,
+  InitializeBindings,
+} from '../../../utils/initialization-utils';
+import {
+  defaultNumberFormatter,
+  NumberFormatter,
+} from '../../formats/format-common';
+
+/**
+ * The `atomic-result-number` component renders the value of a number result field.
+ */
+@Component({
+  tag: 'atomic-result-number-v1',
+  shadow: false,
+})
+export class AtomicResultNumber {
+  @InitializeBindings() public bindings!: Bindings;
+  @ResultContext() private result!: Result;
+
+  @Element() host!: HTMLElement;
+
+  @State() public error!: Error;
+
+  /**
+   * The result field which the component should use.
+   * This will look for the fields in the Result object first, and then in the Result.raw object.
+   * It is important to include the necessary field in the ResultList component.
+   */
+  @Prop() field!: string;
+
+  @State() formatter: NumberFormatter = defaultNumberFormatter;
+
+  @Listen('atomic/numberFormat')
+  public setFormat(event: CustomEvent<NumberFormatter>) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.formatter = event.detail;
+  }
+
+  private get value() {
+    const value = ResultTemplatesHelpers.getResultProperty(
+      this.result,
+      this.field
+    );
+    if (value === null) {
+      return null;
+    }
+    const valueAsNumber = parseFloat(`${value}`);
+    return Number.isNaN(valueAsNumber) ? null : valueAsNumber;
+  }
+
+  private formatValue(value: number) {
+    try {
+      return this.formatter(value, this.bindings.i18n.languages);
+    } catch (error) {
+      this.error = new Error(
+        `atomic-result-number value "${value}" could not be formatted correctly.`
+      );
+      return value;
+    }
+  }
+
+  public render() {
+    const value = this.value;
+
+    if (value === null) {
+      return;
+    }
+
+    return this.formatValue(value);
+  }
+}

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
@@ -28,9 +28,9 @@ export class AtomicResultNumber {
   @State() public error!: Error;
 
   /**
-   * The result field which the component should use.
-   * This will look for the fields in the Result object first, and then in the Result.raw object.
-   * It is important to include the necessary field in the ResultList component.
+   * The field that the component should use.
+   * The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first.
+   * Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
    */
   @Prop() field!: string;
 

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
@@ -12,6 +12,8 @@ import {
 
 /**
  * The `atomic-result-number` component renders the value of a number result field.
+ *
+ * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
  */
 @Component({
   tag: 'atomic-result-number-v1',

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-number/atomic-result-number.tsx
@@ -59,9 +59,7 @@ export class AtomicResultNumber {
     try {
       return this.formatter(value, this.bindings.i18n.languages);
     } catch (error) {
-      this.error = new Error(
-        `atomic-result-number value "${value}" could not be formatted correctly.`
-      );
+      this.error = error;
       return value;
     }
   }

--- a/packages/atomic/src/pages/v1.html
+++ b/packages/atomic/src/pages/v1.html
@@ -249,6 +249,9 @@
           <atomic-numeric-range start="8000" end="100000" label="Popular"></atomic-numeric-range>
           <atomic-numeric-range start="100000" end="999999999" label="Treasured"></atomic-numeric-range>
         </atomic-numeric-facet-v1>
+        <atomic-numeric-facet-v1 field="sncost" label="Cost">
+          <atomic-format-currency currency="CAD"></atomic-format-currency>
+        </atomic-numeric-facet-v1>
         <atomic-timeframe-facet label="Timeframe" with-date-picker>
           <atomic-timeframe unit="hour"></atomic-timeframe>
           <atomic-timeframe unit="day"></atomic-timeframe>
@@ -279,7 +282,7 @@
           </atomic-sort-dropdown>
         </div>
         <atomic-no-results-v1></atomic-no-results-v1>
-        <atomic-result-list-v1 fields-to-include="snrating">
+        <atomic-result-list-v1 fields-to-include="snrating,sncost">
           <atomic-result-template>
             <template>
               <style>
@@ -366,6 +369,13 @@
                   <atomic-field-condition class="field" if-defined="filetype">
                     <span class="field-label"><atomic-text value="fileType"></atomic-text>:</span>
                     <atomic-result-text field="filetype"></atomic-result-text>
+                  </atomic-field-condition>
+
+                  <atomic-field-condition class="field" if-defined="sncost">
+                    <span class="field-label">Cost:</span>
+                    <atomic-result-number-v1 field="sncost">
+                      <atomic-format-currency currency="CAD"></atomic-format-currency>
+                    </atomic-result-number-v1>
                   </atomic-field-condition>
 
                   <span class="field">


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-900

Removed old formatting props from the v1 result number and added support for formatting components.

E.g.:
```html
<atomic-result-number field="sncost">
  <atomic-format-currency currency="CAD"></atomic-format-currency>
</atomic-result-number>
```

![image](https://user-images.githubusercontent.com/54454747/129422160-810d2a18-df1d-44f1-b210-dcaa7524b1e1.png)
