### PR TITLE
feat(atomic): added maximum width for mobile list & grid results with large images

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -40,6 +40,9 @@ atomic-result-list-v1 {
     @screen mobile-only {
       &.image-large {
         @mixin atomic-list-with-dividers;
+        display: grid;
+        justify-content: space-evenly;
+        grid-template-columns: minmax(auto, 35rem);
       }
 
       &.image-small,
@@ -83,7 +86,7 @@ atomic-result-list-v1 {
       padding: 2rem;
       &.image-large {
         @mixin atomic-list-with-dividers;
-        grid-template-columns: auto;
+        grid-template-columns: minmax(auto, 35rem);
       }
       &.image-small {
         grid-template-columns: repeat(auto-fill, 9.5rem);

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -99,7 +99,7 @@ atomic-result-list-v1 {
       &.image-large {
         @media not all and (min-width: 768px) {
           @mixin atomic-list-with-dividers;
-          grid-template-columns: auto;
+          grid-template-columns: minmax(auto, 35rem);
         }
         @media (min-width: 768px) {
           @mixin atomic-grid-with-cards;

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -82,31 +82,38 @@ atomic-result-list-v1 {
       }
     }
 
+    @define-mixin atomic-grid-with-cards {
+      @mixin atomic-list-with-cards;
+      grid-column-gap: 2.5rem;
+      grid-row-gap: 2.5rem;
+
+      /* TODO: Remove v1 suffix */
+      atomic-result-v1,
+      atomic-result-placeholder-v1 {
+        margin: -1rem;
+      }
+    }
+
     @screen mobile-only {
       padding: 2rem;
       &.image-large {
-        @mixin atomic-list-with-dividers;
-        grid-template-columns: minmax(auto, 35rem);
+        @media not all and (min-width: 768px) {
+          @mixin atomic-list-with-dividers;
+          grid-template-columns: auto;
+        }
+        @media (min-width: 768px) {
+          @mixin atomic-grid-with-cards;
+          grid-template-columns: 1fr 1fr;
+        }
       }
       &.image-small {
+        @mixin atomic-grid-with-cards;
         grid-template-columns: repeat(auto-fill, 9.5rem);
       }
       &.image-icon,
       &.image-none {
+        @mixin atomic-grid-with-cards;
         grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
-      }
-      &.image-small,
-      &.image-icon,
-      &.image-none {
-        @mixin atomic-list-with-cards;
-        grid-column-gap: 2.5rem;
-        grid-row-gap: 2.5rem;
-
-        /* TODO: Remove v1 suffix */
-        atomic-result-v1,
-        atomic-result-placeholder-v1 {
-          margin: -1rem;
-        }
       }
     }
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-936

Once results reach the maximum width, they are centered like this:
<details>
<summary>List view</summary>

![image](https://user-images.githubusercontent.com/54454747/131185897-8c77c655-3f4f-4b77-9852-6d016a6e5469.png)
</details>

<details>
<summary>Grid view (767px)</summary>

![image](https://user-images.githubusercontent.com/54454747/131359156-534c1a30-d0d2-448b-92ae-04cb77824f33.png)
</details>

<details>
<summary>Grid view (1023px)</summary>

![image](https://user-images.githubusercontent.com/54454747/131358503-38d653be-fb50-48f6-bb46-fab58b26a274.png)
</details>


