### PR TITLE
docs(atomic): copy atomic resources to storybook static on build

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -37,7 +37,7 @@
     "npm:publish": "node ../../scripts/deploy/publish.js",
     "npm:publish:alpha": "node ../../scripts/deploy/publish.js alpha",
     "storybook": "npm run storybook:lit-analyze && start-storybook -s ./dist -p 6006",
-    "build:storybook": "npm run storybook:lit-analyze && build-storybook",
+    "build:storybook": "npm run storybook:lit-analyze && build-storybook && cp -r dist/ storybook-static/",
     "storybook:lit-analyze": "lit-analyzer dist/types/components.d.ts src/components/**/*.stories.tsx"
   },
   "dependencies": {


### PR DESCRIPTION
Needed in order for the static website uploaded on s3 to have the necessary JS/CSS resources for Atomic without too much URL rewrite with cryptic Webpack config.

https://coveord.atlassian.net/browse/KIT-1190