### PR TITLE
feat(productlisting): allow setting the additional fields + add facet manager and missing interfaces

### DIFF
--- a/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
+++ b/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
@@ -12,6 +12,7 @@ import {buildThunkExtraArguments} from '../thunk-extra-arguments';
 import {
   ProductListingEngineConfiguration,
   productListingEngineConfigurationSchema,
+  getSampleProductListingEngineConfiguration,
 } from './product-listing-engine-configuration';
 import {ProductListingAppState} from '../../state/product-listing-app-state';
 import {ProductListingAPIClient} from '../../api/commerce/product-listings/product-listing-api-client';
@@ -28,7 +29,7 @@ import {
 export {
   ProductListingEngineConfiguration,
   getSampleProductListingEngineConfiguration,
-} from './product-listing-engine-configuration';
+};
 
 const productListingEngineReducers = {productListing};
 type ProductListingEngineReducers = typeof productListingEngineReducers;

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
@@ -1,0 +1,48 @@
+import {facetOptions, productListing} from '../../../app/reducers';
+import {loadReducerError} from '../../../utils/errors';
+import {sortFacets} from '../../../utils/facet-utils';
+import {buildController} from '../../controller/headless-controller';
+import {
+  FacetManager,
+  FacetManagerPayload,
+} from '../../facet-manager/headless-facet-manager';
+import {ProductListingSection} from '../../../state/state-sections';
+import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
+
+/**
+ * Creates a `FacetManager` instance.
+ *
+ * @param productListingEngine - The headless engine.
+ */
+export function buildFacetManager(
+  productListingEngine: ProductListingEngine
+): FacetManager {
+  if (!loadFacetManagerReducers(productListingEngine)) {
+    throw loadReducerError;
+  }
+
+  const controller = buildController(productListingEngine);
+  const getState = () => productListingEngine.state;
+
+  return {
+    ...controller,
+
+    sort<T>(facets: FacetManagerPayload<T>[]) {
+      return sortFacets(facets, this.state.facetIds);
+    },
+
+    get state() {
+      const facets = getState().productListing.facets.results;
+      const facetIds = facets.map((f) => f.facetId);
+
+      return {facetIds};
+    },
+  };
+}
+
+function loadFacetManagerReducers(
+  productListingEngine: ProductListingEngine
+): productListingEngine is ProductListingEngine<ProductListingSection> {
+  productListingEngine.addReducers({productListing, facetOptions});
+  return true;
+}

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
@@ -12,11 +12,12 @@ import {configuration} from '../../app/reducers';
 import {productListingReducer} from '../../features/product-listing/product-listing-slice';
 import {
   fetchProductListing,
+  setAdditionalFields,
   setProductListingUrl,
 } from '../../features/product-listing/product-listing-actions';
 
 describe('headless product-listing', () => {
-  let productRecommendations: ProductListingController;
+  let productListing: ProductListingController;
   let engine: MockProductListingEngine;
 
   const baseOptions: Partial<ProductListingOptions> = {
@@ -25,7 +26,7 @@ describe('headless product-listing', () => {
 
   beforeEach(() => {
     engine = buildMockProductListingEngine();
-    productRecommendations = buildProductListing(engine, {
+    productListing = buildProductListing(engine, {
       options: baseOptions,
     });
   });
@@ -46,8 +47,23 @@ describe('headless product-listing', () => {
     expectContainAction(setProductListingUrl);
   });
 
+  it('dispatches #setAdditionalFields on load if additionalFields is defined', () => {
+    productListing = buildProductListing(engine, {
+      options: {
+        ...baseOptions,
+        additionalFields: ['afield'],
+      },
+    });
+    expectContainAction(setAdditionalFields);
+  });
+
   it('refresh dispatches #fetchProductListing', () => {
-    productRecommendations.refresh();
+    productListing.refresh();
     expectContainAction(fetchProductListing.pending);
+  });
+
+  it('dispatches #setAdditionalFields on load if additionalFields is defined', () => {
+    productListing.setAdditionalFields(['afield']);
+    expectContainAction(setAdditionalFields);
   });
 });

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -1,9 +1,10 @@
 import {
   fetchProductListing,
+  setAdditionalFields,
   setProductListingUrl,
 } from '../../features/product-listing/product-listing-actions';
 import {buildController} from '../controller/headless-controller';
-import {Schema, SchemaValues, StringValue} from '@coveo/bueno';
+import {ArrayValue, Schema, SchemaValues, StringValue} from '@coveo/bueno';
 import {configuration, productListing} from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
@@ -13,6 +14,9 @@ const optionsSchema = new Schema({
   url: new StringValue({
     required: true,
     url: true,
+  }),
+  additionalFields: new ArrayValue<string>({
+    each: new StringValue(),
   }),
 });
 
@@ -49,17 +53,38 @@ export const buildProductListing = (
     })
   );
 
+  if (options.additionalFields) {
+    dispatch(
+      setAdditionalFields({
+        additionalFields: options.additionalFields,
+      })
+    );
+  }
+
   return {
     ...controller,
 
     get state() {
-      const {products, error, isLoading} = getState().productListing;
+      const {
+        products,
+        error,
+        isLoading,
+        responseId,
+        additionalFields,
+        url,
+      } = getState().productListing;
       return {
         products,
         error,
         isLoading,
+        responseId,
+        additionalFields,
+        url,
       };
     },
+
+    setAdditionalFields: (additionalFields: string[]) =>
+      dispatch(setAdditionalFields({additionalFields})),
 
     refresh: () => dispatch(fetchProductListing()),
   };

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -16,7 +16,9 @@ const optionsSchema = new Schema({
     url: true,
   }),
   additionalFields: new ArrayValue<string>({
-    each: new StringValue(),
+    each: new StringValue({
+      emptyAllowed: false,
+    }),
   }),
 });
 

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -57,7 +57,10 @@ export const setAdditionalFields = createAction(
     validatePayload(payload, {
       additionalFields: new ArrayValue({
         required: true,
-        each: new StringValue(),
+        each: new StringValue({
+          required: true,
+          emptyAllowed: false,
+        }),
       }),
     })
 );

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -22,9 +22,10 @@ import {
   ProductListingSuccessResponse,
 } from '../../api/commerce/product-listings/product-listing-request';
 import {validatePayload} from '../../utils/validate-payload';
-import {StringValue} from '@coveo/bueno';
+import {ArrayValue, StringValue} from '@coveo/bueno';
 import {SortBy} from '../sort/sort';
 import {ProductListingState} from './product-listing-state';
+
 export interface SetProductListingUrlPayload {
   /**
    * The url used to determine which product listing to fetch.
@@ -39,6 +40,24 @@ export const setProductListingUrl = createAction(
       url: new StringValue({
         required: true,
         url: true,
+      }),
+    })
+);
+
+export interface SetAdditionalFieldsPayload {
+  /**
+   * The additional fields to fetch with the product listing.
+   */
+  additionalFields: string[];
+}
+
+export const setAdditionalFields = createAction(
+  'productlisting/setAdditionalFields',
+  (payload: SetAdditionalFieldsPayload) =>
+    validatePayload(payload, {
+      additionalFields: new ArrayValue({
+        required: true,
+        each: new StringValue(),
       }),
     })
 );

--- a/packages/headless/src/features/product-listing/product-listing-slice.test.ts
+++ b/packages/headless/src/features/product-listing/product-listing-slice.test.ts
@@ -6,6 +6,7 @@ import {
 import {productListingReducer} from './product-listing-slice';
 import {
   fetchProductListing,
+  setAdditionalFields,
   setProductListingUrl,
 } from './product-listing-actions';
 import {buildFetchProductListingResponse} from '../../test/mock-product-listing';
@@ -31,6 +32,17 @@ describe('product-listing-slice', () => {
         })
       ).url
     ).toEqual('http://bloup.com/🐬');
