### PR TITLE
fix(atomic): allowed printable uri to be expanded on grid results

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
@@ -80,7 +80,10 @@ export class AtomicResultPrintableUri {
         <button
           part="result-printable-uri-list-ellipsis"
           aria-label={this.strings.collapsedUriParts()}
-          onClick={() => (this.listExpanded = true)}
+          onClick={(e) => {
+            e.preventDefault();
+            this.listExpanded = true;
+          }}
         >
           ...
         </button>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1163

Expanding the printable uri on a grid result was redirecting to the clickUri of the result, since the grid result is wrapped in a `<a>` tag.