### PR TITLE
feat(commerce): build the product-listing package, make it work

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist/",
     "recommendation/",
-    "product-recommendation/"
+    "product-recommendation/",
+    "product-listing/"
   ],
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",

--- a/packages/headless/product-listing/package-lock.json
+++ b/packages/headless/product-listing/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "product-listing",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/packages/headless/product-listing/package.json
+++ b/packages/headless/product-listing/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "product-listing",
+  "description": "Headless Product Listing Module",
+  "main": "../dist/product-listing/headless.js",
+  "module": "../dist/product-listing/headless.esm.js",
+  "browser": "../dist/browser/product-listing/headless.esm.js",
+  "types": "../dist/definitions/product-listing.index.d.ts",
+  "license": "Apache-2.0"
+}

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -57,6 +57,10 @@ const nodejs = [
     input: 'src/product-recommendation.index.ts',
     outDir: 'dist/product-recommendation'
   },
+  {
+    input: 'src/product-listing.index.ts',
+    outDir: 'dist/product-listing'
+  },
 ].map(buildNodeConfiguration);
 
 function buildNodeConfiguration({input, outDir}) {
@@ -119,6 +123,13 @@ const browser = [
     output: [
       buildUmdOutput('dist/browser/product-recommendation', 'CoveoHeadlessProductRecommendation'),
       buildEsmOutput('dist/browser/product-recommendation')
+    ]
+  },
+  {
+    input: 'src/product-listing.index.ts',
+    output: [
+      buildUmdOutput('dist/browser/product-listing', 'CoveoHeadlessProductListing'),
+      buildEsmOutput('dist/browser/product-listing')
     ]
   },
 ].map(buildBrowserConfiguration);
@@ -192,6 +203,10 @@ const dev = [
     input: 'src/product-recommendation.index.ts',
     output: [buildEsmOutput('../atomic/src/external-builds/product-recommendation')],
   },
+  {
+    input: 'src/product-listing.index.ts',
+    output: [buildEsmOutput('../atomic/src/external-builds/product-listing')],
+  },
 ].map(buildBrowserConfiguration);
 
 // Api-extractor cannot resolve import() types, so we use dts to create a file that api-extractor
