### PR TITLE
KIT-1019 support relative urls

### DIFF
--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -4,7 +4,7 @@ import {
   validatePayload,
   requiredNonEmptyString,
 } from '../../utils/validate-payload';
-import {StringValue, BooleanValue, Value} from '@coveo/bueno';
+import {BooleanValue, Value} from '@coveo/bueno';
 import {IRuntimeEnvironment} from 'coveo.analytics';
 
 const originSchemaOnConfigUpdate = () => nonEmptyString;
@@ -40,7 +40,7 @@ export const updateBasicConfiguration = createAction(
     validatePayload(payload, {
       accessToken: nonEmptyString,
       organizationId: nonEmptyString,
-      platformUrl: new StringValue({url: true, emptyAllowed: false}),
+      platformUrl: nonEmptyString,
     })
 );
 
@@ -83,7 +83,7 @@ export const updateSearchConfiguration = createAction(
   'configuration/updateSearchConfiguration',
   (payload: UpdateSearchConfigurationActionCreatorPayload) =>
     validatePayload(payload, {
-      apiBaseUrl: new StringValue({url: true, emptyAllowed: false}),
+      apiBaseUrl: nonEmptyString,
       pipeline: nonEmptyString,
       searchHub: nonEmptyString,
       timezone: nonEmptyString,
@@ -141,7 +141,7 @@ export const updateAnalyticsConfiguration = createAction(
       enabled: new BooleanValue({default: true}),
       originLevel2: originSchemaOnConfigUpdate(),
       originLevel3: originSchemaOnConfigUpdate(),
-      apiBaseUrl: new StringValue({url: true, emptyAllowed: false}),
+      apiBaseUrl: nonEmptyString,
       runtimeEnvironment: new Value(),
       anonymous: new BooleanValue({default: false}),
     })

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -75,6 +75,12 @@ describe('configuration slice', () => {
         )
       ).toEqual(expectedState);
     });
+
+    it('setting platformUrl to a relative url does not return an error', () => {
+      const platformUrl = '/rest/search/v2';
+      const action = updateBasicConfiguration({platformUrl});
+      expect('error' in action).toBe(false);
+    });
   });
 
   describe('updateAnalyticsConfiguration', () => {
@@ -128,6 +134,12 @@ describe('configuration slice', () => {
         )
       ).toEqual(expectedState);
     });
+
+    it('setting apiBaseUrl to a relative url does not return an error', () => {
+      const apiBaseUrl = '/rest/ua';
+      const action = updateAnalyticsConfiguration({apiBaseUrl});
+      expect('error' in action).toBe(false);
+    });
   });
 
   describe('updateSearchConfiguration', () => {
@@ -152,6 +164,7 @@ describe('configuration slice', () => {
         )
       ).toEqual(expectedState);
     });
+
     it('works on existing state', () => {
       const expectedState: ConfigurationState = {
         ...existingState,
@@ -172,6 +185,12 @@ describe('configuration slice', () => {
           })
         )
       ).toEqual(expectedState);
+    });
+
+    it('setting apiBaseUrl to a relative url does not return an error', () => {
+      const apiBaseUrl = '/rest/search/v2';
+      const action = updateSearchConfiguration({apiBaseUrl});
+      expect('error' in action).toBe(false);
     });
   });
 


### PR DESCRIPTION
Opting to loosen the validation to just a string, rather than needing to work with [complex regexs](https://github.com/coveo/ui-kit/pull/1020/files#diff-77f7c6dbefaa1941ae6e15438b7aa4c0dc17d9da6e387f5b39f0aabc6b99d36cR14).

https://coveord.atlassian.net/browse/KIT-1019