### PR TITLE
feat(atomic): added sections support to result tables

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -686,9 +686,25 @@ export namespace Components {
          */
         "content": string;
         /**
+          * How large or small results should be.
+         */
+        "density": ResultDisplayDensity;
+        /**
+          * How results should be displayed.
+         */
+        "display": ResultDisplayLayout;
+        /**
+          * How large or small the visual section of results should be.
+         */
+        "image": ResultDisplayImageSize;
+        /**
           * The result item.
          */
         "result": Result;
+        /**
+          * Whether this result should use `atomic-result-section-*` components.
+         */
+        "useSections": boolean;
     }
     interface AtomicTableElement {
         /**
@@ -1864,9 +1880,25 @@ declare namespace LocalJSX {
          */
         "content": string;
         /**
+          * How large or small results should be.
+         */
+        "density"?: ResultDisplayDensity;
+        /**
+          * How results should be displayed.
+         */
+        "display"?: ResultDisplayLayout;
+        /**
+          * How large or small the visual section of results should be.
+         */
+        "image"?: ResultDisplayImageSize;
+        /**
           * The result item.
          */
         "result": Result;
+        /**
+          * Whether this result should use `atomic-result-section-*` components.
+         */
+        "useSections"?: boolean;
     }
     interface AtomicTableElement {
         /**

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -24,6 +24,7 @@ import {
   getResultDisplayClasses,
 } from '../atomic-result/atomic-result-display-options';
 import {TemplateContent} from '../atomic-result-template/atomic-result-template';
+import {containsSection} from '../../utils/result-section-utils';
 
 /**
  * The `atomic-result-list` component is responsible for displaying query results by applying one or more result templates.
@@ -221,6 +222,7 @@ export class AtomicResultList implements InitializableComponent {
                   <atomic-table-cell
                     result={result}
                     content={column.innerHTML}
+                    useSections={containsSection(column)}
                   ></atomic-table-cell>
                 </td>
               ))}

--- a/packages/atomic/src/components/atomic-result-template/atomic-result-template.tsx
+++ b/packages/atomic/src/components/atomic-result-template/atomic-result-template.tsx
@@ -5,17 +5,7 @@ import {
   ResultTemplatesHelpers,
 } from '@coveo/headless';
 import {MapProp} from '../../utils/props-utils';
-
-const resultSectionTags = [
-  'atomic-result-section-visual',
-  'atomic-result-section-badges',
-  'atomic-result-section-actions',
-  'atomic-result-section-title',
-  'atomic-result-section-title-metadata',
-  'atomic-result-section-emphasized',
-  'atomic-result-section-excerpt',
-  'atomic-result-section-bottom-metadata',
-];
+import {containsSection} from '../../utils/result-section-utils';
 
 export interface TemplateContent {
   innerHTML: string;
@@ -106,7 +96,7 @@ export class AtomicResultTemplate {
       conditions: this.getConditions(),
       content: {
         innerHTML: this.getContent(),
-        usesSections: this.getTemplateHasSections(),
+        usesSections: containsSection(this.getTemplateElement().content),
       },
       priority: 1,
     };
@@ -119,12 +109,6 @@ export class AtomicResultTemplate {
   private getTemplateElement() {
     return (
       this.host.querySelector('template') ?? document.createElement('template')
-    );
-  }
-
-  private getTemplateHasSections() {
-    return Array.from(this.getTemplateElement().content.children).some(
-      (element) => resultSectionTags.includes(element.tagName.toLowerCase())
     );
   }
 

--- a/packages/atomic/src/components/atomic-table-result/atomic-result-cell.pcss
+++ b/packages/atomic/src/components/atomic-table-result/atomic-result-cell.pcss
@@ -1,0 +1,45 @@
+@import '../../global/global.pcss';
+@import '../atomic-result/atomic-result-with-sections.pcss';
+@import '../atomic-result/atomic-result-row-desktop.pcss';
+@import '../atomic-result/atomic-result-row-mobile.pcss';
+@import '../atomic-result/atomic-result-cell-desktop.pcss';
+@import '../atomic-result/atomic-result-cell-mobile.pcss';
+
+:host {
+  @apply font-sans font-normal;
+}
+
+.cell-root {
+  &.with-sections {
+    @mixin result-with-sections;
+
+    &.display-list {
+      @screen desktop-only {
+        @mixin row-result-desktop;
+      }
+      @screen mobile-only {
+        @mixin row-result-mobile;
+      }
+    }
+    &.display-grid {
+      &.image-large {
+        @screen desktop-only {
+          @mixin cell-result-desktop;
+        }
+        @screen mobile-only {
+          @mixin row-result-mobile;
+        }
+      }
+      &.image-small,
+      &.image-icon,
+      &.image-none {
+        @screen desktop-only {
+          @mixin cell-result-desktop;
+        }
+        @screen mobile-only {
+          @mixin cell-result-mobile;
+        }
+      }
+    }
+  }
+}

--- a/packages/atomic/src/components/atomic-table-result/atomic-table-cell.tsx
+++ b/packages/atomic/src/components/atomic-table-result/atomic-table-cell.tsx
@@ -1,11 +1,18 @@
 import {Component, h, Listen, Prop} from '@stencil/core';
 import {Result} from '@coveo/headless';
+import {
+  getResultDisplayClasses,
+  ResultDisplayDensity,
+  ResultDisplayImageSize,
+  ResultDisplayLayout,
+} from '../atomic-result/atomic-result-display-options';
 
 /**
  * The `atomic-table-cell` component is used internally by the `atomic-result-list` component.
  */
 @Component({
   tag: 'atomic-table-cell',
+  styleUrl: 'atomic-result-cell.pcss',
   shadow: true,
 })
 export class AtomicTableCell {
@@ -19,6 +26,26 @@ export class AtomicTableCell {
    */
   @Prop() content!: string;
 
+  /**
+   * Whether this result should use `atomic-result-section-*` components.
+   */
+  @Prop() useSections = true;
+
+  /**
+   * How results should be displayed.
+   */
+  @Prop() display: ResultDisplayLayout = 'list';
+
+  /**
+   * How large or small results should be.
+   */
+  @Prop() density: ResultDisplayDensity = 'normal';
+
+  /**
+   * How large or small the visual section of results should be.
+   */
+  @Prop() image: ResultDisplayImageSize = 'icon';
+
   @Listen('atomic/resolveResult')
   public resolveResult(event: CustomEvent) {
     event.preventDefault();
@@ -26,7 +53,24 @@ export class AtomicTableCell {
     event.detail(this.result);
   }
 
+  private getClasses() {
+    const classes = getResultDisplayClasses(
+      this.display,
+      this.density,
+      this.image
+    );
+    if (this.useSections) {
+      classes.push('with-sections');
+    }
+    return classes;
+  }
+
   public render() {
-    return <div innerHTML={this.content}></div>;
+    return (
+      <div
+        class={`cell-root ${this.getClasses().join(' ')}`}
+        innerHTML={this.content}
+      ></div>
+    );
   }
 }

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -395,8 +395,18 @@
                 </atomic-result-fields-list>
               </atomic-result-section-bottom-metadata>
               <atomic-table-element label="Description">
-                <atomic-result-link field="title"></atomic-result-link>
-                <atomic-result-text field="excerpt"></atomic-result-text>
+                <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
+                <atomic-result-section-title-metadata>
+                  <atomic-field-condition class="field" if-defined="snrating">
+                    <atomic-result-rating field="snrating"></atomic-result-rating>
+                  </atomic-field-condition>
+                  <atomic-field-condition class="field" if-not-defined="snrating">
+                    <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
+                  </atomic-field-condition>
+                </atomic-result-section-title-metadata>
+                <atomic-result-section-excerpt>
+                  <atomic-result-text field="excerpt"></atomic-result-text>
+                </atomic-result-section-excerpt>
               </atomic-table-element>
               <atomic-table-element label="author">
                 <atomic-result-text field="author"></atomic-result-text>

--- a/packages/atomic/src/utils/result-section-utils.ts
+++ b/packages/atomic/src/utils/result-section-utils.ts
@@ -1,0 +1,16 @@
+const resultSectionTags = [
+  'atomic-result-section-visual',
+  'atomic-result-section-badges',
+  'atomic-result-section-actions',
+  'atomic-result-section-title',
+  'atomic-result-section-title-metadata',
+  'atomic-result-section-emphasized',
+  'atomic-result-section-excerpt',
+  'atomic-result-section-bottom-metadata',
+];
+
+export function containsSection(element: ParentNode) {
+  return Array.from(element.children).some((child) =>
+    resultSectionTags.includes(child.tagName.toLowerCase())
+  );
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1053

As discussed with Johnny, this PR adds support for result sections in tables.

Visual demo (using 3 sections): https://rjnks.csb.app/
Demo to fork if you want to play around with templates: https://codesandbox.io/s/kit-1053-rjnks