### PR TITLE
fix(atomic): make result template line-height relative to font-size

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -82,13 +82,13 @@
     &.image-large,
     &.image-small {
       atomic-result-section-visual {
-        margin: 0 auto * var(--atomic-line-height-ratio) rem auto;
+        margin: 0 auto 1.5rem auto;
       }
     }
 
     &.image-icon {
       atomic-result-section-badges {
-        margin-bottom: * var(--atomic-line-height-ratio) rem;
+        margin-bottom: 1.5rem;
       }
     }
 

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -31,63 +31,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 2.25rem;
       height: 2.5rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
+
       max-height: 4rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.75rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-lg);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-lg);
+
       margin-top: 2.25rem;
       max-height: 4.5rem;
       @mixin line-clamp 3;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.75rem;
       max-height: 4rem;
     }
@@ -112,63 +97,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.75rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
+
       max-height: 3rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.375rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1.75rem;
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.375rem;
       max-height: 3.5rem;
     }
@@ -193,63 +163,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1.25rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
+
       max-height: 3rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.9375rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1.25rem;
       max-height: 1.25rem;
       @mixin line-clamp 1;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.9375rem;
       max-height: 3.25rem;
     }

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -33,7 +33,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -42,7 +42,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 2.25rem;
       height: 2.5rem;
@@ -51,7 +51,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 4rem;
       @mixin line-clamp 2;
@@ -60,7 +60,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.75rem;
     }
@@ -69,14 +69,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-lg);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 2.25rem;
       max-height: 4.5rem;
@@ -86,7 +86,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.75rem;
       max-height: 4rem;
@@ -97,13 +97,13 @@
     &.image-large,
     &.image-small {
       atomic-result-section-visual {
-        margin: 0 auto 1.5rem auto;
+        margin: 0 auto * var(--atomic-line-height-ratio) rem auto;
       }
     }
 
     &.image-icon {
       atomic-result-section-badges {
-        margin-bottom: 1.5rem;
+        margin-bottom: * var(--atomic-line-height-ratio) rem;
       }
     }
 
@@ -114,7 +114,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -123,7 +123,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.75rem;
       height: 2rem;
@@ -132,7 +132,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3rem;
       @mixin line-clamp 2;
@@ -141,7 +141,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.375rem;
     }
@@ -150,14 +150,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.75rem;
       max-height: 2.5rem;
@@ -167,7 +167,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.75rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.375rem;
       max-height: 3.5rem;
@@ -195,7 +195,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -204,7 +204,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.25rem;
       height: 2rem;
@@ -213,7 +213,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3rem;
       @mixin line-clamp 2;
@@ -222,7 +222,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.9375rem;
     }
@@ -231,14 +231,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.25rem;
       max-height: 1.25rem;
@@ -248,7 +248,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.625rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.9375rem;
       max-height: 3.25rem;

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
@@ -20,7 +20,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -29,7 +29,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.25rem;
       height: 2rem;
@@ -38,7 +38,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-lg);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3rem;
       @mixin line-clamp 2;
@@ -47,7 +47,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1rem;
     }
@@ -56,14 +56,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1.25rem;
       max-height: 2.5rem;
@@ -73,7 +73,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1rem;
       max-height: 3rem;
@@ -88,7 +88,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -97,7 +97,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1rem;
       height: 2rem;
@@ -106,7 +106,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-lg);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3rem;
       @mixin line-clamp 2;
@@ -115,7 +115,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.75rem;
     }
@@ -124,14 +124,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 1rem;
       max-height: 2.5rem;
@@ -141,7 +141,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.75rem;
       max-height: 3rem;
@@ -156,7 +156,7 @@
     atomic-result-section-badges {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-bottom: 1rem;
       height: 2rem;
@@ -165,7 +165,7 @@
     atomic-result-section-actions {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.75rem;
       height: 2rem;
@@ -174,7 +174,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-lg);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3rem;
       @mixin line-clamp 2;
@@ -183,7 +183,7 @@
     atomic-result-section-title-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.5rem;
     }
@@ -192,14 +192,14 @@
       font-weight: 500;
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
     atomic-result-section-excerpt {
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.75rem;
       max-height: 1.25rem;
@@ -209,7 +209,7 @@
     atomic-result-section-bottom-metadata {
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       margin-top: 0.5rem;
       max-height: 3rem;

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
@@ -18,63 +18,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1.25rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-lg);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-lg);
+
       max-height: 3rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1.25rem;
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 1rem;
       max-height: 3rem;
     }
@@ -86,63 +71,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-lg);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-lg);
+
       max-height: 3rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.75rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 1rem;
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.75rem;
       max-height: 3rem;
     }
@@ -154,63 +124,48 @@
     }
 
     atomic-result-section-badges {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-bottom: 1rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 0.75rem;
       height: 2rem;
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-lg);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-lg);
+
       max-height: 3rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-title-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.5rem;
     }
 
     atomic-result-section-emphasized {
       font-weight: 500;
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       margin-top: 0.75rem;
       max-height: 1.25rem;
       @mixin line-clamp 1;
     }
 
     atomic-result-section-bottom-metadata {
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       margin-top: 0.5rem;
       max-height: 3rem;
     }

