### PR TITLE
fix(atomic): fix line clamp max height & break word in title section

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-cell-desktop.pcss
@@ -48,8 +48,8 @@
 
     atomic-result-section-title {
       @mixin set-font-size var(--atomic-text-2xl);
+      word-break: break-word;
 
-      max-height: 4rem;
       @mixin line-clamp 2;
     }
 
@@ -67,7 +67,6 @@
       @mixin set-font-size var(--atomic-text-lg);
 
       margin-top: 2.25rem;
-      max-height: 4.5rem;
       @mixin line-clamp 3;
     }
 
@@ -113,8 +112,7 @@
 
     atomic-result-section-title {
       @mixin set-font-size var(--atomic-text-xl);
-
-      max-height: 3rem;
+      word-break: break-word;
       @mixin line-clamp 2;
     }
 
@@ -132,7 +130,6 @@
       @mixin set-font-size var(--atomic-text-base);
 
       margin-top: 1.75rem;
-      max-height: 2.5rem;
       @mixin line-clamp 2;
     }
 
@@ -178,8 +175,7 @@
 
     atomic-result-section-title {
       @mixin set-font-size var(--atomic-text-xl);
-
-      max-height: 3rem;
+      word-break: break-word;
       @mixin line-clamp 2;
     }
 
@@ -197,7 +193,6 @@
       @mixin set-font-size var(--atomic-text-base);
 
       margin-top: 1.25rem;
-      max-height: 1.25rem;
       @mixin line-clamp 1;
     }
 


### PR DESCRIPTION
Original problem was about title being cutoff when it could not wrap (ie: a title contains underscore), so I've added a `word-break: break-word` rule.

The text would start to wrap properly, however the bottom of the title text is cutoff when it wraps on two line, because there's max height applied.

@btaillon I'm not a 100% sure about this one, since your last changes on this file were about switching from a `min-height` to a `max-height` for sections.

I don't think it's necessary ? Don't we want sections to stretch "as much as needed" depending on their content ?

https://coveord.atlassian.net/browse/KIT-1155