### PR TITLE
ci: fix chown issue in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,6 @@ node('linux && docker') {
             'atomic': {
               sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'
               sh 'cd packages/atomic && npm run start:prod & npx wait-on http://localhost:3333'
-              sh 'if [-d /tmp ] ; then chown -R $(whoami) /tmp ; fi'
               sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome --quiet'
             },
             'quantic': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ node('linux && docker') {
             'atomic': {
               sh 'cd packages/atomic && ./node_modules/cypress/bin/cypress install'
               sh 'cd packages/atomic && npm run start:prod & npx wait-on http://localhost:3333'
-              sh 'chown -R $(whoami) /tmp'
+              sh 'if [-d /tmp ] ; then chown -R $(whoami) /tmp ; fi'
               sh 'cd packages/atomic && NO_COLOR=1 ./node_modules/cypress/bin/cypress run --record --key 0e9d8bcc-a33a-4562-8604-c04e7bed0c7e --browser chrome --quiet'
             },
             'quantic': {


### PR DESCRIPTION
I think that changed when I did the versions bump with renovate last week. 
That step is no longer necessary it seems 🤷


https://coveord.atlassian.net/browse/KIT-1272