### PR TITLE
feat(headless): support static filter in url

### DIFF
--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -12,6 +12,8 @@ import {buildMockFacetValueRequest} from '../../test/mock-facet-value-request';
 import {buildMockNumericFacetRequest} from '../../test/mock-numeric-facet-request';
 import {buildMockNumericFacetValue} from '../../test/mock-numeric-facet-value';
 import {buildMockSearchParameters} from '../../test/mock-search-parameters';
+import {buildMockStaticFilterSlice} from '../../test/mock-static-filter-slice';
+import {buildMockStaticFilterValue} from '../../test/mock-static-filter-value';
 import {buildMockTabSlice} from '../../test/mock-tab-state';
 import {
   buildSearchParameterManager,
@@ -158,6 +160,28 @@ describe('search parameter manager', () => {
 
     it('when the parameter is equal to the default value, it is not included', () => {
       expect('numberOfResults' in manager.state.parameters).toBe(false);
+    });
+  });
+
+  describe('#state.parameters.sf', () => {
+    it('when a static filter has a selected value, only selected values are included', () => {
+      const id = 'a';
+      const selected = buildMockStaticFilterValue({
+        caption: 'a',
+        state: 'selected',
+      });
+      const idle = buildMockStaticFilterValue({caption: 'b', state: 'idle'});
+      const filter = buildMockStaticFilterSlice({id, values: [selected, idle]});
+
+      engine.state.staticFilterSet = {[id]: filter};
+      expect(manager.state.parameters.sf).toEqual({[id]: [selected.caption]});
+    });
+
+    it('when no static filters have selected values, the #sf parameter is not included', () => {
+      const filter = buildMockStaticFilterSlice();
+
+      engine.state.staticFilterSet = {a: filter};
+      expect('sf' in manager.state.parameters).toBe(false);
     });
   });
 
@@ -337,6 +361,13 @@ describe('search parameter manager', () => {
     const dateRanges = [buildMockDateFacetValue({state: 'selected'})];
     engine.state.dateFacetSet = {
       created: buildMockDateFacetRequest({currentValues: dateRanges}),
+    };
+
+    const staticFilterValues = [
+      buildMockStaticFilterValue({state: 'selected'}),
+    ];
+    engine.state.staticFilterSet = {
+      a: buildMockStaticFilterSlice({id: 'a', values: staticFilterValues}),
     };
 
     const tab = buildMockTabSlice({id: 'a', isActive: true});

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -19,6 +19,7 @@ import {initialSearchParameterSelector} from '../../features/search-parameters/s
 import {executeSearch} from '../../features/search/search-actions';
 import {logParametersChange} from '../../features/search-parameters/search-parameter-analytics-actions';
 import {deepEqualAnyOrder} from '../../utils/compare-utils';
+import {StaticFilterValue} from '../../features/static-filter-set/static-filter-set-state';
 
 export {SearchParameters};
 
@@ -231,14 +232,16 @@ function getStaticFilters(state: Partial<SearchParametersState>) {
 
   const sf = Object.entries(state.staticFilterSet)
     .map(([id, filter]) => {
-      const selectedValues = filter.values
-        .filter((v) => v.state === 'selected')
-        .map((v) => v.caption);
+      const selectedValues = getSelectedStaticFilterValues(filter.values);
       return selectedValues.length ? {[id]: selectedValues} : {};
     })
     .reduce((acc, obj) => ({...acc, ...obj}), {});
 
   return Object.keys(sf).length ? {sf} : {};
+}
+
+function getSelectedStaticFilterValues(values: StaticFilterValue[]) {
+  return values.filter((v) => v.state === 'selected').map((v) => v.caption);
 }
 
 function getFacets(state: Partial<SearchParametersState>) {

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -232,15 +232,15 @@ function getStaticFilters(state: Partial<SearchParametersState>) {
 
   const sf = Object.entries(state.staticFilterSet)
     .map(([id, filter]) => {
-      const selectedValues = getSelectedStaticFilterValues(filter.values);
-      return selectedValues.length ? {[id]: selectedValues} : {};
+      const selectedCaptions = getSelectedStaticFilterCaptions(filter.values);
+      return selectedCaptions.length ? {[id]: selectedCaptions} : {};
     })
     .reduce((acc, obj) => ({...acc, ...obj}), {});
 
   return Object.keys(sf).length ? {sf} : {};
 }
 
-function getSelectedStaticFilterValues(values: StaticFilterValue[]) {
+function getSelectedStaticFilterCaptions(values: StaticFilterValue[]) {
   return values.filter((v) => v.state === 'selected').map((v) => v.caption);
 }
 

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -140,6 +140,7 @@ function getActiveSearchParameters(engine: SearchEngine): SearchParameters {
     ...getNumericFacets(state),
     ...getDateFacets(state),
     ...getDebug(state),
+    ...getStaticFilters(state),
   };
 }
 
@@ -221,6 +222,23 @@ function getSortCriteria(state: Partial<SearchParametersState>) {
   const sortCriteria = state.sortCriteria;
   const shouldInclude = sortCriteria !== getSortCriteriaInitialState();
   return shouldInclude ? {sortCriteria} : {};
+}
+
+function getStaticFilters(state: Partial<SearchParametersState>) {
+  if (state.staticFilterSet === undefined) {
+    return {};
+  }
+
+  const sf = Object.entries(state.staticFilterSet)
+    .map(([id, filter]) => {
+      const selectedValues = filter.values
+        .filter((v) => v.state === 'selected')
+        .map((v) => v.caption);
+      return selectedValues.length ? {[id]: selectedValues} : {};
+    })
+    .reduce((acc, obj) => ({...acc, ...obj}), {});
+
+  return Object.keys(sf).length ? {sf} : {};
 }
 
 function getFacets(state: Partial<SearchParametersState>) {

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -69,6 +69,11 @@ export interface SearchParameters {
   sortCriteria?: string;
 
   /**
+   * A record of the static filters, where the key is the static filter id, and value is an array containing the selected static filter values.
+   */
+  sf?: Record<string, string[]>;
+
+  /**
    * The active tab id.
    */
   tab?: string;

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -69,7 +69,7 @@ export interface SearchParameters {
   sortCriteria?: string;
 
   /**
-   * A record of the static filters, where the key is the static filter id, and value is an array containing the selected static filter values.
+   * A record of the static filters, where the key is the static filter id, and value is an array containing the selected static filter captions.
    */
   sf?: Record<string, string[]>;
 

--- a/packages/headless/src/features/search-parameters/search-parameter-schema.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-schema.ts
@@ -22,5 +22,6 @@ export const searchParametersDefinition: SchemaDefinition<
   nf: new RecordValue(),
   df: new RecordValue(),
   debug: new BooleanValue(),
+  sf: new RecordValue(),
   tab: new StringValue(),
 };

--- a/packages/headless/src/features/search-parameters/search-parameter-selectors.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-selectors.ts
@@ -26,6 +26,7 @@ export function initialSearchParameterSelector(
     nf: {},
     df: {},
     debug: getDebugInitialState(),
+    sf: {},
     tab: '',
   };
 }

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.test.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.test.ts
@@ -190,6 +190,16 @@ describe('buildSearchParameterSerializer', () => {
       expect(result).toEqual({aq: '@author==alice'});
     });
 
+    it('deserializes two static filters correctly', () => {
+      const result = deserialize('sf[author]=a,b&sf[filetype]=c,d');
+      expect(result).toEqual({
+        sf: {
+          author: ['a', 'b'],
+          filetype: ['c', 'd'],
+        },
+      });
+    });
+
     it('deserializes two facets correctly', () => {
       const result = deserialize('f[author]=a,b&f[filetype]=c,d');
       expect(result).toEqual({
@@ -379,7 +389,8 @@ describe('buildSearchParameterSerializer', () => {
         }),
       ],
     };
-    const parameters = buildMockSearchParameters({f, cf, nf, df});
+    const sf = {fileType: ['a', 'b']};
+    const parameters = buildMockSearchParameters({f, cf, nf, df, sf});
 
     const {serialize, deserialize} = buildSearchParameterSerializer();
     const serialized = serialize(parameters);

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
@@ -10,7 +10,8 @@ const delimiter = '&';
 const equal = '=';
 const rangeDelimiter = '..';
 
-type UnknownFacetObject = {[field: string]: unknown[]};
+type SearchParameterKey = keyof SearchParameters;
+type UnknownObject = {[field: string]: unknown[]};
 
 export function buildSearchParameterSerializer() {
   return {serialize, deserialize};
@@ -109,20 +110,14 @@ function deserialize(fragment: string): SearchParameters {
   const parts = fragment.split(delimiter);
   const keyValuePairs = parts
     .map((part) => splitOnFirstEqual(part))
-    .map(preprocessFacetPairs)
+    .map(preprocessObjectPairs)
     .filter(isValidPair)
     .map(cast);
 
   return keyValuePairs.reduce((acc: SearchParameters, pair) => {
     const [key, val] = pair;
 
-    if (
-      key === 'f' ||
-      key === 'cf' ||
-      key === 'nf' ||
-      key === 'df' ||
-      key === 'sf'
-    ) {
+    if (keyIsForObjectValue(key)) {
       const mergedValues = {...acc[key], ...(val as object)};
       return {...acc, [key]: mergedValues};
     }
@@ -138,25 +133,25 @@ function splitOnFirstEqual(str: string) {
   return [first, second];
 }
 
-function preprocessFacetPairs(pair: string[]) {
+function preprocessObjectPairs(pair: string[]) {
   const [key, val] = pair;
-  const facetKey = /^(f|cf|nf|df|sf)\[(.+)\]$/;
-  const result = facetKey.exec(key);
+  const objectKey = /^(f|cf|nf|df|sf)\[(.+)\]$/;
+  const result = objectKey.exec(key);
 
   if (!result) {
     return pair;
   }
 
   const paramKey = result[1];
-  const facetId = result[2];
+  const id = result[2];
   const values = val.split(',');
-  const processedValues = processFacetValues(paramKey, values);
-  const obj = {[facetId]: processedValues};
+  const processedValues = processObjectValues(paramKey, values);
+  const obj = {[id]: processedValues};
 
   return [paramKey, JSON.stringify(obj)];
 }
 
-function processFacetValues(key: string, values: string[]) {
+function processObjectValues(key: string, values: string[]) {
   if (key === 'nf') {
     return buildNumericRanges(values);
   }
@@ -188,7 +183,7 @@ function buildDateRanges(ranges: string[]) {
     .map(([start, end]) => buildDateRange({start, end, state: 'selected'}));
 }
 
-function isValidPair<K extends keyof SearchParameters>(
+function isValidPair<K extends SearchParameterKey>(
   pair: string[]
 ): pair is [K, string] {
   const validKey = isValidKey(pair[0]);
@@ -196,7 +191,7 @@ function isValidPair<K extends keyof SearchParameters>(
   return validKey && lengthOfTwo;
 }
 
-function isValidKey(key: string): key is keyof SearchParameters {
+function isValidKey(key: string): key is SearchParameterKey {
   const supportedParameters: Record<keyof Required<SearchParameters>, boolean> =
     {
       q: true,
@@ -218,9 +213,7 @@ function isValidKey(key: string): key is keyof SearchParameters {
   return key in supportedParameters;
 }
 
-function cast<K extends keyof SearchParameters>(
-  pair: [K, string]
-): [K, unknown] {
+function cast<K extends SearchParameterKey>(pair: [K, string]): [K, unknown] {
   const [key, value] = pair;
 
   if (key === 'enableQuerySyntax') {
@@ -239,26 +232,27 @@ function cast<K extends keyof SearchParameters>(
     return [key, parseInt(value)];
   }
 
-  if (
-    key === 'f' ||
-    key === 'cf' ||
-    key === 'nf' ||
-    key === 'df' ||
-    key === 'sf'
-  ) {
-    return [key, castUnknownFacetObject(value)];
+  if (keyIsForObjectValue(key)) {
+    return [key, castUnknownObject(value)];
   }
 
   return [key, decodeURIComponent(value)];
 }
 
-function castUnknownFacetObject(value: string) {
-  const jsonParsed = JSON.parse(value) as UnknownFacetObject;
-  const ret = {} as UnknownFacetObject;
+function castUnknownObject(value: string) {
+  const jsonParsed: UnknownObject = JSON.parse(value);
+  const ret: UnknownObject = {};
   Object.entries(jsonParsed).forEach((entry) => {
-    const [facetId, values] = entry;
-    ret[facetId] = values.map((v) => (isString(v) ? decodeURIComponent(v) : v));
+    const [id, values] = entry;
+    ret[id] = values.map((v) => (isString(v) ? decodeURIComponent(v) : v));
   });
 
   return ret;
+}
+
+function keyIsForObjectValue(
+  key: SearchParameterKey
+): key is 'f' | 'cf' | 'nf' | 'df' | 'sf' {
+  const keys = ['f', 'cf', 'nf', 'df', 'sf'];
+  return keys.includes(key);
 }

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
@@ -117,7 +117,7 @@ function deserialize(fragment: string): SearchParameters {
   return keyValuePairs.reduce((acc: SearchParameters, pair) => {
     const [key, val] = pair;
 
-    if (keyIsForObjectValue(key)) {
+    if (keyHasObjectValue(key)) {
       const mergedValues = {...acc[key], ...(val as object)};
       return {...acc, [key]: mergedValues};
     }
@@ -232,7 +232,7 @@ function cast<K extends SearchParameterKey>(pair: [K, string]): [K, unknown] {
     return [key, parseInt(value)];
   }
 
-  if (keyIsForObjectValue(key)) {
+  if (keyHasObjectValue(key)) {
     return [key, castUnknownObject(value)];
   }
 
@@ -250,7 +250,7 @@ function castUnknownObject(value: string) {
   return ret;
 }
 
-function keyIsForObjectValue(
+function keyHasObjectValue(
   key: SearchParameterKey
 ): key is 'f' | 'cf' | 'nf' | 'df' | 'sf' {
   const keys = ['f', 'cf', 'nf', 'df', 'sf'];

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
@@ -30,7 +30,7 @@ function serializePair(pair: [string, unknown]) {
     return '';
   }
 
-  if (key === 'f' || key === 'cf') {
+  if (key === 'f' || key === 'cf' || key === 'sf') {
     return isFacetObject(val) ? serializeFacets(key, val) : '';
   }
 
@@ -116,7 +116,13 @@ function deserialize(fragment: string): SearchParameters {
   return keyValuePairs.reduce((acc: SearchParameters, pair) => {
     const [key, val] = pair;
 
-    if (key === 'f' || key === 'cf' || key === 'nf' || key === 'df') {
+    if (
+      key === 'f' ||
+      key === 'cf' ||
+      key === 'nf' ||
+      key === 'df' ||
+      key === 'sf'
+    ) {
       const mergedValues = {...acc[key], ...(val as object)};
       return {...acc, [key]: mergedValues};
     }
@@ -134,7 +140,7 @@ function splitOnFirstEqual(str: string) {
 
 function preprocessFacetPairs(pair: string[]) {
   const [key, val] = pair;
-  const facetKey = /^(f|cf|nf|df)\[(.+)\]$/;
+  const facetKey = /^(f|cf|nf|df|sf)\[(.+)\]$/;
   const result = facetKey.exec(key);
 
   if (!result) {
@@ -205,6 +211,7 @@ function isValidKey(key: string): key is keyof SearchParameters {
       nf: true,
       df: true,
       debug: true,
+      sf: true,
       tab: true,
     };
 
@@ -232,7 +239,13 @@ function cast<K extends keyof SearchParameters>(
     return [key, parseInt(value)];
   }
 
-  if (key === 'f' || key === 'cf' || key === 'nf' || key === 'df') {
+  if (
+    key === 'f' ||
+    key === 'cf' ||
+    key === 'nf' ||
+    key === 'df' ||
+    key === 'sf'
+  ) {
     return [key, castUnknownFacetObject(value)];
   }
 

--- a/packages/headless/src/features/static-filter-set/static-filter-set-slice.test.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-slice.test.ts
@@ -1,5 +1,6 @@
 import {buildMockStaticFilterSlice} from '../../test/mock-static-filter-slice';
 import {buildMockStaticFilterValue} from '../../test/mock-static-filter-value';
+import {restoreSearchParameters} from '../search-parameters/search-parameter-actions';
 import {
   deselectAllStaticFilterValues,
   registerStaticFilter,
@@ -136,6 +137,35 @@ describe('static-filter-set slice', () => {
     it('when the id is an empty string, the action detects an error', () => {
       const action = deselectAllStaticFilterValues('');
       expect('error' in action).toBe(true);
+    });
+  });
+
+  describe('#restoreSearchParameters', () => {
+    it(`when the #sf record contains a valid id and caption, and the caption in state is not selected,
+    it selects it`, () => {
+      const id = 'a';
+      const value = buildMockStaticFilterValue({caption: 'a', state: 'idle'});
+      const filter = buildMockStaticFilterSlice({values: [value]});
+
+      const action = restoreSearchParameters({sf: {[id]: [value.caption]}});
+      const state = staticFilterSetReducer({a: filter}, action);
+
+      expect(state[id].values).toEqual([{...value, state: 'selected'}]);
+    });
+
+    it(`when the #sf record is empty, and a caption in state is selected,
+    it sets it to idle`, () => {
+      const id = 'a';
+      const value = buildMockStaticFilterValue({
+        caption: 'a',
+        state: 'selected',
+      });
+      const filter = buildMockStaticFilterSlice({values: [value]});
+
+      const action = restoreSearchParameters({sf: {}});
+      const state = staticFilterSetReducer({a: filter}, action);
+
+      expect(state[id].values).toEqual([{...value, state: 'idle'}]);
     });
   });
 });

--- a/packages/headless/src/features/static-filter-set/static-filter-set-slice.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-slice.ts
@@ -1,4 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {restoreSearchParameters} from '../search-parameters/search-parameter-actions';
 import {
   deselectAllStaticFilterValues,
   registerStaticFilter,
@@ -46,5 +47,18 @@ export const staticFilterSetReducer = createReducer(
         }
 
         filter.values.forEach((v) => (v.state = 'idle'));
+      })
+      .addCase(restoreSearchParameters, (state, action) => {
+        const sf = action.payload.sf || {};
+
+        Object.entries(state).forEach(([id, filter]) => {
+          const selected = sf[id] || [];
+
+          filter.values.forEach((value) => {
+            value.state = selected.includes(value.caption)
+              ? 'selected'
+              : 'idle';
+          });
+        });
       })
 );

--- a/packages/headless/src/test/mock-search-parameters.ts
+++ b/packages/headless/src/test/mock-search-parameters.ts
@@ -16,6 +16,7 @@ export function buildMockSearchParameters(
     nf: {},
     df: {},
     debug: false,
+    sf: {},
     tab: '',
     ...config,
   };


### PR DESCRIPTION
This PR adds active static filter captions to the url, using a similar form to facets and category facets:

```
sf[id]=caption1,caption2
```

Next step: Documentation and samples