### PR TITLE
docs(atomic): visual improvements for result components documentation 

### DIFF
--- a/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.stories.tsx
@@ -11,7 +11,7 @@ const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
     additionalChildMarkup: () =>
       html`
         <div>
-          This text visibility can be controlled by the field conditions
+          The visibility of this text can be controlled by the field conditions
           component
         </div>
       `,


### PR DESCRIPTION
Various visual improvements for the Result components:

* Force a max width on the search interface by creating/merging a default config with `additionalMarkup`
* Query only one result on the API by creating/merging a default config with  `preprocessRequest`
* Add a container around result list with dashed border, to convey the information about result template acting as container for your result.

https://coveord.atlassian.net/browse/KIT-1213