### PR TITLE
fix(quantic): fix alignement for sort when query is too long

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -35,7 +35,7 @@
                   <c-quantic-tab label="Community" expression="@objecttype==&quot;Message&quot;" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Files" expression="@boxdocumenttype==File OR @spcontenttype==Document" engine-id={engineId}></c-quantic-tab>
                 </ul>
-                <div class="slds-grid slds-wrap slds-grid_vertical-align-center slds-m-vertical_small">
+                <div class="slds-grid slds-wrap slds-var-m-vertical_small">
                   <c-quantic-summary class="slds-order_2 slds-medium-order_1 slds-size_1-of-1 slds-medium-size_7-of-12" engine-id={engineId}>
                   </c-quantic-summary>
                   <c-quantic-sort class="slds-order_1 slds-medium-order_2 slds-size_1-of-1 slds-medium-size_5-of-12" engine-id={engineId}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85293211/136291295-0a01308f-e775-403e-9689-74544141fd4a.png)
