### PR TITLE
fix(headless): specify dymanically required node bundle dependencies as peer dependencies

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -36,6 +36,10 @@
     "doc:extract": "node ./scripts/extract-documentation.js",
     "doc:parse": "ts-node --project ./doc-parser/tsconfig.build.json ./doc-parser/doc-parser.ts"
   },
+  "peerDependencies": {
+    "encoding": "^0.1.13",
+    "pino-pretty": "^6.0.0"
+  },
   "dependencies": {
     "@coveo/bueno": "^0.32.5",
     "@reduxjs/toolkit": "^1.5.0",


### PR DESCRIPTION
Screenshot available in the jira for the webpack error this change solves.

https://coveord.atlassian.net/browse/KIT-952