### PR TITLE
fix(quantic): use objecttype in template label when available.

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
@@ -172,7 +172,7 @@ export default class QuanticResultLabel extends LightningElement {
       case 'knowledge':
         return this.labels.knowledge;
       default:
-        return undefined;
+        return objType;
     }
   }
 


### PR DESCRIPTION
An error in the code was causing filetype to be used despite objecttype being available.

<img width="571" alt="Screen Shot 2021-10-19 at 4 21 13 PM" src="https://user-images.githubusercontent.com/16785453/137984696-2b9f214f-d3ff-4c65-b0a9-81192c0092cf.png">
