### PR TITLE
fix(headless): support selecting deep category facet values

### DIFF
--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -445,6 +445,37 @@ describe('category facet slice', () => {
         ]);
       });
 
+      it('when the value path contains more than one segement, it selects it', () => {
+        const selection = buildMockCategoryFacetValue({
+          value: 'B',
+          path: ['A', 'B'],
+        });
+        const action = toggleSelectCategoryFacetValue({
+          facetId,
+          selection,
+          retrieveCount,
+        });
+        const finalState = categoryFacetSetReducer(state, action);
+        const currentValues = finalState[facetId]!.request.currentValues;
+
+        const child = buildMockCategoryFacetValueRequest({
+          value: 'B',
+          state: 'selected',
+          retrieveChildren: true,
+          retrieveCount,
+        });
+
+        const parent = buildMockCategoryFacetValueRequest({
+          value: 'A',
+          state: 'idle',
+          children: [child],
+          retrieveChildren: false,
+          retrieveCount,
+        });
+
+        expect(currentValues).toEqual([parent]);
+      });
+
       it('sets the numberOfValues to request to 1', () => {
         const selection = buildMockCategoryFacetValue({
           value: 'A',

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -558,25 +558,27 @@ describe('category facet slice', () => {
           retrieveCount,
         });
 
-        it("does not add the selection to the parent's children array", () => {
+        it('overwrites the parent, and adds the selection as a child', () => {
           const finalState = categoryFacetSetReducer(state, action);
-          expect(
-            finalState[facetId]?.request.currentValues[0].children
-          ).toEqual([]);
-        });
 
-        it('keeps the parent #state to selected', () => {
-          const finalState = categoryFacetSetReducer(state, action);
-          expect(finalState[facetId]?.request.currentValues[0].state).toBe(
-            'selected'
-          );
-        });
+          const currentValues = finalState[facetId]!.request.currentValues;
 
-        it('keeps the parent #retrieveChildren to true', () => {
-          const finalState = categoryFacetSetReducer(state, action);
-          expect(
-            finalState[facetId]?.request.currentValues[0].retrieveChildren
-          ).toBe(true);
+          const child = buildMockCategoryFacetValueRequest({
+            value: 'B',
+            state: 'selected',
+            retrieveChildren: true,
+            retrieveCount,
+          });
+
+          const parent = buildMockCategoryFacetValueRequest({
+            value: 'C',
+            state: 'idle',
+            children: [child],
+            retrieveChildren: false,
+            retrieveCount,
+          });
+
+          expect(currentValues).toEqual([parent]);
         });
       });
     });

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -445,7 +445,7 @@ describe('category facet slice', () => {
         ]);
       });
 
