### PR TITLE
feat(atomic): added live region for screen readers 

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -14,6 +14,8 @@ import { TemplateContent } from "./components/atomic-result-template/atomic-resu
 import { i18n } from "i18next";
 import { InitializationOptions } from "./components/atomic-search-interface/atomic-search-interface";
 export namespace Components {
+    interface AtomicAriaLive {
+    }
     interface AtomicBreadbox {
     }
     interface AtomicCategoryFacet {
@@ -755,6 +757,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLAtomicAriaLiveElement extends Components.AtomicAriaLive, HTMLStencilElement {
+    }
+    var HTMLAtomicAriaLiveElement: {
+        prototype: HTMLAtomicAriaLiveElement;
+        new (): HTMLAtomicAriaLiveElement;
+    };
     interface HTMLAtomicBreadboxElement extends Components.AtomicBreadbox, HTMLStencilElement {
     }
     var HTMLAtomicBreadboxElement: {
@@ -1128,6 +1136,7 @@ declare global {
         new (): HTMLAtomicTimeframeFacetElement;
     };
     interface HTMLElementTagNameMap {
+        "atomic-aria-live": HTMLAtomicAriaLiveElement;
         "atomic-breadbox": HTMLAtomicBreadboxElement;
         "atomic-category-facet": HTMLAtomicCategoryFacetElement;
         "atomic-color-facet": HTMLAtomicColorFacetElement;
@@ -1193,6 +1202,8 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface AtomicAriaLive {
+    }
     interface AtomicBreadbox {
     }
     interface AtomicCategoryFacet {
@@ -1924,6 +1935,7 @@ declare namespace LocalJSX {
         "withDatePicker"?: boolean;
     }
     interface IntrinsicElements {
+        "atomic-aria-live": AtomicAriaLive;
         "atomic-breadbox": AtomicBreadbox;
         "atomic-category-facet": AtomicCategoryFacet;
         "atomic-color-facet": AtomicColorFacet;
@@ -1992,6 +2004,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "atomic-aria-live": LocalJSX.AtomicAriaLive & JSXBase.HTMLAttributes<HTMLAtomicAriaLiveElement>;
             "atomic-breadbox": LocalJSX.AtomicBreadbox & JSXBase.HTMLAttributes<HTMLAtomicBreadboxElement>;
             "atomic-category-facet": LocalJSX.AtomicCategoryFacet & JSXBase.HTMLAttributes<HTMLAtomicCategoryFacetElement>;
             "atomic-color-facet": LocalJSX.AtomicColorFacet & JSXBase.HTMLAttributes<HTMLAtomicColorFacetElement>;

--- a/packages/atomic/src/components/atomic-search-interface/atomic-aria-live.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-aria-live.tsx
@@ -1,0 +1,71 @@
+import {
+  buildQuerySummary,
+  buildSearchStatus,
+  QuerySummary,
+  QuerySummaryState,
+  SearchStatus,
+  SearchStatusState,
+} from '@coveo/headless';
+import {Component, h, Host, State} from '@stencil/core';
+import {
+  Bindings,
+  BindStateToController,
+  InitializeBindings,
+} from '../../utils/initialization-utils';
+
+/**
+ * The `atomic-aria-live` component notifies screen readers of changes in the search interface.
+ * @internal
+ */
+@Component({
+  tag: 'atomic-aria-live',
+  shadow: false,
+})
+export class AtomicAriaLive {
+  @InitializeBindings() public bindings!: Bindings;
+  @State() public error!: Error;
+
+  protected searchStatus!: SearchStatus;
+  @BindStateToController('searchStatus')
+  @State()
+  private searchStatusState!: SearchStatusState;
+  protected querySummary!: QuerySummary;
+  @BindStateToController('querySummary')
+  @State()
+  private querySummaryState!: QuerySummaryState;
+
+  private get searchSummary() {
+    if (!this.searchStatusState.firstSearchExecuted) {
+      return '';
+    }
+    if (this.searchStatusState.isLoading) {
+      return this.bindings.i18n.t('loading-results');
+    }
+    if (!this.searchStatusState.hasResults) {
+      return this.bindings.i18n.t('no-results');
+    }
+    return this.bindings.i18n.t('showing-results-of', {
+      count: this.querySummaryState.lastResult,
+      first: this.querySummaryState.firstResult.toLocaleString(),
+      last: this.querySummaryState.lastResult.toLocaleString(),
+      total: this.querySummaryState.total.toLocaleString(),
+    });
+  }
+
+  public initialize() {
+    this.searchStatus = buildSearchStatus(this.bindings.engine);
+    this.querySummary = buildQuerySummary(this.bindings.engine);
+  }
+
+  public render() {
+    return (
+      <Host
+        role="status"
+        aria-live="polite" // redundant, but recommended in Mozilla's doc
+        style={{position: 'absolute', right: '10000px'}}
+      >
+        {this.searchSummary}
+      </Host>
+    );
+  }
+}

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -374,6 +374,7 @@ export class AtomicSearchInterface {
           bindings={this.bindings}
         ></atomic-relevance-inspector>
       ),
+      <atomic-aria-live></atomic-aria-live>,
       <slot></slot>,
     ];
   }

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -1097,5 +1097,9 @@
   "only": {
     "en": "only",
     "fr": "seulement"
+  },
+  "loading-results": {
+    "en": "Loading new results",
+    "fr": "Chargement de nouveaux résultats"
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-244

Tested with:
* JAWS
* NVDA
* VoiceOver (iOS)
* TalkBack
* VoiceOver (Mac OS)

The region notifies screen reader users of the following events:
* `Loading new results`
* `Results {{first}}-{{last}} of {{total}}` (re-used that string due to the amount of translations for it)
* `No results`

There's a few caveats with this:
1. Screen readers will always read out "Loading new results" before reading "Results #-# of #", even if results finished loading long before it started saying "Loading new results".
2. Hearing "Results #-# of #" or "No results" is a bit confusing on its own when you're interacting with facets or the sort button. Do you think I should create new strings for those that use verbs in the continuous tense? @dlutzCoveo @npushkarskii @johnnyCoveo 