### PR TITLE
docs(atomic): normalize storybook id

### DIFF
--- a/packages/atomic/.storybook/default-story-shared.tsx
+++ b/packages/atomic/.storybook/default-story-shared.tsx
@@ -110,6 +110,7 @@ export default function sharedDefaultStory(
 
   const defaultModuleExport = {
     title,
+    id: componentTag,
     argTypes: mapPropsToArgTypes(componentTag),
     parameters: {
       docs: {
@@ -146,6 +147,7 @@ export default function sharedDefaultStory(
 
   exportedStory.loaders = [defaultLoader];
   exportedStory.decorators = [defaultDecorator];
+  exportedStory.storyName = componentTag;
 
   return {
     defaultModuleExport,

--- a/packages/atomic/src/components/atomic-no-results/atomic-no-results.stories.tsx
+++ b/packages/atomic/src/components/atomic-no-results/atomic-no-results.stories.tsx
@@ -1,7 +1,7 @@
 import defaultStory from '../../../.storybook/default-story';
 
 const {defaultModuleExport, exportedStory} = defaultStory(
-  'Atomic/NoResult',
+  'Atomic/NoResults',
   'atomic-no-results',
   {},
   {


### PR DESCRIPTION
Force the storybook ID (what generates permalink to a specific story) to the component tag instead of "the name of the story", as it makes it harder to have dead links in doc website.

https://coveord.atlassian.net/browse/KIT-1285