### PR TITLE
fix(quantic): fixed packaging credentials

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -2,7 +2,7 @@ name: Create Quantic Package
 
 env:
   SFDX_AUTH_JWT_INSTANCE_URL: https://login.salesforce.com
-  SFDX_AUTH_JWT_USERNAME: sfdc.integration.devv2.hub@coveo.com
+  SFDX_AUTH_JWT_USERNAME: rdaccess@coveo.com
   SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
   SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
   PACKAGE_ID: 0Ho6g000000k9g8CAA

--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -2,9 +2,9 @@ name: Create Quantic Package
 
 env:
   SFDX_AUTH_JWT_INSTANCE_URL: https://login.salesforce.com
-  SFDX_AUTH_JWT_USERNAME: rdaccess@coveo.com
-  SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-  SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+  SFDX_AUTH_JWT_USERNAME: sfdc.integration.devv2.hub@coveo.com
+  SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_PACKAGE_JWT_KEY }}
+  SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_PACKAGE_CLIENT_ID }}
   PACKAGE_ID: 0Ho6g000000k9g8CAA
 
 on:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4104

The `SFDX_AUTH_CLIENT_ID` and `SFDX_AUTH_JWT_KEY` have been updated to use an organization better suited to create scratch orgs. However, the packaging workflow must use the same organization as before.

The packaging workflow now relies on `SFDX_AUTH_PACKAGE_CLIENT_ID` and `SFDX_AUTH_PACKAGE_JWT_KEY` secrets.

And it [works again](https://github.com/coveo/ui-kit/actions/runs/1288306902).