### PR TITLE
docs(headless): update sortCriteria to describe 'automatic' default

### DIFF
--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet-options.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet-options.ts
@@ -62,7 +62,8 @@ export interface FacetOptions {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
+   * The criterion to use for sorting returned facet values.
+   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestFacetRequest-sortCriteria).
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet-options.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet-options.ts
@@ -62,7 +62,7 @@ export interface FacetOptions {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values.
+   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -62,7 +62,8 @@ export interface FacetOptions {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
+   * The criterion to use for sorting returned facet values.
+   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestFacetRequest-sortCriteria).
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -62,7 +62,7 @@ export interface FacetOptions {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values.
+   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -56,7 +56,7 @@ export interface RegisterFacetActionCreatorPayload {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values.
+   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -56,7 +56,8 @@ export interface RegisterFacetActionCreatorPayload {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned facet values. The default value of `automatic` adjusts the sort based on whether the facet is expanded or not, and whether the full list of values is being displayed.
+   * The criterion to use for sorting returned facet values.
+   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestFacetRequest-sortCriteria).
    *
    * @defaultValue `automatic`
    */


### PR DESCRIPTION
Updated sortCriteria annotation for facets in Headless to explain the default behaviour of `automatic`. Prompted by [this discussion](https://coveord.atlassian.net/browse/DOC-10113).