### PR TITLE
docs(atomic): fix code sample issue stuck in read only mode

### DIFF
--- a/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
+++ b/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
@@ -78,6 +78,9 @@ export const CodeSamplePanel = () => {
             editor.setScrollTop(0);
             editor.updateOptions({readOnly: true});
           });
+          editor.onDidBlurEditorText(() => {
+            editor.updateOptions({readOnly: false});
+          });
           editor.onDidChangeModelContent(() =>
             editor.getAction('editor.action.formatDocument').run()
           );


### PR DESCRIPTION
When focusing on the code editor, we switch to read only mode, so that users don't try to modify the code sample and expect it to be reflected in the live example.

However, this means that any new code added in the sample after that point (ie: you go back and modify new props on the component) would not be formatted correctly.

The `format this document` action in Monaco editor does not work when the editor is in read only mode.

So, we switch to read-only=true when focusing in, and back to read-only=false when focusing out.

https://coveord.atlassian.net/browse/KIT-1211