### PR TITLE
feat(core): remove executeSearch from date and numeric facets actions

### DIFF
--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -33,6 +33,8 @@ import {configuration, dateFacetSet, search} from '../../../../app/reducers';
 import {loadReducerError} from '../../../../utils/errors';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
 import {deselectAllFacetValues} from '../../../../features/facets/facet-set/facet-set-actions';
+import {executeSearch} from '../../../../features/search/search-actions';
+import {getAnalyticsActionForToggleRangeFacetSelect} from '../../../../features/facets/range-facets/generic/range-facet-utils';
 
 export {
   DateFacetOptions,
@@ -169,6 +171,11 @@ export function buildDateFacet(
 
   const handleToggleSelect = (selection: DateFacetValue) => {
     dispatch(executeToggleDateFacetSelect({facetId, selection}));
+    dispatch(
+      executeSearch(
+        getAnalyticsActionForToggleRangeFacetSelect(facetId, selection)
+      )
+    );
   };
 
   return {

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -32,6 +32,8 @@ import {configuration, numericFacetSet, search} from '../../../../app/reducers';
 import {loadReducerError} from '../../../../utils/errors';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
 import {deselectAllFacetValues} from '../../../../features/facets/facet-set/facet-set-actions';
+import {executeSearch} from '../../../../features/search/search-actions';
+import {getAnalyticsActionForToggleRangeFacetSelect} from '../../../../features/facets/range-facets/generic/range-facet-utils';
 
 export {
   buildNumericRange,
@@ -168,6 +170,11 @@ export function buildNumericFacet(
 
   const handleToggleSelect = (selection: NumericFacetValue) => {
     dispatch(executeToggleNumericFacetSelect({facetId, selection}));
+    dispatch(
+      executeSearch(
+        getAnalyticsActionForToggleRangeFacetSelect(facetId, selection)
+      )
+    );
   };
 
   return {
@@ -180,7 +187,7 @@ export function buildNumericFacet(
         dispatch(deselectAllFacetValues(facetId));
       }
 
-      dispatch(executeToggleNumericFacetSelect({facetId, selection}));
+      handleToggleSelect(selection);
     },
 
     get state() {

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.test.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.test.ts
@@ -21,7 +21,11 @@ describe('date facet controller actions', () => {
           payload: {facetId, selection},
         }),
         expect.objectContaining({
-          type: 'rangeFacet/executeToggleSelect/pending',
+          type: 'rangeFacet/executeToggleSelect',
+        }),
+        expect.objectContaining({
+          type: 'facetOptions/update',
+          payload: {freezeFacetOrder: true},
         }),
       ])
     );

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
@@ -10,6 +10,7 @@ import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {RecordValue} from '@coveo/bueno';
 import {dateFacetValueDefinition} from '../generic/range-facet-validate-payload';
 import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
+import {updateFacetOptions} from '../../../facet-options/facet-options-actions';
 
 const definition = {
   facetId: facetIdDefinition,
@@ -34,5 +35,6 @@ export const executeToggleDateFacetSelect = createAsyncThunk<
     validatePayload(payload, definition);
     dispatch(toggleSelectDateFacetValue(payload));
     dispatch(executeToggleRangeFacetSelect(payload));
+    dispatch(updateFacetOptions({freezeFacetOrder: true}));
   }
 );

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
@@ -1,6 +1,5 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {DateFacetValue} from './interfaces/response';
-import {AsyncThunkSearchOptions} from '../../../../api/search/search-api-client';
 import {
   ConfigurationSection,
   DateFacetSection,
@@ -10,6 +9,7 @@ import {toggleSelectDateFacetValue} from './date-facet-actions';
 import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {RecordValue} from '@coveo/bueno';
 import {dateFacetValueDefinition} from '../generic/range-facet-validate-payload';
+import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
 
 const definition = {
   facetId: facetIdDefinition,
@@ -27,7 +27,7 @@ export const executeToggleDateFacetSelect = createAsyncThunk<
     facetId: string;
     selection: DateFacetValue;
   },
-  AsyncThunkSearchOptions<ConfigurationSection & DateFacetSection>
+  AsyncThunkOptions<ConfigurationSection & DateFacetSection>
 >(
   'dateFacet/executeToggleSelect',
   (payload, {dispatch, extra: {validatePayload}}) => {

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.test.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.test.ts
@@ -16,11 +16,7 @@ describe('range facet controller actions', () => {
 
     expect(engine.actions).toEqual([
       expect.objectContaining({
-        type: 'rangeFacet/executeToggleSelect/pending',
-      }),
-      expect.objectContaining({
-        type: 'facetOptions/update',
-        payload: {freezeFacetOrder: true},
+        type: 'rangeFacet/executeToggleSelect',
       }),
     ]);
   });

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.test.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.test.ts
@@ -22,9 +22,6 @@ describe('range facet controller actions', () => {
         type: 'facetOptions/update',
         payload: {freezeFacetOrder: true},
       }),
-      expect.objectContaining({
-        type: 'search/executeSearch/pending',
-      }),
     ]);
   });
 });

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
@@ -1,13 +1,11 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
-import {AsyncThunkSearchOptions} from '../../../../api/search/search-api-client';
 import {ConfigurationSection} from '../../../../state/state-sections';
