### PR TITLE
feat(commerce): cover product listings with tests

### DIFF
--- a/packages/headless/src/api/commerce/product-listings/product-listing-api-client.test.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-api-client.test.ts
@@ -1,0 +1,114 @@
+import {buildMockProductListingAPIClient} from '../../../test/mock-product-listing-api-client';
+import {PlatformClient} from '../../platform-client';
+import {ProductListingAPIClient} from './product-listing-api-client';
+import {
+  ProductListingRequest,
+  ProductListingSuccessResponse,
+} from './product-listing-request';
+
+describe('product listing api client', () => {
+  const platformUrl = 'https://platformdev.cloud.coveo.com';
+  const organizationId = 'some org id';
+  const accessToken = 'some access token';
+  const url = 'http://bloup.com/🐟';
+
+  let client: ProductListingAPIClient;
+  let platformCallMock: jest.Mock;
+
+  beforeEach(() => {
+    client = buildMockProductListingAPIClient();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockPlatformCall = (fakeResponse: any) => {
+    platformCallMock = jest.fn();
+
+    platformCallMock.mockReturnValue(fakeResponse);
+    PlatformClient.call = platformCallMock;
+  };
+
+  describe('getProducts', () => {
+    const buildGetProductsRequest = (
+      req: Partial<ProductListingRequest> = {}
+    ): ProductListingRequest => ({
+      platformUrl,
+      organizationId,
+      accessToken,
+      url,
+      ...req,
+    });
+
+    it('should call the platform endpoint with the correct arguments', async () => {
+      const request = buildGetProductsRequest({
+        additionalFields: ['some field'],
+      });
+
+      mockPlatformCall({
+        ok: true,
+        json: () => Promise.resolve('some content'),
+      });
+
+      await client.getProducts(request);
+
+      expect(platformCallMock).toBeCalled();
+      const mockRequest = platformCallMock.mock.calls[0][0];
+      expect(mockRequest).toMatchObject({
+        method: 'POST',
+        contentType: 'application/json',
+        url: `${request.platformUrl}/rest/organizations/${request.organizationId}/commerce/v1/products/listing`,
+        accessToken: request.accessToken,
+        requestParams: {
+          url: request.url,
+          additionalFields: request.additionalFields,
+        },
+      });
+    });
+
+    it('should return error response on failure', async () => {
+      const request = buildGetProductsRequest();
+
+      const expectedError = {
+        statusCode: 401,
+        message: 'Unauthorized',
+        type: 'authorization',
+      };
+
+      mockPlatformCall({
+        ok: false,
+        json: () => Promise.resolve(expectedError),
+      });
+
+      const response = await client.getProducts(request);
+
+      expect(response).toMatchObject({
+        error: expectedError,
+      });
+    });
+
+    it('should return success response on success', async () => {
+      const request = buildGetProductsRequest();
+
+      const expectedBody: ProductListingSuccessResponse = {
+        products: [],
+        pagination: {
+          totalCount: 31,
+        },
+        responseId: 'ba7e83ac-6b54-46c1-8789-01f144cfd3b1',
+      };
+
+      mockPlatformCall({
+        ok: true,
+        json: () => Promise.resolve(expectedBody),
+      });
+
+      const response = await client.getProducts(request);
+
+      expect(response).toMatchObject({
+        success: expectedBody,
+      });
+    });
+  });
+});

--- a/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
+++ b/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
@@ -16,7 +16,6 @@ import {
 import {ProductListingAppState} from '../../state/product-listing-app-state';
 import {ProductListingAPIClient} from '../../api/commerce/product-listings/product-listing-api-client';
 import {ProductListingThunkExtraArguments} from '../product-listing-thunk-extra-arguments';
-import {ProductListingSection} from '../../state/state-sections';
 import {productListing} from '../reducers';
 
 export {
@@ -29,7 +28,6 @@ type ProductListingEngineReducers = typeof productListingEngineReducers;
 type ProductListingEngineState = StateFromReducersMapObject<
   ProductListingEngineReducers
 > &
-  ProductListingSection &
   Partial<ProductListingAppState>;
 
 /**

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
@@ -1,0 +1,53 @@
+import {
+  buildMockProductListingEngine,
+  MockProductListingEngine,
+} from '../../test/mock-engine';
+import {
+  buildProductListing,
+  ProductListingController,
+  ProductListingOptions,
+} from './headless-product-listing';
+import {Action} from 'redux';
+import {configuration} from '../../app/reducers';
+import {productListingReducer} from '../../features/product-listing/product-listing-slice';
+import {
+  fetchProductListing,
+  setProductListingUrl,
+} from '../../features/product-listing/product-listing-actions';
+
+describe('headless product-listing', () => {
+  let productRecommendations: ProductListingController;
+  let engine: MockProductListingEngine;
+
+  const baseOptions: Partial<ProductListingOptions> = {
+    url: 'https://someurl.com',
+  };
+
+  beforeEach(() => {
+    engine = buildMockProductListingEngine();
+    productRecommendations = buildProductListing(engine, {
+      options: baseOptions,
+    });
+  });
+
+  const expectContainAction = (action: Action) => {
+    const found = engine.actions.find((a) => a.type === action.type);
+    expect(engine.actions).toContainEqual(found);
+  };
+
+  it('adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      productListing: productListingReducer,
+      configuration,
+    });
+  });
+
+  it('dispatches #setProductListingUrl on load', () => {
+    expectContainAction(setProductListingUrl);
+  });
+
+  it('refresh dispatches #fetchProductListing', () => {
+    productRecommendations.refresh();
+    expectContainAction(fetchProductListing.pending);
+  });
+});

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -48,7 +48,6 @@ export const buildProductListing = (
       url: options.url!,
     })
   );
-  dispatch(fetchProductListing());
 
   return {
     ...controller,
@@ -61,6 +60,8 @@ export const buildProductListing = (
         isLoading,
       };
     },
+
+    refresh: () => dispatch(fetchProductListing()),
   };
 };
 

--- a/packages/headless/src/features/product-listing/product-listing-actions-loader.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions-loader.ts
@@ -1,0 +1,56 @@
+import {AsyncThunkAction, PayloadAction} from '@reduxjs/toolkit';
+import {AsyncThunkProductListingOptions} from '../../api/commerce/product-listings/product-listing-api-client';
+import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
+import {productListing} from '../../app/reducers';
+import {
+  SetProductListingUrlPayload,
+  FetchProductListingThunkReturn,
+  fetchProductListing,
+  setProductListingUrl,
+  StateNeededByFetchProductListing,
+} from './product-listing-actions';
+
+export {SetProductListingUrlPayload};
+
+/**
+ * The product listings action creators.
+ */
+export interface ProductListingActionCreators {
+  /**
+   * Updates the product listing url field.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  setProductListingUrl(
+    payload: SetProductListingUrlPayload
+  ): PayloadAction<SetProductListingUrlPayload>;
+
+  /**
+   * Refreshes the product listing.
+   *
+   * @returns A dispatchable action.
+   */
+  fetchProductListing(): AsyncThunkAction<
+    FetchProductListingThunkReturn,
+    void,
+    AsyncThunkProductListingOptions<StateNeededByFetchProductListing>
+  >;
+}
+
+/**
+ * Loads the `productListing` reducer and returns possible action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadProductListingActions(
+  engine: ProductListingEngine
+): ProductListingActionCreators {
+  engine.addReducers({productListing});
+
+  return {
+    setProductListingUrl,
+    fetchProductListing,
+  };
+}

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -21,11 +21,8 @@ import {
   ProductListingRequest,
   ProductListingSuccessResponse,
 } from '../../api/commerce/product-listings/product-listing-request';
-import {
-  requiredNonEmptyString,
-  validatePayload,
-} from '../../utils/validate-payload';
-
+import {validatePayload} from '../../utils/validate-payload';
+import {StringValue} from '@coveo/bueno';
 export interface SetProductListingUrlPayload {
   /**
    * The url used to determine which product listing to fetch.
@@ -34,10 +31,13 @@ export interface SetProductListingUrlPayload {
 }
 
 export const setProductListingUrl = createAction(
-  'productListing/setUrl',
+  'productlisting/setUrl',
   (payload: SetProductListingUrlPayload) =>
     validatePayload(payload, {
-      url: requiredNonEmptyString,
+      url: new StringValue({
+        required: true,
+        url: true,
+      }),
     })
 );
 
@@ -67,7 +67,7 @@ export const fetchProductListing = createAsyncThunk<
   void,
   AsyncThunkProductListingOptions<StateNeededByFetchProductListing>
 >(
-  'productListing/fetch',
+  'productlisting/fetch',
   async (_action, {getState, rejectWithValue, extra}) => {
     const state = getState();
     const {productListingClient} = extra;

--- a/packages/headless/src/features/product-listing/product-listing-slice.test.ts
+++ b/packages/headless/src/features/product-listing/product-listing-slice.test.ts
@@ -1,0 +1,76 @@
+import {buildMockProductRecommendation} from '../../test/mock-product-recommendation';
+import {
+  getProductListingInitialState,
+  ProductListingState,
+} from './product-listing-state';
+import {productListingReducer} from './product-listing-slice';
+import {
+  fetchProductListing,
+  setProductListingUrl,
+} from './product-listing-actions';
+import {buildFetchProductListingResponse} from '../../test/mock-product-listing';
+
+describe('product-listing-slice', () => {
+  let state: ProductListingState;
+  beforeEach(() => {
+    state = getProductListingInitialState();
+  });
+  it('should have an initial state', () => {
+    expect(productListingReducer(undefined, {type: 'foo'})).toEqual(
+      getProductListingInitialState()
+    );
+  });
+
+  it('should allow to set the product recommendations skus', () => {
+    expect(
+      productListingReducer(
+        state,
+        setProductListingUrl({
+          url: 'http://bloup.com/🐬',
+        })
+      ).url
+    ).toEqual('http://bloup.com/🐬');
+  });
+
+  it('when a fetchProductListing fulfilled is received, it updates the state to the received payload', () => {
+    const result = buildMockProductRecommendation();
+    const response = buildFetchProductListingResponse({
+      products: [result],
+    });
+
+    const action = fetchProductListing.fulfilled(response, '');
+    const finalState = productListingReducer(state, action);
+
+    expect(finalState.products[0]).toEqual(result);
+    expect(finalState.isLoading).toBe(false);
+  });
+
+  it('set the error on rejection', () => {
+    const err = {
+      message: 'message',
+      statusCode: 500,
+      type: 'type',
+    };
+    const action = {type: 'productlisting/fetch/rejected', payload: err};
+    const finalState = productListingReducer(state, action);
+    expect(finalState.error).toEqual(err);
+    expect(finalState.isLoading).toBe(false);
+  });
+
+  it('set the error to null on success', () => {
+    const err = {message: 'message', statusCode: 500, type: 'type'};
+    state.error = err;
+
+    const response = buildFetchProductListingResponse();
+
+    const action = fetchProductListing.fulfilled(response, '');
+    const finalState = productListingReducer(state, action);
+    expect(finalState.error).toBeNull();
+  });
+
+  it('set the isLoading state to true during getProductRecommendations.pending', () => {
+    const pendingAction = fetchProductListing.pending('');
+    const finalState = productListingReducer(state, pendingAction);
+    expect(finalState.isLoading).toBe(true);
+  });
+});

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -24,6 +24,9 @@ import {SearchEngine} from '../app/search-engine/search-engine';
 import {RecommendationEngine} from '../app/recommendation-engine/recommendation-engine';
 import {CoreEngine} from '../app/engine';
 import {ProductRecommendationEngine} from '../app/product-recommendation-engine/product-recommendation-engine';
+import {ProductListingEngine} from '../app/product-listing-engine/product-listing-engine';
+import {ProductListingAppState} from '../state/product-listing-app-state';
+import {buildMockProductListingState} from './mock-product-listing-state';
 
 type AsyncActionCreator<ThunkArg> = ActionCreatorWithPreparedPayload<
   [string, ThunkArg],
@@ -36,7 +39,8 @@ type AsyncActionCreator<ThunkArg> = ActionCreatorWithPreparedPayload<
 type AppState =
   | SearchAppState
   | RecommendationAppState
-  | ProductRecommendationsAppState;
+  | ProductRecommendationsAppState
+  | ProductListingAppState;
 
 interface MockEngine {
   actions: AnyAction[];
@@ -82,6 +86,16 @@ export function buildMockProductRecommendationsAppEngine(
   > = {}
 ): MockProductRecommendationEngine {
   return buildMockCoreEngine(config, buildMockProductRecommendationsState);
+}
+
+export interface MockProductListingEngine
+  extends ProductListingEngine,
+    MockEngine {}
+
+export function buildMockProductListingEngine(
+  config: Partial<ProductListingEngine<ProductListingAppState>> = {}
+): MockProductListingEngine {
+  return buildMockCoreEngine(config, buildMockProductListingState);
 }
 
 interface MockCoreEngine<T extends object> extends CoreEngine<T>, MockEngine {}

--- a/packages/headless/src/test/mock-product-listing-api-client.ts
+++ b/packages/headless/src/test/mock-product-listing-api-client.ts
@@ -1,0 +1,16 @@
+import pino from 'pino';
+import {
+  ProductListingAPIClient,
+  ProductListingAPIClientOptions,
+} from '../api/commerce/product-listings/product-listing-api-client';
+import {NoopPreprocessRequest} from '../api/preprocess-request';
+
+export function buildMockProductListingAPIClient(
+  options?: Partial<ProductListingAPIClientOptions>
+) {
+  return new ProductListingAPIClient({
+    preprocessRequest: NoopPreprocessRequest,
+    logger: pino({level: 'silent'}),
+    ...options,
+  });
+}

--- a/packages/headless/src/test/mock-product-listing-state.ts
+++ b/packages/headless/src/test/mock-product-listing-state.ts
@@ -1,0 +1,30 @@
+import {getConfigurationInitialState} from '../features/configuration/configuration-state';
+import {ProductListingAppState} from '../state/product-listing-app-state';
+import {getProductListingInitialState} from '../features/product-listing/product-listing-state';
+import {getCategoryFacetSetInitialState} from '../features/facets/category-facet-set/category-facet-set-state';
+import {getDateFacetSetInitialState} from '../features/facets/range-facets/date-facet-set/date-facet-set-state';
+import {getFacetOptionsInitialState} from '../features/facet-options/facet-options-state';
+import {getFacetOrderInitialState} from '../features/facets/facet-order/facet-order-state';
+import {getFacetSetInitialState} from '../features/facets/facet-set/facet-set-state';
+import {getNumericFacetSetInitialState} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-set-state';
+import {getPaginationInitialState} from '../features/pagination/pagination-state';
+import {getSortCriteriaInitialState} from '../features/sort-criteria/sort-criteria-state';
+
+export function buildMockProductListingState(
+  config: Partial<ProductListingAppState> = {}
+): ProductListingAppState {
+  return {
+    configuration: getConfigurationInitialState(),
+    productListing: getProductListingInitialState(),
+    categoryFacetSet: getCategoryFacetSetInitialState(),
+    dateFacetSet: getDateFacetSetInitialState(),
+    facetOptions: getFacetOptionsInitialState(),
+    facetOrder: getFacetOrderInitialState(),
+    facetSet: getFacetSetInitialState(),
+    numericFacetSet: getNumericFacetSetInitialState(),
+    pagination: getPaginationInitialState(),
+    sortCriteria: getSortCriteriaInitialState(),
+    version: 'unit-testing-version',
+    ...config,
+  };
+}

--- a/packages/headless/src/test/mock-product-listing.ts
+++ b/packages/headless/src/test/mock-product-listing.ts
@@ -1,0 +1,18 @@
+import {ProductListingSuccessResponse} from '../api/commerce/product-listings/product-listing-request';
+import {FetchProductListingThunkReturn} from '../features/product-listing/product-listing-actions';
+
+export function buildFetchProductListingResponse(
+  response: Partial<ProductListingSuccessResponse> = {}
+): FetchProductListingThunkReturn {
+  return {
+    response: {
+      pagination: {
+        totalCount: 0,
+        ...(response?.pagination || {}),
+      },
+      products: [],
+      responseId: '',
+      ...(response || {}),
+    },
+  };
+}


### PR DESCRIPTION
[COM-1185]

Added some UTs, so here it is :)

I used this diff as a reference on what to cover: https://github.com/coveo/ui-kit/compare/feat-com-1185-product-listings-poc-build

Also added the action creator as suggested by Benjamin, because why not

[COM-1185]: https://coveord.atlassian.net/browse/COM-1185