### PR TITLE
for @nlafrance, fix eslint-disable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ui-kit",
       "devDependencies": {
         "@actions/github": "4.0.0",
         "@commitlint/config-conventional": "12.1.4",

--- a/packages/atomic/package-lock.json
+++ b/packages/atomic/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@coveo/atomic",
-      "version": "1.14.6",
+      "version": "1.15.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/bueno": "^0.32.8",
-        "@coveo/headless": "^1.31.7",
+        "@coveo/bueno": "^0.33.0",
+        "@coveo/headless": "^1.33.0",
         "@salesforce-ux/design-system": "^2.16.1",
         "coveo-styleguide": "^9.26.0",
         "dayjs": "^1.10.4",
@@ -1621,16 +1621,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-      "integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
       "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1640,18 +1640,86 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+    "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
-      "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "core-js-compat": "^3.18.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
       "version": "6.3.0",
@@ -2141,16 +2209,16 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.8.tgz",
-      "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.31.7",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.7.tgz",
-      "integrity": "sha512-0q0JDoKTG0xvhCbpSH9sN6BKKNgtV2MI/w20z1c/JHpO9l1FrgnTK6szkoDXRA1fiZ+FjJaZkntqdx1fkl6rEg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.33.0.tgz",
+      "integrity": "sha512-xq8XKbSGeXqtnAEsEFCd+jvD+6JwVFeNRgR8wWc79+XJIm0Wj8futHf9dGOfpRefRmvyLI/7qn4Sgy7Jw1IgoA==",
       "dependencies": {
-        "@coveo/bueno": "^0.32.8",
+        "@coveo/bueno": "^0.33.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -2170,6 +2238,29 @@
       "peerDependencies": {
         "encoding": "^0.1.13",
         "pino-pretty": "^6.0.0"
+      }
+    },
+    "node_modules/@coveo/headless/node_modules/@reduxjs/toolkit": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
+      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
+      "dependencies": {
+        "immer": "^9.0.6",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0",
+        "react-redux": "^7.2.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cypress/request": {
@@ -2992,55 +3083,6 @@
         "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
       }
     },
-    "node_modules/@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "@react-native-community/cli-types": "^6.0.0",
-        "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
-        "command-exists": "^1.2.8",
-        "commander": "^2.19.0",
-        "cosmiconfig": "^5.1.0",
-        "deepmerge": "^3.2.0",
-        "envinfo": "^7.7.2",
-        "execa": "^1.0.0",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.3",
-        "joi": "^17.2.1",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-stream-zip": "^1.9.1",
-        "ora": "^3.4.0",
-        "pretty-format": "^26.6.2",
-        "prompts": "^2.4.0",
-        "semver": "^6.3.0",
-        "serve-static": "^1.13.1",
-        "strip-ansi": "^5.2.0",
-        "sudo-prompt": "^9.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "bin": {
-        "react-native": "build/bin.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/@react-native-community/cli-debugger-ui": {
       "version": "6.0.0-rc.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0-rc.0.tgz",
@@ -3051,39 +3093,26 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -3094,99 +3123,48 @@
         "xmldoc": "^1.1.2"
       }
     },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
       }
     },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -3207,33 +3185,19 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
         "shell-quote": "1.6.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/is-wsl": {
@@ -3246,27 +3210,15 @@
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "peer": true,
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/open": {
@@ -3311,126 +3263,6 @@
         "ora": "^3.4.0"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "peer": true,
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/deepmerge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-      "peer": true,
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "peer": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",
@@ -3448,29 +3280,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
-    },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
-      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
-      "dependencies": {
-        "immer": "^9.0.6",
-        "redux": "^4.1.0",
-        "redux-thunk": "^2.3.0",
-        "reselect": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0",
-        "react-redux": "^7.2.1"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/plugin-alias": {
       "version": "3.1.5",
@@ -6346,11 +6155,12 @@
       }
     },
     "node_modules/@types/pino-pretty": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.1.tgz",
-      "integrity": "sha512-l1ntNXdpVWsnPYUk5HyO5Lxfr38zLCgxVfEn/9Zhhm+nGF04/BiIou/m8XPwvoVZLV+livUo79VdHXMJPfUYxA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "dependencies": {
-        "@types/pino": "*"
+        "@types/node": "*",
+        "@types/pino": "6.3"
       }
     },
     "node_modules/@types/pino-std-serializers": {
@@ -8153,9 +7963,9 @@
       }
     },
     "node_modules/big-integer": {
-      "version": "1.6.50",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-      "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "peer": true,
       "engines": {
         "node": ">=0.6"
@@ -9470,23 +9280,136 @@
       }
     },
     "node_modules/coveo.analytics": {
-      "version": "2.18.50",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.50.tgz",
-      "integrity": "sha512-zHouwVBfdvP2NXXeiCZDk8BtofKrYQeoLhdFTp/RwgS84jpHCtD3YstqXBEDN/kjWFtOaTt7YoRpmk2bcL8DMw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
       }
     },
     "node_modules/coveo.analytics/node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.9.tgz",
