### PR TITLE
ci: added verbose logging to npm publish in GHA

### DIFF
--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
+      - run: npm config set loglevel verbose --global
       - run: npm run npm:publish:alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1303

It should already be verbose since it was given the `--verbose` parameter, but I guess it's not since it's failing without any details.