### PR TITLE
docs(headless-react): fix query syntax builder samples

### DIFF
--- a/packages/samples/headless-react/src/components/static-filter/static-filter.fn.tsx
+++ b/packages/samples/headless-react/src/components/static-filter/static-filter.fn.tsx
@@ -35,7 +35,7 @@ const youtubeExpression = buildQueryExpression()
     operator: 'isExactly',
     values: ['youtubevideo'],
   })
-  .toString();
+  .toQuerySyntax();
 
 const dropboxExpression = buildQueryExpression()
   .addStringField({
@@ -48,7 +48,7 @@ const dropboxExpression = buildQueryExpression()
     operator: 'isExactly',
     values: ['File'],
   })
-  .toString();
+  .toQuerySyntax();
 
 const youtube = buildStaticFilterValue({
   caption: 'Youtube',

--- a/packages/samples/headless-react/src/components/tab/tab.fn.tsx
+++ b/packages/samples/headless-react/src/components/tab/tab.fn.tsx
@@ -26,7 +26,7 @@ const messageExpression = buildQueryExpression()
     operator: 'isExactly',
     values: ['Message'],
   })
-  .toString();
+  .toQuerySyntax();
 
 const controller = buildTab(engine, {
   initialState: {isActive: true},

--- a/packages/samples/headless-react/src/pages/SearchPage.tsx
+++ b/packages/samples/headless-react/src/pages/SearchPage.tsx
@@ -363,7 +363,7 @@ export class SearchPage extends Component {
         operator: 'isExactly',
         values: ['Message'],
       })
-      .toString();
+      .toQuerySyntax();
   }
 
   private get confluenceExpression() {
@@ -379,7 +379,7 @@ export class SearchPage extends Component {
         values: ['Space'],
         negate: true,
       })
-      .toString();
+      .toQuerySyntax();
   }
 
   private executeInitialSearch() {
@@ -419,7 +419,7 @@ export class SearchPage extends Component {
         operator: 'isExactly',
         values: ['youtubevideo'],
       })
-      .toString();
+      .toQuerySyntax();
 
     const dropboxExpression = buildQueryExpression()
       .addStringField({
@@ -432,7 +432,7 @@ export class SearchPage extends Component {
         operator: 'isExactly',
         values: ['File'],
       })
-      .toString();
+      .toQuerySyntax();
 
     return [
       buildStaticFilterValue({


### PR DESCRIPTION
I changed the method to generate the string expression in response to a PR comment, but did not adjust the samples.
Caught this while clicking around to test the ESM bundle generated by esbuild,
 
https://coveord.atlassian.net/browse/KIT-1274