### PR TITLE
fix(headless): use origin level 2 for interface change analytics event

### DIFF
--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -4,7 +4,6 @@ import {
   requiredNonEmptyString,
   nonEmptyString,
 } from '../../utils/validate-payload';
-import {getAdvancedSearchQueriesInitialState} from '../advanced-search-queries/advanced-search-queries-state';
 import {Result} from '../../api/search/search/result';
 import {
   AnalyticsType,
@@ -14,6 +13,7 @@ import {
   validateResultPayload,
 } from './analytics-utils';
 import {OmniboxSuggestionMetadata} from '../query-suggest/query-suggest-analytics-actions';
+import {getConfigurationInitialState} from '../configuration/configuration-state';
 
 export interface SearchEventPayload {
   /** The identifier of the search action (e.g., `interfaceLoad`). */
@@ -151,8 +151,8 @@ export const logInterfaceChange = makeAnalyticsAction(
   (client, state) =>
     client.logInterfaceChange({
       interfaceChangeTo:
-        state.advancedSearchQueries?.cq ||
-        getAdvancedSearchQueriesInitialState().cq,
+        state.configuration?.analytics.originLevel2 ||
+        getConfigurationInitialState().analytics.originLevel2,
     })
 );
 

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -13,7 +13,6 @@ import {
   validateResultPayload,
 } from './analytics-utils';
 import {OmniboxSuggestionMetadata} from '../query-suggest/query-suggest-analytics-actions';
-import {getConfigurationInitialState} from '../configuration/configuration-state';
 
 export interface SearchEventPayload {
   /** The identifier of the search action (e.g., `interfaceLoad`). */
@@ -150,9 +149,7 @@ export const logInterfaceChange = makeAnalyticsAction(
   AnalyticsType.Search,
   (client, state) =>
     client.logInterfaceChange({
-      interfaceChangeTo:
-        state.configuration?.analytics.originLevel2 ||
-        getConfigurationInitialState().analytics.originLevel2,
+      interfaceChangeTo: state.configuration.analytics.originLevel2,
     })
 );
 

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -22,7 +22,10 @@ import {SearchEventResponse} from 'coveo.analytics/dist/definitions/events';
 import {AsyncThunkAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {requiredNonEmptyString} from '../../utils/validate-payload';
 import {ThunkExtraArguments} from '../../app/thunk-extra-arguments';
-import {PipelineSection} from '../../state/state-sections';
+import {
+  ConfigurationSection,
+  PipelineSection,
+} from '../../state/state-sections';
 import {RecommendationAppState} from '../../state/recommendation-app-state';
 import {ResultWithFolding} from '../folding/folding-slice';
 import {getAllIncludedResultsFrom} from '../folding/folding-utils';
@@ -66,7 +69,7 @@ export const makeAnalyticsAction = <T extends AnalyticsType>(
   analyticsType: T,
   log: (
     client: CoveoSearchPageClient,
-    state: Partial<SearchAppState>
+    state: ConfigurationSection & Partial<SearchAppState>
   ) => Promise<void | SearchEventResponse> | void,
   provider: (state: Partial<SearchAppState>) => SearchPageClientProvider = (
     s


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-938