### PR TITLE
fix(atomic): add toggle on search interface host element on no results

### DIFF
--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -18,6 +18,8 @@ import {
   SearchEngine,
   loadSearchConfigurationActions,
   SearchEngineConfiguration,
+  SearchStatus,
+  buildSearchStatus,
 } from '@coveo/headless';
 import {Bindings, InitializeEvent} from '../../utils/initialization-utils';
 import i18next, {i18n} from 'i18next';
@@ -41,7 +43,9 @@ export type InitializationOptions = Pick<
 })
 export class AtomicSearchInterface {
   private urlManager!: UrlManager;
+  private searchStatus!: SearchStatus;
   private unsubscribeUrlManager: Unsubscribe = () => {};
+  private unsubscribeSearchStatus: Unsubscribe = () => {};
   private hangingComponentsInitialization: InitializeEvent[] = [];
   private initialized = false;
   private store = createStore<AtomicStore>(initialStore());
@@ -146,6 +150,7 @@ export class AtomicSearchInterface {
 
   public disconnectedCallback() {
     this.unsubscribeUrlManager();
+    this.unsubscribeSearchStatus();
     window.removeEventListener('hashchange', this.onHashChange);
   }
 
@@ -190,6 +195,7 @@ export class AtomicSearchInterface {
     this.initEngine(options);
     await this.initI18n();
     this.initComponents();
+    this.initSearchStatus();
     this.initUrlManager();
 
     this.initialized = true;
@@ -283,6 +289,21 @@ export class AtomicSearchInterface {
     );
 
     window.addEventListener('hashchange', this.onHashChange);
+  }
+
+  private initSearchStatus() {
+    this.searchStatus = buildSearchStatus(this.engine!);
+    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => {
+      const hasNoResultsAfterInitialSearch =
+        !this.searchStatus.state.hasResults &&
+        this.searchStatus.state.firstSearchExecuted &&
+        !this.searchStatus.state.hasError;
+
+      this.host.classList.toggle(
+        'atomic-search-interface-no-results',
+        hasNoResultsAfterInitialSearch
+      );
+    });
   }
 
   private updateHash() {

--- a/packages/atomic/src/pages/v1.html
+++ b/packages/atomic/src/pages/v1.html
@@ -186,6 +186,12 @@
         margin: var(--spacing) 0;
       }
 
+      .atomic-search-interface-no-results .topbar,
+      .atomic-search-interface-no-results .results,
+      .atomic-search-interface-no-results .pagination {
+        display: none;
+      }
+
       @media only screen and (min-width: 1024px) {
         atomic-search-interface {
           column-gap: var(--spacing);


### PR DESCRIPTION
For this fix, this depends on the layout of the page (different section in v1.html that are not part of Atomic itself).

I've added a toggle class on the host search interface element, so that different layout can leverage that class to determine how each section should react (in this case, display: none)

https://coveord.atlassian.net/browse/KIT-968