### PR TITLE
fix(atomic): fix margin right badge element to 8px

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.pcss
@@ -5,7 +5,3 @@
   place-items: center;
   height: 100%;
 }
-
-.result-badge-element {
-  margin-right: 8px;
-}

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -63,7 +63,7 @@ export class AtomicResultBadge {
     return (
       <div
         part="result-badge-element"
-        class="inline-flex place-items-center space-x-1.5 h-full px-3 bg-neutral-light text-neutral-dark text-xs rounded-full result-badge-element"
+        class="inline-flex place-items-center space-x-1.5 h-full px-3 bg-neutral-light text-neutral-dark text-xs rounded-full mr-2"
       >
         {this.icon && this.renderIcon()}
         {(this.field || this.label) && this.renderText()}


### PR DESCRIPTION
I did not find anything in tailwind documentation (https://tailwindcss.com/docs/margin) to allow to specify fixed 8px (only 1px).

So I went with good old class name + css.

https://coveord.atlassian.net/browse/KIT-1042