### PR TITLE
fix(atomic): remove Gaussian Blur for SVG backgrounds

### DIFF
--- a/packages/atomic/src/images/cannot-access.svg
+++ b/packages/atomic/src/images/cannot-access.svg
@@ -10,7 +10,6 @@
 <defs>
 <filter id="filter0_b" x="2.41695" y="2.41707" width="307.401" height="307.401" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="1.83987"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>

--- a/packages/atomic/src/images/indexing.svg
+++ b/packages/atomic/src/images/indexing.svg
@@ -151,7 +151,6 @@
 </filter>
 <filter id="filter7_b" x="111.597" y="39.9202" width="262.422" height="262.422" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="2"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>

--- a/packages/atomic/src/images/magnifying-glass.svg
+++ b/packages/atomic/src/images/magnifying-glass.svg
@@ -41,7 +41,6 @@
 <defs>
 <filter id="filter0_b" x="-3.67968" y="-3.67973" width="319.595" height="319.595" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="1.83987"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>

--- a/packages/atomic/src/images/no-connection.svg
+++ b/packages/atomic/src/images/no-connection.svg
@@ -36,7 +36,6 @@
 <defs>
 <filter id="filter0_b" x="20.5346" y="32.5347" width="271.166" height="271.166" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="1.83987"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>

--- a/packages/atomic/src/images/search-inactive.svg
+++ b/packages/atomic/src/images/search-inactive.svg
@@ -44,7 +44,6 @@
 <defs>
 <filter id="filter0_b" x="2.41695" y="2.41695" width="307.401" height="307.401" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="1.83987"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>

--- a/packages/atomic/src/images/something-wrong.svg
+++ b/packages/atomic/src/images/something-wrong.svg
@@ -24,7 +24,6 @@
 <defs>
 <filter id="filter0_b" x="20.5346" y="20.5346" width="271.166" height="271.166" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="1.83987"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1101

Issue: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/in#workaround_for_backgroundimage

We don't really care for a Gaussian Blur on a flat colored square
![image](https://user-images.githubusercontent.com/4923043/137911613-9f14d67a-035c-4d3f-97e6-9630e88d16f7.png)

Here's one of the SVGs, the background square did not appear in firefox before
<img  alt="Screen Shot 2021-10-19 at 8 45 15 AM" src="https://user-images.githubusercontent.com/4923043/137911885-2d1826f5-261b-41c0-b118-257b8e013342.png">

