### PR TITLE
fix(headless): rework previous state comparison for controllers to allow multiple subscribers

### DIFF
--- a/packages/headless/src/controllers/controller/headless-controller.test.ts
+++ b/packages/headless/src/controllers/controller/headless-controller.test.ts
@@ -63,4 +63,19 @@ describe('Controller', () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
   });
+
+  it('allows subscribing twice to same instance when there is a state change', () => {
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+    cmp.subscribe(firstListener);
+    cmp.subscribe(secondListener);
+
+    updateControllerState({property: 'new value'});
+
+    const allListeners = registeredListeners();
+    allListeners.forEach((l) => l());
+
+    expect(firstListener).toHaveBeenCalledTimes(2);
+    expect(secondListener).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/headless/src/controllers/controller/headless-controller.ts
+++ b/packages/headless/src/controllers/controller/headless-controller.ts
@@ -15,16 +15,15 @@ export interface Controller {
 export function buildController<T extends object>(
   engine: CoreEngine<T>
 ): Controller {
-  const prevState: Map<Symbol, string> = new Map();
+  let prevState: string;
+  const listeners: Map<Symbol, () => void> = new Map();
+  const hasNoListeners = () => listeners.size === 0;
 
-  const hasStateChanged = (
-    currentState: Record<string, unknown>,
-    symbol: Symbol
-  ): boolean => {
+  const hasStateChanged = (currentState: Record<string, unknown>): boolean => {
     try {
       const stringifiedState = JSON.stringify(currentState);
-      const hasChanged = prevState.get(symbol) !== stringifiedState;
-      prevState.set(symbol, stringifiedState);
+      const hasChanged = prevState !== stringifiedState;
+      prevState = stringifiedState;
       return hasChanged;
     } catch (e) {
       console.warn(
@@ -39,15 +38,23 @@ export function buildController<T extends object>(
     subscribe(listener: () => void) {
       listener();
       const symbol = Symbol();
-      prevState.set(symbol, JSON.stringify(this.state));
-      const unsubscribe = engine.subscribe(() => {
-        if (hasStateChanged(this.state, symbol)) {
-          listener();
-        }
-      });
+      let unsubscribe: () => void;
+
+      if (hasNoListeners()) {
+        prevState = JSON.stringify(this.state);
+        unsubscribe = engine.subscribe(() => {
+          if (hasStateChanged(this.state)) {
+            listeners.forEach((listener) => listener());
+          }
+        });
+      }
+      listeners.set(symbol, listener);
+
       return () => {
-        prevState.delete(symbol);
-        unsubscribe();
+        listeners.delete(symbol);
+        if (hasNoListeners()) {
+          unsubscribe && unsubscribe();
+        }
       };
     },
 


### PR DESCRIPTION
Since `prevState` is a local function variable to each controller, the comparison would work only once for the first subscriber function, since it would get "reset" after the first comparison.


In practice:  
```
const myController = buildController()
myController.subscribe(()=> console.log('hello')); // print 'hello' properly on each state change
myController.subscribe(()=> console.log('world')); // print 'world' only once, only on the initial execution.
```


https://coveord.atlassian.net/browse/KIT-1270