### PR TITLE
fix(quantic): show search interface once initialized

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -434,4 +434,11 @@
         <protected>false</protected>
         <shortDescription>Expand [component label]</shortDescription>
     </labels>
+    <labels>
+        <fullName>quantic_Loading</fullName>
+        <value>Loading</value>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Indicates that interface is loading</shortDescription>
+    </labels>
 </CustomLabels>

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.css
@@ -1,0 +1,7 @@
+.search__content_hidden {
+  display: none;
+}
+
+.search__loading-container {
+  height: 10rem;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.html
@@ -1,5 +1,11 @@
 <template>
   <div class={flexipageRegionWidth}>
-    <slot></slot>
+    <template if:false={isInitialized}>
+      <div class="search__loading-container">
+        <lightning-spinner alternative-text={labels.loading} size="large"></lightning-spinner>
+      </div>
+    </template>
+
+    <slot class={contentCssClasses}></slot>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -9,6 +9,7 @@ import {
 import getHeadlessConfiguration from '@salesforce/apex/HeadlessController.getHeadlessConfiguration';
 // @ts-ignore
 import {STANDALONE_SEARCH_BOX_STORAGE_KEY} from 'c/quanticUtils';
+import loading from '@salesforce/label/c.quantic_Loading';
 
 export default class QuanticSearchInterface extends LightningElement {
   /** @type {any} */
@@ -37,6 +38,12 @@ export default class QuanticSearchInterface extends LightningElement {
 
   /** @type {import("coveo").Unsubscribe} */
   unsubscribeUrlManager;
+
+  isInitialized = false;
+
+  labels = {
+    loading,
+  };
 
   connectedCallback() {
     loadDependencies(this).then((CoveoHeadless) => {
@@ -88,6 +95,7 @@ export default class QuanticSearchInterface extends LightningElement {
       );
       if (!redirectData) {
         engine.executeFirstSearch();
+        this.isInitialized = true;
         return;
       }
       window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
@@ -96,6 +104,8 @@ export default class QuanticSearchInterface extends LightningElement {
       engine.dispatch(updateQuery({q: value}));
       engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
     }
+
+    this.isInitialized = true;
   };
 
   get fragment() {
@@ -123,4 +133,8 @@ export default class QuanticSearchInterface extends LightningElement {
   onHashChange = () => {
     this.urlManager.synchronize(this.fragment);
   };
+
+  get contentCssClasses() {
+    return !this.isInitialized ? 'search__content_hidden' : '';
+  }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -93,16 +93,16 @@ export default class QuanticSearchInterface extends LightningElement {
       const redirectData = window.localStorage.getItem(
         STANDALONE_SEARCH_BOX_STORAGE_KEY
       );
-      if (!redirectData) {
+
+      if (redirectData) {
+        window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
+        const {value, analytics} = JSON.parse(redirectData);
+        
+        engine.dispatch(updateQuery({q: value}));
+        engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
+      } else {
         engine.executeFirstSearch();
-        this.isInitialized = true;
-        return;
       }
-      window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
-      const {value, analytics} = JSON.parse(redirectData);
-      
-      engine.dispatch(updateQuery({q: value}));
-      engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
     }
 
     this.isInitialized = true;

--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -220,4 +220,8 @@
         <label>Agrandir {{0}}</label>
         <name>quantic_Expand</name>
     </customLabels>
+    <customLabels>
+        <label>Chargement</label>
+        <name>quantic_Loading</name>
+    </customLabels>
 </Translations>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4092

The reported issue is about flickering when data from the URL hash is loaded into the Quantic search interface. The issue happens because the search interface, and components are all rendered before the URL manager could be initialized. So it makes the search interface display and then update with the URL data. The issue mentions the tab component, but all other components behave the same way.

The proposed solution is to display a loading spinner until the search interface is fully initialized (see [this video](https://share.vidyard.com/watch/iXMQrEj5BzqkEVkQqFPA7n?)).