--- a/packages/atomic/src/components/atomic-result/atomic-result-mixin.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-mixin.pcss
@@ -1,0 +1,9 @@
+/*
+ * Sets a font size & its line height relative to it
+ */
+@define-mixin set-font-size $font-size {
+  --font-size: $font-size;
+  font-size: var(--font-size);
+  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
+  line-height: var(--line-height);
+}

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -7,23 +7,23 @@
   /* == Density styles == */
   &.density-comfortable {
     atomic-result-section-visual {
-      margin-right: 1.5rem;
+      margin-right: * var(--atomic-line-height-ratio) rem;
     }
 
     atomic-result-section-badges {
-      margin-bottom: 1.5rem;
+      margin-bottom: * var(--atomic-line-height-ratio) rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      margin-bottom: 1.5rem;
+      margin-bottom: * var(--atomic-line-height-ratio) rem;
       height: 2.5rem;
     }
 
     atomic-result-section-title {
       --font-size: var(--atomic-text-2xl);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -31,7 +31,7 @@
       margin-top: 1.75rem;
       --font-size: var(--atomic-text-lg);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 4.5rem;
       @mixin line-clamp 3;
@@ -41,7 +41,7 @@
       margin-top: 1.25rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 4rem;
     }
@@ -69,7 +69,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -77,7 +77,7 @@
       margin-top: 1.25rem;
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 2.5rem;
       @mixin line-clamp 2;
@@ -87,7 +87,7 @@
       margin-top: 0.875rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.75rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3.5rem;
     }
@@ -115,7 +115,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -123,7 +123,7 @@
       margin-top: 1rem;
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 1.25rem;
       @mixin line-clamp 1;
@@ -133,7 +133,7 @@
       margin-top: 0.6875rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.625rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3.25rem;
     }
@@ -221,7 +221,7 @@ atomic-result-section-actions {
 atomic-result-section-title-metadata {
   --font-size: var(--atomic-text-sm);
   font-size: var(--font-size);
-  --line-height: 1rem;
+  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);
 }
 
@@ -229,7 +229,7 @@ atomic-result-section-emphasized {
   font-weight: 500;
   --font-size: var(--atomic-text-2xl);
   font-size: var(--font-size);
-  --line-height: 2rem;
+  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);
   margin-top: 0.5rem;
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -21,28 +21,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-2xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-2xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 1.75rem;
-      --font-size: var(--atomic-text-lg);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-lg);
+
       max-height: 4.5rem;
       @mixin line-clamp 3;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 1.25rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 4rem;
     }
 
@@ -67,28 +60,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 1.25rem;
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 0.875rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 3.5rem;
     }
 
@@ -113,28 +99,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 1rem;
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       max-height: 1.25rem;
       @mixin line-clamp 1;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 0.6875rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 3.25rem;
     }
 
@@ -219,7 +198,7 @@ atomic-result-section-actions {
 }
 
 atomic-result-section-title-metadata {
-  --font-size: var(--atomic-text-sm);
+  @mixin set-font-size var(--atomic-text-sm);
   font-size: var(--font-size);
   --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);
