### PR TITLE
fix(quantic): changed quickview style and placement

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
@@ -5,7 +5,7 @@
         <div class="slds-col slds-m-vertical_xx-small slds-m-right_small slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1">
           <c-quantic-result-label result={result}></c-quantic-result-label>
         </div>
-        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_6-of-12 slds-large-size_5-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
+        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_5-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
           <template if:true={result.isRecommendation}>
             <div class="slds-m-right_xx-small">
               <c-quantic-result-badge variant="recommended"></c-quantic-result-badge>
@@ -15,18 +15,20 @@
               <c-quantic-result-badge variant="featured"></c-quantic-result-badge>
           </template>
         </div>
-        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-text-align_right slds-col_bump-left">
-          <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C">
+        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-col_bump-left">
+          <template if:true={resultHasPreview}>
+            <div class="slds-p-right_xx-small">
+              <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
+            </div>
+          </template>
+        </div>
+        <div class="slds-col slds-m-vertical_xx-small slds-order_4 slds-text-align_right">
+          <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C; min-width: 80px;">
             <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
           </p>
         </div>
       </div>
       <div class="slds-grid slds-grid_vertical-align-center slds-m-vertical_x-small">
-        <template if:true={resultHasPreview}>
-          <div class="slds-p-right_x-small">
-            <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
-          </div>
-        </template>
         <h3 class="slds-truncate">
           <span style="color: #157E19">{result.raw.sfstatus} |</span>
           <span class="slds-m-left_xx-small" style="font-size:1.1em; font-weight:700"><c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link></span>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
@@ -5,7 +5,7 @@
           <div class="slds-col slds-m-vertical_xx-small slds-m-right_small slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1">
             <c-quantic-result-label result={result}></c-quantic-result-label>
           </div>
-          <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_6-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
+          <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_5-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
             <template if:true={result.isRecommendation}>
               <div class="slds-m-right_xx-small">
                 <c-quantic-result-badge variant="recommended"></c-quantic-result-badge>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
@@ -15,18 +15,20 @@
                 <c-quantic-result-badge variant="featured"></c-quantic-result-badge>
             </template>
           </div>
-          <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-text-align_right slds-col_bump-left">
-            <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C">
+          <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-col_bump-left">
+            <template if:true={resultHasPreview}>
+              <div class="slds-p-right_xx-small">
+                <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
+              </div>
+            </template>
+          </div>
+          <div class="slds-col slds-m-vertical_xx-small slds-order_4 slds-text-align_right">
+            <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C; min-width: 80px;">
               <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
             </p>
           </div>
         </div>
         <div class="slds-grid slds-grid_vertical-align-center slds-m-vertical_x-small">
-          <template if:true={resultHasPreview}>
-            <div class="slds-p-right_x-small">
-              <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
-            </div>
-          </template>
           <h3 class="slds-truncate" style="font-size:1.1em; font-weight:700">
             <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
           </h3>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
@@ -5,7 +5,7 @@
         <div class="slds-col slds-m-vertical_xx-small slds-m-right_small slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1">
           <c-quantic-result-label result={result}></c-quantic-result-label>
         </div>
-        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_6-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
+        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_5-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
           <template if:true={result.isRecommendation}>
             <div class="slds-m-right_xx-small">
               <c-quantic-result-badge variant="recommended"></c-quantic-result-badge>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
@@ -15,8 +15,15 @@
               <c-quantic-result-badge variant="featured"></c-quantic-result-badge>
           </template>
         </div>
-        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-text-align_right slds-col_bump-left">
-          <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C">
+        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-col_bump-left">
+          <template if:true={resultHasPreview}>
+            <div class="slds-p-right_xx-small">
+              <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
+            </div>
+          </template>
+        </div>
+        <div class="slds-col slds-m-vertical_xx-small slds-order_4 slds-text-align_right">
+          <p class="slds-truncate" style="font-weight: 400; font-size:12px; color:#3E3E3C; min-width: 80px;">
             <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
           </p>
         </div>
@@ -28,11 +35,6 @@
         <div class="slds-col slds-p-left_x-small slds-order_2 slds-large-order_2 slds-size_1-of-1 slds-large-size_9-of-12 slds-text-align_left">
           <div class="slds-grid slds-wrap">
             <div class="slds-grid slds-grid_vertical-align-center slds-order_1 slds-large-order_1 slds-size_1-of-1 slds-large-size_12-of-12 slds-text-align_left" style="font-weight: 700;">
