### PR TITLE
feat(quantic): slots added in quick view

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -18,12 +18,12 @@
   height: 50%;
 }
 
-.quickview__button_base{
+.quickview__button-base{
   border-radius: 0.25rem;
   color: var(--color-text-link-active, #0f2d5d);
 }
 
-.quickview__button_base:hover {
+.quickview__button-base:not([disabled]):hover {
   background-color: #f6f7f9;
   box-shadow: 0 0 0px 0.25rem #f6f7f9;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -18,14 +18,13 @@
   height: 50%;
 }
 
-.quickview__button {
-  color: var(--color-text-link-active, #0f2d5d);
+.quickview__button_base{
   border-radius: 0.25rem;
+  color: var(--color-text-link-active, #0f2d5d);
 }
 
-.quickview__button:hover {
+.quickview__button_base:hover {
   background-color: #f6f7f9;
-  box-shadow: 0 0 0px 0.25rem #f6f7f9;
 }
 
 .slds-modal__footer{

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -25,6 +25,7 @@
 
 .quickview__button_base:hover {
   background-color: #f6f7f9;
+  box-shadow: 0 0 0px 0.25rem #f6f7f9;
 }
 
 .slds-modal__footer{

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -18,7 +18,7 @@
   height: 50%;
 }
 
-.quickview__button-base{
+.quickview__button-base:not([disabled]){
   border-radius: 0.25rem;
   color: var(--color-text-link-active, #0f2d5d);
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -27,3 +27,8 @@
   background-color: #f6f7f9;
   box-shadow: 0 0 0px 0.25rem #f6f7f9;
 }
+
+.slds-modal__footer{
+  background-color: white;
+  text-align: unset;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,12 +1,14 @@
 <template>
   <button class="quickview__button slds-button" onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
-    <lightning-icon 
-      size="x-small"
-      icon-name="utility:preview"
-      title={buttonLabel}
-      alternative-text={buttonLabel}
-      class="slds-current-color">
-    </lightning-icon>
+    <slot name="button">
+      <lightning-icon 
+        size="x-small"
+        icon-name="utility:preview"
+        title={buttonLabel}
+        alternative-text={buttonLabel}
+        class="slds-current-color">
+      </lightning-icon>
+    </slot>
   </button>
 
   <template if:true={isQuickviewOpen}>
@@ -37,6 +39,9 @@
         </template>
         <template if:false={isLoading}>
           <div onclick={stopPropagation} class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap" id="quickview__content-container" lwc:dom="manual"></div>
+          <footer onclick={stopPropagation} class="slds-modal__footer slds-p-top_none slds-p-bottom_none">
+            <slot name="footer"></slot>
+          </footer>
         </template>
       </div>
     </section>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,14 +1,13 @@
 <template>
-  <button class="quickview__button slds-button" onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
-    <slot name="button">
+  <button class={buttonClass} onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
+      {previewButtonLabel}
       <lightning-icon 
         size="x-small"
-        icon-name="utility:preview"
+        icon-name={previewButtonIcon}
         title={buttonLabel}
         alternative-text={buttonLabel}
-        class="slds-current-color">
+        class={buttonIconClass}>
       </lightning-icon>
-    </slot>
   </button>
 
   <template if:true={isQuickviewOpen}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,13 +1,15 @@
 <template>
   <button class={buttonClass} onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
+    <template if:true={hasButtonLabel}>
       {previewButtonLabel}
-      <lightning-icon 
-        size="x-small"
-        icon-name={previewButtonIcon}
-        title={buttonLabel}
-        alternative-text={buttonLabel}
-        class={buttonIconClass}>
-      </lightning-icon>
+    </template>  
+    <lightning-icon 
+      size="x-small"
+      icon-name={previewButtonIcon}
+      title={buttonLabel}
+      alternative-text={buttonLabel}
+      class={buttonIconClass}>
+    </lightning-icon>
   </button>
 
   <template if:true={isQuickviewOpen}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -169,9 +169,6 @@ export default class QuanticResultQuickview extends LightningElement {
       if (!this.hasNoPreview) {
         classNames.push('quickview__button_base');
       }
-      if (this.previewButtonLabel) {
-        classNames.push('slds-var-p-horizontal_medium');
-      }
     }
     else {
       if (this.previewButtonVariant === 'brand') {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -59,7 +59,7 @@ export default class QuanticResultQuickview extends LightningElement {
    * @type {undefined|'brand'|'outline-brand'}
    * @defaultValue `undefined`
    */
-  @api previewButtonVariant = undefined;
+  @api previewButtonVariant;
 
   /** @type {QuickviewState} */
   @track state;

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -51,7 +51,7 @@ export default class QuanticResultQuickview extends LightningElement {
    * @type {string}
    * @defaultValue `undefined`
    */
-  @api previewButtonLabel = undefined;
+  @api previewButtonLabel;
 
   /**
    * The variant of the preview button.

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -1,5 +1,5 @@
-import {LightningElement, api, track} from 'lwc';
-import {getHeadlessEnginePromise} from 'c/quanticHeadlessLoader';
+import { LightningElement, api, track } from 'lwc';
+import { getHeadlessEnginePromise } from 'c/quanticHeadlessLoader';
 
 import close from '@salesforce/label/c.quantic_Close';
 import openPreview from '@salesforce/label/c.quantic_OpenPreview';
@@ -36,6 +36,27 @@ export default class QuanticResultQuickview extends LightningElement {
   * @defaultValue `undefined`
   */
   @api maximumPreviewSize;
+
+  /**
+   * The icon to be shown in the preview button.
+   * @type {string}
+   * @defaultValue `'utility:preview'`
+   */
+  @api previewButtonIcon = 'utility:preview';
+
+  /**
+   * The label to be shown in the preview button.
+   * @type {string}
+   * @defaultValue `''`
+   */
+  @api previewButtonLabel = '';
+
+  /**
+   * The variant the preview button.
+   * @type {''|'brand'|'outline'}
+   * @defaultValue `''`
+   */
+  @api previewButtonVariant = '';
 
   /** @type {QuickviewState} */
   @track state;
@@ -76,7 +97,7 @@ export default class QuanticResultQuickview extends LightningElement {
       result: this.result,
       maximumPreviewSize: Number(this.maximumPreviewSize),
     }
-    this.quickview = CoveoHeadless.buildQuickview(engine, {options});
+    this.quickview = CoveoHeadless.buildQuickview(engine, { options });
     this.unsubscribe = this.quickview.subscribe(() => this.updateState());
 
     this.dispatchHasPreview(this.quickview.state.resultHasPreview);
@@ -98,7 +119,7 @@ export default class QuanticResultQuickview extends LightningElement {
 
   addRecentResult() {
     getHeadlessEnginePromise(this.engineId).then((engine) => {
-      const {pushRecentResult} = CoveoHeadless.loadRecentResultsActions(engine);
+      const { pushRecentResult } = CoveoHeadless.loadRecentResultsActions(engine);
       engine.dispatch(pushRecentResult(JSON.parse(JSON.stringify(this.result))));
     });
   }
@@ -110,7 +131,7 @@ export default class QuanticResultQuickview extends LightningElement {
   stopPropagation(evt) {
     evt.stopPropagation();
   }
-  
+
   dispatchHasPreview(hasPreview) {
     this.dispatchEvent(new CustomEvent('haspreview', {
       detail: {
@@ -139,5 +160,31 @@ export default class QuanticResultQuickview extends LightningElement {
 
   get buttonLabel() {
     return this.hasNoPreview ? this.labels.noPreview : this.labels.openPreview;
+  }
+
+  get buttonClass() {
+    let classNames = ['slds-button'];
+
+    if (!this.previewButtonVariant || !this.previewButtonLabel) {
+      if (!this.hasNoPreview) {
+        classNames.push('quickview__button_base');
+      }
+      if (this.previewButtonLabel) {
+        classNames.push('slds-var-p-horizontal_medium');
+      }
+    }
+    else {
+      if (this.previewButtonVariant === 'brand') {
+        classNames.push('slds-button_brand');
+      } else {
+        classNames.push('slds-button_outline-brand');
+      }
+    }
+
+    return classNames.join(' ');
+  }
+
+  get buttonIconClass() {
+    return `slds-current-color ${!this.previewButtonLabel ? '' : 'slds-button__icon_right'}`;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -150,7 +150,7 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get hasNoPreview() {
-    return true;
+    return !this.state?.resultHasPreview;
   }
 
   get contentContainer() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -181,7 +181,10 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get buttonIconClass() {
-    return `slds-current-color ${!this.previewButtonLabel ? '' : 'slds-button__icon_right'}`;
+    return [
+      'slds-current-color',
+      this.previewButtonLabel && 'slds-button__icon_right'
+    ].join(' ');
   }
 
   get hasButtonLabel(){

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -1,5 +1,5 @@
-import { LightningElement, api, track } from 'lwc';
-import { getHeadlessEnginePromise } from 'c/quanticHeadlessLoader';
+import {LightningElement, api, track} from 'lwc';
+import {getHeadlessEnginePromise} from 'c/quanticHeadlessLoader';
 
 import close from '@salesforce/label/c.quantic_Close';
 import openPreview from '@salesforce/label/c.quantic_OpenPreview';
@@ -49,17 +49,17 @@ export default class QuanticResultQuickview extends LightningElement {
    * The label to be shown in the preview button.
    * @api
    * @type {string}
-   * @defaultValue `''`
+   * @defaultValue `undefined`
    */
-  @api previewButtonLabel = '';
+  @api previewButtonLabel = undefined;
 
   /**
    * The variant of the preview button.
    * @api
-   * @type {''|'brand'|'outline'}
-   * @defaultValue `''`
+   * @type {undefined|'brand'|'outline-brand'}
+   * @defaultValue `undefined`
    */
-  @api previewButtonVariant = '';
+  @api previewButtonVariant = undefined;
 
   /** @type {QuickviewState} */
   @track state;
@@ -100,7 +100,7 @@ export default class QuanticResultQuickview extends LightningElement {
       result: this.result,
       maximumPreviewSize: Number(this.maximumPreviewSize),
     }
-    this.quickview = CoveoHeadless.buildQuickview(engine, { options });
+    this.quickview = CoveoHeadless.buildQuickview(engine, {options});
     this.unsubscribe = this.quickview.subscribe(() => this.updateState());
 
     this.dispatchHasPreview(this.quickview.state.resultHasPreview);
@@ -122,7 +122,7 @@ export default class QuanticResultQuickview extends LightningElement {
 
   addRecentResult() {
     getHeadlessEnginePromise(this.engineId).then((engine) => {
-      const { pushRecentResult } = CoveoHeadless.loadRecentResultsActions(engine);
+      const {pushRecentResult} = CoveoHeadless.loadRecentResultsActions(engine);
       engine.dispatch(pushRecentResult(JSON.parse(JSON.stringify(this.result))));
     });
   }
@@ -170,15 +170,11 @@ export default class QuanticResultQuickview extends LightningElement {
 
     if (!this.previewButtonVariant || !this.previewButtonLabel) {
       if (!this.hasNoPreview) {
-        classNames.push('quickview__button_base');
+        classNames.push('quickview__button-base');
       }
     }
     else {
-      if (this.previewButtonVariant === 'brand') {
-        classNames.push('slds-button_brand');
-      } else {
-        classNames.push('slds-button_outline-brand');
-      }
+      classNames.push(`slds-button_${this.previewButtonVariant}`);
     }
 
     return classNames.join(' ');
@@ -186,5 +182,9 @@ export default class QuanticResultQuickview extends LightningElement {
 
   get buttonIconClass() {
     return `slds-current-color ${!this.previewButtonLabel ? '' : 'slds-button__icon_right'}`;
+  }
+
+  get hasButtonLabel(){
+    return !!this.previewButtonLabel;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -150,7 +150,7 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get hasNoPreview() {
-    return !this.state?.resultHasPreview;
+    return true;
   }
 
   get contentContainer() {
@@ -166,18 +166,10 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get buttonClass() {
-    let classNames = ['slds-button'];
-
-    if (!this.previewButtonVariant || !this.previewButtonLabel) {
-      if (!this.hasNoPreview) {
-        classNames.push('quickview__button-base');
-      }
-    }
-    else {
-      classNames.push(`slds-button_${this.previewButtonVariant}`);
-    }
-
-    return classNames.join(' ');
+    return [
+      'slds-button',
+      this.previewButtonVariant ? `slds-button_${this.previewButtonVariant}` : 'quickview__button-base'
+    ].join(' ')
   }
 
   get buttonIconClass() {
@@ -187,7 +179,7 @@ export default class QuanticResultQuickview extends LightningElement {
     ].join(' ');
   }
 
-  get hasButtonLabel(){
+  get hasButtonLabel() {
     return !!this.previewButtonLabel;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -39,6 +39,7 @@ export default class QuanticResultQuickview extends LightningElement {
 
   /**
    * The icon to be shown in the preview button.
+   * @api
    * @type {string}
    * @defaultValue `'utility:preview'`
    */
@@ -46,13 +47,15 @@ export default class QuanticResultQuickview extends LightningElement {
 
   /**
    * The label to be shown in the preview button.
+   * @api
    * @type {string}
    * @defaultValue `''`
    */
   @api previewButtonLabel = '';
 
   /**
-   * The variant the preview button.
+   * The variant of the preview button.
+   * @api
    * @type {''|'brand'|'outline'}
    * @defaultValue `''`
    */


### PR DESCRIPTION
# Slots Added in Quick view

- ### The button to open the Quick view is now customizable using the following properties  `previewButtonLabel`, `previewButtonIcon` and `previewButtonVariant`.

- ### The ability to have a footer in the quick view where the end user can plug other components using the  slot `footer`.



https://user-images.githubusercontent.com/86681870/145244465-1e7764c8-c7c8-404e-b712-88c87f3e4bc9.mov

## Examples of the  preview buttons that can be displayed: 

- ### Default:
<img width="43" alt="default" src="https://user-images.githubusercontent.com/86681870/145247373-d61d7e80-779f-4396-8bbb-5afc933d2a76.png">

- ### Default when there is no preview
<img width="49" alt="defaultDisabled" src="https://user-images.githubusercontent.com/86681870/145247375-189ceac5-75bc-49be-a936-cc7e7716acda.png">

- ### Brand variant with custom label and custom icon
<img width="151" alt="BrandCustomIconCustomLAbel" src="https://user-images.githubusercontent.com/86681870/145247376-116c6b66-cd33-4c67-8e80-58cee284f156.png">

- ### Brand variant with custom label and custom icon when there is no preview
<img width="154" alt="brandCustomDisabled" src="https://user-images.githubusercontent.com/86681870/145247377-009ee23a-81dd-44bc-83a3-fc291eeca93a.png">

- ### Outline variant with custom label and custom icon
<img width="157" alt="OutlineCustom" src="https://user-images.githubusercontent.com/86681870/145247378-f5c7a702-59fa-4b3d-a211-eaf446379a00.png">

- ### Brand variant with custom label and custom icon when there is no preview
<img width="147" alt="OutlineCustomDisabled" src="https://user-images.githubusercontent.com/86681870/145247379-53e8a894-d806-45ed-a287-f921b8cc973a.png">



