### PR TITLE
ci: added admin token for version bump and reduced fetch depth

### DIFF
--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
   lint-check:
     name: "Check with linter"
@@ -20,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npm run lint:check
   generate-doc:
@@ -30,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npm run doc:generate
   unit-test:
@@ -40,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npx --no-install lerna run copy:staticresources --scope @coveo/quantic
       - run: npm test
@@ -51,8 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-atomic
         with:
@@ -64,8 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-quantic
         with:
@@ -85,6 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Clean directory

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
   lint-check:
     name: "Check with linter"
@@ -30,8 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npm run lint:check
   generate-doc:
@@ -40,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npm run doc:generate
   unit-test:
@@ -50,8 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npx --no-install lerna run copy:staticresources --scope @coveo/quantic
       - run: npm test
@@ -61,8 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-atomic
   e2e-quantic-test:
@@ -71,8 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-quantic
         with:

--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
   npm-publish:
     name: 'Publish to NPM'
@@ -18,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: npm run npm:publish:alpha
         env:
@@ -30,8 +26,6 @@ jobs:
     runs-on: [self-hosted, linux, x64, ec2-alpha]
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: rm -rf veracode && mkdir veracode
       - run: mkdir veracode/auth


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1298

Without authenticating as an admin user in our repo, it's impossible to update a protected branch (`master`, in our case). I created a personal access token and added it to our org (see discussion in `#support-dev_tooling`).

If you look at previous runs, you may notice that it did push *something* though. While only an admin can update the *branch*, any member can push tags or commits.

As for the fetch depth, I happened upon the doc for it (which I should've read earlier), and a fetch depth of 0 fetches the whole git history, which we don't need in most jobs, so I decided to remove it. The default fetch depth is 1 (HEAD only).