### PR TITLE
feat(headless): PoC of ExpressionBuilder

### DIFF
--- a/packages/headless/src/utils/expression-builder.ts
+++ b/packages/headless/src/utils/expression-builder.ts
@@ -1,5 +1,5 @@
-function createExpressionBuilder() {
-  const parts: string[] = [];
+function createExpressionBuilder(expression = '') {
+  const parts = expression ? [expression] : [];
 
   return {
     addStringFieldExpression(

--- a/packages/headless/src/utils/expression-builder.ts
+++ b/packages/headless/src/utils/expression-builder.ts
@@ -1,0 +1,30 @@
+function createExpressionBuilder() {
+  const parts: string[] = [];
+
+  return {
+    addStringFieldExpression(
+      field: string,
+      operator: '==' | '!=',
+      values: string[]
+    ) {
+      const stringValues = values.map((v) => `"${v}"`).join(',');
+      const expression = `${field}==(${stringValues})`;
+      const prefix = operator === '!=' ? 'NOT ' : '';
+
+      parts.push(`${prefix}${expression}`);
+    },
+
+    join(delimiter: 'AND' | 'OR') {
+      const concatenated = parts.join(`) ${delimiter} (`);
+      return `(${concatenated})`;
+    },
+  };
+}
+
+const builder = createExpressionBuilder();
+builder.addStringFieldExpression('filetype', '==', ['pdf']);
+builder.addStringFieldExpression('author', '==', ['alice', 'bob']);
+const expression = builder.join('AND');
+
+console.log(expression);
+// (filetype==("pdf")) AND (author==("alice","bob"))


### PR DESCRIPTION
I just covered string fields in the PoC similar to the [JSUI](https://github.com/coveo/search-ui/blob/master/src/ui/Base/ExpressionBuilder.ts), but it would be possible to add dedicated functions for numeric fields, relative dates, absolute dates, while still providing good type support.