### PR TITLE
feat(headless): renamed interface to match state

### DIFF
--- a/packages/headless/src/features/case-field/case-field-actions.ts
+++ b/packages/headless/src/features/case-field/case-field-actions.ts
@@ -95,7 +95,7 @@ export const buildFetchClassificationRequest = async (
   ...(state.configuration.analytics.enabled && {
     visitorId: await getVisitorID(),
   }),
-  fields: state.caseInputs,
+  fields: state.caseInput,
   locale: state.caseAssistConfiguration.locale,
   debug: state.debug,
 });

--- a/packages/headless/src/state/state-sections.ts
+++ b/packages/headless/src/state/state-sections.ts
@@ -324,12 +324,12 @@ export interface CaseInputSection {
   /**
    * The case inputs.
    */
-  caseInputs: CaseInputState;
+  caseInput: CaseInputState;
 }
 
 export interface CaseFieldSection {
   /**
    * The case fields and their predicted values.
    */
-  caseFields: CaseFieldState;
+  caseField: CaseFieldState;
 }


### PR DESCRIPTION
The reducer names didn't match the interfaces after a renaming effort left them out in the cold.