### PR TITLE
chore(headless): draft PR for react hooks and decorators

### DIFF
--- a/packages/samples/headless-react/src/App.tsx
+++ b/packages/samples/headless-react/src/App.tsx
@@ -4,6 +4,7 @@ import {BrowserRouter, NavLink, Switch, Route} from 'react-router-dom';
 import {RecommendationPage} from './pages/RecommendationPage';
 import {StandaloneSearchBoxPage} from './pages/StandaloneSearchBoxPage';
 import {SamlPage} from './pages/SamlPage';
+import {PageWithHooks} from './pages/PageWithHooks';
 
 function App(props: SearchPageProps) {
   const activeNavLink: React.CSSProperties = {color: 'red'};
@@ -53,6 +54,9 @@ function App(props: SearchPageProps) {
           </Route>
           <Route path="/search-page">
             <SearchPage {...props} />
+          </Route>
+          <Route path="/hooks">
+            <PageWithHooks />
           </Route>
           <Route path="/">
             <SearchPage {...props} />

--- a/packages/samples/headless-react/src/components/facet/facet-hook.ts
+++ b/packages/samples/headless-react/src/components/facet/facet-hook.ts
@@ -1,0 +1,110 @@
+import {
+  buildFacet,
+  Controller,
+  Facet,
+  FacetProps,
+  FacetState,
+  SearchEngine,
+} from '@coveo/headless';
+import React, {useEffect, useState} from 'react';
+
+/**
+ * Example of a specific hook for function component
+ * We would need to create one of those for each Headless controller, and for each sub package of headless
+ * For example, `useFacet` from '@coveo/headless/react', then `useFacet` from '@coveo/headless/productlisting/react' etc.
+ *
+ */
+export const useFacet = (
+  facet: Facet
+): [FacetState, React.Dispatch<React.SetStateAction<FacetState>>] => {
+  const [state, setState] = useState(facet.state);
+  useEffect(() => {
+    facet.subscribe(() => setState(facet.state));
+  }, []);
+
+  return [state, setState];
+};
+
+/**
+ * Example of a generic hook for function component
+ * We would need to create only one hook that would serve for any controller that extends the base Controller type (all of them)
+ */
+export function useController<T extends Controller, S = T['state']>(
+  controller: T
+): [S, React.Dispatch<React.SetStateAction<S>>] {
+  const [state, setState] = useState(controller.state as S);
+  useEffect(() => {
+    controller.subscribe(() => setState(controller.state as S));
+  }, []);
+
+  return [state, setState];
+}
+
+/**
+ * Example of a specific decorator for class components.
+ *  We would need to create one of those for each Headless controller, and for each sub package of headless
+ * For example, `WithFacet` from '@coveo/headless/react', then `WithFacet` from '@coveo/headless/productlisting/react' etc.
+ *
+ */
+interface ReactComponentWithFacet
+  extends React.Component<FacetProps, FacetState> {
+  controller: Facet;
+  context: React.ContextType<React.Context<{engine: SearchEngine}>>;
+}
+
+export function WithFacet() {
+  return function (target: ReactComponentWithFacet, _: string) {
+    const {
+      componentDidMount: originalComponentDidMount,
+      componentWillUnmount: originalComponentWillUnmount,
+    } = target;
+    let unsubscribe: () => void = () => {};
+    target.componentDidMount = function () {
+      this.controller = buildFacet(this.context.engine, this.props);
+      unsubscribe = this.controller.subscribe(() =>
+        this.setState(this.controller.state)
+      );
+      originalComponentDidMount?.call(this);
+    };
+
+    target.componentWillUnmount = function () {
+      unsubscribe();
+      originalComponentWillUnmount?.call(this);
+    };
+  };
+}
+
+/**
+ * Example of a generic decorator for class components.
+ * Should work with any controller that extends the base Controller type (all of them)
+ *
+ * Requires more work for implementers, since they are in charge of building the controller themselves
+ */
+interface ReactComponentWithController<C extends Controller, P, S>
+  extends React.Component<P, S> {
+  controller: C;
+}
+
+export function WithController<C extends Controller, P, S>(
+  buildController: (component: React.Component<P, S>) => C
+) {
+  return function (target: ReactComponentWithController<C, P, S>, _: string) {
+    const {
+      componentDidMount: originalComponentDidMount,
+      componentWillUnmount: originalComponentWillUnmount,
+    } = target;
+    let unsubscribe: () => void = () => {};
+    target.componentDidMount = function () {
+      this.controller = buildController(this);
+      unsubscribe = this.controller.subscribe(() =>
+        this.setState(this.controller.state)
+      );
+      originalComponentDidMount?.call(this);
+    };
+
+    target.componentWillUnmount = function () {
+      unsubscribe();
+      originalComponentWillUnmount?.call(this);
+    };
+  };
+}

--- a/packages/samples/headless-react/src/components/facet/facet.class.decorator.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.class.decorator.tsx
@@ -1,0 +1,121 @@
+import {Component, Context, ContextType} from 'react';
+import {
+  buildFacet,
+  Facet as HeadlessFacet,
+  FacetProps,
+  FacetState,
+  SearchEngine,
+} from '@coveo/headless';
+import {FacetSearch} from './facet-search';
+import {AppContext} from '../../context/engine';
+import {WithController, WithFacet} from './facet-hook';
+
+export class FacetWithSpecificDecorator extends Component<
+  FacetProps,
+  FacetState
+> {
+  static contextType = AppContext;
+  context!: ContextType<Context<{engine: SearchEngine}>>;
+
+  @WithFacet()
+  controller!: HeadlessFacet;
+
+  render() {
+    if (!this.state) {
+      return null;
+    }
+
+    if (!this.state.values.length) {
+      return <div>No facet values</div>;
+    }
+
+    return (
+      <ul>
+        <li>
+          <FacetSearch
+            controller={this.controller.facetSearch}
+            facetState={this.state.facetSearch}
+            isValueSelected={(facetSearchValue) =>
+              !!this.state.values.find(
+                (facetValue) =>
+                  facetValue.value === facetSearchValue.displayValue &&
+                  this.controller.isValueSelected(facetValue)
+              )
+            }
+          />
+        </li>
+        <li>
+          <ul>
+            {this.state.values.map((value) => (
+              <li key={value.value}>
+                <input
+                  type="checkbox"
+                  checked={this.controller.isValueSelected(value)}
+                  onChange={() => this.controller.toggleSelect(value)}
+                  disabled={this.state.isLoading}
+                />
+                {value.value} ({value.numberOfResults} results)
+              </li>
+            ))}
+          </ul>
+        </li>
+      </ul>
+    );
+  }
+}
+
+export class FacetWithGenericDecorator extends Component<
+  FacetProps,
+  FacetState
+> {
+  static contextType = AppContext;
+  context!: ContextType<Context<{engine: SearchEngine}>>;
+
+  @WithController<HeadlessFacet, FacetProps, FacetState>((cmp) =>
+    buildFacet(cmp.context.engine, cmp.props)
+  )
+  controller!: HeadlessFacet;
+
+  render() {
+    if (!this.state) {
+      return null;
+    }
+
+    if (!this.state.values.length) {
+      return <div>No facet values</div>;
+    }
+
+    return (
+      <ul>
+        <li>
+          <FacetSearch
+            controller={this.controller.facetSearch}
+            facetState={this.state.facetSearch}
+            isValueSelected={(facetSearchValue) =>
+              !!this.state.values.find(
+                (facetValue) =>
+                  facetValue.value === facetSearchValue.displayValue &&
+                  this.controller.isValueSelected(facetValue)
+              )
+            }
+          />
+        </li>
+        <li>
+          <ul>
+            {this.state.values.map((value) => (
+              <li key={value.value}>
+                <input
+                  type="checkbox"
+                  checked={this.controller.isValueSelected(value)}
+                  onChange={() => this.controller.toggleSelect(value)}
+                  disabled={this.state.isLoading}
+                />
+                {value.value} ({value.numberOfResults} results)
+              </li>
+            ))}
+          </ul>
+        </li>
+      </ul>
+    );
+  }
+}

--- a/packages/samples/headless-react/src/components/facet/facet.fn.hooks.tsx
+++ b/packages/samples/headless-react/src/components/facet/facet.fn.hooks.tsx
@@ -1,0 +1,55 @@
+import {FunctionComponent} from 'react';
+import {FacetSearch} from './facet-search';
+import {useController} from './facet-hook';
+import {Facet as HeadlessFacet} from '@coveo/headless';
+
+interface FacetProps {
+  controller: HeadlessFacet;
+}
+
+export const FacetWithHook: FunctionComponent<FacetProps> = ({controller}) => {
+  const [state] = useController(controller);
+  return (
+    <ul>
+      <li>
+        <FacetSearch
+          controller={controller.facetSearch}
+          facetState={state.facetSearch}
+          isValueSelected={(facetSearchValue) =>
+            !!state.values.find(
+              (facetValue) =>
+                facetValue.value === facetSearchValue.displayValue &&
+                controller.isValueSelected(facetValue)
+            )
+          }
+        />
+      </li>
+      <li>
+        <ul>
+          {state.values.map((value) => (
+            <li key={value.value}>
+              <input
+                type="checkbox"
+                checked={controller.isValueSelected(value)}
+                onChange={() => controller.toggleSelect(value)}
+                disabled={state.isLoading}
+              />
+              {value.value} ({value.numberOfResults} results)
+            </li>
+          ))}
+        </ul>
+      </li>
+    </ul>
+  );
+};
+
+// usage
+
+/**
+ * ```tsx
+ * const options: FacetOptions = {field: 'objecttype'};
+ * const controller = buildFacet(engine, {options});
+ *
+ * <Facet controller={controller} />;
+ * ```
+ */

--- a/packages/samples/headless-react/src/pages/PageWithHooks.tsx
+++ b/packages/samples/headless-react/src/pages/PageWithHooks.tsx
@@ -1,0 +1,36 @@
+import {
+  buildFacet,
+  buildSearchEngine,
+  getSampleSearchEngineConfiguration,
+} from '@coveo/headless';
+import {useEffect} from 'react';
+import {
+  FacetWithGenericDecorator,
+  FacetWithSpecificDecorator,
+} from '../components/facet/facet.class.decorator';
+import {FacetWithHook} from '../components/facet/facet.fn.hooks';
+
+import {AppContext} from '../context/engine';
+import {Section} from '../layout/section';
+
+export function PageWithHooks() {
+  const engine = buildSearchEngine({
+    configuration: getSampleSearchEngineConfiguration(),
+  });
+
+  const facetController = buildFacet(engine, {options: {field: 'author'}});
+
+  useEffect(() => {
+    engine.executeFirstSearch();
+  }, []);
+
+  return (
+    <AppContext.Provider value={{engine}}>
+      <Section title="standalone-search-box">
+        <FacetWithHook controller={facetController} />
+        <FacetWithSpecificDecorator options={{field: 'source'}} />
+        <FacetWithGenericDecorator options={{field: 'objecttype'}} />
+      </Section>
+    </AppContext.Provider>
+  );
+}

--- a/packages/samples/headless-react/tsconfig.json
+++ b/packages/samples/headless-react/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
+    "experimentalDecorators": true,
+    "target": "es2019",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
# Why
Since many of our clients will be using React it could make sense to offer an opinionated package `@coveo/headless/react` that would help simplify their code (less LOC to write), and guide for best practices.

# Function components

The amount of code saved is relatively low for function components: I wasn't able to come up with a pattern where we could actually create the controller for our users inside the hook, and that would "only run once", and properly return the correct types, as well as re-render properly. I'll do some more investigation, but for the design I have right now, you still need to create the controller and pass it as a prop.

However, the `useController` function would be very low maintenance for us to maintain...

# Class components

The amount of code saved here is more substantial. We would be able to provide either a "Generic" decorator, where the users has to provide a "factory" function for the controller, or "Specific" decorator for each and every controller, where we could call the correct `buildXYZ` function in headless to decide which controller to create. 

The specific decorator pattern would require more maintenance on our part.

# To discuss live (scrum or other)

Is it worth it ? Is it solving "a real problem" ? 



https://coveord.atlassian.net/browse/KIT-1260