### PR TITLE
fix(headless): fix prevent auto select when restoring facet search parameters

### DIFF
--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -500,16 +500,16 @@ describe('facet-set slice', () => {
       expect(finalState['author'].currentValues).toEqual([]);
     });
 
-    it('sets #preventAutoSelect to true on all facets', () => {
+    it('sets #preventAutoSelect to true on facets with at least one value selected', () => {
       const a = 'a';
       const b = 'b';
 
       state[a] = buildMockFacetRequest({preventAutoSelect: false});
       state[b] = buildMockFacetRequest({preventAutoSelect: false});
-      const f = {[b]: []};
+      const f = {[a]: [], [b]: ['foo', 'bar']};
 
       const finalState = facetSetReducer(state, restoreSearchParameters({f}));
-      expect(finalState[a].preventAutoSelect).toBe(true);
+      expect(finalState[a].preventAutoSelect).toBe(false);
       expect(finalState[b].preventAutoSelect).toBe(true);
     });
   });

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -57,7 +57,7 @@ export const facetSetReducer = createReducer(
           const values = f[id] || [];
 
           request.currentValues = values.map(buildSelectedFacetValueRequest);
-          request.preventAutoSelect = true;
+          request.preventAutoSelect = values.length > 0;
           request.numberOfValues = Math.max(
             values.length,
             request.numberOfValues


### PR DESCRIPTION
I * think * this should be the desired behaviour: 

* Allow auto selection for all facets which are in an "inactive" mode (no selection) on initial search parameters restore.
* Prevent auto selection for all facets which are in an "active" mode (has selection) on initial search parameters restore.

The original discuss related to this problem: https://discuss.coveo.com/t/disable-preventautoselect-for-facets-with-headless/6017/6

https://coveord.atlassian.net/browse/KIT-774