### PR TITLE
doc(atomic): fix broken link

### DIFF
--- a/packages/atomic/README.md
+++ b/packages/atomic/README.md
@@ -6,7 +6,7 @@ A web-component library for building modern UIs interfacing with the Coveo platf
 
 ## Getting Started
 
-Once you have cloned the repo, follow the instructions in the top-level [README.md](https://github.com/coveo/ui-kit/src/master/README.md) to install dependencies and link packages.
+Once you have cloned the repo, follow the instructions in the top-level [README.md](../../README.md) to install dependencies and link packages.
 
 To start the project in development mode, run:
 


### PR DESCRIPTION
The link was leading to a 404. So I replaced it with a relative path to be on the safe side. (will be easier if we revamp several readme in a single branch too)