### PR TITLE
fix(quantic): joining multiple types when parsing jsdoc

### DIFF
--- a/packages/quantic/docs/template/lwc-json/publish.js
+++ b/packages/quantic/docs/template/lwc-json/publish.js
@@ -88,7 +88,7 @@ function parseMember(element, parentNode) {
     description: element.description || '',
     required: !element.defaultvalue && !isTagDefined(element, 'optional'),
     defaultValue: element.defaultvalue || '',
-    type: element.type?.names?.[0] || '',
+    type: element.type?.names?.join('|') || '',
   }
   if (prop.type.name === 'function') {
     prop.type.params = element.params || '',

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
@@ -37,7 +37,7 @@ export default class QuanticResultLabel extends LightningElement {
   /**
    * Size of the icon and label to display.
    * @api
-   * @type {string}
+   * @type {'xx-small' | 'x-small' | 'small' | 'medium' | 'large'}
    * @defaultValue `'small'`
    */
   @api size  ='small';


### PR DESCRIPTION
- Fixed jsdoc type def in quanticResultLabel `variant` option.
- Updated template parser to join multiple types. Until now only the first time was taken.

Sample:
```JSON
"properties": [
    {
         "name": "result",
         "attribute": "result",
         "access": "@api",
         "description": "<p>The <a href=\"https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result\">result item</a> to use to infer label and icon.</p>",
         "required": true,
         "defaultValue": "",
          "type": "Result"
    },
    {
           "name": "label",
            "attribute": "label",
            "access": "@api",
            "description": "<p>The label to display.</p>",
            "required": true,
            "defaultValue": "",
            "type": "string"
    },
    {
            "name": "icon",
            "attribute": "icon",
            "access": "@api",
            "description": "<p>The name of the <a href=\"https://www.lightningdesignsystem.com/icons/\">SLDS icon</a> to display.</p>",
            "required": true,
            "defaultValue": "",
            "type": "string"
    },
    {
            "name": "size",
            "attribute": "size",
            "access": "@api",
            "description": "<p>Size of the icon and label to display.</p>",
            "required": false,
            "defaultValue": "`'small'`",
            "type": "'xx-small'|'x-small'|'small'|'medium'|'large'"
    }
 ]
```