### PR TITLE
docs: simplify doc extraction

### DIFF
--- a/packages/headless/config/api-extractor/product-listing.json
+++ b/packages/headless/config/api-extractor/product-listing.json
@@ -1,6 +1,6 @@
 {
   "extends": "./base.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/product-listing.index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/definitions/product-listing.index.d.ts",
   "docModel": {
     "enabled": true,
     "apiJsonFilePath": "<projectFolder>/temp/product-listing.api.json"

--- a/packages/headless/config/api-extractor/product-recommendation.json
+++ b/packages/headless/config/api-extractor/product-recommendation.json
@@ -1,6 +1,6 @@
 {
   "extends": "./base.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/product-recommendation.index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/definitions/product-recommendation.index.d.ts",
   "docModel": {
     "enabled": true,
     "apiJsonFilePath": "<projectFolder>/temp/product-recommendation.api.json"

--- a/packages/headless/config/api-extractor/recommendation.json
+++ b/packages/headless/config/api-extractor/recommendation.json
@@ -1,6 +1,6 @@
 {
   "extends": "./base.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/recommendation.index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/definitions/recommendation.index.d.ts",
   "docModel": {
     "enabled": true,
     "apiJsonFilePath": "<projectFolder>/temp/recommendation.api.json"

--- a/packages/headless/config/api-extractor/search.json
+++ b/packages/headless/config/api-extractor/search.json
@@ -1,6 +1,6 @@
 {
   "extends": "./base.json",
-  "mainEntryPointFilePath": "<projectFolder>/temp/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/definitions/index.d.ts",
   "docModel": {
     "enabled": true,
     "apiJsonFilePath": "<projectFolder>/temp/index.api.json"

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@coveo/headless",
-      "version": "1.31.2",
+      "version": "1.31.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.32.8",
@@ -41,7 +41,6 @@
         "jest-fetch-mock": "3.0.3",
         "rollup": "2.56.3",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-dts": "2.0.1",
         "rollup-plugin-size-snapshot": "0.12.0",
         "rollup-plugin-terser": "7.0.2",
         "ts-jest": "26.5.6",
@@ -10414,16 +10413,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rollup-plugin-dts": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-2.0.1.tgz",
-      "integrity": "sha512-y38NSXIY37YExCumbGBTL5dXg7pL7XD+Kbe98iEHWFN9yiKJf7t4kKBOkml5ylUDjQIXBnNClGDeRktc1T5dmA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "magic-string": "^0.25.7"
       }
     },
     "node_modules/rollup-plugin-size-snapshot": {
@@ -22267,16 +22256,6 @@
           "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
           "dev": true
         }
-      }
-    },
-    "rollup-plugin-dts": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-2.0.1.tgz",
-      "integrity": "sha512-y38NSXIY37YExCumbGBTL5dXg7pL7XD+Kbe98iEHWFN9yiKJf7t4kKBOkml5ylUDjQIXBnNClGDeRktc1T5dmA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "magic-string": "^0.25.7"
       }
     },
     "rollup-plugin-size-snapshot": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -75,7 +75,6 @@
     "jest-fetch-mock": "3.0.3",
     "rollup": "2.56.3",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-dts": "2.0.1",
     "rollup-plugin-size-snapshot": "0.12.0",
     "rollup-plugin-terser": "7.0.2",
     "ts-jest": "26.5.6",

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -7,7 +7,6 @@ import {terser} from 'rollup-plugin-terser';
 import {sizeSnapshot} from 'rollup-plugin-size-snapshot';
 import alias from '@rollup/plugin-alias';
 import * as path from 'path';
-import dts from "rollup-plugin-dts";
 import {readFileSync} from 'fs';
 import copy from 'rollup-plugin-copy'
 
@@ -233,24 +232,6 @@ const dev = [
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
-// Api-extractor cannot resolve import() types, so we use dts to create a file that api-extractor
-// can consume. When the api-extractor limitation is resolved, this step will not be necessary.
-// [https://github.com/microsoft/rushstack/issues/1050]
-const typeDefinitions = [
-  buildTypeDefinitionConfiguration('index.d.ts'),
-  buildTypeDefinitionConfiguration('recommendation.index.d.ts'),
-  buildTypeDefinitionConfiguration('product-recommendation.index.d.ts'),
-  buildTypeDefinitionConfiguration('product-listing.index.d.ts'),
-].filter(b => matchesFilter(b.input));
-
-function buildTypeDefinitionConfiguration(entryFileName) {
-  return {
-    input: `./dist/definitions/${entryFileName}`,
-    output: [{file: `temp/${entryFileName}`, format: "es"}],
-    plugins: [dts()]
-  }
-}
-
-const config = isProduction ? [...nodejs, ...typeDefinitions, ...browser] : dev;
+const config = isProduction ? [...nodejs, ...browser] : dev;
 
 export default config;

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -1,3 +1,6 @@
+import * as TestUtils from './test';
+import * as HighlightUtils from './utils/highlight';
+
 // 3rd Party Libraries
 export {
   Unsubscribe,
@@ -54,6 +57,7 @@ export * from './features/index';
 export * from './features/analytics/index';
 
 // Types & Helpers
+export {TestUtils, HighlightUtils};
 export {Result} from './api/search/search/result';
 export {FieldDescription} from './api/search/fields/fields-response';
 export {Raw} from './api/search/search/raw';
@@ -79,7 +83,6 @@ export {
   ResultTemplate,
   ResultTemplateCondition,
 } from './features/result-templates/result-templates';
-export * as TestUtils from './test';
 export {platformUrl, analyticsUrl} from './api/platform-client';
 export {CategoryFacetSortCriterion} from './features/facets/category-facet-set/interfaces/request';
 export {CategoryFacetValue} from './features/facets/category-facet-set/interfaces/response';
@@ -91,7 +94,6 @@ export {
   RangeFacetRangeAlgorithm,
 } from './features/facets/range-facets/generic/interfaces/request';
 export {buildSearchParameterSerializer} from './features/search-parameters/search-parameter-serializer';
-export * as HighlightUtils from './utils/highlight';
 export {HighlightKeyword} from './utils/highlight';
 export {VERSION} from './utils/version';
 export {


### PR DESCRIPTION
The api-extractor team fixed the import limitation. The work-around of bundling definitions into a single file is no longer needed 🎉 

There is still a smaller limitation though, where it does not understand `export * as NamedExport from ...` syntax.
The work-around is to do it in two steps, first importing as a named export, then exporting the named export.