### PR TITLE
fix(quantic): disable flaky facet test

### DIFF
--- a/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet.cypress.ts
@@ -183,7 +183,7 @@ describe('Facet Test Suite', () => {
           );
         });
 
-        describe('verify analytics', () => {
+        describe.skip('verify analytics', () => {
           before(selectLastFacetValue);
 
           Expect.logFacetSelect(defaultField, 1);
@@ -544,7 +544,7 @@ describe('Facet Test Suite', () => {
           Expect.numberOfIdleLinkValues(defaultNumberOfValues - 1);
         });
 
-        describe('verify analytics', () => {
+        describe.skip('verify analytics', () => {
           before(selectLastFacetValue);
 
           Expect.logFacetSelect(defaultField, 0);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4177

A tentative fix has been merged trying to fix a flaky test. It turned out the test is still flaky and we need some time to investigate.

This PR disables the faulty test so CI is not blocked.