### PR TITLE
fix(atomic): evened out vertical margin on mobile list badge

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -11,7 +11,7 @@
     }
 
     atomic-result-section-badges {
-      margin-bottom: 1.5rem;
+      margin-bottom: 1rem;
       height: 2rem;
     }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1055

The margin above and below the badges section was uneven on a mobile result list when the density was set to comfortable:
![image](https://user-images.githubusercontent.com/54454747/137009923-bf58db7e-b64c-4ac8-84bd-3dedcc265a1b.png)

I made sure that the margin was even for all other layouts where the badge is at the top of the result and an outline surrounds the result.