### PR TITLE
fix(atomic): fix double UA events on click

### DIFF
--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -160,6 +160,16 @@ export class TestFixture {
     };
   }
 
+  public static get urlParts() {
+    return {
+      UA: 'https://analytics.cloud.coveo.com/rest/ua/v15/analytics',
+      Search: 'https://cloud.coveo.com/rest/search/v2',
+      UAClick: 'https://analytics.cloud.coveo.com/rest/ua/v15/analytics/click',
+      UASearch:
+        'https://analytics.cloud.coveo.com/rest/ua/v15/analytics/search',
+    };
+  }
+
   public get elementAliases() {
     return {
       SearchInterface: 'searchInterface',

--- a/packages/atomic/cypress/integration/result-list/result-components/result-link.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-link.cypress.ts
@@ -8,6 +8,8 @@ import {
   resultLinkComponent,
   ResultLinkSelectors,
 } from './result-link-selectors';
+import * as CommonAssertions from '../../common-assertions';
+import {ResultTemplateSelectors} from '../../result-templates/result-template-selectors';
 
 interface ResultLinkProps {
   target?: '_self' | '_blank' | '_parent' | '_top';
@@ -35,15 +37,11 @@ describe('Result Link Component', () => {
         .init();
     });
 
-    it.skip('should remove the component from the DOM', () => {
+    it('should remove the component from the DOM', () => {
       cy.get(resultLinkComponent).should('not.exist');
     });
 
-    it.skip('should log a console error', () => {
-      cy.get(resultLinkComponent)
-        .find('atomic-component-error')
-        .should('exist');
-    });
+    CommonAssertions.assertConsoleError();
   });
 
   describe('when used inside a result template', () => {
@@ -63,6 +61,12 @@ describe('Result Link Component', () => {
         )
         .init();
     }
+
+    it('should log one UA click event', () => {
+      setupResultLink();
+      ResultLinkSelectors.firstInResult().rightclick();
+      cy.shouldBeCalled(TestFixture.urlParts.UAClick, 1);
+    });
 
     it('the "target" prop should set the target on the "a" tag', () => {
       setupResultLink('_parent');

--- a/packages/atomic/cypress/integration/result-list/result-components/result-printable-uri.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-printable-uri.cypress.ts
@@ -82,6 +82,11 @@ describe('Result Printable Uri Component', () => {
         .should('have.attr', 'href', 'https://coveo.com')
         .should('have.attr', 'target', '_self');
     });
+
+    it('should log one UA click event', () => {
+      ResultPrintableUriSelectors.links().first().rightclick();
+      cy.shouldBeCalled(TestFixture.urlParts.UAClick, 1);
+    });
   });
 
   describe('when there is a "parents" property in the result object', () => {

--- a/packages/atomic/cypress/integration/search-interface.cypress.ts
+++ b/packages/atomic/cypress/integration/search-interface.cypress.ts
@@ -70,7 +70,7 @@ describe('Search Interface Component', () => {
     });
 
     it('should not call the analytics server', () => {
-      cy.shouldBeCalled('analytics', 0);
+      cy.shouldBeCalled(TestFixture.urlParts.UA, 0);
     });
   });
 });

--- a/packages/atomic/src/components/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/atomic-result/atomic-result.tsx
@@ -1,6 +1,5 @@
 import {Component, h, Prop, Element, Listen} from '@stencil/core';
 import {Result, SearchEngine} from '@coveo/headless';
-import {bindLogDocumentOpenOnResult} from '../../utils/result-utils';
 import {
   ResultDisplayLayout,
   ResultDisplayDensity,
@@ -61,8 +60,6 @@ export class AtomicResult {
     event.detail(this.result);
   }
 
-  private unbindLogDocumentOpen = () => {};
-
   private getClasses() {
     const classes = getResultDisplayClasses(
       this.display,
@@ -73,18 +70,6 @@ export class AtomicResult {
       classes.push('with-sections');
     }
     return classes;
-  }
-
-  public componentDidRender() {
-    this.unbindLogDocumentOpen = bindLogDocumentOpenOnResult(
-      this.engine,
-      this.result,
-      this.host.shadowRoot!
-    );
-  }
-
-  public disconnectedCallback() {
-    this.unbindLogDocumentOpen();
   }
 
   public render() {


### PR DESCRIPTION
I debated a bit internally about this one.

We had a `bindLogDocumentOpenOnResult` utility function in `AtomicResult` that would scan for all `a` elements in the result element, and then assume/auto log a click event using the result.

While kinda neat, it does add some magic in a place where I'm not sure we should have such magic. 

It's not 100% certain that for any anchor element in a template (where we don't necessarily control all the anchor) we should always assume that it is a "document click".

Since our customers will be able to create custom components (that might contain anchor), I think this would ultimately cause more confusion ?

What do you guys think ?

In any case, I added a couple Cypress tests to verify that we only send one analytics click, to verify the original bug/problem.

https://coveord.atlassian.net/browse/KIT-1108