### PR TITLE
fix(quantic): various timeframe facet issues

### DIFF
--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet-expectations.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet-expectations.ts
@@ -161,11 +161,11 @@ function timeframeWithRangeExpectations(selector: WithDateRangeSelector) {
         .should('contain', message)
         .logDetail(`should display validation error "${message}"`),
 
-    noValidationError: () =>
+    numberOfValidationErrors: (value: number) =>
       selector
         .validationError()
-        .should('not.exist')
-        .logDetail('should display no validation error'),
+        .should('have.length', value)
+        .logDetail(`should display ${value} validation errors`),
   };
 }
 

--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -282,6 +282,7 @@ describe('quantic-timeframe-facet', () => {
         scope('invalid start date format', () => {
           Actions.applyRange('bad start date', validRange.end);
 
+          Expect.numberOfValidationErrors(1);
           Expect.validationError(
             'Your entry does not match the allowed format yyyy-MM-dd.'
           );
@@ -290,6 +291,7 @@ describe('quantic-timeframe-facet', () => {
         scope('invalid end date format', () => {
           Actions.applyRange(validRange.start, 'bad end date');
 
+          Expect.numberOfValidationErrors(1);
           Expect.validationError(
             'Your entry does not match the allowed format yyyy-MM-dd.'
           );
@@ -298,6 +300,7 @@ describe('quantic-timeframe-facet', () => {
         scope('end date smaller than start date', () => {
           Actions.applyRange(invalidRange.start, invalidRange.end);
 
+          Expect.numberOfValidationErrors(1);
           Expect.validationError(
             `Value must be ${invalidRange.end} or earlier.`
           );
@@ -309,7 +312,7 @@ describe('quantic-timeframe-facet', () => {
       scope('when entering a valid range', () => {
         Actions.applyRange(validRange.start, validRange.end);
 
-        Expect.noValidationError();
+        Expect.numberOfValidationErrors(0);
         Expect.urlHashContains('Date_input', validRange.filter);
         Expect.displayClearButton(true);
         Expect.displayValues(false);

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -63,7 +63,10 @@
                 </div>  
               </div>
               <div class="slds-col slds-p-top_x-small">
-                <button class="slds-button slds-button_neutral slds-button_stretch timeframe-facet__apply" type="submit">{labels.apply}</button>
+                <button
+                  class="slds-button slds-button_neutral slds-button_stretch timeframe-facet__apply"
+                  type="submit"
+                  onblur={resetValidationErrors}>{labels.apply}</button>
               </div>
             </div>
           </form>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -5,89 +5,91 @@
     <c-quantic-placeholder variant="card" number-of-rows="5"></c-quantic-placeholder>
   </template>
   <template if:false={showPlaceholder}>
-    <c-quantic-card-container title={label}>
-      <lightning-button-icon
-        slot="actions"
-        class={actionButtonCssClasses}
-        icon-name={actionButtonIcon}
-        alternative-text={actionButtonLabel}
-        onclick={toggleFacetVisibility}
-        onmousedown={preventDefault}
-        variant="bare"
-      ></lightning-button-icon>
+    <template if:true={showFacet}>
+      <c-quantic-card-container title={label}>
+        <lightning-button-icon
+          slot="actions"
+          class={actionButtonCssClasses}
+          icon-name={actionButtonIcon}
+          alternative-text={actionButtonLabel}
+          onclick={toggleFacetVisibility}
+          onmousedown={preventDefault}
+          variant="bare"
+        ></lightning-button-icon>
 
-      <template if:true={hasActiveValues}>
-        <button class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
-          <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={clearFilterLabel} size="xx-small"></lightning-icon>
-          <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
-        </button>
-      </template>
-
-      <template if:false={isCollapsed}>
-        <template if:true={withDatePicker}>
-          <form onsubmit={handleApply}>
-            <div class="slds-grid slds-gutters slds-grid_vertical slds-p-around_x-small">
-              <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center">
-                <div class="slds-col slds-size_1-of-5">
-                  <span class="timeframe-facet__input-label">{labels.startLabel}</span>
-                </div>
-                <div class="slds-col slds-size_4-of-5">
-                  <lightning-input
-                    type="date"
-                    class="timeframe-facet__start-input"
-                    label="Start"
-                    variant="label-hidden"
-                    date-style="short"
-                    min="1401-01-01"
-                    placeholder={datepickerFormat}
-                    value={startDate}
-                    onchange={handleStartDateChange}>
-                  </lightning-input>
-                </div>
-              </div>
-              <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center slds-p-top_x-small">
-                <div class="slds-col slds-size_1-of-5">
-                  <span class="timeframe-facet__input-label">{labels.endLabel}</span>
-                </div>
-                <div class="slds-col slds-size_4-of-5">
-                  <lightning-input
-                    type="date"
-                    class="timeframe-facet__end-input"
-                    label="End"
-                    variant="label-hidden"
-                    date-style="short"
-                    placeholder={datepickerFormat}
-                    value={endDate}
-                    onchange={handleEndDateChange}>
-                  </lightning-input>
-                </div>  
-              </div>
-              <div class="slds-col slds-p-top_x-small">
-                <button
-                  class="slds-button slds-button_neutral slds-button_stretch timeframe-facet__apply"
-                  type="submit"
-                  onblur={resetValidationErrors}>{labels.apply}</button>
-              </div>
-            </div>
-          </form>
+        <template if:true={hasActiveValues}>
+          <button class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small" onclick={clearSelections}>
+            <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={clearFilterLabel} size="xx-small"></lightning-icon>
+            <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
+          </button>
         </template>
 
-        <template if:true={showValues}>
-          <ul class="slds-has-dividers_around-space slds-m-top_medium">
-            <template for:each={formattedValues} for:item="v">
-              <c-quantic-facet-value
-                key={v.key}
-                item={v}
-                is-checked={v.selected}
-                onselectvalue={onSelectValue}
-                formatting-function={formatFacetValue}
-                display-as-link
-              >
-              </c-quantic-facet-value>
-            </template>
-          </ul>
+        <template if:false={isCollapsed}>
+          <template if:true={withDatePicker}>
+            <form onsubmit={handleApply}>
+              <div class="slds-grid slds-gutters slds-grid_vertical slds-p-around_x-small">
+                <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center">
+                  <div class="slds-col slds-size_1-of-5">
+                    <span class="timeframe-facet__input-label">{labels.startLabel}</span>
+                  </div>
+                  <div class="slds-col slds-size_4-of-5">
+                    <lightning-input
+                      type="date"
+                      class="timeframe-facet__start-input"
+                      label="Start"
+                      variant="label-hidden"
+                      date-style="short"
+                      min="1401-01-01"
+                      placeholder={datepickerFormat}
+                      value={startDate}
+                      onchange={handleStartDateChange}>
+                    </lightning-input>
+                  </div>
+                </div>
+                <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center slds-p-top_x-small">
+                  <div class="slds-col slds-size_1-of-5">
+                    <span class="timeframe-facet__input-label">{labels.endLabel}</span>
+                  </div>
+                  <div class="slds-col slds-size_4-of-5">
+                    <lightning-input
+                      type="date"
+                      class="timeframe-facet__end-input"
+                      label="End"
+                      variant="label-hidden"
+                      date-style="short"
+                      placeholder={datepickerFormat}
+                      value={endDate}
+                      onchange={handleEndDateChange}>
+                    </lightning-input>
+                  </div>  
+                </div>
+                <div class="slds-col slds-p-top_x-small">
+                  <button
+                    class="slds-button slds-button_neutral slds-button_stretch timeframe-facet__apply"
+                    type="submit"
+                    onblur={resetValidationErrors}>{labels.apply}</button>
+                </div>
+              </div>
+            </form>
+          </template>
+
+          <template if:true={showValues}>
+            <ul class="slds-has-dividers_around-space slds-m-top_medium">
+              <template for:each={formattedValues} for:item="v">
+                <c-quantic-facet-value
+                  key={v.key}
+                  item={v}
+                  is-checked={v.selected}
+                  onselectvalue={onSelectValue}
+                  formatting-function={formatFacetValue}
+                  display-as-link
+                >
+                </c-quantic-facet-value>
+              </template>
+            </ul>
+          </template>
         </template>
-      </template>
-    </c-quantic-card-container>
+      </c-quantic-card-container>
+    </template>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -1,5 +1,5 @@
 <template>
-  <slot>Timeframes</slot>
+  <slot><!-- Timeframes --></slot>
 
   <template if:true={showPlaceholder}>
     <c-quantic-placeholder variant="card" number-of-rows="5"></c-quantic-placeholder>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -127,6 +127,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   /** @type {DateFilterState} */
   @track dateFilterState;
   showPlaceholder = true;
+  hasResults = false;
   /** @type {string} */
   startDate;
   /** @type {string} */
@@ -169,6 +170,13 @@ export default class QuanticTimeframeFacet extends LightningElement {
     this.unsubscribeFacet?.();
     this.unsubscribeSearchStatus?.();
     this.unsubscribeDateFilter?.();
+  }
+
+  /**
+   * Gets whether to show the facet.
+   */
+  get showFacet() {
+    return this.hasResults || this.hasActiveValues || !!this.dateFilterState.range;
   }
 
   /**
@@ -234,7 +242,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
     const values = this.facetState?.values || [];
 
     return values
-      .filter((value) => value.numberOfResults > 0)
+      .filter((value) => value.numberOfResults > 0 || value.state === 'selected')
       .map((value) => ({
         ...value,
         label: this.formatFacetValue(value),
@@ -290,10 +298,6 @@ export default class QuanticTimeframeFacet extends LightningElement {
     return this.withDatePicker
       ? this.template.querySelector('.timeframe-facet__end-input')
       : null;
-  }
-
-  get datepickerOverflowMessage() {
-    return `The start date should be earlier than ${this.endDatepicker?.value}`;
   }
 
   /**
@@ -356,6 +360,8 @@ export default class QuanticTimeframeFacet extends LightningElement {
     this.showPlaceholder =
       !this.searchStatus?.state?.hasError &&
       !this.searchStatus?.state?.firstSearchExecuted;
+
+    this.hasResults = this.searchStatus.state.hasResults;
   }
 
   updateFacetState() {
@@ -506,7 +512,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   enableRangeValidation() {
-    this.startDatepicker.max = this.endDatepicker.value;
+    this.startDatepicker.max = DateUtils.trimIsoTime(this.endDatepicker.value || '');
     this.startDatepicker.required = true;
     this.endDatepicker.required = true;
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -316,10 +316,7 @@ export class DateUtils {
       );
     }
   
-    const timeIdx = dateString.indexOf('T');
-    const withoutTime =
-      timeIdx !== -1 ? dateString.substring(0, timeIdx) : dateString;
-  
+    const withoutTime = DateUtils.trimIsoTime(dateString);
     const time =
       hours.toString().padStart(2, '0') +
       ':' +
@@ -328,6 +325,11 @@ export class DateUtils {
       seconds.toString().padStart(2, '0');
   
     return new Date(`${withoutTime}T${time}`);
+  }
+
+  static trimIsoTime(dateString) {
+    const timeIdx = dateString.indexOf('T');
+    return timeIdx !== -1 ? dateString.substring(0, timeIdx) : dateString;
   }
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4253

This PR fixes some issues for the timeframe facet.

* Display a single validation message when custom date range is invalid
* Hide validation messages when clicking outside the custom range section
* Hide the facet when no results are returned (unless a timeframe or a custom range is active for the facet)

The end to end tests have been updated accordingly.