-import {getAnalyticsActionForToggleRangeFacetSelect} from './range-facet-utils';
 import {updateFacetOptions} from '../../../facet-options/facet-options-actions';
-import {executeSearch} from '../../../search/search-actions';
 import {
   RangeFacetSelectionPayload,
   rangeFacetSelectionPayloadDefinition,
 } from './range-facet-validate-payload';
+import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
 
 /**
  * Executes a search with the appropriate analytics for a toggle range facet value
@@ -16,7 +14,7 @@ import {
 export const executeToggleRangeFacetSelect = createAsyncThunk<
   void,
   RangeFacetSelectionPayload,
-  AsyncThunkSearchOptions<ConfigurationSection>
+  AsyncThunkOptions<ConfigurationSection>
 >(
   'rangeFacet/executeToggleSelect',
   ({facetId, selection}, {dispatch, extra: {validatePayload}}) => {
@@ -25,12 +23,6 @@ export const executeToggleRangeFacetSelect = createAsyncThunk<
       rangeFacetSelectionPayloadDefinition(selection)
     );
 
-    const analyticsAction = getAnalyticsActionForToggleRangeFacetSelect(
-      facetId,
-      selection
-    );
-
     dispatch(updateFacetOptions({freezeFacetOrder: true}));
-    dispatch(executeSearch(analyticsAction));
   }
 );

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
@@ -1,28 +1,19 @@
-import {createAsyncThunk} from '@reduxjs/toolkit';
-import {ConfigurationSection} from '../../../../state/state-sections';
-import {updateFacetOptions} from '../../../facet-options/facet-options-actions';
+import {createAction} from '@reduxjs/toolkit';
 import {
   RangeFacetSelectionPayload,
   rangeFacetSelectionPayloadDefinition,
 } from './range-facet-validate-payload';
-import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
+import {validatePayload} from '../../../../utils/validate-payload';
 
 /**
  * Executes a search with the appropriate analytics for a toggle range facet value
  * @param payload (RangeFacetSelectionPayload) Object specifying the target facet and selection.
  */
-export const executeToggleRangeFacetSelect = createAsyncThunk<
-  void,
-  RangeFacetSelectionPayload,
-  AsyncThunkOptions<ConfigurationSection>
->(
+export const executeToggleRangeFacetSelect = createAction(
   'rangeFacet/executeToggleSelect',
-  ({facetId, selection}, {dispatch, extra: {validatePayload}}) => {
+  (payload: RangeFacetSelectionPayload) =>
     validatePayload(
-      {facetId, selection},
-      rangeFacetSelectionPayloadDefinition(selection)
-    );
-
-    dispatch(updateFacetOptions({freezeFacetOrder: true}));
-  }
+      payload,
+      rangeFacetSelectionPayloadDefinition(payload.selection)
+    )
 );

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.test.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.test.ts
@@ -21,7 +21,11 @@ describe('numeric facet controller actions', () => {
           payload: {facetId, selection},
         }),
         expect.objectContaining({
-          type: 'rangeFacet/executeToggleSelect/pending',
+          type: 'rangeFacet/executeToggleSelect',
+        }),
+        expect.objectContaining({
+          type: 'facetOptions/update',
+          payload: {freezeFacetOrder: true},
         }),
       ])
     );

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.ts
@@ -10,6 +10,7 @@ import {toggleSelectNumericFacetValue} from './numeric-facet-actions';
 import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {RecordValue} from '@coveo/bueno';
 import {numericFacetValueDefinition} from '../generic/range-facet-validate-payload';
+import {updateFacetOptions} from '../../../facet-options/facet-options-actions';
 
 const definition = {
   facetId: facetIdDefinition,
@@ -36,5 +37,6 @@ export const executeToggleNumericFacetSelect = createAsyncThunk<
     validatePayload(payload, definition);
     dispatch(toggleSelectNumericFacetValue(payload));
     dispatch(executeToggleRangeFacetSelect(payload));
+    dispatch(updateFacetOptions({freezeFacetOrder: true}));
   }
 );


### PR DESCRIPTION
[COM-1202]

After doing the category facet, I decided to split the date and numeric one even more. So here, I am simply removing `executeSearch` from the actions. 

I double-checked that they were not exposed to clients.

Next step is to create the "core" implementation of those components

[COM-1202]: https://coveord.atlassian.net/browse/COM-1202