### PR TITLE
docs(atomic): support result template components 

### DIFF
--- a/packages/atomic/.storybook/default-init.ts
+++ b/packages/atomic/.storybook/default-init.ts
@@ -12,8 +12,7 @@ const orgIdentifier = getSampleSearchEngineConfiguration();
 
 export const initializeInterfaceDebounced = (
   renderComponentFunction: () => string,
-  engineConfig: Partial<SearchEngineConfiguration> = {},
-  wrapperElement: HTMLElement = document.createElement('div')
+  engineConfig: Partial<SearchEngineConfiguration> = {}
 ) => {
   return debounce(
     async () => {
@@ -21,10 +20,8 @@ export const initializeInterfaceDebounced = (
         'atomic-search-interface'
       ) as HTMLElement;
       const clone = searchInterface.cloneNode(false) as SearchInterface;
-      clone.appendChild(wrapperElement);
-
       const childComponent = renderComponentFunction();
-      wrapperElement.innerHTML = childComponent;
+      clone.innerHTML = childComponent;
       searchInterface.replaceWith(clone);
       await clone.initialize({
         ...orgIdentifier,

--- a/packages/atomic/.storybook/default-init.ts
+++ b/packages/atomic/.storybook/default-init.ts
@@ -12,7 +12,8 @@ const orgIdentifier = getSampleSearchEngineConfiguration();
 
 export const initializeInterfaceDebounced = (
   renderComponentFunction: () => string,
-  engineConfig: Partial<SearchEngineConfiguration> = {}
+  engineConfig: Partial<SearchEngineConfiguration> = {},
+  wrapperElement: HTMLElement = document.createElement('div')
 ) => {
   return debounce(
     async () => {
@@ -20,8 +21,10 @@ export const initializeInterfaceDebounced = (
         'atomic-search-interface'
       ) as HTMLElement;
       const clone = searchInterface.cloneNode() as SearchInterface;
+      clone.appendChild(wrapperElement);
+
       const childComponent = renderComponentFunction();
-      clone.innerHTML = childComponent;
+      wrapperElement.innerHTML = childComponent;
       searchInterface.replaceWith(clone);
       await clone.initialize({
         ...orgIdentifier,

--- a/packages/atomic/.storybook/default-init.ts
+++ b/packages/atomic/.storybook/default-init.ts
@@ -20,7 +20,7 @@ export const initializeInterfaceDebounced = (
       const searchInterface = document.querySelector(
         'atomic-search-interface'
       ) as HTMLElement;
-      const clone = searchInterface.cloneNode() as SearchInterface;
+      const clone = searchInterface.cloneNode(false) as SearchInterface;
       clone.appendChild(wrapperElement);
 
       const childComponent = renderComponentFunction();

--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -1,22 +1,73 @@
-import defaultStory, {DefaultStoryAdvancedConfig} from './default-story';
-import {DocsPage} from '@storybook/addon-docs';
+import {h} from '@stencil/core';
 import {Args} from '@storybook/api';
+import {DocsPage} from '@storybook/addon-docs';
+
+import sharedDefaultStory, {
+  DefaultStoryAdvancedConfig,
+  renderArgsToHTMLString,
+} from './default-story-shared';
+import {initializeInterfaceDebounced} from './default-init';
+import {codeSample} from './code-sample/code-sample';
+import {html} from 'lit-html';
 
 export default function defaultResultComponentStory(
   title: string,
   componentTag: string,
   defaultArgs: Args,
   docPage: typeof DocsPage,
-  advancedConfig: DefaultStoryAdvancedConfig = {}
+  advancedConfig: DefaultStoryAdvancedConfig = {
+    additionalMarkup: () => html`
+      <style>
+        atomic-result-list {
+          max-width: 1024px;
+          display: block;
+          margin: auto;
+        }
+      </style>
+    `,
+  }
 ) {
-  const resultList = document.createElement('atomic-result-list');
-  const atomicTemplate = document.createElement('atomic-result-template');
-  const templateElement = document.createElement('template');
-  atomicTemplate.appendChild(templateElement);
-  resultList.appendChild(atomicTemplate);
+  const {defaultModuleExport, exportedStory, getArgs, updateCurrentArgs} =
+    sharedDefaultStory(
+      title,
+      componentTag,
+      defaultArgs,
+      docPage,
+      advancedConfig
+    );
 
-  return defaultStory(title, componentTag, defaultArgs, docPage, {
-    ...{wrapperElement: resultList},
-    ...advancedConfig,
-  });
+  const renderArgsToResultTemplate = (content: string) => {
+    return `<atomic-result-list>\n\t<atomic-result-template>\n\t\t<template>\n\t\t\t${content}\n\t\t</template>\n\t</atomic-result-template>\n</atomic-result-list>`;
+  };
+
+  const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
+    updateCurrentArgs(params.args);
+
+    const htmlString = renderArgsToHTMLString(componentTag, getArgs());
+    return (
+      <div>
+        <Story />
+        {codeSample(renderArgsToResultTemplate(`${htmlString}`))}
+      </div>
+    );
+  };
+
+  const defaultLoader = initializeInterfaceDebounced(
+    () => {
+      return `${renderArgsToResultTemplate(
+        renderArgsToHTMLString(componentTag, getArgs())
+      )}${
+        advancedConfig.additionalMarkup
+          ? advancedConfig.additionalMarkup().strings.join('')
+          : ''
+      }`;
+    },
+    advancedConfig.engineConfig,
+    advancedConfig.wrapperElement
+  );
+
+  exportedStory.loaders = [defaultLoader];
+  exportedStory.decorators = [defaultDecorator];
+
+  return {defaultModuleExport, exportedStory};
 }

--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -52,19 +52,15 @@ export default function defaultResultComponentStory(
     );
   };
 
-  const defaultLoader = initializeInterfaceDebounced(
-    () => {
-      return `${renderArgsToResultTemplate(
-        renderArgsToHTMLString(componentTag, getArgs())
-      )}${
-        advancedConfig.additionalMarkup
-          ? advancedConfig.additionalMarkup().strings.join('')
-          : ''
-      }`;
-    },
-    advancedConfig.engineConfig,
-    advancedConfig.wrapperElement
-  );
+  const defaultLoader = initializeInterfaceDebounced(() => {
+    return `${renderArgsToResultTemplate(
+      renderArgsToHTMLString(componentTag, getArgs())
+    )}${
+      advancedConfig.additionalMarkup
+        ? advancedConfig.additionalMarkup().strings.join('')
+        : ''
+    }`;
+  }, advancedConfig.engineConfig);
 
   exportedStory.loaders = [defaultLoader];
   exportedStory.decorators = [defaultDecorator];

--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -1,0 +1,22 @@
+import defaultStory, {DefaultStoryAdvancedConfig} from './default-story';
+import {DocsPage} from '@storybook/addon-docs';
+import {Args} from '@storybook/api';
+
+export default function defaultResultComponentStory(
+  title: string,
+  componentTag: string,
+  defaultArgs: Args,
+  docPage: typeof DocsPage,
+  advancedConfig: DefaultStoryAdvancedConfig = {}
+) {
+  const resultList = document.createElement('atomic-result-list');
+  const atomicTemplate = document.createElement('atomic-result-template');
+  const templateElement = document.createElement('template');
+  atomicTemplate.appendChild(templateElement);
+  resultList.appendChild(atomicTemplate);
+
+  return defaultStory(title, componentTag, defaultArgs, docPage, {
+    ...{wrapperElement: resultList},
+    ...advancedConfig,
+  });
+}

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -13,7 +13,6 @@ export const ADDON_PARAMETER_KEY = 'shadowParts';
 export interface DefaultStoryAdvancedConfig {
   engineConfig?: Partial<SearchEngineConfiguration>;
   additionalMarkup?: () => TemplateResult;
-  wrapperElement?: HTMLElement;
 }
 
 export function renderArgsToHTMLString(componentTag: string, args: Args) {

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -1,0 +1,99 @@
+import {h} from '@stencil/core';
+import {SearchEngineConfiguration} from '@coveo/headless';
+import {Args} from '@storybook/api';
+import {DocsPage} from '@storybook/addon-docs';
+import {TemplateResult} from 'lit-html';
+import {camelToKebab} from '../src/utils/utils';
+import {mapPropsToArgTypes} from './map-props-to-args';
+import {codeSample} from './code-sample/code-sample';
+import {update} from 'lodash';
+
+export const ADDON_PARAMETER_KEY = 'shadowParts';
+
+export interface DefaultStoryAdvancedConfig {
+  engineConfig?: Partial<SearchEngineConfiguration>;
+  additionalMarkup?: () => TemplateResult;
+  wrapperElement?: HTMLElement;
+}
+
+export function renderArgsToHTMLString(componentTag: string, args: Args) {
+  const el = document.createElement(componentTag);
+  Object.keys(args)
+    .filter((arg) => arg.indexOf(ADDON_PARAMETER_KEY) === -1)
+    .forEach((arg) => {
+      el.setAttribute(camelToKebab(arg), args[arg]);
+    });
+  return el.outerHTML;
+}
+
+export function renderShadowPartsToStyleString(
+  componentTag: string,
+  args: Args
+) {
+  const styleElement = document.createElement('style');
+  const styleRules = Object.keys(args)
+    .filter((arg) => arg.indexOf(ADDON_PARAMETER_KEY) !== -1)
+    .map((arg) => {
+      const shadowPartName = arg.split(`${ADDON_PARAMETER_KEY}:`)[1];
+      const rulesForPartWithoutEmptyLines = (
+        args[arg].split('\n') as string[]
+      ).filter((rule) => rule != '');
+
+      const rulesFormattedByLine = `\t${rulesForPartWithoutEmptyLines.join(
+        '\n\t'
+      )}`;
+
+      return `\n${componentTag}::part(${shadowPartName}) {\n${rulesFormattedByLine}\n}`;
+    })
+    .join('\n');
+
+  const rulesTextNode = document.createTextNode(`\n\t\t${styleRules}\n\n`);
+  styleElement.appendChild(rulesTextNode);
+  return styleElement.outerHTML;
+}
+
+export default function sharedDefaultStory(
+  title: string,
+  componentTag: string,
+  defaultArgs: Args,
+  docPage: typeof DocsPage,
+  advancedConfig: DefaultStoryAdvancedConfig = {}
+) {
+  let currentArgs = {};
+
+  const updateCurrentArgs = (args: Args) => {
+    currentArgs = {...defaultArgs, ...args};
+  };
+
+  const defaultModuleExport = {
+    title,
+    argTypes: mapPropsToArgTypes(componentTag),
+    parameters: {
+      docs: {
+        page: docPage,
+      },
+      [ADDON_PARAMETER_KEY]: componentTag,
+    },
+  };
+
+  const exportedStory = (args: Args) => {
+    updateCurrentArgs(args);
+    return '';
+  };
+
+  const defaultLoader = () => console.log('Not implemented');
+  const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
+    updateCurrentArgs(params.args);
+    return <Story />;
+  };
+
+  exportedStory.loaders = [defaultLoader];
+  exportedStory.decorators = [defaultDecorator];
+
+  return {
+    defaultModuleExport,
+    exportedStory,
+    getArgs: () => currentArgs,
+    updateCurrentArgs,
+  };
+}

--- a/packages/atomic/.storybook/default-story.tsx
+++ b/packages/atomic/.storybook/default-story.tsx
@@ -25,18 +25,14 @@ export default function defaultStory(
       advancedConfig
     );
 
-  const defaultLoader = initializeInterfaceDebounced(
-    () => {
-      const argsToHTMLString = renderArgsToHTMLString(componentTag, getArgs());
-      const additionalMarkupString = advancedConfig.additionalMarkup
-        ? advancedConfig.additionalMarkup().strings.join('')
-        : '';
+  const defaultLoader = initializeInterfaceDebounced(() => {
+    const argsToHTMLString = renderArgsToHTMLString(componentTag, getArgs());
+    const additionalMarkupString = advancedConfig.additionalMarkup
+      ? advancedConfig.additionalMarkup().strings.join('')
+      : '';
 
-      return argsToHTMLString + additionalMarkupString;
-    },
-    advancedConfig.engineConfig,
-    advancedConfig.wrapperElement
-  );
+    return argsToHTMLString + additionalMarkupString;
+  }, advancedConfig.engineConfig);
 
   const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
     updateCurrentArgs(params.args);

--- a/packages/atomic/.storybook/default-story.tsx
+++ b/packages/atomic/.storybook/default-story.tsx
@@ -10,7 +10,7 @@ import {TemplateResult} from 'lit-html';
 
 const ADDON_PARAMETER_KEY = 'shadowParts';
 
-function renderArgsToHTMLString(componentTag: string, args: Args) {
+export function renderArgsToHTMLString(componentTag: string, args: Args) {
   const el = document.createElement(componentTag);
   Object.keys(args)
     .filter((arg) => arg.indexOf(ADDON_PARAMETER_KEY) === -1)
@@ -42,9 +42,11 @@ function renderShadowPartsToStyleString(componentTag: string, args: Args) {
   styleElement.appendChild(rulesTextNode);
   return styleElement.outerHTML;
 }
+
 export interface DefaultStoryAdvancedConfig {
   engineConfig?: Partial<SearchEngineConfiguration>;
   additionalMarkup?: () => TemplateResult;
+  wrapperElement?: HTMLElement;
 }
 
 export default function defaultStory(
@@ -106,8 +108,8 @@ export default function defaultStory(
 
       return argsToHTMLString + additionalMarkupString;
     },
-
-    advancedConfig.engineConfig
+    advancedConfig.engineConfig,
+    advancedConfig.wrapperElement
   );
 
   exportedStory.loaders = [defaultLoader];

--- a/packages/atomic/.storybook/default-story.tsx
+++ b/packages/atomic/.storybook/default-story.tsx
@@ -3,51 +3,11 @@ import {Args} from '@storybook/api';
 import {DocsPage} from '@storybook/addon-docs';
 import {codeSample} from './code-sample/code-sample';
 import {initializeInterfaceDebounced} from './default-init';
-import {mapPropsToArgTypes} from './map-props-to-args';
-import {camelToKebab} from '../src/utils/utils';
-import {SearchEngineConfiguration} from '@coveo/headless';
-import {TemplateResult} from 'lit-html';
-
-const ADDON_PARAMETER_KEY = 'shadowParts';
-
-export function renderArgsToHTMLString(componentTag: string, args: Args) {
-  const el = document.createElement(componentTag);
-  Object.keys(args)
-    .filter((arg) => arg.indexOf(ADDON_PARAMETER_KEY) === -1)
-    .forEach((arg) => {
-      el.setAttribute(camelToKebab(arg), args[arg]);
-    });
-  return el.outerHTML;
-}
-
-function renderShadowPartsToStyleString(componentTag: string, args: Args) {
-  const styleElement = document.createElement('style');
-  const styleRules = Object.keys(args)
-    .filter((arg) => arg.indexOf(ADDON_PARAMETER_KEY) !== -1)
-    .map((arg) => {
-      const shadowPartName = arg.split(`${ADDON_PARAMETER_KEY}:`)[1];
-      const rulesForPartWithoutEmptyLines = (
-        args[arg].split('\n') as string[]
-      ).filter((rule) => rule != '');
-
-      const rulesFormattedByLine = `\t${rulesForPartWithoutEmptyLines.join(
-        '\n\t'
-      )}`;
-
-      return `\n${componentTag}::part(${shadowPartName}) {\n${rulesFormattedByLine}\n}`;
-    })
-    .join('\n');
-
-  const rulesTextNode = document.createTextNode(`\n\t\t${styleRules}\n\n`);
-  styleElement.appendChild(rulesTextNode);
-  return styleElement.outerHTML;
-}
-
-export interface DefaultStoryAdvancedConfig {
-  engineConfig?: Partial<SearchEngineConfiguration>;
-  additionalMarkup?: () => TemplateResult;
-  wrapperElement?: HTMLElement;
-}
+import sharedDefaultStory, {
+  DefaultStoryAdvancedConfig,
+  renderArgsToHTMLString,
+  renderShadowPartsToStyleString,
+} from './default-story-shared';
 
 export default function defaultStory(
   title: string,
@@ -56,52 +16,18 @@ export default function defaultStory(
   docPage: typeof DocsPage,
   advancedConfig: DefaultStoryAdvancedConfig = {}
 ) {
-  let currentArgs = {};
-
-  const updateCurrentArgs = (args: Args) => {
-    currentArgs = {...defaultArgs, ...args};
-  };
-
-  const defaultModuleExport = {
-    title,
-    argTypes: mapPropsToArgTypes(componentTag),
-    parameters: {
-      docs: {
-        page: docPage,
-      },
-      [ADDON_PARAMETER_KEY]: componentTag,
-    },
-  };
-
-  const exportedStory = (args: Args) => {
-    updateCurrentArgs(args);
-    return '';
-  };
-
-  const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
-    updateCurrentArgs(params.args);
-
-    const htmlString = renderArgsToHTMLString(componentTag, currentArgs);
-    const styleString = renderShadowPartsToStyleString(
+  const {defaultModuleExport, exportedStory, getArgs, updateCurrentArgs} =
+    sharedDefaultStory(
+      title,
       componentTag,
-      currentArgs
+      defaultArgs,
+      docPage,
+      advancedConfig
     );
-    return (
-      <div>
-        <Story />
-        <div innerHTML={styleString}></div>
-        {codeSample(styleString)}
-        {codeSample(htmlString)}
-      </div>
-    );
-  };
 
   const defaultLoader = initializeInterfaceDebounced(
     () => {
-      const argsToHTMLString = renderArgsToHTMLString(
-        componentTag,
-        currentArgs
-      );
+      const argsToHTMLString = renderArgsToHTMLString(componentTag, getArgs());
       const additionalMarkupString = advancedConfig.additionalMarkup
         ? advancedConfig.additionalMarkup().strings.join('')
         : '';
@@ -111,6 +37,21 @@ export default function defaultStory(
     advancedConfig.engineConfig,
     advancedConfig.wrapperElement
   );
+
+  const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
+    updateCurrentArgs(params.args);
+
+    const htmlString = renderArgsToHTMLString(componentTag, getArgs());
+    const styleString = renderShadowPartsToStyleString(componentTag, getArgs());
+    return (
+      <div>
+        <Story />
+        <div className="inline-style" innerHTML={styleString}></div>
+        {codeSample(styleString)}
+        {codeSample(htmlString)}
+      </div>
+    );
+  };
 
   exportedStory.loaders = [defaultLoader];
   exportedStory.decorators = [defaultDecorator];

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -539,7 +539,7 @@ export namespace Components {
          */
         "maxNumberOfParts": number;
         /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
+          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
          */
         "target": string;
     }
@@ -1758,7 +1758,7 @@ declare namespace LocalJSX {
          */
         "maxNumberOfParts"?: number;
         /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
+          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
          */
         "target"?: string;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -486,7 +486,7 @@ export namespace Components {
     }
     interface AtomicResultLink {
         /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
+          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
          */
         "target": string;
     }
@@ -1705,7 +1705,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultLink {
         /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
+          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
          */
         "target"?: string;
     }

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.mdx
@@ -1,0 +1,3 @@
+# Result Badge
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.stories.tsx
@@ -1,0 +1,12 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultBadgeDocumentation from './atomic-result-badge.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultBadge',
+  'atomic-result-badge',
+  {field: 'filetype'},
+  ResultBadgeDocumentation
+);
+
+export default defaultModuleExport;
+export const DefaultResultBage = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.mdx
@@ -1,0 +1,3 @@
+# Result Date
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.stories.tsx
@@ -1,12 +1,11 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultLinkDoc from './atomic-result-link.mdx';
+import ResultDateDoc from './atomic-result-date.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
-  'Atomic/ResultList/ResultLink',
-  'atomic-result-link',
+  'Atomic/ResultList/ResultDate',
+  'atomic-result-date',
   {},
-  ResultLinkDoc
+  ResultDateDoc
 );
-
 export default defaultModuleExport;
-export const DefaultResultLink = exportedStory;
+export const DefaultResultDate = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.mdx
@@ -1,0 +1,3 @@
+# Result Fields List
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.stories.tsx
@@ -1,0 +1,13 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultFieldsListDoc from './atomic-result-fields-list.mdx';
+
+// TODO requires KIT-1167 to actually be usable
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultFieldsList',
+  'atomic-result-fields-list',
+  {},
+  ResultFieldsListDoc
+);
+
+export default defaultModuleExport;
+export const DefaultResultFieldsList = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.mdx
@@ -1,0 +1,3 @@
+# Result Icon
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.stories.tsx
@@ -1,12 +1,12 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultLinkDoc from './atomic-result-link.mdx';
+import ResultIconDoc from './atomic-result-icon.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
-  'Atomic/ResultList/ResultLink',
-  'atomic-result-link',
+  'Atomic/ResultList/ResultIcon',
+  'atomic-result-icon',
   {},
-  ResultLinkDoc
+  ResultIconDoc
 );
 
 export default defaultModuleExport;
-export const DefaultResultLink = exportedStory;
+export const DefaultResultIcon = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.mdx
@@ -1,0 +1,3 @@
+# Result Image
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.stories.tsx
@@ -1,0 +1,26 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultImageDoc from './atomic-result-image.mdx';
+
+// TODO: This will require KIT-1178 to actually be usable properly
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultImage',
+  'atomic-result-image',
+  {
+    field: 'randomimage',
+  },
+  ResultImageDoc,
+  {
+    engineConfig: {
+      search: {
+        preprocessSearchResponseMiddleware: (res) => {
+          res.body.results.forEach(
+            (r) => (r.raw['randomimage'] = 'https://picsum.photos/200')
+          );
+          return res;
+        },
+      },
+    },
+  }
+);
+export default defaultModuleExport;
+export const DefaultResultImage = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.mdx
@@ -1,0 +1,3 @@
+# Result link
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.stories.tsx
@@ -1,0 +1,12 @@
+import defaultStory from '../../../../.storybook/default-result-component-story';
+import ResultLinkDoc from './atomic-result-link.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultStory(
+  'Atomic/ResultLink',
+  'atomic-result-link',
+  {},
+  ResultLinkDoc
+);
+
+export default defaultModuleExport;
+export const DefaultResultLink = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.tsx
@@ -31,7 +31,7 @@ export class AtomicResultLink implements InitializableComponent {
   @Element() private host!: HTMLElement;
 
   /**
-   * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).
+   * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).
    *
    * The following keywords have special meanings:
    *

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
@@ -1,0 +1,3 @@
+# Result Multi Value Text
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.stories.tsx
@@ -1,0 +1,13 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultMultiValueDoc from './atomic-result-multi-value-text.mdx';
+
+// TODO: Would benefit from KIT-1178
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultMultiValue',
+  'atomic-result-multi-value-text',
+  {field: 'language'},
+  ResultMultiValueDoc
+);
+
+export default defaultModuleExport;
+export const DefaultMultiValueText = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.mdx
@@ -1,0 +1,3 @@
+# Result number
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.stories.tsx
@@ -1,0 +1,23 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultNumberDoc from './atomic-result-number.mdx';
+
+// TODO: Would benefit a lot from KIT-1167
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultNumber',
+  'atomic-result-number',
+  {field: 'size'},
+  ResultNumberDoc,
+  {
+    engineConfig: {
+      preprocessRequest: (r) => {
+        const parsed = JSON.parse(r.body as string);
+        parsed.fieldsToInclude = [...parsed.fieldsToInclude, 'size'];
+        r.body = JSON.stringify(parsed);
+        return r;
+      },
+    },
+  }
+);
+
+export default defaultModuleExport;
+export const DefaultResultNumber = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.mdx
@@ -1,0 +1,3 @@
+# Result Printable Uri
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.stories.tsx
@@ -1,0 +1,12 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultPrintableUriDoc from './atomic-result-printable-uri.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultPrintableUri',
+  'atomic-result-printable-uri',
+  {},
+  ResultPrintableUriDoc
+);
+
+export default defaultModuleExport;
+export const DefaultResultPrintableUri = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
@@ -45,7 +45,7 @@ export class AtomicResultPrintableUri {
   @Prop() maxNumberOfParts = 5;
 
   /**
-   * Where to open the linked URL, as the name for a browsing context (a tab, window, or <iframe>).
+   * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).
    *
    * The following keywords have special meanings:
    *

--- a/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.mdx
@@ -1,0 +1,3 @@
+# Result Rating
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.stories.tsx
@@ -1,0 +1,23 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultRatingDoc from './atomic-result-rating.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultRating',
+  'atomic-result-rating',
+  {field: 'snrating'},
+  ResultRatingDoc,
+  {
+    engineConfig: {
+      preprocessRequest: (r) => {
+        const parsed = JSON.parse(r.body as string);
+        parsed.aq = '@snrating';
+        parsed.fieldsToInclude = [...parsed.fieldsToInclude, 'snrating'];
+        r.body = JSON.stringify(parsed);
+        return r;
+      },
+    },
+  }
+);
+
+export default defaultModuleExport;
+export const DefaultResultRating = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.mdx
@@ -1,0 +1,3 @@
+# Result Text
+
+TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.stories.tsx
@@ -1,0 +1,11 @@
+import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
+import ResultTextDoc from './atomic-result-text.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/ResultText',
+  'atomic-result-text',
+  {field: 'excerpt'},
+  ResultTextDoc
+);
+export default defaultModuleExport;
+export const DefaultResultText = exportedStory;

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -292,17 +292,6 @@
       <div class="results">
         <atomic-did-you-mean></atomic-did-you-mean>
         <atomic-result-list fields-to-include="snrating,sncost">
-          <atomic-result-template must-match-sourcetype="YouTube">
-            <template>
-              <atomic-result-section-visual image-size="small">
-                <img src="https://picsum.photos/350" class="thumbnail" />
-              </atomic-result-section-visual>
-              <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
-              <atomic-result-section-excerpt
-                ><atomic-result-text field="excerpt"></atomic-result-text
-              ></atomic-result-section-excerpt>
-            </template>
-          </atomic-result-template>
           <atomic-result-template>
             <template>
               <style>
@@ -353,6 +342,10 @@
                 .salesforce-badge::part(result-badge-element) {
                   background-color: #44a1da;
                   color: white;
+                }
+
+                atomic-result-link a {
+                  color: yellow !important;
                 }
               </style>
               <atomic-result-section-visual>


### PR DESCRIPTION
* Created a new `default-result-component-story` module, to power result template components in storybook.

* Extracted a `default-story-shared` module, that is used by both result template and standard components.

* The difference between result components and standard components is in the `decorator` and `loader` function associated with each story, because this is where we control what gets rendered, and how the components are injected in the page. For example, result-template components needs a result list as a parent element.

* The code sample generated is also different for result template component, since we want to show it inside a result list component. That should tie up nicely with KIT-1178 and KIT-1183 

* Created a bunch of storybook stories for all the result templates component, and left a bunch of todo on things to improve.

![image](https://user-images.githubusercontent.com/1591893/140192488-53049b3a-d8d8-4983-ab7b-d7f32f94e413.png)


https://coveord.atlassian.net/browse/KIT-1168