### PR TITLE
fix(quantic): added truncate and removed placeholder min-width

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.css
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.css
@@ -1,6 +1,5 @@
-.search__grid {
+.search__container {
   position: relative;
-  padding: 12px;
   background: #fff;
   border-radius: .25rem;
   background-clip: padding-box;

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -1,65 +1,63 @@
 <template>
-  <div onregisterresulttemplates={handleResultTemplateRegistration}>
-    <div class="search__grid">
-      <c-quantic-search-interface engine-id={engineId} search-hub={searchHub} pipeline={pipeline} disable-state-in-url={disableStateInUrl} skip-first-search={skipFirstSearch}>
-        <div class="slds-grid slds-grid_vertical slds-grid_align-center">
-          <div class="slds-col slds-size_1-of-1 slds-large-size_6-of-12 slds-align-middle">
-            <div class="slds-m-vertical_small">
-              <c-quantic-search-box engine-id={engineId}></c-quantic-search-box>
-            </div>
+  <div class="search__container slds-p-around_medium" onregisterresulttemplates={handleResultTemplateRegistration}>
+    <c-quantic-search-interface engine-id={engineId} search-hub={searchHub} pipeline={pipeline} disable-state-in-url={disableStateInUrl} skip-first-search={skipFirstSearch}>
+      <div class="slds-grid slds-grid_vertical slds-grid_align-center">
+        <div class="slds-col slds-size_1-of-1 slds-large-size_6-of-12 slds-align-middle">
+          <div class="slds-m-vertical_small">
+            <c-quantic-search-box engine-id={engineId}></c-quantic-search-box>
           </div>
-          <div class="slds-col">
-            <div class="slds-grid slds-gutters_direct slds-wrap main slds-grid_align-center">   
-              <div class="slds-col slds-order_2 slds-large-order_1 slds-size_1-of-1 slds-large-size_3-of-12">
-                <c-quantic-facet-manager engine-id={engineId}>
-                  <c-quantic-facet field="objecttype" label="Type" engine-id={engineId} data-cy="type"></c-quantic-facet>
-                  <c-quantic-facet display-values-as="link" field="filetype" label="File Type" engine-id={engineId}></c-quantic-facet>
-                  <c-quantic-numeric-facet field="ytlikecount" label="Youtube Likes" with-input="integer" engine-id={engineId}></c-quantic-numeric-facet>
-                  <c-quantic-timeframe-facet engine-id={engineId} field="date" label="Date">
-                    <c-quantic-timeframe unit="week"></c-quantic-timeframe>
-                    <c-quantic-timeframe unit="month"></c-quantic-timeframe>
-                    <c-quantic-timeframe amount="6" unit="month"></c-quantic-timeframe>
-                    <c-quantic-timeframe unit="year"></c-quantic-timeframe>
-                  </c-quantic-timeframe-facet>
-                  <c-quantic-category-facet field="geographicalhierarchy" label="Country" engine-id={engineId}></c-quantic-category-facet>
-                </c-quantic-facet-manager>
+        </div>
+        <div class="slds-col">
+          <div class="slds-grid slds-gutters_direct slds-wrap main slds-grid_align-center">
+            <div class="slds-col slds-order_2 slds-large-order_1 slds-size_1-of-1 slds-large-size_3-of-12">
+              <c-quantic-facet-manager engine-id={engineId}>
+                <c-quantic-facet field="objecttype" label="Type" engine-id={engineId} data-cy="type"></c-quantic-facet>
+                <c-quantic-facet display-values-as="link" field="filetype" label="File Type" engine-id={engineId}></c-quantic-facet>
+                <c-quantic-numeric-facet field="ytlikecount" label="Youtube Likes" with-input="integer" engine-id={engineId}></c-quantic-numeric-facet>
+                <c-quantic-timeframe-facet engine-id={engineId} field="date" label="Date">
+                  <c-quantic-timeframe unit="week"></c-quantic-timeframe>
+                  <c-quantic-timeframe unit="month"></c-quantic-timeframe>
+                  <c-quantic-timeframe amount="6" unit="month"></c-quantic-timeframe>
+                  <c-quantic-timeframe unit="year"></c-quantic-timeframe>
+                </c-quantic-timeframe-facet>
+                <c-quantic-category-facet field="geographicalhierarchy" label="Country" engine-id={engineId}></c-quantic-category-facet>
+              </c-quantic-facet-manager>
+            </div>
+            <div class="slds-col slds-order_1 slds-large-order_2 slds-size_1-of-1 slds-large-size_6-of-12">
+              <ul class="slds-tabs_default slds-tabs_default__nav" role="tablist">
+                <c-quantic-tab label="All" engine-id={engineId} is-active></c-quantic-tab>
+                <c-quantic-tab label="Articles" expression="@sfkbid" engine-id={engineId}></c-quantic-tab>
+                <c-quantic-tab label="Issues" expression="@jisourcetype AND NOT @jidocumenttype=&quot;WorkLog&quot;" engine-id={engineId}></c-quantic-tab>
+                <c-quantic-tab label="Community" expression="@objecttype==&quot;Message&quot;" engine-id={engineId}></c-quantic-tab>
+                <c-quantic-tab label="Files" expression="@boxdocumenttype==File OR @spcontenttype==Document" engine-id={engineId}></c-quantic-tab>
+              </ul>
+              <div class="slds-grid slds-var-m-top_small">
+                <c-quantic-summary class="slds-var-m-vertical_x-small slds-medium-size_7-of-12" engine-id={engineId}>
+                </c-quantic-summary>
+                <c-quantic-sort class="slds-var-m-vertical_xxx-small slds-medium-size_5-of-12 slds-col_bump-left" engine-id={engineId}>
+                </c-quantic-sort>
               </div>
-              <div class="slds-col slds-order_1 slds-large-order_2 slds-size_1-of-1 slds-large-size_6-of-12">
-                <ul class="slds-tabs_default slds-tabs_default__nav" role="tablist">
-                  <c-quantic-tab label="All" engine-id={engineId} is-active></c-quantic-tab>
-                  <c-quantic-tab label="Articles" expression="@sfkbid" engine-id={engineId}></c-quantic-tab>
-                  <c-quantic-tab label="Issues" expression="@jisourcetype AND NOT @jidocumenttype=&quot;WorkLog&quot;" engine-id={engineId}></c-quantic-tab>
-                  <c-quantic-tab label="Community" expression="@objecttype==&quot;Message&quot;" engine-id={engineId}></c-quantic-tab>
-                  <c-quantic-tab label="Files" expression="@boxdocumenttype==File OR @spcontenttype==Document" engine-id={engineId}></c-quantic-tab>
-                </ul>
-                <div class="slds-grid slds-var-m-top_small">
-                  <c-quantic-summary class="slds-var-m-vertical_x-small slds-medium-size_7-of-12" engine-id={engineId}>
-                  </c-quantic-summary>
-                  <c-quantic-sort class="slds-var-m-vertical_xxx-small slds-medium-size_5-of-12 slds-col_bump-left" engine-id={engineId}>
-                  </c-quantic-sort>
-                </div>
-                <c-quantic-query-error engine-id={engineId}></c-quantic-query-error>
-                <c-quantic-breadcrumb-manager engine-id={engineId}></c-quantic-breadcrumb-manager>
-                <c-quantic-did-you-mean engine-id={engineId}></c-quantic-did-you-mean>
-                <c-quantic-no-results engine-id={engineId}></c-quantic-no-results>
-                <c-quantic-result-list engine-id={engineId}></c-quantic-result-list>
-                <div class="slds-var-m-vertical_medium">
-                    <c-quantic-pager engine-id={engineId}></c-quantic-pager>
-                    <c-quantic-results-per-page engine-id={engineId}></c-quantic-results-per-page>
-                </div>
+              <c-quantic-query-error engine-id={engineId}></c-quantic-query-error>
+              <c-quantic-breadcrumb-manager engine-id={engineId}></c-quantic-breadcrumb-manager>
+              <c-quantic-did-you-mean engine-id={engineId}></c-quantic-did-you-mean>
+              <c-quantic-no-results engine-id={engineId}></c-quantic-no-results>
+              <c-quantic-result-list engine-id={engineId}></c-quantic-result-list>
+              <div class="slds-var-m-vertical_medium">
+                  <c-quantic-pager engine-id={engineId}></c-quantic-pager>
+                  <c-quantic-results-per-page engine-id={engineId}></c-quantic-results-per-page>
               </div>
-              <div class="slds-col slds-order_3 slds-large-order_3 slds-size_1-of-1 slds-large-size_3-of-12">
-                <div class="slds-m-bottom_large">
-                  <c-quantic-recent-queries-list engine-id={engineId}></c-quantic-recent-queries-list>
-                </div>
-                <div class="slds-m-bottom_large">
-                  <c-quantic-recent-results-list engine-id={engineId}></c-quantic-recent-results-list>
-                </div>
+            </div>
+            <div class="slds-col slds-order_3 slds-large-order_3 slds-size_1-of-1 slds-large-size_3-of-12">
+              <div class="slds-m-bottom_large">
+                <c-quantic-recent-queries-list engine-id={engineId}></c-quantic-recent-queries-list>
+              </div>
+              <div class="slds-m-bottom_large">
+                <c-quantic-recent-results-list engine-id={engineId}></c-quantic-recent-results-list>
               </div>
             </div>
           </div>
         </div>
-      </c-quantic-search-interface>
-    </div>
+      </div>
+    </c-quantic-search-interface>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticCardContainer/quanticCardContainer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCardContainer/quanticCardContainer.html
@@ -1,9 +1,11 @@
 <template>
   <host>
     <article class="card">
-      <header class="slds-grid slds-p-horizontal_x-small">
-        <div class="slds-media__body slds-truncate">
-          <h2><span class="slds-text-heading_small">{title}</span></h2>
+      <header class="slds-grid slds-p-horizontal_x-small slds-has-flexi-truncate">
+        <div class="slds-media__body">
+          <h2 class="slds-grid">
+            <span class="slds-text-heading_small slds-truncate">{title}</span>
+          </h2>
         </div>
         <div class="slds-no-flex">
           <slot name="actions"></slot>

--- a/packages/quantic/force-app/main/default/lwc/quanticPlaceholder/quanticPlaceholder.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticPlaceholder/quanticPlaceholder.css
@@ -3,7 +3,6 @@
 }
 
 .placeholder__card-container {
-  min-width: 212px;
   padding-top: 1rem;
   padding-bottom: 1rem;
 }
@@ -30,7 +29,6 @@
 }
 
 .placeholder__result-container {
-  min-width: 475px;
   padding-top: 1.2rem;
   padding-bottom: 1.2rem;
 }


### PR DESCRIPTION
fixed an issue where our card headers were getting clipped. Given the flexible nature of our components and their labels, this is the optimal solution and this truncating behaviour matches the SLDS `lightning-card` component when in narrow containers.

<img width="762" alt="Screen Shot 2021-11-09 at 8 48 58 AM" src="https://user-images.githubusercontent.com/16785453/140935731-7a613a61-aed8-4963-a508-b08b216d6d03.png">

Also removed the fixed min-width from the placeholder component. In narrow containers it overflowed rather nastily. Since adding the `flex-grow` property in another PR it was no longer necessary but stayed behind by mistake.

It's important to note that this does make the placeholders render bizarrely initially in the local dev server though they render as they should in lightning experience. 
The bug is due to the localdevserver's container element and the issue has been reported several times to the team responsible. 
1. https://github.com/forcedotcom/lwc-dev-server-feedback/issues/29
2. https://github.com/forcedotcom/lwc-dev-server-feedback/issues/97
3. https://github.com/forcedotcom/lwc-dev-server-feedback/issues/18

For now I think we should just bite the bullet because by setting a minimum width we are no longer flexible enough to render nicely in the lightning console.