### PR TITLE
fix(quantic): Fix the appearance of the preview button of the quick view

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,17 +1,17 @@
 <template>
-  <button class={buttonClass} onclick={openQuickview} tooltip={buttonLabel} disabled={hasNoPreview}>
+  <button class={buttonClass} onclick={openQuickview} tooltip={buttonLabel} title={buttonLabel} disabled={hasNoPreview}>
     <template if:true={hasButtonLabel}>
       {previewButtonLabel}
     </template>  
-    <lightning-icon 
+    <template if:true={hasIcon}>
+      <lightning-icon 
       size="x-small"
       icon-name={previewButtonIcon}
-      title={buttonLabel}
       alternative-text={buttonLabel}
       class={buttonIconClass}>
-    </lightning-icon>
+      </lightning-icon>
+    </template>
   </button>
-
   <template if:true={isQuickviewOpen}>
     <section onclick={closeQuickview} role="dialog" tabindex="-1" aria-labelledby="quickview-modal-heading" aria-modal="true" aria-describedby="quickview__content-container" class="slds-modal slds-modal_medium slds-fade-in-open">
       <div class="slds-modal__container">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -154,6 +154,10 @@ export default class QuanticResultQuickview extends LightningElement {
     return !this.state?.resultHasPreview;
   }
 
+  get hasIcon() {
+    return !!this.previewButtonIcon;
+  }
+
   get contentContainer() {
     return this.template.querySelector('.quickview__content-container');
   }


### PR DESCRIPTION
Before: 

- Tooltip appearing only when hovering on the icon.
- When `preview-button-icon` is set to `''` an additional right padding was appearing in the preview button.

<img width="885" alt="before" src="https://user-images.githubusercontent.com/86681870/145834143-4dc0d366-7aff-4451-a9e2-c183f94019ad.png">

After:

- Tooltip appearing only when hovering on the whole button.
- When `preview-button-icon` is set to `''` the preview button is now appearing correctly.

<img width="637" alt="fix" src="https://user-images.githubusercontent.com/86681870/145833930-0ed1eb0f-835b-46e3-8e17-2189c0018eab.png">