-      "integrity": "sha512-LrVPfhKqodRiDWCgZp7J2X55JQqOhdQUxbl17RrktIGCZ0ud2XHdNoTIvyI1VccqHoF/CZK6v+G0IoX5NYZ1JA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.11.tgz",
+      "integrity": "sha512-l/I+PK+lh5M25QSdk44aX+UR63ian2d2CSx6WbydwU+RUZmKP7eOEPe+OeaTWgfOFSVtlEqEcP2AbW2YM7ukMA==",
       "dependencies": {
         "merge-options": "^3.0.4"
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || ^0.65.0 || ^0.66.0 || 1000.0.0"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/@react-native-community/cli": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
+      "peer": true,
+      "dependencies": {
+        "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
+        "@react-native-community/cli-hermes": "^6.2.0",
+        "@react-native-community/cli-plugin-metro": "^6.2.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "@react-native-community/cli-types": "^6.0.0",
+        "appdirsjs": "^1.2.4",
+        "chalk": "^4.1.2",
+        "command-exists": "^1.2.8",
+        "commander": "^2.19.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.3",
+        "joi": "^17.2.1",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "minimist": "^1.2.0",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^3.4.0",
+        "pretty-format": "^26.6.2",
+        "prompts": "^2.4.0",
+        "semver": "^6.3.0",
+        "serve-static": "^1.13.1",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "bin": {
+        "react-native": "build/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
+    "node_modules/coveo.analytics/node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "peer": true,
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "peer": true,
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "peer": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/coveo.analytics/node_modules/react": {
@@ -9503,9 +9426,9 @@
       }
     },
     "node_modules/coveo.analytics/node_modules/react-native": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.1.tgz",
-      "integrity": "sha512-BBvytmqlOLL+bRcO0jBiYfg16lYRsYDOC8/5E+bpnhb3EGtU+YCQAYfszw6JL7Hfy0ftnQNP5yj8pt+vqMHXIA==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.3.tgz",
+      "integrity": "sha512-B/dQpuvta9YvF5MihDWefoGlTvxzUHK5X5RjdrXHAu/ihTehJXxEA+m6z/tufp1ZUMDjU+tMZK6gnehzCuYfzw==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -9550,6 +9473,15 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/coveo.analytics/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/coveo.analytics/node_modules/scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -9558,6 +9490,39 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/coveo.analytics/node_modules/use-subscription": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
+      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/coveo.analytics/node_modules/ws": {
@@ -20011,6 +19976,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -20400,12 +20366,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "node_modules/react-native": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.0.0.tgz",
-      "integrity": "sha1-PU5SlHCPmvgKjkbTofesn1+BCrM=",
-      "peer": true
     },
     "node_modules/react-native-codegen": {
       "version": "0.0.7",
@@ -21130,9 +21090,9 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/reselect": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.1.tgz",
-      "integrity": "sha512-Jjt8Us6hAWJpjucyladHvUGR+q1mHHgWtGDXlhvvKyNyIeQ3bjuWLDX0bsTLhbm/gd4iXEACBlODUHBlLWiNnA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -21960,9 +21920,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.0.tgz",
-      "integrity": "sha512-lEPaw654/4/rCJHz/TNzV4GIthqCq4inO+O3aFhbdOvR1bE+2//sVkcS+xlqPdb8gdjQCEE0hE9BuvnVixbnWQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.1.tgz",
+      "integrity": "sha512-o0vJPsRiCW5Q0EmRKjNiiYGy2DqSXcxk4mY9vIBSPwmkH/e/vJ2Tq8EECd5NTiO77x8vlVN+ykDjRQJTqf7eKg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -23874,18 +23834,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/util": {
@@ -26386,28 +26334,79 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-      "integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
       "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "babel-plugin-polyfill-corejs3": {
+        "@babel/helper-define-polyfill-provider": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
-          "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+          "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
           "peer": true,
           "requires": {
-            "@babel/helper-define-polyfill-provider": "^0.2.4",
+            "@babel/helper-compilation-targets": "^7.13.0",
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/traverse": "^7.13.0",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          }
+        },
+        "babel-plugin-polyfill-corejs2": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+          "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+          "peer": true,
+          "requires": {
+            "@babel/compat-data": "^7.13.11",
+            "@babel/helper-define-polyfill-provider": "^0.3.0",
+            "semver": "^6.1.1"
+          }
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+          "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+          "peer": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.3.0",
             "core-js-compat": "^3.18.0"
           }
+        },
+        "babel-plugin-polyfill-regenerator": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+          "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+          "peer": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "peer": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "peer": true
         },
         "semver": {
           "version": "6.3.0",
@@ -26775,16 +26774,16 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.8.tgz",
-      "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "@coveo/headless": {
-      "version": "1.31.7",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.7.tgz",
-      "integrity": "sha512-0q0JDoKTG0xvhCbpSH9sN6BKKNgtV2MI/w20z1c/JHpO9l1FrgnTK6szkoDXRA1fiZ+FjJaZkntqdx1fkl6rEg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.33.0.tgz",
+      "integrity": "sha512-xq8XKbSGeXqtnAEsEFCd+jvD+6JwVFeNRgR8wWc79+XJIm0Wj8futHf9dGOfpRefRmvyLI/7qn4Sgy7Jw1IgoA==",
       "requires": {
-        "@coveo/bueno": "^0.32.8",
+        "@coveo/bueno": "^0.33.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -26800,6 +26799,19 @@
         "redux-thunk": "^2.3.0",
         "ts-debounce": "^3.0.0",
         "web-encoding": "^1.1.4"
+      },
+      "dependencies": {
+        "@reduxjs/toolkit": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
+          "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
+          "requires": {
+            "immer": "^9.0.6",
+            "redux": "^4.1.0",
+            "redux-thunk": "^2.3.0",
+            "reselect": "^4.0.0"
+          }
+        }
       }
     },
     "@cypress/request": {
@@ -27486,138 +27498,6 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
-    "@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
-      "peer": true,
-      "requires": {
-        "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "@react-native-community/cli-types": "^6.0.0",
-        "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
-        "command-exists": "^1.2.8",
-        "commander": "^2.19.0",
-        "cosmiconfig": "^5.1.0",
-        "deepmerge": "^3.2.0",
-        "envinfo": "^7.7.2",
-        "execa": "^1.0.0",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.3",
-        "joi": "^17.2.1",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-stream-zip": "^1.9.1",
-        "ora": "^3.4.0",
-        "pretty-format": "^26.6.2",
-        "prompts": "^2.4.0",
-        "semver": "^6.3.0",
-        "serve-static": "^1.13.1",
-        "strip-ansi": "^5.2.0",
-        "sudo-prompt": "^9.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "peer": true
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "peer": true
-        },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "peer": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "deepmerge": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
-          "peer": true
-        },
-        "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "peer": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "peer": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "peer": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "peer": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "peer": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
     "@react-native-community/cli-debugger-ui": {
       "version": "6.0.0-rc.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0-rc.0.tgz",
@@ -27628,38 +27508,26 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -27668,95 +27536,50 @@
         "logkitty": "^0.7.1",
         "slash": "^3.0.0",
         "xmldoc": "^1.1.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -27779,32 +27602,21 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "requires": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
         "shell-quote": "1.6.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "is-wsl": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -27812,19 +27624,10 @@
           "peer": true
         },
         "mime": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
           "peer": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
         },
         "open": {
           "version": "6.4.0",
@@ -27881,17 +27684,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
-    },
-    "@reduxjs/toolkit": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
-      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
-      "requires": {
-        "immer": "^9.0.6",
-        "redux": "^4.1.0",
-        "redux-thunk": "^2.3.0",
-        "reselect": "^4.0.0"
-      }
     },
     "@rollup/plugin-alias": {
       "version": "3.1.5",
@@ -29935,11 +29727,12 @@
       }
     },
     "@types/pino-pretty": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.1.tgz",
