### PR TITLE
ci: skip cypress tests on tagged builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,7 @@ node('linux && docker') {
       }
 
       stage('Install Chrome') {
-        when { not { tag } }
-        steps {
+        if (!isBump) {
           sh "wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -"
           sh "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list"
           sh "apt-get update"
@@ -43,16 +42,14 @@ node('linux && docker') {
       }
 
       stage('Prepare Cypress') {
-        when { not { tag } }
-        steps {
+        if (!isBump) {
           sh 'apt-get -y install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libgbm-dev libnss3 libasound2 xauth xvfb'
           sh 'rm -rf /var/lib/apt/lists/*'
         }
       }
 
       stage('Cypress Test') {
-        when { not { tag } }
-        steps {
+        if (!isBump) {
           parallel([
             'atomic': {
               sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,10 @@ node('linux && docker') {
         sh 'npm run lint:check'
       }
 
+      stage('Generate Docs') {
+        sh 'npm run doc:generate'
+      }
+
       stage('Unit Test') {
         sh 'npm test'
         junit 'packages/*/reports/*.xml'
@@ -77,10 +81,6 @@ node('linux && docker') {
             }
           ])
         }
-      }
-
-      stage('Generate Docs') {
-        sh 'npm run doc:generate'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,14 +18,6 @@ node('linux && docker') {
         sh 'npm run build'
       }
 
-      stage('Install Chrome') {
-        sh "wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -"
-        sh "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list"
-        sh "apt-get update"
-        sh "apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libxtst6 --no-install-recommends"
-        sh "google-chrome --version"
-      }
-
       stage('Linting') {
         sh 'npm run lint:check'
       }
@@ -35,39 +27,56 @@ node('linux && docker') {
         junit 'packages/*/reports/*.xml'
       }
 
+      stage('Install Chrome') {
+        when { not { tag } }
+        steps {
+          sh "wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -"
+          sh "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list"
+          sh "apt-get update"
+          sh "apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 libxtst6 --no-install-recommends"
+          sh "google-chrome --version"
+        }
+      }
+
       stage('Prepare Cypress') {
-        sh 'apt-get -y install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libgbm-dev libnss3 libasound2 xauth xvfb'
-        sh 'rm -rf /var/lib/apt/lists/*'
+        when { not { tag } }
+        steps {
+          sh 'apt-get -y install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libgbm-dev libnss3 libasound2 xauth xvfb'
+          sh 'rm -rf /var/lib/apt/lists/*'
+        }
       }
 
       stage('Cypress Test') {
-        parallel([
-          'atomic': {
-            sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'
-            sh 'cd packages/atomic && npm run start:prod & npx wait-on http://localhost:3333'
-            sh 'chown -R $(whoami) /tmp'
-            sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome'
-          },
-          'quantic': {
-            withCredentials([
-              string(credentialsId: 'sfdx-auth-client-id', variable: 'SFDX_AUTH_CLIENT_ID'),
-              file(credentialsId: 'sfdx-auth-jwt-key', variable: 'SFDX_AUTH_JWT_KEY'),
-            ]) {
-              withEnv([
-                "HOME=${env.WORKSPACE}/packages/quantic",
-                "BRANCH_NAME=${env.BRANCH_NAME}",
-                'SFDX_AUTH_JWT_INSTANCE_URL=https://login.salesforce.com',
-                'SFDX_AUTH_JWT_USERNAME=rdaccess@coveo.com'
+        when { not { tag } }
+        steps {
+          parallel([
+            'atomic': {
+              sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'
+              sh 'cd packages/atomic && npm run start:prod & npx wait-on http://localhost:3333'
+              sh 'chown -R $(whoami) /tmp'
+              sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome'
+            },
+            'quantic': {
+              withCredentials([
+                string(credentialsId: 'sfdx-auth-client-id', variable: 'SFDX_AUTH_CLIENT_ID'),
+                file(credentialsId: 'sfdx-auth-jwt-key', variable: 'SFDX_AUTH_JWT_KEY'),
               ]) {
-                sh 'cd packages/quantic && ./node_modules/cypress/bin/cypress install'
-                sh 'cd packages/quantic && ./node_modules/.bin/sfdx force:auth:jwt:grant --clientid $SFDX_AUTH_CLIENT_ID --jwtkeyfile $SFDX_AUTH_JWT_KEY --username $SFDX_AUTH_JWT_USERNAME --instanceurl $SFDX_AUTH_JWT_INSTANCE_URL --setdefaultdevhubusername'
-                sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/deploy-community.ts --ci'
-                sh 'cd packages/quantic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --browser chrome'
-                sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/delete-org.ts'
+                withEnv([
+                  "HOME=${env.WORKSPACE}/packages/quantic",
+                  "BRANCH_NAME=${env.BRANCH_NAME}",
+                  'SFDX_AUTH_JWT_INSTANCE_URL=https://login.salesforce.com',
+                  'SFDX_AUTH_JWT_USERNAME=rdaccess@coveo.com'
+                ]) {
+                  sh 'cd packages/quantic && ./node_modules/cypress/bin/cypress install'
+                  sh 'cd packages/quantic && ./node_modules/.bin/sfdx force:auth:jwt:grant --clientid $SFDX_AUTH_CLIENT_ID --jwtkeyfile $SFDX_AUTH_JWT_KEY --username $SFDX_AUTH_JWT_USERNAME --instanceurl $SFDX_AUTH_JWT_INSTANCE_URL --setdefaultdevhubusername'
+                  sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/deploy-community.ts --ci'
+                  sh 'cd packages/quantic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --browser chrome'
+                  sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/delete-org.ts'
+                }
               }
             }
-          }
-        ])
+          ])
+        }
       }
 
       stage('Generate Docs') {


### PR DESCRIPTION
**Context**

Tagged builds are failing often due to flaky cypress tests.

It's important that tagged builds are stable. Failure means packages are not deployed to npm, creating errors for others. Missing npm packages, in combination with bad symlinks, can cause:
- Other people's branches to fail if they pull in the version bump commit from `master` branch.
- Failed installation when running `npm run setup` after pulling the latest `master` branch.

**Proposed solution**

On tagged builds, e2e tests are skipped.

This should not change the risk of deploying regressions. Prior to creating the tag, cypress tests would have run successfully at least twice; on PR and on merge into `master`.
