### PR TITLE
fix(atomic): reduced margin above title metadata section

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -62,7 +62,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 1.75rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {
@@ -143,7 +143,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 1.375rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {
@@ -224,7 +224,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 0.9375rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
@@ -49,7 +49,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 1rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {
@@ -117,7 +117,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 0.75rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {
@@ -185,7 +185,7 @@
       font-size: var(--font-size);
       --line-height: 1rem;
       line-height: var(--line-height);
-      margin-top: 0.5rem;
+      margin-top: 0.475rem;
     }
 
     atomic-result-section-emphasized {

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -47,7 +47,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 1rem;
+      margin-top: 0.475rem;
     }
   }
 
@@ -93,7 +93,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 0.875rem;
+      margin-top: 0.475rem;
     }
   }
 
@@ -139,7 +139,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 0.6875rem;
+      margin-top: 0.475rem;
     }
   }
 

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -47,7 +47,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 0.75rem;
+      margin-top: 0.475rem;
     }
   }
 
@@ -93,7 +93,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 0.625rem;
+      margin-top: 0.475rem;
     }
   }
 
@@ -139,7 +139,7 @@
     }
 
     atomic-result-section-title-metadata {
-      margin-top: 0.4375rem;
+      margin-top: 0.475rem;
     }
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1121

I tried to match the gap seen in the updated design.

Density no longer affects the gap.

# List
![image](https://user-images.githubusercontent.com/54454747/139486670-262d1a19-d63f-498a-ba4f-591ad1589103.png)
![image](https://user-images.githubusercontent.com/54454747/139486766-1ec69930-c4c4-4ce9-97dd-535491f13f19.png)

# Grid
![image](https://user-images.githubusercontent.com/54454747/139486826-67201cda-99bd-4a92-a5c9-84c7513974eb.png)
![image](https://user-images.githubusercontent.com/54454747/139486807-e3190267-2fbf-4345-9c77-b679f031d63a.png)

