### PR TITLE
fix(atomic): make visited printable uri links the  --atomic-visited color

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -30,5 +30,5 @@ atomic-result-printable-uri button:hover {
 }
 
 atomic-result-printable-uri a:visited {
-  color: var(--atomic-on-background);
+  color: var(--atomic-visited);
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1069
<img width="1088" alt="Screen Shot 2021-10-12 at 8 54 26 AM" src="https://user-images.githubusercontent.com/4923043/136960303-a35f39f6-bf08-4fbc-b4fd-06f329427421.png">


