### PR TITLE
fix(quantic): removed default pipeline value

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install NPM dependencies
         working-directory: ./packages/quantic
         run: |
+          npm i -g typescript
           npm i -g sfdx-cli
           npm i
       - name: Build Quantic project

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -51,9 +51,9 @@ export default class QuanticSearchInterface extends LightningElement {
    * The search interface [query pipeline](https://docs.coveo.com/en/180/).
    * @api
    * @type {string}
-   * @defaultValue 'default'
+   * @defaultValue `undefined`
    */
-  @api pipeline = 'default';
+  @api pipeline;
 
   /**
    * Whether the state should not be reflected in the URL parameters.


### PR DESCRIPTION
Removed pipeline default value because it would overwrite searchub configured pipeline when searchhub is specified and pipeline isn't.

[Related discuss post](https://discuss.coveo.com/t/searchhub-and-pipeline-wrong-behavior/6961/9)