### PR TITLE
fix(atomic): change refine toggle closing animation to a simple slide down

### DIFF
--- a/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
@@ -263,7 +263,7 @@ export class AtomicRefineModal implements InitializableComponent {
           class={`w-screen h-screen fixed flex flex-col justify-between bg-background text-on-background left-0 top-0 z-10 ${
             isOpened
               ? 'animate-scaleUpRefineModal'
-              : 'animate-scaleDownRefineModal'
+              : 'animate-slideDownRefineModal'
           }`}
           aria-modal={isOpened.toString()}
         >

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -58,18 +58,18 @@ module.exports = {
       animation: {
         scaleUpRefineModal:
           'scaleUp .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) forwards',
-        scaleDownRefineModal:
-          'scaleDown .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) forwards',
+        slideDownRefineModal:
+          'slideDown .5s linear forwards',
       },
       keyframes: {
         scaleUp: {
           '0%': {transform: 'scale(0.7) translateY(1000px)', opacity: '0.7'},
           '100%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
         },
-        scaleDown: {
-          '0%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
-          '100%': {transform: 'scale(0.7) translateY(1000px)', opacity: '0.7'},
-        },
+        slideDown: {
+          '0%': {transform: 'translateY(0px)', opacity: '1'},
+          '100%': {transform: 'translateY(150vh)', opacity: '0.7'},
+        }
       },
     },
     backgroundColor: (theme) => ({


### PR DESCRIPTION
The closing animation was kind of wacky looking, with the timing function leaving a "shadow" of the modal for a split second at the end as it was getting scaled down.

Changed it to a simpler linear slide down with no scaling effect.

https://coveord.atlassian.net/browse/KIT-1265