### PR TITLE
fix(atomic): import only base styles to prevent font-size override

### DIFF
--- a/packages/atomic/src/components/result-template-components-v1/atomic-result-multi-value-text/atomic-result-multi-value-text.pcss
+++ b/packages/atomic/src/components/result-template-components-v1/atomic-result-multi-value-text/atomic-result-multi-value-text.pcss
@@ -1,4 +1,4 @@
-@import '../../../global/global.pcss';
+@import 'tailwindcss/base';
 
 .separator {
   &::before {


### PR DESCRIPTION
**What's causing the issue?**

The `global.pcss` file contains a style that overrides the `font-size` set by the template section. This makes the font-size of multi-value text larger than `atomic-result-text`.

The `multi-value-text` component imports this file presumably for the base tailwind style overrides. The component uses `ul` and `li` tags, so without the overrides, the default bullet list styles show.

**Solution**

This PR scopes the import to only the base styles instead of the global styles.


https://coveord.atlassian.net/browse/KIT-982