### PR TITLE
fix(atomic,headless): fix result rendering by adding associated searchUid as key

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -127,7 +127,7 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private getId(result: Result) {
-    return result.uniqueId + this.resultListState.searchUid;
+    return result.uniqueId + result.searchUid;
   }
 
   private buildListResults() {

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -113,7 +113,7 @@ export class AtomicResultList implements InitializableComponent {
   private get results() {
     return this.resultListState.results.map((result) => (
       <atomic-result
-        key={`${result.raw.permanentid}${this.resultListState.searchUid}`}
+        key={`${result.raw.permanentid}${result.searchUid}`}
         result={result}
         engine={this.bindings.engine}
         // TODO: decide to get rid of Mustache or not

--- a/packages/headless/src/api/search/search-api-client.ts
+++ b/packages/headless/src/api/search/search-api-client.ts
@@ -137,7 +137,7 @@ export class SearchAPIClient {
     const payload = {response, body};
 
     if (isSuccessSearchResponse(body)) {
-      payload.body = shimResponse(body);
+      payload.body = shimSearchResponse(body);
       const processedResponse = await this.options.postprocessSearchResponseMiddleware(
         payload
       );
@@ -186,7 +186,7 @@ export class SearchAPIClient {
     const body = await response.json();
 
     if (isSuccessSearchResponse(body)) {
-      return {success: body};
+      return {success: assignSearchUid(body)};
     }
 
     return {
@@ -236,7 +236,7 @@ export class SearchAPIClient {
     const body = await response.json();
 
     if (isSuccessSearchResponse(body)) {
-      return {success: body};
+      return {success: assignSearchUid(body)};
     }
 
     return {
@@ -364,7 +364,11 @@ function pickNonBaseParams<Params extends BaseParam>(req: Params) {
   return nonBase;
 }
 
-function shimResponse(response: SearchResponseSuccess) {
+function shimSearchResponse(response: SearchResponseSuccess) {
+  return assignQuestionAnswer(assignSearchUid(response));
+}
+
+function assignQuestionAnswer(response: SearchResponseSuccess) {
   const empty = emptyQuestionAnswer();
   if (isNullOrUndefined(response.questionAnswer)) {
     response.questionAnswer = empty;
@@ -372,5 +376,14 @@ function shimResponse(response: SearchResponseSuccess) {
   }
 
   response.questionAnswer = {...empty, ...response.questionAnswer};
+  return response;
+}
+
+function assignSearchUid(response: SearchResponseSuccess) {
+  response.results = response.results.map((result) => ({
+    ...result,
+    searchUid: response.searchUid,
+  }));
+
   return response;
 }

--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -73,6 +73,11 @@ export interface ProductRecommendation {
    * An object containing the requested additional fields for the product.
    */
   additionalFields: Record<string, unknown>;
+
+  /**
+   * The associated `searchUid` of the response where the result was fetched.
+   */
+  searchUid: string;
 }
 
 // Change this list when changing the fields exposed by `ProductRecommendation`

--- a/packages/headless/src/api/search/search/result.ts
+++ b/packages/headless/src/api/search/search/result.ts
@@ -172,4 +172,9 @@ export interface Result {
    * TopResult
    */
   rankingModifier?: string;
+
+  /**
+   * The associated `searchUid` of the response where the result was fetched.
+   */
+  searchUid: string;
 }

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -101,6 +101,7 @@ export interface FoldedResultListState extends SearchStatusState {
   results: FoldedCollection[];
   /**
    * The unique identifier of the last executed search.
+   * @deprecated The searchUid identifier is now on the `Result` object as well.
    */
   searchUid: string;
   /**

--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -71,6 +71,7 @@ export interface ResultListState extends SearchStatusState {
   results: Result[];
   /**
    * The unique identifier of the last executed search.
+   * @deprecated The searchUid identifier is now on the `Result` object as well.
    */
   searchUid: string;
   /**

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -177,6 +177,7 @@ const mapResultToProductResult = (
 
   return {
     permanentid: result.raw.permanentid!,
+    searchUid: result.searchUid,
     clickUri: result.clickUri,
     ec_name: result.raw.ec_name as string,
     ec_brand: result.raw.ec_brand as string,

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -235,7 +235,10 @@ const getStateAfterResponse: (
     ...getSearchInitialState(),
     duration,
     response,
-    results: response.results,
+    results: response.results.map((result) => ({
+      ...result,
+      searchUid: response.searchUid,
+    })),
   },
 });
 

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -235,10 +235,7 @@ const getStateAfterResponse: (
     ...getSearchInitialState(),
     duration,
     response,
-    results: response.results.map((result) => ({
-      ...result,
-      searchUid: response.searchUid,
-    })),
+    results: response.results,
   },
 });
 

--- a/packages/headless/src/test/mock-result.ts
+++ b/packages/headless/src/test/mock-result.ts
@@ -8,6 +8,7 @@ export function buildMockResult(config: Partial<Result> = {}): Result {
     printableUri: '',
     clickUri: '',
     uniqueId: '',
+    searchUid: '',
     excerpt: '',
     firstSentences: '',
     summary: null,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-906

There was a glitch when fetching more results: the entire result list would disappear and re-render all its elements, even when we only fetch additional result. Fix is explained in the comments