### PR TITLE
fix: (headless): Send correct analytics events from Product Listing controllers

### DIFF
--- a/packages/headless/src/api/analytics/analytics.test.ts
+++ b/packages/headless/src/api/analytics/analytics.test.ts
@@ -13,6 +13,8 @@ import {getSearchInitialState} from '../../features/search/search-state';
 import {getSearchHubInitialState} from '../../features/search-hub/search-hub-state';
 import {buildMockFacetResponse} from '../../test/mock-facet-response';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state';
+import {getProductListingInitialState} from '../../features/product-listing/product-listing-state';
+import {buildMockProductListingState} from '../../test/mock-product-listing-state';
 
 describe('analytics', () => {
   const logger = pino({level: 'silent'});
@@ -208,6 +210,38 @@ describe('analytics', () => {
       };
       const provider = new AnalyticsProvider(state);
       expect(provider.getLanguage()).toEqual('en');
+    });
+
+    it('when productListing is provided, #getSearchUID returns the correct id', () => {
+      const searchUid = 'test';
+      const state = {
+        ...baseState,
+        productListing: {
+          ...getProductListingInitialState(),
+          responseId: searchUid,
+        },
+      };
+      const provider = new AnalyticsProvider(state);
+      expect(provider.getSearchUID()).toEqual(searchUid);
+    });
+
+    it('when facets for productListing are provided, #getFacetState returns the facet state', () => {
+      const state = buildMockProductListingState({
+        productListing: {
+          ...getProductListingInitialState(),
+          facets: {
+            results: [
+              buildMockFacetResponse({
+                values: [
+                  {numberOfResults: 1, value: 'helloooo', state: 'selected'},
+                ],
+              }),
+            ],
+          },
+        },
+      });
+      const provider = new AnalyticsProvider(state);
+      expect(provider.getFacetState().length).toBe(1);
     });
   });
 });

--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -15,6 +15,7 @@ import {
   ConfigurationSection,
   ContextSection,
   PipelineSection,
+  ProductListingSection,
   QuerySection,
   RecommendationSection,
   SearchHubSection,
@@ -37,6 +38,7 @@ export type StateNeededByAnalyticsProvider = ConfigurationSection &
       QuerySection &
       ContextSection &
       RecommendationSection &
+      ProductListingSection &
       SectionNeededForFacetMetadata
   >;
 
@@ -75,6 +77,7 @@ export class AnalyticsProvider implements SearchPageClientProvider {
     return (
       this.state.search?.response.searchUid ||
       this.state.recommendation?.searchUid ||
+      this.state.productListing?.responseId ||
       getSearchInitialState().response.searchUid
     );
   }

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
@@ -1,9 +1,8 @@
+import {CategoryFacetSection} from '../../../state/state-sections';
 import {
-  CategoryFacetSection,
-  ProductListingSection,
-  SearchSection,
-} from '../../../state/state-sections';
-import {baseFacetResponseSelector} from '../facet-set/facet-set-selectors';
+  baseFacetResponseSelector,
+  FacetResponseSection,
+} from '../facet-set/facet-set-selectors';
 import {partitionIntoParentsAndValues} from './category-facet-utils';
 import {CategoryFacetResponse} from './interfaces/response';
 import {AnyFacetResponse} from '../generic/interfaces/generic-facet-response';
