### PR TITLE
fix(atomic): constrain sort dropdown width

### DIFF
--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.pcss
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.pcss
@@ -1,5 +1,10 @@
 @import '../../global/global.pcss';
 
+select {
+  max-width: 192px;
+  text-overflow: ellipsis;
+}
+
 select:hover + div,
 select:focus + div {
   @apply border-primary-light text-primary-light;


### PR DESCRIPTION
When one of the options of the sort dropdown has a long caption, the the `select` element's width expands to accommodate it. This PR sets an arbitrary max-width of `192px` on the `select`. If this value does not suit a client, they can increase width by using the `select` CSS part.


**Before**
![long-caption_before](https://user-images.githubusercontent.com/5565841/131371724-73c50b39-4a93-4966-bf53-ac5b270adf4a.PNG)

**After**
![long-caption_after](https://user-images.githubusercontent.com/5565841/131371733-1c462a9c-4f9b-4c44-96cf-d7c30f3ef73e.PNG)


https://coveord.atlassian.net/browse/KIT-959