-      "integrity": "sha512-l1ntNXdpVWsnPYUk5HyO5Lxfr38zLCgxVfEn/9Zhhm+nGF04/BiIou/m8XPwvoVZLV+livUo79VdHXMJPfUYxA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "requires": {
-        "@types/pino": "*"
+        "@types/node": "*",
+        "@types/pino": "6.3"
       }
     },
     "@types/pino-std-serializers": {
@@ -31444,9 +31237,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.50",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-      "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "peer": true
     },
     "big.js": {
@@ -32494,20 +32287,109 @@
       }
     },
     "coveo.analytics": {
-      "version": "2.18.50",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.50.tgz",
-      "integrity": "sha512-zHouwVBfdvP2NXXeiCZDk8BtofKrYQeoLhdFTp/RwgS84jpHCtD3YstqXBEDN/kjWFtOaTt7YoRpmk2bcL8DMw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "requires": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
       },
       "dependencies": {
         "@react-native-async-storage/async-storage": {
-          "version": "1.15.9",
-          "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.9.tgz",
-          "integrity": "sha512-LrVPfhKqodRiDWCgZp7J2X55JQqOhdQUxbl17RrktIGCZ0ud2XHdNoTIvyI1VccqHoF/CZK6v+G0IoX5NYZ1JA==",
+          "version": "1.15.11",
+          "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.11.tgz",
+          "integrity": "sha512-l/I+PK+lh5M25QSdk44aX+UR63ian2d2CSx6WbydwU+RUZmKP7eOEPe+OeaTWgfOFSVtlEqEcP2AbW2YM7ukMA==",
           "requires": {
             "merge-options": "^3.0.4"
+          }
+        },
+        "@react-native-community/cli": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+          "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
+          "peer": true,
+          "requires": {
+            "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
+            "@react-native-community/cli-hermes": "^6.2.0",
+            "@react-native-community/cli-plugin-metro": "^6.2.0",
+            "@react-native-community/cli-server-api": "^6.2.0",
+            "@react-native-community/cli-tools": "^6.2.0",
+            "@react-native-community/cli-types": "^6.0.0",
+            "appdirsjs": "^1.2.4",
+            "chalk": "^4.1.2",
+            "command-exists": "^1.2.8",
+            "commander": "^2.19.0",
+            "cosmiconfig": "^5.1.0",
+            "deepmerge": "^3.2.0",
+            "envinfo": "^7.7.2",
+            "execa": "^1.0.0",
+            "find-up": "^4.1.0",
+            "fs-extra": "^8.1.0",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.3",
+            "joi": "^17.2.1",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.15",
+            "minimist": "^1.2.0",
+            "node-stream-zip": "^1.9.1",
+            "ora": "^3.4.0",
+            "pretty-format": "^26.6.2",
+            "prompts": "^2.4.0",
+            "semver": "^6.3.0",
+            "serve-static": "^1.13.1",
+            "strip-ansi": "^5.2.0",
+            "sudo-prompt": "^9.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "peer": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "peer": true
+        },
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "peer": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+          "peer": true
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "peer": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "peer": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "react": {
@@ -32521,9 +32403,9 @@
           }
         },
         "react-native": {
-          "version": "0.66.1",
-          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.1.tgz",
-          "integrity": "sha512-BBvytmqlOLL+bRcO0jBiYfg16lYRsYDOC8/5E+bpnhb3EGtU+YCQAYfszw6JL7Hfy0ftnQNP5yj8pt+vqMHXIA==",
+          "version": "0.66.3",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.3.tgz",
+          "integrity": "sha512-B/dQpuvta9YvF5MihDWefoGlTvxzUHK5X5RjdrXHAu/ihTehJXxEA+m6z/tufp1ZUMDjU+tMZK6gnehzCuYfzw==",
           "peer": true,
           "requires": {
             "@jest/create-cache-key-function": "^27.0.1",
@@ -32559,6 +32441,12 @@
             "ws": "^6.1.4"
           }
         },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "peer": true
+        },
         "scheduler": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -32566,6 +32454,30 @@
           "peer": true,
           "requires": {
             "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "use-subscription": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
+          "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+          "peer": true,
+          "requires": {
             "object-assign": "^4.1.1"
           }
         },
@@ -40863,6 +40775,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -41169,12 +41082,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-native": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.0.0.tgz",
-      "integrity": "sha1-PU5SlHCPmvgKjkbTofesn1+BCrM=",
-      "peer": true
     },
     "react-native-codegen": {
       "version": "0.0.7",
@@ -41747,9 +41654,9 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "reselect": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.1.tgz",
-      "integrity": "sha512-Jjt8Us6hAWJpjucyladHvUGR+q1mHHgWtGDXlhvvKyNyIeQ3bjuWLDX0bsTLhbm/gd4iXEACBlODUHBlLWiNnA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "resolve": {
       "version": "1.20.0",
@@ -42429,9 +42336,9 @@
       }
     },
     "sonic-boom": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.0.tgz",
-      "integrity": "sha512-lEPaw654/4/rCJHz/TNzV4GIthqCq4inO+O3aFhbdOvR1bE+2//sVkcS+xlqPdb8gdjQCEE0hE9BuvnVixbnWQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.1.tgz",
+      "integrity": "sha512-o0vJPsRiCW5Q0EmRKjNiiYGy2DqSXcxk4mY9vIBSPwmkH/e/vJ2Tq8EECd5NTiO77x8vlVN+ykDjRQJTqf7eKg==",
       "requires": {
         "atomic-sleep": "^1.0.0"
       }
@@ -43916,15 +43823,6 @@
       "dev": true,
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
-      }
-    },
-    "use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "peer": true,
-      "requires": {
-        "object-assign": "^4.1.1"
       }
     },
     "util": {

--- a/packages/bueno/package-lock.json
+++ b/packages/bueno/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@coveo/bueno",
-      "version": "0.32.7",
+      "version": "0.33.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-alias": "3.1.5",

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@coveo/headless",
-      "version": "1.31.6",
+      "version": "1.33.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/bueno": "^0.32.8",
+        "@coveo/bueno": "^0.33.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -1933,9 +1933,9 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.8.tgz",
-      "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -12353,6 +12353,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -14196,9 +14197,9 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.8.tgz",
-      "integrity": "sha512-GfuE9ZunGWyoMb/zAVijGQI8ruVLi/A2OyQT6Vgzh5c2O0JCEd9+rseCGcaeOyuX7epcq6UKeTDPxznTmeinLw=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",

--- a/packages/quantic/.npmignore
+++ b/packages/quantic/.npmignore
@@ -1,0 +1,1 @@
+scripts

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unpublished-require */
 const {promisify} = require('util');
 const ncp = promisify(require('ncp'));
 const mkdir = promisify(require('fs').mkdir);

--- a/packages/quantic/package-lock.json
+++ b/packages/quantic/package-lock.json
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz",
-      "integrity": "sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
       "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.13.0",
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.0.tgz",
-      "integrity": "sha512-MLM1IOMe9aQBqMWxcRw8dcb9jlM86NIw7KA0Wri91Xkfied+dE0QuBFSBjMNvqzmS0OSIDsMNC24dBEkPUi7ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz",
+      "integrity": "sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==",
       "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -543,13 +543,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz",
-      "integrity": "sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz",
+      "integrity": "sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==",
       "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.0",
+        "@babel/helper-remap-async-to-generator": "^7.16.4",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       },
       "engines": {
@@ -1558,16 +1558,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-      "integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
       "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1701,18 +1701,18 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.0.tgz",
-      "integrity": "sha512-cdTu/W0IrviamtnZiTfixPfIncr2M1VqRrkjzZWlr1B4TVYimCFK5jkyOdP4qw2MrlKHi+b3ORj6x8GoCew8Dg==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.4.tgz",
+      "integrity": "sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-compilation-targets": "^7.16.3",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.0",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.16.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.4",
         "@babel/plugin-proposal-class-properties": "^7.16.0",
         "@babel/plugin-proposal-class-static-block": "^7.16.0",
         "@babel/plugin-proposal-dynamic-import": "^7.16.0",
@@ -1762,7 +1762,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.0",
         "@babel/plugin-transform-new-target": "^7.16.0",
         "@babel/plugin-transform-object-super": "^7.16.0",
-        "@babel/plugin-transform-parameters": "^7.16.0",
+        "@babel/plugin-transform-parameters": "^7.16.3",
         "@babel/plugin-transform-property-literals": "^7.16.0",
         "@babel/plugin-transform-regenerator": "^7.16.0",
         "@babel/plugin-transform-reserved-words": "^7.16.0",
@@ -1775,10 +1775,10 @@
         "@babel/plugin-transform-unicode-regex": "^7.16.0",
         "@babel/preset-modules": "^0.1.5",
         "@babel/types": "^7.16.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
-        "core-js-compat": "^3.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "core-js-compat": "^3.19.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -4434,19 +4434,19 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-hermes": "^6.2.0",
+        "@react-native-community/cli-plugin-metro": "^6.2.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "commander": "^2.19.0",
         "cosmiconfig": "^5.1.0",
@@ -4461,7 +4461,6 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
         "ora": "^3.4.0",
         "pretty-format": "^26.6.2",
@@ -4492,39 +4491,26 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
     },
