### PR TITLE
fix(quantic): fixing flaky facet test

### DIFF
--- a/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
@@ -367,6 +367,7 @@ describe('Facet Test Suite', () => {
         describe('when clicking show more button again', () => {
           function showMoreValuesAgain() {
             showMoreValues();
+            cy.wait(InterceptAliases.Search);
             FacetSelectors.showMoreButton().click();
           }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4177

Let's see if this PR can fix the flaky facet test that validates ordering. I found out that we didn't wait for one of the search request when clicking the show more button. That could explain why the alias wasn't always set properly.