### PR TITLE
feat(atomic,headless): add analytics metadata about headless and atomic version number

### DIFF
--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -242,6 +242,19 @@ export class TestFixture {
     };
   }
 
+  public static getUABody() {
+    return cy.get(TestFixture.interceptAliases.UA) as unknown as Promise<{
+      request: {[key: string]: any};
+    }>;
+  }
+
+  public static getUACustomData() {
+    return TestFixture.getUABody().then(
+      ({request}) =>
+        request.body.customData as {[key: string]: string | string[]}
+    );
+  }
+
   private intercept() {
     cy.intercept({
       method: 'POST',

--- a/packages/atomic/cypress/integration/search-interface.cypress.ts
+++ b/packages/atomic/cypress/integration/search-interface.cypress.ts
@@ -33,6 +33,13 @@ describe('Search Interface Component', () => {
         .should('contain', 'patate')
         .should('contain', 'seconde');
     });
+
+    it('should log libraries versions in analytics custom data', () => {
+      TestFixture.getUACustomData().then((customData) => {
+        expect(customData).to.have.property('coveoAtomicVersion');
+        expect(customData).to.have.property('coveoHeadlessVersion');
+      });
+    });
   });
 
   describe('without an automatic search', () => {

--- a/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
+++ b/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
@@ -1,0 +1,40 @@
+import {
+  AnalyticsConfiguration,
+  SearchEngineConfiguration,
+} from '@coveo/headless';
+import {getAtomicEnvironment} from '../../global/environment';
+
+export function getAnalyticsConfig(
+  searchEngineConfig: SearchEngineConfiguration,
+  enabled: boolean
+): AnalyticsConfiguration {
+  if (searchEngineConfig.analytics) {
+    return {
+      ...searchEngineConfig.analytics,
+      enabled,
+      analyticsClientMiddleware: (event, payload) =>
+        augmentAnalyticsWithAtomicVersion(
+          event,
+          payload,
+          searchEngineConfig.analytics?.analyticsClientMiddleware
+        ),
+    };
+  }
+
+  return {
+    enabled,
+    analyticsClientMiddleware: augmentAnalyticsWithAtomicVersion,
+  };
+}
+
+function augmentAnalyticsWithAtomicVersion(
+  event: string,
+  payload: any,
+  existingMiddleware?: AnalyticsConfiguration['analyticsClientMiddleware']
+) {
+  const out = existingMiddleware ? existingMiddleware(event, payload) : payload;
+  if (out.customData) {
+    out.customData.coveoAtomicVersion = getAtomicEnvironment().version;
+  }
+  return out;
+}

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -310,7 +310,7 @@ export class AtomicSearchInterface {
       ? existingMiddleware(event, payload)
       : payload;
     if (out.customData) {
-      out.customData.CoveoAtomicVersion = getAtomicEnvironment().version;
+      out.customData.coveoAtomicVersion = getAtomicEnvironment().version;
     }
     return out;
   }

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -20,14 +20,14 @@ import {
   SearchStatus,
   buildSearchStatus,
   loadSearchConfigurationActions,
-  AnalyticsConfiguration,
 } from '@coveo/headless';
 import {Bindings, InitializeEvent} from '../../utils/initialization-utils';
 import i18next, {i18n} from 'i18next';
 import Backend, {BackendOptions} from 'i18next-http-backend';
 import {createStore} from '@stencil/store';
-import {getAtomicEnvironment, setCoveoGlobal} from '../../global/environment';
+import {setCoveoGlobal} from '../../global/environment';
 import {AtomicStore, initialStore} from '../../utils/store';
+import {getAnalyticsConfig} from './analytics-config';
 
 export type InitializationOptions = SearchEngineConfiguration;
 
@@ -240,7 +240,7 @@ export class AtomicSearchInterface {
 
   private initEngine(options: InitializationOptions) {
     const searchConfig = this.getSearchConfiguration(options);
-    const analyticsConfig = this.getAnalyticsConfig(options);
+    const analyticsConfig = getAnalyticsConfig(options, this.analytics);
     try {
       this.engine = buildSearchEngine({
         configuration: {
@@ -274,45 +274,6 @@ export class AtomicSearchInterface {
     }
 
     return searchConfigFromProps;
-  }
-
-  private getAnalyticsConfig(
-    options: InitializationOptions
-  ): AnalyticsConfiguration {
-    const enabledFromProps = {
-      enabled: this.analytics,
-    };
-    if (options.analytics) {
-      return {
-        ...options.analytics,
-        ...enabledFromProps,
-        analyticsClientMiddleware: (event, payload) =>
-          this.augmentAnalyticsWithAtomicVersion(
-            event,
-            payload,
-            options.analytics?.analyticsClientMiddleware
-          ),
-      };
-    }
-
-    return {
-      ...enabledFromProps,
-      analyticsClientMiddleware: this.augmentAnalyticsWithAtomicVersion,
-    };
-  }
-
-  private augmentAnalyticsWithAtomicVersion(
-    event: string,
-    payload: any,
-    existingMiddleware?: AnalyticsConfiguration['analyticsClientMiddleware']
-  ) {
-    const out = existingMiddleware
-      ? existingMiddleware(event, payload)
-      : payload;
-    if (out.customData) {
-      out.customData.coveoAtomicVersion = getAtomicEnvironment().version;
-    }
-    return out;
   }
 
   private initI18n() {

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -312,7 +312,7 @@ export class AtomicSearchInterface {
     if (out.customData) {
       out.customData.CoveoAtomicVersion = getAtomicEnvironment().version;
     }
-    return payload;
+    return out;
   }
 
   private initI18n() {

--- a/packages/atomic/src/global/environment.ts
+++ b/packages/atomic/src/global/environment.ts
@@ -9,7 +9,7 @@ function getWindow() {
   return window as unknown as {CoveoAtomic: AtomicEnvironment};
 }
 
-function getAtomicEnvironment(): AtomicEnvironment {
+export function getAtomicEnvironment(): AtomicEnvironment {
   return {
     version: process.env.VERSION!,
     headlessVersion: VERSION,

--- a/packages/headless/src/api/analytics/analytics.test.ts
+++ b/packages/headless/src/api/analytics/analytics.test.ts
@@ -47,9 +47,11 @@ describe('analytics', () => {
       configuration: getConfigurationInitialState(),
     };
 
-    it('when context is not provided, #getBaseMetadata returns an empty object', () => {
+    it('when context is not provided, #getBaseMetadata returns an object with version', () => {
       const provider = new AnalyticsProvider(baseState);
-      expect(provider.getBaseMetadata()).toEqual({});
+      expect(provider.getBaseMetadata()).toEqual({
+        coveoHeadlessVersion: expect.any(String),
+      });
     });
 
     it('when context is provided, #getBaseMetadata returns the correct object', () => {
@@ -62,7 +64,10 @@ describe('analytics', () => {
         },
       };
       const provider = new AnalyticsProvider(state);
-      expect(provider.getBaseMetadata()).toEqual({context_test: 'value'});
+      expect(provider.getBaseMetadata()).toEqual({
+        context_test: 'value',
+        coveoHeadlessVersion: expect.any(String),
+      });
     });
 
     it('when search is not provided, #getSearchUID returns the default id', () => {

--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -20,7 +20,6 @@ import {
   SearchHubSection,
   SearchSection,
 } from '../../state/state-sections';
-import {ContextPayload} from '../../features/context/context-state';
 import {PreprocessRequest} from '../preprocess-request';
 import {getLanguage} from './shared-analytics';
 import {
@@ -28,6 +27,7 @@ import {
   SectionNeededForFacetMetadata,
   getStateNeededForFacetMetadata,
 } from '../../features/facets/facet-set/facet-set-analytics-actions-utils';
+import {VERSION} from '../../utils/version';
 
 export type StateNeededByAnalyticsProvider = ConfigurationSection &
   Partial<
@@ -56,18 +56,18 @@ export class AnalyticsProvider implements SearchPageClientProvider {
       responseTime: this.responseTime,
       results: this.mapResultsToAnalyticsDocument(),
       numberOfResults: this.numberOfResults,
-      getBaseMetadata: this.getBaseMetadata(),
     };
   }
 
   public getBaseMetadata() {
     const {context} = this.state;
     const contextValues = context?.contextValues || {};
-    const formattedObject: ContextPayload = {};
+    const formattedObject: Record<string, string | string[]> = {};
     for (const [key, value] of Object.entries(contextValues)) {
       const formattedKey = `context_${key}`;
       formattedObject[formattedKey] = value;
     }
+    formattedObject['coveoHeadlessVersion'] = VERSION;
     return formattedObject;
   }
 


### PR DESCRIPTION
This is a request from M.Petitclerc.

This helps the UA team track different version of what our commerce clients are using.

https://coveord.atlassian.net/browse/KIT-1269