### PR TITLE
fix(atomic): made result list not dynamically remove placeholders

### DIFF
--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.pcss
@@ -2,6 +2,26 @@
 @import './atomic-result-list-cards.pcss';
 @import './atomic-result-table.pcss';
 
+.list-wrapper.placeholder {
+  atomic-result-v1 {
+    display: none;
+  }
+
+  table.list-root {
+    display: none;
+  }
+}
+
+.list-wrapper:not(.placeholder) {
+  atomic-result-placeholder-v1 {
+    display: none;
+  }
+
+  atomic-result-table-placeholder-v1 {
+    display: none;
+  }
+}
+
 /* CAREFUL! These styles aren't protected by a shadow DOM. */
 /* TODO: Remove v1 suffix */
 atomic-result-list-v1 {

--- a/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list-v1/atomic-result-list.tsx
@@ -69,8 +69,7 @@ export class AtomicResultList implements InitializableComponent {
 
   @Prop() image: ResultDisplayImageSize = 'icon';
 
-  private placeholdersRef: HTMLElement[] = [];
-  private resultsWereRendered = false;
+  private listWrapperRef?: HTMLDivElement;
 
   private get fields() {
     if (this.fieldsToInclude.trim() === '') return [];
@@ -144,7 +143,6 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private buildListPlaceholders() {
-    this.placeholdersRef = [];
     return Array.from(
       {length: this.resultsPerPageState.numberOfResults},
       (_, i) => (
@@ -153,7 +151,6 @@ export class AtomicResultList implements InitializableComponent {
           display={this.display}
           density={this.density}
           image={this.image}
-          ref={(el) => this.placeholdersRef.push(el!)}
         ></atomic-result-placeholder-v1>
       )
     );
@@ -174,13 +171,11 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   private buildTablePlaceholder() {
-    this.placeholdersRef = [];
     return (
       <atomic-result-table-placeholder-v1
         density={this.density}
         image={this.image}
         rows={this.resultsPerPageState.numberOfResults}
-        ref={(el) => this.placeholdersRef.push(el!)}
       ></atomic-result-table-placeholder-v1>
     );
   }
@@ -226,7 +221,7 @@ export class AtomicResultList implements InitializableComponent {
   private buildList() {
     return (
       <div class={`list-root ${this.getClasses().join(' ')}`}>
-        {!this.resultsWereRendered ? this.buildListPlaceholders() : null}
+        {this.buildListPlaceholders()}
         {this.resultListState.results.length ? this.buildListResults() : null}
       </div>
     );
@@ -235,12 +230,23 @@ export class AtomicResultList implements InitializableComponent {
   private buildResultRoot() {
     if (this.display === 'table') {
       return [
-        !this.resultsWereRendered ? this.buildTablePlaceholder() : null,
+        this.buildTablePlaceholder(),
         this.resultListState.results.length ? this.buildTable() : null,
       ];
     }
 
     return this.buildList();
+  }
+
+  private buildResultWrapper() {
+    return (
+      <div
+        class="list-wrapper placeholder"
+        ref={(el) => (this.listWrapperRef = el as HTMLDivElement)}
+      >
+        {this.buildResultRoot()}
+      </div>
+    );
   }
 
   private getClasses() {
@@ -250,7 +256,7 @@ export class AtomicResultList implements InitializableComponent {
       this.image
     );
     if (
-      !this.resultListState.firstSearchExecuted &&
+      this.resultListState.firstSearchExecuted &&
       this.resultList.state.isLoading
     ) {
       classes.push('loading');
@@ -273,10 +279,8 @@ export class AtomicResultList implements InitializableComponent {
   }
 
   public componentDidRender() {
-    if (this.shouldCleanupPlaceholders()) {
-      this.resultsWereRendered = true;
-      this.placeholdersRef.forEach((placeholder) => placeholder.remove());
-      this.placeholdersRef = [];
+    if (this.resultListState.firstSearchExecuted) {
+      this.listWrapperRef?.classList.remove('placeholder');
     }
   }
 
@@ -288,16 +292,8 @@ export class AtomicResultList implements InitializableComponent {
     return (
       <Host>
         {this.templateHasError && <slot></slot>}
-        {this.buildResultRoot()}
+        {this.buildResultWrapper()}
       </Host>
-    );
-  }
-
-  private shouldCleanupPlaceholders() {
-    return (
-      this.resultListState.results.length > 0 &&
-      !this.resultsWereRendered &&
-      this.placeholdersRef.length > 0
     );
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-980

When writing cypress tests for the new result list, I noticed that tests were very flaky; every ~60 tests, a `insertBefore` error would cause the entire result list to stop loading and fail tests.

I wasn't able to pinpoint the exact cause of the error, and experimenting with different ways to display placeholders & results under the same parent didn't lead anywhere.

Given that, in addition to this error, there [was another error when removing placeholders](https://coveord.atlassian.net/browse/KIT-969), I'm thinking this behaviour may not be very well supported by Stencil and I prefer to go for a CSS-only approach.

This change is simply reverting [some changes](https://github.com/coveo/ui-kit/pull/1137/commits/6fa4a14c0534b04413c72bbcab6cf56adefd22e8) I made in another PR.

I ran the same cypress tests about 288 times with these changes and they all passed successfully.

One positive side-effect of this PR is that there is less flickering in the scroll height of the page.