### PR TITLE
fix(headless): trim query string before saving it in recent queries

### DIFF
--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -117,26 +117,6 @@ describe('recent-queries-slice', () => {
     ]);
   });
 
-  it('should not add an empty query to the list', () => {
-    const emptyQueries = ['', '     '];
-    for (const i in emptyQueries) {
-      state.queries = testQueries;
-      state.maxLength = 10;
-      const searchAction = executeSearch.fulfilled(
-        buildMockSearch({
-          queryExecuted: emptyQueries[i],
-          response: buildMockSearchResponse({}),
-        }),
-        '',
-        logSearchEvent({evt: 'foo'})
-      );
-
-      expect(recentQueriesReducer(state, searchAction).queries).toEqual(
-        testQueries
-      );
-    }
-  });
-
   it('should not add new recent query on search fulfilled if queue already contains the query', () => {
     const duplicates = ['what is a query', ' what is a query      '];
     for (const i in duplicates) {
@@ -153,6 +133,24 @@ describe('recent-queries-slice', () => {
 
       expect(recentQueriesReducer(state, searchAction).queries).toEqual(
         testQueries
+      );
+    }
+  });
+
+  it('should not add an empty query to the list', () => {
+    const emptyQueries = ['', '     '];
+    for (const i in emptyQueries) {
+      const searchAction = executeSearch.fulfilled(
+        buildMockSearch({
+          queryExecuted: emptyQueries[i],
+          response: buildMockSearchResponse({}),
+        }),
+        '',
+        logSearchEvent({evt: 'foo'})
+      );
+
+      expect(recentQueriesReducer(state, searchAction).queries.length).toEqual(
+        0
       );
     }
   });

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -12,7 +12,7 @@ import {
   RecentQueriesState,
 } from './recent-queries-state';
 
-describe('recent-queries slice', () => {
+describe('recent-queries-slice', () => {
   let state: RecentQueriesState;
 
   const testQuery = 'what is a query';
@@ -135,5 +135,26 @@ describe('recent-queries slice', () => {
         testQueries
       );
     }
+  });
+
+  it('should place the query at the start of the list if it already exists', () => {
+    state.queries = ['5', '4', '3', '2', '1'];
+    state.maxLength = 5;
+    const searchAction = executeSearch.fulfilled(
+      buildMockSearch({
+        queryExecuted: '3',
+        response: buildMockSearchResponse({}),
+      }),
+      '',
+      logSearchEvent({evt: 'foo'})
+    );
+
+    expect(recentQueriesReducer(state, searchAction).queries).toEqual([
+      '3',
+      '5',
+      '4',
+      '2',
+      '1',
+    ]);
   });
 });

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -134,4 +134,22 @@ describe('recent-queries slice', () => {
       testQueries
     );
   });
+
+  it('should not add new recent query on search fulfilled if queue already contains the query with extra whitespace', () => {
+    const otherTestQuery = ' what is a query      ';
+    state.queries = testQueries;
+    state.maxLength = 10;
+    const searchAction = executeSearch.fulfilled(
+      buildMockSearch({
+        queryExecuted: otherTestQuery,
+        response: buildMockSearchResponse({}),
+      }),
+      '',
+      logSearchEvent({evt: 'foo'})
+    );
+
+    expect(recentQueriesReducer(state, searchAction).queries).toEqual(
+      testQueries
+    );
+  });
 });

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -118,38 +118,22 @@ describe('recent-queries slice', () => {
   });
 
   it('should not add new recent query on search fulfilled if queue already contains the query', () => {
-    const otherTestQuery = 'what is a query';
-    state.queries = testQueries;
-    state.maxLength = 10;
-    const searchAction = executeSearch.fulfilled(
-      buildMockSearch({
-        queryExecuted: otherTestQuery,
-        response: buildMockSearchResponse({}),
-      }),
-      '',
-      logSearchEvent({evt: 'foo'})
-    );
+    const duplicates = ['what is a query', ' what is a query      '];
+    for (const i in duplicates) {
+      state.queries = testQueries;
+      state.maxLength = 10;
+      const searchAction = executeSearch.fulfilled(
+        buildMockSearch({
+          queryExecuted: duplicates[i],
+          response: buildMockSearchResponse({}),
+        }),
+        '',
+        logSearchEvent({evt: 'foo'})
+      );
 
-    expect(recentQueriesReducer(state, searchAction).queries).toEqual(
-      testQueries
-    );
-  });
-
-  it('should not add new recent query on search fulfilled if queue already contains the query with extra whitespace', () => {
-    const otherTestQuery = ' what is a query      ';
-    state.queries = testQueries;
-    state.maxLength = 10;
-    const searchAction = executeSearch.fulfilled(
-      buildMockSearch({
-        queryExecuted: otherTestQuery,
-        response: buildMockSearchResponse({}),
-      }),
-      '',
-      logSearchEvent({evt: 'foo'})
-    );
-
-    expect(recentQueriesReducer(state, searchAction).queries).toEqual(
-      testQueries
-    );
+      expect(recentQueriesReducer(state, searchAction).queries).toEqual(
+        testQueries
+      );
+    }
   });
 });

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -117,6 +117,26 @@ describe('recent-queries-slice', () => {
     ]);
   });
 
+  it('should not add an empty query to the list', () => {
+    const emptyQueries = ['', '     '];
+    for (const i in emptyQueries) {
+      state.queries = testQueries;
+      state.maxLength = 10;
+      const searchAction = executeSearch.fulfilled(
+        buildMockSearch({
+          queryExecuted: emptyQueries[i],
+          response: buildMockSearchResponse({}),
+        }),
+        '',
+        logSearchEvent({evt: 'foo'})
+      );
+
+      expect(recentQueriesReducer(state, searchAction).queries).toEqual(
+        testQueries
+      );
+    }
+  });
+
   it('should not add new recent query on search fulfilled if queue already contains the query', () => {
     const duplicates = ['what is a query', ' what is a query      '];
     for (const i in duplicates) {

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.ts
@@ -21,7 +21,7 @@ export const recentQueriesReducer = createReducer(
         state.queries = [];
       })
       .addCase(executeSearch.fulfilled, (state, action) => {
-        const query = action.payload.queryExecuted;
+        const query = action.payload.queryExecuted.trim();
         if (!query.length || state.queries.includes(query)) {
           return;
         }

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.ts
@@ -22,6 +22,9 @@ export const recentQueriesReducer = createReducer(
       })
       .addCase(executeSearch.fulfilled, (state, action) => {
         const query = action.payload.queryExecuted.trim();
+        if (!query.length) {
+          return;
+        }
         state.queries = state.queries.filter((q) => q !== query);
         const remaining = state.queries.slice(0, state.maxLength - 1);
         state.queries = [query, ...remaining];

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.ts
@@ -22,13 +22,9 @@ export const recentQueriesReducer = createReducer(
       })
       .addCase(executeSearch.fulfilled, (state, action) => {
         const query = action.payload.queryExecuted.trim();
-        if (!query.length || state.queries.includes(query)) {
-          return;
-        }
-        state.queries.unshift(query);
-        if (state.queries.length > state.maxLength) {
-          state.queries.pop();
-        }
+        state.queries = state.queries.filter((q) => q !== query);
+        const remaining = state.queries.slice(0, state.maxLength - 1);
+        state.queries = [query, ...remaining];
       });
   }
 );


### PR DESCRIPTION
trimming query string to avoid this:
![image-20210910-215307](https://user-images.githubusercontent.com/16785453/133847676-1b40aa6b-e8bf-4c77-9e04-5736f9f45b05.png)


