### PR TITLE
chore: improve copy static resources error message

### DIFF
--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -3,7 +3,12 @@ const ncp = promisify(require('ncp'));
 const mkdir = promisify(require('fs').mkdir);
 
 const copy = async (source, dest) => {
-  return await ncp(source, dest);
+  try {
+    return await ncp(source, dest);
+  } catch (e) {
+    console.log(`Failed to copy: ${source}\nDoes the file exist?`);
+    process.exit(1);
+  }
 };
 
 const main = async () => {

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -6,7 +6,7 @@ const copy = async (source, dest) => {
   try {
     return await ncp(source, dest);
   } catch (e) {
-    console.log(`Failed to copy: ${source}\nDoes the file exist?`);
+    console.log(`Failed to copy: ${source}\nDoes the resource exist?`);
     process.exit(1);
   }
 };


### PR DESCRIPTION
At one point while testing different bundles with quantic, I hit this cryptic error:

![copy-resources error](https://user-images.githubusercontent.com/5565841/144683895-bd00e350-d4c5-45af-89b2-4793c8c6a452.PNG)

This PR adjusts to catch and log a hopefully clearer error.

![copy-resources_new-error-message](https://user-images.githubusercontent.com/5565841/144684126-89f84f63-f362-4064-a83c-1478b0d726a9.PNG)

https://coveord.atlassian.net/browse/KIT-1275