-    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -4533,19 +4519,6 @@
         "logkitty": "^0.7.1",
         "slash": "^3.0.0",
         "xmldoc": "^1.1.2"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/cross-spawn": {
@@ -4667,85 +4640,47 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
       }
     },
-    "node_modules/@react-native-community/cli-platform-ios/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
       }
     },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -4806,45 +4741,19 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
         "shell-quote": "1.6.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/@react-native-community/cli-types": {
@@ -4872,22 +4781,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/@jest/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@react-native-community/cli/node_modules/@types/yargs": {
       "version": "15.0.14",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
@@ -4895,19 +4788,6 @@
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli/node_modules/commander": {
@@ -5012,18 +4892,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/@react-native-community/cli/node_modules/npm-run-path": {
@@ -7905,10 +7773,11 @@
       }
     },
     "node_modules/@types/pino-pretty": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.2.tgz",
-      "integrity": "sha512-a4/hqUb8AYNJYtWkR4cVpT9m2bcO6DUO+MLAtaLNCgYhbrleHJiUBgTSZfcFbaZwi1naAIQVKJbHVrj9YRfujQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "dependencies": {
+        "@types/node": "*",
         "@types/pino": "6.3"
       }
     },
@@ -9087,13 +8956,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz",
-      "integrity": "sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
       "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "semver": "^6.1.1"
       },
       "peerDependencies": {
@@ -9101,12 +8970,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
-      "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "core-js-compat": "^3.18.0"
       },
       "peerDependencies": {
@@ -9114,12 +8983,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz",
-      "integrity": "sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4"
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -10906,9 +10775,9 @@
       }
     },
     "node_modules/coveo.analytics": {
-      "version": "2.18.51",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.51.tgz",
-      "integrity": "sha512-VwAauL8YZlByC2EV/SyBshUhD/iF04nDjCtEGJz9xSLyz9vTv65uYTcBHp7vJDfX8ZADOK0/TZdx6ub8r7/sBw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
@@ -18775,9 +18644,9 @@
       }
     },
     "node_modules/metro-config/node_modules/camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -22652,9 +22521,9 @@
       }
     },
     "node_modules/reselect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.2.tgz",
-      "integrity": "sha512-wg60ebcPOtxcptIUfrr7Jt3h4BR86cCW3R7y4qt65lnNb4yz4QgrXcbSioVsIOYguyz42+XTHIyJ5TEruzkFgQ=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -28586,9 +28455,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew=="
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q=="
     },
     "@babel/core": {
       "version": "7.13.16",
@@ -28686,9 +28555,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.4.tgz",
-      "integrity": "sha512-OrpPZ97s+aPi6h2n1OXzdhVis1SGSsMU2aMHgLcOKfsp4/v1NWpx3CWT3lBj5eeBq9cDkPkh+YCfdF7O12uNDQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
       "peer": true,
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
@@ -28781,9 +28650,9 @@
       "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.0.tgz",
-      "integrity": "sha512-MLM1IOMe9aQBqMWxcRw8dcb9jlM86NIw7KA0Wri91Xkfied+dE0QuBFSBjMNvqzmS0OSIDsMNC24dBEkPUi7ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz",
+      "integrity": "sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==",
       "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -28946,13 +28815,13 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.0.tgz",
-      "integrity": "sha512-nyYmIo7ZqKsY6P4lnVmBlxp9B3a96CscbLotlsNuktMHahkDwoPYEjXrZHU0Tj844Z9f1IthVxQln57mhkcExw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz",
+      "integrity": "sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==",
       "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.0",
+        "@babel/helper-remap-async-to-generator": "^7.16.4",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
@@ -29592,16 +29461,16 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-      "integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
       "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
         "semver": "^6.3.0"
       }
     },
@@ -29681,18 +29550,18 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.0.tgz",
-      "integrity": "sha512-cdTu/W0IrviamtnZiTfixPfIncr2M1VqRrkjzZWlr1B4TVYimCFK5jkyOdP4qw2MrlKHi+b3ORj6x8GoCew8Dg==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.4.tgz",
+      "integrity": "sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==",
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-compilation-targets": "^7.16.3",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.0",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.16.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.4",
         "@babel/plugin-proposal-class-properties": "^7.16.0",
         "@babel/plugin-proposal-class-static-block": "^7.16.0",
         "@babel/plugin-proposal-dynamic-import": "^7.16.0",
@@ -29742,7 +29611,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.0",
         "@babel/plugin-transform-new-target": "^7.16.0",
         "@babel/plugin-transform-object-super": "^7.16.0",
-        "@babel/plugin-transform-parameters": "^7.16.0",
+        "@babel/plugin-transform-parameters": "^7.16.3",
         "@babel/plugin-transform-property-literals": "^7.16.0",
         "@babel/plugin-transform-regenerator": "^7.16.0",
         "@babel/plugin-transform-reserved-words": "^7.16.0",
@@ -29755,10 +29624,10 @@
         "@babel/plugin-transform-unicode-regex": "^7.16.0",
         "@babel/preset-modules": "^0.1.5",
         "@babel/types": "^7.16.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.3",
-        "babel-plugin-polyfill-corejs3": "^0.3.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.3",
-        "core-js-compat": "^3.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "core-js-compat": "^3.19.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -31885,19 +31754,19 @@
       }
     },
     "@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-hermes": "^6.2.0",
+        "@react-native-community/cli-plugin-metro": "^6.2.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "commander": "^2.19.0",
         "cosmiconfig": "^5.1.0",
@@ -31912,7 +31781,6 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
         "ora": "^3.4.0",
         "pretty-format": "^26.6.2",
