### PR TITLE
ci: checkout exact commit hash in deployment pipeline custom certifiers

### DIFF
--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -1,5 +1,5 @@
 node('linux && docker') {
-  def commitHash = params.packageName.substring(params.packageName.lastIndexOf('_') + 1)
+  def commitHash = params.packageName.substring(params.packageName.lastIndexOf('/') + 1)
 
   checkout([
     $class: 'GitSCM',

--- a/JenkinsfileQARelease
+++ b/JenkinsfileQARelease
@@ -1,5 +1,5 @@
 node('linux && docker') {
-  def commitHash = params.packageName.substring(params.packageName.lastIndexOf('_') + 1)
+  def commitHash = params.packageName.substring(params.packageName.lastIndexOf('/') + 1)
 
   checkout([
     $class: 'GitSCM',


### PR DESCRIPTION
Checking out the commit hash being deployed will ensure the correct npm package is marked as `latest`, instead of the latest version on the `master` branch.

I tried to test this change, but I could not verify the `packageName` form. There is a discrepancy between [this script](https://github.com/coveo/catalogservice/blob/master/Jenkinsfile_FT#L30), and the [deployment pipeline documentation](https://coveord.atlassian.net/wiki/spaces/CM/pages/1809809522/Team+Certifiers#:~:text=searchapi/searchapi_376ffb108086.zip) on the `packageName` format. Will test after merging,

Special mention: thanks @dlafreniere for your guidance.

Edit: the guess is the `packageName` for ui-kit is of the form `ui-kit/ui-kit/35cf011fe965`. I've [adjusted the delimiter](https://github.com/coveo/ui-kit/pull/1324/commits/ba2fad959dee87b09ea9332f72dc5f51fb06acb2) to take this into account. 