### PR TITLE
docs(atomic): visual improvements for css edition and hide confusing ui options

### DIFF
--- a/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
+++ b/packages/atomic/.storybook/code-sample-addon/code-sample-panel.tsx
@@ -60,6 +60,10 @@ export const CodeSamplePanel = () => {
         position: 'relative',
       }}
     >
+      <p style={{fontWeight: 'bold', fontSize: '1rem'}}>
+        Modify Controls and Shadow Parts to see the changes reflected in this
+        code sample.
+      </p>
       <MonacoEditor
         width="100%"
         height="800px"
@@ -95,7 +99,7 @@ export const CodeSamplePanel = () => {
       <button
         style={{
           position: 'absolute',
-          top: '20px',
+          top: '70px',
           right: '20px',
           backgroundColor: 'white',
           border: '1px solid rgba(0,0,0,0.1)',

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -142,7 +142,11 @@ export default function sharedDefaultStory(
   const defaultLoader = () => console.log('Not implemented');
   const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
     updateCurrentArgs(params.args);
-    return <Story />;
+    return (
+      <div>
+        <Story />
+      </div>
+    );
   };
 
   exportedStory.loaders = [defaultLoader];

--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -142,11 +142,7 @@ export default function sharedDefaultStory(
   const defaultLoader = () => console.log('Not implemented');
   const defaultDecorator = (Story: () => JSX.Element, params: {args: Args}) => {
     updateCurrentArgs(params.args);
-    return (
-      <div>
-        <Story />
-      </div>
-    );
+    return <Story />;
   };
 
   exportedStory.loaders = [defaultLoader];

--- a/packages/atomic/.storybook/manager-head.html
+++ b/packages/atomic/.storybook/manager-head.html
@@ -1,0 +1,16 @@
+<style type="text/css">
+  #about,
+  #release-notes,
+  button[title='Hide addons [A]'] {
+    display: none !important;
+  }
+  #panel-tab-content .docblock-emptyblock {
+    visibility: hidden;
+  }
+  #panel-tab-content .docblock-emptyblock:after {
+    visibility: visible;
+    font-size: 1rem;
+    content: 'This component does not expose any property.';
+    position: absolute;
+  }
+</style>

--- a/packages/atomic/.storybook/shadow-parts-addon/shadow-parts-panel.tsx
+++ b/packages/atomic/.storybook/shadow-parts-addon/shadow-parts-panel.tsx
@@ -45,6 +45,7 @@ export const ShadowPartPanel: React.FunctionComponent<{}> = () => {
                 </button>
                 <textarea
                   style={{display: isOpened ? 'block' : 'none'}}
+                  placeholder="Examples: &#10;background-color: inherit;&#10;color: blue;&#10;font-weight: bold;"
                   onChange={(v) => {
                     updateArgs({
                       [`${ADDON_PARAMETER_KEY}:${part.name}`]: v.target.value,


### PR DESCRIPTION
After discussion with doc team last Friday, some improvements for storybook: 

* Change the default message displayed when a component does not have any property
* Add a placeholder for shadow-parts edition panel that shows that it expects CSS rules
* Hide some UI elements in the navigation menu that can be confusing ( About Storybook section, Storybook release notes, button that allows to hide panel completely)
* Add some clarification for the code sample addon,

https://coveord.atlassian.net/browse/KIT-1249