### PR TITLE
feat(atomic): added preprocessing for field values in atomic-result-multi-value-text

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-components/result-multi-value-text.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-multi-value-text.cypress.ts
@@ -5,7 +5,11 @@ import {
 } from '../../../fixtures/test-fixture';
 import {addFacet} from '../../facets/facet/facet-actions';
 import {FacetSelectors} from '../../facets/facet/facet-selectors';
-import {addResultList, buildTemplateWithSections} from '../result-list-actions';
+import {
+  addFieldValueInResponse,
+  addResultList,
+  buildTemplateWithSections,
+} from '../result-list-actions';
 import {
   assertShouldRenderValues,
   assertDisplaysXMoreLabel,
@@ -21,11 +25,15 @@ import {
   assertConsoleError,
   assertRemovesComponent,
 } from '../../common-assertions';
-import {resultListComponent} from '../result-list-selectors';
+import {
+  resultListComponent,
+  ResultListSelectors,
+} from '../result-list-selectors';
 
 export interface MultiValueTextProps {
   field?: string | number;
   'max-values-to-display'?: number;
+  delimiter?: string;
 }
 
 const addMultiValueText = (
@@ -79,7 +87,7 @@ describe('Result MultiValueText Component', () => {
         .init();
     });
 
-    assertRemovesComponent(ResultMultiValueTextSelectors.shadow);
+    assertRemovesComponent(() => cy.get(resultMultiValueTextComponent));
     assertConsoleError();
   });
 
@@ -91,24 +99,29 @@ describe('Result MultiValueText Component', () => {
           .init();
       });
 
-      assertRemovesComponent(ResultMultiValueTextSelectors.firstInResult);
+      assertRemovesComponent(() =>
+        ResultListSelectors.firstResult().find(resultMultiValueTextComponent)
+      );
     });
 
     describe('when the field value is not a string nor a string array', () => {
       beforeEach(() => {
         new TestFixture()
           .with(addMultiValueText({field: 'hello'}))
-          .withCustomResponse((response) => {
-            response.results.forEach((result) => (result.raw['hello'] = 420));
-          })
+          .with(addFieldValueInResponse('hello', 420))
           .init();
       });
 
-      assertRemovesComponent(ResultMultiValueTextSelectors.firstInResult);
+      assertRemovesComponent(() =>
+        ResultListSelectors.firstResult().find(resultMultiValueTextComponent)
+      );
       assertConsoleError();
     });
 
-    describe('when the field value exists & is a string array', () => {
+    function testWithValidFieldValue(
+      getFieldValues: (valuesToTest: string[]) => string | string[],
+      delimiter?: string
+    ) {
       const field = 'hello_world';
       function prepareValuesWithMaximum(
         valuesAndCaptions: Record<string, string>,
@@ -118,15 +131,20 @@ describe('Result MultiValueText Component', () => {
         return new TestFixture()
           .with(
             addMultiValueText(
-              {field, 'max-values-to-display': maxValuesToDisplay},
+              {
+                field,
+                'max-values-to-display': maxValuesToDisplay,
+                ...(delimiter ? {delimiter} : {}),
+              },
               slot
             )
           )
-          .withCustomResponse((response) => {
-            response.results.forEach((result) => {
-              result.raw[field] = Object.keys(valuesAndCaptions);
-            });
-          })
+          .with(
+            addFieldValueInResponse(
+              field,
+              getFieldValues(Object.keys(valuesAndCaptions))
+            )
+          )
           .withFieldCaptions(field, valuesAndCaptions)
           .withTranslation({'n-more': '{{value}} more'});
       }
@@ -288,6 +306,19 @@ describe('Result MultiValueText Component', () => {
           assertDoesNotDisplayXMoreLabel();
         });
       });
+    }
+
+    describe('when the field value exists & is a string array', () => {
+      testWithValidFieldValue((valuesToTest) =>
+        valuesToTest.map((value) => ` ${value} `)
+      );
+    });
+
+    describe('when the field value exists & is a string', () => {
+      testWithValidFieldValue(
+        (valuesToTest) => valuesToTest.map((value) => ` ${value} `).join(';'),
+        ';'
+      );
     });
   });
 });

