### PR TITLE
fix(quantic): improve/add missing quantic facet tests

### DIFF
--- a/packages/quantic/cypress/integration/example-search.cypress.ts
+++ b/packages/quantic/cypress/integration/example-search.cypress.ts
@@ -6,9 +6,10 @@ import {
   sortByDateDescending,
   selectRegularFacetValue,
 } from '../page-objects/example-search';
+import {InterceptAliases} from '../page-objects/search';
 
 describe('example-search', () => {
-  const pageUrl = `${Cypress.env('examplesUrl')}/s/full-search-example`;
+  const pageUrl = 's/full-search-example';
 
   Cypress.on('uncaught:exception', (err) => {
     if (
@@ -25,7 +26,7 @@ describe('example-search', () => {
   });
 
   beforeEach(() => {
-    cy.visit(pageUrl).then(setupAliases).wait('@search');
+    cy.visit(pageUrl).then(setupAliases).wait(InterceptAliases.Search);
   });
 
   it('should load results automatically', () => {
@@ -43,13 +44,15 @@ describe('example-search', () => {
     it('should trigger query when selecting a facet value', () => {
       cy.visit(pageUrl)
         .then(setupAliases)
-        .wait('@search')
+        .wait(InterceptAliases.Search)
         .then((interception) => {
           const firstFacetValue = interception.response?.body.facets.find(
             (f) => f.field === 'objecttype'
           ).values[0].value;
 
-          selectRegularFacetValue(firstFacetValue).wait('@search');
+          selectRegularFacetValue(firstFacetValue).wait(
+            InterceptAliases.Search
+          );
         });
     });
   });
@@ -57,7 +60,7 @@ describe('example-search', () => {
   describe('when typing a search query', () => {
     it('should trigger query when typing in searchbox', () => {
       searchFor('test')
-        .wait('@search')
+        .wait(InterceptAliases.Search)
         .then((interception) =>
           assert.equal(interception.request.body.q, 'test')
         )
@@ -69,7 +72,7 @@ describe('example-search', () => {
   describe('when changing the sorting', () => {
     it('should trigger query when changing the sorting', () => {
       cy.then(sortByDateDescending)
-        .wait('@search')
+        .wait(InterceptAliases.Search)
         .then((interception) =>
           assert.equal(
             interception.request.body.sortCriteria,
@@ -84,7 +87,7 @@ describe('example-search', () => {
       cy.get(search.summary)
         .should('contain.text', 'Results 1-10')
         .then(() => selectResultPage(2))
-        .wait('@search')
+        .wait(InterceptAliases.Search)
         .then((interception) =>
           assert.equal(interception.request.body.firstResult, 10)
         )

--- a/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
+++ b/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
@@ -57,6 +57,22 @@ export function baseFacetExpectations(selector: BaseFacetSelector) {
       });
     },
 
+    facetValuesEqual: (responseValuesAlias: string) => {
+      it('should contain facet values in specific order', () => {
+        cy.get(responseValuesAlias).then((responseValues) => {
+          selector
+            .valueLabel()
+            .should('have.length', responseValues.length)
+            .then((elements) => {
+              return Cypress.$.makeArray(elements).map(
+                (element) => element.innerText
+              );
+            })
+            .should('deep.equal', responseValues);
+        });
+      });
+    },
+
     logClearFacetValues: (field: string) => {
       it('should log the facet clear all to UA', () => {
         cy.wait(InterceptAliases.UA.Facet.ClearAll).then((interception) => {

--- a/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
+++ b/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
@@ -9,6 +9,12 @@ import {
 
 export function baseFacetExpectations(selector: BaseFacetSelector) {
   return {
+    displayLabel: (display: boolean) => {
+      it(`${should(display)} display the facet`, () => {
+        selector.label().should(display ? 'exist' : 'not.exist');
+      });
+    },
+
     labelContains: (label: string) => {
       it(`should have the label "${label}"`, () => {
         selector.label().contains(label);

--- a/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
+++ b/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
@@ -73,6 +73,12 @@ export function facetWithCheckboxExpectations(
   selector: FacetWithCheckboxSelector
 ) {
   return {
+    selectedCheckboxValuesContain: (value: string) => {
+      it(`${value} should be selected`, () => {
+        selector.selectedCheckboxValue().should('contain', value);
+      });
+    },
+
     numberOfSelectedCheckboxValues: (value: number) => {
       it(`should display ${value} selected checkbox values`, () => {
         selector.selectedCheckboxValue().should('have.length', value);

--- a/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
+++ b/packages/quantic/cypress/integration/facets/facet-common-expectations.ts
@@ -51,6 +51,12 @@ export function baseFacetExpectations(selector: BaseFacetSelector) {
       });
     },
 
+    numberOfValues: (value: number) => {
+      it(`should display ${value} facet values`, () => {
+        selector.values().should('have.length', value);
+      });
+    },
+
     logClearFacetValues: (field: string) => {
       it('should log the facet clear all to UA', () => {
         cy.wait(InterceptAliases.UA.Facet.ClearAll).then((interception) => {

--- a/packages/quantic/cypress/integration/facets/facet/facet-selectors.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet-selectors.ts
@@ -22,7 +22,7 @@ export const FacetSelectors: AllFacetSelectors = {
   facetValueLabelAtIndex: (index: number) =>
     FacetSelectors.valueLabel().eq(index),
   collapseButton: () => FacetSelectors.get().find('.facet__collapse'),
-  expandButton: () => FacetSelectors.get().find('.facet__collapse'),
+  expandButton: () => FacetSelectors.get().find('.facet__expand'),
 
   selectedCheckboxValue: () =>
     FacetSelectors.get().find('.facet__value-text.facet__value_selected'),

--- a/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
@@ -14,6 +14,10 @@ interface FacetOptions {
 }
 
 describe('Facet Test Suite', () => {
+  const defaultField = 'objecttype';
+  const defaultLabel = 'Type';
+  const defaultNumberOfValues = 8;
+
   function visitFacetPage(options: Partial<FacetOptions> = {}) {
     interceptSearch();
 
@@ -21,11 +25,15 @@ describe('Facet Test Suite', () => {
     configure(options);
   }
 
-  describe('with values', () => {
-    const defaultField = 'objecttype';
-    const defaultLabel = 'Type';
-    const defaultNumberOfValues = 8;
+  function loadFromUrlHash(
+    options: Partial<FacetOptions> = {},
+    urlHash: string
+  ) {
+    cy.visit(`${Cypress.env('examplesUrl')}/s/quantic-facet#${urlHash}`);
+    configure(options);
+  }
 
+  describe('with values', () => {
     function setupWithValues() {
       visitFacetPage({
         field: defaultField,
@@ -409,6 +417,27 @@ describe('Facet Test Suite', () => {
       before(setupNoSearch);
 
       Expect.displaySearchInput(false);
+    });
+  });
+
+  describe('with a selected value in the URL', () => {
+    const selectedValue = 'Account';
+
+    function loadWithSelectedValue() {
+      loadFromUrlHash(
+        {
+          field: defaultField,
+        },
+        `f[objecttype]=${selectedValue}`
+      );
+    }
+
+    describe('verify rendering', () => {
+      before(loadWithSelectedValue);
+
+      Expect.numberOfSelectedCheckboxValues(1);
+      Expect.numberOfIdleCheckboxValues(defaultNumberOfValues - 1);
+      Expect.selectedCheckboxValuesContain(selectedValue);
     });
   });
 });

--- a/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
@@ -122,12 +122,11 @@ describe('Facet Test Suite', () => {
 
       function searchForSingleValue() {
         setupWithValues();
-        FacetSelectors.valueLabel()
-          .first()
-          .then((element) => {
-            const facetValue = element.text();
-            FacetSelectors.searchInput().type(facetValue);
-          });
+        const singleValueQuery = 'account';
+        FacetSelectors.searchInput().type(singleValueQuery);
+        for (let i = 0; i < singleValueQuery.length; i++) {
+          cy.wait(InterceptAliases.FacetSearch);
+        }
       }
 
       describe('verify rendering', () => {
@@ -229,7 +228,7 @@ describe('Facet Test Suite', () => {
 
     describe('show more/less values', () => {
       describe('when facet has no more values', () => {
-        function setupWithAllValues() {
+        function showAllValues() {
           visitFacetPage({
             field: defaultField,
             label: defaultLabel,
@@ -239,7 +238,7 @@ describe('Facet Test Suite', () => {
         }
 
         describe('verify rendering', () => {
-          before(setupWithAllValues);
+          before(showAllValues);
 
           Expect.displayShowMoreButton(false);
           Expect.displayShowLessButton(false);
@@ -346,19 +345,21 @@ describe('Facet Test Suite', () => {
     });
   });
 
-  describe('with custom field and label', () => {
-    function setupCustomFieldAndLabel() {
+  describe('with custom field, label, and number of results', () => {
+    function setupCustomOptions() {
       visitFacetPage({
         field: 'language',
         label: 'Language',
+        numberOfValues: 3,
       });
     }
 
     describe('verify rendering', () => {
-      before(setupCustomFieldAndLabel);
+      before(setupCustomOptions);
 
       Expect.labelContains('Language');
       Expect.facetValueContains('English');
+      Expect.numberOfIdleCheckboxValues(3);
     });
   });
 
@@ -371,20 +372,6 @@ describe('Facet Test Suite', () => {
     });
 
     Expect.displayLabel(false);
-  });
-
-  describe('with custom number of results', () => {
-    function setupCustomNumberOfResults() {
-      visitFacetPage({
-        numberOfValues: 3,
-      });
-    }
-
-    describe('verify rendering', () => {
-      before(setupCustomNumberOfResults);
-
-      Expect.numberOfIdleCheckboxValues(3);
-    });
   });
 
   describe('with custom sorting', () => {

--- a/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
@@ -14,6 +14,8 @@ interface FacetOptions {
 }
 
 describe('Facet Test Suite', () => {
+  const pageUrl = `${Cypress.env('examplesUrl')}/s/quantic-facet`;
+
   const defaultField = 'objecttype';
   const defaultLabel = 'Type';
   const defaultNumberOfValues = 8;
@@ -21,7 +23,7 @@ describe('Facet Test Suite', () => {
   function visitFacetPage(options: Partial<FacetOptions> = {}) {
     interceptSearch();
 
-    cy.visit(`${Cypress.env('examplesUrl')}/s/quantic-facet`);
+    cy.visit(pageUrl);
     configure(options);
   }
 
@@ -29,7 +31,9 @@ describe('Facet Test Suite', () => {
     options: Partial<FacetOptions> = {},
     urlHash: string
   ) {
-    cy.visit(`${Cypress.env('examplesUrl')}/s/quantic-facet#${urlHash}`);
+    interceptSearch();
+
+    cy.visit(`${pageUrl}#${urlHash}`);
     configure(options);
   }
 
@@ -270,12 +274,7 @@ describe('Facet Test Suite', () => {
         describe('verify rendering', () => {
           before(showMoreValues);
 
-          it('should display twice the number of values', () => {
-            FacetSelectors.values().should(
-              'have.length',
-              smallNumberOfValues * 2
-            );
-          });
+          Expect.numberOfValues(smallNumberOfValues * 2);
         });
 
         describe('when clicking show more button again', () => {
@@ -288,12 +287,7 @@ describe('Facet Test Suite', () => {
           describe('verify rendering', () => {
             before(showMoreValuesAgain);
 
-            it('should display three times the number of values', () => {
-              FacetSelectors.values().should(
-                'have.length',
-                smallNumberOfValues * 3
-              );
-            });
+            Expect.numberOfValues(smallNumberOfValues * 3);
           });
 
           describe('when clicking show less button', () => {
@@ -306,12 +300,7 @@ describe('Facet Test Suite', () => {
             describe('verify rendering', () => {
               before(showLessValues);
 
-              it('should display the original number of values', () => {
-                FacetSelectors.values().should(
-                  'have.length',
-                  smallNumberOfValues
-                );
-              });
+              Expect.numberOfValues(smallNumberOfValues);
             });
           });
         });

--- a/packages/quantic/cypress/page-objects/example-search.ts
+++ b/packages/quantic/cypress/page-objects/example-search.ts
@@ -1,3 +1,5 @@
+import {InterceptAliases} from './search';
+
 export const selectors = {
   result: 'c-quantic-result',
   searchbox: 'c-quantic-search-box input[type="search"]',
@@ -13,7 +15,7 @@ export const setupAliases = () =>
       'POST',
       'https://platform.cloud.coveo.com/rest/search/v2?organizationId=searchuisamples'
     )
-    .as('search')
+    .as(InterceptAliases.Search.substring(1))
     .get(selectors.result, {timeout: 30000}); // Takes some time to load when server is cold
 
 export const selectRegularFacetValue = (value: string) =>

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line node/no-unpublished-import
+import {CyHttpMessages} from 'cypress/types/net-stubbing';
+
 export const InterceptAliases = {
   UA: {
     Facet: {
@@ -11,8 +14,8 @@ export const InterceptAliases = {
   FacetSearch: '@coveoFacetSearch',
 };
 
-export const interceptSearch = () =>
-  cy
+export function interceptSearch() {
+  return cy
     .intercept('POST', '**/rest/ua/v15/analytics/*', (req) => {
       switch (req.body.actionCause) {
         case 'facetClearAll':
@@ -35,3 +38,13 @@ export const interceptSearch = () =>
 
     .intercept('POST', '**/rest/search/v2/facet?*')
     .as(InterceptAliases.FacetSearch.substring(1));
+}
+
+export function extractFacetValues(
+  response: CyHttpMessages.IncomingResponse | undefined
+) {
+  if (!response || !response.body) {
+    throw new Error('A search response was expected');
+  }
+  return response.body.facets[0].values.map((v) => v.value);
+}

--- a/packages/quantic/cypress/plugins/index.ts
+++ b/packages/quantic/cypress/plugins/index.ts
@@ -1,7 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const getCommunityConfigFile = () => {
+interface CommunityConfig {
+  baseUrl?: string;
+  env?: {
+    examplesUrl?: string;
+  };
+}
+
+async function getCommunityConfigFile(): Promise<CommunityConfig> {
   const pathToConfigFile = path.resolve(
     'cypress',
     'plugins',
@@ -18,11 +25,18 @@ const getCommunityConfigFile = () => {
       }
     });
   });
-};
+}
 
 /**
  * @type {Cypress.PluginConfig}
  */
 module.exports = async () => {
-  return await getCommunityConfigFile();
+  const baseConfig = await getCommunityConfigFile();
+
+  const config = JSON.parse(JSON.stringify(baseConfig)) as CommunityConfig;
+  if (!baseConfig.baseUrl && baseConfig?.env?.examplesUrl) {
+    config.baseUrl = baseConfig?.env?.examplesUrl;
+  }
+
+  return config;
 };

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -3,7 +3,7 @@
     <div class="slds-size_1-of-1">
       <c-quantic-card-container title={label}>
         <lightning-button-icon
-          class="facet__collapse"
+          class={actionButtonCssClasses}
           slot="actions"
           onclick={toggleFacetVisibility}
           onmousedown={preventDefault}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -176,6 +176,10 @@ export default class QuanticFacet extends LightningElement {
     return this.isExpanded ? 'utility:dash' : 'utility:add';
   }
 
+  get actionButtonCssClasses() {
+    return this.isExpanded ? 'facet__collapse' : 'facet__expand';
+  }
+
   get actionButtonLabel() {
     const label = this.isExpanded ? this.labels.collapseFacet : this.labels.expandFacet;
     return I18nUtils.format(label, this.label);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4116

Some tests were missing for the quantic facet. This PR adds them along with some other improvements.

Added tests:

* load selected value from URL hash
* show more/less buttons
* facet with invalid field/no values
* invalid sorting

Other improvements:

* use specific selectors for expand and collapse
* moved facet search tests one level up (they were previously in the "selecting a value" block)
* added some new facet expectations
