### PR TITLE
feat(quantic): removed delimitingCharacter

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -92,14 +92,6 @@ export default class QuanticFacet extends LightningElement {
    */
   @api displayValuesAs = 'checkbox';
   /**
-   * The character that separates values of a multi-value field.
-   * If the field is defined as a "multi-value", each path is delimited by `;`, and each part of a path is delimited by `>`. So the indexed value looks like `parent1>child1; parent2>child2`, and `delimitingCharacter` should be set to `>`.
-   * @api
-   * @type {string}
-   * @defaultValue `'>'`
-   */
-  @api delimitingCharacter = '>';
-  /**
    * Whether not to exclude the parents of folded results when estimating the result count for each facet value.
    * @api
    * @type {boolean}
@@ -186,7 +178,6 @@ export default class QuanticFacet extends LightningElement {
         numberOfValues: Number(this.numberOfValues)
       },
       facetId: this.facetId ?? this.field,
-      delimitingCharacter: this.delimitingCharacter,
       filterFacetCount: !this.noFilterFacetCount,
       injectionDepth: Number(this.injectionDepth),
     };


### PR DESCRIPTION
The option was no-oped in headless and remove in atomic here https://coveord.atlassian.net/browse/KIT-1095