### PR TITLE
feat(atomic): added slot inside of atomic-result-badge

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-components/result-badge-selectors.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-badge-selectors.ts
@@ -5,6 +5,10 @@ export const ResultBadgeSelectors = {
   shadow: () => cy.get(resultBadgeComponent).shadow(),
   firstInResult: () =>
     ResultListSelectors.firstResult().find(resultBadgeComponent),
+  labelPart: () =>
+    ResultBadgeSelectors.firstInResult().find('[part="result-badge-label"]', {
+      includeShadowDom: true,
+    }),
   text: () =>
     ResultBadgeSelectors.firstInResult()
       .find('atomic-text', {includeShadowDom: true})

--- a/packages/atomic/cypress/integration/result-list/result-components/result-badge.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-badge.cypress.ts
@@ -15,15 +15,23 @@ export interface ResultBadgeProps {
   label?: string;
 }
 
-const addResultBadgeInResultList = (props: ResultBadgeProps = {}) =>
-  addResultList(
+const addResultBadgeInResultList = (
+  props: ResultBadgeProps = {},
+  slot?: HTMLElement
+) => {
+  const resultBadgeEl = generateComponentHTML(
+    resultBadgeComponent,
+    props as TagProps
+  );
+  if (slot) {
+    resultBadgeEl.appendChild(slot);
+  }
+  return addResultList(
     buildTemplateWithSections({
-      bottomMetadata: generateComponentHTML(
-        resultBadgeComponent,
-        props as TagProps
-      ),
+      bottomMetadata: resultBadgeEl,
     })
   );
+};
 
 describe('Result Badge Component', () => {
   describe('outside of a result template', () => {
@@ -55,7 +63,7 @@ describe('Result Badge Component', () => {
         );
       });
 
-      describe('when the field value is valid', () => {
+      describe('when the field value is a string', () => {
         const field = 'my-field';
         const rawText = 'hello-world';
         const localizedText = 'Hello, World!';
@@ -76,7 +84,7 @@ describe('Result Badge Component', () => {
         });
       });
 
-      describe('with text', () => {
+      describe('when a label is specified', () => {
         const rawText = 'hello-world';
         const localizedText = 'Hello, World!';
         beforeEach(() => {
@@ -88,6 +96,29 @@ describe('Result Badge Component', () => {
 
         it('renders the localized text', () => {
           ResultBadgeSelectors.text().should('have.text', localizedText);
+        });
+      });
+
+      describe('when a slot is specified', () => {
+        beforeEach(() => {
+          new TestFixture()
+            .with(
+              addResultBadgeInResultList({}, generateComponentHTML('canvas'))
+            )
+            .init();
+        });
+
+        it('should render the specified element', () => {
+          ResultBadgeSelectors.labelPart()
+            .find('slot')
+            .should((el) => {
+              expect(
+                el
+                  .get()[0]
+                  .assignedElements()
+                  .find((el) => el.tagName === 'CANVAS')
+              ).not.to.be.undefined;
+            });
         });
       });
     });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -461,15 +461,15 @@ export namespace Components {
     }
     interface AtomicResultBadge {
         /**
-          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the ResultList component.
+          * The field to display in the badge.  Not compatible with `label` nor slotted elements.
          */
         "field"?: string;
         /**
-          * Specifies the icon to display.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly
+          * Specifies an icon to display at the left-end of the badge. This can be used in conjunction with `field`, `label` or slotted elements.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly
          */
         "icon"?: string;
         /**
-          * The text to display instead of the field.
+          * The text to display in the badge.  Not compatible with `field` nor slotted elements.
          */
         "label"?: string;
     }
@@ -1681,15 +1681,15 @@ declare namespace LocalJSX {
     }
     interface AtomicResultBadge {
         /**
-          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the ResultList component.
+          * The field to display in the badge.  Not compatible with `label` nor slotted elements.
          */
         "field"?: string;
         /**
-          * Specifies the icon to display.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly
+          * Specifies an icon to display at the left-end of the badge. This can be used in conjunction with `field`, `label` or slotted elements.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly
          */
         "icon"?: string;
         /**
-          * The text to display instead of the field.
+          * The text to display in the badge.  Not compatible with `field` nor slotted elements.
          */
         "label"?: string;
     }

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -3,11 +3,32 @@ import {Component, Element, Prop, h} from '@stencil/core';
 import {ResultContext} from '../result-template-decorators';
 
 /**
- * The `atomic-result-badge` element renders a badge containing a field.
- * @part result-badge-element - The badge element with the background color and text color.
- * @part result-badge-icon - The optional icon displayed in the badge element.
- * @part result-badge-label - The optional icon displayed in the badge element.
- * @slot default - Allow to display alternative content instead of a field or text.
+ * The `atomic-result-badge` element renders a badge to highlight special features of a result.
+ *
+ * A badge can either display:
+ * * Text:
+ * ```html
+ * <atomic-result-badge label="Trending"></atomic-result-badge>
+ * ```
+ * * The contents of a field:
+ * ```html
+ * <atomic-result-badge field="objecttype"></atomic-result-badge>
+ * ```
+ * * An icon alone:
+ * ```html
+ * <atomic-result-badge icon="https://my-website.fake/star.svg"></atomic-result-badge>
+ * ```
+ * * Slotted elements:
+ * ```html
+ * <atomic-result-badge icon="https://my-website.fake/stopwatch.svg">
+ *     Deal ends in <my-dynamic-countdown></my-dynamic-countdown>
+ * </atomic-result-badge>
+ * ```
+ *
+ * @part result-badge-element - The decorative outer-most element with the background color and text color.
+ * @part result-badge-icon - The icon displayed at the left-end of the badge, if present.
+ * @part result-badge-label - A wrapper around the contents at the right-end of the badge. This may be text, a field or slotted elements depending on which was configured.
+ * @slot default - The elements to display inside the badge, instead of a field or label.
  */
 @Component({
   tag: 'atomic-result-badge',
@@ -18,19 +39,22 @@ export class AtomicResultBadge {
   @ResultContext() private result!: Result;
   @Element() host!: HTMLElement;
   /**
-   * The result field which the component should use.
-   * This will look in the Result object first, and then in the Result.raw object for the fields.
-   * It is important to include the necessary field in the ResultList component.
+   * The field to display in the badge.
+   *
+   * Not compatible with `label` nor slotted elements.
    */
   @Prop() public field?: string;
 
   /**
-   * The text to display instead of the field.
+   * The text to display in the badge.
+   *
+   * Not compatible with `field` nor slotted elements.
    */
   @Prop() public label?: string;
 
   /**
-   * Specifies the icon to display.
+   * Specifies an icon to display at the left-end of the badge.
+   * This can be used in conjunction with `field`, `label` or slotted elements.
    *
    * - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location.
    * - Use a value that starts with `assets://`, to display an icon from the Atomic package.

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -7,6 +7,7 @@ import {ResultContext} from '../result-template-decorators';
  * @part result-badge-element - The badge element with the background color and text color.
  * @part result-badge-icon - The optional icon displayed in the badge element.
  * @part result-badge-label - The optional icon displayed in the badge element.
+ * @slot default - Allow to display alternative content instead of a field or text.
  */
 @Component({
   tag: 'atomic-result-badge',
@@ -47,16 +48,18 @@ export class AtomicResultBadge {
     );
   }
 
+  private getTextContent() {
+    if (this.field !== undefined) {
+      return <atomic-result-text field={this.field}></atomic-result-text>;
+    }
+    if (this.label !== undefined) {
+      return <atomic-text value={this.label}></atomic-text>;
+    }
+    return <slot></slot>;
+  }
+
   private renderText() {
-    return (
-      <span part="result-badge-label">
-        {this.field ? (
-          <atomic-result-text field={this.field}></atomic-result-text>
-        ) : (
-          <atomic-text value={this.label ?? ''}></atomic-text>
-        )}
-      </span>
-    );
+    return <span part="result-badge-label">{this.getTextContent()}</span>;
   }
 
   private renderBadge() {
@@ -66,7 +69,7 @@ export class AtomicResultBadge {
         class="inline-flex place-items-center space-x-1.5 h-full px-3 bg-neutral-light text-neutral-dark text-xs rounded-full"
       >
         {this.icon && this.renderIcon()}
-        {(this.field || this.label) && this.renderText()}
+        {this.renderText()}
       </div>
     );
   }

--- a/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -8,13 +8,13 @@ import {ResultContext} from '../result-template-decorators';
  * A badge can either display:
  * * Text:
  * ```html
- * <atomic-result-badge label="Trending"></atomic-result-badge>
+ * <atomic-result-badge label="trending"></atomic-result-badge>
  * ```
  * * The contents of a field:
  * ```html
  * <atomic-result-badge field="objecttype"></atomic-result-badge>
  * ```
- * * An icon alone:
+ * * An icon:
  * ```html
  * <atomic-result-badge icon="https://my-website.fake/star.svg"></atomic-result-badge>
  * ```
@@ -27,8 +27,8 @@ import {ResultContext} from '../result-template-decorators';
  *
  * @part result-badge-element - The decorative outer-most element with the background color and text color.
  * @part result-badge-icon - The icon displayed at the left-end of the badge, if present.
- * @part result-badge-label - A wrapper around the contents at the right-end of the badge. This may be text, a field or slotted elements depending on which was configured.
- * @slot default - The elements to display inside the badge, instead of a field or label.
+ * @part result-badge-label - The wrapper around the contents at the right-end of the badge. This may be text, a field or slotted elements depending on which was configured.
+ * @slot default - The element(s) to display inside the badge, instead of a field or label.
  */
 @Component({
   tag: 'atomic-result-badge',

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -355,9 +355,10 @@
                   <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                 </atomic-field-condition>
                 <atomic-result-badge
-                  field="language"
                   icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
-                ></atomic-result-badge>
+                >
+                  <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
+                </atomic-result-badge>
                 <atomic-field-condition must-match-is-recommendation="true">
                   <atomic-result-badge label="Recommended"></atomic-result-badge>
                 </atomic-field-condition>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1092

Allows for the following kind of syntax:
```html
<atomic-result-badge
  icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
>
  <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
</atomic-result-badge>
```

# Example
Badge with the language field:
![image](https://user-images.githubusercontent.com/54454747/146237900-8311d4dc-abc5-4bbb-9cc6-e038cc43fa49.png)

Badge with a `atomic-result-multi-value-text` slotted element:
![image](https://user-images.githubusercontent.com/54454747/146237848-151e09d2-2ca9-4e38-8b9a-4af658a2281b.png)

