### PR TITLE
fix(headless): always build external builds locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ To build a single project for production (for instance, the `product-listing` pa
 npm run build  -- --filter product-listing
 ```
 
-To start all projects in development (you should run `npm run build` at least once first), run:
+To start a single project in development (for instance, the `quantic` package), run:
 
 ```sh
-npm start
+npm start -- --scope @coveo/quantic 
 ```
 
-To start Atomic & Headless simultaneously in development, run:
+To start Atomic & Headless simultaneously in development (recommended), run:
 
 ```sh
 npm run dev

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -222,8 +222,8 @@ function copySourceFiles() {
   });
 }
 
-// For Atomic's development purposes only
-const dev = [
+// For Atomic's local development purposes only
+const local = [
   {
     input: 'src/index.ts',
     output: [buildEsmOutput('../atomic/src/external-builds')],
@@ -246,6 +246,14 @@ const dev = [
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
-const config = isProduction ? [...nodejs, ...browser] : dev;
+const config = [];
+
+if (isProduction) {
+  config.push(...nodejs, ...browser);
+}
+
+if (!isCI) {
+  config.push(...local)
+}
 
 export default config;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1262

The problem was running (from root)
```
npm run setup
npm run build
```
did not create the external-builds that Atomic needs, I changed the config so it runs locally for both dev/prod configs