### PR TITLE
SFINT-4124 subjectInput Component added

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -448,4 +448,11 @@
         <protected>false</protected>
         <shortDescription>Expand [component label]</shortDescription>
     </labels>
+    <labels>
+      <fullName>cookbook_WriteDescriptiveTitle</fullName>
+      <value>Write a descriptive title</value>
+      <language>en_US</language>
+      <protected>false</protected>
+      <shortDescription>Write a descriptive title</shortDescription>
+  </labels>
 </CustomLabels>

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.css
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.css
@@ -1,0 +1,17 @@
+.h2_heading{
+    font-weight: 600;
+}
+.input_count{
+    top: 0;
+    right: 0.75rem;
+    height: 100%;
+    width: 3.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    font-weight: 200;
+}
+ .slds-input{
+    padding-right: 4.375rem;
+    height: 2.5rem;
+}

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.css
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.css
@@ -1,17 +1,14 @@
-.h2_heading{
-    font-weight: 600;
-}
 .input_count{
-    top: 0;
-    right: 0.75rem;
-    height: 100%;
-    width: 3.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    font-weight: 200;
+  top: 0;
+  right: 0.75rem;
+  width: 3.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-weight: 200;
 }
  .slds-input{
-    padding-right: 4.375rem;
-    height: 2.5rem;
+  padding-right: 4.25rem;
+  height: 2.5rem;
 }

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
@@ -1,15 +1,13 @@
 <template>
-  <div class="slds-m-top_medium slds-m-bottom_x-large">
-    <h2 class="slds-text-heading_small slds-m-bottom_x-small">
-      {label}
-    </h2>
-    <div class="slds-is-relative">
-      <div class="slds-form-element">
-        <div class="slds-form-element__control">
-          <input value={value} type="text" class="slds-input" oninput={handleChange} maxlength={maxLength} />
-        </div>
+  <h2 class="slds-text-heading_small slds-m-bottom_x-small">
+    {label}
+  </h2>
+  <div class="slds-is-relative">
+    <div class="slds-form-element">
+      <div class="slds-form-element__control">
+        <input value={value} type="text" class="slds-input" oninput={handleChange} maxlength={maxLength} />
       </div>
-      <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
     </div>
+    <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
@@ -1,0 +1,15 @@
+<template>
+    <div class="slds-m-top_medium slds-m-bottom_x-large">
+        <h2 class="slds-text-heading_small h2_heading slds-m-bottom_x-small">
+            {label}
+        </h2>
+        <div class="slds-is-relative">
+            <div class="slds-form-element">
+                <div class="slds-form-element__control">
+                    <input value={value} type="text" class="slds-input" oninput={handleChange} maxlength={maxLength} />
+                </div>
+            </div>
+            <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
+        </div>
+    </div>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.html
@@ -1,15 +1,15 @@
 <template>
-    <div class="slds-m-top_medium slds-m-bottom_x-large">
-        <h2 class="slds-text-heading_small h2_heading slds-m-bottom_x-small">
-            {label}
-        </h2>
-        <div class="slds-is-relative">
-            <div class="slds-form-element">
-                <div class="slds-form-element__control">
-                    <input value={value} type="text" class="slds-input" oninput={handleChange} maxlength={maxLength} />
-                </div>
-            </div>
-            <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
+  <div class="slds-m-top_medium slds-m-bottom_x-large">
+    <h2 class="slds-text-heading_small slds-m-bottom_x-small">
+      {label}
+    </h2>
+    <div class="slds-is-relative">
+      <div class="slds-form-element">
+        <div class="slds-form-element__control">
+          <input value={value} type="text" class="slds-input" oninput={handleChange} maxlength={maxLength} />
         </div>
+      </div>
+      <span class="slds-is-absolute input_count">{length}/{maxLength}</span>
     </div>
+  </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js
@@ -1,20 +1,56 @@
 import { LightningElement, api } from 'lwc';
+import writeDescriptiveTitle from '@salesforce/label/c.cookbook_WriteDescriptiveTitle';
 
+/**
+ * The `subjectInput` component is an input for the subject of the case. 
+ * @example
+ * <c-subject-input></c-subject-input>
+ */
 export default class SubjectInput extends LightningElement {
-    @api label = "Write a descriptive title";
-    @api maxLength = 100;
-    value = '';
-    length = this.value.length;
+  labels = {
+    writeDescriptiveTitle
+  }
+  /**
+   * The label of the input.
+   * @api
+   * @type {string}
+   * @defaultValue `'Write a descriptive title'`
+   */
+  @api label = this.labels.writeDescriptiveTitle;
 
-    handleChange = (e) => {
-        this.value = e.target.value;
-        this.length = e.target.value.length;
-    }
+  /**
+   * The maximum length of the string to be written in the input.
+   * @api
+   * @type {number}
+   * @defaultValue `100`
+   */
+  @api maxLength = 100;
 
-    @api getValue() {
-        return this.value;
-    }
-    @api getLength() {
-        return this.length;
-    }
+  /** @type {string} */
+  _value = '';
+
+  /** @type {number} */
+  _length = this._value.length;
+
+  handleChange = (e) => {
+    this._value = e.target.value;
+    this._length = e.target.value.length;
+  }
+
+  /**
+   * Returns the value of the input.
+   * @api
+   * @returns {string}
+   */
+  @api get value() {
+    return this._value;
+  }
+
+  /**
+   * Returns the length of the value of the input.
+   * @returns {number}
+   */
+  get length() {
+    return this._length;
+  }
 }

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js
@@ -1,0 +1,20 @@
+import { LightningElement, api } from 'lwc';
+
+export default class SubjectInput extends LightningElement {
+    @api label = "Write a descriptive title";
+    @api maxLength = 100;
+    value = '';
+    length = this.value.length;
+
+    handleChange = (e) => {
+        this.value = e.target.value;
+        this.length = e.target.value.length;
+    }
+
+    @api getValue() {
+        return this.value;
+    }
+    @api getLength() {
+        return this.length;
+    }
+}

--- a/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/subjectInput/subjectInput.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -228,4 +228,8 @@
         <label>Agrandir {{0}}</label>
         <name>quantic_Expand</name>
     </customLabels>
+    <customLabels>
+      <label>Écrivez un titre descriptif</label>
+      <name>cookbook_WriteDescriptiveTitle</name>
+    </customLabels>
 </Translations>


### PR DESCRIPTION
# SubjectInput added.

## Description:
### The `subjectInput` component is an input for the subject of the case. 

## Demo:
https://user-images.githubusercontent.com/86681870/141354025-154e2a8e-d143-48bf-a05d-192164c7c5cd.mov



## Design file: 
https://www.figma.com/file/mGZNYe9DbqIL1NO4m292PG/Case-Assist-User-experience?node-id=348%3A30227

## Note:
### This component will be part of the case assist cookbook and not quantic.