### PR TITLE
feat(headless): match recentquery select with searchbox behaviour

### DIFF
--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.test.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.test.ts
@@ -13,6 +13,8 @@ import {updateQuery} from '../../features/query/query-actions';
 import {executeSearch} from '../../features/search/search-actions';
 import {logClearRecentQueries} from '../../features/recent-queries/recent-queries-analytics-actions';
 import {NumberValue} from '@coveo/bueno';
+import {deselectAllFacets} from '../../features/facets/generic/facet-actions';
+import {updatePage} from '../../features/pagination/pagination-actions';
 
 describe('recent queries list', () => {
   let engine: MockSearchEngine;
@@ -106,10 +108,12 @@ describe('recent queries list', () => {
       engine.state.recentQueries = {...testInitialState, ...testOptions};
       recentQueriesList.executeRecentQuery(0);
 
+      expect(engine.actions).toContainEqual(deselectAllFacets());
       expectContainAction(updateQuery);
       expect(engine.actions).toContainEqual(
         updateQuery({q: testInitialState.queries[0]})
       );
+      expect(engine.actions).toContainEqual(updatePage(1));
       expect(engine.findAsyncAction(executeSearch.pending)).toBeDefined();
     });
   });

--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
@@ -18,6 +18,8 @@ import {
   logClearRecentQueries,
   logRecentQueryClick,
 } from '../../features/recent-queries/recent-queries-analytics-actions';
