### PR TITLE
fix(quantic): copy only main headless browser file

### DIFF
--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -11,8 +11,8 @@ const main = async () => {
 
   try {
     await copy(
-      './node_modules/@coveo/headless/dist',
-      './force-app/main/default/staticresources/coveoheadless'
+      './node_modules/@coveo/headless/dist/browser/headless.js',
+      './force-app/main/default/staticresources/coveoheadless/browser/headless.js'
     );
   } catch (error) {
     console.info(error);

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -15,9 +15,17 @@ const main = async () => {
       './force-app/main/default/staticresources/coveoheadless/browser/',
       {recursive: true}
     );
+    await mkdir(
+      './force-app/main/default/staticresources/coveoheadless/definitions/',
+      {recursive: true}
+    );
     await copy(
       './node_modules/@coveo/headless/dist/browser/headless.js',
       './force-app/main/default/staticresources/coveoheadless/browser/headless.js'
+    );
+    await copy(
+      './node_modules/@coveo/headless/dist/definitions',
+      './force-app/main/default/staticresources/coveoheadless/definitions'
     );
   } catch (error) {
     console.info(error);

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -1,6 +1,7 @@
 /* eslint-disable node/no-unpublished-require */
 const {promisify} = require('util');
 const ncp = promisify(require('ncp'));
+const mkdir = promisify(require('fs').mkdir);
 
 const copy = async (source, dest) => {
   return await ncp(source, dest);
@@ -10,6 +11,10 @@ const main = async () => {
   console.info('Begin copy.');
 
   try {
+    await mkdir(
+      './force-app/main/default/staticresources/coveoheadless/browser/',
+      {recursive: true}
+    );
     await copy(
       './node_modules/@coveo/headless/dist/browser/headless.js',
       './force-app/main/default/staticresources/coveoheadless/browser/headless.js'


### PR DESCRIPTION
So that's kind of an "low change" fix, since it does not touch any source file in Quantic.

The problem is that the dist folder in Headless contains quite a bit of stuff, which exceed the 5mb static resource limit in Salesforce:

* Commerce, Service, Search use case related packages
* Different module type output (umd, esm), both for Node and Browser environments
* Source maps
* Original TypeScript source code for source maps to function properly.
* Definitions file
* Documentation output
* etc..

With the change in this PR, it's bundling just the strict minimum for stuff to work in Quantic, but it means that some feature won't be included today (you'd have to manually include them over time if they are needed).

Possibly, this also means a more sophisticated mechanism to "load" the resources on demand (aka: some changes in `quanticHeadlessLoader`), or split in multiple static resources

https://coveord.atlassian.net/browse/KIT-1210