### PR TITLE
feat(productlisting): Create documentation definitions

### DIFF
--- a/packages/headless/config/api-extractor/product-listing.json
+++ b/packages/headless/config/api-extractor/product-listing.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "mainEntryPointFilePath": "<projectFolder>/temp/product-listing.index.d.ts",
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/temp/product-listing.api.json"
+  }
+}

--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -12,6 +12,7 @@ import {
   Engine,
   resolveEngine,
 } from './src/headless-export-resolvers/engine-resolver';
+import {productListingUseCase} from './use-cases/product-listing';
 import {productRecommendationUseCase} from './use-cases/product-recommendation';
 import {recommendationUseCase} from './use-cases/recommendation';
 import {searchUseCase} from './use-cases/search';
@@ -45,6 +46,11 @@ const useCases: UseCase[] = [
     name: 'product-recommendation',
     entryFile: 'temp/product-recommendation.api.json',
     config: productRecommendationUseCase,
+  },
+  {
+    name: 'product-listing',
+    entryFile: 'temp/product-listing.api.json',
+    config: productListingUseCase,
   },
 ];
 

--- a/packages/headless/doc-parser/use-cases/product-listing.ts
+++ b/packages/headless/doc-parser/use-cases/product-listing.ts
@@ -5,40 +5,100 @@ import {EngineConfiguration} from '../src/headless-export-resolvers/engine-resol
 const controllers: ControllerConfiguration[] = [
   {
     initializer: 'buildProductListing',
-    samplePaths: {},
+    samplePaths: {
+      react_fn: [
+        'packages/samples/headless-react/src/components/product-listing/product-listing.fn.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildPager',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/pager/pager.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/pager/pager.fn.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildResultsPerPage',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/results-per-page/results-per-page.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/results-per-page/results-per-page.fn.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildSort',
     samplePaths: {},
+    utils: [],
   },
   {
     initializer: 'buildFacetManager',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/facet-manager/facet-manager.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/facet-manager/facet-manager.fn.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildFacet',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/facet/facet.class.tsx',
+        'packages/samples/headless-react/src/components/facet/facet-search.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/facet/facet.fn.tsx',
+        'packages/samples/headless-react/src/components/facet/facet-search.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildCategoryFacet',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/category-facet/category-facet.class.tsx',
+        'packages/samples/headless-react/src/components/category-facet/category-facet-search.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/category-facet/category-facet.fn.tsx',
+        'packages/samples/headless-react/src/components/category-facet/category-facet-search.tsx',
+      ],
+    },
   },
   {
     initializer: 'buildNumericFacet',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/numeric-facet/numeric-facet.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/numeric-facet/numeric-facet.fn.tsx',
+      ],
+    },
     utils: ['buildNumericRange'],
   },
   {
     initializer: 'buildDateFacet',
-    samplePaths: {},
+    samplePaths: {
+      react_class: [
+        'packages/samples/headless-react/src/components/date-facet/date-facet.class.tsx',
+        'packages/samples/headless-react/src/components/relative-date-facet/relative-date-facet.class.tsx',
+      ],
+      react_fn: [
+        'packages/samples/headless-react/src/components/date-facet/date-facet.fn.tsx',
+        'packages/samples/headless-react/src/components/relative-date-facet/relative-date-facet.fn.tsx',
+      ],
+    },
     utils: ['buildDateRange'],
   },
 ];

