### PR TITLE
fix(atomic): fix focus trap event target

### DIFF
--- a/packages/atomic/src/components/common/atomic-focus-trap.tsx
+++ b/packages/atomic/src/components/common/atomic-focus-trap.tsx
@@ -98,10 +98,15 @@ export class AtomicFocusTrap {
   }
 
   @Listen('focusin', {target: 'document'})
-  onFocusChanged(e: {originalTarget: HTMLElement}) {
-    if (contains(this.host, e.originalTarget)) {
+  onFocusChanged(e: FocusEvent) {
+    if (!e.target) {
       return;
     }
+
+    if (contains(this.host, e.target as Element)) {
+      return;
+    }
+
     getFirstFocusableDescendant(this.host)?.focus();
   }
 


### PR DESCRIPTION
`originalTarget` is not recommended by MDN, for being non-standard.

https://developer.mozilla.org/en-US/docs/Web/API/Event/Comparison_of_Event_Targets

https://coveord.atlassian.net/browse/KIT-1235