### PR TITLE
fix(quantic): fix the facet when click on collapse/expand button

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -118,7 +118,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get hasSearchResults() {
-    return this.facet?.state.facetSearch.values?.length !== 0;
+    return this.getSearchValues().length > 0;
   }
 
   get canShowMoreSearchResults() {
@@ -126,8 +126,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get facetSearchResults() {
-    const results = this.facet.state.facetSearch.values ?? [];
-    return results.map((result, index) => ({
+    return this.getSearchValues().map((result, index) => ({
       value: result.rawValue,
       index: index,
       numberOfResults: result.count,
@@ -179,6 +178,10 @@ export default class QuanticCategoryFacet extends LightningElement {
 
   get isFacetSearchActive() {
     return this.input?.value !== '';
+  }
+
+  getSearchValues() {
+    return this.facet?.state.facetSearch?.values ?? [];
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -118,7 +118,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get hasSearchResults() {
-    return this.facet?.state.facetSearch.values.length !== 0;
+    return this.facet?.state.facetSearch.values?.length !== 0;
   }
 
   get canShowMoreSearchResults() {
@@ -126,8 +126,8 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get facetSearchResults() {
-    const results = this.facet.state.facetSearch.values;
-    return results?.map((result, index) => ({
+    const results = this.facet.state.facetSearch.values ?? [];
+    return results.map((result, index) => ({
       value: result.rawValue,
       index: index,
       numberOfResults: result.count,

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -181,7 +181,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   getSearchValues() {
-    return this.facet?.state.facetSearch?.values ?? [];
+    return this.facet?.state?.facetSearch?.values ?? [];
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -127,7 +127,7 @@ export default class QuanticCategoryFacet extends LightningElement {
 
   get facetSearchResults() {
     const results = this.facet.state.facetSearch.values;
-    return results.map((result, index) => ({
+    return results?.map((result, index) => ({
       value: result.rawValue,
       index: index,
       numberOfResults: result.count,
@@ -135,7 +135,7 @@ export default class QuanticCategoryFacet extends LightningElement {
       localizedPath: this.buildPath(result.path) ,
       highlightedResult: this.highlightResult(
         result.displayValue,
-        this.input.value
+        this.input?.value
       ),
     }));
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -3,7 +3,7 @@ import {
   registerComponentForInit,
   initializeWithHeadless,
 } from 'c/quanticHeadlessLoader';
-import {I18nUtils} from 'c/quanticUtils';
+import {I18nUtils, regexEncode} from 'c/quanticUtils';
 
 import showMore from '@salesforce/label/c.quantic_ShowMore';
 import showLess from '@salesforce/label/c.quantic_ShowLess';
@@ -140,14 +140,14 @@ export default class QuanticFacet extends LightningElement {
 
   get facetSearchResults() {
     const results = this.facet.state.facetSearch.values;
-    return results.map((result) => ({
+    return results?.map((result) => ({
       value: result.rawValue,
       state: 'idle',
       numberOfResults: result.count,
       checked: false,
       highlightedResult: this.highlightResult(
         result.displayValue,
-        this.input.value
+        this.input?.value
       ),
     }));
   }
@@ -234,19 +234,17 @@ export default class QuanticFacet extends LightningElement {
   }
 
   clearInput() {
-    this.input.value = '';
-    this.facet.facetSearch.updateText(this.input?.value);
+    if(this.input) {
+      this.input.value = '';
+    }
+    this.facet.facetSearch.updateText('');
   }
 
   highlightResult(result, query) {
     if (!query || query.trim() === '') {
       return result;
     }
-    const regex = new RegExp(`(${this.regexEncode(query)})`, 'i');
+    const regex = new RegExp(`(${regexEncode(query)})`, 'i');
     return result.replace(regex, '<b class="facet__search-result_highlight">$1</b>');
-  }
-
-  regexEncode(value) {
-    return value.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -135,12 +135,12 @@ export default class QuanticFacet extends LightningElement {
   }
 
   get hasSearchResults() {
-    return this.facet.state.facetSearch.values.length !== 0;
+    return this.facet.state.facetSearch.values?.length !== 0;
   }
 
   get facetSearchResults() {
-    const results = this.facet.state.facetSearch.values;
-    return results?.map((result) => ({
+    const results = this.facet.state.facetSearch.values ?? [];
+    return results.map((result) => ({
       value: result.rawValue,
       state: 'idle',
       numberOfResults: result.count,

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -185,7 +185,7 @@ export default class QuanticFacet extends LightningElement {
   }
 
   getSearchValues() {
-    return this.facet?.state.facetSearch?.values ?? [];
+    return this.facet?.state?.facetSearch?.values ?? [];
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -135,12 +135,11 @@ export default class QuanticFacet extends LightningElement {
   }
 
   get hasSearchResults() {
-    return this.facet.state.facetSearch.values?.length !== 0;
+    return this.getSearchValues().length > 0;
   }
 
   get facetSearchResults() {
-    const results = this.facet.state.facetSearch.values ?? [];
-    return results.map((result) => ({
+    return this.getSearchValues().map((result) => ({
       value: result.rawValue,
       state: 'idle',
       numberOfResults: result.count,
@@ -183,6 +182,10 @@ export default class QuanticFacet extends LightningElement {
 
   get isFacetSearchActive() {
     return this.input?.value !== '';
+  }
+
+  getSearchValues() {
+    return this.facet?.state.facetSearch?.values ?? [];
   }
 
   /**


### PR DESCRIPTION
The bug happend when we insert text in the iput search of the facet, then we click collapse button and expand button => we got this error message 

![image](https://user-images.githubusercontent.com/85293211/134237546-f5ad019b-876c-4d7b-8cc3-ffd11ab1e6bd.png)

I also add some other verification to avoid problem like we had this morning when the search results are null
