### PR TITLE
ci: specify cypress --quiet option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ node('linux && docker') {
               sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'
               sh 'cd packages/atomic && npm run start:prod & npx wait-on http://localhost:3333'
               sh 'chown -R $(whoami) /tmp'
-              sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome'
+              sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome --quiet'
             },
             'quantic': {
               withCredentials([


### PR DESCRIPTION
This option will remove the cypress logging, but keep the mocha `spec` reporter logs.

Default logging:

![cypress-default-verbosity](https://user-images.githubusercontent.com/5565841/144093375-6904ad8c-c42f-4383-a0a4-de828d74fc76.PNG)


With `--quiet` option:

![cypress-quiet](https://user-images.githubusercontent.com/5565841/144093428-5b33c73a-48d2-484a-85eb-18b47b3cb00e.PNG)




