### PR TITLE
docs(atomic): add storybook support for atomic-icon

### DIFF
--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -4,6 +4,7 @@ import {DocsPage} from '@storybook/addon-docs';
 
 import sharedDefaultStory, {
   DefaultStoryAdvancedConfig,
+  renderAdditionalMarkup,
   renderArgsToHTMLString,
   renderShadowPartsToStyleString,
 } from './default-story-shared';
@@ -204,14 +205,4 @@ const buildConfigPreprocessRequest = (
   }
 
   return preprocessRequestForOneResult;
-};
-
-const renderAdditionalMarkup = (additionalMarkup: () => TemplateResult) => {
-  const rendered = additionalMarkup();
-  if (rendered.values.length > 0) {
-    return (rendered.values as TemplateResult[])
-      .map((value) => value.strings.join(''))
-      .join('');
-  }
-  return rendered.strings.join('');
 };

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -2,7 +2,7 @@ import {h} from '@stencil/core';
 import {SearchEngineConfiguration} from '@coveo/headless';
 import {Args} from '@storybook/api';
 import {DocsPage} from '@storybook/addon-docs';
-import {TemplateResult} from 'lit-html';
+import {render, TemplateResult} from 'lit-html';
 import {mapPropsToArgTypes} from './map-props-to-args';
 import {resultComponentArgTypes} from './map-result-list-props-to-args';
 
