### PR TITLE
fix(atomic): changed color of arrow in printable uri

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -17,6 +17,7 @@ atomic-result-printable-uri li:last-child::after {
   vertical-align: middle;
   width: 0.75rem;
   height: 0.75rem;
+  color: var(--atomic-neutral-dark);
 }
 
 atomic-result-printable-uri a,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1039

Prior to this PR, it was black.

![image](https://user-images.githubusercontent.com/54454747/137008370-d4ff7ad0-47e6-457d-bf8e-f452cd38a10f.png)