--- a/packages/atomic/cypress/integration/result-list/result-components/result-multi-value-text.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-multi-value-text.cypress.ts
@@ -15,10 +15,7 @@ import {
   assertDisplaysXMoreLabel,
   assertDoesNotDisplayXMoreLabel,
 } from './result-multi-value-text-assertions';
-import {
-  resultMultiValueTextComponent,
-  ResultMultiValueTextSelectors,
-} from './result-multi-value-text-selectors';
+import {resultMultiValueTextComponent} from './result-multi-value-text-selectors';
 import * as CommonFacetAssertions from '../../facets/facet-common-assertions';
 import {
   assertAccessibility,

--- a/packages/atomic/cypress/integration/result-list/result-list-actions.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list-actions.ts
@@ -40,7 +40,8 @@ export function buildTemplateWithSections(
 }
 
 export const addFieldValueInResponse =
-  (field: string, fieldValue: string | null) => (fixture: TestFixture) => {
+  (field: string, fieldValue: string | number | string[] | null) =>
+  (fixture: TestFixture) => {
     fixture.withCustomResponse((response) =>
       response.results.forEach((result) => {
         if (fieldValue === null) {

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1696,7 +1696,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultMultiValueText {
         /**
-          * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+          * The delimiter used to separate values when the field isn't indexed as a multi value field.
          */
         "delimiter"?: string | null;
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -510,7 +510,7 @@ export namespace Components {
     }
     interface AtomicResultMultiValueText {
         /**
-          * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+          * The delimiter used to separate values when the field isn't indexed as a multi value field.
          */
         "delimiter": string | null;
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -509,6 +509,9 @@ export namespace Components {
         "imageSize"?: ResultDisplayImageSize;
     }
     interface AtomicResultMultiValueText {
+        /**
+          * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+         */
         "delimiter": string | null;
         /**
           * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
@@ -1692,6 +1695,9 @@ declare namespace LocalJSX {
         "imageSize"?: ResultDisplayImageSize;
     }
     interface AtomicResultMultiValueText {
+        /**
+          * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+         */
         "delimiter"?: string | null;
         /**
           * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -509,6 +509,7 @@ export namespace Components {
         "imageSize"?: ResultDisplayImageSize;
     }
     interface AtomicResultMultiValueText {
+        "delimiter": string | null;
         /**
           * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
          */
@@ -1691,6 +1692,7 @@ declare namespace LocalJSX {
         "imageSize"?: ResultDisplayImageSize;
     }
     interface AtomicResultMultiValueText {
+        "delimiter"?: string | null;
         /**
           * The field that the component should use. The component will try to find this field in the `Result.raw` object unless it finds it in the `Result` object first. Make sure this field is present in the `fieldsToInclude` property of the `atomic-result-list` component.
          */

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
@@ -50,6 +50,9 @@ export class AtomicResultMultiText {
    */
   @Prop() public maxValuesToDisplay = 3;
 
+  /**
+   * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+   */
   @Prop() public delimiter: string | null = null;
 
   private sortedValues: string[] | null = null;

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
@@ -50,6 +50,8 @@ export class AtomicResultMultiText {
    */
   @Prop() public maxValuesToDisplay = 3;
 
+  @Prop() public delimiter: string | null = null;
+
   private sortedValues: string[] | null = null;
 
   public initialize() {
@@ -67,7 +69,7 @@ export class AtomicResultMultiText {
     }
 
     if (Array.isArray(value)) {
-      return value.map((v) => `${v}`);
+      return value.map((v) => `${v}`.trim());
     }
 
     if (typeof value !== 'string' || value.trim() === '') {
@@ -77,7 +79,9 @@ export class AtomicResultMultiText {
       return null;
     }
 
-    return [value];
+    return this.delimiter
+      ? value.split(this.delimiter).map((value) => value.trim())
+      : [value];
   }
 
   private get facetSelectedValues() {

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
@@ -51,7 +51,7 @@ export class AtomicResultMultiText {
   @Prop() public maxValuesToDisplay = 3;
 
   /**
-   * If the field isn't indexed as a multi value field, values are going to be split using this delimiter.
+   * The delimiter used to separate values when the field isn't indexed as a multi value field.
    */
   @Prop() public delimiter: string | null = null;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-985

I made it possible for field values to be split and trimmed in `atomic-result-multi-value-text`.