### PR TITLE
fix(atomic): add .snyk file to ignore unknown @salesforce-ux/design-system license

### DIFF
--- a/packages/atomic/.snyk
+++ b/packages/atomic/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'SNYK:LIC:NPM:SALESFORCE-UX:DESIGN-SYSTEM:UNKNOWN':
+    - '*':
+        reason: None Given
+        expires: 2031-09-22T15:43:23.605Z
+        created: 2021-09-22T15:43:23.611Z
+version: v1.22.1
+patch: {}

--- a/packages/atomic/.snyk
+++ b/packages/atomic/.snyk
@@ -3,7 +3,7 @@
 ignore:
   'SNYK:LIC:NPM:SALESFORCE-UX:DESIGN-SYSTEM:UNKNOWN':
     - '*':
-        reason: None Given
+        reason: License is described in the Readme https://github.com/salesforce-ux/design-system#licenses
         expires: 2031-09-22T15:43:23.605Z
         created: 2021-09-22T15:43:23.611Z
 version: v1.22.1


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1022

Snyk issue: https://app.snyk.io/org/coveo-jsui/project/c9e8d9ee-3d2d-473c-91b3-4c38b42f2f50#issue-snyk:lic:npm:salesforce-ux:design-system:Unknown

Slack thread: https://coveo.slack.com/archives/GDGFC1C2W/p1632254742000800

The dependency seems to follow correct option https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license
```
{
  "license" : "SEE LICENSE IN <filename>"
}
```

Other than ignoring the error, which is in some sense a false flag, I don't see a way to say "@salesforce-ux/design-system" is using X license. Open to other ideas...