### PR TITLE
feat(quantic): tab expression default

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -29,7 +29,7 @@
               </div>
               <div class="slds-col slds-order_1 slds-large-order_2 slds-size_1-of-1 slds-large-size_6-of-12">
                 <ul class="slds-tabs_default slds-tabs_default__nav" role="tablist">
-                  <c-quantic-tab label="All" expression="" engine-id={engineId}></c-quantic-tab>
+                  <c-quantic-tab label="All" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Articles" expression="@sfkbid" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Issues" expression="@jisourcetype AND NOT @jidocumenttype=&quot;WorkLog&quot;" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Community" expression="@objecttype==&quot;Message&quot;" engine-id={engineId}></c-quantic-tab>

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
@@ -10,7 +10,7 @@ export default class QuanticTab extends LightningElement {
   /** @type {string} */
   @api label;
   /** @type {string} */
-  @api expression;
+  @api expression = '';
   /** @type {string} */
   @api engineId;
   /** @type {boolean} */
@@ -37,7 +37,7 @@ export default class QuanticTab extends LightningElement {
   initialize = (engine) => {
     this.tab = CoveoHeadless.buildTab(engine, {
       options: {
-        expression: this.expression ?? '',
+        expression: this.expression,
         id: this.label,
       },
       initialState: {

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
@@ -37,7 +37,7 @@ export default class QuanticTab extends LightningElement {
   initialize = (engine) => {
     this.tab = CoveoHeadless.buildTab(engine, {
       options: {
-        expression: this.expression,
+        expression: this.expression ?? '',
         id: this.label,
       },
       initialState: {


### PR DESCRIPTION
set expression to default to empty string so we don't have to pass an empty string in props