### PR TITLE
refactor: rename toString to toQuerySyntax

### DIFF
--- a/packages/headless/src/utils/query-expression/common/part.ts
+++ b/packages/headless/src/utils/query-expression/common/part.ts
@@ -1,3 +1,3 @@
 export interface Part {
-  toString(): string;
+  toQuerySyntax(): string;
 }

--- a/packages/headless/src/utils/query-expression/date-field/date-field.test.ts
+++ b/packages/headless/src/utils/query-expression/date-field/date-field.test.ts
@@ -1,7 +1,7 @@
 import {buildDateField} from './date-field';
 
 describe('#buildDateField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildDateField({
         field: 'date',
@@ -9,7 +9,7 @@ describe('#buildDateField', () => {
         value: '2021/01/21',
       });
 
-      expect(builder.toString()).toBe('@date>2021/01/21');
+      expect(builder.toQuerySyntax()).toBe('@date>2021/01/21');
     });
 
     it('with #negate set to true', () => {
@@ -20,7 +20,7 @@ describe('#buildDateField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @date>2021/01/21');
+      expect(builder.toQuerySyntax()).toBe('NOT @date>2021/01/21');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/date-field/date-field.ts
+++ b/packages/headless/src/utils/query-expression/date-field/date-field.ts
@@ -21,7 +21,7 @@ export interface DateFieldExpression extends Negatable {
 
 export function buildDateField(config: DateFieldExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const {field, value} = config;
       const operator = getOperatorSymbol(config.operator);
       const prefix = getNegationPrefix(config);

--- a/packages/headless/src/utils/query-expression/date-range-field/date-range-field.test.ts
+++ b/packages/headless/src/utils/query-expression/date-range-field/date-range-field.test.ts
@@ -1,7 +1,7 @@
 import {buildDateRangeField} from './date-range-field';
 
 describe('#buildDateRangeField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildDateRangeField({
         field: 'date',
@@ -9,7 +9,7 @@ describe('#buildDateRangeField', () => {
         to: '2021/06/21',
       });
 
-      expect(builder.toString()).toBe('@date==2021/01/21..2021/06/21');
+      expect(builder.toQuerySyntax()).toBe('@date==2021/01/21..2021/06/21');
     });
 
     it('with #negate set to true', () => {
@@ -20,7 +20,7 @@ describe('#buildDateRangeField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @date==2021/01/21..2021/06/21');
+      expect(builder.toQuerySyntax()).toBe('NOT @date==2021/01/21..2021/06/21');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/date-range-field/date-range-field.ts
+++ b/packages/headless/src/utils/query-expression/date-range-field/date-range-field.ts
@@ -21,7 +21,7 @@ export interface DateRangeFieldExpression extends Negatable {
 
 export function buildDateRangeField(config: DateRangeFieldExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {field, from, to} = config;
       const operator = getOperatorSymbol('isExactly');

--- a/packages/headless/src/utils/query-expression/exact-match/exact-match.test.ts
+++ b/packages/headless/src/utils/query-expression/exact-match/exact-match.test.ts
@@ -1,13 +1,13 @@
 import {buildExactMatch} from './exact-match';
 
 describe('#buildExactMatch', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildExactMatch({
         expression: 'bbc news',
       });
 
-      expect(builder.toString()).toBe('"bbc news"');
+      expect(builder.toQuerySyntax()).toBe('"bbc news"');
     });
 
     it('with #negate set to true', () => {
@@ -16,7 +16,7 @@ describe('#buildExactMatch', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT "bbc news"');
+      expect(builder.toQuerySyntax()).toBe('NOT "bbc news"');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/exact-match/exact-match.ts
+++ b/packages/headless/src/utils/query-expression/exact-match/exact-match.ts
@@ -10,7 +10,7 @@ export interface ExactMatchExpression extends Negatable {
 
 export function buildExactMatch(config: ExactMatchExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {expression} = config;
 

--- a/packages/headless/src/utils/query-expression/field-exists/field-exists.test.ts
+++ b/packages/headless/src/utils/query-expression/field-exists/field-exists.test.ts
@@ -1,13 +1,13 @@
 import {buildFieldExists} from './field-exists';
 
 describe('#buildFieldExists', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildFieldExists({
         field: 'author',
       });
 
-      expect(builder.toString()).toBe('@author');
+      expect(builder.toQuerySyntax()).toBe('@author');
     });
 
     it('with #negate set to true', () => {
@@ -16,7 +16,7 @@ describe('#buildFieldExists', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @author');
+      expect(builder.toQuerySyntax()).toBe('NOT @author');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/field-exists/field-exists.ts
+++ b/packages/headless/src/utils/query-expression/field-exists/field-exists.ts
@@ -10,7 +10,7 @@ export interface FieldExistsExpression extends Negatable {
 
 export function buildFieldExists(config: FieldExistsExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {field} = config;
       return `${prefix}@${field}`;

--- a/packages/headless/src/utils/query-expression/keyword/keyword.test.ts
+++ b/packages/headless/src/utils/query-expression/keyword/keyword.test.ts
@@ -1,13 +1,13 @@
 import {buildKeyword} from './keyword';
 
 describe('#buildKeyword', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildKeyword({
         expression: 'bbc news',
       });
 
-      expect(builder.toString()).toBe('bbc news');
+      expect(builder.toQuerySyntax()).toBe('bbc news');
     });
 
     it('with #negate set to true', () => {
@@ -16,7 +16,7 @@ describe('#buildKeyword', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT (bbc news)');
+      expect(builder.toQuerySyntax()).toBe('NOT (bbc news)');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/keyword/keyword.ts
+++ b/packages/headless/src/utils/query-expression/keyword/keyword.ts
@@ -10,7 +10,7 @@ export interface KeywordExpression extends Negatable {
 
 export function buildKeyword(config: KeywordExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const {expression, negate} = config;
       return negate ? `NOT (${expression})` : expression;
     },

--- a/packages/headless/src/utils/query-expression/near/near.test.ts
+++ b/packages/headless/src/utils/query-expression/near/near.test.ts
@@ -1,7 +1,7 @@
 import {buildNear} from './near';
 
 describe('#buildNear', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with multiple terms', () => {
       const builder = buildNear({
         startTerm: 'keep calm',
@@ -17,7 +17,9 @@ describe('#buildNear', () => {
         ],
       });
 
-      expect(builder.toString()).toBe('keep calm near:1 and near:5 carry on');
+      expect(builder.toQuerySyntax()).toBe(
+        'keep calm near:1 and near:5 carry on'
+      );
     });
 
     it('with #negate set to true', () => {
@@ -32,7 +34,7 @@ describe('#buildNear', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT (keep calm near:5 carry on)');
+      expect(builder.toQuerySyntax()).toBe('NOT (keep calm near:5 carry on)');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/near/near.ts
+++ b/packages/headless/src/utils/query-expression/near/near.ts
@@ -27,7 +27,7 @@ export interface OtherTerm {
 
 export function buildNear(config: NearExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {startTerm, otherTerms} = config;
       const otherTermsExpression = buildOtherTerms(otherTerms);

--- a/packages/headless/src/utils/query-expression/numeric-field/numeric-field.test.ts
+++ b/packages/headless/src/utils/query-expression/numeric-field/numeric-field.test.ts
@@ -1,7 +1,7 @@
 import {buildNumericField} from './numeric-field';
 
 describe('#buildNumericField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('#greaterThan operator', () => {
       const builder = buildNumericField({
         field: 'size',
@@ -9,7 +9,7 @@ describe('#buildNumericField', () => {
         value: 10,
       });
 
-      expect(builder.toString()).toBe('@size>10');
+      expect(builder.toQuerySyntax()).toBe('@size>10');
     });
 
     it('#greaterThanOrEqual operator', () => {
@@ -19,7 +19,7 @@ describe('#buildNumericField', () => {
         value: 10,
       });
 
-      expect(builder.toString()).toBe('@size>=10');
+      expect(builder.toQuerySyntax()).toBe('@size>=10');
     });
 
     it('#lowerThan operator', () => {
@@ -29,7 +29,7 @@ describe('#buildNumericField', () => {
         value: 10,
       });
 
-      expect(builder.toString()).toBe('@size<10');
+      expect(builder.toQuerySyntax()).toBe('@size<10');
     });
 
     it('#lowerThanOrEqual operator', () => {
@@ -39,7 +39,7 @@ describe('#buildNumericField', () => {
         value: 10,
       });
 
-      expect(builder.toString()).toBe('@size<=10');
+      expect(builder.toQuerySyntax()).toBe('@size<=10');
     });
 
     it('#negate set to true', () => {
@@ -50,7 +50,7 @@ describe('#buildNumericField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @size<=10');
+      expect(builder.toQuerySyntax()).toBe('NOT @size<=10');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/numeric-field/numeric-field.ts
+++ b/packages/headless/src/utils/query-expression/numeric-field/numeric-field.ts
@@ -21,7 +21,7 @@ export interface NumericFieldExpression extends Negatable {
 
 export function buildNumericField(config: NumericFieldExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const {field, value} = config;
       const prefix = getNegationPrefix(config);
       const operator = getOperatorSymbol(config.operator);

--- a/packages/headless/src/utils/query-expression/numeric-range-field/numeric-range-field.test.ts
+++ b/packages/headless/src/utils/query-expression/numeric-range-field/numeric-range-field.test.ts
@@ -1,7 +1,7 @@
 import {buildNumericRangeField} from './numeric-range-field';
 
 describe('#buildNumericRangeField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with #negate not specified', () => {
       const builder = buildNumericRangeField({
         field: 'size',
@@ -9,7 +9,7 @@ describe('#buildNumericRangeField', () => {
         to: 20,
       });
 
-      expect(builder.toString()).toBe('@size==10..20');
+      expect(builder.toQuerySyntax()).toBe('@size==10..20');
     });
 
     it('with #negate set to true', () => {
@@ -20,7 +20,7 @@ describe('#buildNumericRangeField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @size==10..20');
+      expect(builder.toQuerySyntax()).toBe('NOT @size==10..20');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/numeric-range-field/numeric-range-field.ts
+++ b/packages/headless/src/utils/query-expression/numeric-range-field/numeric-range-field.ts
@@ -23,7 +23,7 @@ export function buildNumericRangeField(
   config: NumericRangeFieldExpression
 ): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {field, from, to} = config;
       const operator = getOperatorSymbol('isExactly');

--- a/packages/headless/src/utils/query-expression/query-expression.test.ts
+++ b/packages/headless/src/utils/query-expression/query-expression.test.ts
@@ -7,19 +7,19 @@ describe('buildQueryExpression', () => {
     builder = buildQueryExpression({operator: 'and'});
   });
 
-  it('builder with no expression, #toString returns an empty string', () => {
-    expect(builder.toString()).toBe('');
+  it('builder with no expression, #toQuerySyntax returns an empty string', () => {
+    expect(builder.toQuerySyntax()).toBe('');
   });
 
-  it('#addKeyword, #toString returns the expected syntax', () => {
+  it('#addKeyword, #toQuerySyntax returns the expected syntax', () => {
     builder.addKeyword({
       expression: 'bbc news',
     });
 
-    expect(builder.toString()).toBe('bbc news');
+    expect(builder.toQuerySyntax()).toBe('bbc news');
   });
 
-  it('#addNear, #toString returns the expected syntax', () => {
+  it('#addNear, #toQuerySyntax returns the expected syntax', () => {
     builder.addNear({
       startTerm: 'keep calm',
       otherTerms: [
@@ -30,96 +30,96 @@ describe('buildQueryExpression', () => {
       ],
     });
 
-    expect(builder.toString()).toBe('keep calm near:5 carry on');
+    expect(builder.toQuerySyntax()).toBe('keep calm near:5 carry on');
   });
 
-  it('#addExactMatch, #toString returns the expected syntax', () => {
+  it('#addExactMatch, #toQuerySyntax returns the expected syntax', () => {
     builder.addExactMatch({
       expression: 'bbc news',
     });
 
-    expect(builder.toString()).toBe('"bbc news"');
+    expect(builder.toQuerySyntax()).toBe('"bbc news"');
   });
 
-  it('#addFieldExists, #toString returns the expected syntax', () => {
+  it('#addFieldExists, #toQuerySyntax returns the expected syntax', () => {
     builder.addFieldExists({
       field: 'author',
     });
 
-    expect(builder.toString()).toBe('@author');
+    expect(builder.toQuerySyntax()).toBe('@author');
   });
 
   it(`#addStringField, with one expression,
-    #toString returns the expected syntax`, () => {
+    #toQuerySyntax returns the expected syntax`, () => {
     builder.addStringField({
       field: 'author',
       operator: 'contains',
       values: ['al'],
     });
 
-    expect(builder.toString()).toBe('@author="al"');
+    expect(builder.toQuerySyntax()).toBe('@author="al"');
   });
 
-  it('#addStringFacetField, with one expression, #toString returns the expected syntax', () => {
+  it('#addStringFacetField, with one expression, #toQuerySyntax returns the expected syntax', () => {
     builder.addStringFacetField({
       field: 'author',
       operator: 'differentThan',
       value: 'ehughes',
     });
 
-    expect(builder.toString()).toBe('@author<>("ehughes")');
+    expect(builder.toQuerySyntax()).toBe('@author<>("ehughes")');
   });
 
-  it('#addNumericField, with one expression, #toString returns the expected syntax', () => {
+  it('#addNumericField, with one expression, #toQuerySyntax returns the expected syntax', () => {
     builder.addNumericField({
       field: 'size',
       operator: 'greaterThan',
       value: 10,
     });
 
-    expect(builder.toString()).toBe('@size>10');
+    expect(builder.toQuerySyntax()).toBe('@size>10');
   });
 
-  it('#addNumericRangeField, with one expression, #toString returns the expected syntax', () => {
+  it('#addNumericRangeField, with one expression, #toQuerySyntax returns the expected syntax', () => {
     builder.addNumericRangeField({
       field: 'size',
       from: 10,
       to: 20,
     });
 
-    expect(builder.toString()).toBe('@size==10..20');
+    expect(builder.toQuerySyntax()).toBe('@size==10..20');
   });
 
-  it('#addDateField, with one expression, #toString returns the expected syntax', () => {
+  it('#addDateField, with one expression, #toQuerySyntax returns the expected syntax', () => {
     builder.addNumericField({
       field: 'size',
       operator: 'greaterThan',
       value: 10,
     });
 
-    expect(builder.toString()).toBe('@size>10');
+    expect(builder.toQuerySyntax()).toBe('@size>10');
   });
 
-  it('#addDateRangeField, with one expression, #toString returns the expected syntax', () => {
+  it('#addDateRangeField, with one expression, #toQuerySyntax returns the expected syntax', () => {
     builder.addNumericRangeField({
       field: 'size',
       from: 10,
       to: 20,
     });
 
-    expect(builder.toString()).toBe('@size==10..20');
+    expect(builder.toQuerySyntax()).toBe('@size==10..20');
   });
 
-  it('#addQueryExtension, #toString returns the expected syntax', () => {
+  it('#addQueryExtension, #toQuerySyntax returns the expected syntax', () => {
     builder.addQueryExtension({
       name: 'q',
-      parameters: [],
+      parameters: {},
     });
 
-    expect(builder.toString()).toBe('$q()');
+    expect(builder.toQuerySyntax()).toBe('$q()');
   });
 
-  it('#operator is #and, with two expressions, #toString joins them correctly', () => {
+  it('#operator is #and, with two expressions, #toQuerySyntax joins them correctly', () => {
     const builder = buildQueryExpression({operator: 'and'})
       .addStringField({
         field: 'author',
@@ -132,10 +132,10 @@ describe('buildQueryExpression', () => {
         value: 100,
       });
 
-    expect(builder.toString()).toBe('(@author="ehughes") AND (@size>100)');
+    expect(builder.toQuerySyntax()).toBe('(@author="ehughes") AND (@size>100)');
   });
 
-  it('#operator is #or, with two expressions, #toString joins them correctly', () => {
+  it('#operator is #or, with two expressions, #toQuerySyntax joins them correctly', () => {
     const builder = buildQueryExpression({operator: 'or'})
       .addStringField({
         field: 'author',
@@ -148,42 +148,42 @@ describe('buildQueryExpression', () => {
         value: 100,
       });
 
-    expect(builder.toString()).toBe('(@author="ehughes") OR (@size>100)');
+    expect(builder.toQuerySyntax()).toBe('(@author="ehughes") OR (@size>100)');
   });
 
   describe('#addNumericRangeField', () => {
-    it('with one expression, #toString returns the expected syntax', () => {
+    it('with one expression, #toQuerySyntax returns the expected syntax', () => {
       builder.addNumericRangeField({
         field: 'size',
         from: 10,
         to: 20,
       });
 
-      expect(builder.toString()).toBe('@size==10..20');
+      expect(builder.toQuerySyntax()).toBe('@size==10..20');
     });
   });
 
   describe('#addDateField', () => {
-    it('with one expression, #toString returns the expected syntax', () => {
+    it('with one expression, #toQuerySyntax returns the expected syntax', () => {
       builder.addNumericField({
         field: 'size',
         operator: 'greaterThan',
         value: 10,
       });
 
-      expect(builder.toString()).toBe('@size>10');
+      expect(builder.toQuerySyntax()).toBe('@size>10');
     });
   });
 
   describe('#addDateRangeField', () => {
-    it('with one expression, #toString returns the expected syntax', () => {
+    it('with one expression, #toQuerySyntax returns the expected syntax', () => {
       builder.addNumericRangeField({
         field: 'size',
         from: 10,
         to: 20,
       });
 
-      expect(builder.toString()).toBe('@size==10..20');
+      expect(builder.toQuerySyntax()).toBe('@size==10..20');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/query-expression.ts
+++ b/packages/headless/src/utils/query-expression/query-expression.ts
@@ -152,7 +152,7 @@ export interface QueryExpression {
    *
    * @returns A string representation of the configured expressions.
    */
-  toString(): string;
+  toQuerySyntax(): string;
 }
 
 type BooleanOperator = 'and' | 'or';
@@ -234,9 +234,11 @@ export function buildQueryExpression(
       return this;
     },
 
-    toString() {
+    toQuerySyntax() {
       const symbol = getBooleanOperatorSymbol(config.operator);
-      const expression = parts.join(`) ${symbol} (`);
+      const expression = parts
+        .map((part) => part.toQuerySyntax())
+        .join(`) ${symbol} (`);
 
       return parts.length <= 1 ? expression : `(${expression})`;
     },

--- a/packages/headless/src/utils/query-expression/query-extension/query-extension.test.ts
+++ b/packages/headless/src/utils/query-expression/query-extension/query-extension.test.ts
@@ -2,14 +2,14 @@ import {buildQueryExpression} from '../query-expression';
 import {buildQueryExtension} from './query-extension';
 
 describe('#buildQueryExtension', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('with no parameters', () => {
       const builder = buildQueryExtension({
         name: 'q',
         parameters: {},
       });
 
-      expect(builder.toString()).toBe('$q()');
+      expect(builder.toQuerySyntax()).toBe('$q()');
     });
 
     it('with multiple parameters', () => {
@@ -29,7 +29,7 @@ describe('#buildQueryExtension', () => {
         },
       });
 
-      expect(builder.toString()).toBe(
+      expect(builder.toQuerySyntax()).toBe(
         '$qre(expression: @documenttype=="Book", modifier: 100)'
       );
     });

--- a/packages/headless/src/utils/query-expression/query-extension/query-extension.ts
+++ b/packages/headless/src/utils/query-expression/query-extension/query-extension.ts
@@ -17,7 +17,7 @@ type QueryExtensionParameters = Record<string, string | QueryExpression>;
 
 export function buildQueryExtension(config: QueryExtensionExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const {name, parameters} = config;
       const argumentExpression = buildParameters(parameters);
       return `$${name}(${argumentExpression})`;
@@ -29,7 +29,9 @@ function buildParameters(params: QueryExtensionParameters) {
   return Object.entries(params)
     .map((entry) => {
       const [name, value] = entry;
-      return `${name}: ${value.toString()}`;
+      const formatted =
+        typeof value === 'string' ? value : value.toQuerySyntax();
+      return `${name}: ${formatted}`;
     })
     .join(', ');
 }

--- a/packages/headless/src/utils/query-expression/string-facet-field/string-facet-field.test.ts
+++ b/packages/headless/src/utils/query-expression/string-facet-field/string-facet-field.test.ts
@@ -1,7 +1,7 @@
 import {buildStringFacetField} from './string-facet-field';
 
 describe('#buildStringFacetField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('#fuzzyMatch operator', () => {
       const builder = buildStringFacetField({
         field: 'author',
@@ -9,7 +9,9 @@ describe('#buildStringFacetField', () => {
         value: 'hughes',
       });
 
-      expect(builder.toString()).toBe('@author~= $quoteVar(value: hughes)');
+      expect(builder.toQuerySyntax()).toBe(
+        '@author~= $quoteVar(value: hughes)'
+      );
     });
 
     it('#wildcardMatch operator', () => {
@@ -19,7 +21,7 @@ describe('#buildStringFacetField', () => {
         value: '*hughes',
       });
 
-      expect(builder.toString()).toBe('@author*=("*hughes")');
+      expect(builder.toQuerySyntax()).toBe('@author*=("*hughes")');
     });
 
     it('#phoneticMatch operator', () => {
@@ -29,7 +31,7 @@ describe('#buildStringFacetField', () => {
         value: 'Omer',
       });
 
-      expect(builder.toString()).toBe('@author%=("Omer")');
+      expect(builder.toQuerySyntax()).toBe('@author%=("Omer")');
     });
 
     it('#differentThan operator', () => {
@@ -39,7 +41,7 @@ describe('#buildStringFacetField', () => {
         value: 'ehughes',
       });
 
-      expect(builder.toString()).toBe('@author<>("ehughes")');
+      expect(builder.toQuerySyntax()).toBe('@author<>("ehughes")');
     });
 
     it('#regexMatch operator', () => {
@@ -49,7 +51,7 @@ describe('#buildStringFacetField', () => {
         value: 'ehughe[a-z]+',
       });
 
-      expect(builder.toString()).toBe('@author/=("ehughe[a-z]+")');
+      expect(builder.toQuerySyntax()).toBe('@author/=("ehughe[a-z]+")');
     });
 
     it('with #negate set to true', () => {
@@ -60,7 +62,7 @@ describe('#buildStringFacetField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @author*=("*hughes")');
+      expect(builder.toQuerySyntax()).toBe('NOT @author*=("*hughes")');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/string-facet-field/string-facet-field.ts
+++ b/packages/headless/src/utils/query-expression/string-facet-field/string-facet-field.ts
@@ -23,7 +23,7 @@ export function buildStringFacetField(
   config: StringFacetFieldExpression
 ): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const prefix = getNegationPrefix(config);
       const {field, operator, value} = config;
       const symbol = getOperatorSymbol(operator);

--- a/packages/headless/src/utils/query-expression/string-field/string-field.test.ts
+++ b/packages/headless/src/utils/query-expression/string-field/string-field.test.ts
@@ -1,7 +1,7 @@
 import {buildStringField} from './string-field';
 
 describe('#buildStringField', () => {
-  describe('#toString', () => {
+  describe('#toQuerySyntax', () => {
     it('#contains operator, one value', () => {
       const builder = buildStringField({
         field: 'author',
@@ -9,7 +9,7 @@ describe('#buildStringField', () => {
         values: ['al'],
       });
 
-      expect(builder.toString()).toBe('@author="al"');
+      expect(builder.toQuerySyntax()).toBe('@author="al"');
     });
 
     it('#isExactly operator, one value', () => {
@@ -19,7 +19,7 @@ describe('#buildStringField', () => {
         values: ['alice'],
       });
 
-      expect(builder.toString()).toBe('@author=="alice"');
+      expect(builder.toQuerySyntax()).toBe('@author=="alice"');
     });
 
     it('#contains operator with multiple values', () => {
@@ -29,7 +29,7 @@ describe('#buildStringField', () => {
         values: ['al', 'alice'],
       });
 
-      expect(builder.toString()).toBe('@author=("al","alice")');
+      expect(builder.toQuerySyntax()).toBe('@author=("al","alice")');
     });
 
     it('#negate set to true', () => {
@@ -40,7 +40,7 @@ describe('#buildStringField', () => {
         negate: true,
       });
 
-      expect(builder.toString()).toBe('NOT @author="al"');
+      expect(builder.toQuerySyntax()).toBe('NOT @author="al"');
     });
   });
 });

--- a/packages/headless/src/utils/query-expression/string-field/string-field.ts
+++ b/packages/headless/src/utils/query-expression/string-field/string-field.ts
@@ -21,7 +21,7 @@ export interface StringFieldExpression extends Negatable {
 
 export function buildStringField(config: StringFieldExpression): Part {
   return {
-    toString() {
+    toQuerySyntax() {
       const {field} = config;
       const prefix = getNegationPrefix(config);
       const operator = getOperatorSymbol(config.operator);


### PR DESCRIPTION
Good suggestion by @acote-coveo, to ensure the `Part` interface is correctly implemented and prevent unxpected behaviours that might be associated with overriding `toString`.