### PR TITLE
fix(quantic): update to breadcrumb style

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/jsconfig.json
+++ b/packages/quantic/force-app/main/default/lwc/jsconfig.json
@@ -81,6 +81,9 @@
             "c/quanticNumberButton": [
                 "quanticNumberButton/quanticNumberButton.js"
             ],
+            "c/quanticPill": [
+                "quanticPill/quanticPill.js"
+            ],
             "c/quanticSvg": [
                 "quanticSvg/quanticSvg.js"
             ],

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
@@ -18,3 +18,7 @@
 .breadcrumb__container {
   min-width: 0;
 }
+
+.breadcrumb-manager__clear-button a {
+  white-space: nowrap;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
@@ -14,3 +14,7 @@
 .breadcrumb-manager__more-button:hover {
   color: var(--color-text-action-label);
 }
+
+.breadcrumb__container {
+  min-width: 0;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
@@ -1,5 +1,6 @@
 .breadcrumb-manager__line {
     align-items: baseline;
+    min-width: 0;
 }
 
 .breadcrumb-manager__value:hover {
@@ -11,7 +12,6 @@
 }
 
 .breadcrumb-manager__value-line-item {
-    line-height: 0.7;
     white-space: nowrap;
 }
 
@@ -21,4 +21,23 @@
 
 .breadcrumb-manager__more-button:hover {
     color: var(--color-text-action-label);
+}
+
+.breadcrumb__container {
+  display: flex;
+  flex-direction: row;
+  max-width: 100%;
+  border-radius: .25rem;
+}
+
+.breadcrumb__container:hover {
+  background-color: #f6f7f9;
+}
+
+.breadcrumb__text-container {
+  min-width: 0;
+}
+
+a {
+  text-decoration: none;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
@@ -1,43 +1,16 @@
 .breadcrumb-manager__line {
-    align-items: baseline;
-    min-width: 0;
-}
-
-.breadcrumb-manager__value:hover {
-    text-decoration: underline;
-}
-
-.slds-grid div.breadcrumb-manager__column {
-    padding: 0;
-}
-
-.breadcrumb-manager__value-line-item {
-    white-space: nowrap;
-}
-
-.breadcrumb-manager__field-name {
-    white-space: nowrap;
-}
-
-.breadcrumb-manager__more-button:hover {
-    color: var(--color-text-action-label);
-}
-
-.breadcrumb__container {
-  display: flex;
-  flex-direction: row;
-  max-width: 100%;
-  border-radius: .25rem;
-}
-
-.breadcrumb__container:hover {
-  background-color: #f6f7f9;
-}
-
-.breadcrumb__text-container {
+  align-items: baseline;
   min-width: 0;
 }
 
-a {
-  text-decoration: none;
+.slds-grid div.breadcrumb-manager__column {
+  padding: 0;
+}
+
+.breadcrumb-manager__field-name {
+  white-space: nowrap;
+}
+
+.breadcrumb-manager__more-button:hover {
+  color: var(--color-text-action-label);
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -9,15 +9,12 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
-                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value.value}</span>
-                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
-                    </a>
+                    <c-quantic-pill value={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li class="breadcrumb__container">
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>
@@ -29,29 +26,23 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
-                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value}</span>
-                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
-                    </a>
+                    <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li class="breadcrumb__container">
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>
             </li>
           </template>
-          <template for:each={categoryFacetBreadcrumbsValues} for:item="breadcrumb">
+          <template for:each={categoryFacetBreadcrumbsValues} for:item="breadcrumbValue">
             <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumbValue.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <li>
-                  <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumb.deselect}>
-                    <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumb.value}</span>
-                    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
-                  </a>
+                  <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                 </li>
               </ul>
             </li>
@@ -62,15 +53,12 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
-                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value}</span>
-                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
-                    </a>
+                    <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li class="breadcrumb__container">
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>
@@ -78,8 +66,8 @@
           </template>
         </ul>
       </div>
-      <div class="slds-col slds-nowrap breadcrumb-manager__clear-button slds-m-around_xx-small">
-        <ul>
+      <div class="slds-col breadcrumb-manager__column slds-nowrap breadcrumb-manager__clear-button slds-m-left_small">
+        <ul class="slds-m-around_xx-small">
           <li>
             <a onclick={deselectAll}>{labels.clearAllFilters}</a>
           </li>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -9,7 +9,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <c-quantic-pill value={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -26,7 +26,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -42,7 +42,7 @@
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumbValue.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <li>
-                  <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                  <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                 </li>
               </ul>
             </li>
@@ -53,7 +53,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value}>
-                    <c-quantic-pill value={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -1,20 +1,23 @@
 <template>
     <template if:true={hasBreadcrumbs}>
-        <div class="slds-grid slds-var-m-vertical_x-small">
-            <div class="slds-col slds-col_bump-right breadcrumb-manager__column">
+        <div class="slds-grid slds-grid_vertical-align-start slds-size_1-of-1 slds-var-m-vertical_x-small">
+            <div class="slds-col slds-truncate slds-col_bump-right breadcrumb-manager__column">
                 <ul>
                     <template for:each={facetBreadcrumbValues} for:item="breadcrumb">
                         <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-                            <span class="breadcrumb-manager__field-name">{breadcrumb.field} : </span>
-                            <ul class="slds-list_horizontal slds-has-block-links_space slds-grid slds-wrap">
+                            <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+                            <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                                    <li key={breadcrumbValue.value.value} class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumbValue.deselect} class="breadcrumb-manager__value">{breadcrumbValue.value.value} X</a>
-                                    </li>
+                                  <li key={breadcrumbValue.value.value}>
+                                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
+                                      <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
+                                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value.value}</span>
+                                    </a>
+                                  </li>
                                 </template>
                                 <template if:true={breadcrumb.showMoreButton}>
