### PR TITLE
fix(headless): apiClient is undefined in buildProductRecommendationEngine [COM-1345]

### DIFF
--- a/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
+++ b/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
@@ -72,9 +72,10 @@ export function buildProductRecommendationEngine(
 
   const searchAPIClient = createSearchAPIClient(options.configuration, logger);
 
-  const thunkArguments = {
+  const thunkArguments: SearchThunkExtraArguments = {
     ...buildThunkExtraArguments(options.configuration, logger),
     apiClient: searchAPIClient,
+    searchAPIClient,
   };
 
   const augmentedOptions: EngineOptions<ProductRecommendationEngineReducers> = {

--- a/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
+++ b/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
@@ -74,7 +74,7 @@ export function buildProductRecommendationEngine(
 
   const thunkArguments = {
     ...buildThunkExtraArguments(options.configuration, logger),
-    searchAPIClient,
+    apiClient: searchAPIClient,
   };
 
   const augmentedOptions: EngineOptions<ProductRecommendationEngineReducers> = {

--- a/packages/headless/src/app/recommendation-engine/recommendation-engine.ts
+++ b/packages/headless/src/app/recommendation-engine/recommendation-engine.ts
@@ -78,8 +78,9 @@ export function buildRecommendationEngine(
 
   const searchAPIClient = createSearchAPIClient(options.configuration, logger);
 
-  const thunkArguments = {
+  const thunkArguments: SearchThunkExtraArguments = {
     ...buildThunkExtraArguments(options.configuration, logger),
+    apiClient: searchAPIClient,
     searchAPIClient,
   };
 


### PR DESCRIPTION

`searchApiClient` was renamed to `apiClient` but was missed in the thunkArguments