### PR TITLE
fix(atomic): init SafeStorage before calling it

### DIFF
--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -41,13 +41,13 @@ export class AtomicSearchBoxRecentQueries {
   }
 
   private initialize() {
+    this.storage = new SafeStorage();
     this.recentQueriesList = buildRecentQueriesList(this.bindings.engine, {
       initialState: {queries: this.retrieveLocalStorage()},
       options: {maxLength: 1000},
     });
 
     this.recentQueriesList.subscribe(() => this.updateLocalStorage());
-    this.storage = new SafeStorage();
 
     return {
       position: Array.from(this.host.parentNode!.children).indexOf(this.host),


### PR DESCRIPTION
Started seeing an error in the console because of this, `retrieveLocalStorage` calls an undefined `this.storage`
https://coveord.atlassian.net/browse/KIT-1256