### PR TITLE
feat(atomic): made grid results fill remaining screen width

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -71,11 +71,11 @@ atomic-result-list-v1 {
       }
 
       &.image-large {
-        grid-template-columns: repeat(auto-fill, 20.625rem);
+        grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
       }
 
       &.image-small {
-        grid-template-columns: repeat(auto-fill, 15.5rem);
+        grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
       }
     }
 
@@ -86,7 +86,7 @@ atomic-result-list-v1 {
         grid-template-columns: auto;
       }
       &.image-small {
-        grid-template-columns: repeat(auto-fill, 9.5rem);
+        grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
       }
       &.image-icon,
       &.image-none {

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-desktop.pcss
@@ -255,8 +255,9 @@
   /* == Image styles == */
   &.image-large {
     atomic-result-section-visual {
-      width: 20.625rem;
-      height: 20.625rem;
+      aspect-ratio: 1 / 1;
+      width: 100%;
+      height: auto;
     }
 
     atomic-result-section-badges {
@@ -266,8 +267,9 @@
 
   &.image-small {
     atomic-result-section-visual {
-      width: 15.5rem;
-      height: 15.5rem;
+      aspect-ratio: 1 / 1;
+      width: 100%;
+      height: auto;
     }
   }
 

--- a/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result-v1/atomic-result-cell-mobile.pcss
@@ -216,8 +216,9 @@
   /* == Image styles == */
   &.image-small {
     atomic-result-section-visual {
-      width: 9.5rem;
-      height: 9.5rem;
+      aspect-ratio: 1 / 1;
+      width: 100%;
+      height: auto;
     }
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-925

# Previews
## With `image="small"`
<details>
<summary>Minimum width per result (mobile)</summary>

![image](https://user-images.githubusercontent.com/54454747/131182805-087be205-97ea-423a-9a2a-8837960a2dac.png)
</details>

<details>
<summary>Maximum width per result (mobile)</summary>

![image](https://user-images.githubusercontent.com/54454747/131182617-35498cdc-7298-4d9b-85ff-597aaff0d139.png)
</details>

<details>
<summary>Minimum width per result (desktop)</summary>

![image](https://user-images.githubusercontent.com/54454747/131182929-633a04c5-0e00-4b2f-941b-fd0407a55c96.png)
</details>

<details>
<summary>Maximum width per result (desktop)</summary>

![image](https://user-images.githubusercontent.com/54454747/131182957-3058d2a9-66b6-4eec-abaf-b99f83ef91c0.png)
</details>

## With `image="large"`
<details>
<summary>Minimum width per result (desktop)</summary>

![image](https://user-images.githubusercontent.com/54454747/131183065-187abe58-8f8d-43ca-8c36-6189b0b9b3c9.png)
</details>

<details>
<summary>Maximum width per result (desktop)</summary>

![image](https://user-images.githubusercontent.com/54454747/131183105-e584b4d7-0eed-421a-9ecd-06c9e80a1412.png)
</details>