+  });
+
+  it('should allow to set the additional fields', () => {
+    expect(
+      productListingReducer(
+        state,
+        setAdditionalFields({
+          additionalFields: ['ensure'],
+        })
+      ).additionalFields
+    ).toEqual(['ensure']);
   });
 
   it('when a fetchProductListing fulfilled is received, it updates the state to the received payload', () => {

--- a/packages/headless/src/features/product-listing/product-listing-slice.ts
+++ b/packages/headless/src/features/product-listing/product-listing-slice.ts
@@ -2,6 +2,7 @@ import {createReducer} from '@reduxjs/toolkit';
 import {getProductListingInitialState} from './product-listing-state';
 import {
   fetchProductListing,
+  setAdditionalFields,
   setProductListingUrl,
 } from './product-listing-actions';
 
@@ -12,6 +13,9 @@ export const productListingReducer = createReducer(
     builder
       .addCase(setProductListingUrl, (state, action) => {
         state.url = action.payload.url;
+      })
+      .addCase(setAdditionalFields, (state, action) => {
+        state.additionalFields = action.payload.additionalFields;
       })
       .addCase(fetchProductListing.rejected, (state, action) => {
         state.error = action.payload ? action.payload : null;

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -8,8 +8,15 @@ export {
   getSampleProductListingEngineConfiguration,
 } from './app/product-listing-engine/product-listing-engine';
 
+export {ProductRecommendation} from './api/search/search/product-recommendation';
+
 // Actions
 export * from './features/configuration/configuration-actions-loader';
+export {
+  loadProductListingActions,
+  ProductListingActionCreators,
+  SetProductListingUrlPayload,
+} from './features/product-listing/product-listing-actions-loader';
 
 // Controllers
 export {
@@ -49,6 +56,8 @@ export {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
+
+export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 
 export {
   Facet,


### PR DESCRIPTION
[COM-1202]

We were trying out the product listing in our demo environment and we needed all of this to properly render our result templates, so here we go :)

Should be simple enough, there are two commits with simple changes.

[COM-1202]: https://coveord.atlassian.net/browse/COM-1202