@@ -201,6 +216,7 @@ const typeDefinitions = [
   buildTypeDefinitionConfiguration('index.d.ts'),
   buildTypeDefinitionConfiguration('recommendation.index.d.ts'),
   buildTypeDefinitionConfiguration('product-recommendation.index.d.ts'),
+  buildTypeDefinitionConfiguration('product-listing.index.d.ts'),
 ];
 
 function buildTypeDefinitionConfiguration(entryFileName) {

--- a/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
@@ -12,6 +12,7 @@ export type ProductListingBaseParam = {
   accessToken: string;
   organizationId: string;
   platformUrl: string;
+  version?: string;
 };
 
 export type ProductListingRequestParam = {
@@ -54,8 +55,10 @@ export const baseProductListingRequest = (
   PlatformClientCallOptions,
   'accessToken' | 'method' | 'contentType' | 'url'
 > => {
-  const {platformUrl, organizationId, accessToken} = req;
-  const baseUrl = `${platformUrl}/rest/organizations/${organizationId}/commerce/products/listing`;
+  const {platformUrl, organizationId, accessToken, version} = req;
+  const baseUrl = `${platformUrl}/rest/organizations/${organizationId}/commerce/${
+    version || 'v1'
+  }/products/listing`;
   const queryString = buildQueryString(queryStringArguments);
   const effectiveUrl = queryString ? `${baseUrl}?${queryString}` : baseUrl;
 

--- a/packages/headless/src/api/commerce/product-listings/product-listing-request.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-request.ts
@@ -21,7 +21,7 @@ export const buildProductListingRequest = (req: ProductListingRequest) => {
 };
 
 const prepareRequestParams = (req: ProductListingRequest) => {
-  const {accessToken, platformUrl, organizationId, ...params} = req;
+  const {accessToken, platformUrl, organizationId, version, ...params} = req;
   return params;
 };
 
@@ -29,7 +29,9 @@ const prepareRequestParams = (req: ProductListingRequest) => {
  * Defines the content of a successful response from the `/commerce/products/listing` API call.
  */
 export interface ProductListingSuccessResponse {
-  items: ProductRecommendation[];
-  totalCount: number;
+  products: ProductRecommendation[];
+  pagination: {
+    totalCount: number;
+  };
   responseId: string;
 }

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -1,12 +1,20 @@
-import {fetchProductListing} from '../../features/product-listing/product-listing-actions';
+import {
+  fetchProductListing,
+  setProductListingUrl,
+} from '../../features/product-listing/product-listing-actions';
 import {buildController} from '../controller/headless-controller';
-import {Schema, SchemaValues} from '@coveo/bueno';
+import {Schema, SchemaValues, StringValue} from '@coveo/bueno';
 import {configuration, productListing} from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
+import {validateOptions} from '../../utils/validate-payload';
 
-// TODO COM-1185 - Actually add options and dispatch the updates
-const optionsSchema = new Schema({});
+const optionsSchema = new Schema({
+  url: new StringValue({
+    required: true,
+    url: true,
+  }),
+});
 
 export type ProductListingOptions = SchemaValues<typeof optionsSchema>;
 
@@ -19,7 +27,7 @@ export type ProductListingControllerState = ProductListingController['state'];
 
 export const buildProductListing = (
   engine: ProductListingEngine,
-  _props: ProductListingProps = {}
+  props: ProductListingProps = {}
 ) => {
   if (!loadBaseProductListingReducers(engine)) {
     throw loadReducerError;
@@ -29,14 +37,17 @@ export const buildProductListing = (
   const {dispatch} = engine;
   const getState = () => engine.state;
 
-  // TODO COM-1185 - Actually add options and dispatch the updates
-  /*const options = {
-    ...defaultOptions,
+  const options = {
     ...props.options,
-  }
+  };
 
-  validate(options)*/
+  validateOptions(engine, optionsSchema, options, 'buildProductListing');
 
+  dispatch(
+    setProductListingUrl({
+      url: options.url!,
+    })
+  );
   dispatch(fetchProductListing());
 
   return {

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -1,4 +1,4 @@
-import {createAsyncThunk} from '@reduxjs/toolkit';
+import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {isErrorResponse} from '../../api/search/search-api-client';
 import {
   CategoryFacetSection,
@@ -21,6 +21,25 @@ import {
   ProductListingRequest,
   ProductListingSuccessResponse,
 } from '../../api/commerce/product-listings/product-listing-request';
+import {
+  requiredNonEmptyString,
+  validatePayload,
+} from '../../utils/validate-payload';
+
+export interface SetProductListingUrlPayload {
+  /**
+   * The url used to determine which product listing to fetch.
+   */
+  url: string;
+}
+
+export const setProductListingUrl = createAction(
+  'productListing/setUrl',
+  (payload: SetProductListingUrlPayload) =>
+    validatePayload(payload, {
+      url: requiredNonEmptyString,
+    })
+);
 
 export type StateNeededByFetchProductListing = ConfigurationSection &
   ProductListingSection &

--- a/packages/headless/src/features/product-listing/product-listing-slice.ts
+++ b/packages/headless/src/features/product-listing/product-listing-slice.ts
@@ -1,19 +1,25 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {getProductListingInitialState} from './product-listing-state';
-import {fetchProductListing} from './product-listing-actions';
+import {
+  fetchProductListing,
+  setProductListingUrl,
+} from './product-listing-actions';
 
 export const productListingReducer = createReducer(
   getProductListingInitialState(),
 
   (builder) => {
     builder
+      .addCase(setProductListingUrl, (state, action) => {
+        state.url = action.payload.url;
+      })
       .addCase(fetchProductListing.rejected, (state, action) => {
         state.error = action.payload ? action.payload : null;
         state.isLoading = false;
       })
       .addCase(fetchProductListing.fulfilled, (state, action) => {
         state.error = null;
-        state.products = action.payload.response.items;
+        state.products = action.payload.response.products;
         state.responseId = action.payload.response.responseId;
         state.isLoading = false;
       })


### PR DESCRIPTION
[COM-1185]

We now have a working build, engine and controller :confetti_ball: 

Next step is to add some unit tests :smile: 

I managed to get some results with the following Svelte code:

```
<script lang="ts">
  import { token } from "./t";
  import {buildProductListingEngine, buildProductListing} from "@coveo/headless/product-listing";

  const engine = buildProductListingEngine({
    configuration: {
      platformUrl: "https://platformdev.cloud.coveo.com",
      organizationId: "commercestore",
      accessToken: token,
    }
  });

  const productListing = buildProductListing(engine, {
    options: {
      url: "https://ndlr.xyz/testing"
    }
  });

  let data: any;

  productListing.subscribe((d) => {
    data = productListing.state;
  });
</script>

<div>
  {JSON.stringify(data)}
</div>
```

![screenshot-2021-08-25-16-30-20](https://user-images.githubusercontent.com/8355585/130860265-77260831-ca14-46cf-b6d5-6700b6cc8991.png)