### PR TITLE
feat(atomic): made result list use shadowDOM

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-list-selectors.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list-selectors.ts
@@ -10,8 +10,10 @@ type ResultSection =
   | 'excerpt'
   | 'bottomMetadata';
 
+export const resultListComponent = 'atomic-result-list';
+
 export const ResultListSelectors = {
-  component: 'atomic-result-list',
+  shadow: () => cy.get(resultListComponent).shadow(),
   placeholder: 'atomic-result-placeholder',
   result: 'atomic-result',
   sections: <Record<ResultSection, string>>{
@@ -47,17 +49,16 @@ export const generateResultList = (
   slot = '',
   options?: {display?: string; image?: string; density?: string}
 ) =>
-  `<${ResultListSelectors.component}
+  `<${resultListComponent}
     display="${options?.display ?? 'list'}"
     image="${options?.image ?? 'icon'}"
     density="${options?.density ?? 'normal'}"
    >
     ${slot}
-   </${ResultListSelectors.component}>`;
+   </${resultListComponent}>`;
 
 export function getFirstResult() {
-  return cy
-    .get(ResultListSelectors.component)
+  return ResultListSelectors.shadow()
     .find(ResultListSelectors.result)
     .first()
     .shadow();

--- a/packages/atomic/cypress/integration/result-list/result-list-utils.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list-utils.ts
@@ -1,4 +1,4 @@
-import {ResultListSelectors} from './result-list-selectors';
+import {resultListComponent} from './result-list-selectors';
 
 export function withAnySectionnableResultList(assertions: () => void) {
   const viewports = {mobile: 1023, desktop: 1024};
@@ -13,7 +13,7 @@ export function withAnySectionnableResultList(assertions: () => void) {
                   before(() => {
                     const aspectRatio = 16 / 9;
                     cy.viewport(width, width / aspectRatio);
-                    cy.get(ResultListSelectors.component).then((comp) => {
+                    cy.get(resultListComponent).then((comp) => {
                       const resultList = comp.get()[0];
                       resultList.setAttribute('display', display);
                       resultList.setAttribute('image', image);

--- a/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
@@ -9,8 +9,7 @@ import {
 
 describe('Result List Component', () => {
   function getFirstResult() {
-    return cy
-      .get(ResultListSelectors.component)
+    return ResultListSelectors.shadow()
       .find(ResultListSelectors.result)
       .first()
       .shadow();
@@ -18,7 +17,7 @@ describe('Result List Component', () => {
 
   it('should load', () => {
     setUpPage(generateResultList());
-    cy.get(ResultListSelectors.component)
+    ResultListSelectors.shadow()
       .find(ResultListSelectors.result)
       .should('have.length.above', 0);
   });
@@ -29,7 +28,7 @@ describe('Result List Component', () => {
     });
 
     it('should render placeholder components', () => {
-      cy.get(ResultListSelectors.component)
+      ResultListSelectors.shadow()
         .find(ResultListSelectors.placeholder)
         .should('be.visible');
     });
@@ -38,7 +37,7 @@ describe('Result List Component', () => {
   describe('when an initial search is executed', () => {
     it('should render the correct number of results', () => {
       setUpPage(generateResultList());
-      cy.get(ResultListSelectors.component)
+      ResultListSelectors.shadow()
         .find(ResultListSelectors.result)
         .should('have.length', 10);
     });
@@ -88,7 +87,7 @@ describe('Result List Component', () => {
           })
         )
       );
-      cy.get('.list-wrapper:not(.placeholder)');
+      ResultListSelectors.shadow().find('.list-wrapper:not(.placeholder)');
     });
 
     withAnySectionnableResultList(() => {

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -22,7 +22,6 @@
   }
 }
 
-/* CAREFUL! These styles aren't protected by a shadow DOM. */
 .list-root.loading {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -23,115 +23,113 @@
 }
 
 /* CAREFUL! These styles aren't protected by a shadow DOM. */
-atomic-result-list {
-  .list-root.loading {
-    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+.list-root.loading {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 
-    @keyframes pulse {
-      0%,
-      100% {
-        opacity: 0.6;
-      }
-      50% {
-        opacity: 0.2;
-      }
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 0.6;
+    }
+    50% {
+      opacity: 0.2;
+    }
+  }
+}
+
+.list-root.display-table {
+  @mixin atomic-result-table;
+}
+
+.list-root.display-list {
+  display: flex;
+  flex-direction: column;
+
+  atomic-result,
+  atomic-result-placeholder {
+    width: auto;
+  }
+
+  @screen desktop-only {
+    @mixin atomic-list-with-dividers;
+  }
+
+  @screen mobile-only {
+    &.image-large {
+      @mixin atomic-list-with-dividers;
+      display: grid;
+      justify-content: space-evenly;
+      grid-template-columns: minmax(auto, 35rem);
+    }
+
+    &.image-small,
+    &.image-icon,
+    &.image-none {
+      @mixin atomic-list-with-cards;
+    }
+  }
+}
+
+.list-root.display-grid {
+  display: grid;
+  justify-content: space-evenly;
+
+  @screen desktop-only {
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+
+    &.density-comfortable {
+      padding: 2rem 0.75rem;
+      grid-row-gap: 4rem;
+      grid-column-gap: 1.5rem;
+    }
+
+    &.density-normal,
+    &.density-compact {
+      padding: 1.5rem 0.75rem;
+      grid-row-gap: 3rem;
+      grid-column-gap: 1.5rem;
+    }
+
+    &.image-large {
+      grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+    }
+
+    &.image-small {
+      grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
     }
   }
 
-  .list-root.display-table {
-    @mixin atomic-result-table;
-  }
-
-  .list-root.display-list {
-    display: flex;
-    flex-direction: column;
+  @define-mixin atomic-grid-with-cards {
+    @mixin atomic-list-with-cards;
+    grid-column-gap: 2.5rem;
+    grid-row-gap: 2.5rem;
 
     atomic-result,
     atomic-result-placeholder {
-      width: auto;
-    }
-
-    @screen desktop-only {
-      @mixin atomic-list-with-dividers;
-    }
-
-    @screen mobile-only {
-      &.image-large {
-        @mixin atomic-list-with-dividers;
-        display: grid;
-        justify-content: space-evenly;
-        grid-template-columns: minmax(auto, 35rem);
-      }
-
-      &.image-small,
-      &.image-icon,
-      &.image-none {
-        @mixin atomic-list-with-cards;
-      }
+      margin: -1rem;
     }
   }
 
-  .list-root.display-grid {
-    display: grid;
-    justify-content: space-evenly;
-
-    @screen desktop-only {
-      grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
-
-      &.density-comfortable {
-        padding: 2rem 0.75rem;
-        grid-row-gap: 4rem;
-        grid-column-gap: 1.5rem;
+  @screen mobile-only {
+    padding: 2rem;
+    &.image-large {
+      @media not all and (min-width: 768px) {
+        @mixin atomic-list-with-dividers;
+        grid-template-columns: minmax(auto, 35rem);
       }
-
-      &.density-normal,
-      &.density-compact {
-        padding: 1.5rem 0.75rem;
-        grid-row-gap: 3rem;
-        grid-column-gap: 1.5rem;
-      }
-
-      &.image-large {
-        grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
-      }
-
-      &.image-small {
-        grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+      @media (min-width: 768px) {
+        @mixin atomic-grid-with-cards;
+        grid-template-columns: 1fr 1fr;
       }
     }
-
-    @define-mixin atomic-grid-with-cards {
-      @mixin atomic-list-with-cards;
-      grid-column-gap: 2.5rem;
-      grid-row-gap: 2.5rem;
-
-      atomic-result,
-      atomic-result-placeholder {
-        margin: -1rem;
-      }
+    &.image-small {
+      @mixin atomic-grid-with-cards;
+      grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
     }
-
-    @screen mobile-only {
-      padding: 2rem;
-      &.image-large {
-        @media not all and (min-width: 768px) {
-          @mixin atomic-list-with-dividers;
-          grid-template-columns: minmax(auto, 35rem);
-        }
-        @media (min-width: 768px) {
-          @mixin atomic-grid-with-cards;
-          grid-template-columns: 1fr 1fr;
-        }
-      }
-      &.image-small {
-        @mixin atomic-grid-with-cards;
-        grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
-      }
-      &.image-icon,
-      &.image-none {
-        @mixin atomic-grid-with-cards;
-        grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
-      }
+    &.image-icon,
+    &.image-none {
+      @mixin atomic-grid-with-cards;
+      grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
     }
   }
 }

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -31,7 +31,7 @@ import {
 @Component({
   tag: 'atomic-result-list',
   styleUrl: 'atomic-result-list.pcss',
-  shadow: false,
+  shadow: true,
 })
 export class AtomicResultList implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;

--- a/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.pcss
+++ b/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.pcss
@@ -1,6 +1,5 @@
 @import '../atomic-result/atomic-result.pcss';
 
-/* CAREFUL! These styles aren't protected by a shadow DOM. */
 .result-root {
   &.display-grid {
     atomic-result-section-actions {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-997

As far as I recall, the reason not to do this was that this results in a shadowDOM (results) in another shadowDOM (result list) and introduces too many parts for styling.

However, given that we can insert styling directly into result templates, I don't think this is too much of an issue, and I prefer that as opposed to leaking CSS classes. The `index.html` file (formerly v1.html) didn't need any change, all its styles still work with this change.