-      it('when the value path contains more than one segement, it selects it', () => {
+      it('when the value path contains more than one segment, it selects it', () => {
         const selection = buildMockCategoryFacetValue({
           value: 'B',
           path: ['A', 'B'],

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -85,7 +85,10 @@ export const categoryFacetSetReducer = createReducer(
           const missingParent = !parent;
 
           if (missingParent || segment !== parent.value) {
-            parent = buildCategoryFacetValueRequest(segment, retrieveCount);
+            parent = buildSelectedCategoryFacetValueRequest(
+              segment,
+              retrieveCount
+            );
             activeLevel.length = 0;
             activeLevel.push(parent);
           }
@@ -104,7 +107,7 @@ export const categoryFacetSetReducer = createReducer(
           return;
         }
 
-        const valueRequest = buildCategoryFacetValueRequest(
+        const valueRequest = buildSelectedCategoryFacetValueRequest(
           selection.value,
           retrieveCount
         );
@@ -193,7 +196,7 @@ function buildCategoryFacetRequest(
   };
 }
 
-function buildCategoryFacetValueRequest(
+function buildSelectedCategoryFacetValueRequest(
   value: string,
   retrieveCount: number
 ): CategoryFacetValueRequest {

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -93,11 +93,12 @@ export const categoryFacetSetReducer = createReducer(
           return;
         }
 
-        const valueRequest = buildSelectedCategoryFacetValueRequest(
+        const newParent = buildCategoryFacetValueRequest(
           selection.value,
           retrieveCount
         );
-        children.push(valueRequest);
+        newParent.state = 'selected';
+        children.push(newParent);
         request.numberOfValues = 1;
       })
       .addCase(deselectAllCategoryFacetValues, (state, action) => {
@@ -182,7 +183,7 @@ function ensurePathAndReturnChildren(
     const missingParent = !parent;
 
     if (missingParent || segment !== parent.value) {
-      parent = buildSelectedCategoryFacetValueRequest(segment, retrieveCount);
+      parent = buildCategoryFacetValueRequest(segment, retrieveCount);
       children.length = 0;
       children.push(parent);
     }
@@ -207,13 +208,13 @@ function buildCategoryFacetRequest(
   };
 }
 
-function buildSelectedCategoryFacetValueRequest(
+function buildCategoryFacetValueRequest(
   value: string,
   retrieveCount: number
 ): CategoryFacetValueRequest {
   return {
     value,
-    state: 'selected',
+    state: 'idle',
     children: [],
     retrieveChildren: true,
     retrieveCount,

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -13,7 +13,7 @@ import {
 } from './category-facet-set-actions';
 import {CategoryFacetOptionalParameters} from './interfaces/options';
 import {change} from '../../history/history-actions';
-import {CategoryFacetResponse, CategoryFacetValue} from './interfaces/response';
+import {CategoryFacetResponse} from './interfaces/response';
 import {handleFacetUpdateNumberOfValues} from '../generic/facet-reducer-helpers';
 import {selectCategoryFacetSearchResult} from '../facet-search-set/category/category-facet-search-actions';
 import {
@@ -81,6 +81,14 @@ export const categoryFacetSetReducer = createReducer(
         const pathToSelection = path.slice(0, path.length - 1);
 
         for (const segment of pathToSelection) {
+          const parentExists = !!activeLevel[0];
+
+          if (!parentExists) {
+            activeLevel.push(
+              buildCategoryFacetValueRequest(segment, retrieveCount)
+            );
+          }
+
           const parent = activeLevel[0];
 
           if (segment !== parent.value) {
@@ -101,8 +109,8 @@ export const categoryFacetSetReducer = createReducer(
           return;
         }
 
-        const valueRequest = convertCategoryFacetValueToRequest(
-          selection,
+        const valueRequest = buildCategoryFacetValueRequest(
+          selection.value,
           retrieveCount
         );
         activeLevel.push(valueRequest);
@@ -190,11 +198,10 @@ function buildCategoryFacetRequest(
   };
 }
 
-function convertCategoryFacetValueToRequest(
-  categoryFacetValue: CategoryFacetValue,
+function buildCategoryFacetValueRequest(
+  value: string,
   retrieveCount: number
 ): CategoryFacetValueRequest {
-  const {value} = categoryFacetValue;
   return {
     value,
     state: 'selected',

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -82,9 +82,9 @@ export const categoryFacetSetReducer = createReducer(
 
         for (const segment of pathToSelection) {
           let parent = activeLevel[0];
-          const parentExists = !!parent;
+          const missingParent = !parent;
 
-          if (!parentExists || segment !== parent.value) {
+          if (missingParent || segment !== parent.value) {
             parent = buildCategoryFacetValueRequest(segment, retrieveCount);
             activeLevel.length = 0;
             activeLevel.push(parent);

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -81,18 +81,13 @@ export const categoryFacetSetReducer = createReducer(
         const pathToSelection = path.slice(0, path.length - 1);
 
         for (const segment of pathToSelection) {
-          const parentExists = !!activeLevel[0];
+          let parent = activeLevel[0];
+          const parentExists = !!parent;
 
-          if (!parentExists) {
-            activeLevel.push(
-              buildCategoryFacetValueRequest(segment, retrieveCount)
-            );
-          }
-
-          const parent = activeLevel[0];
-
-          if (segment !== parent.value) {
-            return;
+          if (!parentExists || segment !== parent.value) {
+            parent = buildCategoryFacetValueRequest(segment, retrieveCount);
+            activeLevel.length = 0;
+            activeLevel.push(parent);
           }
 
           parent.retrieveChildren = false;


### PR DESCRIPTION
Two changes to the `toggleCategoryFacetValue` action with this PR:

- It's now possible to deep select a category facet value if starting from a pristine state.
- If a category facet has an active path, it now gets overwritten by the new path instead of being a no-op.

Next step: support a string array as an argument.