@@ -31935,18 +31803,6 @@
             "@types/node": "*",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-              "peer": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
           }
         },
         "@types/yargs": {
@@ -31956,16 +31812,6 @@
           "peer": true,
           "requires": {
             "@types/yargs-parser": "*"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
           }
         },
         "commander": {
@@ -32048,15 +31894,6 @@
           "peer": true,
           "requires": {
             "p-locate": "^4.1.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "npm-run-path": {
@@ -32169,38 +32006,26 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -32211,16 +32036,6 @@
         "xmldoc": "^1.1.2"
       },
       "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -32312,80 +32127,47 @@
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -32442,41 +32224,19 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "requires": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
         "shell-quote": "1.6.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "@react-native-community/cli-types": {
@@ -34870,10 +34630,11 @@
       }
     },
     "@types/pino-pretty": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.2.tgz",
-      "integrity": "sha512-a4/hqUb8AYNJYtWkR4cVpT9m2bcO6DUO+MLAtaLNCgYhbrleHJiUBgTSZfcFbaZwi1naAIQVKJbHVrj9YRfujQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "requires": {
+        "@types/node": "*",
         "@types/pino": "6.3"
       }
     },
@@ -35808,33 +35569,33 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.3.tgz",
-      "integrity": "sha512-NDZ0auNRzmAfE1oDDPW2JhzIMXUk+FFe2ICejmt5T4ocKgiQx3e0VCRx9NCAidcMtL2RUZaWtXnmjTCkx0tcbA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
       "peer": true,
       "requires": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "semver": "^6.1.1"
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.3.0.tgz",
-      "integrity": "sha512-JLwi9vloVdXLjzACL80j24bG6/T1gYxwowG44dg6HN/7aTPdyPbJJidf6ajoA3RPHHtW0j9KMrSOLpIZpAnPpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
       "peer": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
         "core-js-compat": "^3.18.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.3.tgz",
-      "integrity": "sha512-JVE78oRZPKFIeUqFGrSORNzQnrDwZR16oiWeGM8ZyjBn2XAT5OjP+wXx5ESuo33nUsFUEJYjtklnsKbxW5L+7g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
       "peer": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.4"
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
       }
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -37268,9 +37029,9 @@
       }
     },
     "coveo.analytics": {
-      "version": "2.18.51",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.51.tgz",
-      "integrity": "sha512-VwAauL8YZlByC2EV/SyBshUhD/iF04nDjCtEGJz9xSLyz9vTv65uYTcBHp7vJDfX8ZADOK0/TZdx6ub8r7/sBw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "requires": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
@@ -43824,9 +43585,9 @@
           }
         },
         "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
           "peer": true
         },
         "jest-get-type": {
@@ -46609,9 +46370,9 @@
       }
     },
     "reselect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.2.tgz",
