### PR TITLE
fix(atomic): adjusted number of columns for grid results

### DIFF
--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.pcss
@@ -94,7 +94,12 @@
     }
 
     &.image-small {
-      grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+      @media not all and (min-width: 1180px) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+      @media (min-width: 1180px) {
+        grid-template-columns: repeat(4, 1fr);
+      }
     }
   }
 
@@ -115,14 +120,19 @@
         grid-template-columns: 1fr 1fr;
       }
     }
-    &.image-small {
-      @mixin atomic-grid-with-cards;
-      grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
-    }
+    &.image-small,
     &.image-icon,
     &.image-none {
       @mixin atomic-grid-with-cards;
-      grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+      @media not all and (min-width: 320px) {
+        grid-template-columns: 1fr;
+      }
+      @media (min-width: 320px) {
+        grid-template-columns: 1fr 1fr;
+      }
+      @media (min-width: 768px) {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
     }
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1057

Can be tested here: https://9qnjv.csb.app/

Originally, I was thinking about adjusting the number of results based on their size or based on the size of the result list, but basing it on the width of the screen allows for adjustments that are less linear.