### PR TITLE
chore: activate isolatedModules ts flag

### DIFF
--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -1,0 +1,148 @@
+const path = require('path');
+const {readFileSync} = require('fs');
+const {build} = require('esbuild');
+const alias = require('esbuild-plugin-alias');
+
+const useCaseEntries = {
+  search: 'src/index.ts',
+  recommendation: 'src/recommendation.index.ts',
+  'product-recommendation': 'src/product-recommendation.index.ts',
+  'product-listing': 'src/product-listing.index.ts',
+  'case-assist': 'src/case-assist.index.ts',
+}
+
+function getGlobalName(useCase) {
+  const map = {
+    search: 'CoveoHeadless',
+    recommendation: 'CoveoHeadlessRecommendation',
+    'product-recommendation': 'CoveoHeadlessProductRecommendation',
+    'product-listing': 'CoveoHeadlessProductListing',
+    'case-assist': 'CoveoHeadlessCaseAssist',
+  }
+
+  const globalName = map[useCase];
+
+  if (globalName) {
+    return globalName;
+  }
+
+  throw new Error(`Please specify a global name for use-case: "${useCase}"`)
+}
+
+function getPackageVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf-8')).version;
+}
+
+/**
+ * @type {import('esbuild').BuildOptions}
+ */
+const base = {
+  bundle: true,
+  tsconfig: './src/tsconfig.build.json',
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.VERSION': JSON.stringify(getPackageVersion())
+  },
+};
+
+const browser = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/browser', useCase);
+  const outfile = `${dir}/headless.js`;
+  
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'iife',
+    globalName: getGlobalName(useCase)
+  });
+})
+
+const browserEsm = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/browser', useCase);
+  const outfile = `${dir}/headless.esm.js`;
+  
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+  });
+})
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
+}
+
+/** 
+ * @param {import('esbuild').BuildOptions} options
+ * @returns {Promise<import('esbuild').BuildResult>}
+ */
+function buildBrowserConfig(options) {
+  return build({
+    ...base,
+    platform: 'browser',
+    minify: true,
+    sourcemap: true,
+    plugins: [
+      alias({
+        'coveo.analytics': path.resolve(
+          __dirname,
+          './node_modules/coveo.analytics/dist/library.es.js'
+        ),
+        'cross-fetch': path.resolve(
+          __dirname,
+          './fetch-ponyfill.js'
+        ),
+        'web-encoding': path.resolve(
+          __dirname,
+          './node_modules/web-encoding/src/lib.js'
+        ),
+      }),
+    ],
+    ...options
+  });
+}
+
+
+const nodeCjs = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/', useCase);
+  const outfile = `${dir}/headless.js`;
+  
+  return buildNodeConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'cjs',
+  });
+})
+
+const nodeEsm = Object.entries(useCaseEntries).map(entry => {
+  const [useCase, entryPoint] = entry;
+  const dir =  getUseCaseDir('dist/', useCase);
+  const outfile = `${dir}/headless.esm.js`;
+  
+  return buildNodeConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+  });
+})
+
+/** 
+ * @param {import('esbuild').BuildOptions} options
+ * @returns {Promise<import('esbuild').BuildResult>}
+ */
+function buildNodeConfig(options) {
+  return build({
+    ...base,
+    platform: 'node',
+    ...options
+  })
+}
+
+async function main() {
+  await Promise.all([...browserEsm, ...browser, ...nodeEsm, ...nodeCjs]);
+}
+
+main();

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -9,7 +9,7 @@ const useCaseEntries = {
   'product-recommendation': 'src/product-recommendation.index.ts',
   'product-listing': 'src/product-listing.index.ts',
   'case-assist': 'src/case-assist.index.ts',
-}
+};
 
 function getGlobalName(useCase) {
   const map = {
@@ -18,7 +18,7 @@ function getGlobalName(useCase) {
     'product-recommendation': 'CoveoHeadlessProductRecommendation',
     'product-listing': 'CoveoHeadlessProductListing',
     'case-assist': 'CoveoHeadlessCaseAssist',
-  }
+  };
 
   const globalName = map[useCase];
 
@@ -26,7 +26,7 @@ function getGlobalName(useCase) {
     return globalName;
   }
 
-  throw new Error(`Please specify a global name for use-case: "${useCase}"`)
+  throw new Error(`Please specify a global name for use-case: "${useCase}"`);
 }
 
 function getPackageVersion() {
@@ -41,40 +41,40 @@ const base = {
   tsconfig: './src/tsconfig.build.json',
   define: {
     'process.env.NODE_ENV': JSON.stringify('production'),
-    'process.env.VERSION': JSON.stringify(getPackageVersion())
+    'process.env.VERSION': JSON.stringify(getPackageVersion()),
   },
 };
 
-const browser = Object.entries(useCaseEntries).map(entry => {
+const browser = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/browser', useCase);
+  const dir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${dir}/headless.js`;
-  
+
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'iife',
-    globalName: getGlobalName(useCase)
+    globalName: getGlobalName(useCase),
   });
-})
+});
 
-const browserEsm = Object.entries(useCaseEntries).map(entry => {
+const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/browser', useCase);
+  const dir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${dir}/headless.esm.js`;
-  
+
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-})
+});
 
 function getUseCaseDir(prefix, useCase) {
   return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
-/** 
+/**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
@@ -90,46 +90,42 @@ function buildBrowserConfig(options) {
           __dirname,
           './node_modules/coveo.analytics/dist/library.es.js'
         ),
-        'cross-fetch': path.resolve(
-          __dirname,
-          './fetch-ponyfill.js'
-        ),
+        'cross-fetch': path.resolve(__dirname, './fetch-ponyfill.js'),
         'web-encoding': path.resolve(
           __dirname,
           './node_modules/web-encoding/src/lib.js'
         ),
       }),
     ],
-    ...options
+    ...options,
   });
 }
 
-
-const nodeCjs = Object.entries(useCaseEntries).map(entry => {
+const nodeCjs = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/', useCase);
+  const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.js`;
-  
+
   return buildNodeConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'cjs',
   });
-})
+});
 
-const nodeEsm = Object.entries(useCaseEntries).map(entry => {
+const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir =  getUseCaseDir('dist/', useCase);
+  const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.esm.js`;
-  
+
   return buildNodeConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-})
+});
 
-/** 
+/**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
@@ -137,8 +133,20 @@ function buildNodeConfig(options) {
   return build({
     ...base,
     platform: 'node',
-    ...options
-  })
+    plugins: [
+      alias({
+        'coveo.analytics': path.resolve(
+          __dirname,
+          './node_modules/coveo.analytics/dist/library.js'
+        ),
+        'web-encoding': path.resolve(
+          __dirname,
+          './node_modules/web-encoding/src/lib.cjs'
+        ),
+      }),
+    ],
+    ...options,
+  });
 }
 
 async function main() {

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -3,6 +3,8 @@ const {readFileSync} = require('fs');
 const {build} = require('esbuild');
 const alias = require('esbuild-plugin-alias');
 
+const devMode = process.argv[2] === 'dev';
+
 const useCaseEntries = {
   search: 'src/index.ts',
   recommendation: 'src/recommendation.index.ts',
@@ -13,6 +15,10 @@ const useCaseEntries = {
 
 function getPackageVersion() {
   return JSON.parse(readFileSync('package.json', 'utf-8')).version;
+}
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
 /**
@@ -30,22 +36,19 @@ const base = {
 const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
+  const outfile = `${outDir}/headless.esm.js`;
 
-  return buildBrowserEsmConfig(entryPoint, outDir);
+  return buildBrowserConfig({
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+    watch: devMode,
+  });
 });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('dist/browser', useCase);
-
-  return buildBrowserEsmConfig(entryPoint, outDir);
-});
-
-function getUseCaseDir(prefix, useCase) {
-  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
-}
-
-function buildBrowserEsmConfig(entryPoint, outDir) {
   const outfile = `${outDir}/headless.esm.js`;
 
   return buildBrowserConfig({
@@ -53,7 +56,7 @@ function buildBrowserEsmConfig(entryPoint, outDir) {
     outfile,
     format: 'esm',
   });
-}
+});
 
 /**
  * @param {import('esbuild').BuildOptions} options

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -11,24 +11,6 @@ const useCaseEntries = {
   'case-assist': 'src/case-assist.index.ts',
 };
 
-// function getGlobalName(useCase) {
-//   const map = {
-//     search: 'CoveoHeadless',
-//     recommendation: 'CoveoHeadlessRecommendation',
-//     'product-recommendation': 'CoveoHeadlessProductRecommendation',
-//     'product-listing': 'CoveoHeadlessProductListing',
-//     'case-assist': 'CoveoHeadlessCaseAssist',
-//   };
-
-//   const globalName = map[useCase];
-
-//   if (globalName) {
-//     return globalName;
-//   }
-
-//   throw new Error(`Please specify a global name for use-case: "${useCase}"`);
-// }
-
 function getPackageVersion() {
   return JSON.parse(readFileSync('package.json', 'utf-8')).version;
 }
@@ -44,19 +26,6 @@ const base = {
     'process.env.VERSION': JSON.stringify(getPackageVersion()),
   },
 };
-
-// const browser = Object.entries(useCaseEntries).map((entry) => {
-//   const [useCase, entryPoint] = entry;
-//   const dir = getUseCaseDir('dist/browser', useCase);
-//   const outfile = `${dir}/headless.js`;
-
-//   return buildBrowserConfig({
-//     entryPoints: [entryPoint],
-//     outfile,
-//     format: 'iife',
-//     globalName: getGlobalName(useCase),
-//   });
-// });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -45,18 +45,18 @@ const base = {
   },
 };
 
-const browser = Object.entries(useCaseEntries).map((entry) => {
-  const [useCase, entryPoint] = entry;
-  const dir = getUseCaseDir('dist/browser', useCase);
-  const outfile = `${dir}/headless.js`;
+// const browser = Object.entries(useCaseEntries).map((entry) => {
+//   const [useCase, entryPoint] = entry;
+//   const dir = getUseCaseDir('dist/browser', useCase);
+//   const outfile = `${dir}/headless.js`;
 
-  return buildBrowserConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'iife',
-    globalName: getGlobalName(useCase),
-  });
-});
+//   return buildBrowserConfig({
+//     entryPoints: [entryPoint],
+//     outfile,
+//     format: 'iife',
+//     globalName: getGlobalName(useCase),
+//   });
+// });
 
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
@@ -150,7 +150,7 @@ function buildNodeConfig(options) {
 }
 
 async function main() {
-  await Promise.all([...browserEsm, ...browser, ...nodeEsm, ...nodeCjs]);
+  await Promise.all([...browserEsm, ...nodeEsm, ...nodeCjs]);
 }
 
 main();

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -27,20 +27,32 @@ const base = {
   },
 };
 
+const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map((entry) => {
+  const [useCase, entryPoint] = entry;
+  const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
+
+  return buildBrowserEsmConfig(entryPoint, outDir);
+});
+
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
-  const dir = getUseCaseDir('dist/browser', useCase);
-  const outfile = `${dir}/headless.esm.js`;
+  const outDir = getUseCaseDir('dist/browser', useCase);
+
+  return buildBrowserEsmConfig(entryPoint, outDir);
+});
+
+function getUseCaseDir(prefix, useCase) {
+  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
+}
+
+function buildBrowserEsmConfig(entryPoint, outDir) {
+  const outfile = `${outDir}/headless.esm.js`;
 
   return buildBrowserConfig({
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   });
-});
-
-function getUseCaseDir(prefix, useCase) {
-  return useCase === 'search' ? prefix : `${prefix}/${useCase}`;
 }
 
 /**
@@ -119,7 +131,7 @@ function buildNodeConfig(options) {
 }
 
 async function main() {
-  await Promise.all([...browserEsm, ...nodeEsm, ...nodeCjs]);
+  await Promise.all([...browserEsm, ...browserEsmForAtomicDevelopment, ...nodeEsm, ...nodeCjs]);
 }
 
 main();

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@coveo/headless",
-      "version": "1.37.0",
+      "version": "1.37.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.34.0",
@@ -37,6 +37,8 @@
         "@rollup/plugin-replace": "2.4.2",
         "@types/jest": "27.0.3",
         "concurrently": "6.4.0",
+        "esbuild": "^0.14.1",
+        "esbuild-plugin-alias": "^0.2.1",
         "jest": "27.4.0",
         "jest-fetch-mock": "3.0.3",
         "rollup": "2.60.1",
@@ -6614,6 +6616,262 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.1.tgz",
+      "integrity": "sha512-J/LhUwELcmz0+CJfiaKzu7Rnj9ffWFLvMx+dKvdOfg+fQmoP6q9glla26LCm9BxpnPUjXChHeubLiMlKab/PYg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.14.1",
+        "esbuild-darwin-64": "0.14.1",
+        "esbuild-darwin-arm64": "0.14.1",
+        "esbuild-freebsd-64": "0.14.1",
+        "esbuild-freebsd-arm64": "0.14.1",
+        "esbuild-linux-32": "0.14.1",
+        "esbuild-linux-64": "0.14.1",
+        "esbuild-linux-arm": "0.14.1",
+        "esbuild-linux-arm64": "0.14.1",
+        "esbuild-linux-mips64le": "0.14.1",
+        "esbuild-linux-ppc64le": "0.14.1",
+        "esbuild-netbsd-64": "0.14.1",
+        "esbuild-openbsd-64": "0.14.1",
+        "esbuild-sunos-64": "0.14.1",
+        "esbuild-windows-32": "0.14.1",
+        "esbuild-windows-64": "0.14.1",
+        "esbuild-windows-arm64": "0.14.1"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.1.tgz",
+      "integrity": "sha512-elQd3hTg93nU2GQ5PPCDAFe5+utxZX96RG8RixqIPxf8pzmyIzcpKG76L/9FabPf3LT1z+nLF1sajCU8eVRDyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.1.tgz",
+      "integrity": "sha512-PR3HZgbPRwsQbbOR1fJrfkt/Cs0JDyI3yzOKg2PPWk0H1AseZDBqPUY9b/0+BIjFwA5Jz/aAiq832hppsuJtNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.1.tgz",
+      "integrity": "sha512-/fiSSOkOEa3co6yYtwgXouz8jZrG0qnXPEKiktFf2BQE8NON3ARTw43ZegaH+xMRFNgYBJEOOZIdzI3sIFEAxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.1.tgz",
+      "integrity": "sha512-ZJV+nfa8E8PdXnRc05PO3YMfgSj7Ko+kdHyGDE6OaNo1cO8ZyfacqLaWkY35shDDaeacklhD8ZR4qq5nbJKX1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.1.tgz",
+      "integrity": "sha512-6N9zTD+SecJr2g9Ohl9C10WIk5FpQ+52bNamRy0sJoHwP31G5ObzKzq8jAtg1Jeggpu6P8auz3P/UL+3YioSwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.1.tgz",
+      "integrity": "sha512-RtPgE6e7WefbAxRjVryisKFJ0nUwR2DMjwmYW/a1a0F1+Ge6FR+RqvgiY0DrM9TtxSUU0eryDXNF4n3UfxX3mg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.1.tgz",
+      "integrity": "sha512-JpxM0ar6Z+2v3vfFrxP7bFb8Wzb6gcGL9MxRqAJplDfGnee8HbfPge6svaazXeX9XJceeEqwxwWGB0qyCcxo7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.1.tgz",
+      "integrity": "sha512-eBRHexCijAYWzcvQLGHxyxIlYOkYhXvcb/O7HvzJfCAVWCnTx9TxxYJ3UppBC6dDFbAq4HwKhskvmesQdKMeBg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.1.tgz",
+      "integrity": "sha512-cFbeZf171bIf+PPLlQDBzagK85lCCxxVdMV1IVUA96Y3kvEgqcy2n9mha+QE1M/T+lIOPDsmLRgH1XqMFwLTSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.1.tgz",
+      "integrity": "sha512-UGb+sqHkL7wOQFLH0RoFhcRAlJNqbqs6GtJd1It5jJ2juOGqAkCv8V12aGDX9oRB6a+Om7cdHcH+6AMZ+qlaww==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.1.tgz",
+      "integrity": "sha512-LIHGkGdy9wYlmkkoVHm6feWhkoi4VBXDiEVyNjXEhlzsBcP/CaRy+B8IJulzaU1ALLiGcsCQ2MC5UbFn/iTvmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.1.tgz",
+      "integrity": "sha512-TWc1QIgtPwaK5nC1GT2ASTuy/CJhNKHN4h5PJRP1186VfI+k2uvXakS7bqO/M26F6jAMy8jDeCtilacqpwsvfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.1.tgz",
+      "integrity": "sha512-Z9/Zb77K+pK9s7mAsvwS56K8tCbLvNZ9UI4QVJSYqDgOmmDJOBT4owWnCqZ5cJI+2y4/F9KwCpFFTNUdPglPKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-plugin-alias": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz",
+      "integrity": "sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==",
+      "dev": true
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.1.tgz",
+      "integrity": "sha512-c4sF8146kNW8529wfkB6vO0ZqPgokyS2hORqKa4p/QKZdp+xrF2NPmvX5aN+Zt14oe6wVZuhYo6LGv7V4Gg04g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.1.tgz",
+      "integrity": "sha512-XP8yElaJtLGGjH7D72t5IWtP0jmc1Jqm4IjQARB17l0LTJO/n+N2X64rDWePJv6qimYxa5p2vTjkZc5v+YZTSQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.1.tgz",
+      "integrity": "sha512-fe+ShdyfiuGcCEdVKW//6MaM4MwikiWBWSBn8mebNAbjRqicH0injDOFVI7aUovAfrEt7+FGkf402s//hi0BVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.1.tgz",
+      "integrity": "sha512-wBVakhcIzQ3NZ33DFM6TjIObXPHaXOsqzvPwefXHvwBSC/N/e/g6fBeM7N/Moj3AmxLjKaB+vePvTGdxk6RPCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -21461,6 +21719,156 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "esbuild": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.1.tgz",
+      "integrity": "sha512-J/LhUwELcmz0+CJfiaKzu7Rnj9ffWFLvMx+dKvdOfg+fQmoP6q9glla26LCm9BxpnPUjXChHeubLiMlKab/PYg==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-arm64": "0.14.1",
+        "esbuild-darwin-64": "0.14.1",
+        "esbuild-darwin-arm64": "0.14.1",
+        "esbuild-freebsd-64": "0.14.1",
+        "esbuild-freebsd-arm64": "0.14.1",
+        "esbuild-linux-32": "0.14.1",
+        "esbuild-linux-64": "0.14.1",
+        "esbuild-linux-arm": "0.14.1",
+        "esbuild-linux-arm64": "0.14.1",
+        "esbuild-linux-mips64le": "0.14.1",
+        "esbuild-linux-ppc64le": "0.14.1",
+        "esbuild-netbsd-64": "0.14.1",
+        "esbuild-openbsd-64": "0.14.1",
+        "esbuild-sunos-64": "0.14.1",
+        "esbuild-windows-32": "0.14.1",
+        "esbuild-windows-64": "0.14.1",
+        "esbuild-windows-arm64": "0.14.1"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.1.tgz",
+      "integrity": "sha512-elQd3hTg93nU2GQ5PPCDAFe5+utxZX96RG8RixqIPxf8pzmyIzcpKG76L/9FabPf3LT1z+nLF1sajCU8eVRDyg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.1.tgz",
+      "integrity": "sha512-PR3HZgbPRwsQbbOR1fJrfkt/Cs0JDyI3yzOKg2PPWk0H1AseZDBqPUY9b/0+BIjFwA5Jz/aAiq832hppsuJtNw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.1.tgz",
+      "integrity": "sha512-/fiSSOkOEa3co6yYtwgXouz8jZrG0qnXPEKiktFf2BQE8NON3ARTw43ZegaH+xMRFNgYBJEOOZIdzI3sIFEAxw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.1.tgz",
+      "integrity": "sha512-ZJV+nfa8E8PdXnRc05PO3YMfgSj7Ko+kdHyGDE6OaNo1cO8ZyfacqLaWkY35shDDaeacklhD8ZR4qq5nbJKX1A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.1.tgz",
+      "integrity": "sha512-6N9zTD+SecJr2g9Ohl9C10WIk5FpQ+52bNamRy0sJoHwP31G5ObzKzq8jAtg1Jeggpu6P8auz3P/UL+3YioSwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.1.tgz",
+      "integrity": "sha512-RtPgE6e7WefbAxRjVryisKFJ0nUwR2DMjwmYW/a1a0F1+Ge6FR+RqvgiY0DrM9TtxSUU0eryDXNF4n3UfxX3mg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.1.tgz",
+      "integrity": "sha512-JpxM0ar6Z+2v3vfFrxP7bFb8Wzb6gcGL9MxRqAJplDfGnee8HbfPge6svaazXeX9XJceeEqwxwWGB0qyCcxo7A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.1.tgz",
+      "integrity": "sha512-eBRHexCijAYWzcvQLGHxyxIlYOkYhXvcb/O7HvzJfCAVWCnTx9TxxYJ3UppBC6dDFbAq4HwKhskvmesQdKMeBg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.1.tgz",
+      "integrity": "sha512-cFbeZf171bIf+PPLlQDBzagK85lCCxxVdMV1IVUA96Y3kvEgqcy2n9mha+QE1M/T+lIOPDsmLRgH1XqMFwLTSg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.1.tgz",
+      "integrity": "sha512-UGb+sqHkL7wOQFLH0RoFhcRAlJNqbqs6GtJd1It5jJ2juOGqAkCv8V12aGDX9oRB6a+Om7cdHcH+6AMZ+qlaww==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.1.tgz",
+      "integrity": "sha512-LIHGkGdy9wYlmkkoVHm6feWhkoi4VBXDiEVyNjXEhlzsBcP/CaRy+B8IJulzaU1ALLiGcsCQ2MC5UbFn/iTvmA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.1.tgz",
+      "integrity": "sha512-TWc1QIgtPwaK5nC1GT2ASTuy/CJhNKHN4h5PJRP1186VfI+k2uvXakS7bqO/M26F6jAMy8jDeCtilacqpwsvfA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.1.tgz",
+      "integrity": "sha512-Z9/Zb77K+pK9s7mAsvwS56K8tCbLvNZ9UI4QVJSYqDgOmmDJOBT4owWnCqZ5cJI+2y4/F9KwCpFFTNUdPglPKA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-plugin-alias": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz",
+      "integrity": "sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==",
+      "dev": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.1.tgz",
+      "integrity": "sha512-c4sF8146kNW8529wfkB6vO0ZqPgokyS2hORqKa4p/QKZdp+xrF2NPmvX5aN+Zt14oe6wVZuhYo6LGv7V4Gg04g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.1.tgz",
+      "integrity": "sha512-XP8yElaJtLGGjH7D72t5IWtP0jmc1Jqm4IjQARB17l0LTJO/n+N2X64rDWePJv6qimYxa5p2vTjkZc5v+YZTSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.1.tgz",
+      "integrity": "sha512-fe+ShdyfiuGcCEdVKW//6MaM4MwikiWBWSBn8mebNAbjRqicH0injDOFVI7aUovAfrEt7+FGkf402s//hi0BVg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.1.tgz",
+      "integrity": "sha512-wBVakhcIzQ3NZ33DFM6TjIObXPHaXOsqzvPwefXHvwBSC/N/e/g6fBeM7N/Moj3AmxLjKaB+vePvTGdxk6RPCg==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -23,7 +23,7 @@
     "product-listing/"
   ],
   "scripts": {
-    "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
+    "start": "concurrently \"npm run typedefinitions -- -w\" \"node esbuild.js dev\"",
     "build": "npm run build:prod --",
     "build:prod": "npm run typedefinitions && node esbuild.js && rollup -c --environment BUILD:production",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -71,6 +71,8 @@
     "@rollup/plugin-replace": "2.4.2",
     "@types/jest": "27.0.3",
     "concurrently": "6.4.0",
+    "esbuild": "^0.14.1",
+    "esbuild-plugin-alias": "^0.2.1",
     "jest": "27.4.0",
     "jest-fetch-mock": "3.0.3",
     "rollup": "2.60.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
     "build": "npm run build:prod --",
-    "build:prod": "npm run typedefinitions && rollup -c --environment BUILD:production",
+    "build:prod": "npm run typedefinitions && node esbuild.js",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -f -r dist/*",
     "test": "jest",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "concurrently \"npm run typedefinitions -- -w\" \"rollup -c -w\"",
     "build": "npm run build:prod --",
-    "build:prod": "npm run typedefinitions && node esbuild.js",
+    "build:prod": "npm run typedefinitions && node esbuild.js && rollup -c --environment BUILD:production",
     "typedefinitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -f -r dist/*",
     "test": "jest",

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -114,35 +114,35 @@ const browser = [
     input: 'src/index.ts',
     output: [
       buildUmdOutput('dist/browser', 'CoveoHeadless'),
-      buildEsmOutput('dist/browser')
+      // buildEsmOutput('dist/browser')
     ]
   },
   {
     input: 'src/case-assist.index.ts',
     output: [
       buildUmdOutput('dist/browser/case-assist', 'CoveoHeadlessCaseAssist'),
-      buildEsmOutput('dist/browser/case-assist')
+      // buildEsmOutput('dist/browser/case-assist')
     ]
   },
   {
     input: 'src/recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/recommendation', 'CoveoHeadlessRecommendation'),
-      buildEsmOutput('dist/browser/recommendation')
+      // buildEsmOutput('dist/browser/recommendation')
     ]
   },
   {
     input: 'src/product-recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-recommendation', 'CoveoHeadlessProductRecommendation'),
-      buildEsmOutput('dist/browser/product-recommendation')
+      // buildEsmOutput('dist/browser/product-recommendation')
     ]
   },
   {
     input: 'src/product-listing.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-listing', 'CoveoHeadlessProductListing'),
-      buildEsmOutput('dist/browser/product-listing')
+      // buildEsmOutput('dist/browser/product-listing')
     ]
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
@@ -246,6 +246,6 @@ const dev = [
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
 
-const config = isProduction ? [...nodejs, ...browser] : dev;
+const config = isProduction ? [...browser] : dev;
 
 export default config;

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -52,7 +52,7 @@ function matchesFilter(value) {
 
 // Browser Bundles
 
-const browser = [
+const browserUmd = [
   {
     input: 'src/index.ts',
     output: [
@@ -130,14 +130,6 @@ function buildUmdOutput(outDir, name) {
   }
 }
 
-function buildEsmOutput(outDir) {
-  return {
-    file: `${outDir}/headless.esm.js`,
-    format: 'es',
-    ...sourceMapConfig(),
-  }
-}
-
 function sourceMapConfig() {
   return {
     sourcemap: isProduction,
@@ -161,38 +153,6 @@ function copySourceFiles() {
   });
 }
 
-// For Atomic's local development purposes only
-const local = [
-  {
-    input: 'src/index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds')],
-  },
-  {
-    input: 'src/case-assist.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/case-assist')],
-  },
-  {
-    input: 'src/recommendation.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/recommendation')],
-  },
-  {
-    input: 'src/product-recommendation.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/product-recommendation')],
-  },
-  {
-    input: 'src/product-listing.index.ts',
-    output: [buildEsmOutput('../atomic/src/external-builds/product-listing')],
-  },
-].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
-
-const config = [];
-
-if (isProduction) {
-  config.push(...browser);
-}
-
-if (!isCI) {
-  config.push(...local)
-}
+const config = isProduction ? browserUmd : [];
 
 export default config;

--- a/packages/headless/rollup.config.js
+++ b/packages/headless/rollup.config.js
@@ -1,5 +1,4 @@
 import resolve from '@rollup/plugin-node-resolve';
-// import json from '@rollup/plugin-json';
 import commonjs from '@rollup/plugin-commonjs';
 import tsPlugin from '@rollup/plugin-typescript';
 import replacePlugin from '@rollup/plugin-replace';
@@ -27,15 +26,15 @@ function replace() {
   return replacePlugin({'process.env.NODE_ENV': JSON.stringify(env), 'process.env.VERSION': JSON.stringify(version)});
 }
 
-// function onWarn(warning, warn) {
-//   const isCircularDependency = warning.code === 'CIRCULAR_DEPENDENCY';
+function onWarn(warning, warn) {
+  const isCircularDependency = warning.code === 'CIRCULAR_DEPENDENCY';
 
-//   if (isCI && isCircularDependency) {
-//     throw new Error(warning.message);
-//   }
+  if (isCI && isCircularDependency) {
+    throw new Error(warning.message);
+  }
 
-//   warn(warning);
-// }
+  warn(warning);
+}
 
 /**
  * @param {string} value
@@ -51,62 +50,6 @@ function matchesFilter(value) {
   return value.includes(filter);
 }
 
-// Node Bundles
-
-// const nodejs = [
-//   {
-//     input: 'src/index.ts',
-//     outDir: 'dist',
-//   },
-//   {
-//     input: 'src/case-assist.index.ts',
-//     outDir: 'dist/case-assist'
-//   },
-//   {
-//     input: 'src/recommendation.index.ts',
-//     outDir: 'dist/recommendation'
-//   },
-//   {
-//     input: 'src/product-recommendation.index.ts',
-//     outDir: 'dist/product-recommendation'
-//   },
-//   {
-//     input: 'src/product-listing.index.ts',
-//     outDir: 'dist/product-listing'
-//   },
-// ].filter(b => matchesFilter(b.input)).map(buildNodeConfiguration);
-
-// function buildNodeConfiguration({input, outDir}) {
-//   return {
-//     input,
-//     output: [
-//       {file: `${outDir}/headless.js`, format: 'cjs'},
-//       {file: `${outDir}/headless.esm.js`, format: 'es'},
-//     ],
-//     plugins: [
-//       resolve({preferBuiltins: true, mainFields: ['main']}),
-//       json(),
-//       commonjs({
-//         // https://github.com/pinojs/pino/issues/688
-//         ignore: ['pino-pretty'],
-//       }),
-//       typescript(),
-//       replace(),
-//     ],
-//     external: [
-//       'os',
-//       'https',
-//       'http',
-//       'stream',
-//       'zlib',
-//       'fs',
-//       'vm',
-//       'util',
-//     ],
-//     onwarn: onWarn,
-//   };
-// }
-
 // Browser Bundles
 
 const browser = [
@@ -114,35 +57,30 @@ const browser = [
     input: 'src/index.ts',
     output: [
       buildUmdOutput('dist/browser', 'CoveoHeadless'),
-      // buildEsmOutput('dist/browser')
     ]
   },
   {
     input: 'src/case-assist.index.ts',
     output: [
       buildUmdOutput('dist/browser/case-assist', 'CoveoHeadlessCaseAssist'),
-      // buildEsmOutput('dist/browser/case-assist')
     ]
   },
   {
     input: 'src/recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/recommendation', 'CoveoHeadlessRecommendation'),
-      // buildEsmOutput('dist/browser/recommendation')
     ]
   },
   {
     input: 'src/product-recommendation.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-recommendation', 'CoveoHeadlessProductRecommendation'),
-      // buildEsmOutput('dist/browser/product-recommendation')
     ]
   },
   {
     input: 'src/product-listing.index.ts',
     output: [
       buildUmdOutput('dist/browser/product-listing', 'CoveoHeadlessProductListing'),
-      // buildEsmOutput('dist/browser/product-listing')
     ]
   },
 ].filter(b => matchesFilter(b.input)).map(buildBrowserConfiguration);
@@ -179,6 +117,7 @@ function buildBrowserConfiguration({input, output}) {
       isProduction && terser(),
       copySourceFiles(),
     ],
+    onwarn: onWarn
   }
 }
 

--- a/packages/headless/src/app/case-assist-engine/case-assist-engine.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine.ts
@@ -19,7 +19,7 @@ import {CaseAssistAPIClient} from '../../api/service/case-assist/case-assist-api
 import {CaseAssistThunkExtraArguments} from '../case-assist-thunk-extra-arguments';
 import {setCaseAssistConfiguration} from '../../features/case-assist-configuration/case-assist-configuration-actions';
 
-export {CaseAssistEngineConfiguration};
+export type {CaseAssistEngineConfiguration};
 
 const caseassistEngineReducers = {
   debug,

--- a/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
+++ b/packages/headless/src/app/product-listing-engine/product-listing-engine.ts
@@ -26,10 +26,8 @@ import {
   NoopPostprocessSearchResponseMiddleware,
 } from '../../api/search/search-api-client-middleware';
 
-export {
-  ProductListingEngineConfiguration,
-  getSampleProductListingEngineConfiguration,
-};
+export type {ProductListingEngineConfiguration};
+export {getSampleProductListingEngineConfiguration};
 
 const productListingEngineReducers = {productListing};
 type ProductListingEngineReducers = typeof productListingEngineReducers;

--- a/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
+++ b/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
@@ -26,10 +26,8 @@ import {setSearchHub} from '../../features/search-hub/search-hub-actions';
 import {isNullOrUndefined} from '@coveo/bueno';
 import {updateSearchConfiguration} from '../../features/configuration/configuration-actions';
 
-export {
-  ProductRecommendationEngineConfiguration,
-  getSampleProductRecommendationEngineConfiguration,
-} from './product-recommendation-engine-configuration';
+export type {ProductRecommendationEngineConfiguration} from './product-recommendation-engine-configuration';
+export {getSampleProductRecommendationEngineConfiguration} from './product-recommendation-engine-configuration';
 
 const productRecommendationEngineReducers = {searchHub, productRecommendations};
 type ProductRecommendationEngineReducers =

--- a/packages/headless/src/app/recommendation-engine/recommendation-engine.ts
+++ b/packages/headless/src/app/recommendation-engine/recommendation-engine.ts
@@ -28,10 +28,8 @@ import {setSearchHub} from '../../features/search-hub/search-hub-actions';
 import {isNullOrUndefined} from '@coveo/bueno';
 import {updateSearchConfiguration} from '../../features/configuration/configuration-actions';
 
-export {
-  RecommendationEngineConfiguration,
-  getSampleRecommendationEngineConfiguration,
-};
+export type {RecommendationEngineConfiguration};
+export {getSampleRecommendationEngineConfiguration};
 
 const recommendationEngineReducers = {
   debug,

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -35,11 +35,8 @@ import {SearchThunkExtraArguments} from '../search-thunk-extra-arguments';
 import {SearchAction} from '../../features/analytics/analytics-utils';
 import {StandaloneSearchBoxAnalytics} from '../../features/standalone-search-box-set/standalone-search-box-set-state';
 
-export {
-  SearchEngineConfiguration,
-  SearchConfigurationOptions,
-  getSampleSearchEngineConfiguration,
-};
+export type {SearchEngineConfiguration, SearchConfigurationOptions};
+export {getSampleSearchEngineConfiguration};
 
 const searchEngineReducers = {debug, pipeline, searchHub, search};
 type SearchEngineReducers = typeof searchEngineReducers;

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -1,29 +1,23 @@
 // 3rd Party Libraries
-export {
-  Unsubscribe,
-  createAction,
-  createAsyncThunk,
-  createReducer,
-  Middleware,
-} from '@reduxjs/toolkit';
+export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 
 // Main App
-export {
+export type {
   CaseAssistEngine,
   CaseAssistEngineOptions,
   CaseAssistEngineConfiguration,
-  buildCaseAssistEngine,
 } from './app/case-assist-engine/case-assist-engine';
+export {buildCaseAssistEngine} from './app/case-assist-engine/case-assist-engine';
 
-export {CoreEngine, ExternalEngineOptions} from './app/engine';
-export {
+export type {CoreEngine, ExternalEngineOptions} from './app/engine';
+export type {
   EngineConfiguration,
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
 } from './app/engine-configuration';
-export {LoggerOptions} from './app/logger';
+export type {LoggerOptions} from './app/logger';
 
-export {LogLevel} from './app/logger';
+export type {LogLevel} from './app/logger';
 
 // Case Assist Action Loaders
 export * from './features/case-input/case-input-actions-loader';
@@ -32,29 +26,27 @@ export * from './features/document-suggestion/document-suggestion-actions-loader
 export * from './features/case-assist/case-assist-analytics-actions-loader';
 
 // Controllers
-export {
-  Controller,
-  buildController,
-} from './controllers/controller/headless-controller';
+export type {Controller} from './controllers/controller/headless-controller';
+export {buildController} from './controllers/controller/headless-controller';
 
-export {
+export type {
   CaseInputState,
   CaseInput,
   CaseInputOptions,
   CaseInputProps,
-  buildCaseInput,
 } from './controllers/case-input/headless-case-input';
+export {buildCaseInput} from './controllers/case-input/headless-case-input';
 
-export {
+export type {
   CaseFieldState,
   CaseField,
   CaseFieldOptions,
   CaseFieldProps,
-  buildCaseField,
 } from './controllers/case-field/headless-case-field';
+export {buildCaseField} from './controllers/case-field/headless-case-field';
 
-export {
+export type {
   DocumentSuggestionList as DocumentSuggestion,
   DocumentSuggestionListState as DocumentSuggestionState,
-  buildDocumentSuggestionList as buildDocumentSuggestion,
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
+export {buildDocumentSuggestionList as buildDocumentSuggestion} from './controllers/document-suggestion-list/headless-document-suggestion-list';

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -13,7 +13,7 @@ import {context} from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {CoreEngine} from '../../app/engine';
 
-export {ContextPayload, ContextValue};
+export type {ContextPayload, ContextValue};
 
 /**
  * The `Context` controller injects [custom contextual information](https://docs.coveo.com/en/399/) into the search requests and usage analytics search events sent from a search interface.

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
@@ -40,7 +40,11 @@ import {defaultFacetSearchOptions} from '../../../../features/facets/facet-searc
 import {CoreEngine} from '../../../../app/engine';
 import {isFacetLoadingResponseSelector} from '../../../../features/facets/facet-set/facet-set-selectors';
 
-export {CategoryFacetValue, CategoryFacetOptions, CategoryFacetSearchOptions};
+export type {
+  CategoryFacetValue,
+  CategoryFacetOptions,
+  CategoryFacetSearchOptions,
+};
 
 export interface CategoryFacetProps {
   /** The options for the `CategoryFacet` controller. */

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
@@ -44,7 +44,7 @@ import {loadReducerError} from '../../../../utils/errors';
 import {CoreEngine} from '../../../../app/engine';
 import {SearchThunkExtraArguments} from '../../../../app/search-thunk-extra-arguments';
 
-export {FacetOptions, FacetSearchOptions, FacetValueState};
+export type {FacetOptions, FacetSearchOptions, FacetValueState};
 
 export interface FacetProps {
   /**

--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/headless-core-date-facet.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/headless-core-date-facet.ts
@@ -34,13 +34,13 @@ import {loadReducerError} from '../../../../../utils/errors';
 import {deselectAllFacetValues} from '../../../../../features/facets/facet-set/facet-set-actions';
 import {CoreEngine} from '../../../../../app/engine';
 
-export {
+export type {
   DateFacetOptions,
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,
-  buildDateRange,
 };
+export {buildDateRange};
 
 export interface DateFacetProps {
   /**

--- a/packages/headless/src/controllers/core/facets/range-facet/numeric-facet/headless-core-numeric-facet.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/numeric-facet/headless-core-numeric-facet.ts
@@ -37,13 +37,13 @@ import {loadReducerError} from '../../../../../utils/errors';
 import {deselectAllFacetValues} from '../../../../../features/facets/facet-set/facet-set-actions';
 import {CoreEngine} from '../../../../../app/engine';
 
-export {
-  buildNumericRange,
+export type {
   NumericRangeOptions,
   NumericRangeRequest,
   NumericFacetValue,
   NumericFacetOptions,
 };
+export {buildNumericRange};
 
 export interface NumericFacetProps {
   /**

--- a/packages/headless/src/controllers/dictionary-field-context/headless-dictionary-field-context.ts
+++ b/packages/headless/src/controllers/dictionary-field-context/headless-dictionary-field-context.ts
@@ -10,7 +10,7 @@ import {DictionaryFieldContextSection} from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';
 import {Controller, buildController} from '../controller/headless-controller';
 
-export {DictionaryFieldContextPayload};
+export type {DictionaryFieldContextPayload};
 
 /**
  * The `DictionaryFieldContext` controller allows specifying which [dictionary field](https://docs.coveo.com/en/2036/index-content/about-fields#dictionary-fields) keys to retrieve.

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -17,7 +17,7 @@ import {loadReducerError} from '../../utils/errors';
 import {configuration, didYouMean} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 
-export {QueryCorrection, WordCorrection};
+export type {QueryCorrection, WordCorrection};
 
 export interface DidYouMean extends Controller {
   /**

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -40,7 +40,7 @@ import {
 } from '../../core/facets/category-facet/headless-core-category-facet';
 import {buildCategoryFacetSearch} from './headless-category-facet-search';
 
-export {
+export type {
   CategoryFacetValue,
   CategoryFacetOptions,
   CategoryFacetSearchOptions,

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -41,7 +41,7 @@ import {getAnalyticsActionForToggleFacetSelect} from '../../../features/facets/f
 import {buildFacetSearch} from '../../core/facets/facet-search/specific/headless-facet-search';
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 
-export {
+export type {
   FacetOptions,
   FacetSearchOptions,
   FacetValueState,

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -20,16 +20,16 @@ import {
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
 import {RangeFacetSortCriterion} from '../../../../features/facets/range-facets/generic/interfaces/request';
 
-export {
+export type {
   DateFacetOptions,
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,
-  buildDateRange,
   DateFacetProps,
   DateFacet,
   DateFacetState,
 };
+export {buildDateRange};
 
 /**
  * Creates a `DateFacet` controller instance.

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
@@ -21,7 +21,7 @@ import {
   DateFilterState,
 } from '../../../core/facets/range-facet/date-facet/headless-core-date-filter';
 
-export {
+export type {
   DateFilterOptions,
   DateFilterInitialState,
   DateFilterRange,

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -25,8 +25,7 @@ import {
   logFacetUpdateSort,
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
 
-export {
-  buildNumericRange,
+export type {
   NumericRangeOptions,
   NumericRangeRequest,
   NumericFacetValue,
@@ -35,6 +34,7 @@ export {
   NumericFacet,
   NumericFacetState,
 };
+export {buildNumericRange};
 
 /**
  * Creates a `NumericFacet` controller instance.

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
@@ -22,7 +22,7 @@ import {
   buildCoreNumericFilter,
 } from '../../../core/facets/range-facet/numeric-facet/headless-core-numeric-filter';
 
-export {
+export type {
   NumericFilterOptions,
   NumericFilterInitialState,
   NumericFilterRange,

--- a/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
+++ b/packages/headless/src/controllers/folded-result-list/headless-folded-result-list.ts
@@ -25,7 +25,7 @@ import {
 } from '../result-list/headless-result-list';
 import {SearchStatusState} from '../search-status/headless-search-status';
 
-export {FoldedCollection, FoldedResult};
+export type {FoldedCollection, FoldedResult};
 
 const optionsSchema = new Schema<Required<FoldingOptions>>(
   foldingOptionsSchemaDefinition

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -1,6 +1,7 @@
-export {Controller, buildController} from './controller/headless-controller';
+export type {Controller} from './controller/headless-controller';
+export {buildController} from './controller/headless-controller';
 
-export {
+export type {
   RelevanceInspectorInitialState,
   RelevanceInspectorProps,
   RelevanceInspectorState,
@@ -15,39 +16,38 @@ export {
   RankingInformation,
   TermWeightReport,
   SecurityIdentity,
-  buildRelevanceInspector,
 } from './relevance-inspector/headless-relevance-inspector';
+export {buildRelevanceInspector} from './relevance-inspector/headless-relevance-inspector';
 
-export {
+export type {
   Context,
   ContextState,
   ContextValue,
   ContextPayload,
-  buildContext,
 } from './context/headless-context';
+export {buildContext} from './context/headless-context';
 
-export {
+export type {
   DictionaryFieldContext,
   DictionaryFieldContextState,
   DictionaryFieldContextPayload,
-  buildDictionaryFieldContext,
 } from './dictionary-field-context/headless-dictionary-field-context';
+export {buildDictionaryFieldContext} from './dictionary-field-context/headless-dictionary-field-context';
 
-export {
+export type {
   DidYouMean,
   DidYouMeanState,
   QueryCorrection,
   WordCorrection,
-  buildDidYouMean,
 } from './did-you-mean/headless-did-you-mean';
+export {buildDidYouMean} from './did-you-mean/headless-did-you-mean';
 
-export {
+export type {
   CategoryFacetOptions,
   CategoryFacetSearchOptions,
   CategoryFacetProps,
   CategoryFacetState,
   CategoryFacet,
-  buildCategoryFacet,
   CategoryFacetValue,
   CategoryFacetSearch,
   CategoryFacetSearchState,
@@ -55,14 +55,14 @@ export {
   CoreCategoryFacet,
   CoreCategoryFacetState,
 } from './facets/category-facet/headless-category-facet';
+export {buildCategoryFacet} from './facets/category-facet/headless-category-facet';
 
-export {
+export type {
   FacetOptions,
   FacetSearchOptions,
   FacetProps,
   FacetState,
   Facet,
-  buildFacet,
   FacetValue,
   FacetValueState,
   FacetSearch,
@@ -71,32 +71,36 @@ export {
   CoreFacet,
   CoreFacetState,
 } from './facets/facet/headless-facet';
+export {buildFacet} from './facets/facet/headless-facet';
 
-export {
+export type {
   DateRangeOptions,
   DateRangeRequest,
   DateRangeInput,
-  buildDateRange,
   DateFacetOptions,
   DateFacetProps,
   DateFacetState,
   DateFacet,
+} from './facets/range-facet/date-facet/headless-date-facet';
+export {
+  buildDateRange,
   buildDateFacet,
 } from './facets/range-facet/date-facet/headless-date-facet';
 
-export {
-  buildNumericRange,
+export type {
   NumericRangeOptions,
   NumericRangeRequest,
-  buildNumericFacet,
   NumericFacetOptions,
   NumericFacetProps,
   NumericFacetState,
   NumericFacet,
 } from './facets/range-facet/numeric-facet/headless-numeric-facet';
-
 export {
-  buildNumericFilter,
+  buildNumericRange,
+  buildNumericFacet,
+} from './facets/range-facet/numeric-facet/headless-numeric-facet';
+
+export type {
   NumericFilter,
   NumericFilterOptions,
   NumericFilterProps,
@@ -104,9 +108,9 @@ export {
   NumericFilterState,
   NumericFilterInitialState,
 } from './facets/range-facet/numeric-facet/headless-numeric-filter';
+export {buildNumericFilter} from './facets/range-facet/numeric-facet/headless-numeric-filter';
 
-export {
-  buildDateFilter,
+export type {
   DateFilter,
   DateFilterOptions,
   DateFilterProps,
@@ -114,58 +118,59 @@ export {
   DateFilterState,
   DateFilterInitialState,
 } from './facets/range-facet/date-facet/headless-date-filter';
+export {buildDateFilter} from './facets/range-facet/date-facet/headless-date-filter';
 
-export {
+export type {
   HistoryManager,
   HistoryManagerState,
-  buildHistoryManager,
 } from './history-manager/headless-history-manager';
+export {buildHistoryManager} from './history-manager/headless-history-manager';
 
-export {
+export type {
   PagerInitialState,
   PagerOptions,
   PagerProps,
   PagerState,
   Pager,
-  buildPager,
 } from './pager/headless-pager';
+export {buildPager} from './pager/headless-pager';
 
-export {
+export type {
   QueryError,
   QueryErrorState,
-  buildQueryError,
 } from './query-error/headless-query-error';
+export {buildQueryError} from './query-error/headless-query-error';
 
-export {
+export type {
   QuerySummaryState,
   QuerySummary,
-  buildQuerySummary,
 } from './query-summary/headless-query-summary';
+export {buildQuerySummary} from './query-summary/headless-query-summary';
 
-export {
+export type {
   ResultListProps,
   ResultListOptions,
   ResultListState,
   ResultList,
-  buildResultList,
 } from './result-list/headless-result-list';
+export {buildResultList} from './result-list/headless-result-list';
 
-export {
+export type {
   InteractiveResultOptions,
   InteractiveResultProps,
   InteractiveResult,
-  buildInteractiveResult,
 } from './result-list/headless-interactive-result';
+export {buildInteractiveResult} from './result-list/headless-interactive-result';
 
-export {
+export type {
   ResultsPerPageInitialState,
   ResultsPerPageProps,
   ResultsPerPageState,
   ResultsPerPage,
-  buildResultsPerPage,
 } from './results-per-page/headless-results-per-page';
+export {buildResultsPerPage} from './results-per-page/headless-results-per-page';
 
-export {
+export type {
   SearchBoxOptions,
   SearchBoxProps,
   SearchBoxState,
@@ -173,46 +178,48 @@ export {
   Suggestion,
   SuggestionHighlightingOptions,
   Delimiters,
-  buildSearchBox,
 } from './search-box/headless-search-box';
+export {buildSearchBox} from './search-box/headless-search-box';
 
-export {
+export type {
   SortInitialState,
   SortProps,
   SortState,
   Sort,
-  buildSort,
 } from './sort/headless-sort';
+export {buildSort} from './sort/headless-sort';
 
-export {
+export type {
   StaticFilterValueOptions,
-  buildStaticFilterValue,
   StaticFilter,
   StaticFilterOptions,
   StaticFilterProps,
   StaticFilterState,
   StaticFilterValue,
   StaticFilterValueState,
+} from './static-filter/headless-static-filter';
+export {
+  buildStaticFilterValue,
   buildStaticFilter,
 } from './static-filter/headless-static-filter';
 
-export {
+export type {
   TabInitialState,
   TabOptions,
   TabProps,
   TabState,
   Tab,
-  buildTab,
 } from './tab/headless-tab';
+export {buildTab} from './tab/headless-tab';
 
-export {
+export type {
   FacetManagerPayload,
   FacetManagerState,
   FacetManager,
-  buildFacetManager,
 } from './facet-manager/headless-facet-manager';
+export {buildFacetManager} from './facet-manager/headless-facet-manager';
 
-export {
+export type {
   NumericFacetBreadcrumb,
   FacetBreadcrumb,
   DateFacetBreadcrumb,
@@ -223,52 +230,52 @@ export {
   BreadcrumbManagerState,
   BreadcrumbManager,
   DeselectableValue,
-  buildBreadcrumbManager,
 } from './breadcrumb-manager/headless-breadcrumb-manager';
+export {buildBreadcrumbManager} from './breadcrumb-manager/headless-breadcrumb-manager';
 
-export {
+export type {
   StandaloneSearchBoxOptions,
   StandaloneSearchBoxAnalytics,
   StandaloneSearchBoxProps,
   StandaloneSearchBoxState,
   StandaloneSearchBox,
-  buildStandaloneSearchBox,
 } from './standalone-search-box/headless-standalone-search-box';
+export {buildStandaloneSearchBox} from './standalone-search-box/headless-standalone-search-box';
 
-export {
+export type {
   SearchParameterManagerProps,
   SearchParameterManagerInitialState,
   SearchParameterManagerState,
   SearchParameterManager,
   SearchParameters,
-  buildSearchParameterManager,
 } from './search-parameter-manager/headless-search-parameter-manager';
+export {buildSearchParameterManager} from './search-parameter-manager/headless-search-parameter-manager';
 
-export {
+export type {
   UrlManagerProps,
   UrlManagerInitialState,
   UrlManagerState,
   UrlManager,
-  buildUrlManager,
 } from './url-manager/headless-url-manager';
+export {buildUrlManager} from './url-manager/headless-url-manager';
 
-export {
+export type {
   SearchStatus,
   SearchStatusState,
-  buildSearchStatus,
 } from './search-status/headless-search-status';
+export {buildSearchStatus} from './search-status/headless-search-status';
 
-export {ErrorPayload} from './controller/error-payload';
+export type {ErrorPayload} from './controller/error-payload';
 
-export {
+export type {
   Quickview,
   QuickviewOptions,
   QuickviewProps,
   QuickviewState,
-  buildQuickview,
 } from './quickview/headless-quickview';
+export {buildQuickview} from './quickview/headless-quickview';
 
-export {
+export type {
   FoldedCollection,
   FoldedResult,
   FoldedResultList,
@@ -276,69 +283,72 @@ export {
   FoldedResultListOptions,
   FoldedResultListProps,
   FoldedResultListState,
-  buildFoldedResultList,
 } from './folded-result-list/headless-folded-result-list';
+export {buildFoldedResultList} from './folded-result-list/headless-folded-result-list';
 
-export {
+export type {
   RedirectionTrigger,
   RedirectionTriggerState,
-  buildRedirectionTrigger,
 } from './triggers/headless-redirection-trigger';
+export {buildRedirectionTrigger} from './triggers/headless-redirection-trigger';
 
-export {
+export type {
   QueryTrigger,
   QueryTriggerState,
-  buildQueryTrigger,
 } from './triggers/headless-query-trigger';
+export {buildQueryTrigger} from './triggers/headless-query-trigger';
 
-export {
+export type {
   ExecuteTrigger,
   ExecuteTriggerState,
-  buildExecuteTrigger,
 } from './triggers/headless-execute-trigger';
+export {buildExecuteTrigger} from './triggers/headless-execute-trigger';
 
-export {ExecuteTriggerParams} from './../api/search/trigger';
+export type {ExecuteTriggerParams} from './../api/search/trigger';
 
-export {
+export type {
   NotifyTrigger,
   NotifyTriggerState,
-  buildNotifyTrigger,
 } from './triggers/headless-notify-trigger';
+export {buildNotifyTrigger} from './triggers/headless-notify-trigger';
 
-export {
+export type {
   SmartSnippet,
   SmartSnippetState,
-  buildSmartSnippet,
   QuestionAnswerDocumentIdentifier,
 } from './smart-snippet/headless-smart-snippet';
+export {buildSmartSnippet} from './smart-snippet/headless-smart-snippet';
 
-export {
+export type {
   SmartSnippetQuestionsList,
   SmartSnippetQuestionsListState,
   SmartSnippetRelatedQuestion,
-  buildSmartSnippetQuestionsList,
 } from './smart-snippet-questions-list/headless-smart-snippet-questions-list';
+export {buildSmartSnippetQuestionsList} from './smart-snippet-questions-list/headless-smart-snippet-questions-list';
 
-export {
+export type {
   RecentQueriesList,
   RecentQueriesState,
-  buildRecentQueriesList,
 } from './recent-queries-list/headless-recent-queries-list';
+export {buildRecentQueriesList} from './recent-queries-list/headless-recent-queries-list';
 
-export {
+export type {
   RecentResultsList,
   RecentResultsState,
-  buildRecentResultsList,
 } from './recent-results-list/headless-recent-results-list';
+export {buildRecentResultsList} from './recent-results-list/headless-recent-results-list';
 
-export {
-  InteractiveRecentResult,
-  buildInteractiveRecentResult,
-} from './recent-results-list/headless-interactive-recent-result';
+export type {InteractiveRecentResult} from './recent-results-list/headless-interactive-recent-result';
+export {buildInteractiveRecentResult} from './recent-results-list/headless-interactive-recent-result';
 
-export {
+export type {
   InteractiveResultCore,
   InteractiveResultCoreOptions,
   InteractiveResultCoreProps,
+} from './core/interactive-result/headless-core-interactive-result';
+export {
+  /**
+   * @deprecated This is an internal controller that will be removed in the next version. Please use `buildInteractiveResult` instead.
+   */
   buildInteractiveResultCore,
 } from './core/interactive-result/headless-core-interactive-result';

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -14,7 +14,7 @@ import {
   PagerState,
 } from '../core/pager/headless-core-pager';
 
-export {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
+export type {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
 
 /**
  * Creates a `Pager` controller instance.

--- a/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet.ts
+++ b/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet.ts
@@ -40,7 +40,7 @@ import {fetchProductListing} from '../../../features/product-listing/product-lis
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 import {buildCategoryFacetSearch} from './headless-product-listing-category-facet-search';
 
-export {
+export type {
   CoreCategoryFacet,
   CoreCategoryFacetState,
   CategoryFacetValue,

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet-manager.ts
@@ -10,7 +10,7 @@ import {
 import {ProductListingSection} from '../../../state/state-sections';
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 
-export {FacetManager, FacetManagerState, FacetManagerPayload};
+export type {FacetManager, FacetManagerState, FacetManagerPayload};
 
 /**
  * Creates a `FacetManager` instance for the product listing.

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
@@ -36,7 +36,7 @@ import {
 import {buildFacetSearch} from '../../core/facets/facet-search/specific/headless-facet-search';
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 
-export {
+export type {
   FacetOptions,
   FacetSearchOptions,
   FacetValueState,

--- a/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
+++ b/packages/headless/src/controllers/product-listing/pager/headless-product-listing-pager.ts
@@ -9,7 +9,7 @@ import {
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 import {fetchProductListing} from '../../../features/product-listing/product-listing-actions';
 
-export {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
+export type {PagerInitialState, PagerOptions, PagerProps, Pager, PagerState};
 
 /**
  * Creates a `Pager` controller instance for the product listing.

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet.ts
@@ -20,17 +20,17 @@ import {RangeFacetSortCriterion} from '../../../../features/facets/range-facets/
 import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
 import {ProductListingEngine} from '../../../../app/product-listing-engine/product-listing-engine';
 
-export {
+export type {
   DateFacetOptions,
   DateFacetValue,
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,
-  buildDateRange,
   DateFacetProps,
   DateFacet,
   DateFacetState,
 };
+export {buildDateRange};
 
 /**
  * Creates a `DateFacet` controller instance for the product listing.

--- a/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter.ts
@@ -21,7 +21,7 @@ import {
 import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
 import {ProductListingEngine} from '../../../../app/product-listing-engine/product-listing-engine';
 
-export {
+export type {
   DateFilterOptions,
   DateFilterInitialState,
   DateFilterRange,

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet.ts
@@ -25,8 +25,7 @@ import {
 import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
 import {ProductListingEngine} from '../../../../app/product-listing-engine/product-listing-engine';
 
-export {
-  buildNumericRange,
+export type {
   NumericRangeOptions,
   NumericRangeRequest,
   NumericFacetValue,
@@ -35,6 +34,7 @@ export {
   NumericFacet,
   NumericFacetState,
 };
+export {buildNumericRange};
 
 /**
  * Creates a `NumericFacet` controller instance for the product listing.

--- a/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.ts
+++ b/packages/headless/src/controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter.ts
@@ -22,7 +22,7 @@ import {
 import {fetchProductListing} from '../../../../features/product-listing/product-listing-actions';
 import {ProductListingEngine} from '../../../../app/product-listing-engine/product-listing-engine';
 
-export {
+export type {
   NumericFilterOptions,
   NumericFilterInitialState,
   NumericFilterRange,

--- a/packages/headless/src/controllers/product-listing/results-per-page/headless-product-listing-results-per-page.ts
+++ b/packages/headless/src/controllers/product-listing/results-per-page/headless-product-listing-results-per-page.ts
@@ -15,7 +15,7 @@ import {
   ResultsPerPageState,
 } from '../../core/results-per-page/headless-core-results-per-page';
 
-export {
+export type {
   ResultsPerPage,
   ResultsPerPageProps,
   ResultsPerPageInitialState,

--- a/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
+++ b/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
@@ -30,16 +30,15 @@ import {
 import {Schema} from '@coveo/bueno';
 import {validateInitialState} from '../../../utils/validate-payload';
 
-export {
+export type {
   SortBy,
   SortDirection,
   SortByRelevance,
   SortByFields,
   SortByFieldsFields,
   SortCriterion,
-  buildRelevanceSortCriterion,
-  buildFieldsSortCriterion,
 };
+export {buildRelevanceSortCriterion, buildFieldsSortCriterion};
 
 export interface ProductListingSortProps {
   /**

--- a/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
+++ b/packages/headless/src/controllers/product-listing/sort/headless-product-listing-sort.ts
@@ -30,15 +30,13 @@ import {
 import {Schema} from '@coveo/bueno';
 import {validateInitialState} from '../../../utils/validate-payload';
 
-export type {
+export type {SortByRelevance, SortByFields, SortByFieldsFields, SortCriterion};
+export {
   SortBy,
   SortDirection,
-  SortByRelevance,
-  SortByFields,
-  SortByFieldsFields,
-  SortCriterion,
+  buildRelevanceSortCriterion,
+  buildFieldsSortCriterion,
 };
-export {buildRelevanceSortCriterion, buildFieldsSortCriterion};
 
 export interface ProductListingSortProps {
   /**

--- a/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-cart-recommendations.ts
@@ -10,7 +10,7 @@ import {CartRecommendationsListOptions} from './headless-cart-recommendations-op
 import {ErrorPayload} from '../controller/error-payload';
 import {ProductRecommendationEngine} from '../../app/product-recommendation-engine/product-recommendation-engine';
 
-export {CartRecommendationsListOptions, ProductRecommendation};
+export type {CartRecommendationsListOptions, ProductRecommendation};
 
 const optionsSchema = new Schema({
   ...baseProductRecommendationsOptionsSchema,

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
@@ -33,7 +33,7 @@ import {loadReducerError} from '../../utils/errors';
 import {validateInitialState} from '../../utils/validate-payload';
 import {buildController, Controller} from '../controller/headless-controller';
 
-export {
+export type {
   RankingInformation,
   DocumentWeights,
   TermWeightReport,

--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
@@ -15,7 +15,7 @@ import {
   ResultsPerPageState,
 } from '../core/results-per-page/headless-core-results-per-page';
 
-export {
+export type {
   ResultsPerPage,
   ResultsPerPageProps,
   ResultsPerPageInitialState,

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -46,7 +46,7 @@ import {
 import {loadReducerError} from '../../utils/errors';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 
-export {SearchBoxOptions, SuggestionHighlightingOptions, Delimiters};
+export type {SearchBoxOptions, SuggestionHighlightingOptions, Delimiters};
 
 export interface SearchBoxProps {
   options?: SearchBoxOptions;

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -21,7 +21,7 @@ import {logParametersChange} from '../../features/search-parameters/search-param
 import {deepEqualAnyOrder} from '../../utils/compare-utils';
 import {StaticFilterValue} from '../../features/static-filter-set/static-filter-set-state';
 
-export {SearchParameters};
+export type {SearchParameters};
 
 export interface SearchParameterManagerProps {
   /**

--- a/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.ts
+++ b/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.ts
@@ -6,7 +6,6 @@ import {
   QuestionAnswer,
   QuestionAnswerDocumentIdentifier,
 } from '../../api/search/search/question-answering';
-export {QuestionAnswerDocumentIdentifier} from '../../api/search/search/question-answering';
 import {
   logCollapseSmartSnippetSuggestion,
   logExpandSmartSnippetSuggestion,
@@ -18,6 +17,8 @@ import {
   collapseSmartSnippetRelatedQuestion,
   expandSmartSnippetRelatedQuestion,
 } from '../../features/question-answering/question-answering-actions';
+
+export type {QuestionAnswerDocumentIdentifier} from '../../api/search/search/question-answering';
 
 /**
  * The `SmartSnippetQuestionsList` controller allows to manage additional queries for which a SmartSnippet model can provide relevant excerpts.

--- a/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.ts
+++ b/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.ts
@@ -2,7 +2,6 @@ import {buildController, Controller} from '../controller/headless-controller';
 import {search, questionAnswering} from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {QuestionAnswerDocumentIdentifier} from '../../api/search/search/question-answering';
-export {QuestionAnswerDocumentIdentifier} from '../../api/search/search/question-answering';
 import {
   logCollapseSmartSnippet,
   logDislikeSmartSnippet,
@@ -17,6 +16,8 @@ import {
   likeSmartSnippet,
 } from '../../features/question-answering/question-answering-actions';
 import {QuestionAnsweringSection} from '../../state/state-sections';
+
+export type {QuestionAnswerDocumentIdentifier} from '../../api/search/search/question-answering';
 
 /**
  * The `SmartSnippet` controller allows to manage the excerpt of a document that would be most likely to answer a particular query .

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -36,7 +36,7 @@ import {
   standaloneSearchBoxSchema,
 } from './headless-standalone-search-box-options';
 
-export {StandaloneSearchBoxOptions, StandaloneSearchBoxAnalytics};
+export type {StandaloneSearchBoxOptions, StandaloneSearchBoxAnalytics};
 
 export interface StandaloneSearchBoxProps {
   options: StandaloneSearchBoxOptions;

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.ts
@@ -27,12 +27,12 @@ import {
   StaticFilterValueOptions,
 } from './static-filter-value';
 
-export {
+export type {
   StaticFilterValue,
   StaticFilterValueState,
   StaticFilterValueOptions,
-  buildStaticFilterValue,
 };
+export {buildStaticFilterValue};
 
 const optionsSchema = new Schema<Required<StaticFilterOptions>>({
   id: staticFilterIdSchema,

--- a/packages/headless/src/features/advanced-search-queries/advanced-search-queries-actions-loader.ts
+++ b/packages/headless/src/features/advanced-search-queries/advanced-search-queries-actions-loader.ts
@@ -7,7 +7,7 @@ import {
   AdvancedSearchQueryActionCreatorPayload,
 } from './advanced-search-queries-actions';
 
-export {AdvancedSearchQueryActionCreatorPayload};
+export type {AdvancedSearchQueryActionCreatorPayload};
 
 /**
  * The advanced search query action creators.

--- a/packages/headless/src/features/analytics/generic-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/generic-analytics-actions-loader.ts
@@ -11,7 +11,7 @@ import {
 } from './analytics-actions';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 
-export {
+export type {
   LogSearchEventActionCreatorPayload,
   LogClickEventActionCreatorPayload,
   LogCustomEventActionCreatorPayload,

--- a/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/search-analytics-actions-loader.ts
@@ -71,7 +71,7 @@ import {
   StaticFilterValueMetadata,
 } from '../static-filter-set/static-filter-set-actions';
 
-export {
+export type {
   LogCategoryFacetBreadcrumbActionCreatorPayload,
   LogFacetBreadcrumbActionCreatorPayload,
   LogFacetDeselectActionCreatorPayload,

--- a/packages/headless/src/features/case-field/case-field-actions-loader.ts
+++ b/packages/headless/src/features/case-field/case-field-actions-loader.ts
@@ -11,7 +11,7 @@ import {
   registerCaseField,
 } from './case-field-actions';
 
-export {SetCaseFieldActionCreatorPayload};
+export type {SetCaseFieldActionCreatorPayload};
 
 /**
  * The case field action creators.

--- a/packages/headless/src/features/case-input/case-input-actions-loader.ts
+++ b/packages/headless/src/features/case-input/case-input-actions-loader.ts
@@ -6,7 +6,7 @@ import {
   SetCaseInputActionCreatorPayload,
 } from './case-input-actions';
 
-export {SetCaseInputActionCreatorPayload};
+export type {SetCaseInputActionCreatorPayload};
 
 /**
  * The case inputs action creators.

--- a/packages/headless/src/features/configuration/configuration-actions-loader.ts
+++ b/packages/headless/src/features/configuration/configuration-actions-loader.ts
@@ -15,7 +15,7 @@ import {
   AnalyticsRuntimeEnvironment,
 } from './configuration-actions';
 
-export {
+export type {
   SetOriginLevel2ActionCreatorPayload,
   SetOriginLevel3ActionCreatorPayload,
   UpdateAnalyticsConfigurationActionCreatorPayload,

--- a/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
+++ b/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
@@ -6,7 +6,7 @@ import {
   UpdateSearchConfigurationActionCreatorPayload,
 } from './configuration-actions';
 
-export {UpdateSearchConfigurationActionCreatorPayload};
+export type {UpdateSearchConfigurationActionCreatorPayload};
 
 /**
  * The search configuration action creators.

--- a/packages/headless/src/features/context/context-actions-loader.ts
+++ b/packages/headless/src/features/context/context-actions-loader.ts
@@ -9,7 +9,7 @@ import {
 } from './context-actions';
 import {ContextPayload} from './context-state';
 
-export {AddContextActionCreatorPayload};
+export type {AddContextActionCreatorPayload};
 
 /**
  * The context action creators.

--- a/packages/headless/src/features/dictionary-field-context/dictionary-field-context-actions-loader.ts
+++ b/packages/headless/src/features/dictionary-field-context/dictionary-field-context-actions-loader.ts
@@ -9,7 +9,7 @@ import {
 } from './dictionary-field-context-actions';
 import {DictionaryFieldContextPayload} from './dictionary-field-context-state';
 
-export {AddDictionaryFieldContextActionCreatorPayload};
+export type {AddDictionaryFieldContextActionCreatorPayload};
 
 /**
  * The dictionary field context action creators.

--- a/packages/headless/src/features/facet-options/facet-options-actions-loader.ts
+++ b/packages/headless/src/features/facet-options/facet-options-actions-loader.ts
@@ -6,7 +6,7 @@ import {
   UpdateFacetOptionsActionCreatorPayload,
 } from './facet-options-actions';
 
-export {UpdateFacetOptionsActionCreatorPayload};
+export type {UpdateFacetOptionsActionCreatorPayload};
 
 /**
  * The facetOptions action creators.

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions-loader.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions-loader.ts
@@ -13,7 +13,7 @@ import {
   UpdateCategoryFacetSortCriterionActionCreatorPayload,
 } from './category-facet-set-actions';
 
-export {
+export type {
   RegisterCategoryFacetActionCreatorPayload,
   ToggleSelectCategoryFacetValueActionCreatorPayload,
   UpdateCategoryFacetNumberOfValuesActionCreatorPayload,

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions-loader.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions-loader.ts
@@ -17,7 +17,7 @@ import {
   UpdateFreezeCurrentValuesActionCreatorPayload,
 } from './facet-set-actions';
 
-export {
+export type {
   RegisterFacetActionCreatorPayload,
   ToggleSelectFacetValueActionCreatorPayload,
   UpdateFacetIsFieldExpandedActionCreatorPayload,

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions-loader.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions-loader.ts
@@ -13,7 +13,7 @@ import {
   updateDateFacetValues,
 } from './date-facet-actions';
 
-export {
+export type {
   RegisterDateFacetActionCreatorPayload,
   ToggleSelectDateFacetValueActionCreatorPayload,
   UpdateDateFacetSortCriterionActionCreatorPayload,

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader.ts
@@ -13,7 +13,7 @@ import {
   UpdateNumericFacetValuesActionCreatorPayload,
 } from './numeric-facet-actions';
 
-export {
+export type {
   RegisterNumericFacetActionCreatorPayload,
   ToggleSelectNumericFacetValueActionCreatorPayload,
   UpdateNumericFacetSortCriterionActionCreatorPayload,

--- a/packages/headless/src/features/folding/folding-actions-loader.ts
+++ b/packages/headless/src/features/folding/folding-actions-loader.ts
@@ -10,7 +10,7 @@ import {
   StateNeededByLoadCollection,
 } from './folding-actions';
 
-export {RegisterFoldingActionCreatorPayload};
+export type {RegisterFoldingActionCreatorPayload};
 
 /**
  * The folding action creators.

--- a/packages/headless/src/features/index.ts
+++ b/packages/headless/src/features/index.ts
@@ -29,10 +29,8 @@ export * from './breadcrumb/breadcrumb-actions-loader';
 export * from './recent-queries/recent-queries-actions-loader';
 export * from './recent-results/recent-results-actions-loader';
 
-export {
-  ResultTemplatesManager,
-  buildResultTemplatesManager,
-} from './result-templates/result-templates-manager';
+export type {ResultTemplatesManager} from './result-templates/result-templates-manager';
+export {buildResultTemplatesManager} from './result-templates/result-templates-manager';
 
 import {
   getResultProperty as getResultPropertyAlias,

--- a/packages/headless/src/features/product-listing/product-listing-actions-loader.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions-loader.ts
@@ -10,7 +10,7 @@ import {
   StateNeededByFetchProductListing,
 } from './product-listing-actions';
 
-export {SetProductListingUrlPayload};
+export type {SetProductListingUrlPayload};
 
 /**
  * The product listings action creators.

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions-loader.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions-loader.ts
@@ -20,7 +20,7 @@ import {
   StateNeededByGetProductRecommendations,
 } from './product-recommendations-actions';
 
-export {
+export type {
   SetProductRecommendationsAdditionalFieldsActionCreatorPayload,
   SetProductRecommendationsBrandFilterActionCreatorPayload,
   SetProductRecommendationsCategoryFilterActionCreatorPayload,

--- a/packages/headless/src/features/query-set/query-set-actions-loader.ts
+++ b/packages/headless/src/features/query-set/query-set-actions-loader.ts
@@ -8,7 +8,7 @@ import {
   UpdateQuerySetQueryActionCreatorPayload,
 } from './query-set-actions';
 
-export {
+export type {
   RegisterQuerySetQueryActionCreatorPayload,
   UpdateQuerySetQueryActionCreatorPayload,
 };

--- a/packages/headless/src/features/query-suggest/query-suggest-actions-loader.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions-loader.ts
@@ -15,7 +15,7 @@ import {
   StateNeededByQuerySuggest,
 } from './query-suggest-actions';
 
-export {
+export type {
   ClearQuerySuggestActionCreatorPayload,
   FetchQuerySuggestionsActionCreatorPayload,
   RegisterQuerySuggestActionCreatorPayload,

--- a/packages/headless/src/features/query/query-actions-loader.ts
+++ b/packages/headless/src/features/query/query-actions-loader.ts
@@ -3,7 +3,7 @@ import {query} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {updateQuery, UpdateQueryActionCreatorPayload} from './query-actions';
 
-export {UpdateQueryActionCreatorPayload};
+export type {UpdateQueryActionCreatorPayload};
 
 /**
  * The query action creators.

--- a/packages/headless/src/features/recommendation/recommendation-actions-loader.ts
+++ b/packages/headless/src/features/recommendation/recommendation-actions-loader.ts
@@ -10,7 +10,7 @@ import {
   SetRecommendationIdActionCreatorPayload,
 } from './recommendation-actions';
 
-export {SetRecommendationIdActionCreatorPayload};
+export type {SetRecommendationIdActionCreatorPayload};
 
 /**
  * The recommendation action creators.

--- a/packages/headless/src/features/redirection/redirection-actions-loader.ts
+++ b/packages/headless/src/features/redirection/redirection-actions-loader.ts
@@ -8,7 +8,7 @@ import {
   RedirectionState,
 } from './redirection-actions';
 
-export {CheckForRedirectionActionCreatorPayload};
+export type {CheckForRedirectionActionCreatorPayload};
 
 /**
  * The redirection action creators.

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
@@ -14,7 +14,7 @@ import {
   StateNeededForRedirect,
 } from './standalone-search-box-set-actions';
 
-export {
+export type {
   RegisterStandaloneSearchBoxActionCreatorPayload,
   FetchRedirectUrlActionCreatorPayload,
   UpdateAnalyticsToSearchFromLinkActionCreatorPayload,

--- a/packages/headless/src/features/static-filter-set/static-filter-set-actions-loader.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-actions-loader.ts
@@ -9,7 +9,7 @@ import {
   deselectAllStaticFilterValues,
 } from './static-filter-set-actions';
 
-export {
+export type {
   RegisterStaticFilterActionCreatorPayload,
   ToggleSelectStaticFilterValueActionCreatorPayload,
 };

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -2,36 +2,36 @@ import * as TestUtils from './test';
 import * as HighlightUtils from './utils/highlight';
 
 // 3rd Party Libraries
-export {
-  Unsubscribe,
-  createAction,
-  createAsyncThunk,
-  createReducer,
-  Middleware,
-} from '@reduxjs/toolkit';
+export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export {createAction, createAsyncThunk, createReducer} from '@reduxjs/toolkit';
 
 // Main App
-export {
+export type {
   SearchEngine,
   SearchEngineOptions,
   SearchEngineConfiguration,
   SearchConfigurationOptions,
+} from './app/search-engine/search-engine';
+export {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
 } from './app/search-engine/search-engine';
 
-export {CoreEngine, ExternalEngineOptions} from './app/engine';
-export {
+export type {CoreEngine, ExternalEngineOptions} from './app/engine';
+export type {
   EngineConfiguration,
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
 } from './app/engine-configuration';
-export {LoggerOptions} from './app/logger';
+export type {LoggerOptions} from './app/logger';
 
-export {LogLevel} from './app/logger';
+export type {LogLevel} from './app/logger';
 
 // State
-export {SearchParametersState, SearchAppState} from './state/search-app-state';
+export type {
+  SearchParametersState,
+  SearchAppState,
+} from './state/search-app-state';
 
 // Controllers
 export * from './controllers/index';
@@ -58,17 +58,11 @@ export * from './features/analytics/index';
 
 // Types & Helpers
 export {TestUtils, HighlightUtils};
-export {Result} from './api/search/search/result';
-export {FieldDescription} from './api/search/fields/fields-response';
-export {Raw} from './api/search/search/raw';
-export {
+export type {Result} from './api/search/search/result';
+export type {FieldDescription} from './api/search/fields/fields-response';
+export type {Raw} from './api/search/search/raw';
+export type {
   SortCriterion,
-  buildDateSortCriterion,
-  buildCriterionExpression,
-  buildFieldSortCriterion,
-  buildNoSortCriterion,
-  buildQueryRankingExpressionSortCriterion,
-  buildRelevanceSortCriterion,
   SortBy,
   SortByDate,
   SortByField,
@@ -77,29 +71,39 @@ export {
   SortByRelevancy,
   SortOrder,
 } from './features/sort-criteria/criteria';
-export {parseCriterionExpression} from './features/sort-criteria/criteria-parser';
-export {ResultTemplatesManager} from './features/result-templates/result-templates-manager';
 export {
+  buildDateSortCriterion,
+  buildCriterionExpression,
+  buildFieldSortCriterion,
+  buildNoSortCriterion,
+  buildQueryRankingExpressionSortCriterion,
+  buildRelevanceSortCriterion,
+} from './features/sort-criteria/criteria';
+export {parseCriterionExpression} from './features/sort-criteria/criteria-parser';
+export type {ResultTemplatesManager} from './features/result-templates/result-templates-manager';
+export type {
   ResultTemplate,
   ResultTemplateCondition,
 } from './features/result-templates/result-templates';
 export {platformUrl, analyticsUrl} from './api/platform-client';
-export {CategoryFacetSortCriterion} from './features/facets/category-facet-set/interfaces/request';
-export {CategoryFacetValue} from './features/facets/category-facet-set/interfaces/response';
-export {DateFacetValue} from './features/facets/range-facets/date-facet-set/interfaces/response';
-export {FacetSortCriterion} from './features/facets/facet-set/interfaces/request';
-export {NumericFacetValue} from './features/facets/range-facets/numeric-facet-set/interfaces/response';
-export {
+export type {CategoryFacetSortCriterion} from './features/facets/category-facet-set/interfaces/request';
+export type {CategoryFacetValue} from './features/facets/category-facet-set/interfaces/response';
+export type {DateFacetValue} from './features/facets/range-facets/date-facet-set/interfaces/response';
+export type {FacetSortCriterion} from './features/facets/facet-set/interfaces/request';
+export type {NumericFacetValue} from './features/facets/range-facets/numeric-facet-set/interfaces/response';
+export type {
   RangeFacetSortCriterion,
   RangeFacetRangeAlgorithm,
 } from './features/facets/range-facets/generic/interfaces/request';
 export {buildSearchParameterSerializer} from './features/search-parameters/search-parameter-serializer';
-export {HighlightKeyword} from './utils/highlight';
+export type {HighlightKeyword} from './utils/highlight';
 export {VERSION} from './utils/version';
-export {
+export type {
   RelativeDate,
   RelativeDatePeriod,
   RelativeDateUnit,
+} from './api/search/date/relative-date';
+export {
   deserializeRelativeDate,
   validateRelativeDate,
 } from './api/search/date/relative-date';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -63,15 +63,15 @@ export type {FieldDescription} from './api/search/fields/fields-response';
 export type {Raw} from './api/search/search/raw';
 export type {
   SortCriterion,
-  SortBy,
   SortByDate,
   SortByField,
   SortByNoSort,
   SortByQRE,
   SortByRelevancy,
-  SortOrder,
 } from './features/sort-criteria/criteria';
 export {
+  SortBy,
+  SortOrder,
   buildDateSortCriterion,
   buildCriterionExpression,
   buildFieldSortCriterion,

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -60,14 +60,14 @@ export type {
   ProductListingSortProps,
   ProductListingSort,
   ProductListingSortState,
-  SortBy,
   SortByFields,
   SortByFieldsFields,
   SortByRelevance,
   SortCriterion,
-  SortDirection,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
 export {
+  SortBy,
+  SortDirection,
   buildSort,
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -1,88 +1,86 @@
-export {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 
-export {
+export type {
   ProductListingEngine,
   ProductListingEngineConfiguration,
   ProductListingEngineOptions,
+} from './app/product-listing-engine/product-listing-engine';
+export {
   buildProductListingEngine,
   getSampleProductListingEngineConfiguration,
 } from './app/product-listing-engine/product-listing-engine';
 
-export {CoreEngine, ExternalEngineOptions} from './app/engine';
-export {
+export type {CoreEngine, ExternalEngineOptions} from './app/engine';
+export type {
   EngineConfiguration,
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
 } from './app/engine-configuration';
-export {LoggerOptions} from './app/logger';
-export {LogLevel} from './app/logger';
+export type {LoggerOptions} from './app/logger';
+export type {LogLevel} from './app/logger';
 
-export {ProductRecommendation} from './api/search/search/product-recommendation';
+export type {ProductRecommendation} from './api/search/search/product-recommendation';
 
 // Actions
 export * from './features/configuration/configuration-actions-loader';
-export {
-  loadProductListingActions,
-  ProductListingActionCreators,
-  SetProductListingUrlPayload,
-} from './features/product-listing/product-listing-actions-loader';
+export * from './features/product-listing/product-listing-actions-loader';
 
 // Controllers
-export {
-  Controller,
-  buildController,
-} from './controllers/controller/headless-controller';
+export type {Controller} from './controllers/controller/headless-controller';
+export {buildController} from './controllers/controller/headless-controller';
 
-export {
+export type {
   ProductListingState,
   ProductListing,
   ProductListingOptions,
   ProductListingProps,
   ProductListingControllerState,
-  buildProductListing,
 } from './controllers/product-listing/headless-product-listing';
+export {buildProductListing} from './controllers/product-listing/headless-product-listing';
 
-export {
+export type {
   PagerInitialState,
   PagerOptions,
   PagerProps,
   PagerState,
   Pager,
-  buildPager,
 } from './controllers/product-listing/pager/headless-product-listing-pager';
+export {buildPager} from './controllers/product-listing/pager/headless-product-listing-pager';
 
-export {
+export type {
   ResultsPerPageInitialState,
   ResultsPerPageProps,
   ResultsPerPageState,
   ResultsPerPage,
-  buildResultsPerPage,
 } from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
+export {buildResultsPerPage} from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
 
-export {
+export type {
   ProductListingSortInitialState,
   ProductListingSortProps,
   ProductListingSort,
   ProductListingSortState,
-  buildSort,
   SortBy,
   SortByFields,
   SortByFieldsFields,
   SortByRelevance,
   SortCriterion,
   SortDirection,
+} from './controllers/product-listing/sort/headless-product-listing-sort';
+export {
+  buildSort,
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
 
-export {
+export type {
   FacetManager,
   FacetManagerPayload,
   FacetManagerState,
-  buildFacetManager,
 } from './controllers/product-listing/facet/headless-product-listing-facet-manager';
+export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 
-export {
+export type {
   CoreFacet,
   CoreFacetState,
   Facet,
@@ -95,10 +93,10 @@ export {
   FacetValue,
   FacetValueState,
   SpecificFacetSearchResult,
-  buildFacet,
 } from './controllers/product-listing/facet/headless-product-listing-facet';
+export {buildFacet} from './controllers/product-listing/facet/headless-product-listing-facet';
 
-export {
+export type {
   CoreCategoryFacet,
   CoreCategoryFacetState,
   CategoryFacet,
@@ -110,10 +108,10 @@ export {
   CategoryFacetState,
   CategoryFacetValue,
   CategoryFacetSearchResult,
-  buildCategoryFacet,
 } from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
+export {buildCategoryFacet} from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
 
-export {
+export type {
   DateFacet,
   DateFacetOptions,
   DateFacetProps,
@@ -122,12 +120,13 @@ export {
   DateRangeInput,
   DateRangeOptions,
   DateRangeRequest,
+} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
+export {
   buildDateFacet,
   buildDateRange,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
 
-export {
-  buildDateFilter,
+export type {
   DateFilter,
   DateFilterOptions,
   DateFilterProps,
@@ -135,8 +134,9 @@ export {
   DateFilterState,
   DateFilterInitialState,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
+export {buildDateFilter} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
 
-export {
+export type {
   NumericFacet,
   NumericFacetOptions,
   NumericFacetProps,
@@ -144,12 +144,13 @@ export {
   NumericFacetValue,
   NumericRangeOptions,
   NumericRangeRequest,
+} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
+export {
   buildNumericFacet,
   buildNumericRange,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
 
-export {
-  buildNumericFilter,
+export type {
   NumericFilter,
   NumericFilterOptions,
   NumericFilterProps,
@@ -157,3 +158,4 @@ export {
   NumericFilterState,
   NumericFilterInitialState,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
+export {buildNumericFilter} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';

--- a/packages/headless/src/product-recommendation.index.ts
+++ b/packages/headless/src/product-recommendation.index.ts
@@ -1,21 +1,23 @@
-export {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 
-export {
+export type {
   ProductRecommendationEngine,
   ProductRecommendationEngineOptions,
   ProductRecommendationEngineConfiguration,
+} from './app/product-recommendation-engine/product-recommendation-engine';
+export {
   buildProductRecommendationEngine,
   getSampleProductRecommendationEngineConfiguration,
 } from './app/product-recommendation-engine/product-recommendation-engine';
 
-export {CoreEngine, ExternalEngineOptions} from './app/engine';
-export {
+export type {CoreEngine, ExternalEngineOptions} from './app/engine';
+export type {
   EngineConfiguration,
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
 } from './app/engine-configuration';
-export {LoggerOptions} from './app/logger';
-export {LogLevel} from './app/logger';
+export type {LoggerOptions} from './app/logger';
+export type {LogLevel} from './app/logger';
 
 // Actions
 export * from './features/configuration/configuration-actions-loader';
@@ -25,71 +27,69 @@ export * from './features/dictionary-field-context/dictionary-field-context-acti
 export * from './features/search-hub/search-hub-actions-loader';
 
 // Controllers
-export {
-  Controller,
-  buildController,
-} from './controllers/controller/headless-controller';
+export type {Controller} from './controllers/controller/headless-controller';
+export {buildController} from './controllers/controller/headless-controller';
 
-export {
+export type {
   FrequentlyBoughtTogetherListOptions,
   FrequentlyBoughtTogetherListProps,
   FrequentlyBoughtTogetherListState,
   FrequentlyBoughtTogetherList,
-  buildFrequentlyBoughtTogetherList,
 } from './controllers/product-recommendations/headless-frequently-bought-together';
+export {buildFrequentlyBoughtTogetherList} from './controllers/product-recommendations/headless-frequently-bought-together';
 
-export {
+export type {
   CartRecommendationsListOptions,
   CartRecommendationsListProps,
   CartRecommendationsListState,
   ProductRecommendation,
   CartRecommendationsList,
-  buildCartRecommendationsList,
 } from './controllers/product-recommendations/headless-cart-recommendations';
+export {buildCartRecommendationsList} from './controllers/product-recommendations/headless-cart-recommendations';
 
-export {
+export type {
   FrequentlyViewedTogetherListOptions,
   FrequentlyViewedTogetherListProps,
   FrequentlyViewedTogetherListState,
   FrequentlyViewedTogetherList,
-  buildFrequentlyViewedTogetherList,
 } from './controllers/product-recommendations/headless-frequently-viewed-together';
+export {buildFrequentlyViewedTogetherList} from './controllers/product-recommendations/headless-frequently-viewed-together';
 
-export {
+export type {
   PopularBoughtRecommendationsListOptions,
   PopularBoughtRecommendationsListProps,
   PopularBoughtRecommendationsListState,
   PopularBoughtRecommendationsList,
-  buildPopularBoughtRecommendationsList,
 } from './controllers/product-recommendations/headless-popular-bought-recommendations';
+export {buildPopularBoughtRecommendationsList} from './controllers/product-recommendations/headless-popular-bought-recommendations';
 
-export {
+export type {
   PopularViewedRecommendationsListOptions,
   PopularViewedRecommendationsListProps,
   PopularViewedRecommendationsListState,
   PopularViewedRecommendationsList,
-  buildPopularViewedRecommendationsList,
 } from './controllers/product-recommendations/headless-popular-viewed-recommendations';
+export {buildPopularViewedRecommendationsList} from './controllers/product-recommendations/headless-popular-viewed-recommendations';
 
-export {
+export type {
   UserInterestRecommendationsListOptions,
   UserInterestRecommendationsListProps,
   UserInterestRecommendationsListState,
   UserInterestRecommendationsList,
-  buildUserInterestRecommendationsList,
 } from './controllers/product-recommendations/headless-user-interest-recommendations';
+export {buildUserInterestRecommendationsList} from './controllers/product-recommendations/headless-user-interest-recommendations';
 
-export {
+export type {
   Context,
   ContextState,
   ContextValue,
   ContextPayload,
-  buildContext,
 } from './controllers/context/headless-context';
+export {buildContext} from './controllers/context/headless-context';
 
-export {
+export type {
   DictionaryFieldContext,
   DictionaryFieldContextState,
   DictionaryFieldContextPayload,
-  buildDictionaryFieldContext,
 } from './controllers/dictionary-field-context/headless-dictionary-field-context';
+export {buildDictionaryFieldContext} from './controllers/dictionary-field-context/headless-dictionary-field-context';

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -1,21 +1,23 @@
-export {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 
-export {
+export type {
   RecommendationEngine,
   RecommendationEngineOptions,
   RecommendationEngineConfiguration,
+} from './app/recommendation-engine/recommendation-engine';
+export {
   buildRecommendationEngine,
   getSampleRecommendationEngineConfiguration,
 } from './app/recommendation-engine/recommendation-engine';
 
-export {CoreEngine, ExternalEngineOptions} from './app/engine';
-export {
+export type {CoreEngine, ExternalEngineOptions} from './app/engine';
+export type {
   EngineConfiguration,
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
 } from './app/engine-configuration';
-export {LoggerOptions} from './app/logger';
-export {LogLevel} from './app/logger';
+export type {LoggerOptions} from './app/logger';
+export type {LogLevel} from './app/logger';
 
 // Actions
 export * from './features/configuration/configuration-actions-loader';
@@ -30,35 +32,33 @@ export * from './features/recommendation/recommendation-actions-loader';
 export * from './features/recommendation/recommendation-click-analytics-actions-loader';
 
 // Controllers
-export {
-  Controller,
-  buildController,
-} from './controllers/controller/headless-controller';
+export type {Controller} from './controllers/controller/headless-controller';
+export {buildController} from './controllers/controller/headless-controller';
 
-export {
+export type {
   RecommendationListOptions,
   RecommendationListProps,
   RecommendationListState,
   RecommendationList,
-  buildRecommendationList,
 } from './controllers/recommendation/headless-recommendation';
+export {buildRecommendationList} from './controllers/recommendation/headless-recommendation';
 
-export {
+export type {
   Context,
   ContextState,
   ContextValue,
   ContextPayload,
-  buildContext,
 } from './controllers/context/headless-context';
+export {buildContext} from './controllers/context/headless-context';
 
-export {
+export type {
   DictionaryFieldContext,
   DictionaryFieldContextState,
   DictionaryFieldContextPayload,
-  buildDictionaryFieldContext,
 } from './controllers/dictionary-field-context/headless-dictionary-field-context';
+export {buildDictionaryFieldContext} from './controllers/dictionary-field-context/headless-dictionary-field-context';
 
 // Miscellaneous
-export {Result} from './api/search/search/result';
-export {HighlightKeyword} from './utils/highlight';
-export {Raw} from './api/search/search/raw';
+export type {Result} from './api/search/search/result';
+export type {HighlightKeyword} from './utils/highlight';
+export type {Raw} from './api/search/search/raw';

--- a/packages/headless/src/tsconfig.build.json
+++ b/packages/headless/src/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  },
   "exclude": [
     "./**/*.test.ts"
   ]

--- a/packages/headless/src/utils/query-expression/query-expression.ts
+++ b/packages/headless/src/utils/query-expression/query-expression.ts
@@ -33,7 +33,7 @@ import {
   StringFieldExpression,
 } from './string-field/string-field';
 
-export {
+export type {
   KeywordExpression,
   NearExpression,
   OtherTerm,

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "declaration": false,
     "lib": ["DOM", "ES2019"],
     "module": "ESNext",

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "isolatedModules": true,
     "declaration": false,
     "lib": ["DOM", "ES2019"],
     "module": "ESNext",


### PR DESCRIPTION
**Context**
Similar to [Babel](https://www.typescriptlang.org/tsconfig#isolatedModules), esbuild recommends enabling the [isolatedModules](https://esbuild.github.io/content-types/#isolated-modules) flag. When the flag is true, we need to specify when we are exporting a type vs. a value.

**Caveat**
However, this flag prevents importing `const` enums in the typescript code base. It turns out there is a difference between defining a non-const enum as,
```
export enum Animal {} -> generates an object.
```
versus using the `const` keyword
```
export const enum Animal {} -> does not generate an object
``` 
I recommend this [write up](https://ncjamieson.com/dont-export-const-enums/) for more details.

**Issue**
The `api-extractor-model` is [exporting const enums](https://github.com/microsoft/rushstack/blob/master/apps/api-extractor-model/src/items/ApiItem.ts#L18), which we are using in the doc-parser. The `isolatedModules` flag detects these instances and throws errors.

**Solutions**
- Set the `isolatedModules` flag in the `tsconfig.build.json` scoped to just headless (current PR). The problem with this is there are no warnings in the IDE. Errors are caught only at "build" time when generating type declarations, instead of at compile time.
- Adjust doc-parser instances to not use `api-extractor-model`s exported enums (i.e. duplicate/cast where needed). This would be better short-term, but longer-term could introduce issues if `api-extractor-model` adjusts their enums.
- Adjust the `api-extractor-model` project to not use `const` before the `enum`. I will explore with them, since they did this for [another project](https://github.com/microsoft/rushstack/pull/3060) a few days ago.