-      "integrity": "sha512-wg60ebcPOtxcptIUfrr7Jt3h4BR86cCW3R7y4qt65lnNb4yz4QgrXcbSioVsIOYguyz42+XTHIyJ5TEruzkFgQ=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "resolve": {
       "version": "1.20.0",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -36,6 +36,9 @@
   "dependencies": {
     "@coveo/headless": "^1.33.0"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "devDependencies": {
     "@ckeditor/jsdoc-plugins": "^25.4.4",
     "@octokit/graphql": "^4.8.0",

--- a/packages/quantic/scripts/build/create-package.ts
+++ b/packages/quantic/scripts/build/create-package.ts
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/node-builtins */
 import * as fs from 'fs';
 import * as sfdx from './util/sfdx-commands';
 import * as path from 'path';

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -3,8 +3,7 @@ import * as path from 'path';
 import {StepLogger, StepsRunner} from './util/log';
 import * as sfdx from './util/sfdx-commands';
 import {SfdxJWTAuth} from './util/sfdx-commands';
-// eslint-disable-next-line node/no-unpublished-require
-const waitOn = require('wait-on');
+import waitOn from 'wait-on';
 
 interface Options {
   configFile: string;

--- a/packages/quantic/scripts/build/util/github.ts
+++ b/packages/quantic/scripts/build/util/github.ts
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unpublished-import */
 import {graphql} from '@octokit/graphql';
 import {
   Repository,

--- a/packages/quantic/scripts/build/util/sfdx.ts
+++ b/packages/quantic/scripts/build/util/sfdx.ts
@@ -1,5 +1,4 @@
 import {exec} from 'child_process';
-// eslint-disable-next-line node/no-unpublished-import
 import strip from 'strip-color';
 import * as path from 'path';
 

--- a/packages/samples/atomic/package-lock.json
+++ b/packages/samples/atomic/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "coveo-atomic-example-070-alpha33",
-      "version": "0.33.5",
+      "version": "0.33.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "serve": "11.3.2"

--- a/packages/samples/headless-react/package-lock.json
+++ b/packages/samples/headless-react/package-lock.json
@@ -5,9 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.42.0",
+      "name": "headless-react",
+      "version": "0.43.6",
       "dependencies": {
-        "@coveo/headless": "^1.31.0",
+        "@coveo/headless": "^1.33.0",
         "@testing-library/jest-dom": "5.14.1",
         "@testing-library/react": "11.2.7",
         "@testing-library/user-event": "13.2.1",
@@ -1373,16 +1374,16 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.32.7",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.7.tgz",
-      "integrity": "sha512-sUw+/2BwPPFdX0rapuPie+71eSPBVVea9lJPBLk7xJMlzVmWmAzl0vHabHsTs3GmGjW+POYFWBJbWKK5iv7Mug=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.0.tgz",
-      "integrity": "sha512-fInIpikQ1mXQCXqgKVH6X7INxhakDXoQYOeDsiV+XkAE9sMjEF+5sFLT/0RV5KLHPTzhYa5uXDIHuUXqAxndcA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.33.0.tgz",
+      "integrity": "sha512-xq8XKbSGeXqtnAEsEFCd+jvD+6JwVFeNRgR8wWc79+XJIm0Wj8futHf9dGOfpRefRmvyLI/7qn4Sgy7Jw1IgoA==",
       "dependencies": {
-        "@coveo/bueno": "^0.32.7",
+        "@coveo/bueno": "^0.33.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -2339,9 +2340,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.9.tgz",
-      "integrity": "sha512-LrVPfhKqodRiDWCgZp7J2X55JQqOhdQUxbl17RrktIGCZ0ud2XHdNoTIvyI1VccqHoF/CZK6v+G0IoX5NYZ1JA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.11.tgz",
+      "integrity": "sha512-l/I+PK+lh5M25QSdk44aX+UR63ian2d2CSx6WbydwU+RUZmKP7eOEPe+OeaTWgfOFSVtlEqEcP2AbW2YM7ukMA==",
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -2350,19 +2351,19 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-hermes": "^6.2.0",
+        "@react-native-community/cli-plugin-metro": "^6.2.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "commander": "^2.19.0",
         "cosmiconfig": "^5.1.0",
@@ -2377,7 +2378,6 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
         "ora": "^3.4.0",
         "pretty-format": "^26.6.2",
@@ -2408,14 +2408,14 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
@@ -2436,16 +2436,19 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli-hermes/node_modules/color-convert": {
@@ -2488,13 +2491,13 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -2521,16 +2524,19 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli-platform-android/node_modules/color-convert": {
@@ -2605,16 +2611,17 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
       }
@@ -2635,16 +2642,19 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/color-convert": {
@@ -2687,21 +2697,20 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
       }
     },
@@ -2721,16 +2730,19 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/color-convert": {
@@ -2773,13 +2785,13 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "dependencies": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -2800,16 +2812,15 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
@@ -2832,16 +2843,19 @@
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/color-convert": {
@@ -2881,9 +2895,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "peer": true,
       "bin": {
         "mime": "cli.js"
@@ -2971,16 +2985,19 @@
       }
     },
     "node_modules/@react-native-community/cli/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@react-native-community/cli/node_modules/color-convert": {
@@ -3159,11 +3176,11 @@
       "peer": true
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
-      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
+      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
       "dependencies": {
-        "immer": "^9.0.1",
+        "immer": "^9.0.6",
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0"
@@ -3901,9 +3918,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/pino": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.11.tgz",
-      "integrity": "sha512-S7+fLONqSpHeW9d7TApUqO6VN47KYgOXhCNKwGBVLHObq8HhaAYlVqUNdfnvoXjCMiwE5xcPm/5R2ZUh8bgaXQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
+      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
       "dependencies": {
         "@types/node": "*",
         "@types/pino-pretty": "*",
@@ -3912,11 +3929,12 @@
       }
     },
     "node_modules/@types/pino-pretty": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.1.tgz",
-      "integrity": "sha512-l1ntNXdpVWsnPYUk5HyO5Lxfr38zLCgxVfEn/9Zhhm+nGF04/BiIou/m8XPwvoVZLV+livUo79VdHXMJPfUYxA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "dependencies": {
-        "@types/pino": "*"
+        "@types/node": "*",
+        "@types/pino": "6.3"
       }
     },
     "node_modules/@types/pino-std-serializers": {
@@ -5631,9 +5649,9 @@
       }
     },
     "node_modules/big-integer": {
-      "version": "1.6.50",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-      "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "peer": true,
       "engines": {
         "node": ">=0.6"
@@ -6703,9 +6721,9 @@
       }
     },
     "node_modules/coveo.analytics": {
-      "version": "2.18.50",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.50.tgz",
-      "integrity": "sha512-zHouwVBfdvP2NXXeiCZDk8BtofKrYQeoLhdFTp/RwgS84jpHCtD3YstqXBEDN/kjWFtOaTt7YoRpmk2bcL8DMw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
@@ -7244,9 +7262,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
-      "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "peer": true,
       "engines": {
         "node": "*"
@@ -9265,9 +9283,9 @@
       }
     },
     "node_modules/fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastify-warning": {
       "version": "0.2.0",
@@ -14515,6 +14533,36 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/metro-react-native-babel-preset/node_modules/@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
     "node_modules/metro-react-native-babel-preset/node_modules/react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -14522,6 +14570,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro-react-native-babel-preset/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/metro-react-native-babel-transformer": {
@@ -14540,6 +14597,45 @@
       },
       "peerDependencies": {
         "@babel/core": "*"
+      }
+    },
+    "node_modules/metro-react-native-babel-transformer/node_modules/@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/metro-react-native-babel-transformer/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/metro-resolver": {
@@ -16208,9 +16304,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.1.tgz",
-      "integrity": "sha512-QQf67BU+cANnc/2U+wzUV20UjO5oBryWpnNyKshdLfT9BdeiXlh9wxLGmOjAuBWMYITdMs+BtJSQQNlGRNbWpA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
+      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
       "dependencies": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.8",
@@ -17893,9 +17989,9 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/quick-format-unescaped": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
-      "integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -18166,9 +18262,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.1.tgz",
-      "integrity": "sha512-BBvytmqlOLL+bRcO0jBiYfg16lYRsYDOC8/5E+bpnhb3EGtU+YCQAYfszw6JL7Hfy0ftnQNP5yj8pt+vqMHXIA==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.3.tgz",
+      "integrity": "sha512-B/dQpuvta9YvF5MihDWefoGlTvxzUHK5X5RjdrXHAu/ihTehJXxEA+m6z/tufp1ZUMDjU+tMZK6gnehzCuYfzw==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -18640,9 +18736,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -18656,9 +18752,12 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.0.tgz",
+      "integrity": "sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -18939,9 +19038,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/reselect": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "node_modules/resolve": {
       "version": "1.18.1",
@@ -20073,9 +20172,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.2.2.tgz",
-      "integrity": "sha512-tSkj2MFPpOt7VZ2IDmjcUrDlbyxUKqOQUvZBy98EdzGqaKptT3lFXWeQ1RYYGPjz597A8iG54lrGLTg4kEiAaA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.1.tgz",
+      "integrity": "sha512-o0vJPsRiCW5Q0EmRKjNiiYGy2DqSXcxk4mY9vIBSPwmkH/e/vJ2Tq8EECd5NTiO77x8vlVN+ykDjRQJTqf7eKg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -24856,16 +24955,16 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.32.7",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.32.7.tgz",
-      "integrity": "sha512-sUw+/2BwPPFdX0rapuPie+71eSPBVVea9lJPBLk7xJMlzVmWmAzl0vHabHsTs3GmGjW+POYFWBJbWKK5iv7Mug=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.33.0.tgz",
+      "integrity": "sha512-C+aik0Vr9qq0gG8qgMWZZT4MVDowkhBWVUgf7C4xKqxZb1Rdl2joUKoR9m2r2womL6aVsOiUWXdXgs/iKVvFIQ=="
     },
     "@coveo/headless": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.31.0.tgz",
-      "integrity": "sha512-fInIpikQ1mXQCXqgKVH6X7INxhakDXoQYOeDsiV+XkAE9sMjEF+5sFLT/0RV5KLHPTzhYa5uXDIHuUXqAxndcA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.33.0.tgz",
+      "integrity": "sha512-xq8XKbSGeXqtnAEsEFCd+jvD+6JwVFeNRgR8wWc79+XJIm0Wj8futHf9dGOfpRefRmvyLI/7qn4Sgy7Jw1IgoA==",
       "requires": {
-        "@coveo/bueno": "^0.32.7",
+        "@coveo/bueno": "^0.33.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -25627,27 +25726,27 @@
       }
     },
     "@react-native-async-storage/async-storage": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.9.tgz",
