### PR TITLE
docs(headless): apply Relative Date links in annotations

### DIFF
--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
@@ -22,12 +22,12 @@ export type DateRangeInput = AbsoluteDate | RelativeDate;
 
 export interface DateRangeOptions {
   /**
-   * The starting value for the date range. A date range can be either absolute or relative.
+   * The starting value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/).
    */
   start: DateRangeInput;
 
   /**
-   * The ending value for the date range. A date range can be either absolute or relative.
+   * The ending value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/).
    */
   end: DateRangeInput;
 

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
@@ -13,7 +13,7 @@ export interface DateRangeRequest {
   start: string;
 
   /**
-   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit"
+   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit".
    */
   end: string;
 

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
@@ -8,12 +8,12 @@ import {AnyFacetRequest} from '../../../generic/interfaces/generic-facet-request
  */
 export interface DateRangeRequest {
   /**
-   * The starting value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the Relative date format "period-amount-unit"
+   * The starting value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit".
    */
   start: string;
 
   /**
-   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the Relative date format "period-amount-unit"
+   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit"
    */
   end: string;
 


### PR DESCRIPTION
Links were originally added manually on docs site and source annotations were not updated. 