### PR TITLE
chore(headless): cleanup jsdoc above actions

### DIFF
--- a/packages/headless/src/features/advanced-search-queries/advanced-search-queries-actions.ts
+++ b/packages/headless/src/features/advanced-search-queries/advanced-search-queries-actions.ts
@@ -19,10 +19,6 @@ export interface AdvancedSearchQueryActionCreatorPayload {
   lq?: string;
 }
 
-/**
- * Update the values of the advanced search queries.
- * @param (advancedSearchQueries)  The current state of the advanced search queries.
- */
 export const updateAdvancedSearchQueries = createAction(
   'advancedSearchQueries/update',
   (payload: AdvancedSearchQueryActionCreatorPayload) =>
@@ -33,10 +29,6 @@ export const updateAdvancedSearchQueries = createAction(
     })
 );
 
-/**
- * Registers the initial state of the advanced search queries.
- * @param (advancedSearchQueries)  The initial state of the advanced search queries.
- */
 export const registerAdvancedSearchQueries = createAction(
   'advancedSearchQueries/register',
   (payload: AdvancedSearchQueryActionCreatorPayload) =>

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -56,10 +56,6 @@ export interface LogSearchEventActionCreatorPayload {
   meta?: Record<string, unknown>;
 }
 
-/**
- * Logs a search event.
- * @param p (SearchEventPayload) The search event payload.
- */
 export const logSearchEvent = (p: LogSearchEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/search',
@@ -83,10 +79,6 @@ export interface LogClickEventActionCreatorPayload {
   result: Result;
 }
 
-/**
- * Logs a click event.
- * @param p (ClickEventPayload) The click event payload.
- */
 export const logClickEvent = (p: LogClickEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/click',
@@ -118,10 +110,6 @@ export interface LogCustomEventActionCreatorPayload {
   meta?: Record<string, unknown>;
 }
 
-/**
- * Logs a custom event.
- * @param p (CustomEventPayload) The custom event payload.
- */
 export const logCustomEvent = (p: LogCustomEventActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/generic/custom',
@@ -132,18 +120,12 @@ export const logCustomEvent = (p: LogCustomEventActionCreatorPayload) =>
     }
   )();
 
-/**
- * Logs an interface load event.
- */
 export const logInterfaceLoad = makeAnalyticsAction(
   'analytics/interface/load',
   AnalyticsType.Search,
   (client) => client.logInterfaceLoad()
 );
 
-/**
- * Logs an interface change event.
- */
 export const logInterfaceChange = makeAnalyticsAction(
   'analytics/interface/change',
   AnalyticsType.Search,

--- a/packages/headless/src/features/case-assist-configuration/case-assist-configuration-actions.ts
+++ b/packages/headless/src/features/case-assist-configuration/case-assist-configuration-actions.ts
@@ -16,9 +16,6 @@ export interface SetCaseAssistConfigurationActionCreatorPayload {
   locale?: string;
 }
 
-/**
- * Set case assist configuration.
- */
 export const setCaseAssistConfiguration = createAction(
   'caseAssistConfiguration/set',
   (payload: SetCaseAssistConfigurationActionCreatorPayload) =>

--- a/packages/headless/src/features/case-field/case-field-actions.ts
+++ b/packages/headless/src/features/case-field/case-field-actions.ts
@@ -29,9 +29,6 @@ export interface SetCaseFieldActionCreatorPayload {
   fieldValue: string;
 }
 
-/**
- * Registers a case field with the specified field and value.
- */
 export const registerCaseField = createAction(
   'caseAssist/caseField/register',
   (payload: SetCaseFieldActionCreatorPayload) =>
@@ -41,9 +38,6 @@ export const registerCaseField = createAction(
     })
 );
 
-/**
- * Updates the specified case field with the provided value.
- */
 export const updateCaseField = createAction(
   'caseAssist/caseField/update',
   (payload: SetCaseFieldActionCreatorPayload) =>

--- a/packages/headless/src/features/case-input/case-input-actions.ts
+++ b/packages/headless/src/features/case-input/case-input-actions.ts
@@ -16,9 +16,6 @@ export interface SetCaseInputActionCreatorPayload {
   fieldValue: string;
 }
 
-/**
- * Adds or updates the case inputs with the specified field and value.
- */
 export const updateCaseInput = createAction(
   'caseAssist/caseInput/update',
   (payload: SetCaseInputActionCreatorPayload) =>

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -28,12 +28,6 @@ export interface UpdateBasicConfigurationActionCreatorPayload {
   platformUrl?: string;
 }
 
-/**
- * Updates the global headless engine configuration.
- * @param accessToken (string) The access token to use to authenticate requests against the Coveo Cloud endpoints. Typically, this will be an API key or search token that grants the privileges to execute queries and push usage analytics data in the target Coveo Cloud organization.
- * @param organizationId (string) The unique identifier of the target Coveo Cloud organization (e.g., `mycoveocloudorganizationg8tp8wu3`)
- * @param platformUrl (string) The Plaform URL to use (e.g., `https://platform.cloud.coveo.com`).
- */
 export const updateBasicConfiguration = createAction(
   'configuration/updateBasicConfiguration',
   (payload: UpdateBasicConfigurationActionCreatorPayload) =>
@@ -71,14 +65,6 @@ export interface UpdateSearchConfigurationActionCreatorPayload {
   timezone?: string;
 }
 
-/**
- * Updates the search configuration.
- * @param apiBaseUrl (string) The Search API base URL to use (e.g., `https://platform.cloud.coveo.com/rest/search/v2`).
- * @param pipeline (string) The name of the query pipeline to use for the query (e.g., `External Search`).
- * @param searchHub (string) The first level of origin of the request, typically the identifier of the graphical search interface from which the request originates (e.g., `ExternalSearch`).
- * @param locale (string) The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
- * @param timezone (string) The [tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) identifier of the time zone of the user.
- */
 export const updateSearchConfiguration = createAction(
   'configuration/updateSearchConfiguration',
   (payload: UpdateSearchConfigurationActionCreatorPayload) =>
@@ -125,15 +111,6 @@ export interface UpdateAnalyticsConfigurationActionCreatorPayload {
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;
 
-/**
- * Updates the analytics configuration.
- * @param enabled (boolean) Whether to enable usage analytics tracking.
- * @param originLevel2 (string) The origin level 2 usage analytics event metadata whose value should typically be the identifier of the tab from which the usage analytics event originates (e.g., `All`).
- * @param originLevel3 (string) The origin level 3 usage analytics event metadata whose value should typically be the URL of the page that linked to the search interface that’s making the request (e.g., `https://connect.coveo.com/s/`).
- * @param apiBaseUrl (string) The Usage Analytics API base URL to use (e.g., `https://platform.cloud.coveo.com/rest/ua`).
- * @param runtimeEnvironment (IRuntimeEnvironment) The Coveo analytics runtime to use, see https://github.com/coveo/coveo.analytics.js for more info.
- * @param anonymous (boolean) Whether the interaction that caused the search interface to log the event was triggered by an anonymous user.
- */
 export const updateAnalyticsConfiguration = createAction(
   'configuration/updateAnalyticsConfiguration',
   (payload: UpdateAnalyticsConfigurationActionCreatorPayload) =>
@@ -147,13 +124,7 @@ export const updateAnalyticsConfiguration = createAction(
     })
 );
 
-/**
- * Disables analytics tracking.
- */
 export const disableAnalytics = createAction('configuration/analytics/disable');
-/**
- * Enables analytics tracking.
- */
 export const enableAnalytics = createAction('configuration/analytics/enable');
 
 export interface SetOriginLevel2ActionCreatorPayload {
@@ -163,10 +134,6 @@ export interface SetOriginLevel2ActionCreatorPayload {
   originLevel2: string;
 }
 
-/**
- * Sets originLevel2 for analytics tracking.
- * @param originLevel2 (string) The origin level 2 usage analytics event metadata whose value should typically be the identifier of the tab (e.g., `All`).
- */
 export const setOriginLevel2 = createAction(
   'configuration/analytics/originlevel2',
   (payload: SetOriginLevel2ActionCreatorPayload) =>
@@ -180,10 +147,6 @@ export interface SetOriginLevel3ActionCreatorPayload {
   originLevel3: string;
 }
 
-/**
- * Sets originLevel3 for analytics tracking.
- * @param originLevel3 (string) The origin level 3 usage analytics event metadata whose value should typically be the URL of the page that linked to the search interface (e.g., `https://connect.coveo.com/s/`).
- */
 export const setOriginLevel3 = createAction(
   'configuration/analytics/originlevel3',
   (payload: SetOriginLevel3ActionCreatorPayload) =>

--- a/packages/headless/src/features/context/context-actions.ts
+++ b/packages/headless/src/features/context/context-actions.ts
@@ -21,10 +21,6 @@ const nonEmptyPayload = (contextKey: string, contextValue: ContextValue) => {
   return {payload: {contextKey, contextValue}};
 };
 
-/**
- * Sets the query context.
- * @param payload (Context) The new context (e.g., {age: "18-35"}).
- */
 export const setContext = createAction(
   'context/set',
   (payload: ContextPayload) => {
@@ -47,20 +43,12 @@ export interface AddContextActionCreatorPayload {
   contextValue: ContextValue;
 }
 
-/**
- * Adds a new context value.
- * @param payload ({contextKey: string; contextValue: ContextValue}) The key-value pair to add to the context (e.g., `{contextKey: "age", contextValue: "18-35"}`).
- */
 export const addContext = createAction(
   'context/add',
   (payload: AddContextActionCreatorPayload) =>
     nonEmptyPayload(payload.contextKey, payload.contextValue)
 );
 
-/**
- * Removes a context key-value pair.
- * @param key (string) The key to remove from the context (e.g., `"age"`).
- */
 export const removeContext = createAction('context/remove', (payload: string) =>
   validatePayload(payload, requiredNonEmptyString)
 );

--- a/packages/headless/src/features/debug/debug-actions.ts
+++ b/packages/headless/src/features/debug/debug-actions.ts
@@ -1,11 +1,4 @@
 import {createAction} from '@reduxjs/toolkit';
 
-/**
- * Enables debug information on requests.
- */
 export const enableDebug = createAction('debug/enable');
-
-/**
- * Disables debug information on requests.
- */
 export const disableDebug = createAction('debug/disable');

--- a/packages/headless/src/features/did-you-mean/did-you-mean-actions.ts
+++ b/packages/headless/src/features/did-you-mean/did-you-mean-actions.ts
@@ -4,19 +4,10 @@ import {
   requiredNonEmptyString,
 } from '../../utils/validate-payload';
 
-/**
- * Enables did-you-mean.
- */
 export const enableDidYouMean = createAction('didYouMean/enable');
 
-/**
- * Disables did-you-mean.
- */
 export const disableDidYouMean = createAction('didYouMean/disable');
-/**
- * Applies a did-you-mean correction.
- * @param correction (string) The target correction (e.g., `"corrected string"`).
- */
+
 export const applyDidYouMeanCorrection = createAction(
   'didYouMean/correction',
   (payload: string) => validatePayload(payload, requiredNonEmptyString)

--- a/packages/headless/src/features/did-you-mean/did-you-mean-analytics-actions.ts
+++ b/packages/headless/src/features/did-you-mean/did-you-mean-analytics-actions.ts
@@ -1,17 +1,11 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Logs a did-you-mean click event, i.e., when a user clicks on a did-you-mean suggestion.
- */
 export const logDidYouMeanClick = makeAnalyticsAction(
   'analytics/didyoumean/click',
   AnalyticsType.Search,
   (client) => client.logDidYouMeanClick()
 );
 
-/**
- * Logs a did-you-mean automatic event, i.e., when the interface automatically selects a did-you-mean suggestion.
- */
 export const logDidYouMeanAutomatic = makeAnalyticsAction(
   'analytics/didyoumean/automatic',
   AnalyticsType.Search,

--- a/packages/headless/src/features/facet-options/facet-options-actions.ts
+++ b/packages/headless/src/features/facet-options/facet-options-actions.ts
@@ -9,10 +9,6 @@ export interface UpdateFacetOptionsActionCreatorPayload {
   freezeFacetOrder?: boolean;
 }
 
-/**
- * Updates options that affect facet reordering. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#definitions-RestFacetOptions).
- * @param {Partial<FacetOptions>} facetOptions The options to update.
- */
 export const updateFacetOptions = createAction(
   'facetOptions/update',
   (payload: UpdateFacetOptionsActionCreatorPayload) =>

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
@@ -96,10 +96,6 @@ const registerCategoryFacetPayloadDefinition = {
   filterByBasePath: new BooleanValue({required: false}),
 };
 
-/**
- * Registers a category facet in the category facet set.
- * @param (RegisterCategoryFacetActionCreatorPayload) The options to register the category facet with.
- */
 export const registerCategoryFacet = createAction(
   'categoryFacet/register',
   (payload: RegisterCategoryFacetActionCreatorPayload) =>
@@ -123,11 +119,6 @@ export interface ToggleSelectCategoryFacetValueActionCreatorPayload {
   retrieveCount: number;
 }
 
-/**
- * Toggles a category facet value.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (CategoryFacetValue) The target category facet value.
- */
 export const toggleSelectCategoryFacetValue = createAction(
   'categoryFacet/toggleSelectValue',
   (payload: ToggleSelectCategoryFacetValueActionCreatorPayload) => {
@@ -141,9 +132,6 @@ export const toggleSelectCategoryFacetValue = createAction(
   }
 );
 
-/** Deselects all values of a category facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const deselectAllCategoryFacetValues = createAction(
   'categoryFacet/deselectAll',
   (payload: string) => validatePayload(payload, facetIdDefinition)
@@ -161,10 +149,6 @@ export interface UpdateCategoryFacetNumberOfValuesActionCreatorPayload {
   numberOfValues: number;
 }
 
-/** Updates the number of values of a category facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param numberOfValues (number) The new number of facet values (e.g., `10`).
- */
 export const updateCategoryFacetNumberOfValues = createAction(
   'categoryFacet/updateNumberOfValues',
   (payload: UpdateCategoryFacetNumberOfValuesActionCreatorPayload) =>
@@ -186,11 +170,6 @@ export interface UpdateCategoryFacetSortCriterionActionCreatorPayload {
   criterion: CategoryFacetSortCriterion;
 }
 
-/**
- * Updates the the sort criterion for the category facet
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param criterion (FacetSortCriterion) The criterion by which to sort the facet.
- */
 export const updateCategoryFacetSortCriterion = createAction(
   'categoryFacet/updateSortCriterion',
   (payload: UpdateCategoryFacetSortCriterionActionCreatorPayload) =>

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
@@ -49,10 +49,6 @@ const getCategoryFacetMetadata = (
   };
 };
 
-/**
- * Logs a category facet breadcrumb event.
- * @param payload (LogCategoryFacetBreadcrumbActionCreatorPayload) Object specifying the target facet and path.
- */
 export const logCategoryFacetBreadcrumb = (
   payload: LogCategoryFacetBreadcrumbActionCreatorPayload
 ) =>

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-actions.ts
@@ -20,8 +20,6 @@ const categoryFacetSearchResultDefinition = {
   count: new NumberValue({required: true, min: 0}),
 };
 
-/** Selects the corresponding category facet value for the provided
- * category facet search result */
 export const selectCategoryFacetSearchResult = createAction(
   'categoryFacet/selectSearchResult',
   (payload: {facetId: string; value: CategoryFacetSearchResult}) =>
@@ -31,10 +29,6 @@ export const selectCategoryFacetSearchResult = createAction(
     })
 );
 
-/**
- * Registers a category facet search box with the specified options.
- * @param (FacetSearchOptions) An object specifying the target facet and facet search box options.
- */
 export const registerCategoryFacetSearch = createAction(
   'categoryFacetSearch/register',
   (payload: FacetSearchOptions) =>

--- a/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
@@ -19,10 +19,6 @@ import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
 import {ClientThunkExtraArguments} from '../../../../app/thunk-extra-arguments';
 import {FacetSearchAPIClient} from '../../../../api/search/search-api-client';
 
-/**
- * Executes a facet search (i.e., a search for facet values in a facet search box).
- * @param facetId (string) The unique identifier of the facet for which to perform a facet search (e.g., `"1"`).
- */
 export const executeFacetSearch = createAsyncThunk<
   {facetId: string; response: FacetSearchResponse},
   string,
@@ -55,10 +51,6 @@ export const executeFacetSearch = createAsyncThunk<
   }
 );
 
-/**
- * Resets the query and empties the values of the facet search.
- * @param facetId (string) The unique identifier of the facet for which to perform a facet search (e.g., `"1"`).
- */
 export const clearFacetSearch = createAction(
   'facetSearch/clearResults',
   (payload: {facetId: string}) =>

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-actions.ts
@@ -25,30 +25,18 @@ type selectFacetSearchResultPayload = {
   value: SpecificFacetSearchResult;
 };
 
-/**
- * Registers a facet search box with the specified options.
- * @param (FacetSearchOptions) An object specifying the target facet and facet search box options.
- */
 export const registerFacetSearch = createAction(
   'facetSearch/register',
   (payload: FacetSearchOptions) =>
     validatePayload(payload, facetSearchOptionsDefinition)
 );
 
-/**
- * Updates the options of a facet search box.
- * @param (FacetSearchOptions) An object specifying the target facet and facet search box options.
- */
 export const updateFacetSearch = createAction(
   'facetSearch/update',
   (payload: FacetSearchOptions) =>
     validatePayload(payload, facetSearchOptionsDefinition)
 );
 
-/**
- * Selects a facet search result.
- * @param (selectFacetSearchResultPayload) An object that specifies the target facet and facet search result.
- */
 export const selectFacetSearchResult = createAction(
   'facetSearch/toggleSelectValue',
   (payload: selectFacetSearchResultPayload) =>

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -73,10 +73,7 @@ const facetRegistrationOptionsDefinition = {
   numberOfValues: new NumberValue({required: false, min: 1}),
   sortCriteria: new Value<FacetSortCriterion>({required: false}),
 };
-/**
- * Registers a facet in the facet set.
- * @param (RegisterFacetActionCreatorPayload) The options to register the facet with.
- */
+
 export const registerFacet = createAction(
   'facet/register',
   (payload: RegisterFacetActionCreatorPayload) =>
@@ -95,11 +92,6 @@ export interface ToggleSelectFacetValueActionCreatorPayload {
   selection: FacetValue;
 }
 
-/**
- * Toggles a facet value.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (FacetValue) The target facet value.
- */
 export const toggleSelectFacetValue = createAction(
   'facet/toggleSelectValue',
   (payload: ToggleSelectFacetValueActionCreatorPayload) =>
@@ -109,10 +101,6 @@ export const toggleSelectFacetValue = createAction(
     })
 );
 
-/**
- * Deselects all values of a facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const deselectAllFacetValues = createAction(
   'facet/deselectAll',
   (payload: string) => validatePayload(payload, facetIdDefinition)
@@ -130,11 +118,6 @@ export interface UpdateFacetSortCriterionActionCreatorPayload {
   criterion: FacetSortCriterion;
 }
 
-/**
- * Updates the sort criterion of a facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param criterion (FacetSortCriterion) The criterion by which to sort the facet.
- */
 export const updateFacetSortCriterion = createAction(
   'facet/updateSortCriterion',
   (payload: UpdateFacetSortCriterionActionCreatorPayload) =>
@@ -156,11 +139,6 @@ export interface UpdateFacetNumberOfValuesActionCreatorPayload {
   numberOfValues: number;
 }
 
-/**
- * Updates the number of values of a facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param numberOfValues (number) The new number of facet values (e.g., `10`).
- */
 export const updateFacetNumberOfValues = createAction(
   'facet/updateNumberOfValues',
   (payload: UpdateFacetNumberOfValuesActionCreatorPayload) =>
@@ -182,11 +160,6 @@ export interface UpdateFacetIsFieldExpandedActionCreatorPayload {
   isFieldExpanded: boolean;
 }
 
-/**
- * Whether to expand (show more values than initially configured) or shrink down the facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param isFieldExpanded (boolean) Whether to expand or shrink down the facet.
- */
 export const updateFacetIsFieldExpanded = createAction(
   'facet/updateIsFieldExpanded',
   (payload: UpdateFacetIsFieldExpandedActionCreatorPayload) =>
@@ -208,11 +181,6 @@ export interface UpdateFreezeCurrentValuesActionCreatorPayload {
   freezeCurrentValues: boolean;
 }
 
-/**
- * Updates the updateFreezeCurrentValues flag of a facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param freezeCurrentValues (boolean) Whether the values should be frozen in the next request.
- */
 export const updateFreezeCurrentValues = createAction(
   'facet/updateFreezeCurrentValues',
   (payload: UpdateFreezeCurrentValuesActionCreatorPayload) =>

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -16,10 +16,6 @@ import {
   buildFacetSelectionChangeMetadata,
 } from './facet-set-analytics-actions-utils';
 
-/**
- * Logs a facet show more event.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const logFacetShowMore = (facetId: string) =>
   makeAnalyticsAction(
     'analytics/facet/showMore',
@@ -33,10 +29,7 @@ export const logFacetShowMore = (facetId: string) =>
       return client.logFacetShowMore(metadata);
     }
   )();
-/**
- * Logs a facet show less event.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
+
 export const logFacetShowLess = (facetId: string) =>
   makeAnalyticsAction(
     'analytics/facet/showLess',
@@ -52,10 +45,6 @@ export const logFacetShowLess = (facetId: string) =>
     }
   )();
 
-/**
- * Logs a facet search event.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const logFacetSearch = (facetId: string) =>
   makeAnalyticsAction(
     'analytics/facet/search',
@@ -81,10 +70,6 @@ export interface LogFacetUpdateSortActionCreatorPayload {
   criterion: FacetSortCriterion | RangeFacetSortCriterion;
 }
 
-/**
- * Logs a facet sort event.
- * @param payload (LogFacetUpdateSortActionCreatorPayload) Object specifying the facet and sort criterion.
- */
 export const logFacetUpdateSort = (
   payload: LogFacetUpdateSortActionCreatorPayload
 ) =>
@@ -109,10 +94,6 @@ export const logFacetUpdateSort = (
     }
   )();
 
-/**
- * Logs a facet clear all event.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const logFacetClearAll = (facetId: string) =>
   makeAnalyticsAction(
     'analytics/facet/reset',
@@ -139,10 +120,6 @@ export interface LogFacetSelectActionCreatorPayload {
   facetValue: string;
 }
 
-/**
- * Logs a facet value selection event.
- * @param payload (LogFacetSelectActionCreatorPayload) Object specifying the target facet and value.
- */
 export const logFacetSelect = (payload: LogFacetSelectActionCreatorPayload) =>
   makeAnalyticsAction(
     'analytics/facet/select',
@@ -175,10 +152,6 @@ export interface LogFacetDeselectActionCreatorPayload {
   facetValue: string;
 }
 
-/**
- * Logs a facet deselect event.
- * @param payload (LogFacetDeselectActionCreatorPayload) Object specifying the target facet and value.
- */
 export const logFacetDeselect = (
   payload: LogFacetDeselectActionCreatorPayload
 ) =>
@@ -212,10 +185,6 @@ export interface LogFacetBreadcrumbActionCreatorPayload {
   facetValue: string;
 }
 
-/**
- * Logs a facet breadcrumb event.
- * @param payload (LogFacetBreadcrumbActionCreatorPayload) Object specifying the target facet and value.
- */
 export const logFacetBreadcrumb = (
   payload: LogFacetBreadcrumbActionCreatorPayload
 ) =>

--- a/packages/headless/src/features/facets/facet-set/facet-set-controller-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-controller-actions.ts
@@ -16,11 +16,6 @@ const definition = {
   selection: new RecordValue({values: facetValueDefinition}),
 };
 
-/**
- * Toggles the facet value and then executes a search with the appropriate analytics tag.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (FacetValue) The target facet value.
- */
 export const executeToggleFacetSelect = createAsyncThunk<
   void,
   {

--- a/packages/headless/src/features/facets/generic/facet-generic-analytics-actions.ts
+++ b/packages/headless/src/features/facets/generic/facet-generic-analytics-actions.ts
@@ -3,9 +3,6 @@ import {
   makeAnalyticsAction,
 } from '../../analytics/analytics-utils';
 
-/**
- * Logs clear all breadcrumbs event e.g. when a user click to remove all filters at once
- */
 export const logClearBreadcrumbs = () =>
   makeAnalyticsAction(
     'analytics/facet/deselectAllBreadcrumbs',

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
@@ -145,10 +145,6 @@ export function validateManualDateRanges(
   });
 }
 
-/**
- * Registers a date facet.
- * @param (RegisterDateFacetActionCreatorPayload) The options to register the facet with.
- */
 export const registerDateFacet = createAction(
   'dateFacet/register',
   (payload: RegisterDateFacetActionCreatorPayload) => {
@@ -174,11 +170,6 @@ export interface ToggleSelectDateFacetValueActionCreatorPayload {
   selection: DateFacetValue;
 }
 
-/**
- * Toggles a date facet value.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (DateFacetValue) The target date facet value.
- */
 export const toggleSelectDateFacetValue = createAction(
   'dateFacet/toggleSelectValue',
   (payload: ToggleSelectDateFacetValueActionCreatorPayload) =>
@@ -200,11 +191,6 @@ export interface UpdateDateFacetValuesActionCreatorPayload {
   values: DateFacetValue[];
 }
 
-/**
- * Updates date facet values.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param values (DateFacetValue[]) The date facet values.
- */
 export const updateDateFacetValues = createAction(
   'dateFacet/updateFacetValues',
   (payload: UpdateDateFacetValuesActionCreatorPayload) => {
@@ -235,13 +221,6 @@ export interface UpdateDateFacetSortCriterionActionCreatorPayload {
   criterion: RangeFacetSortCriterion;
 }
 
-/** Updates the sort criterion of a date facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param criterion (RangeFacetSortCriterion) The target criterion.
- */
 export const updateDateFacetSortCriterion = updateRangeFacetSortCriterion;
 
-/** Deselects all values of a date facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const deselectAllDateFacetValues = deselectAllFacetValues;

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-analytics-actions.ts
@@ -19,10 +19,6 @@ export interface LogDateFacetBreadcrumbActionCreatorPayload {
   selection: DateFacetValue;
 }
 
-/**
- * Logs a date facet breadcrumb event.
- * @param payload (LogDateFacetBreadcrumbActionCreatorPayload) Object specifying the target facet and selection.
- */
 export const logDateFacetBreadcrumb = (
   payload: LogDateFacetBreadcrumbActionCreatorPayload
 ) =>

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-controller-actions.ts
@@ -17,11 +17,6 @@ const definition = {
   selection: new RecordValue({values: dateFacetValueDefinition}),
 };
 
-/**
- * Toggles the date facet value and then executes a search with the appropriate analytics tag.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (DateFacetValue) The target date facet value.
- */
 export const executeToggleDateFacetSelect = createAsyncThunk<
   void,
   {

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-actions.ts
@@ -4,11 +4,6 @@ import {validatePayload} from '../../../../utils/validate-payload';
 import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {Value} from '@coveo/bueno';
 
-/**
- * Updates the sort criterion of a range facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param criterion (RangeFacetSortCriterion) The target criterion.
- */
 export const updateRangeFacetSortCriterion = createAction(
   'rangeFacet/updateSortCriterion',
   (payload: {facetId: string; criterion: RangeFacetSortCriterion}) =>

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-controller-actions.ts
@@ -5,10 +5,6 @@ import {
 } from './range-facet-validate-payload';
 import {validatePayload} from '../../../../utils/validate-payload';
 
-/**
- * Executes a search with the appropriate analytics for a toggle range facet value
- * @param payload (RangeFacetSelectionPayload) Object specifying the target facet and selection.
- */
 export const executeToggleRangeFacetSelect = createAction(
   'rangeFacet/executeToggleSelect',
   (payload: RangeFacetSelectionPayload) =>

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
@@ -132,10 +132,6 @@ export function validateManualNumericRanges(
   });
 }
 
-/**
- * Registers a numeric facet.
- * @param (RegisterNumericFacetActionCreatorPayload) The options to register the facet with.
- */
 export const registerNumericFacet = createAction(
   'numericFacet/register',
   (payload: RegisterNumericFacetActionCreatorPayload) => {
@@ -161,11 +157,6 @@ export interface ToggleSelectNumericFacetValueActionCreatorPayload {
   selection: NumericFacetValue;
 }
 
-/**
- * Toggles a numeric facet value.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (NumericFacetValue) The target numeric facet value.
- */
 export const toggleSelectNumericFacetValue = createAction(
   'numericFacet/toggleSelectValue',
   (payload: ToggleSelectNumericFacetValueActionCreatorPayload) =>
@@ -187,11 +178,6 @@ export interface UpdateNumericFacetValuesActionCreatorPayload {
   values: NumericFacetValue[];
 }
 
-/**
- * Updates numeric facet values.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param values (NumericFacetValue[]) The numeric facet values.
- */
 export const updateNumericFacetValues = createAction(
   'numericFacet/updateFacetValues',
   (payload: UpdateNumericFacetValuesActionCreatorPayload) => {
@@ -222,13 +208,6 @@ export interface UpdateNumericFacetSortCriterionActionCreatorPayload {
   criterion: RangeFacetSortCriterion;
 }
 
-/** Updates the sort criterion of a numeric facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param criterion (RangeFacetSortCriterion) The target criterion.
- */
 export const updateNumericFacetSortCriterion = updateRangeFacetSortCriterion;
 
-/** Deselects all values of a numeric facet.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- */
 export const deselectAllNumericFacetValues = deselectAllFacetValues;

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions.ts
@@ -19,9 +19,6 @@ export interface LogNumericFacetBreadcrumbActionCreatorPayload {
   selection: NumericFacetValue;
 }
 
-/**
- * Logs a numeric facet breadcrumb event.
- */
 export const logNumericFacetBreadcrumb = (
   payload: LogNumericFacetBreadcrumbActionCreatorPayload
 ) =>

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions.ts
@@ -19,11 +19,6 @@ const definition = {
 
 const executeToggleNumericFacetSelectType = 'numericFacet/executeToggleSelect';
 
-/**
- * Toggles the numeric facet value and then executes a search with the appropriate analytics tag.
- * @param facetId (string) The unique identifier of the facet (e.g., `"1"`).
- * @param selection (NumericFacetValue) The target numeric facet value.
- */
 export const executeToggleNumericFacetSelect = createAsyncThunk<
   void,
   {

--- a/packages/headless/src/features/fields/fields-actions.ts
+++ b/packages/headless/src/features/fields/fields-actions.ts
@@ -16,36 +16,15 @@ const nonEmptyArray = new ArrayValue({
   required: true,
 });
 
-/**
- * Registers the fields to include in the query response.
- * @param payload (string[]) The target fields (e.g., `["field1", "field2"]`).
- */
 export const registerFieldsToInclude = createAction(
   'fields/registerFieldsToInclude',
   (payload: string[]) => validatePayload<string[]>(payload, nonEmptyArray)
 );
 
-/**
- * Enable fetch all fields.
- *
- * This should not be used in any production environment, as it can have a negative impact on query execution time.
- *
- * Should be used for debugging purposes.
- */
 export const enableFetchAllFields = createAction('fields/fetchall/enable');
 
-/**
- * Disable fetch all fields.
- */
 export const disableFetchAllFields = createAction('fields/fetchall/disable');
 
-/**
- * Retrieve fields descrption from the index.
- *
- * This should not be used in any production environment, as it can have a negative impact on query execution time.
- *
- * Should be used for debugging purposes.
- */
 export const fetchFieldsDescription = createAsyncThunk<
   FieldDescription[],
   void,

--- a/packages/headless/src/features/history/history-actions.ts
+++ b/packages/headless/src/features/history/history-actions.ts
@@ -5,23 +5,13 @@ import {HistoryState} from './history-state';
 export const undo = createAction('history/undo');
 export const redo = createAction('history/redo');
 
-/**
- * Creates a snapshot of the current request parameters and adds it to the interface history.
- * @param (SearchParametersState) The current state of the search parameters.
- */
 export const snapshot = createAction<HistoryState>('history/snapshot');
 
-/**
- * Moves backward in the interface history.
- */
 export const back = createAsyncThunk('history/back', async (_, {dispatch}) => {
   dispatch(undo());
   await dispatch(change());
 });
 
-/**
- * Moves forward in the interface history.
- */
 export const forward = createAsyncThunk(
   'history/forward',
   async (_, {dispatch}) => {
@@ -30,9 +20,6 @@ export const forward = createAsyncThunk(
   }
 );
 
-/**
- * Updates the interface state as per the current step in the interface history.
- */
 export const change = createAsyncThunk(
   'history/change',
   async (_, {getState}) => {

--- a/packages/headless/src/features/history/history-analytics-actions.ts
+++ b/packages/headless/src/features/history/history-analytics-actions.ts
@@ -1,27 +1,18 @@
 import {SearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Logs an event which represents a move forward in the interface history.
- */
 export const logNavigateForward = makeAnalyticsAction(
   'history/analytics/forward',
   AnalyticsType.Search,
   (client) => client.logSearchEvent('historyForward' as SearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
 );
 
-/**
- * Logs an event which represents a move backward in the interface history.
- */
 export const logNavigateBackward = makeAnalyticsAction(
   'history/analytics/backward',
   AnalyticsType.Search,
   (client) => client.logSearchEvent('historyBackward' as SearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
 );
 
-/**
- * Logs an event which represents when no results is shown and the end users cancel last action.
- */
 export const logNoResultsBack = makeAnalyticsAction(
   'history/analytics/noresultsback',
   AnalyticsType.Search,

--- a/packages/headless/src/features/pagination/pagination-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-actions.ts
@@ -4,48 +4,26 @@ import {validatePayload} from '../../utils/validate-payload';
 
 const numberValue = new NumberValue({required: true, min: 0});
 
-/**
- * Initializes the `numberOfResults` query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-numberOfResults).
- * @param payload (number) The initial number of results.
- */
 export const registerNumberOfResults = createAction(
   'pagination/registerNumberOfResults',
   (payload: number) => validatePayload(payload, numberValue)
 );
 
-/**
- * Updates the `numberOfResults` query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-numberOfResults).
- * @param payload (number) The new number of results.
- */
 export const updateNumberOfResults = createAction(
   'pagination/updateNumberOfResults',
   (payload: number) => validatePayload(payload, numberValue)
 );
 
-/**
- * Sets the initial page by initializing the `firstResult` query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-firstResult).
- * @param payload (number) The initial page number.
- */
 export const registerPage = createAction(
   'pagination/registerPage',
   (payload: number) => validatePayload(payload, numberValue)
 );
 
-/**
- * Updates the page by updating the `firstResult` query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-firstResult).
- * @param payload (number) The new page number.
- */
 export const updatePage = createAction(
   'pagination/updatePage',
   (payload: number) => validatePayload(payload, numberValue)
 );
 
-/**
- * Updates the page to the next page.
- */
 export const nextPage = createAction('pagination/nextPage');
 
-/**
- * Updates the page to the previous page.
- */
 export const previousPage = createAction('pagination/previousPage');

--- a/packages/headless/src/features/pagination/pagination-analytics-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-analytics-actions.ts
@@ -3,9 +3,6 @@ import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 import {currentPageSelector} from './pagination-selectors';
 import {getPaginationInitialState} from './pagination-state';
 
-/**
- * Log pager resize
- */
 export const logPagerResize = makeAnalyticsAction(
   'analytics/pager/resize',
   AnalyticsType.Search,
@@ -17,9 +14,6 @@ export const logPagerResize = makeAnalyticsAction(
     })
 );
 
-/**
- * Log page number
- */
 export const logPageNumber = makeAnalyticsAction(
   'analytics/pager/number',
   AnalyticsType.Search,
@@ -29,9 +23,6 @@ export const logPageNumber = makeAnalyticsAction(
     })
 );
 
-/**
- * Log pager next
- */
 export const logPageNext = makeAnalyticsAction(
   'analytics/pager/next',
   AnalyticsType.Search,
@@ -41,9 +32,6 @@ export const logPageNext = makeAnalyticsAction(
     })
 );
 
-/**
- * Log pager previous
- */
 export const logPagePrevious = makeAnalyticsAction(
   'analytics/pager/previous',
   AnalyticsType.Search,

--- a/packages/headless/src/features/pipeline/pipeline-actions.ts
+++ b/packages/headless/src/features/pipeline/pipeline-actions.ts
@@ -2,10 +2,6 @@ import {createAction} from '@reduxjs/toolkit';
 import {validatePayload} from '../../utils/validate-payload';
 import {StringValue} from '@coveo/bueno';
 
-/**
- * Sets the query pipeline.
- * @param payload (string) The query pipeline to set (may be empty).
- */
 export const setPipeline = createAction('pipeline/set', (payload: string) =>
   validatePayload(
     payload,

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -84,9 +84,6 @@ export interface FetchProductListingThunkReturn {
   response: ProductListingSuccessResponse;
 }
 
-/**
- * Fetches a product listing.
- */
 export const fetchProductListing = createAsyncThunk<
   FetchProductListingThunkReturn,
   void,

--- a/packages/headless/src/features/product-recommendations/product-recommendations-analytics.actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-analytics.actions.ts
@@ -4,9 +4,6 @@ import {
 } from '../../api/analytics/product-recommendations-analytics';
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Logs a search event with an `actionCause` value of `recommendationInterfaceLoad`.
- */
 export const logProductRecommendations = makeAnalyticsAction(
   'analytics/productrecommendations/load',
   AnalyticsType.Search,

--- a/packages/headless/src/features/query-set/query-set-actions.ts
+++ b/packages/headless/src/features/query-set/query-set-actions.ts
@@ -22,11 +22,6 @@ export interface RegisterQuerySetQueryActionCreatorPayload {
   query: string;
 }
 
-/**
- * Registers a query in the query set.
- * @param id (string) The unique identifier of the target query.
- * @param query (string) The initial basic query expression.
- */
 export const registerQuerySetQuery = createAction(
   'querySet/register',
   (payload: RegisterQuerySetQueryActionCreatorPayload) =>
@@ -45,11 +40,6 @@ export interface UpdateQuerySetQueryActionCreatorPayload {
   query: string;
 }
 
-/**
- * Updates a query in the query set.
- * @param id (string) The unique identifier of the target query.
- * @param query (string) The new basic query expression.
- */
 export const updateQuerySetQuery = createAction(
   'querySet/update',
   (payload: UpdateQuerySetQueryActionCreatorPayload) =>

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -52,12 +52,6 @@ export interface RegisterQuerySuggestActionCreatorPayload {
   count?: number;
 }
 
-/**
- * Registers a new query suggest entity to the headless state to enable the Coveo ML query suggestions feature.
- * @param id (string) A unique identifier for the new query suggest entity (e.g., `b953ab2e-022b-4de4-903f-68b2c0682942`).
- * @param q (string) The partial basic query expression for which to request query suggestions (e.g., `cov`).
- * @param count (number) The number of query suggestions to request from Coveo ML (e.g., `3`). Default: `5`.
- */
 export const registerQuerySuggest = createAction(
   'querySuggest/register',
   (payload: RegisterQuerySuggestActionCreatorPayload) =>
@@ -68,10 +62,6 @@ export const registerQuerySuggest = createAction(
     })
 );
 
-/**
- * Unregisters an existing query suggest entity from the headless state.
- * @param id (string) The unique identifier of the query suggest entity to unregister (e.g., `b953ab2e-022b-4de4-903f-68b2c0682942`).
- */
 export const unregisterQuerySuggest = createAction(
   'querySuggest/unregister',
   (payload: {id: string}) => validatePayload(payload, idDefinition)
@@ -89,11 +79,6 @@ export interface SelectQuerySuggestionActionCreatorPayload {
   expression: string;
 }
 
-/**
- * Selects a suggestion provided through a specific query suggest entity.
- * @param id (string) The unique identifier of the target query suggest entity (e.g., `b953ab2e-022b-4de4-903f-68b2c0682942`).
- * @param expression (string) The selected query suggestion (e.g., `coveo`).
- */
 export const selectQuerySuggestion = createAction(
   'querySuggest/selectSuggestion',
   (payload: SelectQuerySuggestionActionCreatorPayload) =>
@@ -110,10 +95,6 @@ export interface ClearQuerySuggestActionCreatorPayload {
   id: string;
 }
 
-/**
- * Clears the list of query suggestions in a specific query suggest entity.
- * @param id (string) The unique identifier of the target query suggest entity (e.g., `b953ab2e-022b-4de4-903f-68b2c0682942`).
- */
 export const clearQuerySuggest = createAction(
   'querySuggest/clear',
   (payload: ClearQuerySuggestActionCreatorPayload) =>
@@ -131,10 +112,6 @@ export interface FetchQuerySuggestionsThunkReturn
   extends FetchQuerySuggestionsActionCreatorPayload,
     QuerySuggestSuccessResponse {}
 
-/**
- * Fetches a list of query suggestions for a specific query suggest entity according to the current headless state.
- * @param id (string) The unique identifier of the target query suggest entity (e.g., `b953ab2e-022b-4de4-903f-68b2c0682942`).
- */
 export const fetchQuerySuggestions = createAsyncThunk<
   FetchQuerySuggestionsThunkReturn,
   FetchQuerySuggestionsActionCreatorPayload,

--- a/packages/headless/src/features/query/query-actions.ts
+++ b/packages/headless/src/features/query/query-actions.ts
@@ -14,10 +14,6 @@ export interface UpdateQueryActionCreatorPayload {
   enableQuerySyntax?: boolean;
 }
 
-/**
- * Updates the basic query expression.
- * @param q (string) The new basic query expression (e.g., `acme tornado seeds`).
- */
 export const updateQuery = createAction(
   'query/updateQuery',
   (payload: UpdateQueryActionCreatorPayload) =>

--- a/packages/headless/src/features/query/query-analytics-actions.ts
+++ b/packages/headless/src/features/query/query-analytics-actions.ts
@@ -1,8 +1,5 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Log searchbox submit
- */
 export const logSearchboxSubmit = makeAnalyticsAction(
   'analytics/searchbox/submit',
   AnalyticsType.Search,

--- a/packages/headless/src/features/question-answering/question-answering-actions.ts
+++ b/packages/headless/src/features/question-answering/question-answering-actions.ts
@@ -5,35 +5,20 @@ import {
   QuestionAnsweringDocumentIdActionCreatorPayload,
 } from './question-answering-document-id';
 
-/**
- * Expand a smart snippet.
- */
 export const expandSmartSnippet = createAction('smartSnippet/expand');
-/**
- * Collapse a smart snippet.
- */
+
 export const collapseSmartSnippet = createAction('smartSnippet/collapse');
-/**
- * Like, or thumbs up, a smart snippet.
- */
+
 export const likeSmartSnippet = createAction('smartSnippet/like');
-/**
- * Dislike, or thumbs down, a smart snippet.
- */
+
 export const dislikeSmartSnippet = createAction('smartSnippet/dislike');
 
-/**
- * Expand a related question.
- */
 export const expandSmartSnippetRelatedQuestion = createAction(
   'smartSnippet/related/expand',
   (payload: QuestionAnsweringDocumentIdActionCreatorPayload) =>
     validatePayload(payload, documentIdentifierPayloadDefinition())
 );
 
-/**
- * Collapse a related question.
- */
 export const collapseSmartSnippetRelatedQuestion = createAction(
   'smartSnippet/related/collapse',
   (payload: QuestionAnsweringDocumentIdActionCreatorPayload) =>

--- a/packages/headless/src/features/recent-queries/recent-queries-actions.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-actions.ts
@@ -21,19 +21,12 @@ const registerRecentQueriesPayloadDefinition = {
   maxLength: new NumberValue({required: true, min: 1, default: 10}),
 };
 
-/**
- * Initializes the `recentQueries` state.
- * @param payload (RegisterRecentQueriesCreatorPayload) The initial state and options.
- */
 export const registerRecentQueries = createAction(
   'recentQueries/registerRecentQueries',
   (payload: RegisterRecentQueriesCreatorPayload) =>
     validatePayload(payload, registerRecentQueriesPayloadDefinition)
 );
 
-/**
- * Clears the recent queries list.
- */
 export const clearRecentQueries = createAction(
   'recentQueries/clearRecentQueries'
 );

--- a/packages/headless/src/features/recent-queries/recent-queries-analytics-actions.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-analytics-actions.ts
@@ -1,8 +1,5 @@
 import {makeAnalyticsAction, AnalyticsType} from '../analytics/analytics-utils';
 
-/**
- * Logs a custom event with an `actionCause` value of `clearRecentQueries`.
- */
 export const logClearRecentQueries = makeAnalyticsAction(
   'analytics/recentQueries/clear',
   AnalyticsType.Custom,
@@ -11,9 +8,6 @@ export const logClearRecentQueries = makeAnalyticsAction(
   }
 );
 
-/**
- * Logs a search event with an `actionCause` value of `recentQueriesClick`.
- */
 export const logRecentQueryClick = makeAnalyticsAction(
   'analytics/recentQueries/click',
   AnalyticsType.Search,

--- a/packages/headless/src/features/recent-results/recent-results-actions.ts
+++ b/packages/headless/src/features/recent-results/recent-results-actions.ts
@@ -26,20 +26,12 @@ const registerRecentResultsPayloadDefinition = {
   maxLength: new NumberValue({required: true, min: 1, default: 10}),
 };
 
-/**
- * Initialize the `recentResults` state.
- * @param payload (RegisterRecentResultsCreatorPayload) The initial state and options.
- */
 export const registerRecentResults = createAction(
   'recentResults/registerRecentResults',
   (payload: RegisterRecentResultsCreatorPayload) =>
     validatePayload(payload, registerRecentResultsPayloadDefinition)
 );
 
-/**
- * Push a recent result to the list.
- * @param payload (Result) The recently viewed result to push to the list.
- */
 export const pushRecentResult = createAction(
   'recentResults/pushRecentResult',
   (payload: Result) => {
@@ -50,9 +42,6 @@ export const pushRecentResult = createAction(
   }
 );
 
-/**
- * Clear the recent results list.
- */
 export const clearRecentResults = createAction(
   'recentResults/clearRecentResults'
 );

--- a/packages/headless/src/features/recent-results/recent-results-analytics-actions.ts
+++ b/packages/headless/src/features/recent-results/recent-results-analytics-actions.ts
@@ -20,15 +20,9 @@ export const logRecentResultClickThunk = (result: Result) =>
     }
   );
 
-/**
- * Logs a custom event with an `actionCause` value of `recentResultClick`.
- */
 export const logRecentResultClick = (result: Result) =>
   logRecentResultClickThunk(result)();
 
-/**
- * Logs a custom event with an `actionCause` value of `clearRecentResults`.
- */
 export const logClearRecentResults = makeAnalyticsAction(
   'analytics/recentResults/clear',
   AnalyticsType.Custom,

--- a/packages/headless/src/features/recommendation/recommendation-actions.ts
+++ b/packages/headless/src/features/recommendation/recommendation-actions.ts
@@ -36,9 +36,6 @@ export interface SetRecommendationIdActionCreatorPayload {
   id: string;
 }
 
-/**
- * Set recommendation identifier.
- */
 export const setRecommendationId = createAction(
   'recommendation/set',
   (payload: SetRecommendationIdActionCreatorPayload) =>
@@ -47,9 +44,6 @@ export const setRecommendationId = createAction(
     })
 );
 
-/**
- * Get recommendations.
- */
 export const getRecommendations = createAsyncThunk<
   GetRecommendationsThunkReturn,
   void,

--- a/packages/headless/src/features/recommendation/recommendation-analytics-actions.ts
+++ b/packages/headless/src/features/recommendation/recommendation-analytics-actions.ts
@@ -7,9 +7,6 @@ import {
   validateResultPayload,
 } from '../analytics/analytics-utils';
 
-/**
- * Logs a search event with an `actionCause` value of `recommendationInterfaceLoad`.
- */
 export const logRecommendationUpdate = makeAnalyticsAction(
   'analytics/recommendation/update',
   AnalyticsType.Search,

--- a/packages/headless/src/features/redirection/redirection-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-actions.ts
@@ -26,10 +26,6 @@ export interface CheckForRedirectionActionCreatorPayload {
   defaultRedirectionUrl: string;
 }
 
-/**
- * Preprocesses the query for the current headless state, and updates the redirection URL if a redirect trigger was fired in the query pipeline.
- * @param defaultRedirectionUrl (string) The default URL to which to redirect the user.
- */
 export const checkForRedirection = createAsyncThunk<
   string,
   CheckForRedirectionActionCreatorPayload,

--- a/packages/headless/src/features/redirection/redirection-analytics-actions.ts
+++ b/packages/headless/src/features/redirection/redirection-analytics-actions.ts
@@ -1,8 +1,5 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Log redirection
- */
 export const logRedirection = makeAnalyticsAction(
   'analytics/redirection',
   AnalyticsType.Search,

--- a/packages/headless/src/features/result-preview/result-preview-analytics-actions.ts
+++ b/packages/headless/src/features/result-preview/result-preview-analytics-actions.ts
@@ -7,10 +7,6 @@ import {
   validateResultPayload,
 } from '../analytics/analytics-utils';
 
-/**
- * Logs a document quickview click event.
- * @param result - The result that was previewed.
- */
 export const logDocumentQuickview = (result: Result) => {
   return buildDocumentQuickviewThunk(result)();
 };

--- a/packages/headless/src/features/result/result-analytics-actions.ts
+++ b/packages/headless/src/features/result/result-analytics-actions.ts
@@ -20,9 +20,5 @@ export const logDocumentOpenThunk = (result: Result) =>
     }
   );
 
-/**
- * Logs a click event with an `actionCause` value of `documentOpen`.
- * @param result (Result) The result that was opened.
- */
 export const logDocumentOpen = (result: Result) =>
   logDocumentOpenThunk(result)();

--- a/packages/headless/src/features/search-hub/search-hub-actions.ts
+++ b/packages/headless/src/features/search-hub/search-hub-actions.ts
@@ -2,10 +2,6 @@ import {createAction} from '@reduxjs/toolkit';
 import {validatePayload} from '../../utils/validate-payload';
 import {StringValue} from '@coveo/bueno';
 
-/**
- * Sets the search hub.
- * @param payload (string) The new search hub (may be empty).
- */
 export const setSearchHub = createAction('searchHub/set', (payload: string) =>
   validatePayload(
     payload,

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -79,7 +79,6 @@ export interface SearchParameters {
   tab?: string;
 }
 
-/** Restores search parameters from e.g. a url*/
 export const restoreSearchParameters = createAction(
   'searchParameters/restore',
   (payload: SearchParameters) =>

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -117,10 +117,6 @@ export const prepareForSearchWithQuery = createAsyncThunk<
   dispatch(updatePage(1));
 });
 
-/**
- * Executes a search query.
- * @param analyticsAction (SearchAction) The analytics action to log after a successful query.
- */
 export const executeSearch = createAsyncThunk<
   ExecuteSearchThunkReturn,
   SearchAction,

--- a/packages/headless/src/features/sort-criteria/sort-criteria-actions.ts
+++ b/packages/headless/src/features/sort-criteria/sort-criteria-actions.ts
@@ -6,19 +6,12 @@ import {EnumValue, isArray, SchemaDefinition} from '@coveo/bueno';
 const criterionDefinition = {
   by: new EnumValue<SortBy>({enum: SortBy, required: true}),
 } as SchemaDefinition<SortCriterion>;
-/**
- * Initializes the sortCriteria query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-sortCriteria).
- * @param payload (SortCriterion) The initial sort criterion.
- */
+
 export const registerSortCriterion = createAction(
   'sortCriteria/register',
   (payload: SortCriterion | SortCriterion[]) => validate(payload)
 );
 
-/**
- * Updates the sortCriteria query parameter. For more information, refer to [the documentation on query parameters](https://docs.coveo.com/en/1461/cloud-v2-developers/query-parameters#RestQueryParameters-sortCriteria).
- * @param payload (SortCriterion) The sort criterion to set.
- */
 export const updateSortCriterion = createAction(
   'sortCriteria/update',
   (payload: SortCriterion | SortCriterion[]) => validate(payload)

--- a/packages/headless/src/features/sort-criteria/sort-criteria-analytics-actions.ts
+++ b/packages/headless/src/features/sort-criteria/sort-criteria-analytics-actions.ts
@@ -1,9 +1,6 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 import {getSortCriteriaInitialState} from './sort-criteria-state';
 
-/**
- * Log results sort
- */
 export const logResultsSort = makeAnalyticsAction(
   'analytics/sort/results',
   AnalyticsType.Search,

--- a/packages/headless/src/features/triggers/trigger-analytics-actions.ts
+++ b/packages/headless/src/features/triggers/trigger-analytics-actions.ts
@@ -1,8 +1,5 @@
 import {AnalyticsType, makeAnalyticsAction} from '../analytics/analytics-utils';
 
-/**
- * Log trigger query
- */
 export const logTriggerQuery = makeAnalyticsAction(
   'analytics/trigger/query',
   AnalyticsType.Search,
@@ -14,9 +11,6 @@ export const logTriggerQuery = makeAnalyticsAction(
   }
 );
 
-/**
- * Log trigger notify
- */
 export const logNotifyTrigger = makeAnalyticsAction(
   'analytics/trigger/notify',
   AnalyticsType.Search,
@@ -30,9 +24,6 @@ export const logNotifyTrigger = makeAnalyticsAction(
   }
 );
 
-/**
- * Log trigger redirection
- */
 export const logTriggerRedirect = makeAnalyticsAction(
   'analytics/trigger/redirect',
   AnalyticsType.Search,


### PR DESCRIPTION
Action loaders removed the need for jsdoc above the actions. I postponed the cleanup at the time because it was internal and low-priority. The goal of doing it now is to reassure contributors that they do not need to annotate the actions when adding new ones.

https://coveord.atlassian.net/browse/KIT-1292