### PR TITLE
feat(productlisting): create product listing date and numeric ranges

### DIFF
--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.test.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.test.ts
@@ -1,0 +1,107 @@
+import {
+  DateFacet,
+  buildDateFacet,
+  DateFacetOptions,
+} from './headless-product-listing-date-facet';
+import {
+  MockProductListingEngine,
+  buildMockProductListingEngine,
+} from '../../../../test/mock-engine';
+import {buildMockDateFacetValue} from '../../../../test/mock-date-facet-value';
+import {buildMockDateFacetRequest} from '../../../../test/mock-date-facet-request';
+import {configuration, dateFacetSet, search} from '../../../../app/reducers';
+import {DateFacetValue} from '../../../../features/facets/range-facets/date-facet-set/interfaces/response';
+import {ProductListingAppState} from '../../../../state/product-listing-app-state';
+import {buildMockProductListingState} from '../../../../test/mock-product-listing-state';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+
+describe('date facet', () => {
+  const facetId = '1';
+  let options: DateFacetOptions;
+  let state: ProductListingAppState;
+  let engine: MockProductListingEngine;
+  let dateFacet: DateFacet;
+
+  beforeEach(() => {
+    options = {
+      facetId,
+      field: 'created',
+      generateAutomaticRanges: true,
+    };
+
+    state = buildMockProductListingState();
+    state.dateFacetSet[facetId] = buildMockDateFacetRequest();
+
+    engine = buildMockProductListingEngine({state});
+    dateFacet = buildDateFacet(engine, {options});
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      dateFacetSet,
+      configuration,
+      search,
+    });
+  });
+
+  describe('#toggleSelect', () => {
+    it('dispatches #fetchProductListing', () => {
+      const value = buildMockDateFacetValue();
+      dateFacet.toggleSelect(value);
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#deselectAll', () => {
+    it('dispatches #fetchProductListing', () => {
+      dateFacet.deselectAll();
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#sortBy', () => {
+    it('dispatches #fetchProductListing', () => {
+      dateFacet.sortBy('descending');
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  function testCommonToggleSingleSelect(facetValue: () => DateFacetValue) {
+    it('dispatches #fetchProductListing', () => {
+      dateFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  }
+
+  describe('#toggleSingleSelect when the value state is "idle"', () => {
+    const facetValue = () => buildMockDateFacetValue({state: 'idle'});
+
+    testCommonToggleSingleSelect(facetValue);
+  });
+
+  describe('#toggleSingleSelect when the value state is not "idle"', () => {
+    const facetValue = () => buildMockDateFacetValue({state: 'selected'});
+
+    testCommonToggleSingleSelect(facetValue);
+  });
+});

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
@@ -1,0 +1,76 @@
+import {DateRangeRequest} from '../../../../features/facets/range-facets/date-facet-set/interfaces/request';
+import {DateFacetValue} from '../../../../features/facets/range-facets/date-facet-set/interfaces/response';
+
+import {getAnalyticsActionForToggleRangeFacetSelect} from '../../../../features/facets/range-facets/generic/range-facet-utils';
+import {DateFacetOptions} from '../../../core/facets/range-facet/date-facet/headless-date-facet-options';
+import {
+  buildCoreDateFacet,
+  buildDateRange,
+  DateFacet,
+  DateFacetProps,
+  DateFacetState,
+  DateRangeInput,
+  DateRangeOptions,
+} from '../../../core/facets/range-facet/date-facet/headless-core-date-facet';
+import {
+  logFacetClearAll,
+  logFacetUpdateSort,
+} from '../../../../features/facets/facet-set/facet-set-analytics-actions';
+import {RangeFacetSortCriterion} from '../../../../features/facets/range-facets/generic/interfaces/request';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+import {ProductListingEngine} from '../../../../product-listing.index';
+
+export {
+  DateFacetOptions,
+  DateRangeInput,
+  DateRangeOptions,
+  DateRangeRequest,
+  buildDateRange,
+  DateFacetProps,
+  DateFacet,
+  DateFacetState,
+};
+
+/**
+ * Creates a `DateFacet` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `DateFacet` controller properties.
+ * @returns A `DateFacet` controller instance.
+ */
+export function buildDateFacet(
+  engine: ProductListingEngine,
+  props: DateFacetProps
+): DateFacet {
+  const coreController = buildCoreDateFacet(engine, props);
+  const dispatch = engine.dispatch;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+
+    deselectAll() {
+      coreController.deselectAll();
+      dispatch(fetchProductListing());
+      dispatch(logFacetClearAll(getFacetId()));
+    },
+
+    sortBy(criterion: RangeFacetSortCriterion) {
+      coreController.sortBy(criterion);
+      dispatch(fetchProductListing());
+      dispatch(logFacetUpdateSort({facetId: getFacetId(), criterion}));
+    },
+
+    toggleSelect: (selection: DateFacetValue) => {
+      coreController.toggleSelect(selection);
+      dispatch(fetchProductListing());
+      dispatch(
+        getAnalyticsActionForToggleRangeFacetSelect(getFacetId(), selection)
+      );
+    },
+
+    get state() {
+      return coreController.state;
+    },
+  };
+}

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.test.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.test.ts
@@ -1,0 +1,62 @@
+import {
+  buildMockProductListingEngine,
+  MockProductListingEngine,
+} from '../../../../test';
+import {buildMockDateFacetRequest} from '../../../../test/mock-date-facet-request';
+import {
+  buildDateFilter,
+  DateFilter,
+  DateFilterInitialState,
+  DateFilterOptions,
+} from './headless-product-listing-date-filter';
+import {buildMockDateFacetValue} from '../../../../test/mock-date-facet-value';
+import {ProductListingAppState} from '../../../../state/product-listing-app-state';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+import {buildMockProductListingState} from '../../../../test/mock-product-listing-state';
+
+describe('date filter', () => {
+  const facetId = '1';
+  let options: DateFilterOptions;
+  let initialState: DateFilterInitialState | undefined;
+  let state: ProductListingAppState;
+  let engine: MockProductListingEngine;
+  let dateFacet: DateFilter;
+  beforeEach(() => {
+    initialState = undefined;
+
+    options = {
+      facetId,
+      field: 'created',
+    };
+
+    state = buildMockProductListingState();
+    state.dateFacetSet[facetId] = buildMockDateFacetRequest();
+
+    engine = buildMockProductListingEngine({state});
+    dateFacet = buildDateFilter(engine, {options, initialState});
+  });
+
+  describe('#setRange', () => {
+    it('dispatches #fetchProductListing', () => {
+      const value = buildMockDateFacetValue();
+      dateFacet.setRange(value);
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#clear', () => {
+    it('dispatches #fetchProductListing', () => {
+      dateFacet.clear();
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+});

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.ts
@@ -1,0 +1,81 @@
+import {
+  ConfigurationSection,
+  DateFacetSection,
+  SearchSection,
+} from '../../../../state/state-sections';
+import {loadReducerError} from '../../../../utils/errors';
+import {configuration, dateFacetSet, search} from '../../../../app/reducers';
+import {
+  logFacetClearAll,
+  logFacetSelect,
+} from '../../../../features/facets/facet-set/facet-set-analytics-actions';
+import {
+  buildCoreDateFilter,
+  DateFilter,
+  DateFilterInitialState,
+  DateFilterOptions,
+  DateFilterProps,
+  DateFilterRange,
+  DateFilterState,
+} from '../../../core/facets/range-facet/date-facet/headless-core-date-filter';
+import {ProductListingEngine} from '../../../../product-listing.index';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+
+export {
+  DateFilterOptions,
+  DateFilterInitialState,
+  DateFilterRange,
+  DateFilterProps,
+  DateFilterState,
+  DateFilter,
+};
+
+export function buildDateFilter(
+  engine: ProductListingEngine,
+  props: DateFilterProps
+): DateFilter {
+  if (!loadDateFilterReducer(engine)) {
+    throw loadReducerError;
+  }
+
+  const coreController = buildCoreDateFilter(engine, props);
+  const {dispatch} = engine;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+    clear: () => {
+      coreController.clear();
+      dispatch(fetchProductListing());
+      dispatch(logFacetClearAll(getFacetId()));
+    },
+    setRange: (range) => {
+      const success = coreController.setRange(range);
+      if (success) {
+        dispatch(fetchProductListing());
+        dispatch(
+          logFacetSelect({
+            facetId: getFacetId(),
+            facetValue: `${range.start}..${range.end}`,
+          })
+        );
+      }
+      return success;
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+      };
+    },
+  };
+}
+
+function loadDateFilterReducer(
+  engine: ProductListingEngine
+): engine is ProductListingEngine<
+  DateFacetSection & ConfigurationSection & SearchSection
+> {
+  engine.addReducers({dateFacetSet, configuration, search});
+  return true;
+}

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.test.ts
@@ -1,0 +1,107 @@
+import {
+  NumericFacet,
+  buildNumericFacet,
+  NumericFacetOptions,
+} from './headless-product-listing-numeric-facet';
+import {
+  MockProductListingEngine,
+  buildMockProductListingEngine,
+} from '../../../../test/mock-engine';
+import {buildMockNumericFacetValue} from '../../../../test/mock-numeric-facet-value';
+import {buildMockNumericFacetRequest} from '../../../../test/mock-numeric-facet-request';
+import {configuration, numericFacetSet, search} from '../../../../app/reducers';
+import {NumericFacetValue} from '../../../../features/facets/range-facets/numeric-facet-set/interfaces/response';
+import {buildMockProductListingState} from '../../../../test/mock-product-listing-state';
+import {ProductListingAppState} from '../../../../state/product-listing-app-state';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+
+describe('numeric facet', () => {
+  const facetId = '1';
+  let options: NumericFacetOptions;
+  let state: ProductListingAppState;
+  let engine: MockProductListingEngine;
+  let numericFacet: NumericFacet;
+
+  beforeEach(() => {
+    options = {
+      facetId,
+      field: 'created',
+      generateAutomaticRanges: true,
+    };
+
+    state = buildMockProductListingState();
+    state.numericFacetSet[facetId] = buildMockNumericFacetRequest();
+
+    engine = buildMockProductListingEngine({state});
+    numericFacet = buildNumericFacet(engine, {options});
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      numericFacetSet,
+      configuration,
+      search,
+    });
+  });
+
+  describe('#toggleSelect', () => {
+    it('dispatches #fetchProductListing', () => {
+      const value = buildMockNumericFacetValue();
+      numericFacet.toggleSelect(value);
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#deselectAll', () => {
+    it('dispatches #fetchProductListing', () => {
+      numericFacet.deselectAll();
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#sortBy', () => {
+    it('dispatches #fetchProductListing', () => {
+      numericFacet.sortBy('descending');
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  function testCommonToggleSingleSelect(facetValue: () => NumericFacetValue) {
+    it('dispatches #fetchProductListing', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  }
+
+  describe('#toggleSingleSelect when the value state is "idle"', () => {
+    const facetValue = () => buildMockNumericFacetValue({state: 'idle'});
+
+    testCommonToggleSingleSelect(facetValue);
+  });
+
+  describe('#toggleSingleSelect when the value state is not "idle"', () => {
+    const facetValue = () => buildMockNumericFacetValue({state: 'selected'});
+
+    testCommonToggleSingleSelect(facetValue);
+  });
+});

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
@@ -1,0 +1,96 @@
+import {NumericRangeRequest} from '../../../../features/facets/range-facets/numeric-facet-set/interfaces/request';
+import {NumericFacetValue} from '../../../../features/facets/range-facets/numeric-facet-set/interfaces/response';
+import {
+  ConfigurationSection,
+  NumericFacetSection,
+  SearchSection,
+} from '../../../../state/state-sections';
+import {configuration, numericFacetSet, search} from '../../../../app/reducers';
+import {loadReducerError} from '../../../../utils/errors';
+import {getAnalyticsActionForToggleRangeFacetSelect} from '../../../../features/facets/range-facets/generic/range-facet-utils';
+import {
+  buildCoreNumericFacet,
+  buildNumericRange,
+  NumericFacet,
+  NumericFacetOptions,
+  NumericFacetProps,
+  NumericFacetState,
+  NumericRangeOptions,
+} from '../../../core/facets/range-facet/numeric-facet/headless-core-numeric-facet';
+import {RangeFacetSortCriterion} from '../../../../features/facets/range-facets/generic/interfaces/request';
+import {
+  logFacetClearAll,
+  logFacetUpdateSort,
+} from '../../../../features/facets/facet-set/facet-set-analytics-actions';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+import {ProductListingEngine} from '../../../../product-listing.index';
+
+export {
+  buildNumericRange,
+  NumericRangeOptions,
+  NumericRangeRequest,
+  NumericFacetValue,
+  NumericFacetOptions,
+  NumericFacetProps,
+  NumericFacet,
+  NumericFacetState,
+};
+
+/**
+ * Creates a `NumericFacet` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `NumericFacet` properties.
+ * @returns A `NumericFacet` controller instance.
+ */
+export function buildNumericFacet(
+  engine: ProductListingEngine,
+  props: NumericFacetProps
+): NumericFacet {
+  if (!loadNumericFacetReducers(engine)) {
+    throw loadReducerError;
+  }
+
+  const coreController = buildCoreNumericFacet(engine, props);
+  const dispatch = engine.dispatch;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+
+    deselectAll() {
+      coreController.deselectAll();
+      dispatch(fetchProductListing());
+      dispatch(logFacetClearAll(getFacetId()));
+    },
+
+    sortBy(criterion: RangeFacetSortCriterion) {
+      coreController.sortBy(criterion);
+      dispatch(fetchProductListing());
+      dispatch(logFacetUpdateSort({facetId: getFacetId(), criterion}));
+    },
+
+    toggleSelect: (selection: NumericFacetValue) => {
+      coreController.toggleSelect(selection);
+      dispatch(fetchProductListing());
+      dispatch(
+        getAnalyticsActionForToggleRangeFacetSelect(getFacetId(), selection)
+      );
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+      };
+    },
+  };
+}
+
+function loadNumericFacetReducers(
+  engine: ProductListingEngine
+): engine is ProductListingEngine<
+  NumericFacetSection & ConfigurationSection & SearchSection
+> {
+  engine.addReducers({numericFacetSet, configuration, search});
+  return true;
+}

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.test.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.test.ts
@@ -1,0 +1,64 @@
+import {
+  buildMockProductListingEngine,
+  MockProductListingEngine,
+} from '../../../../test';
+import {buildMockNumericFacetRequest} from '../../../../test/mock-numeric-facet-request';
+import {
+  buildNumericFilter,
+  NumericFilter,
+  NumericFilterInitialState,
+  NumericFilterOptions,
+} from './headless-product-listing-numeric-filter';
+import {buildMockNumericFacetValue} from '../../../../test/mock-numeric-facet-value';
+import {ProductListingAppState} from '../../../../state/product-listing-app-state';
+import {buildMockProductListingState} from '../../../../test/mock-product-listing-state';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+
+describe('numeric filter', () => {
+  const facetId = '1';
+  let options: NumericFilterOptions;
+  let initialState: NumericFilterInitialState | undefined;
+  let state: ProductListingAppState;
+  let engine: MockProductListingEngine;
+  let numericFacet: NumericFilter;
+
+  beforeEach(() => {
+    initialState = undefined;
+
+    options = {
+      facetId,
+      field: 'created',
+    };
+
+    state = buildMockProductListingState();
+    state.numericFacetSet[facetId] = buildMockNumericFacetRequest();
+
+    engine = buildMockProductListingEngine({state});
+    numericFacet = buildNumericFilter(engine, {options, initialState});
+  });
+
+  describe('#setRange', () => {
+    it('dispatches #fetchProductListing', () => {
+      const value = buildMockNumericFacetValue();
+      numericFacet.setRange(value);
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+
+  describe('#clear', () => {
+    it('dispatches #fetchProductListing', () => {
+      numericFacet.clear();
+
+      expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: fetchProductListing.pending.type,
+        })
+      );
+    });
+  });
+});

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.ts
@@ -1,0 +1,82 @@
+import {
+  ConfigurationSection,
+  NumericFacetSection,
+  SearchSection,
+} from '../../../../state/state-sections';
+import {loadReducerError} from '../../../../utils/errors';
+import {configuration, numericFacetSet, search} from '../../../../app/reducers';
+import {
+  logFacetClearAll,
+  logFacetSelect,
+} from '../../../../features/facets/facet-set/facet-set-analytics-actions';
+
+import {
+  NumericFilterOptions,
+  NumericFilterInitialState,
+  NumericFilterRange,
+  NumericFilterProps,
+  NumericFilterState,
+  NumericFilter,
+  buildCoreNumericFilter,
+} from '../../../core/facets/range-facet/numeric-facet/headless-core-numeric-filter';
+import {ProductListingEngine} from '../../../../product-listing.index';
+import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
+
+export {
+  NumericFilterOptions,
+  NumericFilterInitialState,
+  NumericFilterRange,
+  NumericFilterProps,
+  NumericFilterState,
+  NumericFilter,
+};
+
+export function buildNumericFilter(
+  engine: ProductListingEngine,
+  props: NumericFilterProps
+): NumericFilter {
+  if (!loadNumericFilterReducer(engine)) {
+    throw loadReducerError;
+  }
+
+  const coreController = buildCoreNumericFilter(engine, props);
+  const {dispatch} = engine;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+    clear: () => {
+      coreController.clear();
+      dispatch(fetchProductListing());
+      dispatch(logFacetClearAll(getFacetId()));
+    },
+    setRange: (range) => {
+      const success = coreController.setRange(range);
+      if (success) {
+        dispatch(fetchProductListing());
+        dispatch(
+          logFacetSelect({
+            facetId: getFacetId(),
+            facetValue: `${range.start}..${range.end}`,
+          })
+        );
+      }
+      return success;
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+      };
+    },
+  };
+}
+
+function loadNumericFilterReducer(
+  engine: ProductListingEngine
+): engine is ProductListingEngine<
+  NumericFacetSection & ConfigurationSection & SearchSection
+> {
+  engine.addReducers({numericFacetSet, configuration, search});
+  return true;
+}

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -85,3 +85,47 @@ export {
   CategoryFacetSearchResult,
   buildCategoryFacet,
 } from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
+
+export {
+  DateFacet,
+  DateFacetOptions,
+  DateFacetProps,
+  DateFacetState,
+  DateRangeInput,
+  DateRangeOptions,
+  DateRangeRequest,
+  buildDateFacet,
+  buildDateRange,
+} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
+
+export {
+  buildDateFilter,
+  DateFilter,
+  DateFilterOptions,
+  DateFilterProps,
+  DateFilterRange,
+  DateFilterState,
+  DateFilterInitialState,
+} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
+
+export {
+  NumericFacet,
+  NumericFacetOptions,
+  NumericFacetProps,
+  NumericFacetState,
+  NumericFacetValue,
+  NumericRangeOptions,
+  NumericRangeRequest,
+  buildNumericFacet,
+  buildNumericRange,
+} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
+
+export {
+  buildNumericFilter,
+  NumericFilter,
+  NumericFilterOptions,
+  NumericFilterProps,
+  NumericFilterRange,
+  NumericFilterState,
+  NumericFilterInitialState,
+} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';


### PR DESCRIPTION
[COM-1285]

Pretty much a copy of the base headless ones, but using `fetchProductListing`

[COM-1285]: https://coveord.atlassian.net/browse/COM-1285