### PR TITLE
ci: add missing bracket to production Jenkinsfile

### DIFF
--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -23,7 +23,7 @@ node('linux && docker') {
 
     stage('Quantic publish') {
       withCredentials([
-        string(credentialsId: 'github-coveobot_token', variable: 'GITHUB_TOKEN'),
+        usernamePassword(credentialsId: 'github-commit-token', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN'),
         string(credentialsId: 'sfdx-auth-pkg-client-id', variable: 'SFDX_AUTH_CLIENT_ID'),
         file(credentialsId: 'sfdx-auth-pkg-jwt-key', variable: 'SFDX_AUTH_JWT_KEY'),
       ]) {

--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -23,7 +23,7 @@ node('linux && docker') {
 
     stage('Quantic publish') {
       withCredentials([
-        usernamePassword(credentialsId: 'github-coveobot-token', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN'),
+        string(credentialsId: 'github-coveobot_token', variable: 'GITHUB_TOKEN'),
         string(credentialsId: 'sfdx-auth-pkg-client-id', variable: 'SFDX_AUTH_CLIENT_ID'),
         file(credentialsId: 'sfdx-auth-pkg-jwt-key', variable: 'SFDX_AUTH_JWT_KEY'),
       ]) {

--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -30,7 +30,7 @@ node('linux && docker') {
         withEnv([
           'SFDX_AUTH_JWT_USERNAME=sfdc.integration.devv2.hub@coveo.com'
         ]) {
-          sh 'cd packages/quantic && npm run build'
+          sh 'npm run build'
           sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/create-package.ts --remove-translations --promote --ci'
         }
       }

--- a/JenkinsfileProductionRelease
+++ b/JenkinsfileProductionRelease
@@ -33,6 +33,7 @@ node('linux && docker') {
           sh 'cd packages/quantic && npm run build'
           sh 'cd packages/quantic && ./node_modules/.bin/ts-node scripts/build/create-package.ts --remove-translations --promote --ci'
         }
+      }
     }
 
     stage('Notify Docs') {

--- a/packages/quantic/package-lock.json
+++ b/packages/quantic/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@coveo/quantic",
-      "version": "1.1.4",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/headless": "^1.38.1"
+        "@coveo/headless": "^1.41.7"
       },
       "devDependencies": {
         "@ckeditor/jsdoc-plugins": "^25.4.4",
@@ -23,6 +23,7 @@
         "chalk": "4.1.2",
         "change-case": "4.1.2",
         "cypress": "8.7.0",
+        "dotenv": "^10.0.0",
         "eslint": "7.32.0",
         "eslint-plugin-cypress": "2.12.1",
         "jest-junit": "12.3.0",
@@ -2085,16 +2086,16 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.0.tgz",
-      "integrity": "sha512-B+uKp0WKds0JyZDb+aZ78a5xhrOyxVcwRXna1bIi3S8aI1IiQVhrVYk3SYmwCVluzLyToORPOiR2kk++1KpaFg=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.1.tgz",
+      "integrity": "sha512-hxtGHHIYD5/1jxh/xoTbmQVnO8p7B2NBNW13beASgvOALyhiRompj1qDeWePIZKoLyABopgc+Im3VCxytRihMA=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.39.0.tgz",
-      "integrity": "sha512-V1XQnC45JiGsrOxhb8hvkjgoqUw5yryc93H991mHvJZm+ur8KiGLLACdDQmpgMM5/bw19EAJSNGgNzA/Jg1N5A==",
+      "version": "1.41.7",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.41.7.tgz",
+      "integrity": "sha512-HMJe1Ks0I81aos21NqOzEA0VVCUBxqEwy+TXbvpLh1huoqN1DVQWBJlUbKzaLOKc6gOppUEH6UM4GS5r10zn3w==",
       "dependencies": {
-        "@coveo/bueno": "^0.34.0",
+        "@coveo/bueno": "^0.34.1",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -12308,6 +12309,15 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dtrace-provider": {
@@ -33750,16 +33760,16 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.0.tgz",
-      "integrity": "sha512-B+uKp0WKds0JyZDb+aZ78a5xhrOyxVcwRXna1bIi3S8aI1IiQVhrVYk3SYmwCVluzLyToORPOiR2kk++1KpaFg=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.1.tgz",
+      "integrity": "sha512-hxtGHHIYD5/1jxh/xoTbmQVnO8p7B2NBNW13beASgvOALyhiRompj1qDeWePIZKoLyABopgc+Im3VCxytRihMA=="
     },
     "@coveo/headless": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.39.0.tgz",
-      "integrity": "sha512-V1XQnC45JiGsrOxhb8hvkjgoqUw5yryc93H991mHvJZm+ur8KiGLLACdDQmpgMM5/bw19EAJSNGgNzA/Jg1N5A==",
+      "version": "1.41.7",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.41.7.tgz",
+      "integrity": "sha512-HMJe1Ks0I81aos21NqOzEA0VVCUBxqEwy+TXbvpLh1huoqN1DVQWBJlUbKzaLOKc6gOppUEH6UM4GS5r10zn3w==",
       "requires": {
-        "@coveo/bueno": "^0.34.0",
+        "@coveo/bueno": "^0.34.1",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -42088,6 +42098,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
     },
     "dtrace-provider": {
       "version": "0.6.0",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -51,6 +51,7 @@
     "chalk": "4.1.2",
     "change-case": "4.1.2",
     "cypress": "8.7.0",
+    "dotenv": "^10.0.0",
     "eslint": "7.32.0",
     "eslint-plugin-cypress": "2.12.1",
     "jest-junit": "12.3.0",


### PR DESCRIPTION
The production jenkins script had a missing bracket, which prevented it from running. The file [now builds](https://searchuibuilds.dev.cloud.coveo.com/job/ui-kit-production-release/58/) on jenkins.

Also tweaked the github credentials (old `credentialId` did not exist), and adjusted to build all packages, since quantic needs headless files.

![groovy-compilation-error](https://user-images.githubusercontent.com/5565841/146604517-e8d0f176-dcce-40f3-8a83-4e604b14e009.PNG)


https://coveord.atlassian.net/browse/KIT-1302