### PR TITLE
Sfint 4127

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -448,4 +448,11 @@
         <protected>false</protected>
         <shortDescription>Expand [component label]</shortDescription>
     </labels>
+    <labels>
+      <fullName>cookbook_SectionTitle</fullName>
+      <value>Which product is related to your problem?</value>
+      <language>en_US</language>
+      <protected>false</protected>
+      <shortDescription>Which product is related to your problem?</shortDescription>
+  </labels>
 </CustomLabels>

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.css
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.css
@@ -1,0 +1,3 @@
+.title{
+  font-weight: bold;
+}

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.html
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.html
@@ -1,3 +1,3 @@
 <template>
-    <h2 class="slds-text-heading_small title">{title}</h2>
+  <h2 class="slds-text-heading_small title">{title}</h2>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.html
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.html
@@ -1,0 +1,3 @@
+<template>
+    <h2 class="slds-text-heading_small title">{title}</h2>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js
@@ -1,9 +1,19 @@
 import { LightningElement, api } from 'lwc';
+import sectionTitle from '@salesforce/label/c.cookbook_SectionTitle';
 
+/**
+ * The `sectionTitle` component is a title to mark the beginning of the case classification section.
+ * @example
+ * <c-section-title></c-section-title>
+ */
 export default class SectionTitle extends LightningElement {
+  labels = {
+    sectionTitle
+  }
+
   /**
    * The section title
    * @type {string}
    */
-  @api title = 'Which product is related to your problem?'
+  @api title = this.labels.sectionTitle;
 }

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js
@@ -1,0 +1,9 @@
+import { LightningElement, api } from 'lwc';
+
+export default class SectionTitle extends LightningElement {
+  /**
+   * The section title
+   * @type {string}
+   */
+  @api title = 'Which product is related to your problem?'
+}

--- a/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/sectionTitle/sectionTitle.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -228,4 +228,8 @@
         <label>Agrandir {{0}}</label>
         <name>quantic_Expand</name>
     </customLabels>
+    <customLabels>
+      <label>Quel produit est lié à votre problème ?</label>
+      <name>cookbook_SectionTitle</name>
+    </customLabels>
 </Translations>


### PR DESCRIPTION
# Section Title component  added.

## 🚨⚠️ Note: This component will be part of the case assist cookbook and not quantic.

### Description: A title to mark the beginning of the case classification section.

### Demo:
<img width="373" alt="sectionTitle_wp" src="https://user-images.githubusercontent.com/86681870/141806689-a8db01f2-84f7-4aec-811f-4b705842f2f5.png">


### Design file: 
https://www.figma.com/file/mGZNYe9DbqIL1NO4m292PG/Case-Assist-User-experience?node-id=348%3A30227
