### PR TITLE
fix(headless): fix platformURL exported function

### DIFF
--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -35,17 +35,17 @@ describe('platformUrl helper', () => {
     );
   });
 
-  it(`when the region is us-east-1
+  it(`when the region is us
   should not return it in the url e.g. https://platform.cloud.coveo.com`, () => {
-    expect(platformUrl({region: 'us-east-1'})).toBe(
+    expect(platformUrl({region: 'us'})).toBe(
       'https://platform.cloud.coveo.com'
     );
   });
 
-  it(`when the region is not us-east-1
-  should return it in the url e.g. https://platform-us-west-2.cloud.coveo.com`, () => {
-    expect(platformUrl({region: 'us-west-2'})).toBe(
-      'https://platform-us-west-2.cloud.coveo.com'
+  it(`when the region is not us
+  should return it in the url e.g. https://platform-eu.cloud.coveo.com`, () => {
+    expect(platformUrl({region: 'eu'})).toBe(
+      'https://platform-eu.cloud.coveo.com'
     );
   });
 });

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -88,10 +88,10 @@ export class PlatformClient {
 }
 
 type PlatformCombination =
-  | {env: 'dev'; region: 'us-east-1' | 'eu-west-1' | 'eu-west-3'}
-  | {env: 'qa'; region: 'us-east-1' | 'eu-west-1' | 'ap-southeast-2'}
-  | {env: 'hipaa'; region: 'us-east-1'}
-  | {env: 'prod'; region: 'us-east-1' | 'us-west-2' | 'eu-west-1'};
+  | {env: 'dev'; region: 'us' | 'eu'}
+  | {env: 'qa'; region: 'us' | 'eu'}
+  | {env: 'hipaa'; region: 'us'}
+  | {env: 'prod'; region: 'us' | 'eu' | 'au'};
 
 type PlatformEnvironment = PlatformCombination['env'];
 
@@ -104,7 +104,7 @@ export function platformUrl<E extends PlatformEnvironment = 'prod'>(options?: {
       ? ''
       : options.environment;
   const urlRegion =
-    !options || !options.region || options.region === 'us-east-1'
+    !options || !options.region || options.region === 'us'
       ? ''
       : `-${options.region}`;
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -15,7 +15,7 @@ import {
 } from './configuration-state';
 
 describe('configuration slice', () => {
-  const url = platformUrl({environment: 'dev', region: 'eu-west-3'});
+  const url = platformUrl({environment: 'dev', region: 'eu'});
   const existingState: ConfigurationState = {
     ...getConfigurationInitialState(),
     accessToken: 'mytoken123',


### PR DESCRIPTION
Luckily, we currently only use that function internally with "no parameter", which did return the correct default platform URL.

However, the function is exported globally in Headless (not 100% sure why, but 🤷 ), which means someone could have stumbled upon that bug.

I validated the correct endpoint and region available using https://platform.cloud.coveo.com/rest/global/regions (switching per environment).

The only valid external facing URL as far as Headless is concerned are the "main endpoint".

https://coveord.atlassian.net/browse/KIT-1064