### PR TITLE
feat(atomic): added pulse animation while results are being replaced

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -4,6 +4,20 @@
 /* CAREFUL! These styles aren't protected by a shadow DOM. */
 /* TODO: Remove v1 suffix */
 atomic-result-list-v1 {
+  .list-root.loading {
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+
+    @keyframes pulse {
+      0%,
+      100% {
+        opacity: 0.6;
+      }
+      50% {
+        opacity: 0.2;
+      }
+    }
+  }
+
   .list-root.display-table {
     padding: 2rem 0;
 

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -218,7 +218,15 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private getClasses() {
-    return getResultDisplayClasses(this.display, this.density, this.image);
+    const classes = getResultDisplayClasses(
+      this.display,
+      this.density,
+      this.image
+    );
+    if (!this.showPlaceholder && this.resultList.state.isLoading) {
+      classes.push('loading');
+    }
+    return classes;
   }
 
   @Listen('scroll', {target: 'window'})


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-914

The pulse animation is the same as Tailwind's, but the opacities are changed.

| `opacity: 0.6` | `opacity: 0.2` |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/130271014-50b01bda-7c8c-4569-a0fe-bc7dc0e0a050.png) | ![image](https://user-images.githubusercontent.com/54454747/130271051-e16faa46-4176-43ad-b9e9-468bfa8e569b.png) |
