### PR TITLE
ci: installed build-essential in self-hosted GHA runner

### DIFF
--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - run: |
+          apt update
+          apt install -y build-essential
       - run: rm -rf veracode && mkdir veracode
       - run: mkdir veracode/auth
       - run: cp -R packages/auth/src packages/auth/package.json packages/auth/package-lock.json veracode/auth


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1304

The build [here](https://github.com/coveo/ui-kit/runs/4587320178?check_suite_focus=true) was failing because make and GCC were missing. I asked dev tooling, they told me `apt` should be available within the runner.