@@ -227,7 +206,7 @@ atomic-result-section-title-metadata {
 
 atomic-result-section-emphasized {
   font-weight: 500;
-  --font-size: var(--atomic-text-2xl);
+  @mixin set-font-size var(--atomic-text-2xl);
   font-size: var(--font-size);
   --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -7,16 +7,16 @@
   /* == Density styles == */
   &.density-comfortable {
     atomic-result-section-visual {
-      margin-right: * var(--atomic-line-height-ratio) rem;
+      margin-right: 1.5rem;
     }
 
     atomic-result-section-badges {
-      margin-bottom: * var(--atomic-line-height-ratio) rem;
+      margin-bottom: 1.5rem;
       height: 2rem;
     }
 
     atomic-result-section-actions {
-      margin-bottom: * var(--atomic-line-height-ratio) rem;
+      margin-bottom: 1.5rem;
       height: 2.5rem;
     }
 
@@ -199,16 +199,10 @@ atomic-result-section-actions {
 
 atomic-result-section-title-metadata {
   @mixin set-font-size var(--atomic-text-sm);
-  font-size: var(--font-size);
-  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-  line-height: var(--line-height);
 }
 
 atomic-result-section-emphasized {
   font-weight: 500;
   @mixin set-font-size var(--atomic-text-2xl);
-  font-size: var(--font-size);
-  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-  line-height: var(--line-height);
   margin-top: 0.5rem;
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -214,14 +214,10 @@ atomic-result-section-actions {
 
 atomic-result-section-title-metadata {
   @mixin set-font-size var(--atomic-text-sm);
-  font-size: var(--font-size);
 }
 
 atomic-result-section-emphasized {
   font-weight: 500;
   @mixin set-font-size var(--atomic-text-2xl);
-  font-size: var(--font-size);
-  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-  line-height: var(--line-height);
   margin-top: 0.5rem;
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -21,28 +21,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 1.25rem;
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 0.75rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 4rem;
     }
 
@@ -67,28 +60,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 1rem;
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 0.625rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 3.5rem;
     }
 
@@ -113,28 +99,21 @@
     }
 
     atomic-result-section-title {
-      --font-size: var(--atomic-text-xl);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-xl);
     }
 
     atomic-result-section-excerpt {
       margin-top: 0.75rem;
-      --font-size: var(--atomic-text-base);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-base);
+
       max-height: 1.25rem;
       @mixin line-clamp 1;
     }
 
     atomic-result-section-bottom-metadata {
       margin-top: 0.4375rem;
-      --font-size: var(--atomic-text-sm);
-      font-size: var(--font-size);
-      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
-      line-height: var(--line-height);
+      @mixin set-font-size var(--atomic-text-sm);
+
       max-height: 3.25rem;
     }
 
@@ -234,13 +213,13 @@ atomic-result-section-actions {
 }
 
 atomic-result-section-title-metadata {
-  --font-size: var(--atomic-text-sm);
+  @mixin set-font-size var(--atomic-text-sm);
   font-size: var(--font-size);
 }
 
 atomic-result-section-emphasized {
   font-weight: 500;
-  --font-size: var(--atomic-text-2xl);
+  @mixin set-font-size var(--atomic-text-2xl);
   font-size: var(--font-size);
   --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -23,7 +23,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -31,7 +31,7 @@
       margin-top: 1.25rem;
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 2.5rem;
       @mixin line-clamp 2;
@@ -41,7 +41,7 @@
       margin-top: 0.75rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 2rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 4rem;
     }
@@ -69,7 +69,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -77,7 +77,7 @@
       margin-top: 1rem;
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 2.5rem;
       @mixin line-clamp 2;
@@ -87,7 +87,7 @@
       margin-top: 0.625rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.75rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3.5rem;
     }
@@ -115,7 +115,7 @@
     atomic-result-section-title {
       --font-size: var(--atomic-text-xl);
       font-size: var(--font-size);
-      --line-height: 1.5rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
     }
 
@@ -123,7 +123,7 @@
       margin-top: 0.75rem;
       --font-size: var(--atomic-text-base);
       font-size: var(--font-size);
-      --line-height: 1.25rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 1.25rem;
       @mixin line-clamp 1;
@@ -133,7 +133,7 @@
       margin-top: 0.4375rem;
       --font-size: var(--atomic-text-sm);
       font-size: var(--font-size);
-      --line-height: 1.625rem;
+      --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
       line-height: var(--line-height);
       max-height: 3.25rem;
     }
@@ -242,7 +242,7 @@ atomic-result-section-emphasized {
   font-weight: 500;
   --font-size: var(--atomic-text-2xl);
   font-size: var(--font-size);
-  --line-height: 2rem;
+  --line-height: calc(var(--font-size) * var(--atomic-line-height-ratio));
   line-height: var(--line-height);
   margin-top: 0.5rem;
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result.pcss
@@ -1,4 +1,5 @@
 @import '../../global/global.pcss';
+@import './atomic-result-mixin.pcss';
 @import './atomic-result-with-sections.pcss';
 @import './atomic-result-row-desktop.pcss';
 @import './atomic-result-row-mobile.pcss';

--- a/packages/atomic/src/components/atomic-table-result/atomic-result-cell.pcss
+++ b/packages/atomic/src/components/atomic-table-result/atomic-result-cell.pcss
@@ -1,4 +1,5 @@
 @import '../../global/global.pcss';
+@import '../atomic-result/atomic-result-mixin.pcss';
 @import '../atomic-result/atomic-result-with-sections.pcss';
 @import '../atomic-result/atomic-result-row-desktop.pcss';
 

--- a/packages/atomic/src/themes/accessible.css
+++ b/packages/atomic/src/themes/accessible.css
@@ -36,4 +36,5 @@
   --atomic-text-lg: 1rem; /* 16px */
   --atomic-text-xl: 1.125rem; /* 18px */
   --atomic-text-2xl: 1.5rem; /* 24px */
+  --atomic-line-height-ratio: 1.5;
 }

--- a/packages/atomic/src/themes/coveo.css
+++ b/packages/atomic/src/themes/coveo.css
@@ -36,4 +36,5 @@
   --atomic-text-lg: 1rem; /* 16px */
   --atomic-text-xl: 1.125rem; /* 18px */
   --atomic-text-2xl: 1.5rem; /* 24px */
+  --atomic-line-height-ratio: 1.5;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1070

To make the line height relative to the font size, instead of adding a variable for each sizes, I created the `--atomic-line-height-ratio` variable. In most cases it should not need to be updated, but for some fonts the current ratio could be better.