-                                    <li class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumb.expandButtonClick} class="slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                                    <li class="breadcrumb__container">
+                                        <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                                     </li>
                                 </template>
                             </ul>
@@ -66,12 +69,12 @@
                     </template>
                 </ul>
             </div>
-            <div class="slds-col breadcrumb-manager__column">
-                <ul class="slds-list_horizontal slds-has-block-links_space">
-                    <li class="breadcrumb-manager__value-line-item">
-                        <a onclick={deselectAll}>{labels.clearAllFilters}</a>
-                    </li>
-                </ul>
+            <div class="slds-col slds-nowrap breadcrumb-manager__clear-button slds-m-around_xx-small">
+              <ul>
+                <li>
+                  <a onclick={deselectAll}>{labels.clearAllFilters}</a>
+                </li>
+              </ul>
             </div>
         </div>
     </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -9,7 +9,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -26,7 +26,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -42,7 +42,7 @@
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumbValue.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <li class="breadcrumb__container">
-                  <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                  <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
                 </li>
               </ul>
             </li>
@@ -53,7 +53,7 @@
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -8,12 +8,12 @@
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                  <li key={breadcrumbValue.value.value}>
+                  <li key={breadcrumbValue.value.value} class="breadcrumb__container">
                     <c-quantic-pill label={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
-                  <li class="breadcrumb__container">
+                  <li>
                     <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
@@ -25,12 +25,12 @@
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                  <li key={breadcrumbValue.value.value}>
+                  <li key={breadcrumbValue.value.value} class="breadcrumb__container">
                     <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
-                  <li class="breadcrumb__container">
+                  <li>
                     <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
@@ -38,10 +38,10 @@
             </li>
           </template>
           <template for:each={categoryFacetBreadcrumbsValues} for:item="breadcrumbValue">
-            <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
+            <li key={breadcrumbValue.facetId} class="slds-list_horizontal breadcrumb-manager__line">
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumbValue.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
-                <li>
+                <li class="breadcrumb__container">
                   <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                 </li>
               </ul>
@@ -52,12 +52,12 @@
               <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
               <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                  <li key={breadcrumbValue.value.value}>
+                  <li key={breadcrumbValue.value} class="breadcrumb__container">
                     <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} deselect={breadcrumbValue.deselect}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
-                  <li class="breadcrumb__container">
+                  <li>
                     <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -1,81 +1,90 @@
 <template>
