### PR TITLE
docs(atomic): storybook for search interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "**/*.ts?(x)": [
       "npm run lint:fix"
     ],
-    "**/*.{scss,css,pcss,html}": [
+    "**/*.{scss,css,pcss,html,mdx}": [
       "prettier --print-width 120 --write"
     ]
   },

--- a/packages/atomic/.storybook/atomic-search-interface-storybook-helper.ts
+++ b/packages/atomic/.storybook/atomic-search-interface-storybook-helper.ts
@@ -3,7 +3,6 @@ import {getDocumentationFromTag} from './map-props-to-args';
 import {renderArgsToHTMLString} from './default-story-shared';
 
 function generateSampleValue(property: JsonDocsProp) {
-  console.log(property.type);
   if (property.default) {
     return property.default.replace(/'/g, '');
   }

--- a/packages/atomic/.storybook/atomic-search-interface-storybook-helper.ts
+++ b/packages/atomic/.storybook/atomic-search-interface-storybook-helper.ts
@@ -1,0 +1,37 @@
+import {JsonDocsProp} from '@stencil/core/internal';
+import {getDocumentationFromTag} from './map-props-to-args';
+import {renderArgsToHTMLString} from './default-story-shared';
+
+function generateSampleValue(property: JsonDocsProp) {
+  console.log(property.type);
+  if (property.default) {
+    return property.default.replace(/'/g, '');
+  }
+  if (property.values[0].value) {
+    return property.values[0].value;
+  }
+  switch (property.type) {
+    case 'boolean':
+      return true;
+    case 'string':
+    default:
+      return 'foo';
+  }
+}
+
+export const SearchInterfaceDocumentation = getDocumentationFromTag(
+  'atomic-search-interface'
+);
+
+export function propertyToCodeSample(property: JsonDocsProp) {
+  const isReadOnlyProperty = ['engine', 'i18n'];
+  if (isReadOnlyProperty.indexOf(property.name) !== -1) {
+    return 'This property should not be modified directly.';
+  }
+
+  return renderArgsToHTMLString(
+    'atomic-search-interface',
+    {[property.name]: generateSampleValue(property)},
+    {}
+  );
+}

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
@@ -1,0 +1,3 @@
+# Search Interface
+
+TODO

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
@@ -1,3 +1,57 @@
+import AtomicDocumentation from '../../../docs/atomic-docs.json';
+import {Meta} from '@storybook/addon-docs';
+import {mapPropsToArgTypes, getDocumentationFromTag} from '../../../.storybook/map-props-to-args';
+import {renderArgsToHTMLString} from '../../../.storybook/default-story-shared';
+import {
+  typeToSampleValue,
+  SearchInterfaceDocumentation,
+  propertyToCodeSample,
+} from '../../../.storybook/atomic-search-interface-storybook-helper';
+
+<Meta title="Atomic/SearchInterface" />
+
 # Search Interface
 
-TODO
+<p>{SearchInterfaceDocumentation.docs}</p>
+
+## Properties available
+
+<table
+  style={{
+    textAlign: 'left',
+    fontSize: '13px',
+    borderCollapse: 'collapse',
+    lineHeight: '3rem',
+  }}
+>
+  <thead>
+    <tr key="header">
+      <th>Name</th>
+      <th>Description</th>
+      <th>Type</th>
+      <th>Default value</th>
+      <th>Code sample</th>
+    </tr>
+  </thead>
+  <tbody>
+    {SearchInterfaceDocumentation.props.map((prop) => {
+      const {name, docs, values, type} = prop;
+      return (
+        <tr key={name}>
+          <td>{name}</td>
+          <td>{docs}</td>
+          <td>
+            {values
+              .map((v) => v.value || v.type)
+              .filter((v) => v !== 'undefined')
+              .join(',')}
+          </td>
+          <td>{prop.default}</td>
+          <td>
+            <code style={{}}>{propertyToCodeSample(prop)}</code>
+          </td>
+        </tr>
+      );
+    })}
+  </tbody>
+</table>

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
@@ -48,7 +48,7 @@ import {
           </td>
           <td>{prop.default}</td>
           <td>
-            <code style={{}}>{propertyToCodeSample(prop)}</code>
+            <code>{propertyToCodeSample(prop)}</code>
           </td>
         </tr>
       );

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
@@ -1,0 +1,11 @@
+import {Args} from '@storybook/api';
+import {mapPropsToArgTypes} from '../../../.storybook/map-props-to-args';
+
+export default {
+  title: 'Atomic/SearchInterface',
+  argTypes: mapPropsToArgTypes('atomic-search-interface'),
+};
+
+export const DefaultSearchInterface = (args: Args) => {
+  return `<atomic-search-interface></atomic-search-interface>`;
+};

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
@@ -1,11 +1,18 @@
-import {Args} from '@storybook/api';
-import {mapPropsToArgTypes} from '../../../.storybook/map-props-to-args';
+import SearchInterfaceDoc from './atomic-search-interface.mdx';
 
 export default {
   title: 'Atomic/SearchInterface',
-  argTypes: mapPropsToArgTypes('atomic-search-interface'),
+  parameters: {
+    previewTabs: {
+      canvas: {
+        hidden: true,
+      },
+    },
+    viewMode: 'docs',
+    docs: {
+      page: SearchInterfaceDoc,
+    },
+  },
 };
 
-export const DefaultSearchInterface = (args: Args) => {
-  return `<atomic-search-interface></atomic-search-interface>`;
-};
+export const DefaultSearchInterface = () => {};


### PR DESCRIPTION
As explained, the canvas view for Search interface did not work very well, after a couple of trials and errors.

So instead, I made it so the canvas is hidden for the Search interface, and instead we only have a doc page (.mdx), where we render a table dynamically with all the props, and some code sample to showcase an example of each option.

We will still need to have an actual article about the component itself, though ! 

https://coveord.atlassian.net/browse/KIT-1226