### PR TITLE
ci: changed tag condition for workflows to match every tag

### DIFF
--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags-ignore:
-      - "@coveo/*"
+      - "**"
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -2,7 +2,7 @@ name: Publish Robot
 on:
   push:
     tags:
-      - "@coveo/*"
+      - "**"
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1299

According to [this](https://stackoverflow.com/a/63646054), the build condition may have failed because the tags already existed, due to a previous issue with the build.