### PR TITLE
feat(quantic): refactoring of initalize functions

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -49,12 +49,11 @@ export default class QuanticBreadcrumbManager extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /** @param {import("coveo").SearchEngine} engine */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
     this.unsubscribe = this.breadcrumbManager.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -43,7 +43,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   disconnectedCallback() {
@@ -53,8 +53,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.facet = CoveoHeadless.buildCategoryFacet(engine, {
       options: {
         field: this.field,

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
@@ -52,14 +52,13 @@ export default class QuanticDateFacet extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.facet = CoveoHeadless.buildDateFacet(engine, {
       options: {
         field: this.field,

--- a/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
@@ -34,14 +34,13 @@ export default class QuanticDidYouMean extends LightningElement {
   }
   
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.didYouMean = CoveoHeadless.buildDidYouMean(engine);
     this.unsubscribe = this.didYouMean.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -65,8 +65,7 @@ export default class QuanticFacet extends LightningElement {
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     const options = {
       field: this.field,
       sortCriteria: this.sortCriteria,
@@ -83,7 +82,7 @@ export default class QuanticFacet extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
     this.input = this.template.querySelector('.facet__searchbox-input');
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -69,14 +69,13 @@ export default class QuanticNoResults extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
     this.historyManager = CoveoHeadless.buildHistoryManager(engine);
     this.querySummary = CoveoHeadless.buildQuerySummary(engine);

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -56,14 +56,13 @@ export default class QuanticNumericFacet extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.facet = CoveoHeadless.buildNumericFacet(engine, {
       options: {
         field: this.field,

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
@@ -34,14 +34,13 @@ export default class QuanticPager extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.pager = CoveoHeadless.buildPager(engine);
     this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
     this.unsubscribe = this.pager.subscribe(() => this.updateState());

--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
@@ -49,14 +49,13 @@ export default class QuanticQueryError extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.queryError = CoveoHeadless.buildQueryError(engine);
     this.unsubscribe = this.queryError.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.js
@@ -37,14 +37,13 @@ export default class QuanticRecentQueriesList extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
   * @param {import("coveo").SearchEngine} engine
   */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.recentQueriesList = CoveoHeadless.buildRecentQueriesList(engine, {
       initialState: {
         queries: getItemFromLocalStorage(this.localStorageKey) ?? [],

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentResultLink/quanticRecentResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentResultLink/quanticRecentResultLink.js
@@ -22,8 +22,7 @@ export default class QuanticResultLink extends LightningElement {
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.engine = engine;
     ResultUtils.bindClickEventsOnResult(
       this.engine,

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.js
@@ -41,14 +41,13 @@ export default class QuanticRecentResultsList extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.recentResultsList = CoveoHeadless.buildRecentResultsList(engine, {
       initialState: {
         results: getItemFromLocalStorage(this.localStorageKey) ?? []

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -22,8 +22,7 @@ export default class QuanticResultLink extends LightningElement {
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.engine = engine;
     ResultUtils.bindClickEventsOnResult(
       this.engine,

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -19,14 +19,13 @@ export default class QuanticResultList extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.resultList = CoveoHeadless.buildResultList(engine);
     this.resultTemplatesManager = CoveoHeadless.buildResultTemplatesManager(
       engine

--- a/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
@@ -25,14 +25,13 @@ export default class QuanticResultsPerPage extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.resultsPerPage = CoveoHeadless.buildResultsPerPage(engine);
     this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
     this.unsubscribe = this.resultsPerPage.subscribe(() => this.updateState());

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
@@ -54,8 +54,7 @@ export default class QuanticSearchBox extends LightningElement {
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.searchBox = CoveoHeadless.buildSearchBox(engine, {
       options: {
         numberOfSuggestions: this.numberOfSuggestions,
@@ -75,7 +74,7 @@ export default class QuanticSearchBox extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   disconnectedCallback() {

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
@@ -42,14 +42,13 @@ export default class QuanticSort extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.sort = CoveoHeadless.buildSort(engine);
     this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
     this.unsubscribeSort = this.sort.subscribe(() => this.updateState());

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
@@ -73,7 +73,7 @@ export default class QuanticStandaloneSearchBox extends NavigationMixin(
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   get actualSearchBox() {
@@ -86,8 +86,7 @@ export default class QuanticStandaloneSearchBox extends NavigationMixin(
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.searchBox = CoveoHeadless.buildSearchBox(engine, {
       options: this.searchBoxOptions,
     });

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
@@ -39,14 +39,13 @@ export default class QuanticSummary extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
    * @param {import("coveo").SearchEngine} engine
    */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.querySummary = CoveoHeadless.buildQuerySummary(engine);
     this.unsubscribe = this.querySummary.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
@@ -21,14 +21,13 @@ export default class QuanticTab extends LightningElement {
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.engineId, this.initialize.bind(this));
+    initializeWithHeadless(this, this.engineId, this.initialize);
   }
 
   /**
   * @param {import("coveo").SearchEngine} engine
   */
-  @api
-  initialize(engine) {
+  initialize = (engine) => {
     this.tab = CoveoHeadless.buildTab(engine, {
       options: {
         expression: this.expression,
@@ -56,5 +55,4 @@ export default class QuanticTab extends LightningElement {
   get tabClass() {
     return `slds-tabs_default__item ${this.isActive ? 'slds-is-active' : ''}`
   }
-
 }


### PR DESCRIPTION
- The @api decorator on the initialization function isn't necessary for us and AFAIK shouldn't be used by quantic users wrapping these components.
- (Personal preference alert) Arrow functions > binding. Can't remember why we were binding in the first place.