### PR TITLE
fix(quantic): align show more button

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -14,7 +14,7 @@
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li>
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-grid slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>
@@ -31,7 +31,7 @@
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li>
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-grid slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>
@@ -58,7 +58,7 @@
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
                   <li>
-                    <a onclick={breadcrumb.expandButtonClick} class="slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
+                    <a onclick={breadcrumb.expandButtonClick} class="slds-grid slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</a>
                   </li>
                 </template>
               </ul>


### PR DESCRIPTION
All the breadcrumb pills are slds-grid which comes with certain dimensions so adding grid to the show-more button ensures they are aligned when displayed.

### Before
![image-20211008-202629](https://user-images.githubusercontent.com/16785453/136624177-3ae0d543-9f79-4540-b7bb-17628bc23258.png)

### After
<img width="694" alt="Screen Shot 2021-10-08 at 4 59 28 PM" src="https://user-images.githubusercontent.com/16785453/136624199-e77a5701-a2ca-4edb-af7d-ba2f8027e811.png">

