### PR TITLE
feat(atomic): keep placeholders while results are rendering

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list-dividers.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list-dividers.pcss
@@ -69,7 +69,7 @@
       background-color: var(--atomic-neutral);
     }
 
-    &:first-child::before {
+    &:first-of-type::before {
       display: none;
     }
   }

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -2,26 +2,6 @@
 @import './atomic-result-list-cards.pcss';
 @import './atomic-result-table.pcss';
 
-.list-wrapper.placeholder {
-  atomic-result-v1 {
-    display: none;
-  }
-
-  table.list-root {
-    display: none;
-  }
-}
-
-.list-wrapper:not(.placeholder) {
-  atomic-result-placeholder-v1 {
-    display: none;
-  }
-
-  atomic-result-table-placeholder-v1 {
-    display: none;
-  }
-}
-
 /* CAREFUL! These styles aren't protected by a shadow DOM. */
 /* TODO: Remove v1 suffix */
 atomic-result-list-v1 {

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -2,6 +2,26 @@
 @import './atomic-result-list-cards.pcss';
 @import './atomic-result-table.pcss';
 
+.list-wrapper.placeholder {
+  atomic-result-v1 {
+    display: none;
+  }
+
+  table.list-root {
+    display: none;
+  }
+}
+
+.list-wrapper:not(.placeholder) {
+  atomic-result-placeholder-v1 {
+    display: none;
+  }
+
+  atomic-result-table-placeholder-v1 {
+    display: none;
+  }
+}
+
 /* CAREFUL! These styles aren't protected by a shadow DOM. */
 /* TODO: Remove v1 suffix */
 atomic-result-list-v1 {

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -69,6 +69,8 @@ export class AtomicResultList implements InitializableComponent {
 
   @Prop() image: ResultDisplayImageSize = 'icon';
 
+  private listWrapperRef?: HTMLDivElement;
+
   private get showPlaceholder() {
     return !this.resultListState.firstSearchExecuted;
   }
@@ -144,20 +146,21 @@ export class AtomicResultList implements InitializableComponent {
     return result.uniqueId + this.resultListState.searchResponseId;
   }
 
+  private buildListPlaceholders() {
+    return Array.from(
+      {length: this.resultsPerPageState.numberOfResults},
+      (_, i) => (
+        <atomic-result-placeholder-v1
+          key={`placeholder-${i}`}
+          display={this.display}
+          density={this.density}
+          image={this.image}
+        ></atomic-result-placeholder-v1>
+      )
+    );
+  }
+
   private buildListResults() {
-    if (this.showPlaceholder) {
-      return Array.from(
-        {length: this.resultsPerPageState.numberOfResults},
-        (_, i) => (
-          <atomic-result-placeholder-v1
-            key={`placeholder-${i}`}
-            display={this.display}
-            density={this.density}
-            image={this.image}
-          ></atomic-result-placeholder-v1>
-        )
-      );
-    }
     return this.resultListState.results.map((result) => (
       <atomic-result-v1
         key={this.getId(result)}
@@ -171,17 +174,17 @@ export class AtomicResultList implements InitializableComponent {
     ));
   }
 
-  private buildTable() {
-    if (this.showPlaceholder) {
-      return (
-        <atomic-result-table-placeholder-v1
-          density={this.density}
-          image={this.image}
-          rows={this.resultsPerPageState.numberOfResults}
-        ></atomic-result-table-placeholder-v1>
-      );
-    }
+  private buildTablePlaceholder() {
+    return (
+      <atomic-result-table-placeholder-v1
+        density={this.density}
+        image={this.image}
+        rows={this.resultsPerPageState.numberOfResults}
+      ></atomic-result-table-placeholder-v1>
+    );
+  }
 
+  private buildTable() {
     const fieldColumns = Array.from(
       parseHTML(
         this.getTemplate(this.resultListState.results[0])
@@ -222,18 +225,34 @@ export class AtomicResultList implements InitializableComponent {
   private buildList() {
     return (
       <div class={`list-root ${this.getClasses().join(' ')}`}>
-        {this.buildListResults()}
+        {this.resultListState.results.length ? this.buildListResults() : null}
+        {this.buildListPlaceholders()}
       </div>
     );
   }
 
   private buildResultRoot() {
-    if (this.display === 'table' && this.resultListState.results.length) {
-      return this.buildTable();
+    if (this.display === 'table') {
+      return [
+        this.buildTablePlaceholder(),
+        this.resultListState.results.length ? this.buildTable() : null,
+      ];
     }
 
     return this.buildList();
   }
+
+  private buildResultWrapper() {
+    return (
+      <div
+        class="list-wrapper placeholder"
+        ref={(el) => (this.listWrapperRef = el as HTMLDivElement)}
+      >
+        {this.buildResultRoot()}
+      </div>
+    );
+  }
+
   private getClasses() {
     const classes = getResultDisplayClasses(
       this.display,
@@ -260,6 +279,12 @@ export class AtomicResultList implements InitializableComponent {
     }
   }
 
+  public componentDidRender() {
+    if (!this.showPlaceholder) {
+      this.listWrapperRef?.classList.remove('placeholder');
+    }
+  }
+
   public render() {
     if (this.resultListState.hasError) {
       return;
@@ -268,7 +293,7 @@ export class AtomicResultList implements InitializableComponent {
     return (
       <Host>
         {this.templateHasError && <slot></slot>}
-        {this.buildResultRoot()}
+        {this.buildResultWrapper()}
       </Host>
     );
   }

--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.tsx
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-fields-list/atomic-result-fields-list.tsx
@@ -25,7 +25,7 @@ export class AtomicResultFieldsList {
     this.resizeObserver.disconnect();
   }
 
-  public componentWasRendered() {
+  public componentDidRender() {
     this.update();
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-948

* [list demo](https://ftohe.csb.app/)
* [table demo](https://htz09.csb.app/)

This change ensures that placeholders for results stay while results aren't done rendering. This causes a bit of movement in the rest of the UI though.