-      "integrity": "sha512-LrVPfhKqodRiDWCgZp7J2X55JQqOhdQUxbl17RrktIGCZ0ud2XHdNoTIvyI1VccqHoF/CZK6v+G0IoX5NYZ1JA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.11.tgz",
+      "integrity": "sha512-l/I+PK+lh5M25QSdk44aX+UR63ian2d2CSx6WbydwU+RUZmKP7eOEPe+OeaTWgfOFSVtlEqEcP2AbW2YM7ukMA==",
       "requires": {
         "merge-options": "^3.0.4"
       }
     },
     "@react-native-community/cli": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.1.0.tgz",
-      "integrity": "sha512-Ck1XjvsnYYVYqooxmSlvRvGMGgxj3t+evUGlg80b+TxnurhlGq8D8pW7++L/sECChI43YWMBtLIdAYG/lGkN8Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha512-dQMkpg8wLTtUg9YIGqm7OXNw558d5Cb/ehd8Z0Sx2WSXjj/d1Tm0eK8aL4/QFEUBI10CO6VGFTTe/8dIDxWSFg==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-hermes": "^6.1.0",
-        "@react-native-community/cli-plugin-metro": "^6.1.0",
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-hermes": "^6.2.0",
+        "@react-native-community/cli-plugin-metro": "^6.2.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "@react-native-community/cli-types": "^6.0.0",
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "commander": "^2.19.0",
         "cosmiconfig": "^5.1.0",
@@ -25662,7 +25761,6 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "node-stream-zip": "^1.9.1",
         "ora": "^3.4.0",
         "pretty-format": "^26.6.2",
@@ -25690,9 +25788,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -25832,14 +25930,14 @@
       }
     },
     "@react-native-community/cli-hermes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.1.0.tgz",
-      "integrity": "sha512-BJyzGlUqnggbBL4Vh4cIC08oKOK4PoelxZFEo7TjFjfdBKvbM6955JN77ExJ7IdeLuGVpY4vaMwAJdx5l7LxKg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-6.2.0.tgz",
+      "integrity": "sha512-7Uqnyb/kXiX4YPSxFn+tLhmABY4QV9w/SLX2TKh5L09rxDeNzXd6zNJW+98BTgi0ujy2UQY51MoexEKRMZK7Wg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-platform-android": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-platform-android": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       },
@@ -25854,9 +25952,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -25896,13 +25994,13 @@
       }
     },
     "@react-native-community/cli-platform-android": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.1.0.tgz",
-      "integrity": "sha512-MBYGfgCpieoqskKc5QyQYIPc74DBEW60JaacQLntHjPLCEXG+hPsJi3AuXeNTJYPki5pyiSp3kviqciUvrS96A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-6.2.0.tgz",
+      "integrity": "sha512-QLxwClcbxVhuIGsQiIpqRnoJzRdpN2B+y/Yt2OGgDHXGbuOXulgt4D+8AhvZXrB4jyAcEUlFg/048v3RGQQudw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "execa": "^1.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
@@ -25923,9 +26021,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -25991,16 +26089,17 @@
       }
     },
     "@react-native-community/cli-platform-ios": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.1.0.tgz",
-      "integrity": "sha512-whIm55fUeJUHrqZ2ecZ6FycZ5c/R3ZK8ViHwZQ+wM4uhXY8YSkrjnrJPUg68Q8inLkrAliLisypfm1z+VqJljw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-6.2.0.tgz",
+      "integrity": "sha512-k15MhExxLiLDDZOeuPgvTxbp0CsoLQQpk2Du0HjZDePqqWcKJylQqMZru1o8HuQHPcEr+b71HIs5V+lKyFYpfg==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "glob": "^7.1.3",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.15",
+        "ora": "^3.4.0",
         "plist": "^3.0.2",
         "xcode": "^2.0.0"
       },
@@ -26015,9 +26114,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -26057,21 +26156,20 @@
       }
     },
     "@react-native-community/cli-plugin-metro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.1.0.tgz",
-      "integrity": "sha512-ltHJquEgA6H4OTIUqWIkNm/xxAB9D4DK2K9M0jie9FfkOoqBXA7QS2WnC8GEa6a+3VIDwevB0RJsch218FdZCw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-6.2.0.tgz",
+      "integrity": "sha512-JfmzuFNzOr+dFTUQJo1rV0t87XAqgHRTMYXNleQVt8otOVCk1FSCgKlgqMdvQc/FCx2ZjoMWEEV/g0LrPI8Etw==",
       "peer": true,
       "requires": {
-        "@react-native-community/cli-server-api": "^6.1.0",
-        "@react-native-community/cli-tools": "^6.1.0",
-        "chalk": "^3.0.0",
+        "@react-native-community/cli-server-api": "^6.2.0",
+        "@react-native-community/cli-tools": "^6.2.0",
+        "chalk": "^4.1.2",
         "metro": "^0.66.1",
         "metro-config": "^0.66.1",
         "metro-core": "^0.66.1",
         "metro-react-native-babel-transformer": "^0.66.1",
         "metro-resolver": "^0.66.1",
         "metro-runtime": "^0.66.1",
-        "mkdirp": "^0.5.1",
         "readline": "^1.3.0"
       },
       "dependencies": {
@@ -26085,9 +26183,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -26127,13 +26225,13 @@
       }
     },
     "@react-native-community/cli-server-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.1.0.tgz",
-      "integrity": "sha512-WEJzdoF4JNUogZAd+Gdgbr+D/S/PHGjxH+PDjk3ST9pAUxEHb6naNwEl5dSJUY/ecBV63latNZkKunRyvFAx9A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-6.2.0.tgz",
+      "integrity": "sha512-OnbnYclhoDpjge33QO5Slhfn0DsmLzzAgyrSCnb24HhSqwq7ObjMHaLpoEhpajzLG71wq5oKh0APEQjiL4Mknw==",
       "peer": true,
       "requires": {
         "@react-native-community/cli-debugger-ui": "^6.0.0-rc.0",
-        "@react-native-community/cli-tools": "^6.1.0",
+        "@react-native-community/cli-tools": "^6.2.0",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.0",
@@ -26156,16 +26254,15 @@
       }
     },
     "@react-native-community/cli-tools": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.1.0.tgz",
-      "integrity": "sha512-MT8syhvk0vpfyYyHlcDoGicKcqMtBN7WPmDeyW16u+eKBtw/+EKq+86cFCuOHCfHK20ujG1mZqA1txxlCbu8GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-6.2.0.tgz",
+      "integrity": "sha512-08ssz4GMEnRxC/1FgTTN/Ud7mExQi5xMphItPjfHiTxpZPhrFn+IMx6mya0ncFEhhxQ207wYlJMRLPRRdBZ8oA==",
       "peer": true,
       "requires": {
         "appdirsjs": "^1.2.4",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.2",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "mkdirp": "^0.5.1",
         "node-fetch": "^2.6.0",
         "open": "^6.2.0",
         "semver": "^6.3.0",
@@ -26182,9 +26279,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -26219,9 +26316,9 @@
           "peer": true
         },
         "mime": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
           "peer": true
         },
         "open": {
@@ -26290,11 +26387,11 @@
       "peer": true
     },
     "@reduxjs/toolkit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
