### PR TITLE
feat(core): allow building headless with a filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm start
 
 **Note:** You should build all separate projects at least once before running the `npm start` command the first time.
 
+To build a single project for production (for instance, the `product-listing` package), run:
+
+```sh
+npm run build  -- --filter product-listing
+```
+
 To run all FTs for Atomic using Cypress, run: (need to start all projects in development before
 
 **Note:** You should build all separate projects at least once before running tests.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
-    "build": "npm run clean && npm run build:prod",
+    "build": "npm run clean && npm run build:prod --",
     "build:prod": "npm run typedefinitions && rollup -c --environment BUILD:production",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -f -r dist/*",

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -37,6 +37,19 @@ function onWarn(warning, warn) {
   warn(warning);
 }
 
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function matchesFilter(value) {
+  const filterIndex = process.argv.indexOf("--filter");
+  if (filterIndex === -1) {
+    return true;
+  }
+
+  const filter = process.argv[filterIndex + 1];
+  return value.includes(filter);
+}
 
 // Node Bundles
 
@@ -61,7 +74,7 @@ const nodejs = [
     input: 'src/product-listing.index.ts',
     outDir: 'dist/product-listing'
   },
-].map(buildNodeConfiguration);
+].filter(b => matchesFilter(b.input)).map(buildNodeConfiguration);
 
 function buildNodeConfiguration({input, outDir}) {
   return {
@@ -132,7 +145,7 @@ const browser = [
       buildEsmOutput('dist/browser/product-listing')
     ]
   },
-].map(buildBrowserConfiguration);
+].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
 function buildBrowserConfiguration({input, output}) {
   return {
@@ -207,7 +220,7 @@ const dev = [
     input: 'src/product-listing.index.ts',
     output: [buildEsmOutput('../atomic/src/external-builds/product-listing')],
   },
-].map(buildBrowserConfiguration);
+].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
 // Api-extractor cannot resolve import() types, so we use dts to create a file that api-extractor
 // can consume. When the api-extractor limitation is resolved, this step will not be necessary.
@@ -217,7 +230,7 @@ const typeDefinitions = [
   buildTypeDefinitionConfiguration('recommendation.index.d.ts'),
   buildTypeDefinitionConfiguration('product-recommendation.index.d.ts'),
   buildTypeDefinitionConfiguration('product-listing.index.d.ts'),
-];
+].filter(b => matchesFilter(b.input));
 
 function buildTypeDefinitionConfiguration(entryFileName) {
   return {


### PR DESCRIPTION
[COM-1202]

This is just an experiment I did, and it seemed to work pretty well, so let me know what you think!

Usage:  `npm run build -- --filter product-listing` would only build the `product-listing` package.

[COM-1202]: https://coveord.atlassian.net/browse/COM-1202