### PR TITLE
fix(atomic): stop escaping platform URL for query error

### DIFF
--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.tsx
@@ -97,6 +97,7 @@ export class AtomicQueryError implements InitializableComponent {
           title: this.bindings.i18n.t('disconnected'),
           description: this.bindings.i18n.t('check-your-connection', {
             url: this.url,
+            interpolation: {escapeValue: false},
           }),
         };
       case noEndpointsException:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1174

Safe from XSS here, since we aren't using innerHTML, but putting the description directly in the JSX