### PR TITLE
docs(atomic): add support for accessibility addon

### DIFF
--- a/packages/atomic/.storybook/default-init.ts
+++ b/packages/atomic/.storybook/default-init.ts
@@ -4,8 +4,7 @@ import {
 } from '@coveo/headless';
 import {debounce} from 'lodash';
 import {addons} from '@storybook/addons';
-import { A11Y_EXTENSION_EVENTS } from './register';
-
+import {A11Y_EXTENSION_EVENTS} from './register';
 
 interface SearchInterface extends HTMLElement {
   initialize: (cfg: SearchEngineConfiguration) => Promise<void>;

--- a/packages/atomic/.storybook/default-init.ts
+++ b/packages/atomic/.storybook/default-init.ts
@@ -3,6 +3,10 @@ import {
   SearchEngineConfiguration,
 } from '@coveo/headless';
 import {debounce} from 'lodash';
+import {addons} from '@storybook/addons';
+import { A11Y_EXTENSION_EVENTS } from './register';
+
+
 interface SearchInterface extends HTMLElement {
   initialize: (cfg: SearchEngineConfiguration) => Promise<void>;
   executeFirstSearch: () => Promise<void>;
@@ -29,6 +33,7 @@ export const initializeInterfaceDebounced = (
       });
 
       await clone.executeFirstSearch();
+      addons.getChannel().emit(A11Y_EXTENSION_EVENTS.SEARCH_EXECUTED);
     },
     1000,
     {trailing: true}

--- a/packages/atomic/.storybook/main.js
+++ b/packages/atomic/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-docs',
     '@storybook/addon-controls',
     '@storybook/addon-viewport',
