### PR TITLE
feat(quantic): remove old scratch organizations

### DIFF
--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -130,7 +130,7 @@ async function buildOptions(): Promise<Options> {
 async function deleteOldOrgs(log: StepLogger, options: Options): Promise<void> {
   log('Deleting old scratch organizations...');
 
-  await sfdx.deleteActiveScratchOrgs({
+  await sfdx.deleteOldScratchOrgs({
     devHubUsername: options.jwt.username,
     scratchOrgName: getCiOrgName(),
     jwtClientId: options.jwt.clientId,

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -130,14 +130,14 @@ async function buildOptions(): Promise<Options> {
 async function deleteOldOrgs(log: StepLogger, options: Options): Promise<void> {
   log('Deleting old scratch organizations...');
 
-  await sfdx.deleteOldScratchOrgs({
+  const nbDeleted = await sfdx.deleteOldScratchOrgs({
     devHubUsername: options.jwt.username,
     scratchOrgName: getCiOrgName(),
     jwtClientId: options.jwt.clientId,
     jwtKeyFile: options.jwt.keyFile,
   });
 
-  log('Scratch organizations deleted.');
+  log(`${nbDeleted} scratch organizations deleted.`);
 }
 
 async function ensureScratchOrgExists(log: StepLogger, options: Options) {

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -195,12 +195,13 @@ interface DeleteOldScratchOrgsArguments {
 
 export async function deleteOldScratchOrgs(
   args: DeleteOldScratchOrgsArguments
-): Promise<void> {
+): Promise<number> {
   const usernames = await getOldScratchOrgUsernames(
     args.devHubUsername,
     args.scratchOrgName
   );
 
+  let nbDeletedOrgs = 0;
   for (const username of usernames) {
     try {
       await authorizeOrg({
@@ -210,11 +211,14 @@ export async function deleteOldScratchOrgs(
         jwtKeyFile: args.jwtKeyFile,
       });
       await deleteOrg(username);
+      nbDeletedOrgs += 1;
     } catch (error) {
       console.warn(`Failed to delete organization ${username}`);
       console.warn(JSON.stringify(error));
     }
   }
+
+  return nbDeletedOrgs;
 }
 
 export async function orgExists(alias: string): Promise<boolean> {

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -27,6 +27,15 @@ export interface SfdxActiveScratchOrgsResponse extends SfdxResponse {
   };
 }
 
+export interface SfdxOldScratchOrgsResponse extends SfdxResponse {
+  result: {
+    records: {
+      SignupUsername: string;
+      CreatedDate: string;
+    }[];
+  };
+}
+
 export interface SfdxCreateOrgResponse extends SfdxResponse {
   result: SfdxOrg;
 }
@@ -98,6 +107,26 @@ export async function getActiveScratchOrgUsernames(
   return response.result.records.map((r) => r.SignupUsername);
 }
 
+export async function getOldScratchOrgUsernames(
+  devHubAlias: string,
+  scratchOrgName: string
+): Promise<string[]> {
+  const response = await sfdx<SfdxOldScratchOrgsResponse>(
+    `force:data:soql:query -u ${devHubAlias} -q "SELECT SignupUsername, CreatedDate FROM ScratchOrgInfo WHERE OrgName='${scratchOrgName}' AND Status != 'Deleted'"`
+  );
+
+  const ageThresholdMsec = 2 * 60 * 60 * 1000;
+  const isOldOrg = (createdDateString: string) => {
+    const created = new Date(createdDateString).getTime();
+    const now = new Date(Date.now()).getTime();
+    return now - created > ageThresholdMsec;
+  };
+
+  return response.result.records
+    .filter((r) => isOldOrg(r.CreatedDate))
+    .map((r) => r.SignupUsername);
+}
+
 export interface AuthorizeOrgArguments {
   username: string;
   isScratchOrg: boolean;
@@ -137,6 +166,37 @@ export async function deleteActiveScratchOrgs(
   args: DeleteActiveScratchOrgsArguments
 ): Promise<void> {
   const usernames = await getActiveScratchOrgUsernames(
+    args.devHubUsername,
+    args.scratchOrgName
+  );
+
+  for (const username of usernames) {
+    try {
+      await authorizeOrg({
+        username,
+        isScratchOrg: true,
+        jwtClientId: args.jwtClientId,
+        jwtKeyFile: args.jwtKeyFile,
+      });
+      await deleteOrg(username);
+    } catch (error) {
+      console.warn(`Failed to delete organization ${username}`);
+      console.warn(JSON.stringify(error));
+    }
+  }
+}
+
+interface DeleteOldScratchOrgsArguments {
+  devHubUsername: string;
+  scratchOrgName: string;
+  jwtClientId: string;
+  jwtKeyFile: string;
+}
+
+export async function deleteOldScratchOrgs(
+  args: DeleteOldScratchOrgsArguments
+): Promise<void> {
+  const usernames = await getOldScratchOrgUsernames(
     args.devHubUsername,
     args.scratchOrgName
   );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4259

This PR updates the `deploy-community` to delete the scratch organizations (for a given branch) that are more than 2 hours old. With concurrent builds, a scratch organization could be deleted by job-2 while job-1 was still executing tests.