@@ -88,6 +88,12 @@ export function renderShadowPartsToStyleString(
   const rulesTextNode = document.createTextNode(`\n\t\t${styleRules}\n\n`);
   styleElement.appendChild(rulesTextNode);
   return styleElement.outerHTML;
+}
+
+export function renderAdditionalMarkup(additionalMarkup: () => TemplateResult) {
+  const el = document.createElement('div');
+  render(additionalMarkup(), el);
+  return el.innerHTML;
 }
 
 export default function sharedDefaultStory(

--- a/packages/atomic/.storybook/default-story.tsx
+++ b/packages/atomic/.storybook/default-story.tsx
@@ -4,6 +4,7 @@ import {DocsPage} from '@storybook/addon-docs';
 import {initializeInterfaceDebounced} from './default-init';
 import sharedDefaultStory, {
   DefaultStoryAdvancedConfig,
+  renderAdditionalMarkup,
   renderArgsToHTMLString,
   renderShadowPartsToStyleString,
 } from './default-story-shared';
@@ -32,7 +33,7 @@ export default function defaultStory(
       advancedConfig
     );
     const additionalMarkupString = advancedConfig.additionalMarkup
-      ? advancedConfig.additionalMarkup().strings.join('')
+      ? renderAdditionalMarkup(advancedConfig.additionalMarkup)
       : '';
 
     return argsToHTMLString + additionalMarkupString;

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -23,7 +23,7 @@
     "licenses/"
   ],
   "scripts": {
-    "build": "npm run build:locales && npm run build:stencil && npm run build:utils && npm run build:storybook && npm run doc:listassets",
+    "build": "npm run build:locales && npm run build:stencil && npm run build:utils && npm run doc:listassets && npm run build:storybook",
     "build:utils": "node --max-old-space-size=4096 ./node_modules/rollup/dist/bin/rollup -c --environment BUILD:production",
     "build:locales": "node --max-old-space-size=4096 ./scripts/split-locales.js",
     "build:stencil": "node --max_old_space_size=6144 ./node_modules/@stencil/core/bin/stencil build",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -23,7 +23,7 @@
     "licenses/"
   ],
   "scripts": {
-    "build": "npm run build:locales && npm run build:stencil && npm run build:utils && npm run build:storybook",
+    "build": "npm run build:locales && npm run build:stencil && npm run build:utils && npm run build:storybook && npm run doc:listassets",
     "build:utils": "node --max-old-space-size=4096 ./node_modules/rollup/dist/bin/rollup -c --environment BUILD:production",
     "build:locales": "node --max-old-space-size=4096 ./scripts/split-locales.js",
     "build:stencil": "node --max_old_space_size=6144 ./node_modules/@stencil/core/bin/stencil build",
@@ -39,7 +39,8 @@
     "npm:publish:alpha": "node ../../scripts/deploy/publish.js alpha",
     "storybook": "npm run storybook:lit-analyze && start-storybook -s ./dist -p 6006",
     "build:storybook": "npm run storybook:lit-analyze && build-storybook && ncp dist/ storybook-static/",
-    "storybook:lit-analyze": "lit-analyzer dist/types/components.d.ts src/components/**/*.stories.tsx"
+    "storybook:lit-analyze": "lit-analyzer dist/types/components.d.ts src/components/**/*.stories.tsx",
+    "doc:listassets": "node scripts/list-assets.js"
   },
   "dependencies": {
     "@coveo/bueno": "^0.32.8",

--- a/packages/atomic/scripts/list-assets.js
+++ b/packages/atomic/scripts/list-assets.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+
+const files = fs.readdirSync('dist/atomic/assets');
+fs.writeFileSync('docs/assets.json', JSON.stringify({assets: files}));

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.mdx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.mdx
@@ -1,0 +1,3 @@
+# Did You Mean
+
+TODO

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.stories.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.stories.tsx
@@ -1,0 +1,22 @@
+import defaultStory from '../../../.storybook/default-story';
+import DidYouMeanDoc from './atomic-did-you-mean.mdx';
+
+const {defaultModuleExport, exportedStory} = defaultStory(
+  'Atomic/DidYouMean',
+  'atomic-did-you-mean',
+  {},
+  DidYouMeanDoc,
+  {
+    engineConfig: {
+      preprocessRequest: (r) => {
+        const parsed = JSON.parse(r.body as string);
+        parsed.q = 'testt';
+        r.body = JSON.stringify(parsed);
+        return r;
+      },
+    },
+  }
+);
+
+export default defaultModuleExport;
+export const DefaultDidYouMean = exportedStory;

--- a/packages/atomic/src/components/atomic-icon/atomic-icon.mdx
+++ b/packages/atomic/src/components/atomic-icon/atomic-icon.mdx
@@ -1,0 +1,3 @@
+# Icon
+
+TODO

--- a/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
+++ b/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
@@ -31,6 +31,9 @@ const {defaultModuleExport, exportedStory} = defaultStory(
             border-top: 2px dashed black;
             padding-top: 20px;
           }
+          .asset-container {
+            text-align: center;
+          }
           .assets-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -52,7 +55,7 @@ const {defaultModuleExport, exportedStory} = defaultStory(
               const backgroundColor =
                 bgIcons[snakeToCamel(asset.replace('.svg', ''))] ||
                 'transparent';
-              return html`<div>
+              return html`<div class="asset-container">
                 <div>
                   <atomic-icon
                     icon="${assetReference}"

--- a/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
+++ b/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
@@ -1,0 +1,76 @@
+import {html} from 'lit-html';
+import defaultStory from '../../../.storybook/default-story';
+import IconDoc from './atomic-icon.mdx';
+import AssetsList from '../../../docs/assets.json';
+import bgIcons from '@salesforce-ux/design-system/design-tokens/dist/bg-standard.common';
+
+function snakeToCamel(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/([_][a-z])/g, (group) => group.toUpperCase().replace('_', ''));
+}
+
+const {defaultModuleExport, exportedStory} = defaultStory(
+  'Atomic/Icon',
+  'atomic-icon',
+  {
+    icon: 'assets://account.svg',
+  },
+  IconDoc,
+  {
+    additionalMarkup: () => {
+      return html`
+        <style>
+          atomic-icon {
+            background-color: black;
+            width: 100px;
+            height: 100px;
+          }
+          .assets-container {
+            margin: 20px 0px;
+            border-top: 2px dashed black;
+            padding-top: 20px;
+          }
+          .assets-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 2rem;
+            margin-top: 20px;
+          }
+          .asset-reference {
+            font-weight: bold;
+            word-break: break-all;
+            font-size: 12px;
+          }
+        </style>
+        <div class="assets-container">
+          All available assets:
+
+          <div class="assets-grid">
+            ${AssetsList.assets.map((asset) => {
+              const assetReference = `assets://${asset}`;
+              const backgroundColor =
+                bgIcons[snakeToCamel(asset.replace('.svg', ''))] ||
+                'transparent';
+              return html`<div>
+                <div>
+                  <atomic-icon
+                    icon="${assetReference}"
+                    style="background-color:${backgroundColor};"
+                  ></atomic-icon>
+                </div>
+                <div>
+                  ${asset}
+                  <div class="asset-reference">(${assetReference})</div>
+                </div>
+              </div>`;
+            })}
+          </div>
+        </div>
+      `;
+    },
+  }
+);
+
+export default defaultModuleExport;
+export const DefaultIcon = exportedStory;


### PR DESCRIPTION
* Add a new script to list assets on build, and output to doc folder `assets.json`.
* Display all assets in the `atomic-icon` story in a grid.
* Bonus: Added Did you mean story config (was missing)

![image](https://user-images.githubusercontent.com/1591893/142059009-e91e2483-999a-4879-99a2-1da7aa3b4c0e.png)



https://coveord.atlassian.net/browse/KIT-1224