-              <template if:true={resultHasPreview}>
-                <div class="slds-p-right_x-small">
-                  <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
-                </div>
-              </template>
               <h3 class="slds-truncate" style="font-size:1.1em; font-weight:700">
                 <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
               </h3>

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.css
@@ -6,4 +6,5 @@
 .result__date {
   font-size: .9em;
   color:#3E3E3C;
+  min-width: 80px;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
@@ -5,7 +5,7 @@
         <div class="slds-col slds-m-vertical_xx-small slds-m-right_small slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1">
           <c-quantic-result-label result={result}></c-quantic-result-label>
         </div>
-        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_6-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
+        <div class="slds-col slds-grid slds-order_1 slds-size_1-of-1 slds-medium-size_5-of-12 slds-large-size_5-of-12 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
           <template if:true={result.isRecommendation}>
             <div class="slds-m-right_xx-small">
               <c-quantic-result-badge variant="recommended"></c-quantic-result-badge>
@@ -15,18 +15,20 @@
             <c-quantic-result-badge variant="featured"></c-quantic-result-badge>
           </template>
         </div>
-        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-text-align_right slds-col_bump-left">
+        <div class="slds-col slds-m-vertical_xx-small slds-order_3 slds-col_bump-left">
+          <template if:true={resultHasPreview}>
+            <div class="slds-p-right_xx-small">
+              <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
+            </div>
+          </template>
+        </div>
+        <div class="slds-col slds-m-vertical_xx-small slds-order_4 slds-text-align_right">
           <p class="slds-truncate result__date">
             <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
           </p>
         </div>
       </div>
       <div class="slds-grid slds-grid_vertical-align-center slds-m-vertical_x-small">
-        <template if:true={resultHasPreview}>
-          <div class="slds-p-right_x-small">
-            <c-quantic-result-quickview engine-id={engineId} result={result}></c-quantic-result-quickview>
-          </div>
-        </template>
         <h3 class="slds-truncate result__title">
           <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
         </h3>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -17,3 +17,13 @@
   width: 100%;
   height: 50%;
 }
+
+.quickview__button {
+  color: var(--color-text-link-active, #0f2d5d);
+  border-radius: 0.25rem;
+}
+
+.quickview__button:hover {
+  background-color: #f6f7f9;
+  box-shadow: 0 0 0px 0.25rem #f6f7f9;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,17 +1,18 @@
 <template>
-  <lightning-button-icon
-    title={buttonLabel}
-    alternative-text={buttonLabel}
-    tooltip={buttonLabel}
-    icon-name="utility:preview"
-    size="small"
-    disabled={hasNoPreview}
-    onclick={openQuickview}
-  ></lightning-button-icon>
+  <button class="quickview__button slds-button" onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
+    <lightning-icon 
+      size="x-small"
+      icon-name="utility:preview"
+      title={buttonLabel}
+      alternative-text={buttonLabel}
+      class="slds-current-color">
+    </lightning-icon>
+  </button>
+
   <template if:true={isQuickviewOpen}>
     <section onclick={closeQuickview} role="dialog" tabindex="-1" aria-labelledby="quickview-modal-heading" aria-modal="true" aria-describedby="quickview__content-container" class="slds-modal slds-modal_medium slds-fade-in-open">
-      <div class="slds-modal__container" onclick={stopPropagation}>
-        <header class="slds-modal__header">
+      <div class="slds-modal__container">
+        <header class="slds-modal__header" onclick={stopPropagation}>
           <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" onclick={closeQuickview}>
             <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={labels.close}></lightning-icon>
           </button>
@@ -30,12 +31,12 @@
           </h3>
         </header>
         <template if:true={isLoading}>
-          <div class="quickview__spinner-container slds-modal__content slds-p-around_large slds-is-relative">
+          <div onclick={stopPropagation} class="quickview__spinner-container slds-modal__content slds-p-around_large slds-is-relative">
             <lightning-spinner alternative-text="Loading" size="large"></lightning-spinner>
           </div>
         </template>
         <template if:false={isLoading}>
-          <div class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap" id="quickview__content-container" lwc:dom="manual"></div>
+          <div onclick={stopPropagation} class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap" id="quickview__content-container" lwc:dom="manual"></div>
         </template>
       </div>
     </section>


### PR DESCRIPTION
- Fixed a bug when clicking above or below the modal to close it.
- Updated style to this based on lengthy deliberation and democratic action.
<img width="614" alt="Screen Shot 2021-10-29 at 4 54 56 PM" src="https://user-images.githubusercontent.com/16785453/139500551-3ffcb65a-2072-4f9b-8024-88f92ce73eb7.png">
