### PR TITLE
feat(commerce): support pagination in product listing engine

### DIFF
--- a/packages/headless/src/controllers/pager/headless-product-listing-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-product-listing-pager.ts
@@ -1,0 +1,50 @@
+import {
+  buildCorePager,
+  PagerInitialState,
+  PagerOptions,
+  PagerProps,
+  Pager,
+  PagerState,
+} from '../core/pager/headless-core-pager';
+import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
+import {fetchProductListing} from '../../features/product-listing/product-listing-actions';
+
+export {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
+
+/**
+ * Creates a `Pager` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `Pager` properties.
+ * @returns A `Pager` controller instance.
+ * */
+export function buildPager(
+  engine: ProductListingEngine,
+  props: PagerProps = {}
+): Pager {
+  const {dispatch} = engine;
+  const pager = buildCorePager(engine, props);
+
+  return {
+    ...pager,
+
+    get state() {
+      return pager.state;
+    },
+
+    selectPage(page: number) {
+      pager.selectPage(page);
+      dispatch(fetchProductListing());
+    },
+
+    nextPage() {
+      pager.nextPage();
+      dispatch(fetchProductListing());
+    },
+
+    previousPage() {
+      pager.previousPage();
+      dispatch(fetchProductListing());
+    },
+  };
+}

--- a/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.test.ts
+++ b/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.test.ts
@@ -1,0 +1,51 @@
+import {
+  Pager,
+  PagerOptions,
+  PagerInitialState,
+  buildPager,
+} from './headless-product-listing-pager';
+import {
+  buildMockProductListingEngine,
+  MockProductListingEngine,
+} from '../../../test/mock-engine';
+import {fetchProductListing} from '../../../features/product-listing/product-listing-actions';
+
+describe('Pager', () => {
+  let engine: MockProductListingEngine;
+  let options: PagerOptions;
+  let initialState: PagerInitialState;
+  let pager: Pager;
+
+  function initPager() {
+    pager = buildPager(engine, {options, initialState});
+  }
+
+  beforeEach(() => {
+    options = {};
+    initialState = {};
+    engine = buildMockProductListingEngine();
+    initPager();
+  });
+
+  it('initializes', () => {
+    expect(pager).toBeTruthy();
+  });
+
+  it('#selectPage dispatches #fetchProductListing', () => {
+    pager.selectPage(2);
+    const action = engine.findAsyncAction(fetchProductListing.pending);
+    expect(action).toBeTruthy();
+  });
+
+  it('#nextPage dispatches #fetchProductListing', () => {
+    pager.nextPage();
+    const action = engine.findAsyncAction(fetchProductListing.pending);
+    expect(action).toBeTruthy();
+  });
+
+  it('#previousPage dispatches #fetchProductListing', () => {
+    pager.previousPage();
+    const action = engine.findAsyncAction(fetchProductListing.pending);
+    expect(engine.actions).toContainEqual(action);
+  });
+});

--- a/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
+++ b/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
@@ -5,9 +5,9 @@ import {
   PagerProps,
   Pager,
   PagerState,
-} from '../core/pager/headless-core-pager';
-import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
-import {fetchProductListing} from '../../features/product-listing/product-listing-actions';
+} from '../../core/pager/headless-core-pager';
+import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
+import {fetchProductListing} from '../../../features/product-listing/product-listing-actions';
 
 export {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
 

--- a/packages/headless/src/features/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.test.ts
@@ -36,6 +36,8 @@ import {deselectAllFacets} from '../facets/generic/facet-actions';
 import {selectFacetSearchResult} from '../facets/facet-search-set/specific/specific-facet-search-actions';
 import {selectCategoryFacetSearchResult} from '../facets/facet-search-set/category/category-facet-search-actions';
 import {Action} from '@reduxjs/toolkit';
+import {fetchProductListing} from '../product-listing/product-listing-actions';
+import {buildFetchProductListingResponse} from '../../test/mock-product-listing';
 
 describe('pagination slice', () => {
   let state: PaginationState;
@@ -155,6 +157,20 @@ describe('pagination slice', () => {
     const finalState = paginationReducer(state, action);
     expect(finalState.totalCountFiltered).toBe(
       search.response.totalCountFiltered
+    );
+  });
+
+  it('fetchProductListing.fulfilled updates totalCountFiltered to the response value', () => {
+    const response = buildFetchProductListingResponse({
+      pagination: {
+        totalCount: 100,
+      },
+    });
+    const action = fetchProductListing.fulfilled(response, '');
+
+    const finalState = paginationReducer(state, action);
+    expect(finalState.totalCountFiltered).toBe(
+      response.response.pagination.totalCount
     );
   });
 

--- a/packages/headless/src/features/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.ts
@@ -30,6 +30,7 @@ import {
 import {deselectAllFacets} from '../facets/generic/facet-actions';
 import {selectFacetSearchResult} from '../facets/facet-search-set/specific/specific-facet-search-actions';
 import {selectCategoryFacetSearchResult} from '../facets/facet-search-set/category/category-facet-search-actions';
+import {fetchProductListing} from '../product-listing/product-listing-actions';
 
 export const minimumPage = 1;
 export const maximumNumberOfResultsFromIndex = 1000;
@@ -89,6 +90,10 @@ export const paginationReducer = createReducer(
       .addCase(executeSearch.fulfilled, (state, action) => {
         const {response} = action.payload;
         state.totalCountFiltered = response.totalCountFiltered;
+      })
+      .addCase(fetchProductListing.fulfilled, (state, action) => {
+        const {response} = action.payload;
+        state.totalCountFiltered = response.pagination.totalCount;
       })
       .addCase(deselectAllFacetValues, (state) => {
         handlePaginationReset(state);

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -118,9 +118,11 @@ export const buildProductListingRequest = (
     ...(state.pagination && {
       pagination: {
         numberOfValues: state.pagination.numberOfResults,
-        page: Math.ceil(
-          state.pagination.firstResult / (state.pagination.numberOfResults || 1)
-        ),
+        page:
+          Math.ceil(
+            state.pagination.firstResult /
+              (state.pagination.numberOfResults || 1)
+          ) + 1,
       },
     }),
     ...(state.sortCriteria && {

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -32,4 +32,4 @@ export {
   PagerState,
   Pager,
   buildPager,
-} from './controllers/pager/headless-product-listing-pager';
+} from './controllers/product-listing/pager/headless-product-listing-pager';

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -24,3 +24,12 @@ export {
   ProductListingControllerState,
   buildProductListing,
 } from './controllers/product-listing/headless-product-listing';
+
+export {
+  PagerInitialState,
+  PagerOptions,
+  PagerProps,
+  PagerState,
+  Pager,
+  buildPager,
+} from './controllers/pager/headless-product-listing-pager';


### PR DESCRIPTION
[COM-1185]

I tried to plug in the `pager` in my demo using Product Listing. I noticed a small change: page is 1 based in our API instead of 0 based, and I had to create a new pager from the core one that executes the right search.

That's pretty much it!

[COM-1185]: https://coveord.atlassian.net/browse/COM-1185