### PR TITLE
ci: generate headless bundles using esbuild

### DIFF
--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -1,0 +1,148 @@
+const path = require('path');
+const {readFileSync} = require('fs');
+const {build} = require('esbuild');
+const alias = require('esbuild-plugin-alias');
+
+const useCaseEntries = {
+  search: 'src/index.ts',
+  recommendation: 'src/recommendation.index.ts',
+  'product-recommendation': 'src/product-recommendation.index.ts',
+  'product-listing': 'src/product-listing.index.ts',
+  'case-assist': 'src/case-assist.index.ts',
+}
+
+function getGlobalName(useCase) {
+  const map = {
+    search: 'CoveoHeadless',
+    recommendation: 'CoveoHeadlessRecommendation',
+    'product-recommendation': 'CoveoHeadlessProductRecommendation',
+    'product-listing': 'CoveoHeadlessProductListing',
+    'case-assist': 'CoveoHeadlessCaseAssist',
+  }
+
+  const globalName = map[useCase];
+
+  if (globalName) {
+    return globalName;
+  }
+
+  throw new Error(`Please specify a global name for use-case: "${useCase}"`)
+}
+
+function getPackageVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf-8')).version;
+}
+
+/**
+ * @type {import('esbuild').BuildOptions}
+ */
+const base = {
+  bundle: true,
+  tsconfig: './src/tsconfig.build.json',
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.VERSION': JSON.stringify(getPackageVersion())
+  },
+};
+
+const browser = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/browser', useCase);
+  const outfile = `${dir}/headless.js`;
+  
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'iife',
+    globalName: getGlobalName(useCase)
+  });
+})
+
+const browserEsm = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/browser', useCase);
+  const outfile = `${dir}/headless.esm.js`;
+  
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+  });
+})
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
+}
+
+/** 
+ * @param {import('esbuild').BuildOptions} options
+ * @returns {Promise<import('esbuild').BuildResult>}
+ */
+function buildBrowserConfig(options) {
+  return build({
+    ...base,
+    platform: 'browser',
+    minify: true,
+    sourcemap: true,
+    plugins: [
+      alias({
+        'coveo.analytics': path.resolve(
+          __dirname,
+          './node_modules/coveo.analytics/dist/library.es.js'
+        ),
+        'cross-fetch': path.resolve(
+          __dirname,
+          './fetch-ponyfill.js'
+        ),
+        'web-encoding': path.resolve(
+          __dirname,
+          './node_modules/web-encoding/src/lib.js'
+        ),
+      }),
+    ],
+    ...options
+  });
+}
+
+
+const nodeCjs = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/', useCase);
+  const outfile = `${dir}/headless.js`;
+  
+  return buildNodeConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'cjs',
+  });
+})
+
+const nodeEsm = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/', useCase);
+  const outfile = `${dir}/headless.esm.js`;
+  
+  return buildNodeConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+  });
+})
+
+/** 
+ * @param {import('esbuild').BuildOptions} options
+ * @returns {Promise<import('esbuild').BuildResult>}
+ */
+function buildNodeConfig(options) {
+  return build({
+    ...base,
+    platform: 'node',
+    ...options
+  })
+}
+
+async function main() {
+  await Promise.all([...browserEsm, ...browser, ...nodeEsm, ...nodeCjs]);
+}
+
+main();

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -9,7 +9,7 @@ const useCaseEntries = {
   'product-recommendation': 'src/product-recommendation.index.ts',
   'product-listing': 'src/product-listing.index.ts',
   'case-assist': 'src/case-assist.index.ts',
-}
+};
 
 function getGlobalName(useCase) {
   const map = {
@@ -18,7 +18,7 @@ function getGlobalName(useCase) {
     'product-recommendation': 'CoveoHeadlessProductRecommendation',
     'product-listing': 'CoveoHeadlessProductListing',
     'case-assist': 'CoveoHeadlessCaseAssist',
-  }
+  };
 
   const globalName = map[useCase];
 
@@ -26,7 +26,7 @@ function getGlobalName(useCase) {
     return globalName;
   }
 
-  throw new Error(`Please specify a global name for use-case: "${useCase}"`)
+  throw new Error(`Please specify a global name for use-case: "${useCase}"`);
 }
 
 function getPackageVersion() {
@@ -41,40 +41,40 @@ const base = {
   tsconfig: './src/tsconfig.build.json',
   define: {
     'process.env.NODE_ENV': JSON.stringify('production'),
-    'process.env.VERSION': JSON.stringify(getPackageVersion())
+    'process.env.VERSION': JSON.stringify(getPackageVersion()),
   },
 };
 
-const browser = Object.entries(useCaseEntries).map(entry => {
+const browser = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/browser', useCase);
+  const dir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${dir}/headless.js`;
-  
+
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'iife',
-    globalName: getGlobalName(useCase)
+    globalName: getGlobalName(useCase),
   });
-})
+});
 
-const browserEsm = Object.entries(useCaseEntries).map(entry => {
+const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/browser', useCase);
+  const dir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${dir}/headless.esm.js`;
-  
+
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-})
+});
 
 function getUseCaseDir(prefix, useCase) {
   return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
-/** 
+/**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
@@ -90,46 +90,42 @@ function buildBrowserConfig(options) {
           __dirname,
           './node_modules/coveo.analytics/dist/library.es.js'
         ),
-        'cross-fetch': path.resolve(
-          __dirname,
-          './fetch-ponyfill.js'
-        ),
+        'cross-fetch': path.resolve(__dirname, './fetch-ponyfill.js'),
         'web-encoding': path.resolve(
           __dirname,
           './node_modules/web-encoding/src/lib.js'
         ),
       }),
     ],
-    ...options
+    ...options,
   });
 }
 
-
-const nodeCjs = Object.entries(useCaseEntries).map(entry => {
+const nodeCjs = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/', useCase);
+  const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.js`;
-  
+
   return buildNodeConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'cjs',
   });
-})
+});
 
-const nodeEsm = Object.entries(useCaseEntries).map(entry => {
+const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/', useCase);
+  const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.esm.js`;
-  
+
   return buildNodeConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-})
+});
 
-/** 
+/**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
@@ -137,8 +133,20 @@ function buildNodeConfig(options) {
   return build({
     ...base,
     platform: 'node',
-    ...options
-  })
+    plugins: [
+      alias({
+        'coveo.analytics': path.resolve(
+          __dirname,
+          './node_modules/coveo.analytics/dist/library.js'
+        ),
+        'web-encoding': path.resolve(
+          __dirname,
+          './node_modules/web-encoding/src/lib.cjs'
+        ),
+      }),
+    ],
+    ...options,
+  });
 }
 
 async function main() {

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -3,6 +3,8 @@ const {readFileSync} = require('fs');
 const {build} = require('esbuild');
 const alias = require('esbuild-plugin-alias');
 
+const devMode = process.argv[2] === 'dev';
+
 const useCaseEntries = {
   search: 'src/index.ts',
   recommendation: 'src/recommendation.index.ts',
@@ -13,6 +15,10 @@ const useCaseEntries = {
 
 function getPackageVersion() {
   return JSON.parse(readFileSync('package.json', 'utf-8')).version;
+}
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
 /**
@@ -30,22 +36,19 @@ const base = {
 const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
+  const outfile = `${outDir}/headless.esm.js`;
 
-  return buildBrowserEsmConfig(entryPoint, outDir);
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+    watch: devMode,
+  });
 });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('dist/browser', useCase);
-
-  return buildBrowserEsmConfig(entryPoint, outDir);
-});
-
-function getUseCaseDir(prefix, useCase) {
-  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
-}
-
-function buildBrowserEsmConfig(entryPoint, outDir) {
   const outfile = `${outDir}/headless.esm.js`;
 
   return buildBrowserConfig({
@@ -53,7 +56,7 @@ function buildBrowserEsmConfig(entryPoint, outDir) {
     outfile,
     format: 'esm',
   });
-}
+});
 
 /**
  * @param {import('esbuild').BuildOptions} options

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -11,24 +11,6 @@ const useCaseEntries = {
   'case-assist': 'src/case-assist.index.ts',
 };
 
-// function getGlobalName(useCase) {
-//   const map = {
-//     search: 'CoveoHeadless',
-//     recommendation: 'CoveoHeadlessRecommendation',
-//     'product-recommendation': 'CoveoHeadlessProductRecommendation',
-//     'product-listing': 'CoveoHeadlessProductListing',
-//     'case-assist': 'CoveoHeadlessCaseAssist',
-//   };
-
-//   const globalName = map[useCase];
-
-//   if (globalName) {
-//     return globalName;
-//   }
-
-//   throw new Error(`Please specify a global name for use-case: "${useCase}"`);
-// }
-
 function getPackageVersion() {
   return JSON.parse(readFileSync('package.json', 'utf-8')).version;
 }
@@ -44,19 +26,6 @@ const base = {
     'process.env.VERSION': JSON.stringify(getPackageVersion()),
   },
 };
-
-// const browser = Object.entries(useCaseEntries).map((entry) => {
-//   const [useCase, entryPoint] = entry;
-//   const dir = getUseCaseDir('dist/browser', useCase);
-//   const outfile = `${dir}/headless.js`;
-
-//   return buildBrowserConfig({
-//     entryPoints: [entryPoint],
-//     outfile,
-//     format: 'iife',
-//     globalName: getGlobalName(useCase),
-//   });
-// });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -45,18 +45,18 @@ const base = {
   },
 };
 
-const browser = Object.entries(useCaseEntries).map((entry) => {
-  const [useCase, entryPoint] = entry;
-  const dir = getUseCaseDir('dist/browser', useCase);
-  const outfile = `${dir}/headless.js`;
+// const browser = Object.entries(useCaseEntries).map((entry) => {
+//   const [useCase, entryPoint] = entry;
+//   const dir = getUseCaseDir('dist/browser', useCase);
+//   const outfile = `${dir}/headless.js`;
 
-  return buildBrowserConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'iife',
-    globalName: getGlobalName(useCase),
-  });
-});
+//   return buildBrowserConfig({
+//     entryPoints: [entryPoint],
+//     outfile,
+//     format: 'iife',
+//     globalName: getGlobalName(useCase),
+//   });
+// });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
@@ -150,7 +150,7 @@ function buildNodeConfig(options) {
 }
 
 async function main() {
-  await Promise.all([...browserEsm, ...browser, ...nodeEsm, ...nodeCjs]);
+  await Promise.all([...browserEsm, ...nodeEsm, ...nodeCjs]);
 }
 
 main();

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -27,20 +27,32 @@ const base = {
   },
 };
 
+const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map((entry) => {
+  const [useCase, entryPoint] = entry;
+  const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
+
+  return buildBrowserEsmConfig(entryPoint, outDir);
+});
+
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir = getUseCaseDir('dist/browser', useCase);
-  const outfile = `${dir}/headless.esm.js`;
+  const outDir = getUseCaseDir('dist/browser', useCase);
+
+  return buildBrowserEsmConfig(entryPoint, outDir);
+});
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
+}
+
+function buildBrowserEsmConfig(entryPoint, outDir) {
+  const outfile = `${outDir}/headless.esm.js`;
 
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-});
-
-function getUseCaseDir(prefix, useCase) {
-  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
 /**
@@ -119,7 +131,7 @@ function buildNodeConfig(options) {
 }
 
 async function main() {
-  await Promise.all([...browserEsm, ...nodeEsm, ...nodeCjs]);
+  await Promise.all([...browserEsm, ...browserEsmForAtomicDevelopment, ...nodeEsm, ...nodeCjs]);
 }
 
 main();

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@coveo/headless",
-      "version": "1.37.0",
+      "version": "1.37.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.34.0",
@@ -37,6 +37,8 @@
         "@rollup/plugin-replace": "2.4.2",
         "@types/jest": "27.0.3",
         "concurrently": "6.4.0",
+        "esbuild": "^0.14.1",
+        "esbuild-plugin-alias": "^0.2.1",
         "jest": "27.4.0",
         "jest-fetch-mock": "3.0.3",
         "rollup": "2.60.1",
@@ -6614,6 +6616,262 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.1.tgz",
+      "integrity": "sha512-J/LhUwELcmz0+CJfiaKzu7Rnj9ffWFLvMx+dKvdOfg+fQmoP6q9glla26LCm9BxpnPUjXChHeubLiMlKab/PYg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.14.1",
+        "esbuild-darwin-64": "0.14.1",
+        "esbuild-darwin-arm64": "0.14.1",
+        "esbuild-freebsd-64": "0.14.1",
+        "esbuild-freebsd-arm64": "0.14.1",
+        "esbuild-linux-32": "0.14.1",
+        "esbuild-linux-64": "0.14.1",
+        "esbuild-linux-arm": "0.14.1",
+        "esbuild-linux-arm64": "0.14.1",
+        "esbuild-linux-mips64le": "0.14.1",
+        "esbuild-linux-ppc64le": "0.14.1",
+        "esbuild-netbsd-64": "0.14.1",
+        "esbuild-openbsd-64": "0.14.1",
+        "esbuild-sunos-64": "0.14.1",
+        "esbuild-windows-32": "0.14.1",
+        "esbuild-windows-64": "0.14.1",
+        "esbuild-windows-arm64": "0.14.1"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.1.tgz",
+      "integrity": "sha512-elQd3hTg93nU2GQ5PPCDAFe5+utxZX96RG8RixqIPxf8pzmyIzcpKG76L/9FabPf3LT1z+nLF1sajCU8eVRDyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.1.tgz",
+      "integrity": "sha512-PR3HZgbPRwsQbbOR1fJrfkt/Cs0JDyI3yzOKg2PPWk0H1AseZDBqPUY9b/0+BIjFwA5Jz/aAiq832hppsuJtNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.1.tgz",
+      "integrity": "sha512-/fiSSOkOEa3co6yYtwgXouz8jZrG0qnXPEKiktFf2BQE8NON3ARTw43ZegaH+xMRFNgYBJEOOZIdzI3sIFEAxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.1.tgz",
+      "integrity": "sha512-ZJV+nfa8E8PdXnRc05PO3YMfgSj7Ko+kdHyGDE6OaNo1cO8ZyfacqLaWkY35shDDaeacklhD8ZR4qq5nbJKX1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.1.tgz",
+      "integrity": "sha512-6N9zTD+SecJr2g9Ohl9C10WIk5FpQ+52bNamRy0sJoHwP31G5ObzKzq8jAtg1Jeggpu6P8auz3P/UL+3YioSwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.1.tgz",
+      "integrity": "sha512-RtPgE6e7WefbAxRjVryisKFJ0nUwR2DMjwmYW/a1a0F1+Ge6FR+RqvgiY0DrM9TtxSUU0eryDXNF4n3UfxX3mg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.1.tgz",
+      "integrity": "sha512-JpxM0ar6Z+2v3vfFrxP7bFb8Wzb6gcGL9MxRqAJplDfGnee8HbfPge6svaazXeX9XJceeEqwxwWGB0qyCcxo7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.1.tgz",
+      "integrity": "sha512-eBRHexCijAYWzcvQLGHxyxIlYOkYhXvcb/O7HvzJfCAVWCnTx9TxxYJ3UppBC6dDFbAq4HwKhskvmesQdKMeBg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.1.tgz",
+      "integrity": "sha512-cFbeZf171bIf+PPLlQDBzagK85lCCxxVdMV1IVUA96Y3kvEgqcy2n9mha+QE1M/T+lIOPDsmLRgH1XqMFwLTSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.1.tgz",
+      "integrity": "sha512-UGb+sqHkL7wOQFLH0RoFhcRAlJNqbqs6GtJd1It5jJ2juOGqAkCv8V12aGDX9oRB6a+Om7cdHcH+6AMZ+qlaww==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.1.tgz",
+      "integrity": "sha512-LIHGkGdy9wYlmkkoVHm6feWhkoi4VBXDiEVyNjXEhlzsBcP/CaRy+B8IJulzaU1ALLiGcsCQ2MC5UbFn/iTvmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.1.tgz",
+      "integrity": "sha512-TWc1QIgtPwaK5nC1GT2ASTuy/CJhNKHN4h5PJRP1186VfI+k2uvXakS7bqO/M26F6jAMy8jDeCtilacqpwsvfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.1.tgz",
+      "integrity": "sha512-Z9/Zb77K+pK9s7mAsvwS56K8tCbLvNZ9UI4QVJSYqDgOmmDJOBT4owWnCqZ5cJI+2y4/F9KwCpFFTNUdPglPKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-plugin-alias": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz",
+      "integrity": "sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==",
+      "dev": true
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.1.tgz",
+      "integrity": "sha512-c4sF8146kNW8529wfkB6vO0ZqPgokyS2hORqKa4p/QKZdp+xrF2NPmvX5aN+Zt14oe6wVZuhYo6LGv7V4Gg04g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.1.tgz",
+      "integrity": "sha512-XP8yElaJtLGGjH7D72t5IWtP0jmc1Jqm4IjQARB17l0LTJO/n+N2X64rDWePJv6qimYxa5p2vTjkZc5v+YZTSQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.1.tgz",
+      "integrity": "sha512-fe+ShdyfiuGcCEdVKW//6MaM4MwikiWBWSBn8mebNAbjRqicH0injDOFVI7aUovAfrEt7+FGkf402s//hi0BVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.1.tgz",
+      "integrity": "sha512-wBVakhcIzQ3NZ33DFM6TjIObXPHaXOsqzvPwefXHvwBSC/N/e/g6fBeM7N/Moj3AmxLjKaB+vePvTGdxk6RPCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -21461,6 +21719,156 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "esbuild": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.1.tgz",
+      "integrity": "sha512-J/LhUwELcmz0+CJfiaKzu7Rnj9ffWFLvMx+dKvdOfg+fQmoP6q9glla26LCm9BxpnPUjXChHeubLiMlKab/PYg==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-arm64": "0.14.1",
+        "esbuild-darwin-64": "0.14.1",
+        "esbuild-darwin-arm64": "0.14.1",
+        "esbuild-freebsd-64": "0.14.1",
+        "esbuild-freebsd-arm64": "0.14.1",
+        "esbuild-linux-32": "0.14.1",
+        "esbuild-linux-64": "0.14.1",
+        "esbuild-linux-arm": "0.14.1",
+        "esbuild-linux-arm64": "0.14.1",
+        "esbuild-linux-mips64le": "0.14.1",
+        "esbuild-linux-ppc64le": "0.14.1",
+        "esbuild-netbsd-64": "0.14.1",
+        "esbuild-openbsd-64": "0.14.1",
+        "esbuild-sunos-64": "0.14.1",
+        "esbuild-windows-32": "0.14.1",
+        "esbuild-windows-64": "0.14.1",
+        "esbuild-windows-arm64": "0.14.1"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.1.tgz",
+      "integrity": "sha512-elQd3hTg93nU2GQ5PPCDAFe5+utxZX96RG8RixqIPxf8pzmyIzcpKG76L/9FabPf3LT1z+nLF1sajCU8eVRDyg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.1.tgz",
+      "integrity": "sha512-PR3HZgbPRwsQbbOR1fJrfkt/Cs0JDyI3yzOKg2PPWk0H1AseZDBqPUY9b/0+BIjFwA5Jz/aAiq832hppsuJtNw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.1.tgz",
+      "integrity": "sha512-/fiSSOkOEa3co6yYtwgXouz8jZrG0qnXPEKiktFf2BQE8NON3ARTw43ZegaH+xMRFNgYBJEOOZIdzI3sIFEAxw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.1.tgz",
+      "integrity": "sha512-ZJV+nfa8E8PdXnRc05PO3YMfgSj7Ko+kdHyGDE6OaNo1cO8ZyfacqLaWkY35shDDaeacklhD8ZR4qq5nbJKX1A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.1.tgz",
+      "integrity": "sha512-6N9zTD+SecJr2g9Ohl9C10WIk5FpQ+52bNamRy0sJoHwP31G5ObzKzq8jAtg1Jeggpu6P8auz3P/UL+3YioSwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.1.tgz",
+      "integrity": "sha512-RtPgE6e7WefbAxRjVryisKFJ0nUwR2DMjwmYW/a1a0F1+Ge6FR+RqvgiY0DrM9TtxSUU0eryDXNF4n3UfxX3mg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.1.tgz",
+      "integrity": "sha512-JpxM0ar6Z+2v3vfFrxP7bFb8Wzb6gcGL9MxRqAJplDfGnee8HbfPge6svaazXeX9XJceeEqwxwWGB0qyCcxo7A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.1.tgz",
+      "integrity": "sha512-eBRHexCijAYWzcvQLGHxyxIlYOkYhXvcb/O7HvzJfCAVWCnTx9TxxYJ3UppBC6dDFbAq4HwKhskvmesQdKMeBg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.1.tgz",
+      "integrity": "sha512-cFbeZf171bIf+PPLlQDBzagK85lCCxxVdMV1IVUA96Y3kvEgqcy2n9mha+QE1M/T+lIOPDsmLRgH1XqMFwLTSg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.1.tgz",
+      "integrity": "sha512-UGb+sqHkL7wOQFLH0RoFhcRAlJNqbqs6GtJd1It5jJ2juOGqAkCv8V12aGDX9oRB6a+Om7cdHcH+6AMZ+qlaww==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.1.tgz",
+      "integrity": "sha512-LIHGkGdy9wYlmkkoVHm6feWhkoi4VBXDiEVyNjXEhlzsBcP/CaRy+B8IJulzaU1ALLiGcsCQ2MC5UbFn/iTvmA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.1.tgz",
+      "integrity": "sha512-TWc1QIgtPwaK5nC1GT2ASTuy/CJhNKHN4h5PJRP1186VfI+k2uvXakS7bqO/M26F6jAMy8jDeCtilacqpwsvfA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.1.tgz",
+      "integrity": "sha512-Z9/Zb77K+pK9s7mAsvwS56K8tCbLvNZ9UI4QVJSYqDgOmmDJOBT4owWnCqZ5cJI+2y4/F9KwCpFFTNUdPglPKA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-plugin-alias": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz",
+      "integrity": "sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==",
+      "dev": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.1.tgz",
+      "integrity": "sha512-c4sF8146kNW8529wfkB6vO0ZqPgokyS2hORqKa4p/QKZdp+xrF2NPmvX5aN+Zt14oe6wVZuhYo6LGv7V4Gg04g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.1.tgz",
+      "integrity": "sha512-XP8yElaJtLGGjH7D72t5IWtP0jmc1Jqm4IjQARB17l0LTJO/n+N2X64rDWePJv6qimYxa5p2vTjkZc5v+YZTSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.1.tgz",
+      "integrity": "sha512-fe+ShdyfiuGcCEdVKW//6MaM4MwikiWBWSBn8mebNAbjRqicH0injDOFVI7aUovAfrEt7+FGkf402s//hi0BVg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.1.tgz",
+      "integrity": "sha512-wBVakhcIzQ3NZ33DFM6TjIObXPHaXOsqzvPwefXHvwBSC/N/e/g6fBeM7N/Moj3AmxLjKaB+vePvTGdxk6RPCg==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -23,7 +23,7 @@
     "product-listing/"
   ],
   "scripts": {
-    "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
+    "start": "concurrently \"npm run typedefinitions -- -w\" \"node esbuild.js dev\"",
     "build": "npm run build:prod --",
     "build:prod": "npm run typedefinitions && node esbuild.js && rollup -c --environment BUILD:production",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -71,6 +71,8 @@
     "@rollup/plugin-replace": "2.4.2",
     "@types/jest": "27.0.3",
     "concurrently": "6.4.0",
+    "esbuild": "^0.14.1",
+    "esbuild-plugin-alias": "^0.2.1",
     "jest": "27.4.0",
     "jest-fetch-mock": "3.0.3",
     "rollup": "2.60.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
     "build": "npm run build:prod --",
-    "build:prod": "npm run typedefinitions && rollup -c --environment BUILD:production",
+    "build:prod": "npm run typedefinitions && node esbuild.js",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -f -r dist/*",
     "test": "jest",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
     "build": "npm run build:prod --",
-    "build:prod": "npm run typedefinitions && node esbuild.js",
+    "build:prod": "npm run typedefinitions && node esbuild.js && rollup -c --environment BUILD:production",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -f -r dist/*",
     "test": "jest",

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -114,35 +114,35 @@ const browser = [
     input: 'src/index.ts',
     output: [
       buildUmdOutput('dist/browser', 'CoveoHeadless'),
-      buildEsmOutput('dist/browser')
+      // buildEsmOutput('dist/browser')
     ]
   },
   {
     input: 'src/case-assist.index.ts',
     output: [
       buildUmdOutput('dist/browser/case-assist', 'CoveoHeadlessCaseAssist'),
-      buildEsmOutput('dist/browser/case-assist')
+      // buildEsmOutput('dist/browser/case-assist')
     ]
   },
   {
     input: 'src/recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/recommendation', 'CoveoHeadlessRecommendation'),
-      buildEsmOutput('dist/browser/recommendation')
+      // buildEsmOutput('dist/browser/recommendation')
     ]
   },
   {
     input: 'src/product-recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-recommendation', 'CoveoHeadlessProductRecommendation'),
-      buildEsmOutput('dist/browser/product-recommendation')
+      // buildEsmOutput('dist/browser/product-recommendation')
     ]
   },
   {
     input: 'src/product-listing.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-listing', 'CoveoHeadlessProductListing'),
-      buildEsmOutput('dist/browser/product-listing')
+      // buildEsmOutput('dist/browser/product-listing')
     ]
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
@@ -246,6 +246,6 @@ const dev = [
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
-const config = isProduction ? [...nodejs, ...browser] : dev;
+const config = isProduction ? [...browser] : dev;
 
 export default config;

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -52,7 +52,7 @@ function matchesFilter(value) {
 
 // Browser Bundles
 
-const browser = [
+const browserUmd = [
   {
     input: 'src/index.ts',
     output: [
@@ -130,14 +130,6 @@ function buildUmdOutput(outDir, name) {
   }
 }
 
-function buildEsmOutput(outDir) {
-  return {
-    file: `${outDir}/headless.esm.js`,
-    format: 'es',
-    ...sourceMapConfig(),
-  }
-}
-
 function sourceMapConfig() {
   return {
     sourcemap: isProduction,
@@ -161,38 +153,6 @@ function copySourceFiles() {
   });
 }
 
-// For Atomic's local development purposes only
-const local = [
-  {
-    input: 'src/index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds')],
-  },
-  {
-    input: 'src/case-assist.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/case-assist')],
-  },
-  {
-    input: 'src/recommendation.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/recommendation')],
-  },
-  {
-    input: 'src/product-recommendation.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/product-recommendation')],
-  },
-  {
-    input: 'src/product-listing.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/product-listing')],
-  },
-].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
-
-const config = [];
-
-if (isProduction) {
-  config.push(...browser);
-}
-
-if (!isCI) {
-  config.push(...local)
-}
+const config = isProduction ? browserUmd : [];
 
 export default config;

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -1,5 +1,4 @@
 import resolve from '@rollup/plugin-node-resolve';
-// import json from '@rollup/plugin-json';
 import commonjs from '@rollup/plugin-commonjs';
 import tsPlugin from '@rollup/plugin-typescript';
 import replacePlugin from '@rollup/plugin-replace';
@@ -27,15 +26,15 @@ function replace() {
   return replacePlugin({'process.env.NODE_ENV': JSON.stringify(env), 'process.env.VERSION': JSON.stringify(version)});
 }
 
-// function onWarn(warning, warn) {
-//   const isCircularDependency = warning.code === 'CIRCULAR_DEPENDENCY';
+function onWarn(warning, warn) {
+  const isCircularDependency = warning.code === 'CIRCULAR_DEPENDENCY';
 
-//   if (isCI && isCircularDependency) {
-//     throw new Error(warning.message);
-//   }
+  if (isCI && isCircularDependency) {
+    throw new Error(warning.message);
+  }
 
-//   warn(warning);
-// }
+  warn(warning);
+}
 
 /**
  * @param {string} value
@@ -51,62 +50,6 @@ function matchesFilter(value) {
   return value.includes(filter);
 }
 
-// Node Bundles
-
-// const nodejs = [
-//   {
-//     input: 'src/index.ts',
-//     outDir: 'dist',
-//   },
-//   {
-//     input: 'src/case-assist.index.ts',
-//     outDir: 'dist/case-assist'
-//   },
-//   {
-//     input: 'src/recommendation.index.ts',
-//     outDir: 'dist/recommendation'
-//   },
-//   {
-//     input: 'src/product-recommendation.index.ts',
-//     outDir: 'dist/product-recommendation'
-//   },
-//   {
-//     input: 'src/product-listing.index.ts',
-//     outDir: 'dist/product-listing'
-//   },
-// ].filter(b => matchesFilter(b.input)).map(buildNodeConfiguration);
-
-// function buildNodeConfiguration({input, outDir}) {
-//   return {
-//     input,
-//     output: [
-//       {file: `${outDir}/headless.js`, format: 'cjs'},
-//       {file: `${outDir}/headless.esm.js`, format: 'es'},
-//     ],
-//     plugins: [
-//       resolve({preferBuiltins: true, mainFields: ['main']}),
-//       json(),
-//       commonjs({
-//         // https://github.com/pinojs/pino/issues/688
-//         ignore: ['pino-pretty'],
-//       }),
-//       typescript(),
-//       replace(),
-//     ],
-//     external: [
-//       'os',
-//       'https',
-//       'http',
-//       'stream',
-//       'zlib',
-//       'fs',
-//       'vm',
-//       'util',
-//     ],
-//     onwarn: onWarn,
-//   };
-// }
-
 // Browser Bundles
 
 const browser = [
@@ -114,35 +57,30 @@ const browser = [
     input: 'src/index.ts',
     output: [
       buildUmdOutput('dist/browser', 'CoveoHeadless'),
-      // buildEsmOutput('dist/browser')
     ]
   },
   {
     input: 'src/case-assist.index.ts',
     output: [
       buildUmdOutput('dist/browser/case-assist', 'CoveoHeadlessCaseAssist'),
-      // buildEsmOutput('dist/browser/case-assist')
     ]
   },
   {
     input: 'src/recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/recommendation', 'CoveoHeadlessRecommendation'),
-      // buildEsmOutput('dist/browser/recommendation')
     ]
   },
   {
     input: 'src/product-recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-recommendation', 'CoveoHeadlessProductRecommendation'),
-      // buildEsmOutput('dist/browser/product-recommendation')
     ]
   },
   {
     input: 'src/product-listing.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-listing', 'CoveoHeadlessProductListing'),
-      // buildEsmOutput('dist/browser/product-listing')
     ]
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
@@ -179,6 +117,7 @@ function buildBrowserConfiguration({input, output}) {
       isProduction && terser(),
       copySourceFiles(),
     ],
+    onwarn: onWarn
   }
 }
 


### PR DESCRIPTION
Build time (my machine): ~1 second (esbuild only)
Build time (Jenkins): 109 seconds (esbuild-rollup hybrid) vs. 234 seconds (rollup only)
Esbuild minified bundle size: ~3% larger

### Bundle size comparison (minified)
Percentage comparisons are versus rollup.

|Use Case | Rollup (kb) | Esbuild (kb) | Diff (%) | Terser minification | Diff (%)
|---|---|---|---|---|---
|search|243|260| 7 | 255 | 5
|recommendation|176|182| 3 | 178 | 1
|product recommendation|177|183| 3
|product listing|193|199 | 3
|case-assist|179|181 | 1

Terser provides smaller bundles at the cost of additional time and configuration complexity due to using two tools (not included in this PR). Rollup still outperforms. I only ran the terser benchmark for two use-cases.

**Summary**
Salesforce needs a UMD bundle, so using esbuild OOTB is not possible. It might be [possible to wrap](https://github.com/evanw/esbuild/issues/507#issuecomment-727690399) the `iife` bundle to make it a UMD, but there might some unknown pitfalls. I prefer to explore this in a separate PR.

The hybrid solution slows the production build (rollup umd generation takes ~1min locally), but is still significantly faster. One benefit though is a smaller UMD bundle size, which is helpful since UMD bundles are typically consumed fully (no treeshaking).
Dev builds are very fast because they are powered purely by esbuild.


