### PR TITLE
ci(headless-react): only validate types; skip bundle

### DIFF
--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "prepublishOnly": "exit 1",
     "dev": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "tsc --noEmit",
     "build:server": "tsc --project ./tsconfig.server.json",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Jenkins build time: 102s -> 12s

Since the headless-react project is not deployed anywhere, we can save the compute involved in generating a production bundle. The build step now only checks for typescript errors.

https://coveord.atlassian.net/browse/KIT-1282