### PR TITLE
chore(atomic): set target to es2019

### DIFF
--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -7,6 +7,8 @@
     "lib": ["dom", "es2020"],
     "moduleResolution": "node",
     "module": "esnext",
+    // create-react-app compatibility 
+    // https://github.com/facebook/create-react-app/issues/9468#issuecomment-692963920
     "target": "es2019",
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["dom", "es2020"],
     "moduleResolution": "node",
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2019",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",


### PR DESCRIPTION
Built with --stats didn't see any significant changes, the dist/atomic folder is 5.7mb for both
https://coveord.atlassian.net/browse/KIT-1240