-      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.2.tgz",
+      "integrity": "sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==",
       "requires": {
-        "immer": "^9.0.1",
+        "immer": "^9.0.6",
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0"
@@ -26867,9 +26964,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/pino": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.11.tgz",
-      "integrity": "sha512-S7+fLONqSpHeW9d7TApUqO6VN47KYgOXhCNKwGBVLHObq8HhaAYlVqUNdfnvoXjCMiwE5xcPm/5R2ZUh8bgaXQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
+      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
       "requires": {
         "@types/node": "*",
         "@types/pino-pretty": "*",
@@ -26878,11 +26975,12 @@
       }
     },
     "@types/pino-pretty": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.1.tgz",
-      "integrity": "sha512-l1ntNXdpVWsnPYUk5HyO5Lxfr38zLCgxVfEn/9Zhhm+nGF04/BiIou/m8XPwvoVZLV+livUo79VdHXMJPfUYxA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.3.tgz",
+      "integrity": "sha512-Up2guG601DADD1xr4o3WSibPLpVgNVXGrdFg3Kl+RaS8Ym3XvlT8UV9/IH+8Mk4ykNAAOemQ4QkfDZKCjgYszA==",
       "requires": {
-        "@types/pino": "*"
+        "@types/node": "*",
+        "@types/pino": "6.3"
       }
     },
     "@types/pino-std-serializers": {
@@ -28377,9 +28475,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.50",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-      "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "peer": true
     },
     "big.js": {
@@ -29288,9 +29386,9 @@
       }
     },
     "coveo.analytics": {
-      "version": "2.18.50",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.50.tgz",
-      "integrity": "sha512-zHouwVBfdvP2NXXeiCZDk8BtofKrYQeoLhdFTp/RwgS84jpHCtD3YstqXBEDN/kjWFtOaTt7YoRpmk2bcL8DMw==",
+      "version": "2.18.52",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.52.tgz",
+      "integrity": "sha512-aLwZzllA9+zyEc9q/Ihp3k1nSv2ClmOl85eS3Z+DloBVykF65BniDFANgtti7CI/ZoH+Z6lPhzYIqetJfgvKRg==",
       "requires": {
         "@react-native-async-storage/async-storage": "^1.15.8",
         "cross-fetch": "^3.1.4"
@@ -29731,9 +29829,9 @@
       }
     },
     "dateformat": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
-      "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "peer": true
     },
     "dayjs": {
@@ -31393,9 +31491,9 @@
       "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg=="
     },
     "fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastify-warning": {
       "version": "0.2.0",
@@ -35741,6 +35839,7 @@
       "integrity": "sha512-H/nLBAz0MgfDloSe1FjyH4EnbokHFdncyERvLPXDACY3ROVRCeUyFNo70ywRGXW2NMbrV4H7KUyU4zkfWhC2HQ==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.14.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -35782,10 +35881,39 @@
         "react-refresh": "^0.4.0"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+          "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+          "peer": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-compilation-targets": "^7.16.0",
+            "@babel/helper-module-transforms": "^7.16.0",
+            "@babel/helpers": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "semver": "^6.3.0",
+            "source-map": "^0.5.0"
+          }
+        },
         "react-refresh": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
           "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
+          "peer": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "peer": true
         }
       }
@@ -35796,12 +35924,44 @@
       "integrity": "sha512-z1ab7ihIT0pJrwgi9q2IH+LcW/xUWMQ0hH+Mrk7wbKQB0RnJdXFoxphrfoVHBHMUu+TBPetUcEkKawkK1e7Cng==",
       "peer": true,
       "requires": {
+        "@babel/core": "^7.14.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.4.7",
         "metro-babel-transformer": "0.66.2",
         "metro-react-native-babel-preset": "0.66.2",
         "metro-source-map": "0.66.2",
         "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+          "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+          "peer": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-compilation-targets": "^7.16.0",
+            "@babel/helper-module-transforms": "^7.16.0",
+            "@babel/helpers": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "semver": "^6.3.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "peer": true
+        }
       }
     },
     "metro-resolver": {
@@ -37014,9 +37174,9 @@
       }
     },
     "pino": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.1.tgz",
-      "integrity": "sha512-QQf67BU+cANnc/2U+wzUV20UjO5oBryWpnNyKshdLfT9BdeiXlh9wxLGmOjAuBWMYITdMs+BtJSQQNlGRNbWpA==",
+      "version": "6.13.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
+      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.8",
@@ -38418,9 +38578,9 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "quick-format-unescaped": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
-      "integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "raf": {
       "version": "3.4.1",
@@ -38634,9 +38794,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-native": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.1.tgz",
-      "integrity": "sha512-BBvytmqlOLL+bRcO0jBiYfg16lYRsYDOC8/5E+bpnhb3EGtU+YCQAYfszw6JL7Hfy0ftnQNP5yj8pt+vqMHXIA==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.66.3.tgz",
+      "integrity": "sha512-B/dQpuvta9YvF5MihDWefoGlTvxzUHK5X5RjdrXHAu/ihTehJXxEA+m6z/tufp1ZUMDjU+tMZK6gnehzCuYfzw==",
       "peer": true,
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -38992,9 +39152,9 @@
       }
     },
     "redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -39008,9 +39168,10 @@
       }
     },
     "redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.0.tgz",
+      "integrity": "sha512-/y6ZKQNU/0u8Bm7ROLq9Pt/7lU93cT0IucYMrubo89ENjxPa7i8pqLKu6V4X7/TvYovQ6x01unTeyeZ9lgXiTA==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -39239,9 +39400,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "reselect": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.4.tgz",
+      "integrity": "sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ=="
     },
     "resolve": {
       "version": "1.18.1",
@@ -40196,9 +40357,9 @@
       }
     },
     "sonic-boom": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.2.2.tgz",
-      "integrity": "sha512-tSkj2MFPpOt7VZ2IDmjcUrDlbyxUKqOQUvZBy98EdzGqaKptT3lFXWeQ1RYYGPjz597A8iG54lrGLTg4kEiAaA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.1.tgz",
+      "integrity": "sha512-o0vJPsRiCW5Q0EmRKjNiiYGy2DqSXcxk4mY9vIBSPwmkH/e/vJ2Tq8EECd5NTiO77x8vlVN+ykDjRQJTqf7eKg==",
       "requires": {
         "atomic-sleep": "^1.0.0"
       }


### PR DESCRIPTION
fix a bunch of eslint-ignore.

engine in package.json is to fix the node/no-unsupported-features/node-builtins (i.e. specify which version of node to use for dev. I defaulted on maintenance LTS and above)

.npmignore is to fix the no-unpublished-import/require. Because you're not specifying which file you're publishing ('cause you ain't a npm package), you need to either add a file field in the package.json to specify the 'true sources', or do a npmignore to remove the non-source file. (think allow/ban list).
I did a npmignore here because 'twas easier for me, but the file approach is good as well.
