### PR TITLE
doc(atomic): add sample for using Headless through Atomic

### DIFF
--- a/packages/atomic/src/pages/examples/custom.html
+++ b/packages/atomic/src/pages/examples/custom.html
@@ -11,13 +11,13 @@
     <script>
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
-        const interface = document.querySelector('#search');
-        await interface.initialize({
+        const searchInterface = document.querySelector('#search');
+        await searchInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });
 
-        interface.executeFirstSearch();
+        searchInterface.executeFirstSearch();
       })();
     </script>
     <!-- Custom Atomic Component using the initializeBindings method -->
@@ -82,7 +82,7 @@
     </script>
   </head>
   <body>
-    <atomic-search-interface id="search">
+    <atomic-search-interface>
       <custom-component></custom-component>
       <atomic-query-summary></atomic-query-summary>
       <atomic-result-list>

--- a/packages/atomic/src/pages/examples/external.html
+++ b/packages/atomic/src/pages/examples/external.html
@@ -28,22 +28,22 @@
     <script>
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
-        const interface1 = document.querySelector('#interface-1');
-        const interface2 = document.querySelector('#interface-2');
+        const searchInterface1 = document.querySelector('#interface-1');
+        const searchInterface2 = document.querySelector('#interface-2');
 
         await Promise.all([
-          interface1.initialize({
+          searchInterface1.initialize({
             accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
             organizationId: 'searchuisamples',
           }),
-          interface2.initialize({
+          searchInterface2.initialize({
             accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
             organizationId: 'electronicscoveodemocomo0n2fu8v',
           }),
         ]);
 
-        interface1.executeFirstSearch();
-        interface2.executeFirstSearch();
+        searchInterface1.executeFirstSearch();
+        searchInterface2.executeFirstSearch();
       })();
     </script>
   </head>

--- a/packages/atomic/src/pages/examples/headless.html
+++ b/packages/atomic/src/pages/examples/headless.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Coveo Atomic: Headless example</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {loadAdvancedSearchQueryActions, loadContextActions} from '/build/headless/headless.esm.js';
+      // CDN example: 'https://static.cloud.coveo.com/atomic/v1/atomic.esm.js/headless/headless.esm.js'
+
+      function setExpression(engine) {
+        const action = loadAdvancedSearchQueryActions(engine).updateAdvancedSearchQueries({
+          aq: '@author=amoreau',
+        });
+        engine.dispatch(action);
+      }
+
+      function setContext(engine) {
+        const action = loadContextActions(engine).addContext({
+          contextKey: 'headless',
+          contextValue: 'very good',
+        });
+        engine.dispatch(action);
+      }
+
+      async function main() {
+        await customElements.whenDefined('atomic-search-interface');
+        const searchInterface = document.querySelector('#search');
+        await searchInterface.initialize({
+          accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+          organizationId: 'searchuisamples',
+        });
+
+        const engine = searchInterface.engine;
+        setExpression(engine);
+        setContext(engine);
+
+        searchInterface.executeFirstSearch();
+      }
+      main();
+    </script>
+  </head>
+  <body>
+    <atomic-search-interface>
+      <atomic-search-box></atomic-search-box>
+      <atomic-query-summary></atomic-query-summary>
+      <atomic-result-list></atomic-result-list>
+    </atomic-search-interface>
+  </body>
+</html>

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -11,7 +11,7 @@
     <script>
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
-        const searchInterface = document.querySelector('#search');
+        const searchInterface = document.querySelector('atomic-search-interface');
 
         // Initialization
         await searchInterface.initialize({
@@ -237,7 +237,7 @@
   </head>
 
   <body>
-    <atomic-search-interface id="search">
+    <atomic-search-interface>
       <div class="header-bg"></div>
       <atomic-search-box></atomic-search-box>
       <atomic-facet-manager>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1289

It was a question asked on the Coveo Community https://coveocommunity.slack.com/archives/C02DY81L6GM/p1638973899000900

Responded and kept the sample so we can reference to it. @dlutzCoveo  we should write a usage article on Using Headless along with Atomic, the html I provide here should help!