### PR TITLE
feat(atomic): Add PoC of custom sort option

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -120,6 +120,10 @@ export namespace Components {
     }
     interface AtomicFacet {
         /**
+          * Places the specified values at the top of the facet if found in the the search api response.
+         */
+        "customSort": string;
+        /**
           * The character that separates values of a multi-value field.
          */
         "delimitingCharacter": string;
@@ -1276,6 +1280,10 @@ declare namespace LocalJSX {
     interface AtomicDidYouMean {
     }
     interface AtomicFacet {
+        /**
+          * Places the specified values at the top of the facet if found in the the search api response.
+         */
+        "customSort"?: string;
         /**
           * The character that separates values of a multi-value field.
          */

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -145,7 +145,10 @@ export class AtomicFacet
    * Minimum: `0`
    */
   @Prop() public injectionDepth = 1000;
-  // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
+  /**
+   * Places the specified values at the top of the facet if found in the the search api response.
+   */
+  @Prop() public customSort = '';
 
   private validateProps() {
     new Schema({
@@ -314,8 +317,9 @@ export class AtomicFacet
   }
 
   private renderValues() {
+    const sortedValues = this.sortedValues;
     return this.renderValuesContainer(
-      this.facetState.values.map((value) =>
+      sortedValues.map((value) =>
         this.renderValue(value, () =>
           this.displayValuesAs === 'link'
             ? this.facet.toggleSingleSelect(value)
@@ -323,6 +327,25 @@ export class AtomicFacet
         )
       )
     );
+  }
+
+  private get sortedValues() {
+    const configured = this.customSort.split(',');
+    const valueMap: Record<string, FacetValue> = this.facetState.values.reduce(
+      (map, curr) => ({...map, [curr.value]: curr}),
+      {}
+    );
+
+    const prioritized: FacetValue[] = [];
+    configured.forEach((value) => {
+      if (value in valueMap) {
+        prioritized.push(valueMap[value]);
+        delete valueMap[value];
+      }
+    });
+
+    const remaining = Object.values(valueMap);
+    return [...prioritized, ...remaining];
   }
 
   private renderSearchResults() {

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -237,7 +237,7 @@
       <atomic-search-box></atomic-search-box>
       <atomic-facet-manager>
         <atomic-category-facet field="geographicalhierarchy" label="World Atlas" with-search> </atomic-category-facet>
-        <atomic-facet field="author" label="Authors"></atomic-facet>
+        <atomic-facet field="author" label="Authors" custom-sort="BillV"></atomic-facet>
         <atomic-facet field="language" label="Language"></atomic-facet>
         <atomic-facet field="objecttype" label="Type" display-values-as="link"></atomic-facet>
         <atomic-facet field="year" label="Year" display-values-as="box"></atomic-facet>


### PR DESCRIPTION
This PoC follows the apporach used by the JSUI dynamic facets.
The values are reordered only if they exist in the facet search response.

Since the sort is purely client-side, there was not much that headless could help with.

I will explore a different approach using `freezeCurrentValues` in a separate branch, 

https://coveord.atlassian.net/browse/KIT-753