### PR TITLE
feat(atomic): allow rating icons in the breadcrumb

### DIFF
--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.pcss
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.pcss
@@ -1,4 +1,5 @@
 @import '../../global/global.pcss';
+@import '../atomic-rating/atomic-rating.pcss';
 
 .max-w-snippet {
   max-width: 30ch;

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -1,4 +1,4 @@
-import {Component, h, State, Element} from '@stencil/core';
+import {Component, h, State, Element, VNode} from '@stencil/core';
 import {
   Bindings,
   InitializableComponent,
@@ -22,6 +22,7 @@ interface Breadcrumb {
   facetId: string;
   label: string;
   formattedValue: string[];
+  content?: VNode;
   deselect: () => void;
 }
 
@@ -147,20 +148,26 @@ export class AtomicBreadbox implements InitializableComponent {
         <Button
           part="breadcrumb-button"
           style="outline-neutral"
-          class="py-2 px-3 flex items-baseline btn-pill"
+          class="py-2 px-3 flex items-center btn-pill"
           title={`${breadcrumb.label}: ${fullValue}`}
           onClick={() => breadcrumb.deselect()}
         >
           <span
             part="breadcrumb-label"
-            class="max-w-snippet truncate with-colon text-neutral-dark mr-px"
+            class="max-w-snippet truncate with-colon text-neutral-dark mr-0.5"
           >
             {breadcrumb.label}
           </span>
-          <span part="breadcrumb-value" class="max-w-snippet truncate">
-            {value}
+          <span
+            part="breadcrumb-value"
+            class={breadcrumb.content ? '' : 'max-w-snippet truncate'}
+          >
+            {breadcrumb.content ?? value}
           </span>
-          <atomic-icon class="w-2 ml-2" icon={CloseIcon}></atomic-icon>
+          <atomic-icon
+            class="w-2.5 h-2.5 ml-2 mt-px"
+            icon={CloseIcon}
+          ></atomic-icon>
         </Button>
       </li>
     );
@@ -270,6 +277,9 @@ export class AtomicBreadbox implements InitializableComponent {
         formattedValue: [
           this.bindings.store.state.numericFacets[facetId].format(value.value),
         ],
+        content: this.bindings.store.state.numericFacets[facetId].content?.(
+          value.value
+        ),
       }));
   }
 

--- a/packages/atomic/src/components/atomic-rating/atomic-rating.tsx
+++ b/packages/atomic/src/components/atomic-rating/atomic-rating.tsx
@@ -40,12 +40,10 @@ export const Rating: FunctionalComponent<RatingProps> = (props) => {
   };
 
   return (
-    <div class="inline-block relative left-0 top-0" part="value-rating">
-      <div class="relative left-0 top-0 z-0 flex items-center gap-0.5 pt-0.5 pb-0.5">
-        {emptyIconDisplay()}
-      </div>
+    <div class="relative" part="value-rating">
+      <div class="z-0 flex gap-0.5">{emptyIconDisplay()}</div>
       <div
-        class="absolute left-0 top-0 z-1 flex items-center gap-0.5 pt-0.5 pb-0.5 overflow-hidden"
+        class="absolute left-0 top-0 z-1 flex gap-0.5 overflow-hidden"
         style={{width}}
       >
         {filledIconDisplay()}

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -158,6 +158,7 @@ export class AtomicRatingFacet
       facetId: this.facetId!,
       element: this.host,
       format: (value) => this.formatFacetValue(value),
+      content: (value) => this.ratingContent(value),
     });
   }
 
@@ -191,6 +192,16 @@ export class AtomicRatingFacet
     });
   }
 
+  private ratingContent(facetValue: NumericFacetValue) {
+    return (
+      <Rating
+        numberOfTotalIcons={this.maxValueInIndex}
+        numberOfActiveIcons={facetValue.start}
+        icon={this.icon}
+      ></Rating>
+    );
+  }
+
   private renderHeader() {
     return (
       <FacetHeader
@@ -217,11 +228,7 @@ export class AtomicRatingFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
           >
-            <Rating
-              numberOfTotalIcons={this.maxValueInIndex}
-              numberOfActiveIcons={facetValue.start}
-              icon={this.icon}
-            ></Rating>
+            {this.ratingContent(facetValue)}
           </FacetValueCheckbox>
         );
       case 'link':
@@ -233,11 +240,7 @@ export class AtomicRatingFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
           >
-            <Rating
-              numberOfTotalIcons={this.maxValueInIndex}
-              numberOfActiveIcons={facetValue.start}
-              icon={this.icon}
-            ></Rating>
+            {this.ratingContent(facetValue)}
           </FacetValueLink>
         );
     }

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -141,6 +141,7 @@ export class AtomicRatingRangeFacet
       facetId: this.facetId!,
       element: this.host,
       format: (value) => this.formatFacetValue(value),
+      content: (value) => this.ratingContent(value),
     });
   }
 
@@ -172,6 +173,19 @@ export class AtomicRatingRangeFacet
       start: facetValue.start,
       end: facetValue.end,
     });
+  }
+
+  private ratingContent(facetValue: NumericFacetValue) {
+    return (
+      <div class="flex items-center">
+        <Rating
+          numberOfTotalIcons={this.maxValueInIndex}
+          numberOfActiveIcons={facetValue.start}
+          icon={this.icon}
+        ></Rating>
+        {this.renderLabelText(facetValue)}
+      </div>
+    );
   }
 
   private renderHeader() {
@@ -215,12 +229,7 @@ export class AtomicRatingRangeFacet
         i18n={this.bindings.i18n}
         onClick={onClick}
       >
-        <Rating
-          numberOfTotalIcons={this.maxValueInIndex}
-          numberOfActiveIcons={facetValue.start}
-          icon={this.icon}
-        ></Rating>
-        {this.renderLabelText(facetValue)}
+        {this.ratingContent(facetValue)}
       </FacetValueLink>
     );
   }

--- a/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -43,7 +43,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
         ref={(ref) => (labelRef = ref!)}
         htmlFor={id}
         part="value-checkbox-label"
-        class="group"
+        class="group items-center"
         onMouseDown={(e) => createRipple(e, {color: 'neutral'})}
       >
         {children}

--- a/packages/atomic/src/utils/store.ts
+++ b/packages/atomic/src/utils/store.ts
@@ -3,6 +3,7 @@ import {
   DateFacetValue,
   SortCriterion,
 } from '@coveo/headless';
+import {VNode} from '@stencil/core';
 import {ObservableMap} from '@stencil/store';
 
 interface FacetInfo {
@@ -11,6 +12,7 @@ interface FacetInfo {
 
 interface FacetValueFormat<ValueType> {
   format(facetValue: ValueType): string;
+  content?(facetValue: ValueType): VNode;
 }
 
 type FacetType = 'facets' | 'numericFacets' | 'dateFacets' | 'categoryFacets';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1102
<img width="754" alt="Screen Shot 2021-10-12 at 12 23 05 PM" src="https://user-images.githubusercontent.com/4923043/136995163-ad873054-fe3d-4d6d-aa28-7d5312909c63.png">
