### PR TITLE
fix(quantic): pluralization with en-CA locale

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/jsconfig.json
+++ b/packages/quantic/force-app/main/default/lwc/jsconfig.json
@@ -89,6 +89,7 @@
     "include": [
         "**/*",
         "../../../../.sfdx/typings/lwc/**/*.d.ts",
+        "../../../../typings/lwc/**/*.d.ts",
         "../../../../coveo.d.ts"
     ],
     "typeAcquisition": {

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -1,7 +1,7 @@
 import {I18nUtils} from "c/quanticUtils";
 
 describe('c/quanticUtils', () => {
-  describe('I18nService', () => {
+  describe('I18nUtils', () => {
     it('getTextWithDecorator should return text wrapped in given tags', () => {
       const text = 'sample text';
       const startTag = '<test-start-tag>';
@@ -40,10 +40,14 @@ describe('c/quanticUtils', () => {
       });
 
       describe('given other locale', () => {
-        it('should return label name', () => {
-          jest.mock('@salesforce/i18n/locale', () => 'en-CA');
+        jest.resetModules();
+        jest.mock('@salesforce/i18n/locale', () => ({
+          default: 'de-DE'
+        }));
+        const withOtherLocale = require('c/quanticUtils');
 
-          expect(() => I18nUtils.getLabelNameWithCount(testLabelName, 2)).not.toThrow();
+        it('should return label name without failing', () => {
+          expect(() => withOtherLocale.I18nUtils.getLabelNameWithCount(testLabelName, 2)).not.toThrow();
         });
       });
     });

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -38,6 +38,14 @@ describe('c/quanticUtils', () => {
       it('should return singular variant if count is equal to -1', () => {
         expect(I18nUtils.getLabelNameWithCount(testLabelName, -1)).toBe(testLabelName);
       });
+
+      describe('given other locale', () => {
+        it('should return label name', () => {
+          jest.mock('@salesforce/i18n/locale', () => 'en-CA');
+
+          expect(() => I18nUtils.getLabelNameWithCount(testLabelName, 2)).not.toThrow();
+        });
+      });
     });
 
     describe('format', () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -54,11 +54,6 @@ export class Debouncer {
 }
 
 export class I18nUtils{
-  static isPluralInLocale = {
-    "en-US": (count) => count !== 0 && Math.abs(count) !== 1,
-    "fr-CA": (count) => Math.abs(count) >= 2
-  }
-
   static getTextWithDecorator(text, startTag, endTag) {
     return `${startTag}${text}${endTag}`;
   }
@@ -67,10 +62,14 @@ export class I18nUtils{
     return I18nUtils.getTextWithDecorator(text, '<b>', '</b>');
   }
 
+  static isSingular(count) {
+    return new Intl.PluralRules(LOCALE).select(count) === 'one';
+  }
+
   static getLabelNameWithCount(labelName, count) {
     if (count === 0) {
       return `${labelName}_zero`;
-    } else if (I18nUtils.isPluralInLocale[LOCALE](count)) {
+    } else if (!I18nUtils.isSingular(count)) {
       return `${labelName}_plural`;
     } 
     return labelName;

--- a/packages/quantic/jest.config.js
+++ b/packages/quantic/jest.config.js
@@ -11,5 +11,8 @@ module.exports = {
       },
     ],
   ],
+  moduleNameMapper: {
+    "^@salesforce/i18n/": "<rootDir>/typings/lwc/customlabels.d.ts"
+  }
   // add any custom configurations here
 };

--- a/packages/quantic/tsconfig.json
+++ b/packages/quantic/tsconfig.json
@@ -8,7 +8,7 @@
         "baseUrl": "force-app/main/default/lwc",
         "target": "es2016",
         "module": "ESNext",
-        "lib": ["es2016", "dom"],
+        "lib": ["es2016", "dom", "ES2018.Intl"],
         "paths": {
             "c/quanticDateFacet": [
                 "quanticDateFacet/quanticDateFacet.js"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4050

Opening the `exampleSearch` component using the `en-CA` locale raised this error.

    Uncaught (in promise) TypeError: a.isPluralInLocale[i.default] is not a function
        at Function.getLabelNameWithCount (quanticUtils.js:formatted:43)
        at Q.get summaryLabel [as summaryLabel] (quanticSummary.js:4)
        ...

The reason is that the `I18nUtils` class was only handling `en-US` and `fr-CA` locales.

This PR fixes the issue by leveraging [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) to find out which plural rule applies in the current locale.