@@ -16,7 +15,7 @@ function isCategoryFacetResponse(
 }
 
 export const categoryFacetResponseSelector = (
-  state: CategoryFacetSection & Partial<SearchSection | ProductListingSection>,
+  state: CategoryFacetSection & Partial<FacetResponseSection>,
   facetId: string
 ) => {
   const response = baseFacetResponseSelector(state, facetId);
@@ -35,7 +34,7 @@ export const categoryFacetRequestSelector = (
 };
 
 export const categoryFacetSelectedValuesSelector = (
-  state: CategoryFacetSection & Partial<SearchSection | ProductListingSection>,
+  state: CategoryFacetSection & Partial<FacetResponseSection>,
   facetId: string
 ) => {
   const facetResponse = categoryFacetResponseSelector(state, facetId);

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
@@ -1,5 +1,6 @@
 import {
   CategoryFacetSection,
+  ProductListingSection,
   SearchSection,
 } from '../../../state/state-sections';
 import {baseFacetResponseSelector} from '../facet-set/facet-set-selectors';
@@ -15,7 +16,7 @@ function isCategoryFacetResponse(
 }
 
 export const categoryFacetResponseSelector = (
-  state: CategoryFacetSection & SearchSection,
+  state: CategoryFacetSection & Partial<SearchSection | ProductListingSection>,
   facetId: string
 ) => {
   const response = baseFacetResponseSelector(state, facetId);
@@ -34,7 +35,7 @@ export const categoryFacetRequestSelector = (
 };
 
 export const categoryFacetSelectedValuesSelector = (
-  state: CategoryFacetSection & SearchSection,
+  state: CategoryFacetSection & Partial<SearchSection | ProductListingSection>,
   facetId: string
 ) => {
   const facetResponse = categoryFacetResponseSelector(state, facetId);

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -4,6 +4,7 @@ import {
   DateFacetSection,
   FacetSection,
   NumericFacetSection,
+  ProductListingSection,
   SearchSection,
 } from '../../../state/state-sections';
 import {getSearchInitialState} from '../../search/search-state';
@@ -24,12 +25,13 @@ import {getFacetSetInitialState} from './facet-set-state';
 import {FacetRequest} from './interfaces/request';
 import {FacetValue} from './interfaces/response';
 import {categoryFacetSelectedValuesSelector} from '../category-facet-set/category-facet-set-selectors';
+import {getProductListingInitialState} from '../../product-listing/product-listing-state';
 
 export type SectionNeededForFacetMetadata = FacetSection &
   CategoryFacetSection &
   DateFacetSection &
   NumericFacetSection &
-  SearchSection;
+  Partial<SearchSection | ProductListingSection>;
 
 export type FacetSelectionChangeMetadata = {
   facetId: string;
@@ -72,7 +74,14 @@ export function getStateNeededForFacetMetadata(
     categoryFacetSet: s.categoryFacetSet || getCategoryFacetSetInitialState(),
     dateFacetSet: s.dateFacetSet || getDateFacetSetInitialState(),
     numericFacetSet: s.numericFacetSet || getNumericFacetSetInitialState(),
-    search: s.search || getSearchInitialState(),
+    ...('search' in s && {
+      search: s.search ? s.search : getSearchInitialState(),
+    }),
+    ...('productListing' in s && {
+      productListing: s.productListing
+        ? s.productListing
+        : getProductListingInitialState(),
+    }),
   };
 }
 
@@ -81,7 +90,7 @@ export const buildFacetStateMetadata = (
 ) => {
   const facetState: FacetStateMetadata[] = [];
 
-  state.search.response.facets.forEach((facetResponse, facetIndex) => {
+  getFacetResponse(state).forEach((facetResponse, facetIndex) => {
     const facetType = getFacetType(state, facetResponse.facetId);
     const facetResponseAnalytics = mapFacetResponseToAnalytics(
       facetResponse,
@@ -137,6 +146,13 @@ export const buildFacetStateMetadata = (
   });
 
   return facetState;
+};
+
+const getFacetResponse = (state: SectionNeededForFacetMetadata) => {
+  if ('productListing' in state && state.productListing)
+    return state.productListing.facets.results;
+  if ('search' in state && state.search) return state.search.response.facets;
+  return [];
 };
 
 const mapFacetValueToAnalytics = (

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -4,8 +4,6 @@ import {
   DateFacetSection,
   FacetSection,
   NumericFacetSection,
-  ProductListingSection,
-  SearchSection,
 } from '../../../state/state-sections';
 import {getSearchInitialState} from '../../search/search-state';
 import {getCategoryFacetSetInitialState} from '../category-facet-set/category-facet-set-state';
@@ -26,12 +24,13 @@ import {FacetRequest} from './interfaces/request';
 import {FacetValue} from './interfaces/response';
 import {categoryFacetSelectedValuesSelector} from '../category-facet-set/category-facet-set-selectors';
 import {getProductListingInitialState} from '../../product-listing/product-listing-state';
+import {FacetResponseSection} from './facet-set-selectors';
 
 export type SectionNeededForFacetMetadata = FacetSection &
   CategoryFacetSection &
   DateFacetSection &
   NumericFacetSection &
-  Partial<SearchSection | ProductListingSection>;
+  Partial<FacetResponseSection>;
 
 export type FacetSelectionChangeMetadata = {
   facetId: string;

--- a/packages/headless/src/features/facets/facet-set/facet-set-selectors.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-selectors.ts
@@ -6,8 +6,10 @@ import {FacetSection} from '../../../state/state-sections';
 import {FacetResponse, FacetValue} from './interfaces/response';
 import {AnyFacetResponse} from '../generic/interfaces/generic-facet-response';
 
+export type FacetResponseSection = SearchSection | ProductListingSection;
+
 export const baseFacetResponseSelector = (
-  state: Partial<SearchSection | ProductListingSection>,
+  state: Partial<FacetResponseSection>,
   id: string
 ) => {
   if ('productListing' in state && state.productListing) {
@@ -35,7 +37,7 @@ function isFacetResponse(
   return !!response && response.facetId in state.facetSet;
 }
 export const facetResponseSelector = (
-  state: (ProductListingSection | SearchSection) & FacetSection,
+  state: FacetResponseSection & FacetSection,
   facetId: string
 ) => {
   const response = baseFacetResponseSelector(state, facetId);
@@ -47,7 +49,7 @@ export const facetResponseSelector = (
 };
 
 export const facetResponseSelectedValuesSelector = (
-  state: (ProductListingSection | SearchSection) & FacetSection,
+  state: FacetResponseSection & FacetSection,
   facetId: string
 ): FacetValue[] => {
   const response = facetResponseSelector(state, facetId);
@@ -58,9 +60,7 @@ export const facetResponseSelectedValuesSelector = (
   return response.values.filter((value) => value.state === 'selected');
 };
 
-export const isFacetLoadingResponseSelector = (
-  state: SearchSection | ProductListingSection
-) => {
+export const isFacetLoadingResponseSelector = (state: FacetResponseSection) => {
   if ('productListing' in state) {
     return state.productListing.isLoading;
   }

--- a/packages/headless/src/features/facets/facet-set/facet-set-selectors.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-selectors.ts
@@ -7,18 +7,21 @@ import {FacetResponse, FacetValue} from './interfaces/response';
 import {AnyFacetResponse} from '../generic/interfaces/generic-facet-response';
 
 export const baseFacetResponseSelector = (
-  state: SearchSection | ProductListingSection,
+  state: Partial<SearchSection | ProductListingSection>,
   id: string
 ) => {
-  if ('productListing' in state) {
+  if ('productListing' in state && state.productListing) {
     return state.productListing.facets.results.find(
       (response) => response.facetId === id
     );
   }
 
-  return state.search.response.facets.find(
-    (response) => response.facetId === id
-  );
+  if ('search' in state && state.search) {
+    return state.search.response.facets.find(
+      (response) => response.facetId === id
+    );
+  }
+  return undefined;
 };
 
 export const facetRequestSelector = (state: FacetSection, id: string) => {


### PR DESCRIPTION
A bad request (400) error occurred when sending usage analytics requests from a Product Listing controllers.
After investigation there are 2 problems identified:
1. No SearchUID from product listing response was set.
2. Facet state form Search was queried but should be from Product Listing.

https://coveord.atlassian.net/browse/COM-1341

To validate:
Prerequisite: a page with Product Listing controllers like https://github.com/coveo/saqdemo. 
Open the network tab in chrome dev tools and filter on `search?visitor`.
Do facet related actions.
Previously you would get a 400 response.
Now you get a 200 response when these changes are applied.