### PR TITLE
fix(atomic): add util to hide sections using inline styling

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -240,9 +240,4 @@
       display: none;
     }
   }
-
-  /* == Common styles == */
-  atomic-result-section-badges.empty {
-    display: block;
-  }
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-mobile.pcss
@@ -195,8 +195,4 @@
   atomic-result-section-actions {
     overflow-x: auto;
   }
-
-  atomic-result-section-badges.empty {
-    display: block;
-  }
 }

--- a/packages/atomic/src/components/atomic-result/atomic-result-with-sections.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-with-sections.pcss
@@ -52,10 +52,6 @@
   atomic-result-section-bottom-metadata {
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &.empty {
-      display: none;
-    }
   }
 
   &.image-icon {

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-actions.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-actions.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section allows the information seeker to perform an action on an item without having to view its details.
@@ -19,6 +19,6 @@ export class AtomicResultSectionActions {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-badges.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-badges.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section provides badges that highlight special features of the item.
@@ -18,6 +18,6 @@ export class AtomicResultSectionBadges {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-bottom-metadata.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-bottom-metadata.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section displays additional descriptive information about the item.
@@ -19,6 +19,6 @@ export class AtomicResultSectionBottomMetadata {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-emphasized.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-emphasized.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section displays the field that's important for its search criteria.
@@ -17,6 +17,6 @@ export class AtomicResultSectionEmphasized {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-excerpt.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-excerpt.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section contains an informative summary of the item's content.
@@ -18,6 +18,6 @@ export class AtomicResultSectionExcerpt {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-title-metadata.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-title-metadata.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section surfaces some fields that are directly related to the title of the item.
@@ -18,6 +18,6 @@ export class AtomicResultSectionTitleMetadata {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-title.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-title.tsx
@@ -1,5 +1,5 @@
 import {Element, Component} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 
 /**
  * This section identifies the item by its name, and its main use is to make the result list scannable.
@@ -18,6 +18,6 @@ export class AtomicResultSectionTitle {
   @Element() private host!: HTMLElement;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-visual.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-sections/atomic-result-section-visual.tsx
@@ -1,5 +1,5 @@
 import {Element, Component, Prop} from '@stencil/core';
-import {containsVisualElement} from '../../../utils/utils';
+import {hideEmptySection} from '../../../utils/result-section-utils';
 import {ResultDisplayImageSize} from '../../atomic-result/atomic-result-display-options';
 
 /**
@@ -26,6 +26,6 @@ export class AtomicResultSectionVisual {
   @Prop() public imageSize?: ResultDisplayImageSize;
 
   public componentDidRender() {
-    this.host.classList.toggle('empty', !containsVisualElement(this.host));
+    hideEmptySection(this.host);
   }
 }

--- a/packages/atomic/src/utils/result-section-utils.ts
+++ b/packages/atomic/src/utils/result-section-utils.ts
@@ -1,3 +1,5 @@
+import {containsVisualElement} from './utils';
+
 const resultSectionTags = [
   'atomic-result-section-visual',
   'atomic-result-section-badges',
@@ -13,4 +15,8 @@ export function containsSection(element: ParentNode) {
   return Array.from(element.children).some((child) =>
     resultSectionTags.includes(child.tagName.toLowerCase())
   );
+}
+
+export function hideEmptySection(element: HTMLElement) {
+  element.style.display = containsVisualElement(element) ? '' : 'none';
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1153

The "empty" class was being overriden by other styles, mainly the line-clamp mixin. Setting it inline will ensure it's not overriden