### PR TITLE
fix(headless): added some debounce to click actions

### DIFF
--- a/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
+++ b/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
@@ -3,6 +3,7 @@ import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {loadReducerError} from '../../../utils/errors';
 import {ConfigurationSection} from '../../../state/state-sections';
 import {Result} from '../../../api/search/search/result';
+import {debounce} from 'ts-debounce';
 
 export interface InteractiveResultCoreOptions {
   /**
@@ -82,7 +83,7 @@ export function buildInteractiveResultCore(
   let longPressTimer: NodeJS.Timeout;
 
   return {
-    select: action,
+    select: debounce(action, defaultDelay, {isImmediate: true}),
 
     beginDelayedSelect() {
       longPressTimer = setTimeout(action, options.selectionDelay);

--- a/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
+++ b/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
@@ -23,7 +23,7 @@ export interface InteractiveResultCoreOptions {
    *
    * @defaultValue `1000`
    */
-  debounceDelay?: number;
+  debounceWait?: number;
 }
 
 export interface InteractiveResultCoreProps {
@@ -84,14 +84,14 @@ export function buildInteractiveResultCore(
   const defaultDelay = 1000;
   const options: Required<InteractiveResultCoreOptions> = {
     selectionDelay: defaultDelay,
-    debounceDelay: defaultDelay,
+    debounceWait: defaultDelay,
     ...props.options,
   };
 
   let longPressTimer: NodeJS.Timeout;
 
   return {
-    select: debounce(action, options.debounceDelay, {isImmediate: true}),
+    select: debounce(action, options.debounceWait, {isImmediate: true}),
 
     beginDelayedSelect() {
       longPressTimer = setTimeout(action, options.selectionDelay);

--- a/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
+++ b/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
@@ -17,6 +17,13 @@ export interface InteractiveResultCoreOptions {
    * @defaultValue `1000`
    */
   selectionDelay?: number;
+
+  /**
+   * The number of seconds for which the debounced function should continue catching subsequent calls.
+   *
+   * @defaultValue `1000`
+   */
+  debounceDelay?: number;
 }
 
 export interface InteractiveResultCoreProps {
@@ -77,13 +84,14 @@ export function buildInteractiveResultCore(
   const defaultDelay = 1000;
   const options: Required<InteractiveResultCoreOptions> = {
     selectionDelay: defaultDelay,
+    debounceDelay: defaultDelay,
     ...props.options,
   };
 
   let longPressTimer: NodeJS.Timeout;
 
   return {
-    select: debounce(action, options.selectionDelay, {isImmediate: true}),
+    select: debounce(action, options.debounceDelay, {isImmediate: true}),
 
     beginDelayedSelect() {
       longPressTimer = setTimeout(action, options.selectionDelay);

--- a/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
+++ b/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
@@ -83,7 +83,7 @@ export function buildInteractiveResultCore(
   let longPressTimer: NodeJS.Timeout;
 
   return {
-    select: debounce(action, defaultDelay, {isImmediate: true}),
+    select: debounce(action, options.selectionDelay, {isImmediate: true}),
 
     beginDelayedSelect() {
       longPressTimer = setTimeout(action, options.selectionDelay);

--- a/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.test.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.test.ts
@@ -68,6 +68,8 @@ describe('InteractiveRecentResult', () => {
 
   it('when calling select(), logs recentResultClick', () => {
     interactiveRecentResult.select();
+    jest.runAllTimers();
+
     expectLogRecentResultActionPending();
   });
 });

--- a/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
@@ -39,7 +39,8 @@ export function buildInteractiveRecentResult(
   const debounceDelay = 1000;
   const debouncedAnalytics = debounce(
     () => engine.dispatch(logRecentResultClick(props.options.result)),
-    debounceDelay
+    debounceDelay,
+    {isImmediate: true}
   );
 
   return buildInteractiveResultCore(engine, props, debouncedAnalytics);

--- a/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
@@ -1,3 +1,4 @@
+import {debounce} from 'ts-debounce';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {logRecentResultClick} from '../../features/recent-results/recent-results-analytics-actions';
 import {
@@ -34,7 +35,12 @@ export function buildInteractiveRecentResult(
   engine: SearchEngine,
   props: InteractiveRecentResultProps
 ): InteractiveRecentResult {
-  const action = () =>
-    engine.dispatch(logRecentResultClick(props.options.result));
-  return buildInteractiveResultCore(engine, props, action);
+  // 1 second is a reasonable amount of time to catch most longpress actions.
+  const debounceDelay = 1000;
+  const debouncedAnalytics = debounce(
+    () => engine.dispatch(logRecentResultClick(props.options.result)),
+    debounceDelay
+  );
+
+  return buildInteractiveResultCore(engine, props, debouncedAnalytics);
 }

--- a/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-interactive-recent-result.ts
@@ -1,4 +1,3 @@
-import {debounce} from 'ts-debounce';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {logRecentResultClick} from '../../features/recent-results/recent-results-analytics-actions';
 import {
@@ -35,13 +34,8 @@ export function buildInteractiveRecentResult(
   engine: SearchEngine,
   props: InteractiveRecentResultProps
 ): InteractiveRecentResult {
-  // 1 second is a reasonable amount of time to catch most longpress actions.
-  const debounceDelay = 1000;
-  const debouncedAnalytics = debounce(
-    () => engine.dispatch(logRecentResultClick(props.options.result)),
-    debounceDelay,
-    {isImmediate: true}
-  );
+  const logAnalytics = () =>
+    engine.dispatch(logRecentResultClick(props.options.result));
 
-  return buildInteractiveResultCore(engine, props, debouncedAnalytics);
+  return buildInteractiveResultCore(engine, props, logAnalytics);
 }

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.test.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.test.ts
@@ -69,6 +69,7 @@ describe('InteractiveResult', () => {
 
   it('when calling select() should add the result to recent results list', () => {
     interactiveResult.select();
+    jest.runAllTimers();
 
     expect(
       engine.actions.find((a) => a.type === pushRecentResult.type)

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.ts
@@ -36,19 +36,25 @@ export function buildInteractiveResult(
   props: InteractiveResultProps
 ): InteractiveResult {
   let wasOpened = false;
-  const debounceDelay = 500;
+  // 1 second is a reasonable amount of time to catch most longpress actions.
+  const debounceDelay = 1000;
   const debouncedPushRecentResult = debounce(
     () => engine.dispatch(pushRecentResult(props.options.result)),
-    debounceDelay
+    debounceDelay,
+    {isImmediate: true}
   );
 
-  const action = () => {
-    debouncedPushRecentResult();
+  const logAnalyticsIfNeverOpened = () => {
     if (wasOpened) {
       return;
     }
     wasOpened = true;
     engine.dispatch(logDocumentOpen(props.options.result));
+  };
+
+  const action = () => {
+    logAnalyticsIfNeverOpened();
+    debouncedPushRecentResult();
   };
 
   return buildInteractiveResultCore(engine, props, action);

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.ts
@@ -1,3 +1,4 @@
+import {debounce} from 'ts-debounce';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {pushRecentResult} from '../../features/recent-results/recent-results-actions';
 import {logDocumentOpen} from '../../features/result/result-analytics-actions';
@@ -35,18 +36,19 @@ export function buildInteractiveResult(
   props: InteractiveResultProps
 ): InteractiveResult {
   let wasOpened = false;
+  const debounceDelay = 500;
+  const debouncedPushRecentResult = debounce(
+    () => engine.dispatch(pushRecentResult(props.options.result)),
+    debounceDelay
+  );
 
-  const logAnalyticsIfNeverOpened = () => {
+  const action = () => {
+    debouncedPushRecentResult();
     if (wasOpened) {
       return;
     }
     wasOpened = true;
     engine.dispatch(logDocumentOpen(props.options.result));
-  };
-
-  const action = () => {
-    logAnalyticsIfNeverOpened();
-    engine.dispatch(pushRecentResult(props.options.result));
   };
 
   return buildInteractiveResultCore(engine, props, action);

--- a/packages/headless/src/controllers/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/result-list/headless-interactive-result.ts
@@ -1,4 +1,3 @@
-import {debounce} from 'ts-debounce';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {pushRecentResult} from '../../features/recent-results/recent-results-actions';
 import {logDocumentOpen} from '../../features/result/result-analytics-actions';
@@ -36,13 +35,6 @@ export function buildInteractiveResult(
   props: InteractiveResultProps
 ): InteractiveResult {
   let wasOpened = false;
-  // 1 second is a reasonable amount of time to catch most longpress actions.
-  const debounceDelay = 1000;
-  const debouncedPushRecentResult = debounce(
-    () => engine.dispatch(pushRecentResult(props.options.result)),
-    debounceDelay,
-    {isImmediate: true}
-  );
 
   const logAnalyticsIfNeverOpened = () => {
     if (wasOpened) {
@@ -54,7 +46,7 @@ export function buildInteractiveResult(
 
   const action = () => {
     logAnalyticsIfNeverOpened();
-    debouncedPushRecentResult();
+    engine.dispatch(pushRecentResult(props.options.result));
   };
 
   return buildInteractiveResultCore(engine, props, action);

--- a/packages/headless/src/features/recent-results/recent-results-slice.ts
+++ b/packages/headless/src/features/recent-results/recent-results-slice.ts
@@ -25,9 +25,8 @@ export const recentResultsReducer = createReducer(
         state.results = state.results.filter(
           (r) => r.uniqueId !== result.uniqueId
         );
-        state.results.unshift(result);
-        if (state.results.length > state.maxLength) {
-          state.results.pop();
+        if (state.results.unshift(result) > state.maxLength) {
+          state.results.length = state.maxLength;
         }
       });
   }

--- a/packages/headless/src/features/recent-results/recent-results-slice.ts
+++ b/packages/headless/src/features/recent-results/recent-results-slice.ts
@@ -25,9 +25,8 @@ export const recentResultsReducer = createReducer(
         state.results = state.results.filter(
           (r) => r.uniqueId !== result.uniqueId
         );
-        if (state.results.unshift(result) > state.maxLength) {
-          state.results.length = state.maxLength;
-        }
+        const remaining = state.results.slice(0, state.maxLength - 1);
+        state.results = [result, ...remaining];
       });
   }
 );


### PR DESCRIPTION
I misunderstood how the `wasOpened` was used before so the recentResults actions were being dispatched several times on each click as we have the event running on 3 handlers.

Unlike the regular result action, we want these to run when a result is clicked (once), regardless of if they've been clicked before, so I added a debounce to catch the extra dispatches instead.