### PR TITLE
docs(atomic): remove mdx files from storybook config

### DIFF
--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -112,13 +112,12 @@ export default function defaultResultComponentStory(
   title: string,
   componentTag: string,
   defaultArgs: Args,
-  docPage: typeof DocsPage,
   advancedConfig: DefaultStoryAdvancedConfig = {}
 ) {
   const config = buildConfigWithDefaultValues(advancedConfig);
 
   const {defaultModuleExport, exportedStory, getArgs, updateCurrentArgs} =
-    sharedDefaultStory(title, componentTag, defaultArgs, docPage, true, config);
+    sharedDefaultStory(title, componentTag, defaultArgs, true, config);
 
   defaultModuleExport.argTypes = {
     ...resultComponentArgTypes,

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -1,7 +1,6 @@
 import {h} from '@stencil/core';
 import {SearchEngineConfiguration} from '@coveo/headless';
 import {Args} from '@storybook/api';
-import {DocsPage} from '@storybook/addon-docs';
 import {render, TemplateResult} from 'lit-html';
 import {mapPropsToArgTypes} from './map-props-to-args';
 import {resultComponentArgTypes} from './map-result-list-props-to-args';
@@ -100,7 +99,6 @@ export default function sharedDefaultStory(
   title: string,
   componentTag: string,
   defaultArgs: Args,
-  docPage: typeof DocsPage,
   isResultComponent: boolean,
   advancedConfig: DefaultStoryAdvancedConfig = {}
 ) {
@@ -115,8 +113,9 @@ export default function sharedDefaultStory(
     argTypes: mapPropsToArgTypes(componentTag),
     parameters: {
       docs: {
-        page: docPage,
+        page: null,
       },
+      viewMode: 'canvas',
       [ADDON_PARAMETER_KEY]: {
         componentTag,
         isResultComponent,

--- a/packages/atomic/.storybook/default-story.tsx
+++ b/packages/atomic/.storybook/default-story.tsx
@@ -13,7 +13,6 @@ export default function defaultStory(
   title: string,
   componentTag: string,
   defaultArgs: Args,
-  docPage: typeof DocsPage,
   advancedConfig: DefaultStoryAdvancedConfig = {}
 ) {
   const {defaultModuleExport, exportedStory, getArgs, updateCurrentArgs} =
@@ -21,7 +20,6 @@ export default function defaultStory(
       title,
       componentTag,
       defaultArgs,
-      docPage,
       false,
       advancedConfig
     );

--- a/packages/atomic/.storybook/preview.js
+++ b/packages/atomic/.storybook/preview.js
@@ -27,4 +27,13 @@ export const parameters = {
     element: 'atomic-search-interface',
     manual: true,
   },
+  docs: {
+    page: null,
+    disable: true,
+  },
+  previewTabs: {
+    'storybook/docs/panel': {
+      hidden: true
+    }
+  }
 };

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.mdx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.mdx
@@ -1,3 +1,0 @@
-# Breadbox
-
-TODO

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.stories.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.stories.tsx
@@ -1,12 +1,10 @@
 import defaultStory from '../../../.storybook/default-story';
-import BreadboxDoc from './atomic-breadbox.mdx';
 import {html} from 'lit-html';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/Breadbox',
   'atomic-breadbox',
   {},
-  BreadboxDoc,
   {
     additionalMarkup: () =>
       html`

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.mdx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.mdx
@@ -1,3 +1,0 @@
-# Did You Mean
-
-TODO

--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.stories.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import DidYouMeanDoc from './atomic-did-you-mean.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/DidYouMean',
   'atomic-did-you-mean',
   {},
-  DidYouMeanDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.mdx
+++ b/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.mdx
@@ -1,3 +1,0 @@
-# Facet Manager
-
-TODO

--- a/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.stories.tsx
+++ b/packages/atomic/src/components/atomic-facet-manager/atomic-facet-manager.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../.storybook/default-story';
-import FacetManagerDoc from './atomic-facet-manager.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/FacetManager',
   'atomic-facet-manager',
   {},
-  FacetManagerDoc,
   {
     additionalMarkup: () => html`
       <style>

--- a/packages/atomic/src/components/atomic-icon/atomic-icon.mdx
+++ b/packages/atomic/src/components/atomic-icon/atomic-icon.mdx
@@ -1,3 +1,0 @@
-# Icon
-
-TODO

--- a/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
+++ b/packages/atomic/src/components/atomic-icon/atomic-icon.stories.tsx
@@ -1,6 +1,5 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../.storybook/default-story';
-import IconDoc from './atomic-icon.mdx';
 import AssetsList from '../../../docs/assets.json';
 import bgIcons from '@salesforce-ux/design-system/design-tokens/dist/bg-standard.common';
 
@@ -16,7 +15,6 @@ const {defaultModuleExport, exportedStory} = defaultStory(
   {
     icon: 'assets://account.svg',
   },
-  IconDoc,
   {
     additionalMarkup: () => {
       return html`

--- a/packages/atomic/src/components/atomic-load-more-results/atomic-load-more-results.mdx
+++ b/packages/atomic/src/components/atomic-load-more-results/atomic-load-more-results.mdx
@@ -1,3 +1,0 @@
-# Load more Results
-
-TODO

--- a/packages/atomic/src/components/atomic-load-more-results/atomic-load-more-results.stories.tsx
+++ b/packages/atomic/src/components/atomic-load-more-results/atomic-load-more-results.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import LoadMoreResultsDoc from './atomic-load-more-results.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/LoadMoreResults',
   'atomic-load-more-results',
-  {},
-  LoadMoreResultsDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/atomic-no-results/atomic-no-results.mdx
+++ b/packages/atomic/src/components/atomic-no-results/atomic-no-results.mdx
@@ -1,3 +1,0 @@
-# No Results
-
-TODO

--- a/packages/atomic/src/components/atomic-no-results/atomic-no-results.stories.tsx
+++ b/packages/atomic/src/components/atomic-no-results/atomic-no-results.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import NoResultsDoc from './atomic-no-results.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NoResult',
   'atomic-no-results',
   {},
-  NoResultsDoc,
   {
     engineConfig: {
       search: {

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.mdx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.mdx
@@ -1,3 +1,0 @@
-# Pager
-
-TODO

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.stories.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import PagerDoc from './atomic-pager.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/Pager',
   'atomic-pager',
-  {},
-  PagerDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.mdx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.mdx
@@ -1,3 +1,0 @@
-# Query Error
-
-TODO

--- a/packages/atomic/src/components/atomic-query-error/atomic-query-error.stories.tsx
+++ b/packages/atomic/src/components/atomic-query-error/atomic-query-error.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import QueryErrorDoc from './atomic-query-error.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/QueryError',
   'atomic-query-error',
   {},
-  QueryErrorDoc,
   {
     engineConfig: {
       accessToken: 'invalidtoken',

--- a/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.stories.tsx
+++ b/packages/atomic/src/components/atomic-query-summary/atomic-query-summary.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import QuerySummaryDoc from './atomic-query-summary.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/QuerySummary',
   'atomic-query-summary',
-  {},
-  QuerySummaryDoc
+  {}
 );
 export default defaultModuleExport;
 export const DefaultQuerySummary = exportedStory;

--- a/packages/atomic/src/components/atomic-refine-toggle/atomic-refine-toggle.mdx
+++ b/packages/atomic/src/components/atomic-refine-toggle/atomic-refine-toggle.mdx
@@ -1,3 +1,0 @@
-# Refine Toggle
-
-TODO

--- a/packages/atomic/src/components/atomic-refine-toggle/atomic-refine-toggle.stories.tsx
+++ b/packages/atomic/src/components/atomic-refine-toggle/atomic-refine-toggle.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../.storybook/default-story';
-import RefineToggleDoc from './atomic-refine-toggle.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/RefineToggle',
   'atomic-refine-toggle',
   {},
-  RefineToggleDoc,
   {
     additionalMarkup: () => html`
       <div style="display:none;">

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.mdx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.mdx
@@ -1,3 +1,0 @@
-# Atomic Result List
-
-TODO

--- a/packages/atomic/src/components/atomic-result-list/atomic-result-list.stories.tsx
+++ b/packages/atomic/src/components/atomic-result-list/atomic-result-list.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import ResultListDoc from './atomic-result-list.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/ResultList',
   'atomic-result-list',
-  {},
-  ResultListDoc
+  {}
 );
 export default defaultModuleExport;
 export const DefaultResultList = exportedStory;

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.mdx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.mdx
@@ -1,3 +1,0 @@
-# Results per page
-
-TODO

--- a/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.stories.tsx
+++ b/packages/atomic/src/components/atomic-results-per-page/atomic-results-per-page.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import ResultsPerPageDoc from './atomic-results-per-page.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/ResultsPerPage',
   'atomic-results-per-page',
-  {},
-  ResultsPerPageDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.stories.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import SearchboxDoc from './atomic-search-box.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/Searchbox',
   'atomic-search-box',
-  {},
-  SearchboxDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.stories.tsx
@@ -7,6 +7,9 @@ export default {
       canvas: {
         hidden: true,
       },
+      'storybook/docs/panel': {
+        hidden: false,
+      },
     },
     viewMode: 'docs',
     docs: {

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.mdx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.mdx
@@ -1,3 +1,0 @@
-# Sort Dropdown
-
-TODO

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.stories.tsx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../.storybook/default-story';
-import SortDropdownDoc from './atomic-sort-dropdown.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/SortDropdown',
   'atomic-sort-dropdown',
   {},
-  SortDropdownDoc,
   {
     additionalChildMarkup: () => html`
       <atomic-sort-expression

--- a/packages/atomic/src/components/atomic-sort-expression/atomic-sort-expression.mdx
+++ b/packages/atomic/src/components/atomic-sort-expression/atomic-sort-expression.mdx
@@ -1,3 +1,0 @@
-# Sort Expression
-
-TODO

--- a/packages/atomic/src/components/atomic-sort-expression/atomic-sort-expression.stories.tsx
+++ b/packages/atomic/src/components/atomic-sort-expression/atomic-sort-expression.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import SortExpressionDoc from './atomic-sort-expression.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/SortDropdown/SortExpression',
   'atomic-sort-expression',
   {label: 'Relevance', expression: 'relevancy'},
-  SortExpressionDoc,
   {parentElement: () => document.createElement('atomic-sort-dropdown')}
 );
 

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.mdx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.mdx
@@ -1,3 +1,0 @@
-# Category Facet
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import CategoryFacetDoc from './atomic-category-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/CategoryFacet',
   'atomic-category-facet',
   {field: 'geographicalhierarchy'},
-  CategoryFacetDoc,
   {
     additionalMarkup: () => html`<style>
       atomic-category-facet {

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.mdx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.mdx
@@ -1,3 +1,0 @@
-# Color Facet
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import ColorFacetDoc from './atomic-color-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/ColorFacet',
   'atomic-color-facet',
   {field: 'filetype', numberOfValues: '9'},
-  ColorFacetDoc,
   {
     additionalMarkup: () => html`<style>
       atomic-color-facet {

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.mdx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.mdx
@@ -1,3 +1,0 @@
-# Facet
-
-This is the documentation that will appear in Storybook "Docs" panel for a facet.

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import FacetDoc from './atomic-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/Facet',
   'atomic-facet',
   {field: 'objecttype'},
-  FacetDoc,
   {
     additionalMarkup: () => html`<style>
       atomic-facet {

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import NumericFacetDoc from './atomic-numeric-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NumericFacet',
   'atomic-numeric-facet',
   {field: 'ytviewcount'},
-  NumericFacetDoc,
   {
     additionalMarkup: () => html`<style>
       atomic-numeric-facet {

--- a/packages/atomic/src/components/facets/atomic-numeric-range/atomic-numeric-range.mdx
+++ b/packages/atomic/src/components/facets/atomic-numeric-range/atomic-numeric-range.mdx
@@ -1,3 +1,0 @@
-# Numeric Range
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-numeric-range/atomic-numeric-range.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-range/atomic-numeric-range.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../../.storybook/default-story';
-import NumericRangeDoc from './atomic-numeric-range.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NumericFacet/Range',
   'atomic-numeric-range',
   {start: 0, end: 1000},
-  NumericRangeDoc,
   {
     parentElement: () => {
       const numericFacet = document.createElement('atomic-numeric-facet');

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.mdx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.mdx
@@ -1,3 +1,0 @@
-# Rating Facet
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import RatingFacetDoc from './atomic-rating-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/RatingFacet',
   'atomic-rating-facet',
   {field: 'snrating'},
-  RatingFacetDoc,
   {
     additionalMarkup: () => html`<style>
       atomic-rating-facet {

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.mdx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.mdx
@@ -1,3 +1,0 @@
-# Timeframe Facet
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.stories.tsx
@@ -1,6 +1,5 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import TimeframeFacetDoc from './atomic-timeframe-facet.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/TimeframeFacet',
@@ -8,7 +7,6 @@ const {defaultModuleExport, exportedStory} = defaultStory(
   {
     unit: 'year',
   },
-  TimeframeFacetDoc,
   {
     additionalMarkup: () => html`
       <style>

--- a/packages/atomic/src/components/facets/atomic-timeframe/atomic-timeframe.mdx
+++ b/packages/atomic/src/components/facets/atomic-timeframe/atomic-timeframe.mdx
@@ -1,3 +1,0 @@
-# Timeframe
-
-TODO

--- a/packages/atomic/src/components/facets/atomic-timeframe/atomic-timeframe.stories.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe/atomic-timeframe.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultStory from '../../../../.storybook/default-story';
-import TimeframeDoc from './atomic-timeframe.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/TimeframeFacet/Timeframe',
   'atomic-timeframe',
   {unit: 'year'},
-  TimeframeDoc,
   {
     additionalMarkup: () => html`
       <style>

--- a/packages/atomic/src/components/formats/atomic-format-currency.mdx
+++ b/packages/atomic/src/components/formats/atomic-format-currency.mdx
@@ -1,3 +1,0 @@
-# Format currency
-
-TODO

--- a/packages/atomic/src/components/formats/atomic-format-currency.numeric-facet.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-currency.numeric-facet.stories.tsx
@@ -1,5 +1,4 @@
 import defaultStory from '../../../.storybook/default-story';
-import FormatCurrencyDoc from './atomic-format-currency.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NumericFacet/Format/Currency',
@@ -7,7 +6,6 @@ const {defaultModuleExport, exportedStory} = defaultStory(
   {
     currency: 'USD',
   },
-  FormatCurrencyDoc,
   {
     parentElement: () => {
       const numericFacetElement = document.createElement(

--- a/packages/atomic/src/components/formats/atomic-format-currency.result-number.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-currency.result-number.stories.tsx
@@ -1,5 +1,4 @@
 import defaultResultComponentStory from '../../../.storybook/default-result-component-story';
-import FormatCurrencyDoc from './atomic-format-currency.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultNumber/Format/Currency',
@@ -7,7 +6,6 @@ const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   {
     currency: 'USD',
   },
-  FormatCurrencyDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/formats/atomic-format-number.mdx
+++ b/packages/atomic/src/components/formats/atomic-format-number.mdx
@@ -1,3 +1,0 @@
-# Format number 
-
-TODO

--- a/packages/atomic/src/components/formats/atomic-format-number.numeric-facet.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-number.numeric-facet.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import FormatNumberDoc from './atomic-format-number.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NumericFacet/Format/Number',
   'atomic-format-number',
   {},
-  FormatNumberDoc,
   {
     parentElement: () => {
       const numericFacetElement = document.createElement(

--- a/packages/atomic/src/components/formats/atomic-format-number.result-number.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-number.result-number.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../.storybook/default-result-component-story';
-import FormatNumberDoc from './atomic-format-number.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultNumber/Format/Number',
   'atomic-format-number',
   {},
-  FormatNumberDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/formats/atomic-format-unit.mdx
+++ b/packages/atomic/src/components/formats/atomic-format-unit.mdx
@@ -1,3 +1,0 @@
-# Format unit
-
-TODO

--- a/packages/atomic/src/components/formats/atomic-format-unit.numeric-facet.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-unit.numeric-facet.stories.tsx
@@ -1,11 +1,9 @@
 import defaultStory from '../../../.storybook/default-story';
-import FormatUnitDoc from './atomic-format-unit.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/NumericFacet/Format/Unit',
   'atomic-format-unit',
   {unit: 'byte'},
-  FormatUnitDoc,
   {
     parentElement: () => {
       const numericFacetElement = document.createElement(

--- a/packages/atomic/src/components/formats/atomic-format-unit.result-number.stories.tsx
+++ b/packages/atomic/src/components/formats/atomic-format-unit.result-number.stories.tsx
@@ -1,5 +1,4 @@
 import defaultResultComponentStory from '../../../.storybook/default-result-component-story';
-import FormatUnitDoc from './atomic-format-unit.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultNumber/Format/Unit',
@@ -7,7 +6,6 @@ const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   {
     unit: 'byte',
   },
-  FormatUnitDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.mdx
@@ -1,3 +1,0 @@
-# Field Condition
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-field-condition/atomic-field-condition.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import FieldConditionDoc from './atomic-field-condition.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/FieldCondition',
   'atomic-field-condition',
   {},
-  FieldConditionDoc,
   {
     additionalChildMarkup: () =>
       html`

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.mdx
@@ -1,3 +1,0 @@
-# Result Badge
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultBadgeDocumentation from './atomic-result-badge.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultBadge',
   'atomic-result-badge',
-  {field: 'filetype'},
-  ResultBadgeDocumentation
+  {field: 'filetype'}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.mdx
@@ -1,3 +1,0 @@
-# Result Date
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-date/atomic-result-date.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultDateDoc from './atomic-result-date.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultDate',
   'atomic-result-date',
-  {},
-  ResultDateDoc
+  {}
 );
 export default defaultModuleExport;
 export const DefaultResultDate = exportedStory;

--- a/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.mdx
@@ -1,3 +1,0 @@
-# Result Fields List
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.stories.tsx
@@ -1,12 +1,10 @@
 import {html} from 'lit-html';
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultFieldsListDoc from './atomic-result-fields-list.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultFieldsList',
   'atomic-result-fields-list',
   {},
-  ResultFieldsListDoc,
   {
     additionalChildMarkup: () => html`
       <style>

--- a/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.mdx
@@ -1,3 +1,0 @@
-# Result Icon
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-icon/atomic-result-icon.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultIconDoc from './atomic-result-icon.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultIcon',
   'atomic-result-icon',
-  {},
-  ResultIconDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.mdx
@@ -1,3 +1,0 @@
-# Result Image
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.stories.tsx
@@ -1,5 +1,4 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultImageDoc from './atomic-result-image.mdx';
 
 // TODO: This will require KIT-1178 to actually be usable properly
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
@@ -8,7 +7,6 @@ const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   {
     field: 'randomimage',
   },
-  ResultImageDoc,
   {
     engineConfig: {
       search: {

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.mdx
@@ -1,3 +1,0 @@
-# Result link
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-link/atomic-result-link.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultLinkDoc from './atomic-result-link.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultLink',
   'atomic-result-link',
-  {},
-  ResultLinkDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
@@ -1,3 +1,0 @@
-# Result Multi Value Text
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.stories.tsx
@@ -1,12 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultMultiValueDoc from './atomic-result-multi-value-text.mdx';
 
-// TODO: Would benefit from KIT-1178
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultMultiValue',
   'atomic-result-multi-value-text',
-  {field: 'language'},
-  ResultMultiValueDoc
+  {field: 'language'}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.mdx
@@ -1,3 +1,0 @@
-# Result number
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-number/atomic-result-number.stories.tsx
@@ -1,13 +1,10 @@
 import {html} from 'lit-html';
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultNumberDoc from './atomic-result-number.mdx';
 
-// TODO: Would benefit a lot from KIT-1167
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultNumber',
   'atomic-result-number',
   {field: 'size'},
-  ResultNumberDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.mdx
@@ -1,3 +1,0 @@
-# Result Printable Uri
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultPrintableUriDoc from './atomic-result-printable-uri.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultPrintableUri',
   'atomic-result-printable-uri',
-  {},
-  ResultPrintableUriDoc
+  {}
 );
 
 export default defaultModuleExport;

--- a/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.mdx
@@ -1,3 +1,0 @@
-# Result Rating
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-rating/atomic-result-rating.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultRatingDoc from './atomic-result-rating.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultRating',
   'atomic-result-rating',
   {field: 'snrating'},
-  ResultRatingDoc,
   {
     engineConfig: {
       preprocessRequest: (r) => {

--- a/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.mdx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.mdx
@@ -1,3 +1,0 @@
-# Result Text
-
-TODO

--- a/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.stories.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-text/atomic-result-text.stories.tsx
@@ -1,11 +1,9 @@
 import defaultResultComponentStory from '../../../../.storybook/default-result-component-story';
-import ResultTextDoc from './atomic-result-text.mdx';
 
 const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
   'Atomic/ResultList/ResultText',
   'atomic-result-text',
-  {field: 'excerpt'},
-  ResultTextDoc
+  {field: 'excerpt'}
 );
 export default defaultModuleExport;
 export const DefaultResultText = exportedStory;


### PR DESCRIPTION
After a small meeting on Friday, we will change up a bit the way we want to integrate Storybook in our doc website. All the "long form" written article for each individual component will be done outside of Storybook.

This PR removes all the "TODO" mdx files.

https://coveord.atlassian.net/browse/KIT-1248