### PR TITLE
docs(atomic): support shadow parts for results components

### DIFF
--- a/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
+++ b/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
@@ -35,19 +35,20 @@ export const CodeSamplePanel = () => {
   const {componentTag, isResultComponent, advancedConfig} =
     storyParameters as StoryParameters;
 
+  const componentToHTML = renderArgsToHTMLString(
+    componentTag,
+    args,
+    advancedConfig
+  );
+  const stylingToHTML = renderShadowPartsToStyleString(componentTag, args);
+  const htmlCodeWithSpacing = addSpacingBetweenStylingAndHTML(
+    componentToHTML,
+    stylingToHTML
+  );
+
   const codeString = isResultComponent
-    ? renderArgsToResultTemplate(
-        addSpacingBetweenStylingAndHTML(
-          renderArgsToHTMLString(componentTag, args, advancedConfig),
-          renderShadowPartsToStyleString(componentTag, args)
-        ),
-        () => args,
-        false
-      )
-    : addSpacingBetweenStylingAndHTML(
-        renderArgsToHTMLString(componentTag, args, advancedConfig),
-        renderShadowPartsToStyleString(componentTag, args)
-      );
+    ? renderArgsToResultTemplate(htmlCodeWithSpacing, () => args, false)
+    : htmlCodeWithSpacing;
 
   return (
     <div

--- a/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
+++ b/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
@@ -77,7 +77,7 @@ export const CodeSamplePanel = () => {
 
           delay(
             () => editor.getAction('editor.action.formatDocument').run(),
-            200
+            100
           );
           editor.onDidFocusEditorText(() => {
             editor.setScrollTop(0);

--- a/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
+++ b/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
@@ -35,14 +35,19 @@ export const CodeSamplePanel = () => {
   const {componentTag, isResultComponent, advancedConfig} =
     storyParameters as StoryParameters;
 
-  const styleString = renderShadowPartsToStyleString(componentTag, args);
-  const htmlString = isResultComponent
+  const codeString = isResultComponent
     ? renderArgsToResultTemplate(
-        renderArgsToHTMLString(componentTag, args, advancedConfig),
+        addSpacingBetweenStylingAndHTML(
+          renderArgsToHTMLString(componentTag, args, advancedConfig),
+          renderShadowPartsToStyleString(componentTag, args)
+        ),
         () => args,
         false
       )
-    : renderArgsToHTMLString(componentTag, args, advancedConfig);
+    : addSpacingBetweenStylingAndHTML(
+        renderArgsToHTMLString(componentTag, args, advancedConfig),
+        renderShadowPartsToStyleString(componentTag, args)
+      );
 
   return (
     <div
@@ -59,7 +64,7 @@ export const CodeSamplePanel = () => {
         height="800px"
         theme="vs-dark"
         defaultValue={''}
-        value={addSpacingBetweenStylingAndHTML(htmlString, styleString)}
+        value={codeString}
         defaultLanguage="html"
         options={{
           theme: 'vs-dark',
@@ -72,7 +77,7 @@ export const CodeSamplePanel = () => {
 
           delay(
             () => editor.getAction('editor.action.formatDocument').run(),
-            100
+            200
           );
           editor.onDidFocusEditorText(() => {
             editor.setScrollTop(0);

--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -5,6 +5,7 @@ import {DocsPage} from '@storybook/addon-docs';
 import sharedDefaultStory, {
   DefaultStoryAdvancedConfig,
   renderArgsToHTMLString,
+  renderShadowPartsToStyleString,
 } from './default-story-shared';
 import {initializeInterfaceDebounced} from './default-init';
 import {html} from 'lit-html';
@@ -129,7 +130,8 @@ export default function defaultResultComponentStory(
 
   const defaultLoader = initializeInterfaceDebounced(() => {
     return `${renderArgsToResultTemplate(
-      renderArgsToHTMLString(componentTag, getArgs(), advancedConfig),
+      renderArgsToHTMLString(componentTag, getArgs(), advancedConfig) +
+        renderShadowPartsToStyleString(componentTag, getArgs()),
       getArgs,
       true
     )}${


### PR DESCRIPTION
There are 3 result components with Shadow Dom that needs this support: 
* ResultRating
* MultiValueText
* ResultBadge

https://coveord.atlassian.net/browse/KIT-1204