### PR TITLE
fix(quantic): shorten localized string description

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -208,7 +208,7 @@
         <value>Check the {{0}} for similar errors or {{1}} for more information.</value>
         <language>en_US</language>
         <protected>false</protected>
-        <shortDescription>Check the community for similar errors or contact Coveo support for more information.</shortDescription>
+        <shortDescription>Check the community for similar errors or contact Coveo for more information.</shortDescription>
     </labels>
     <labels>
         <fullName>quantic_Community</fullName>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4046

It appears that a localized string `shortDescription` value must not exceed 80 characters long. When the description is too long, deployment fails with the following error.

    Value too long for field: MasterLabel maximum length is:80 (206:13)

**Testing the fix**

Assuming your scratch org alias is `LWC`, execute the following command from the quantic package folder.

    sfdx force:source:deploy -u LWC -p force-app/main

With the fix, the command should complete successfully.
