### PR TITLE
(not merging) JSX "failed" breadcrumb resize exploration

### DIFF
--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -58,7 +58,6 @@ export class AtomicBreadbox implements InitializableComponent {
   @State() public error!: Error;
   @State() private isCollapsed = true;
 
-  // TODO: KIT-924 Automatically adapt the number of element of the breadbox
   private collapseThreshold = 5;
 
   public initialize() {
@@ -231,7 +230,6 @@ export class AtomicBreadbox implements InitializableComponent {
       ? sortedBreadcrumbs.slice(0, this.collapseThreshold)
       : sortedBreadcrumbs;
 
-    // TODO: update collapse KIT-924
     return [
       slicedBreadcrumbs.map((breadcrumb) => this.renderBreadcrumb(breadcrumb)),
       this.isCollapsed &&
@@ -253,7 +251,17 @@ export class AtomicBreadbox implements InitializableComponent {
         <span part="label" class="font-bold p-2 pl-0 with-colon">
           {this.bindings.i18n.t('filters')}
         </span>
-        <ul class="flex flex-wrap gap-1">{this.renderBreadcrumbs()}</ul>
+        <div class="relative flex-grow">
+          <ul
+            class={`flex gap-1 ${
+              this.isCollapsed
+                ? 'flex-nowrap overflow-hidden absolute w-full'
+                : 'flex-wrap'
+            }`}
+          >
+            {this.renderBreadcrumbs()}
+          </ul>
+        </div>
       </div>
     );
   }

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -168,9 +168,11 @@ export class AtomicBreadbox implements InitializableComponent {
 
   private updateShowMoreValue(value: number) {
     if (value === 0) {
-      this.showMore.style.display = 'none';
+      this.hide(this.showMore);
       return;
     }
+
+    this.show(this.showMore);
     this.showMore.textContent = `+ ${value.toLocaleString(
       this.bindings.i18n.language
     )}`;

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -32,6 +32,7 @@ module.exports = {
         DEFAULT: 'var(--atomic-border-radius)',
         md: 'var(--atomic-border-radius-md)',
         lg: 'var(--atomic-border-radius-lg)',
+        xl: 'var(--atomic-border-radius-xl)',
       },
       fontWeight: {
         normal: 'var(--atomic-font-normal)',


### PR DESCRIPTION
I wasn't successful in my explorations with JSX, mainly how could I, during the rendering loop, known that there is too many element or alternatively, if there would be enough space for an additional element. We basically have to render everything every time:
- the breadcrumbs change from headless
- the element is resized
Then we have to adapt once the elements are rendered, which will often cause a re-render, showing a warning in the console and we visually get a glitch every time we resize along with lagging because of the bad performance.
<img width="818" alt="Screen Shot 2021-09-27 at 8 48 59 AM" src="https://user-images.githubusercontent.com/4923043/134912558-324edd8e-1abe-4091-85c7-05040ac24e10.png">

Merged the [previous PR ](https://github.com/coveo/ui-kit/pull/1241)instead