+import {deselectAllFacets} from '../../features/facets/generic/facet-actions';
+import {updatePage} from '../../features/pagination/pagination-actions';
 
 export interface RecentQueriesListProps {
   /**
@@ -178,7 +180,9 @@ export function buildRecentQueriesList(
       if (errorMessage) {
         throw new Error(errorMessage);
       }
+      dispatch(deselectAllFacets());
       dispatch(updateQuery({q: this.state.queries[index]}));
+      dispatch(updatePage(1));
       dispatch(executeSearch(logRecentQueryClick()));
     },
   };

--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
@@ -12,14 +12,14 @@ import {
   validateInitialState,
   validateOptions,
 } from '../../utils/validate-payload';
-import {executeSearch} from '../../features/search/search-actions';
-import {updateQuery} from '../../features/query/query-actions';
+import {
+  executeSearch,
+  prepareForSearchWithQuery,
+} from '../../features/search/search-actions';
 import {
   logClearRecentQueries,
   logRecentQueryClick,
 } from '../../features/recent-queries/recent-queries-analytics-actions';
-import {deselectAllFacets} from '../../features/facets/generic/facet-actions';
-import {updatePage} from '../../features/pagination/pagination-actions';
 
 export interface RecentQueriesListProps {
   /**
@@ -180,9 +180,7 @@ export function buildRecentQueriesList(
       if (errorMessage) {
         throw new Error(errorMessage);
       }
-      dispatch(deselectAllFacets());
-      dispatch(updateQuery({q: this.state.queries[index]}));
-      dispatch(updatePage(1));
+      dispatch(prepareForSearchWithQuery({q: this.state.queries[index]}));
       dispatch(executeSearch(logRecentQueryClick()));
     },
   };

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -4,14 +4,15 @@ import {
   registerQuerySuggest,
   selectQuerySuggestion,
 } from '../../features/query-suggest/query-suggest-actions';
-import {updateQuery} from '../../features/query/query-actions';
 import {
   registerQuerySetQuery,
   updateQuerySetQuery,
 } from '../../features/query-set/query-set-actions';
-import {executeSearch} from '../../features/search/search-actions';
+import {
+  executeSearch,
+  prepareForSearchWithQuery,
+} from '../../features/search/search-actions';
 import {buildController, Controller} from '../controller/headless-controller';
-import {updatePage} from '../../features/pagination/pagination-actions';
 import {logSearchboxSubmit} from '../../features/query/query-analytics-actions';
 import {
   ConfigurationSection,
@@ -43,7 +44,6 @@ import {
   search,
 } from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
-import {deselectAllFacets} from '../../features/facets/generic/facet-actions';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 
 export {SearchBoxOptions, SuggestionHighlightingOptions, Delimiters};
@@ -172,9 +172,7 @@ export function buildSearchBox(
   const performSearch = async (analytics: SearchAction) => {
     const {enableQuerySyntax} = options;
 
-    dispatch(deselectAllFacets());
-    dispatch(updateQuery({q: getValue(), enableQuerySyntax}));
-    dispatch(updatePage(1));
+    dispatch(prepareForSearchWithQuery({q: getValue(), enableQuerySyntax}));
     await dispatch(executeSearch(analytics));
   };
 

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -5,12 +5,10 @@ import {search} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {ClientThunkExtraArguments} from '../../app/thunk-extra-arguments';
 import {SearchAction} from '../analytics/analytics-utils';
-import {UpdateQueryActionCreatorPayload} from '../query/query-actions';
 import {
   executeSearch,
   ExecuteSearchThunkReturn,
   fetchMoreResults,
-  prepareForSearchWithQuery,
   StateNeededByExecuteSearch,
 } from './search-actions';
 
@@ -57,20 +55,6 @@ export interface SearchActionCreators {
       ClientThunkExtraArguments<SearchAPIClient>
     >
   >;
-
-  /**
-   * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
-   *
-   * @param payload - The action creator payload.
-   * @returns A dispatchable action.
-   */
-  prepareForSearchWithQuery(
-    payload: UpdateQueryActionCreatorPayload
-  ): AsyncThunkAction<
-    void,
-    UpdateQueryActionCreatorPayload,
-    AsyncThunkOptions<StateNeededByExecuteSearch>
-  >;
 }
 
 /**
@@ -84,6 +68,5 @@ export function loadSearchActions(engine: SearchEngine): SearchActionCreators {
   return {
     executeSearch,
     fetchMoreResults,
-    prepareForSearchWithQuery,
   };
 }

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -61,8 +61,7 @@ export interface SearchActionCreators {
   /**
    * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
    *
-   * @param q (string) The new basic query expression (e.g., `acme tornado seeds`).
-   * @param enableQuerySyntax (boolean) Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * @param payload - The action creator payload.
    */
   prepareForSearchWithQuery(
     payload: UpdateQueryActionCreatorPayload

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -62,6 +62,7 @@ export interface SearchActionCreators {
    * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
    *
    * @param payload - The action creator payload.
+   * @returns A dispatchable action.
    */
   prepareForSearchWithQuery(
     payload: UpdateQueryActionCreatorPayload

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -5,10 +5,12 @@ import {search} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {ClientThunkExtraArguments} from '../../app/thunk-extra-arguments';
 import {SearchAction} from '../analytics/analytics-utils';
+import {UpdateQueryActionCreatorPayload} from '../query/query-actions';
 import {
   executeSearch,
   ExecuteSearchThunkReturn,
   fetchMoreResults,
+  prepareForSearchWithQuery,
   StateNeededByExecuteSearch,
 } from './search-actions';
 
@@ -55,6 +57,20 @@ export interface SearchActionCreators {
       ClientThunkExtraArguments<SearchAPIClient>
     >
   >;
+
+  /**
+   * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
+   *
+   * @param q (string) The new basic query expression (e.g., `acme tornado seeds`).
+   * @param enableQuerySyntax (boolean) Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   */
+  prepareForSearchWithQuery(
+    payload: UpdateQueryActionCreatorPayload
+  ): AsyncThunkAction<
+    void,
+    UpdateQueryActionCreatorPayload,
+    AsyncThunkOptions<StateNeededByExecuteSearch>
+  >;
 }
 
 /**
@@ -68,5 +84,6 @@ export function loadSearchActions(engine: SearchEngine): SearchActionCreators {
   return {
     executeSearch,
     fetchMoreResults,
+    prepareForSearchWithQuery,
   };
 }

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -56,6 +56,7 @@ import {BooleanValue, StringValue} from '@coveo/bueno';
 import {deselectAllFacets} from '../facets/generic/facet-actions';
 import {updatePage} from '../pagination/pagination-actions';
 import {validatePayload} from '../../utils/validate-payload';
+import {AsyncThunkOptions} from '../../app/async-thunk-options';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -115,7 +116,7 @@ const fetchFromAPI = async (
 export const prepareForSearchWithQuery = createAsyncThunk<
   void,
   UpdateQueryActionCreatorPayload,
-  AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+  AsyncThunkOptions<StateNeededByExecuteSearch>
 >('search/prepareForSearchWithQuery', (payload, thunk) => {
   const {dispatch} = thunk;
   validatePayload(payload, {

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -110,8 +110,7 @@ const fetchFromAPI = async (
 
 /**
  * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
- * @param q (string) The new basic query expression (e.g., `acme tornado seeds`).
- * @param enableQuerySyntax (boolean) Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+ * @param payload - The action creator payload.
  */
 export const prepareForSearchWithQuery = createAsyncThunk<
   void,

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -8,7 +8,10 @@ import {SearchResponseSuccess} from '../../api/search/search/search-response';
 import {snapshot} from '../history/history-actions';
 import {logDidYouMeanAutomatic} from '../did-you-mean/did-you-mean-analytics-actions';
 import {applyDidYouMeanCorrection} from '../did-you-mean/did-you-mean-actions';
-import {updateQuery} from '../query/query-actions';
+import {
+  updateQuery,
+  UpdateQueryActionCreatorPayload,
+} from '../query/query-actions';
 import {
   AdvancedSearchQueriesSection,
   CategoryFacetSection,
@@ -49,6 +52,10 @@ import {
   mapSearchResponse,
 } from './search-mappings';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/build-search-request';
+import {BooleanValue, StringValue} from '@coveo/bueno';
+import {deselectAllFacets} from '../facets/generic/facet-actions';
+import {updatePage} from '../pagination/pagination-actions';
+import {validatePayload} from '../../utils/validate-payload';
 
 export type StateNeededByExecuteSearch = ConfigurationSection &
   Partial<
@@ -99,6 +106,27 @@ const fetchFromAPI = async (
   const queryExecuted = state.query?.q || '';
   return {response, duration, queryExecuted, requestExecuted: request};
 };
+
+/**
+ * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
+ * @param q (string) The new basic query expression (e.g., `acme tornado seeds`).
+ * @param enableQuerySyntax (boolean) Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+ */
+export const prepareForSearchWithQuery = createAsyncThunk<
+  void,
+  UpdateQueryActionCreatorPayload,
+  AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+>('search/prepareForSearchWithQuery', (payload, thunk) => {
+  const {dispatch} = thunk;
+  validatePayload(payload, {
+    q: new StringValue(),
+    enableQuerySyntax: new BooleanValue(),
+  });
+
+  dispatch(deselectAllFacets());
+  dispatch(updateQuery(payload));
+  dispatch(updatePage(1));
+});
 
 /**
  * Executes a search query.

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -108,10 +108,6 @@ const fetchFromAPI = async (
   return {response, duration, queryExecuted, requestExecuted: request};
 };
 
-/**
- * Prepares the search state for a search with a query by setting the query string and resetting facet and pager states.
- * @param payload - The action creator payload.
- */
 export const prepareForSearchWithQuery = createAsyncThunk<
   void,
   UpdateQueryActionCreatorPayload,


### PR DESCRIPTION
#### The problem
Clicking on a recent query would not recent facet selection and pager. The behaviour should be consistent with executing the query in the searchbox which would clear facets and reset pager.

#### The fix
The action for recent-queries-list item selection now dispatches those actions.