### PR TITLE
fix(atomic): explicitly define exports

### DIFF
--- a/packages/atomic/src/index.ts
+++ b/packages/atomic/src/index.ts
@@ -1,6 +1,6 @@
-export * from './components';
+export {Components, JSX} from './components';
 
-export * from './utils/result-utils';
+export {bindLogDocumentOpenOnResult} from './utils/result-utils';
 
 export {
   initializeBindings,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1271

Importing `@coveo/atomic` in another Stencil project, it tries looking for an index.js in collection/component/, which doesn't exist