### PR TITLE
fix(atomic): change selected facet box from border to box-shadow

### DIFF
--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.pcss
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.pcss
@@ -13,5 +13,5 @@
 }
 
 .value-box.selected {
-  @apply border-primary border-2;
+  box-shadow: 0 0 0 1px var(--atomic-primary);
 }


### PR DESCRIPTION
Since a 2px border is always going to change/affect the size of elements around it on selection,, there's a couple solution.

1- Change selected border to 1px. It makes it pretty "subtle" to see that a value is selected, however. 
2- Use an outline instead of a border. Outline cannot be rounded/cannot have border radius.
3- Box shadow, which is not * exactly * looking like a border, but I think it's "close enough".

https://coveord.atlassian.net/browse/KIT-1006