+    '@storybook/addon-a11y',
     './preset.js',
   ],
   webpack: (config) => {

--- a/packages/atomic/.storybook/preview.js
+++ b/packages/atomic/.storybook/preview.js
@@ -23,4 +23,8 @@ export const decorators = [
 
 export const parameters = {
   controls: {expanded: true, hideNoControlsWarning: true},
+  a11y: {
+    element: 'atomic-search-interface',
+    manual: true,
+  },
 };

--- a/packages/atomic/.storybook/register.js
+++ b/packages/atomic/.storybook/register.js
@@ -3,11 +3,15 @@ import {addons, types} from '@storybook/addons';
 import {AddonPanel} from '@storybook/components';
 import {ShadowPartPanel} from './shadow-parts-addon/shadow-parts-panel';
 import {CodeSamplePanel} from './code-sample-addon/code-sample-panel';
+import {debounce} from 'lodash';
 
 const ADDON_ID_SHADOW_PARTS = 'shadow_parts';
 const PANEL_ID_SHADOW_PARTS = `${ADDON_ID_SHADOW_PARTS}/panel`;
 const ADDON_ID_CODE_SAMPLE = 'code_sample';
 const PANEL_ID_CODE_SAMPLE = `${ADDON_ID_CODE_SAMPLE}/panel`;
+export const A11Y_EXTENSION_EVENTS = {
+  SEARCH_EXECUTED: 'a11y/extension/search_executed',
+};
 
 addons.register('SHADOW_PARTS', () => {
   addons.add(PANEL_ID_SHADOW_PARTS, {
@@ -31,4 +35,15 @@ addons.register('CODE_SAMPLE', () => {
       </AddonPanel>
     ),
   });
+});
+
+addons.register('A11Y_EXTENSION', (api) => {
+  const rerunAccessibilityTest = debounce(
+    () => {
+      api.emit('storybook/a11y/manual', api.getCurrentStoryData().id);
+    },
+    500,
+    {leading: false, trailing: true}
+  );
+  api.on(A11Y_EXTENSION_EVENTS.SEARCH_EXECUTED, rerunAccessibilityTest);
 });

--- a/packages/atomic/package-lock.json
+++ b/packages/atomic/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@coveo/atomic",
-      "version": "1.14.4",
+      "version": "1.14.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.32.8",
-        "@coveo/headless": "^1.31.6",
+        "@coveo/headless": "^1.31.7",
         "@salesforce-ux/design-system": "^2.16.1",
         "coveo-styleguide": "^9.26.0",
         "dayjs": "^1.10.4",
@@ -31,6 +31,7 @@
         "@stencil/core": "^2.10.0",
         "@stencil/postcss": "^2.1.0",
         "@stencil/store": "^1.5.0",
+        "@storybook/addon-a11y": "^6.3.12",
         "@storybook/addon-controls": "^6.3.12",
         "@storybook/addon-docs": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
@@ -2145,9 +2146,9 @@
       "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.31.6",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.6.tgz",
-      "integrity": "sha512-t3qrcleesWmdcy7eKZg7RfRXnRTTwblguewHJUwda3iWaYJrKxBSM4H2ckW0scYDDRnF4xixOmUknIMJCNjePg==",
+      "version": "1.31.7",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.7.tgz",
+      "integrity": "sha512-0q0JDoKTG0xvhCbpSH9sN6BKKNgtV2MI/w20z1c/JHpO9l1FrgnTK6szkoDXRA1fiZ+FjJaZkntqdx1fkl6rEg==",
       "dependencies": {
         "@coveo/bueno": "^0.32.8",
         "@reduxjs/toolkit": "^1.5.0",
@@ -3629,6 +3630,57 @@
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=1.9.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.3.12.tgz",
+      "integrity": "sha512-q1NdRHFJV6sLEEJw0hatCc5ZIthELqM/AWdrEWDyhcJNyiq7Tq4nKqQBMTQSYwHiUAmxVgw7i4oa1vM2M51/3g==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.3.12",
+        "@storybook/api": "6.3.12",
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-api": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/components": "6.3.12",
+        "@storybook/core-events": "6.3.12",
+        "@storybook/theming": "6.3.12",
+        "axe-core": "^4.2.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.20",
+        "react-sizeme": "^3.0.1",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/core-js": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
+      "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -26728,9 +26780,9 @@
       "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
     },
     "@coveo/headless": {
-      "version": "1.31.6",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.6.tgz",
-      "integrity": "sha512-t3qrcleesWmdcy7eKZg7RfRXnRTTwblguewHJUwda3iWaYJrKxBSM4H2ckW0scYDDRnF4xixOmUknIMJCNjePg==",
+      "version": "1.31.7",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.7.tgz",
+      "integrity": "sha512-0q0JDoKTG0xvhCbpSH9sN6BKKNgtV2MI/w20z1c/JHpO9l1FrgnTK6szkoDXRA1fiZ+FjJaZkntqdx1fkl6rEg==",
       "requires": {
         "@coveo/bueno": "^0.32.8",
         "@reduxjs/toolkit": "^1.5.0",
@@ -27960,6 +28012,38 @@
       "integrity": "sha512-fe5fCF6dgVlDM1iLRkkJUyUh0Tfx305asVGgMAJjIs7Q+x/b1pGgTLROm9Ibr53PZuFwr5Kg+4h9p4FLbYqHgA==",
       "dev": true,
       "requires": {}
+    },
+    "@storybook/addon-a11y": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.3.12.tgz",
+      "integrity": "sha512-q1NdRHFJV6sLEEJw0hatCc5ZIthELqM/AWdrEWDyhcJNyiq7Tq4nKqQBMTQSYwHiUAmxVgw7i4oa1vM2M51/3g==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.3.12",
+        "@storybook/api": "6.3.12",
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-api": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/components": "6.3.12",
+        "@storybook/core-events": "6.3.12",
+        "@storybook/theming": "6.3.12",
+        "axe-core": "^4.2.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.20",
+        "react-sizeme": "^3.0.1",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.19.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
+          "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+          "dev": true
+        }
+      }
     },
     "@storybook/addon-actions": {
       "version": "6.3.12",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -64,6 +64,7 @@
     "@stencil/core": "^2.10.0",
     "@stencil/postcss": "^2.1.0",
     "@stencil/store": "^1.5.0",
+    "@storybook/addon-a11y": "^6.3.12",
     "@storybook/addon-controls": "^6.3.12",
     "@storybook/addon-docs": "^6.3.12",
     "@storybook/addon-essentials": "^6.3.12",


### PR DESCRIPTION
We need to tweak the base addon a bit to put it in "manual" mode, that re-run accessibility test only after the query has been executed.

But otherwise seems to be working great !

https://coveord.atlassian.net/browse/KIT-1233