-    <template if:true={hasBreadcrumbs}>
-        <div class="slds-grid slds-grid_vertical-align-start slds-size_1-of-1 slds-var-m-vertical_x-small">
-            <div class="slds-col slds-truncate slds-col_bump-right breadcrumb-manager__column">
-                <ul>
-                    <template for:each={facetBreadcrumbValues} for:item="breadcrumb">
-                        <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-                            <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
-                            <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
-                                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                                  <li key={breadcrumbValue.value.value}>
-                                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
-                                      <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
-                                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value.value}</span>
-                                    </a>
-                                  </li>
-                                </template>
-                                <template if:true={breadcrumb.showMoreButton}>
-                                    <li class="breadcrumb__container">
-                                        <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
-                                    </li>
-                                </template>
-                            </ul>
-                        </li>
-                    </template>
-                    <template for:each={numericFacetBreadcrumbsValues} for:item="breadcrumb">
-                        <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-                            <span class="breadcrumb-manager__field-name">{breadcrumb.field} : </span>
-                            <ul class="slds-list_horizontal slds-has-block-links_space slds-grid slds-wrap">
-                                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                                    <li key={breadcrumbValue.value} class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumbValue.deselect} class="breadcrumb-manager__value">{breadcrumbValue.value} X</a>
-                                    </li>
-                                </template>
-                                <template if:true={breadcrumb.showMoreButton}>
-                                    <li class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumb.expandButtonClick} class="slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
-                                    </li>
-                                </template>
-                            </ul>
-                        </li>
-                    </template>
-                    <template for:each={categoryFacetBreadcrumbsValues} for:item="breadcrumb">
-                        <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-                            <span class="breadcrumb-manager__field-name">{breadcrumb.field} : </span>
-                            <ul class="slds-list_horizontal slds-has-block-links_space slds-grid slds-wrap">
-                                <li class="breadcrumb-manager__value-line-item">
-                                    <a onclick={breadcrumb.deselect} class="breadcrumb-manager__value">{breadcrumb.value} X</a>
-                                </li>
-                            </ul>
-                        </li>
-                    </template>
-                    <template for:each={dateFacetBreadcrumbsValues} for:item="breadcrumb">
-                        <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
-                            <span class="breadcrumb-manager__field-name">{breadcrumb.field} : </span>
-                            <ul class="slds-list_horizontal slds-has-block-links_space slds-grid slds-wrap">
-                                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                                    <li key={breadcrumbValue.value} class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumbValue.deselect} class="breadcrumb-manager__value">{breadcrumbValue.value} X</a>
-                                    </li>
-                                </template>
-                                <template if:true={breadcrumb.showMoreButton}>
-                                    <li class="breadcrumb-manager__value-line-item">
-                                        <a onclick={breadcrumb.expandButtonClick} class="slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
-                                    </li>
-                                </template>
-                            </ul>
-                        </li>
-                    </template>
-                </ul>
-            </div>
-            <div class="slds-col slds-nowrap breadcrumb-manager__clear-button slds-m-around_xx-small">
-              <ul>
+  <template if:true={hasBreadcrumbs}>
+    <div class="slds-grid slds-grid_vertical-align-start slds-size_1-of-1 slds-var-m-vertical_x-small">
+      <div class="slds-col slds-truncate slds-col_bump-right breadcrumb-manager__column">
+        <ul>
+          <template for:each={facetBreadcrumbValues} for:item="breadcrumb">
+            <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
+              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+              <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
+                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
+                  <li key={breadcrumbValue.value.value}>
+                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
+                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value.value}</span>
+                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
+                    </a>
+                  </li>
+                </template>
+                <template if:true={breadcrumb.showMoreButton}>
+                  <li class="breadcrumb__container">
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                  </li>
+                </template>
+              </ul>
+            </li>
+          </template>
+          <template for:each={numericFacetBreadcrumbsValues} for:item="breadcrumb">
+            <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
+              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+              <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
+                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
+                  <li key={breadcrumbValue.value.value}>
+                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
+                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value}</span>
+                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
+                    </a>
+                  </li>
+                </template>
+                <template if:true={breadcrumb.showMoreButton}>
+                  <li class="breadcrumb__container">
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                  </li>
+                </template>
+              </ul>
+            </li>
+          </template>
+          <template for:each={categoryFacetBreadcrumbsValues} for:item="breadcrumb">
+            <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
+              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+              <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
                 <li>
-                  <a onclick={deselectAll}>{labels.clearAllFilters}</a>
+                  <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumb.deselect}>
+                    <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumb.value}</span>
+                    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
+                  </a>
                 </li>
               </ul>
-            </div>
-        </div>
-    </template>
+            </li>
+          </template>
+          <template for:each={dateFacetBreadcrumbsValues} for:item="breadcrumb">
+            <li key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__line">
+              <span class="slds-col slds-gutters breadcrumb-manager__field-name">{breadcrumb.field} : </span>
+              <ul class="slds-col slds-truncate slds-gutters slds-list_horizontal slds-grid slds-wrap">
+                <template for:each={breadcrumb.values} for:item="breadcrumbValue">
+                  <li key={breadcrumbValue.value.value}>
+                    <a class="breadcrumb__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-around_xx-small" onclick={breadcrumbValue.deselect}>
+                      <span class="nowrap breadcrumb__text-container slds-truncate">{breadcrumbValue.value}</span>
+                      <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text="remove breadcrumb" size="xx-small"></lightning-icon>
+                    </a>
+                  </li>
+                </template>
+                <template if:true={breadcrumb.showMoreButton}>
+                  <li class="breadcrumb__container">
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-around_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                  </li>
+                </template>
+              </ul>
+            </li>
+          </template>
+        </ul>
+      </div>
+      <div class="slds-col slds-nowrap breadcrumb-manager__clear-button slds-m-around_xx-small">
+        <ul>
+          <li>
+            <a onclick={deselectAll}>{labels.clearAllFilters}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
@@ -13,7 +13,7 @@
         >
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
-          <button class="facet__clear-button slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
+          <button class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
             <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
             <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -15,7 +15,7 @@
         <template if:true={hasActiveValues}>
           <lightning-button 
             icon-name="utility:close"
