### PR TITLE
chore(headless,atomic): re-added vscode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "reinstall dependencies & rebuild",
+			"dependsOn": [
+				"reinstall dependencies",
+				"build"
+			],
+			"dependsOrder": "sequence",
+			"problemMatcher": []
+		},
+		{
+			"type": "shell",
+			"problemMatcher": [],
+			"label": "reinstall dependencies",
+			"command": "rimraf **/node_modules && npm run setup",
+			"dependsOn": [
+				"discard package-lock.json changes"
+			]
+		},
+		{
+			"type": "shell",
+			"problemMatcher": [],
+			"label": "discard package-lock.json changes",
+			"command": "git checkout HEAD -- **/package-lock.json"
+		},
+		{
+			"type": "shell",
+			"problemMatcher": [],
+			"label": "build",
+			"command": "npm run build"
+		}
+	]
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1201

@dlutzCoveo I'm not sure why, but they were removed in your PR (https://github.com/coveo/ui-kit/pull/1430). I'm guessing this wasn't on purpose, but I'm curious what removed it, especially since `tasks.json` is ignored by git.