### PR TITLE
fix(quantic): set default tab is-active

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -21,7 +21,7 @@
               </div>
               <div class="slds-col slds-order_1 slds-large-order_2 slds-size_1-of-1 slds-large-size_6-of-12">
                 <ul class="slds-tabs_default slds-tabs_default__nav" role="tablist">
-                  <c-quantic-tab label="All" engine-id={engineId}></c-quantic-tab>
+                  <c-quantic-tab label="All" engine-id={engineId} is-active></c-quantic-tab>
                   <c-quantic-tab label="Articles" expression="@sfkbid" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Issues" expression="@jisourcetype AND NOT @jidocumenttype=&quot;WorkLog&quot;" engine-id={engineId}></c-quantic-tab>
                   <c-quantic-tab label="Community" expression="@objecttype==&quot;Message&quot;" engine-id={engineId}></c-quantic-tab>


### PR DESCRIPTION
The `All` tab needed to be given the `set-active` prop to display as selected by default.
Even if the default search state is the same as with "All", this didn't correspond to a selected tab.