-            class="facet__clear-filter slds-p-horizontal_x-small"
+            class="slds-grid_vertical-align-center facet__clear-filter slds-p-horizontal_x-small"
             variant="base" 
             value={clearFilterLabel} 
             onclick={clearSelections}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -13,7 +13,7 @@
         >
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
-          <button class="facet__clear-button slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
+          <button class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
             <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
             <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
@@ -37,11 +37,11 @@
   background-color: #f6f7f9;
 }
 
-.facet__clear-button {
+.facet__clear-filter {
   line-height: inherit;
 }
 
-.facet__clear-button:focus {
+.facet__clear-filter:focus {
   outline: none;
   -webkit-box-shadow: none;
   box-shadow: none;

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
@@ -15,3 +15,7 @@ li {
 .facet__value_selected{
   font-weight: bold;
 }
+
+.facet__value-checkbox {
+  min-width: unset;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -13,7 +13,7 @@
         ></lightning-input>
       </template>
       <template if:true={isChecked}>
-        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small slds-text-body_small nowrap facet__value-text facet__value_selected">qe;orijs;dfgms;dklfgsdlfkgjnsdl;fkgj;sdlfjg;sdlkgjs;dlfkgj;sdlfkgjs;dflkgj;s</span>
+        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small slds-text-body_small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
         <span class="nowrap slds-text-body_small facet__number-of-results facet__value_selected">({item.numberOfResults})</span>
       </template>
       <template if:false={isChecked}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -4,6 +4,7 @@
       <template if:false={displayAsLink}>
         <lightning-input 
           type="checkbox"
+          class="facet__value-checkbox"
           variant="label-hidden"
           label="Facet value option"
           name="facet value checkbox"
@@ -12,7 +13,7 @@
         ></lightning-input>
       </template>
       <template if:true={isChecked}>
-        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small slds-text-body_small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
+        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small slds-text-body_small nowrap facet__value-text facet__value_selected">qe;orijs;dfgms;dklfgsdlfkgjnsdl;fkgj;sdlfjg;sdlkgjs;dlfkgj;sdlfkgjs;dflkgj;s</span>
         <span class="nowrap slds-text-body_small facet__number-of-results facet__value_selected">({item.numberOfResults})</span>
       </template>
       <template if:false={isChecked}>

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
@@ -13,7 +13,7 @@
         >
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
-          <button class="facet__clear-button slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
+          <button class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
             <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
             <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
@@ -1,0 +1,17 @@
+.pill__container {
+  display: flex;
+  flex-direction: row;
+  border-radius: .25rem;
+}
+
+.pill__container:hover {
+  background-color: #f6f7f9;
+}
+
+.pill__text-container {
+  min-width: 0;
+}
+
+a {
+  text-decoration: none;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
@@ -1,0 +1,6 @@
+<template>
+  <a class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small" onclick={deselect}>
+    <span class="nowrap pill__text-container slds-truncate">{value}</span>
+    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
+  </a>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
@@ -1,6 +1,6 @@
 <template>
   <a class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small" onclick={deselect}>
-    <span class="nowrap pill__text-container slds-truncate">{label}</span>
+    <span class="slds-nowrap pill__text-container slds-truncate">{label}</span>
     <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
   </a>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
@@ -1,6 +1,6 @@
 <template>
   <a class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small" onclick={deselect}>
-    <span class="nowrap pill__text-container slds-truncate">{value}</span>
+    <span class="nowrap pill__text-container slds-truncate">{label}</span>
     <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
   </a>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
@@ -1,7 +1,27 @@
 import {LightningElement, api} from 'lwc';
 
-export default class QuanticBreadcrumb extends LightningElement {
-  @api value;
-  @api deselect;
+/**
+ * The `QuanticPill` component is used internally to display a deselectable button.
+ * @example
+ * <c-quantic-pill label="Case" alt-text="Remove Case filter" deselect={myDeselectFunction}></c-quantic-pill>
+ */
+export default class QuanticPill extends LightningElement {
+  /**
+   * The value to display inside the button.
+   * @api
+   * @type {string}
+   */
+  @api label;
+  /**
+   * The alternative text to be assigned to the button icon.
+   * @api
+   * @type {string}
+   */
   @api altText;
+  /**
+   * The function to be executed when the pill is clicked.
+   * @api
+   * @type {Function}
+   */
+  @api deselect;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
@@ -1,0 +1,7 @@
+import {LightningElement, api} from 'lwc';
+
+export default class QuanticBreadcrumb extends LightningElement {
+  @api value;
+  @api deselect;
+  @api altText;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
@@ -2,8 +2,9 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticPill` component is used internally to display a deselectable button.
+ * @fires CustomEvent#deselect
  * @example
- * <c-quantic-pill label="Case" alt-text="Remove Case filter" deselect={myDeselectFunction}></c-quantic-pill>
+ * <c-quantic-pill label="Case" alt-text="Remove Case filter" ondeselect={myDeselectFunction}></c-quantic-pill>
  */
 export default class QuanticPill extends LightningElement {
   /**
@@ -18,10 +19,8 @@ export default class QuanticPill extends LightningElement {
    * @type {string}
    */
   @api altText;
-  /**
-   * The function to be executed when the pill is clicked.
-   * @api
-   * @type {Function}
-   */
-  @api deselect;
+  
+  deselect() {
+    this.dispatchEvent(new CustomEvent('deselect'));
+  }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
@@ -17,11 +17,9 @@
         <ul>
           <template for:each={queries} for:item="query" for:index="index">
             <li key={query} class="slds-grid" value={index} onclick={executeQuery}>
-              <a class="recent-query__container slds-size_1-of-1 slds-p-around_x-small">
+              <a class="recent-query__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
                 <lightning-icon class="recent-query__icon slds-current-color" icon-name="utility:search" alternative-text="search icon" size="xx-small"></lightning-icon>
-                <span class="slds-text-body_small nowrap query-text__container slds-truncate">
-                {query}
-                </span>
+                <span class="slds-text-body_small nowrap query-text__container slds-truncate">{query}</span>
               </a>
             </li>
           </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
@@ -17,7 +17,7 @@
         <ul>
           <template for:each={results} for:item="result">
             <li class="slds-grid" key={result.uniqueId}>
-              <div class="recent-result__container slds-size_1-of-1 slds-p-around_x-small">
+              <div class="recent-result__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
                 <lightning-icon class="recent-result__icon slds-current-color" icon-name="utility:page" alternative-text="page icon" size="xx-small"></lightning-icon>
                 <div class="slds-text-body_small nowrap result-link__container">
                   <c-quantic-recent-result-link result={result} engine-id={engineId}></c-quantic-recent-result-link>

--- a/packages/quantic/tsconfig.json
+++ b/packages/quantic/tsconfig.json
@@ -67,6 +67,9 @@
             "c/quanticNumberButton": [
                 "quanticNumberButton/quanticNumberButton.js"
             ],
+            "c/quanticPill": [
+                "quanticPill/quanticPill.js"
+            ],
             "c/quanticHeadlessLoader": [
                 "quanticHeadlessLoader/quanticHeadlessLoader.js"
             ],


### PR DESCRIPTION
Updated breadcrumb component to fix long string truncating behaviour and swap the "X" for an icon.
To do this we added a `quanticPill` component to avoid duplicated markup for each breadcrumb.
Named it "Pill" over breadcrumb because it could be used in different contexts as well.

### Before
<img width="813" alt="Screen Shot 2021-10-04 at 9 03 43 AM" src="https://user-images.githubusercontent.com/16785453/135856267-1f11fcf0-6f05-428f-93a0-ced39fd06eaa.png">

### After

<img width="617" alt="Screen Shot 2021-10-04 at 9 04 34 AM" src="https://user-images.githubusercontent.com/16785453/135856411-53913819-db4d-44a6-8b9a-8dd06153fa4c.png">

<img width="617" alt="135872685-3fb221b8-c701-49cf-bb01-8c343ed808bd" src="https://user-images.githubusercontent.com/16785453/135898769-02ea43f6-a9e3-4b1b-af88-8cb72ea7ac67.png">

<img width="617" alt="Screen Shot 2021-10-04 at 9 05 31 AM" src="https://user-images.githubusercontent.com/16785453/135856507-64c96a08-f312-4c59-a1a6-9b835e7cecdf.png">