### PR TITLE
fix(atomic,headless): fix result rendering by adding searchResponseId

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -141,7 +141,7 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private getId(result: Result) {
-    return result.uniqueId + this.resultListState.searchUid;
+    return result.uniqueId + this.resultListState.queryId;
   }
 
   private buildListResults() {

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -141,7 +141,7 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private getId(result: Result) {
-    return result.uniqueId + this.resultListState.queryId;
+    return result.uniqueId + this.resultListState.searchResponseId;
   }
 
   private buildListResults() {

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -113,7 +113,7 @@ export class AtomicResultList implements InitializableComponent {
   private get results() {
     return this.resultListState.results.map((result) => (
       <atomic-result
-        key={`${result.raw.permanentid}${this.resultListState.queryId}`}
+        key={`${result.raw.permanentid}${this.resultListState.searchResponseId}`}
         result={result}
         engine={this.bindings.engine}
         // TODO: decide to get rid of Mustache or not

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -113,7 +113,7 @@ export class AtomicResultList implements InitializableComponent {
   private get results() {
     return this.resultListState.results.map((result) => (
       <atomic-result
-        key={`${result.raw.permanentid}${this.resultListState.searchUid}`}
+        key={`${result.raw.permanentid}${this.resultListState.queryId}`}
         result={result}
         engine={this.bindings.engine}
         // TODO: decide to get rid of Mustache or not

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -101,13 +101,13 @@ export interface FoldedResultListState extends SearchStatusState {
   results: FoldedCollection[];
   /**
    * The unique identifier of the last executed search.
-   * @deprecated - Use the `queryId` instead.
+   * @deprecated - Use the `searchResponseId` instead.
    */
   searchUid: string;
   /**
    * The unique identifier of the response where the results were fetched, this value does not change when loading more results.
    */
-  queryId: string;
+  searchResponseId: string;
   /**
    * Whether more results are available, using the same parameters as the last successful query.
    *

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -101,8 +101,13 @@ export interface FoldedResultListState extends SearchStatusState {
   results: FoldedCollection[];
   /**
    * The unique identifier of the last executed search.
+   * @deprecated - Use the `queryId` instead.
    */
   searchUid: string;
+  /**
+   * The unique identifier of the response where the results were fetched, this value does not change when loading more results.
+   */
+  queryId: string;
   /**
    * Whether more results are available, using the same parameters as the last successful query.
    *

--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -71,8 +71,13 @@ export interface ResultListState extends SearchStatusState {
   results: Result[];
   /**
    * The unique identifier of the last executed search.
+   * @deprecated - Use the `queryId` instead.
    */
   searchUid: string;
+  /**
+   * The unique identifier of the response where the results were fetched, this value does not change when loading more results.
+   */
+  queryId: string;
   /**
    * Whether more results are available, using the same parameters as the last successful query.
    *
@@ -165,6 +170,7 @@ export function buildResultList(
         results: state.search.results,
         searchUid: state.search.response.searchUid,
         moreResultsAvailable: moreResultsAvailable(),
+        queryId: state.search.queryId,
       };
     },
 

--- a/packages/headless/src/controllers/result-list/headless-result-list.ts
+++ b/packages/headless/src/controllers/result-list/headless-result-list.ts
@@ -71,13 +71,13 @@ export interface ResultListState extends SearchStatusState {
   results: Result[];
   /**
    * The unique identifier of the last executed search.
-   * @deprecated - Use the `queryId` instead.
+   * @deprecated - Use the `searchResponseId` instead.
    */
   searchUid: string;
   /**
    * The unique identifier of the response where the results were fetched, this value does not change when loading more results.
    */
-  queryId: string;
+  searchResponseId: string;
   /**
    * Whether more results are available, using the same parameters as the last successful query.
    *
@@ -170,7 +170,7 @@ export function buildResultList(
         results: state.search.results,
         searchUid: state.search.response.searchUid,
         moreResultsAvailable: moreResultsAvailable(),
-        queryId: state.search.queryId,
+        searchResponseId: state.search.searchResponseId,
       };
     },
 

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -45,6 +45,7 @@ export const searchReducer = createReducer(
     builder.addCase(executeSearch.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);
       state.results = action.payload.response.results;
+      state.queryId = action.payload.response.searchUid;
     });
     builder.addCase(fetchMoreResults.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -45,7 +45,7 @@ export const searchReducer = createReducer(
     builder.addCase(executeSearch.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);
       state.results = action.payload.response.results;
-      state.queryId = action.payload.response.searchUid;
+      state.searchResponseId = action.payload.response.searchUid;
     });
     builder.addCase(fetchMoreResults.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);

--- a/packages/headless/src/features/search/search-state.ts
+++ b/packages/headless/src/features/search/search-state.ts
@@ -33,7 +33,7 @@ export interface SearchState {
   /**
    * The unique ID of the query, taken from the response's `searchUid. This value will not change when loading more results.
    */
-  queryId: string;
+  searchResponseId: string;
 }
 
 export function emptyQuestionAnswer() {
@@ -66,6 +66,6 @@ export function getSearchInitialState(): SearchState {
     automaticallyCorrected: false,
     isLoading: false,
     results: [],
-    queryId: '',
+    searchResponseId: '',
   };
 }

--- a/packages/headless/src/features/search/search-state.ts
+++ b/packages/headless/src/features/search/search-state.ts
@@ -30,6 +30,10 @@ export interface SearchState {
    * The list of results.
    */
   results: Result[];
+  /**
+   * The unique ID of the query, taken from the response's `searchUid. This value will not change when loading more results.
+   */
+  queryId: string;
 }
 
 export function emptyQuestionAnswer() {
@@ -62,5 +66,6 @@ export function getSearchInitialState(): SearchState {
     automaticallyCorrected: false,
     isLoading: false,
     results: [],
+    queryId: '',
   };
 }

--- a/packages/headless/src/test/mock-search-state.ts
+++ b/packages/headless/src/test/mock-search-state.ts
@@ -12,7 +12,7 @@ export function buildMockSearchState(
     automaticallyCorrected: false,
     isLoading: false,
     results: [],
-    queryId: '',
+    searchResponseId: '',
     ...config,
   };
 }

--- a/packages/headless/src/test/mock-search-state.ts
+++ b/packages/headless/src/test/mock-search-state.ts
@@ -12,6 +12,7 @@ export function buildMockSearchState(
     automaticallyCorrected: false,
     isLoading: false,
     results: [],
+    queryId: '',
     ...config,
   };
 }


### PR DESCRIPTION
An alternative, perhaps less controversial, solution to https://github.com/coveo/ui-kit/pull/1103 
https://coveord.atlassian.net/browse/KIT-906