### PR TITLE
docs(atomic): atomic-result-list: adds minor fixes to shadow parts' descriptions

### DIFF
--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.tsx
@@ -29,8 +29,8 @@ import {LinkWithResultAnalytics} from '../result-link/result-link';
 /**
  * The `atomic-result-list` component is responsible for displaying query results by applying one or more result templates.
  *
- * @part result-list - The element containing every results of a result list
- * @part result-list-grid-clickable - The clickable element on a result when displayed as a grid
+ * @part result-list - The element containing every result of a result list
+ * @part result-list-grid-clickable - The clickable result when results are displayed as a grid
  * @part result-table - The element of the result table containing a heading and a body
  * @part result-table-heading - The element containing the row of cells in the result table's heading
  * @part result-table-heading-row - The element containing cells of the result table's heading


### PR DESCRIPTION
This is just a quick follow-up to the recent PR #1473 as it was merged without my approval and fixes.