### PR TITLE
fix(headless): send filterFacetCount param with facet search request

### DIFF
--- a/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
@@ -17,6 +17,7 @@ export interface BaseFacetSearchRequest
     BaseParam {
   field: string;
   searchContext: SearchRequest;
+  filterFacetCount: boolean;
 }
 
 export interface FacetSearchType<T extends 'specific' | 'hierarchical'> {

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.test.ts
@@ -2,10 +2,10 @@ import {createMockState} from '../../../../test/mock-state';
 import {buildMockCategoryFacetSearch} from '../../../../test/mock-category-facet-search';
 import {buildMockCategoryFacetValueRequest} from '../../../../test/mock-category-facet-value-request';
 import {SearchAppState} from '../../../../state/search-app-state';
-import {buildCategoryFacetSearchRequest} from '../../../../features/facets/facet-search-set/category/category-facet-search-request-builder';
+import {buildCategoryFacetSearchRequest} from './category-facet-search-request-builder';
 import {buildMockCategoryFacetSlice} from '../../../../test/mock-category-facet-slice';
 import {buildMockCategoryFacetRequest} from '../../../../test/mock-category-facet-request';
-import {buildSearchRequest} from '../../../../features/search/search-request';
+import {buildSearchRequest} from '../../../search/search-request';
 
 describe('#buildCategoryFacetSearchRequest', () => {
   const id = '1';
@@ -58,6 +58,13 @@ describe('#buildCategoryFacetSearchRequest', () => {
     state.categoryFacetSet[id] = buildMockCategoryFacetSlice({request});
 
     expect(buildParams().field).toBe(field);
+  });
+
+  it('retrieves #filterFacetCount from the categoryFacetSet', () => {
+    const request = buildMockCategoryFacetRequest({filterFacetCount: true});
+    state.categoryFacetSet[id] = buildMockCategoryFacetSlice({request});
+
+    expect(buildParams().filterFacetCount).toBe(true);
   });
 
   it('retrieves the #delimitingCharacter from the categoryFacetSet', () => {

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.ts
@@ -11,7 +11,8 @@ export const buildCategoryFacetSearchRequest = (
   const categoryFacet = state.categoryFacetSet[id]!.request;
 
   const {captions, query, numberOfValues} = options;
-  const {field, delimitingCharacter, basePath} = categoryFacet;
+  const {field, delimitingCharacter, basePath, filterFacetCount} =
+    categoryFacet;
   const searchContext = buildSearchRequest(state).request;
   const path = getPathToSelectedCategoryFacetItem(categoryFacet);
   const ignorePaths = path.length ? [path] : [];
@@ -29,6 +30,7 @@ export const buildCategoryFacetSearchRequest = (
     delimitingCharacter,
     ignorePaths,
     searchContext,
+    filterFacetCount,
     type: 'hierarchical',
   };
 };

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.test.ts
@@ -3,8 +3,8 @@ import {buildMockFacetValueRequest} from '../../../../test/mock-facet-value-requ
 import {buildMockFacetRequest} from '../../../../test/mock-facet-request';
 import {buildMockFacetSearch} from '../../../../test/mock-facet-search';
 import {SearchAppState} from '../../../../state/search-app-state';
-import {buildSpecificFacetSearchRequest} from '../../../../features/facets/facet-search-set/specific/specific-facet-search-request-builder';
-import {buildSearchRequest} from '../../../../features/search/search-request';
+import {buildSpecificFacetSearchRequest} from './specific-facet-search-request-builder';
+import {buildSearchRequest} from '../../../search/search-request';
 
 describe('#buildSpecificFacetSearchRequest', () => {
   const id = '1';
@@ -48,6 +48,12 @@ describe('#buildSpecificFacetSearchRequest', () => {
     state.facetSet[id].field = field;
 
     expect(buildParams().field).toBe(field);
+  });
+
+  it('retrieves #filterFacetCount from the facetSet', () => {
+    state.facetSet[id].filterFacetCount = true;
+
+    expect(buildParams().filterFacetCount).toBe(true);
   });
 
   it('builds the #ignoreValues from the facetSet non-idle #currentValues', () => {

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
@@ -7,7 +7,7 @@ export const buildSpecificFacetSearchRequest = (
   state: StateNeededForSpecificFacetSearch
 ): SpecificFacetSearchRequest => {
   const {captions, query, numberOfValues} = state.facetSearchSet[id].options;
-  const {field, currentValues} = state.facetSet[id];
+  const {field, currentValues, filterFacetCount} = state.facetSet[id];
   const searchContext = buildSearchRequest(state).request;
   const ignoreValues = currentValues
     .filter((v) => v.state !== 'idle')
@@ -24,6 +24,7 @@ export const buildSpecificFacetSearchRequest = (
     field,
     ignoreValues,
     searchContext,
+    filterFacetCount,
     type: 'specific',
   };
 };


### PR DESCRIPTION
**Context**

Bass Pro reported seeing incorrect facet search counts when using folding. This PR sends the `filterFacetCount` param with the search request. The value of the property is `true` by default.

**Next steps**

If there is no use-case for having `filterFacetCount` set to `false`, we can deprecate and eventually remove the option. Will follow up with @acote-coveo and @francistb based on this [comment](https://coveo.slack.com/archives/C02ABMU1HPC/p1636570145014800?thread_ts=1636569017.011500&cid=C02ABMU1HPC).

https://coveord.atlassian.net/browse/KIT-1207