### PR TITLE
fix(atomic): removed margins outside results

### DIFF
--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list-cards.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list-cards.pcss
@@ -2,7 +2,6 @@
   atomic-result,
   atomic-result-placeholder {
     border: 1px solid var(--atomic-neutral);
-    margin: 1rem;
     padding: 1rem;
     border-radius: 1rem;
   }

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list-dividers.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list-dividers.pcss
@@ -1,7 +1,5 @@
 @define-mixin atomic-list-with-dividers {
   &.density-comfortable {
-    padding: 2rem 1rem;
-
     atomic-result,
     atomic-result-placeholder {
       &::before {
@@ -11,8 +9,6 @@
   }
 
   &.density-normal {
-    padding: 1.5rem 1rem;
-
     atomic-result,
     atomic-result-placeholder {
       &::before {
@@ -21,8 +17,6 @@
     }
 
     @screen mobile-only {
-      padding: 1.75rem 1rem;
-
       atomic-result,
       atomic-result-placeholder {
         &::before {
@@ -33,8 +27,6 @@
   }
 
   &.density-compact {
-    padding: 1rem 1rem;
-
     atomic-result,
     atomic-result-placeholder {
       &::before {
@@ -43,8 +35,6 @@
     }
 
     @screen mobile-only {
-      padding: 1.5rem 1rem;
-
       atomic-result,
       atomic-result-placeholder {
         &::before {

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -64,6 +64,8 @@
     &.image-small,
     &.image-icon,
     &.image-none {
+      grid-row-gap: 1rem;
+
       @mixin atomic-list-with-cards;
     }
   }
@@ -77,14 +79,12 @@
     grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
 
     &.density-comfortable {
-      padding: 2rem 0.75rem;
       grid-row-gap: 4rem;
       grid-column-gap: 1.5rem;
     }
 
     &.density-normal,
     &.density-compact {
-      padding: 1.5rem 0.75rem;
       grid-row-gap: 3rem;
       grid-column-gap: 1.5rem;
     }
@@ -100,17 +100,11 @@
 
   @define-mixin atomic-grid-with-cards {
     @mixin atomic-list-with-cards;
-    grid-column-gap: 2.5rem;
-    grid-row-gap: 2.5rem;
-
-    atomic-result,
-    atomic-result-placeholder {
-      margin: -1rem;
-    }
+    grid-column-gap: 0.5rem;
+    grid-row-gap: 0.5rem;
   }
 
   @screen mobile-only {
-    padding: 2rem;
     &.image-large {
       @media not all and (min-width: 768px) {
         @mixin atomic-list-with-dividers;

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -112,6 +112,7 @@
       /* Example of generic layout styling, mobile-first  */
       :root {
         --spacing: 16px;
+        --spacing-col: 32px;
         --search-box-width: 648px;
       }
 
@@ -200,7 +201,7 @@
 
       @media only screen and (min-width: 1024px) {
         atomic-search-interface {
-          column-gap: var(--spacing);
+          column-gap: var(--spacing-col);
           grid-template-columns: 1fr minmax(150px, 325px) minmax(500px, 1100px) 1fr;
           grid-template-areas:
             '. .      search      .'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1054

The first reason that prompted this change was that results weren't aligned with the query summary, filter button and search box. The second reason was that results were too small on a mobile grid with a small image.

I felt like it would be easier to style the result list if it has no margins (which is already the case for results on their own), so I decided to remove all margins outside the result list altogether.

This may be slightly breaking in existing implementations, but not very meaningfully.

One flaw with this change is that density no longer controls margins outside the result list, but I think the change is worth that small sacrifice.

# Examples
## Small mobile grid
<details>
<summary>Comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/137004835-b8515da5-44d0-4835-bf28-02dbda2cd87f.png) | ![image](https://user-images.githubusercontent.com/54454747/137003320-edda7cfd-f4d1-461e-be97-b44081354f57.png) |
</details>

## Large mobile grid
<details>
<summary>Comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/137004891-f3399624-3fa3-4da1-b740-2a33a3da35ad.png) | ![image](https://user-images.githubusercontent.com/54454747/137004150-3be022fd-deb6-419c-8be7-e60a7e990933.png) |
</details>

## Icon desktop list
<details>
<summary>Comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/137004959-0f264887-edfe-4a56-b6ea-557073c98d75.png) | ![image](https://user-images.githubusercontent.com/54454747/137004206-a7d16265-2c25-4f1c-aa26-70df775cb1b5.png) |
</details>

## Large desktop grid
<details>
<summary>Comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/137004996-4e0eed09-a4f5-4d66-be8b-9cd7d67f915a.png) | ![image](https://user-images.githubusercontent.com/54454747/137004270-b60891cf-3429-4c5b-a1c9-37b794be734f.png) |
</details>