### PR TITLE
fix(headless): remove ca.js/src import

### DIFF
--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
@@ -1,5 +1,5 @@
 import {ArrayValue} from '@coveo/bueno';
-import {CategoryFacetMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
+import type {CategoryFacetMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
 import {SearchAppState} from '../../../state/search-app-state';
 import {
   requiredNonEmptyString,

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
@@ -1,4 +1,4 @@
-import {FacetRangeMetadata} from 'coveo.analytics/src/searchPage/searchPageEvents';
+import type {FacetRangeMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
 import {SearchAppState} from '../../../../state/search-app-state';
 import {RangeFacetSelectionPayload} from './range-facet-validate-payload';
 


### PR DESCRIPTION
We're importing source files in TypeScript from `coveo.analytics` and that makes webpack cough a little when someone tries to use headless.

When possible we should not import stuff that is not exported as we do, but if we do it regardless, we should import declaration files.

This causes issues for example with `@coveo/angular`.

I reckon this changeset ain't a big deal, because they actually look more like a typo than something that was done on purpose, given that there are already other occurrences of `import ... from 'coveo.analytics/dist/definitions'` in the codebase.