### PR TITLE
ci: publish package if first publish

### DIFF
--- a/scripts/deploy/publish.js
+++ b/scripts/deploy/publish.js
@@ -9,8 +9,14 @@ const pathToPackageJSON = resolve(process.cwd(), './package.json');
 const pkg = JSON.parse(readFileSync(pathToPackageJSON));
 const packageRef = `${pkg.name}@${pkg.version}`;
 
-function isPublished() {
-  return !!execSync(`npm view ${packageRef}`).toString().length;
+function shouldPublish() {
+  try {
+    const packageVersionNotPublished = !execSync(`npm view ${packageRef}`).toString().length;
+    return packageVersionNotPublished;
+  } catch (e) {
+    const isFirstPublish = e.toString().includes('404 Not Found');
+    return isFirstPublish;
+  }
 }
 
 function publish() {
@@ -23,7 +29,7 @@ function publish() {
   });
 }
 
-if (!isPublished()) {
+if (shouldPublish()) {
   publish();
 } else {
   console.info(


### PR DESCRIPTION
When a package does not exist on npm (e.g. when a package is being published for the first time), `npm view` throws an error.

https://coveord.atlassian.net/browse/KIT-1246