### PR TITLE
fix(atomic): assign color to printable uri links

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.pcss
@@ -1,12 +1,14 @@
-atomic-result-link a {
-  color: var(--atomic-on-background);
-}
+atomic-result-link {
+  a {
+    color: var(--atomic-on-background);
 
-atomic-result-link a:hover {
-  text-decoration: underline;
-  color: var(--atomic-primary);
-}
+    &:hover {
+      text-decoration: underline;
+      color: var(--atomic-primary);
+    }
 
-atomic-result-link a:visited {
-  color: var(--atomic-visited);
+    &:visited {
+      color: var(--atomic-visited);
+    }
+  }
 }

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.pcss
@@ -1,6 +1,19 @@
 atomic-result-printable-uri {
   max-width: 100%;
 
+  a,
+  button {
+    color: var(--atomic-primary);
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:visited {
+      color: var(--atomic-visited);
+    }
+  }
+
   ul {
     display: flex;
     flex-wrap: wrap;
@@ -11,25 +24,12 @@ atomic-result-printable-uri {
     align-items: center;
     max-width: 100%;
 
-    a,
-    button {
-      color: var(--atomic-primary);
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
     a {
       display: inline-block;
       vertical-align: middle;
       max-width: 100%;
       text-overflow: ellipsis;
       overflow: hidden;
-
-      a:visited {
-        color: var(--atomic-visited);
-      }
     }
 
     white-space: nowrap;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1152
Printable uri can display a list of links or a single link, depending on the data.

<img width="846" alt="Screen Shot 2021-11-01 at 4 08 28 PM" src="https://user-images.githubusercontent.com/4923043/139734907-cd7bb37e-e99e-428e-bcf9-ec2e80cf148b.png">