--- a/packages/headless/doc-parser/use-cases/product-listing.ts
+++ b/packages/headless/doc-parser/use-cases/product-listing.ts
@@ -1,0 +1,56 @@
+import {ActionLoaderConfiguration} from '../src/headless-export-resolvers/action-loader-resolver';
+import {ControllerConfiguration} from '../src/headless-export-resolvers/controller-resolver';
+import {EngineConfiguration} from '../src/headless-export-resolvers/engine-resolver';
+
+const controllers: ControllerConfiguration[] = [
+  {
+    initializer: 'buildProductListing',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildPager',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildResultsPerPage',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildSort',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildFacetManager',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildFacet',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildCategoryFacet',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildNumericFacet',
+    samplePaths: {},
+    utils: ['buildNumericRange'],
+  },
+  {
+    initializer: 'buildDateFacet',
+    samplePaths: {},
+    utils: ['buildDateRange'],
+  },
+];
+
+const actionLoaders: ActionLoaderConfiguration[] = [
+  {
+    initializer: 'loadProductListingActions',
+  },
+];
+
+const engine: EngineConfiguration = {
+  initializer: 'buildProductListingEngine',
+};
+
+export const productListingUseCase = {controllers, actionLoaders, engine};

--- a/packages/headless/src/api/commerce/product-listings/product-listing-api-client.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-api-client.ts
@@ -66,7 +66,7 @@ export class ProductListingAPIClient {
    * Retrieves the product listing from the API.
    *
    * @param req - The request parameters.
-   * @returns The products for the requested listing.
+   * @returns The products for the requested product listing.
    */
   async getProducts(
     req: ProductListingRequest

--- a/packages/headless/src/app/product-listing-engine/product-listing-engine-configuration.ts
+++ b/packages/headless/src/app/product-listing-engine/product-listing-engine-configuration.ts
@@ -17,9 +17,9 @@ export const productListingEngineConfigurationSchema =
   });
 
 /**
- * Creates a sample product recommendation engine configuration.
+ * Creates a sample product listing engine configuration.
  *
- * @returns The sample product recommendation engine configuration.
+ * @returns The sample product listing engine configuration.
  */
 export function getSampleProductListingEngineConfiguration(): ProductListingEngineConfiguration {
   return {

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
@@ -5,9 +5,12 @@ import {buildController} from '../../controller/headless-controller';
 import {
   FacetManager,
   FacetManagerPayload,
+  FacetManagerState,
 } from '../../facet-manager/headless-facet-manager';
 import {ProductListingSection} from '../../../state/state-sections';
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
+
+export {FacetManager, FacetManagerState, FacetManagerPayload};
 
 /**
  * Creates a `FacetManager` instance for the product listing.

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
@@ -10,7 +10,7 @@ import {ProductListingSection} from '../../../state/state-sections';
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 
 /**
- * Creates a `FacetManager` instance.
+ * Creates a `FacetManager` instance for the product listing.
  *
  * @param productListingEngine - The headless engine.
  */

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
@@ -45,7 +45,7 @@ export {
 };
 
 /**
- * Creates a `Facet` controller instance.
+ * Creates a `Facet` controller instance for the product listing.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `Facet` properties.

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../test/mock-engine';
 import {
   buildProductListing,
-  ProductListingController,
+  ProductListing,
   ProductListingOptions,
 } from './headless-product-listing';
 import {Action} from 'redux';
@@ -17,10 +17,10 @@ import {
 } from '../../features/product-listing/product-listing-actions';
 
 describe('headless product-listing', () => {
-  let productListing: ProductListingController;
+  let productListing: ProductListing;
   let engine: MockProductListingEngine;
 
-  const baseOptions: Partial<ProductListingOptions> = {
+  const baseOptions: ProductListingOptions = {
     url: 'https://someurl.com',
   };
 

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -88,10 +88,10 @@ export type ProductListingControllerState = ProductListingController['state'];
  * @param props - The configurable `ProductListingController` properties.
  * @returns A `ProductListingController` controller instance.
  */
-export const buildProductListing = (
+export function buildProductListing(
   engine: ProductListingEngine,
   props: ProductListingProps = {}
-): ProductListingController => {
+): ProductListingController {
   if (!loadBaseProductListingReducers(engine)) {
     throw loadReducerError;
   }
@@ -148,7 +148,7 @@ export const buildProductListing = (
 
     refresh: () => dispatch(fetchProductListing()),
   };
-};
+}
 
 function loadBaseProductListingReducers(
   engine: ProductListingEngine

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -26,14 +26,14 @@ const optionsSchema = new Schema({
 
 export interface ProductListingOptions {
   /**
-   * The initial url used to retrieve the product listing.
+   * The initial URL used to retrieve the product listing.
    */
   url: string;
 
   /**
    * The initial additional fields to retrieve with the product listing.
    */
-  additionalFields: string[];
+  additionalFields?: string[];
 }
 
 export interface ProductListingProps {
@@ -44,18 +44,18 @@ export interface ProductListingProps {
 }
 
 /**
- * The `ProductListing` headless controller allows the end user to configure and retrieve product listing data.
+ * The `ProductListing` controller allows the end user to configure and retrieve product listing data.
  */
-export interface ProductListingController extends Controller {
+export interface ProductListing extends Controller {
   /**
-   * Changes the current url used to retrieve product listing.
-   * @param url - The new url.
+   * Changes the current URL used to retrieve product listing.
+   * @param url - The new URL.
    */
   setUrl(url: string): void;
 
   /**
    * Sets the additional fields to request in addition to the standard commerce fields.
-   * @param additionalFields - The new additional fields
+   * @param additionalFields - The new additional fields.
    */
   setAdditionalFields(additionalFields: string[]): void;
 
@@ -79,7 +79,7 @@ export interface ProductListingState {
   url: string;
 }
 
-export type ProductListingControllerState = ProductListingController['state'];
+export type ProductListingControllerState = ProductListing['state'];
 
 /**
  * Creates a `ProductListingController` controller instance.
@@ -91,7 +91,7 @@ export type ProductListingControllerState = ProductListingController['state'];
 export function buildProductListing(
   engine: ProductListingEngine,
   props: ProductListingProps = {}
-): ProductListingController {
+): ProductListing {
   if (!loadBaseProductListingReducers(engine)) {
     throw loadReducerError;
   }

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -3,12 +3,14 @@ import {
   setAdditionalFields,
   setProductListingUrl,
 } from '../../features/product-listing/product-listing-actions';
-import {buildController} from '../controller/headless-controller';
-import {ArrayValue, Schema, SchemaValues, StringValue} from '@coveo/bueno';
+import {buildController, Controller} from '../controller/headless-controller';
+import {ArrayValue, Schema, StringValue} from '@coveo/bueno';
 import {configuration, productListing} from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
 import {validateOptions} from '../../utils/validate-payload';
+import {ProductRecommendation} from '../../product-listing.index';
+import {ProductListingAPIErrorStatusResponse} from '../../api/commerce/product-listings/product-listing-api-client';
 
 const optionsSchema = new Schema({
   url: new StringValue({
@@ -22,19 +24,74 @@ const optionsSchema = new Schema({
   }),
 });
 
-export type ProductListingOptions = SchemaValues<typeof optionsSchema>;
+export interface ProductListingOptions {
+  /**
+   * The initial url used to retrieve the product listing.
+   */
+  url: string;
+
+  /**
+   * The initial additional fields to retrieve with the product listing.
+   */
+  additionalFields: string[];
+}
 
 export interface ProductListingProps {
+  /**
+   * The initial options that should be applied to this `ProductListing` controller.
+   */
   options?: ProductListingOptions;
 }
 
-export type ProductListingController = ReturnType<typeof buildProductListing>;
+/**
+ * The `ProductListing` headless controller allows the end user to configure and retrieve product listing data.
+ */
+export interface ProductListingController extends Controller {
+  /**
+   * Changes the current url used to retrieve product listing.
+   * @param url - The new url.
+   */
+  setUrl(url: string): void;
+
+  /**
+   * Sets the additional fields to request in addition to the standard commerce fields.
+   * @param additionalFields - The new additional fields
+   */
+  setAdditionalFields(additionalFields: string[]): void;
+
+  /**
+   * Refreshes the product listing.
+   */
+  refresh(): void;
+
+  /**
+   * A scoped and simplified part of the headless state that is relevant to the `ProductListing` controller.
+   * */
+  state: ProductListingState;
+}
+
+export interface ProductListingState {
+  products: ProductRecommendation[];
+  error: ProductListingAPIErrorStatusResponse | null;
+  isLoading: boolean;
+  responseId: string;
+  additionalFields: string[];
+  url: string;
+}
+
 export type ProductListingControllerState = ProductListingController['state'];
 
+/**
+ * Creates a `ProductListingController` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `ProductListingController` properties.
+ * @returns A `ProductListingController` controller instance.
+ */
 export const buildProductListing = (
   engine: ProductListingEngine,
   props: ProductListingProps = {}
-) => {
+): ProductListingController => {
   if (!loadBaseProductListingReducers(engine)) {
     throw loadReducerError;
   }

--- a/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
+++ b/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
@@ -12,7 +12,7 @@ import {fetchProductListing} from '../../../features/product-listing/product-lis
 export {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
 
 /**
- * Creates a `Pager` controller instance.
+ * Creates a `Pager` controller instance for the product listing.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `Pager` properties.

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
@@ -22,6 +22,7 @@ import {ProductListingEngine} from '../../../../app/product-listing-engine/produ
 
 export {
   DateFacetOptions,
+  DateFacetValue,
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
@@ -32,7 +32,7 @@ export {
 };
 
 /**
- * Creates a `DateFacet` controller instance.
+ * Creates a `DateFacet` controller instance for the product listing.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `DateFacet` controller properties.

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
@@ -37,7 +37,7 @@ export {
 };
 
 /**
- * Creates a `NumericFacet` controller instance.
+ * Creates a `NumericFacet` controller instance for the product listing.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `NumericFacet` properties.

--- a/packages/headless/src/controllers/product-listing/results-per-page/headless-product-listing-results-per-page.ts
+++ b/packages/headless/src/controllers/product-listing/results-per-page/headless-product-listing-results-per-page.ts
@@ -23,7 +23,7 @@ export {
 };
 
 /**
- * Creates a `ResultsPerPage` controller instance.
+ * Creates a `ResultsPerPage` controller instance for the product listing.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `ResultsPerPage` properties.

--- a/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
+++ b/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
@@ -41,23 +41,17 @@ export {
   buildFieldsSortCriterion,
 };
 
-export interface ProductListingSort extends Controller {
-  sortBy(criterion: SortCriterion): void;
-
-  isSortedBy(criterion: SortCriterion): boolean;
-
-  state: ProductListingSortState;
-}
-
-export interface ProductListingSortState {
-  sort: SortCriterion;
-}
-
 export interface ProductListingSortProps {
+  /**
+   * The initial state that should be applied to this `Sort` controller.
+   */
   initialState?: ProductListingSortInitialState;
 }
 
 export interface ProductListingSortInitialState {
+  /**
+   * The initial sort criterion to register in state.
+   */
   criterion?: SortCriterion;
 }
 
@@ -76,6 +70,42 @@ function validateSortInitialState(
   validateInitialState(engine, schema, state, 'buildSort');
 }
 
+export interface ProductListingSort extends Controller {
+  /**
+   * Updates the sort criterion and executes a new query.
+   *
+   * @param criterion - The new sort criterion.
+   */
+  sortBy(criterion: SortCriterion): void;
+
+  /**
+   * Checks whether the specified sort criterion matches the value in state.
+   *
+   * @param criterion - The criterion to compare.
+   * @returns `true` if the passed sort criterion matches the value in state, and `false` otherwise.
+   */
+  isSortedBy(criterion: SortCriterion): boolean;
+
+  /**
+   * A scoped and simplified part of the headless state that is relevant to the `Sort` controller.
+   */
+  state: ProductListingSortState;
+}
+
+export interface ProductListingSortState {
+  /**
+   * The current sort criterion.
+   */
+  sort: SortCriterion;
+}
+
+/**
+ * Creates a `Sort` controller instance for the product listing.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `Sort` controller properties.
+ * @returns A `Sort` controller instance.
+ */
 export function buildSort(
   engine: ProductListingEngine,
   props: ProductListingSortProps = {}

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -25,6 +25,7 @@ import {validatePayload} from '../../utils/validate-payload';
 import {ArrayValue, StringValue} from '@coveo/bueno';
 import {SortBy} from '../sort/sort';
 import {ProductListingState} from './product-listing-state';
+import {logQueryError} from '../search/search-analytics-actions';
 
 export interface SetProductListingUrlPayload {
   /**
@@ -92,7 +93,7 @@ export const fetchProductListing = createAsyncThunk<
   AsyncThunkProductListingOptions<StateNeededByFetchProductListing>
 >(
   'productlisting/fetch',
-  async (_action, {getState, rejectWithValue, extra}) => {
+  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
     const state = getState();
     const {productListingClient} = extra;
     const fetched = await productListingClient.getProducts(
@@ -100,7 +101,7 @@ export const fetchProductListing = createAsyncThunk<
     );
 
     if (isErrorResponse(fetched)) {
-      // TODO COM-1185: See if we need this: dispatch(logQueryError(fetched.response.error));
+      dispatch(logQueryError(fetched.error));
       return rejectWithValue(fetched.error);
     }
 
@@ -135,7 +136,6 @@ export const buildProductListingRequest = (
           advancedParameters: state.productListing.advancedParameters || {},
         }
       : {}),
-    // TODO COM-1185: properly implement facet options
     ...(facets.length && {
       facets: {
         requests: facets,

--- a/packages/headless/src/features/product-listing/product-listing-state.ts
+++ b/packages/headless/src/features/product-listing/product-listing-state.ts
@@ -2,7 +2,7 @@ import {ProductListingAPIErrorStatusResponse} from '../../api/commerce/product-l
 import {ProductRecommendation} from '../../api/search/search/product-recommendation';
 import {AnyFacetResponse} from '../facets/generic/interfaces/generic-facet-response';
 
-export type ProductListingState = {
+export interface ProductListingState {
   url: string;
   clientId: string;
   additionalFields: string[];
@@ -16,7 +16,7 @@ export type ProductListingState = {
   error: ProductListingAPIErrorStatusResponse | null;
   isLoading: boolean;
   responseId: string;
-};
+}
 
 export const getProductListingInitialState = (): ProductListingState => ({
   url: '',

--- a/packages/headless/src/features/sort/sort-actions-loader.ts
+++ b/packages/headless/src/features/sort/sort-actions-loader.ts
@@ -4,12 +4,33 @@ import {SortCriterion} from './sort';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {registerSortCriterion, updateSortCriterion} from './sort-actions';
 
+/**
+ * The sort action creators.
+ */
 export interface SortActionCreators {
+  /**
+   * Initializes the sort query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-sortCriteria).
+   *
+   * @param criterion - The initial sort.
+   * @returns A dispatchable action.
+   */
   registerSortCriterion(criterion: SortCriterion): PayloadAction<SortCriterion>;
 
+  /**
+   * Updates the sort query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-sortCriteria).
+   *
+   * @param criterion - The sort to set.
+   * @returns A dispatchable action.
+   */
   updateSortCriterion(criterion: SortCriterion): PayloadAction<SortCriterion>;
 }
 
+/**
+ * Loads the `sort` reducer and returns possible action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
 export function loadSortActions(engine: SearchEngine): SortActionCreators {
   engine.addReducers({sort});
 

--- a/packages/headless/src/features/sort/sort-actions-loader.ts
+++ b/packages/headless/src/features/sort/sort-actions-loader.ts
@@ -1,7 +1,7 @@
 import {PayloadAction} from '@reduxjs/toolkit';
+import {CoreEngine} from '../../app/engine';
 import {sort} from '../../app/reducers';
 import {SortCriterion} from './sort';
-import {SearchEngine} from '../../app/search-engine/search-engine';
 import {registerSortCriterion, updateSortCriterion} from './sort-actions';
 
 /**
@@ -31,7 +31,7 @@ export interface SortActionCreators {
  * @param engine - The headless engine.
  * @returns An object holding the action creators.
  */
-export function loadSortActions(engine: SearchEngine): SortActionCreators {
+export function loadSortActions(engine: CoreEngine): SortActionCreators {
   engine.addReducers({sort});
 
   return {

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -35,7 +35,7 @@ export {
 
 export {
   ProductListingState,
-  ProductListing as ProductListingController,
+  ProductListing,
   ProductListingOptions,
   ProductListingProps,
   ProductListingControllerState,

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -35,7 +35,7 @@ export {
 
 export {
   ProductListingState,
-  ProductListingController,
+  ProductListing as ProductListingController,
   ProductListingOptions,
   ProductListingProps,
   ProductListingControllerState,

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -8,6 +8,15 @@ export {
   getSampleProductListingEngineConfiguration,
 } from './app/product-listing-engine/product-listing-engine';
 
+export {CoreEngine, ExternalEngineOptions} from './app/engine';
+export {
+  EngineConfiguration,
+  AnalyticsConfiguration,
+  AnalyticsRuntimeEnvironment,
+} from './app/engine-configuration';
+export {LoggerOptions} from './app/logger';
+export {LogLevel} from './app/logger';
+
 export {ProductRecommendation} from './api/search/search/product-recommendation';
 
 // Actions
@@ -25,6 +34,7 @@ export {
 } from './controllers/controller/headless-controller';
 
 export {
+  ProductListingState,
   ProductListingController,
   ProductListingOptions,
   ProductListingProps,
@@ -65,7 +75,12 @@ export {
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
 
-export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
+export {
+  FacetManager,
+  FacetManagerPayload,
+  FacetManagerState,
+  buildFacetManager,
+} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 
 export {
   Facet,
@@ -99,6 +114,7 @@ export {
   DateFacetOptions,
   DateFacetProps,
   DateFacetState,
+  DateFacetValue,
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,

--- a/packages/samples/headless-react/src/components/product-listing/product-listing.fn.tsx
+++ b/packages/samples/headless-react/src/components/product-listing/product-listing.fn.tsx
@@ -1,0 +1,35 @@
+import {useEffect, useState, FunctionComponent} from 'react';
+import {ProductListing as HeadlessProductListing} from '@coveo/headless/product-listing';
+
+interface ProductListingProps {
+  controller: HeadlessProductListing;
+}
+
+export const ProductListing: FunctionComponent<ProductListingProps> = (
+  props
+) => {
+  const {controller} = props;
+  const [state, setState] = useState(controller.state);
+
+  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+
+  return (
+    <ul>
+      {state.products.map(({ec_name, clickUri, permanentid}) => (
+        <li key={permanentid}>
+          <a href={clickUri}>{ec_name}</a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// usage
+
+/**
+ * ```tsx
+ * const controller = buildProductListing(engine);
+ *
+ * <ProductListing controller={controller} />;
+ * ```
+ */

--- a/packages/samples/headless-react/src/context/engine.ts
+++ b/packages/samples/headless-react/src/context/engine.ts
@@ -1,10 +1,12 @@
 import {SearchEngine} from '@coveo/headless';
+import {ProductListingEngine} from '@coveo/headless/product-listing';
 import {RecommendationEngine} from '@coveo/headless/recommendation';
 import {createContext} from 'react';
 
 export interface AppContextType {
   engine: SearchEngine;
   recommendationEngine: RecommendationEngine;
+  productListingEngine: ProductListingEngine;
 }
 
 export const AppContext = createContext<Partial<AppContextType>>({});


### PR DESCRIPTION
I think this is all :thinking: 

There were a lot of jsdoc that was carried over from the split into core controllers. I went through pretty much all of the changes from [this commit](https://github.com/coveo/ui-kit/pull/1260) to ensure that they all were documented.

Then I ran the script to generate the doc a couple of times until it stopped complaining about missing interfaces :hehehehehe:

The Sort one was missing a lot of them, so it would be important to review it