### PR TITLE
docs(atomic): fix props table visual glitch for search interface story

### DIFF
--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.mdx
@@ -1,5 +1,5 @@
 import AtomicDocumentation from '../../../docs/atomic-docs.json';
-import {Meta} from '@storybook/addon-docs';
+import {Meta, Source} from '@storybook/addon-docs';
 import {mapPropsToArgTypes, getDocumentationFromTag} from '../../../.storybook/map-props-to-args';
 import {renderArgsToHTMLString} from '../../../.storybook/default-story-shared';
 import {
@@ -7,6 +7,7 @@ import {
   SearchInterfaceDocumentation,
   propertyToCodeSample,
 } from '../../../.storybook/atomic-search-interface-storybook-helper';
+import StoryStyle from './atomic-search-interface.stories.css';
 
 <Meta title="Atomic/SearchInterface" />
 
@@ -16,14 +17,7 @@ import {
 
 ## Properties available
 
-<table
-  style={{
-    textAlign: 'left',
-    fontSize: '13px',
-    borderCollapse: 'collapse',
-    lineHeight: '3rem',
-  }}
->
+<table className="search-interface-props-table">
   <thead>
     <tr key="header">
       <th>Name</th>
@@ -44,11 +38,11 @@ import {
             {values
               .map((v) => v.value || v.type)
               .filter((v) => v !== 'undefined')
-              .join(',')}
+              .join(' ')}
           </td>
           <td>{prop.default}</td>
           <td>
-            <code>{propertyToCodeSample(prop)}</code>
+            <Source code={propertyToCodeSample(prop)} language="html" />
           </td>
         </tr>
       );

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.css
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.css
@@ -1,0 +1,28 @@
+.search-interface-props-table {
+  text-align: left;
+  font-size: 13px;
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.search-interface-props-table th,
+.search-interface-props-table td {
+  word-break: break-word;
+}
+
+.search-interface-props-table th:nth-of-type(1),
+.search-interface-props-table td:nth-of-type(1),
+.search-interface-props-table th:nth-of-type(3),
+.search-interface-props-table td:nth-of-type(3),
+.search-interface-props-table th:nth-of-type(4),
+.search-interface-props-table td:nth-of-type(4) {
+  width: 10%;
+}
+
+.search-interface-props-table th:nth-of-type(2),
+.search-interface-props-table td:nth-of-type(2),
+.search-interface-props-table th:nth-of-type(5),
+.search-interface-props-table td:nth-of-type(5) {
+  width: 40%;
+}


### PR DESCRIPTION
Fixing some overflow problem for the props table in search interface, as well as using the `Source` component available from storybook for the small code sample.
https://coveord.atlassian.net/browse/KIT-1232