### PR TITLE
fix(headless): prevent state update when all reducer keys already exist

### DIFF
--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -1,6 +1,7 @@
 import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments';
 import {buildEngine, CoreEngine, EngineOptions} from './engine';
 import * as Store from '../app/store';
+import {configuration} from './reducers';
 
 describe('engine', () => {
   let options: EngineOptions<{}>;
@@ -92,5 +93,17 @@ describe('engine', () => {
         name: 'coveo-headless',
       })
     );
+  });
+
+  it('when calling addReducers and all keys already exist, it does not update state', () => {
+    options.reducers = {configuration};
+    initEngine();
+
+    const stateListener = jest.fn();
+
+    engine.subscribe(stateListener);
+    engine.addReducers({configuration});
+
+    expect(stateListener).not.toHaveBeenCalled();
   });
 });

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -168,6 +168,12 @@ function buildCoreEngine<
 
   return {
     addReducers(reducers: ReducersMapObject) {
+      const keys = Object.keys(reducers);
+
+      if (reducerManager.containsAll(keys)) {
+        return;
+      }
+
       reducerManager.add(reducers);
       store.replaceReducer(reducerManager.combinedReducer);
     },

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -168,9 +168,7 @@ function buildCoreEngine<
 
   return {
     addReducers(reducers: ReducersMapObject) {
-      const keys = Object.keys(reducers);
-
-      if (reducerManager.containsAll(keys)) {
+      if (reducerManager.containsAll(reducers)) {
         return;
       }
 

--- a/packages/headless/src/app/reducer-manager.test.ts
+++ b/packages/headless/src/app/reducer-manager.test.ts
@@ -18,4 +18,14 @@ describe('ReducerManager', () => {
     const state = manager.combinedReducer(undefined, {type: ''});
     expect(state).toEqual({pagination: getPaginationInitialState()});
   });
+
+  it('when all keys exist, #containsAll returns true', () => {
+    const manager = createReducerManager({pagination, search});
+    expect(manager.containsAll(['pagination', 'search'])).toBe(true);
+  });
+
+  it('when only some keys exist, #containsAll returns false', () => {
+    const manager = createReducerManager({pagination});
+    expect(manager.containsAll(['pagination', 'search'])).toBe(false);
+  });
 });

--- a/packages/headless/src/app/reducer-manager.test.ts
+++ b/packages/headless/src/app/reducer-manager.test.ts
@@ -21,11 +21,11 @@ describe('ReducerManager', () => {
 
   it('when all keys exist, #containsAll returns true', () => {
     const manager = createReducerManager({pagination, search});
-    expect(manager.containsAll(['pagination', 'search'])).toBe(true);
+    expect(manager.containsAll({pagination, search})).toBe(true);
   });
 
   it('when only some keys exist, #containsAll returns false', () => {
     const manager = createReducerManager({pagination});
-    expect(manager.containsAll(['pagination', 'search'])).toBe(false);
+    expect(manager.containsAll({pagination, search})).toBe(false);
   });
 });

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -3,6 +3,7 @@ import {combineReducers, ReducersMapObject, Reducer} from '@reduxjs/toolkit';
 export interface ReducerManager {
   combinedReducer: Reducer;
   add: (newReducers: ReducersMapObject) => void;
+  containsAll(keys: string[]): boolean;
 }
 
 export function createReducerManager(
@@ -13,6 +14,10 @@ export function createReducerManager(
   return {
     get combinedReducer() {
       return combineReducers(reducers);
+    },
+
+    containsAll(keys: string[]) {
+      return keys.every((key) => key in reducers);
     },
 
     add(newReducers: ReducersMapObject) {

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -3,7 +3,7 @@ import {combineReducers, ReducersMapObject, Reducer} from '@reduxjs/toolkit';
 export interface ReducerManager {
   combinedReducer: Reducer;
   add: (newReducers: ReducersMapObject) => void;
-  containsAll(keys: string[]): boolean;
+  containsAll(newReducers: ReducersMapObject): boolean;
 }
 
 export function createReducerManager(
@@ -16,7 +16,8 @@ export function createReducerManager(
       return combineReducers(reducers);
     },
 
-    containsAll(keys: string[]) {
+    containsAll(newReducers: ReducersMapObject) {
+      const keys = Object.keys(newReducers);
       return keys.every((key) => key in reducers);
     },
 


### PR DESCRIPTION
React logs a warning when a state change occurs while the `render` function is executing.
The state change happens because controllers call `addReducer`, which calls `replaceReducer`, which triggers a state update.

Since `addReducers` never supported overrides, it was possible to add an early return to avoid calling `replaceReducer` when all keys exist.

The approach is the same as the initial attempt to [solving the HMR bug](https://github.com/coveo/ui-kit/pull/1146#discussion_r698780946). One concern I had is it closes the door to overriding reducers. If overriding does becomes a requirement, we would need a dedicated `overrideReducers` method.

https://coveord.atlassian.net/browse/KIT-761