### PR TITLE
fix(atomic): maintained keyboard focus on facets for accessibility

### DIFF
--- a/packages/atomic/cypress/integration/common-assertions.ts
+++ b/packages/atomic/cypress/integration/common-assertions.ts
@@ -1,5 +1,4 @@
 import {TestFixture} from '../fixtures/test-fixture';
-import {AriaLiveSelectors} from './aria-live-selectors';
 import {ComponentErrorSelectors} from './component-error-selectors';
 
 export interface ComponentSelector {

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet-actions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet-actions.ts
@@ -11,6 +11,7 @@ export const canadaHierarchyIndex = [0, 1, 0, 4];
 export const togoHierarchy = ['Africa', 'Togo', 'Lome'];
 export const hierarchicalField = 'geographicalhierarchy';
 export const defaultNumberOfValues = 5;
+export const categoryFacetLabel = 'Atlas';
 
 export interface CategoryFacetSetupOptions {
   field: string;

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
@@ -206,3 +206,9 @@ export function assertDisplayAllCategoriesButton(display: boolean) {
     );
   });
 }
+
+export function assertFocusActiveParent() {
+  it('should focus on the active parent', () => {
+    CategoryFacetSelectors.activeParentValue().should('be.focused');
+  });
+}

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -255,7 +255,7 @@ describe('Category Facet Test Suites', () => {
         function setupSelectFirstParent() {
           setupGoDeeperLastLevel();
           cy.wait(TestFixture.interceptAliases.UA);
-          CategoryFacetSelectors.parentValue().first().click();
+          CategoryFacetSelectors.parentValue().first().focus().click();
           cy.wait(TestFixture.interceptAliases.Search);
         }
 

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -17,7 +17,10 @@ import {
   categoryFacetLabel,
 } from './category-facet-actions';
 import {TestFixture} from '../../../fixtures/test-fixture';
-import {typeFacetSearchQuery} from '../facet-common-actions';
+import {
+  pressShowMoreUntilImpossible,
+  typeFacetSearchQuery,
+} from '../facet-common-actions';
 
 describe('Category Facet Test Suites', () => {
   describe('with default settings', () => {
@@ -396,6 +399,27 @@ describe('Category Facet Test Suites', () => {
       describe('verify analytics', () => {
         before(setupShowMore);
         CategoryFacetAssertions.assertLogFacetShowMore();
+      });
+
+      describe('repeatedly until there\'s no more "Show more" button', () => {
+        function setupRepeatShowMore() {
+          setupWithDefaultSettings();
+          pressShowMoreUntilImpossible(CategoryFacetSelectors);
+        }
+
+        describe('verify rendering', () => {
+          before(setupRepeatShowMore);
+
+          CommonFacetAssertions.assertDisplayShowMoreButton(
+            CategoryFacetSelectors,
+            false
+          );
+          CommonFacetAssertions.assertDisplayShowLessButton(
+            CategoryFacetSelectors,
+            true
+          );
+          CommonFacetAssertions.assertFocusShowLess(CategoryFacetSelectors);
+        });
       });
 
       describe('when selecting the "Show less" button', () => {

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -255,7 +255,7 @@ describe('Category Facet Test Suites', () => {
         function setupSelectFirstParent() {
           setupGoDeeperLastLevel();
           cy.wait(TestFixture.interceptAliases.UA);
-          CategoryFacetSelectors.parentValue().first().focus().click();
+          CategoryFacetSelectors.parentValue().first().click();
           cy.wait(TestFixture.interceptAliases.Search);
         }
 
@@ -278,6 +278,11 @@ describe('Category Facet Test Suites', () => {
           );
           CategoryFacetAssertions.assertPathInBreadcrumb(selectedPath);
           CategoryFacetAssertions.assertPathInUrl(selectedPath);
+        });
+
+        describe('test accessibility', () => {
+          beforeEach(setupSelectFirstParent);
+
           CategoryFacetAssertions.assertFocusActiveParent();
         });
 
@@ -635,6 +640,7 @@ describe('Category Facet Test Suites', () => {
           CategoryFacetAssertions.assertNumberOfChildValues(1);
           CategoryFacetAssertions.assertNumberOfParentValues(2);
           CommonFacetAssertions.assertSearchInputEmpty(CategoryFacetSelectors);
+          CategoryFacetAssertions.assertFocusActiveParent();
         });
       });
 

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -14,6 +14,7 @@ import {
   addCategoryFacet,
   hierarchicalField,
   selectSearchResultAt,
+  categoryFacetLabel,
 } from './category-facet-actions';
 import {TestFixture} from '../../../fixtures/test-fixture';
 import {typeFacetSearchQuery} from '../facet-common-actions';
@@ -55,7 +56,7 @@ describe('Category Facet Test Suites', () => {
       );
       CommonFacetAssertions.assertLabelContains(
         CategoryFacetSelectors,
-        'Atlas'
+        categoryFacetLabel
       );
       CategoryFacetAssertions.assertValuesSortedByOccurences();
     });
@@ -92,6 +93,7 @@ describe('Category Facet Test Suites', () => {
         );
         CategoryFacetAssertions.assertPathInBreadcrumb(selectedPath);
         CategoryFacetAssertions.assertPathInUrl(selectedPath);
+        CategoryFacetAssertions.assertFocusActiveParent();
 
         describe('when collapsing the facet', () => {
           before(() => {
@@ -178,6 +180,30 @@ describe('Category Facet Test Suites', () => {
           CategoryFacetAssertions.assertNumberOfParentValues(0);
           CategoryFacetAssertions.assertNoBreadcrumb();
           CategoryFacetAssertions.assertNoPathInUrl();
+          CommonFacetAssertions.assertFocusHeader(CategoryFacetSelectors);
+        });
+
+        describe('verify analytics', () => {
+          before(setupClear);
+          CategoryFacetAssertions.assertLogClearFacetValues();
+        });
+      });
+
+      describe('when clicking the active value', () => {
+        function setupClear() {
+          setupGoDeeperOneLevel();
+          cy.wait(TestFixture.interceptAliases.UA);
+          CategoryFacetSelectors.activeParentValue().click();
+          cy.wait(TestFixture.interceptAliases.Search);
+        }
+
+        describe('verify rendering', () => {
+          before(setupClear);
+          CategoryFacetAssertions.assertDisplayAllCategoriesButton(false);
+          CategoryFacetAssertions.assertNumberOfParentValues(0);
+          CategoryFacetAssertions.assertNoBreadcrumb();
+          CategoryFacetAssertions.assertNoPathInUrl();
+          CommonFacetAssertions.assertFocusHeader(CategoryFacetSelectors);
         });
 
         describe('verify analytics', () => {
@@ -217,6 +243,7 @@ describe('Category Facet Test Suites', () => {
         );
         CategoryFacetAssertions.assertPathInBreadcrumb(canadaHierarchy);
         CategoryFacetAssertions.assertPathInUrl(canadaHierarchy);
+        CategoryFacetAssertions.assertFocusActiveParent();
       });
 
       describe('verify analytics', () => {
@@ -251,11 +278,92 @@ describe('Category Facet Test Suites', () => {
           );
           CategoryFacetAssertions.assertPathInBreadcrumb(selectedPath);
           CategoryFacetAssertions.assertPathInUrl(selectedPath);
+          CategoryFacetAssertions.assertFocusActiveParent();
         });
 
         describe('verify analytics', () => {
           before(setupSelectFirstParent);
           CategoryFacetAssertions.assertLogFacetSelect(selectedPath);
+        });
+
+        describe('when selecting the label button to collapse', () => {
+          function setupSelectLabelCollapse() {
+            setupSelectFirstParent();
+            cy.wait(TestFixture.interceptAliases.Search);
+            CategoryFacetSelectors.labelButton().click();
+          }
+
+          describe('verify rendering', () => {
+            before(setupSelectLabelCollapse);
+            CommonFacetAssertions.assertDisplayFacet(
+              CategoryFacetSelectors,
+              true
+            );
+            CommonAssertions.assertAccessibility(categoryFacetComponent);
+            CommonAssertions.assertContainsComponentError(
+              CategoryFacetSelectors,
+              false
+            );
+            CommonFacetAssertions.assertDisplayClearButton(
+              CategoryFacetSelectors,
+              true
+            );
+            CommonFacetAssertions.assertDisplayValues(
+              CategoryFacetSelectors,
+              false
+            );
+            CommonFacetAssertions.assertLabelContains(
+              CategoryFacetSelectors,
+              categoryFacetLabel
+            );
+          });
+
+          describe('when selecting the label button to expand', () => {
+            function setupSelectLabelExpand() {
+              setupSelectLabelCollapse();
+              CategoryFacetSelectors.labelButton().click();
+            }
+
+            before(setupSelectLabelExpand);
+
+            CommonFacetAssertions.assertDisplayClearButton(
+              CategoryFacetSelectors,
+              false
+            );
+            CommonFacetAssertions.assertDisplayValues(
+              CategoryFacetSelectors,
+              true
+            );
+            CommonFacetAssertions.assertDisplayShowMoreButton(
+              CategoryFacetSelectors,
+              true
+            );
+          });
+
+          describe('when selecting the "Clear" button', () => {
+            function setupClearBoxValues() {
+              setupSelectLabelCollapse();
+              cy.wait(TestFixture.interceptAliases.UA);
+              CategoryFacetSelectors.clearButton().click();
+              cy.wait(TestFixture.interceptAliases.Search);
+            }
+
+            describe('verify rendering', () => {
+              before(setupClearBoxValues);
+
+              CommonFacetAssertions.assertDisplayClearButton(
+                CategoryFacetSelectors,
+                false
+              );
+              CommonFacetAssertions.assertFocusHeader(CategoryFacetSelectors);
+            });
+
+            describe('verify analytics', () => {
+              before(setupClearBoxValues);
+
+              CategoryFacetAssertions.assertLogClearFacetValues();
+            });
+          });
         });
       });
     });
@@ -306,6 +414,7 @@ describe('Category Facet Test Suites', () => {
             CategoryFacetSelectors,
             false
           );
+          CommonFacetAssertions.assertFocusShowMore(CategoryFacetSelectors);
         });
 
         describe('verify analytics', () => {

--- a/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
@@ -10,7 +10,10 @@ import {
   colorFacetComponent,
   ColorFacetSelectors,
 } from './color-facet-selectors';
-import {typeFacetSearchQuery} from '../facet-common-actions';
+import {
+  pressShowMoreUntilImpossible,
+  typeFacetSearchQuery,
+} from '../facet-common-actions';
 import * as FacetAssertions from '../facet/facet-assertions';
 import * as ColorFacetAssertions from './color-facet-assertions';
 import * as CommonAssertions from '../../common-assertions';
@@ -218,6 +221,29 @@ describe('Color Facet Test Suites', () => {
     describe('verify analytics', () => {
       before(setupSelectShowMore);
       FacetAssertions.assertLogFacetShowMore(colorFacetField);
+    });
+
+    describe('repeatedly until there\'s no more "Show more" button', () => {
+      function setupRepeatShowMore() {
+        new TestFixture()
+          .with(addColorFacet({field: colorFacetField, label: colorFacetLabel}))
+          .init();
+        pressShowMoreUntilImpossible(ColorFacetSelectors);
+      }
+
+      describe('verify rendering', () => {
+        before(setupRepeatShowMore);
+
+        CommonFacetAssertions.assertDisplayShowMoreButton(
+          ColorFacetSelectors,
+          false
+        );
+        CommonFacetAssertions.assertDisplayShowLessButton(
+          ColorFacetSelectors,
+          true
+        );
+        CommonFacetAssertions.assertFocusShowLess(ColorFacetSelectors);
+      });
     });
 
     describe('when selecting the "Show less" button', () => {

--- a/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
@@ -123,6 +123,7 @@ describe('Color Facet Test Suites', () => {
             ColorFacetAssertions.assertNumberOfIdleBoxValues(
               colorFacetDefaultNumberOfValues
             );
+            CommonFacetAssertions.assertFocusHeader(ColorFacetSelectors);
           });
 
           describe('verify analytics', () => {
@@ -212,6 +213,7 @@ describe('Color Facet Test Suites', () => {
       ColorFacetAssertions.assertNumberOfIdleBoxValues(
         colorFacetDefaultNumberOfValues * 2
       );
+      CommonFacetAssertions.assertFocusShowMore(ColorFacetSelectors);
     });
     describe('verify analytics', () => {
       before(setupSelectShowMore);

--- a/packages/atomic/cypress/integration/facets/facet-common-actions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-actions.ts
@@ -3,6 +3,7 @@ import {
   FacetWithCheckboxSelector,
   FacetWithLinkSelector,
   FacetWithSearchSelector,
+  FacetWithShowMoreLessSelector,
 } from './facet-common-assertions';
 
 export function selectIdleCheckboxValueAt(
@@ -33,5 +34,19 @@ export function typeFacetSearchQuery(
     if (index < characters.length - 1) {
       cy.wait(TestFixture.interceptAliases.UA);
     }
+  });
+}
+
+export function pressShowMoreUntilImpossible(
+  FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector
+) {
+  FacetWithShowMoreLessSelector.showMoreButton().then((jq) => {
+    const [el] = jq.filter(':visible');
+    if (!el) {
+      return;
+    }
+    el.click();
+    cy.wait(TestFixture.interceptAliases.Search);
+    pressShowMoreUntilImpossible(FacetWithShowMoreLessSelector);
   });
 }

--- a/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
@@ -291,3 +291,11 @@ export function assertFocusShowMore(
     FacetWithShowMoreLessSelector.showMoreButton().should('be.focused');
   });
 }
+
+export function assertFocusShowLess(
+  FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector
+) {
+  it('should focus on the show less button', () => {
+    FacetWithShowMoreLessSelector.showLessButton().should('be.focused');
+  });
+}

--- a/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
@@ -277,3 +277,17 @@ export function assertDisplayShowLessButton(
     );
   });
 }
+
+export function assertFocusHeader(BaseFacetSelector: BaseFacetSelector) {
+  it('should focus on the header', () => {
+    BaseFacetSelector.labelButton().should('be.focused');
+  });
+}
+
+export function assertFocusShowMore(
+  FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector
+) {
+  it('should focus on the show more button', () => {
+    FacetWithShowMoreLessSelector.showMoreButton().should('be.focused');
+  });
+}

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -8,6 +8,7 @@ import {
   selectIdleBoxValueAt,
 } from './facet-actions';
 import {
+  pressShowMoreUntilImpossible,
   selectIdleCheckboxValueAt,
   selectIdleLinkValueAt,
   typeFacetSearchQuery,
@@ -679,6 +680,24 @@ describe('Facet v1 Test Suites', () => {
       before(setupSelectShowMore);
 
       FacetAssertions.assertLogFacetShowMore(field);
+    });
+
+    describe('repeatedly until there\'s no more "Show more" button', () => {
+      function setupRepeatShowMore() {
+        new TestFixture().with(addFacet({field, label})).init();
+        pressShowMoreUntilImpossible(FacetSelectors);
+      }
+
+      describe('verify rendering', () => {
+        before(setupRepeatShowMore);
+
+        CommonFacetAssertions.assertDisplayShowMoreButton(
+          FacetSelectors,
+          false
+        );
+        CommonFacetAssertions.assertDisplayShowLessButton(FacetSelectors, true);
+        CommonFacetAssertions.assertFocusShowLess(FacetSelectors);
+      });
     });
 
     describe('when selecting the "Show less" button', () => {

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -125,6 +125,7 @@ describe('Facet v1 Test Suites', () => {
               FacetSelectors,
               defaultNumberOfValues
             );
+            CommonFacetAssertions.assertFocusHeader(FacetSelectors);
           });
           describe('verify analytics', () => {
             before(setupClearCheckboxValues);
@@ -671,6 +672,7 @@ describe('Facet v1 Test Suites', () => {
         FacetSelectors,
         defaultNumberOfValues * 2
       );
+      CommonFacetAssertions.assertFocusShowMore(FacetSelectors);
     });
 
     describe('verify analytics', () => {

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet.cypress.ts
@@ -152,6 +152,7 @@ describe('Numeric Facet V1 Test Suites', () => {
                 NumericFacetSelectors,
                 8
               );
+              CommonFacetAssertions.assertFocusHeader(NumericFacetSelectors);
             });
 
             describe('verify analytics', () => {

--- a/packages/atomic/cypress/integration/facets/rating-facet/rating-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/rating-facet/rating-facet.cypress.ts
@@ -177,6 +177,38 @@ describe('Rating Facet Test Suites', () => {
           before(setupSelectLinkValue);
           RatingFacetAssertions.assertLogRatingFacetSelect(ratingFacetField);
         });
+
+        describe('when selecting the "Clear" button', () => {
+          function setupClearCheckboxValues() {
+            setupSelectLinkValue();
+            cy.wait(TestFixture.interceptAliases.UA);
+            RatingFacetSelectors.clearButton().click();
+            cy.wait(TestFixture.interceptAliases.Search);
+          }
+
+          describe('verify rendering', () => {
+            before(setupClearCheckboxValues);
+
+            CommonFacetAssertions.assertDisplayClearButton(
+              RatingFacetSelectors,
+              false
+            );
+            CommonFacetAssertions.assertNumberOfSelectedLinkValues(
+              RatingFacetSelectors,
+              0
+            );
+            CommonFacetAssertions.assertNumberOfIdleLinkValues(
+              RatingFacetSelectors,
+              ratingFacetDefaultNumberOfIntervals
+            );
+            CommonFacetAssertions.assertFocusHeader(RatingFacetSelectors);
+          });
+          describe('verify analytics', () => {
+            before(setupClearCheckboxValues);
+
+            CommonFacetAssertions.assertLogClearFacetValues(ratingFacetField);
+          });
+        });
       });
     });
   });

--- a/packages/atomic/cypress/integration/facets/rating-range-facet/rating-range-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/rating-range-facet/rating-range-facet.cypress.ts
@@ -98,6 +98,39 @@ describe('Rating Range Test Suites', () => {
         before(setupSelectLinkValue);
         RatingFacetAssertions.assertLogRatingFacetSelect(ratingRangeFacetField);
       });
+
+      describe('when selecting the "Clear filter" button', () => {
+        function setupClearCheckboxValues() {
+          setupSelectLinkValue();
+          cy.wait(TestFixture.interceptAliases.UA);
+          RatingRangeFacetSelectors.clearButton().click();
+          cy.wait(TestFixture.interceptAliases.Search);
+        }
+        describe('verify rendering', () => {
+          before(setupClearCheckboxValues);
+
+          CommonFacetAssertions.assertDisplayClearButton(
+            RatingRangeFacetSelectors,
+            false
+          );
+          CommonFacetAssertions.assertNumberOfSelectedLinkValues(
+            RatingRangeFacetSelectors,
+            0
+          );
+          CommonFacetAssertions.assertNumberOfIdleLinkValues(
+            RatingRangeFacetSelectors,
+            ratingRangeFacetDefaultNumberOfIntervals
+          );
+          CommonFacetAssertions.assertFocusHeader(RatingRangeFacetSelectors);
+        });
+
+        describe('verify analytics', () => {
+          before(setupClearCheckboxValues);
+          CommonFacetAssertions.assertLogClearFacetValues(
+            ratingRangeFacetField
+          );
+        });
+      });
     });
   });
 

--- a/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -135,6 +135,7 @@ describe('Timeframe Facet V1 Test Suites', () => {
               TimeframeFacetSelectors,
               defaultNumberOfValues
             );
+            CommonFacetAssertions.assertFocusHeader(TimeframeFacetSelectors);
           });
 
           describe('verify analytics', () => {

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.pcss
@@ -4,7 +4,7 @@
 
 .parent-button,
 .parent-active {
-  @apply w-full py-2.5 pr-2 pl-7 text-left;
+  @apply w-full pl-7 mt-2.5 text-left;
 }
 
 .parent-button {
@@ -12,7 +12,7 @@
 }
 
 .parent-active {
-  @apply truncate font-bold;
+  @apply truncate;
 }
 
 .back-arrow {

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.pcss
@@ -2,17 +2,12 @@
 @import '../facet-common.pcss';
 @import '../facet-search/facet-search.pcss';
 
-.parent-button,
 .parent-active {
-  @apply w-full pl-7 mt-2.5 text-left;
+  @apply pl-7;
 }
 
 .parent-button {
-  @apply relative flex items-center;
-}
-
-.parent-active {
-  @apply truncate;
+  @apply w-full py-2.5 pr-2 pl-7 text-left relative flex items-center;
 }
 
 .back-arrow {

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -161,16 +161,16 @@ export class AtomicCategoryFacet
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
   @FocusTarget()
-  protected showMoreFocus!: FocusTargetController;
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected showLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected activeValueFocus!: FocusTargetController;
+  private activeValueFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -38,6 +38,10 @@ import {CategoryFacetSearchResult} from '../category-facet-search-result/categor
 import {registerFacetToStore} from '../../../utils/store';
 import {Button} from '../../common/button';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -155,6 +159,9 @@ export class AtomicCategoryFacet
    */
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
+
+  @MaintainFocus()
+  protected showMoreFocus!: PersistentFocus;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -391,10 +398,12 @@ export class AtomicCategoryFacet
             this.facet.showMoreValues();
           }}
           onShowLess={() => {
+            this.showMoreFocus.focusAfterSearch();
             this.facet.showLessValues();
           }}
           canShowLessValues={this.facetState.canShowLessValues}
           canShowMoreValues={this.facetState.canShowMoreValues}
+          showMoreRef={this.showMoreFocus.setElement}
         ></FacetShowMoreLess>
       </div>
     );

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -163,6 +163,9 @@ export class AtomicCategoryFacet
   @MaintainFocus()
   protected showMoreFocus!: PersistentFocus;
 
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
+
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     const options: CategoryFacetOptions = {
@@ -217,7 +220,11 @@ export class AtomicCategoryFacet
         }
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        onClearFilters={() => this.facet.deselectAll()}
+        onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
+          this.facet.deselectAll();
+        }}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -166,6 +166,9 @@ export class AtomicCategoryFacet
   @MaintainFocus()
   protected headerFocus!: PersistentFocus;
 
+  @MaintainFocus()
+  protected activeValueFocus!: PersistentFocus;
+
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     const options: CategoryFacetOptions = {
@@ -224,7 +227,12 @@ export class AtomicCategoryFacet
           this.headerFocus.focusAfterSearch();
           this.facet.deselectAll();
         }}
-        headerRef={this.headerFocus.setElement}
+        headerRef={(header) => {
+          this.headerFocus.setElement(header);
+          if (!this.hasParents) {
+            this.activeValueFocus.setElement(header);
+          }
+        }}
       ></FacetHeader>
     );
   }
@@ -263,7 +271,10 @@ export class AtomicCategoryFacet
           style="text-neutral"
           part="all-categories-button"
           class="parent-button"
-          onClick={() => this.facet.deselectAll()}
+          onClick={() => {
+            this.activeValueFocus.focusAfterSearch();
+            this.facet.deselectAll();
+          }}
         >
           <atomic-icon
             aria-hidden="true"
@@ -294,7 +305,11 @@ export class AtomicCategoryFacet
           style="text-neutral"
           part="parent-button"
           class="parent-button"
-          onClick={() => this.facet.toggleSelect(facetValue)}
+          ariaPressed="false"
+          onClick={() => {
+            this.activeValueFocus.focusAfterSearch();
+            this.facet.toggleSelect(facetValue);
+          }}
           ariaLabel={ariaLabel}
         >
           <atomic-icon
@@ -316,18 +331,35 @@ export class AtomicCategoryFacet
 
     const nonActiveParents = this.facetState.parents.slice(0, -1);
     const activeParent = this.facetState.parents.slice(-1)[0];
+    const activeParentDisplayValue = getFieldValueCaption(
+      this.field,
+      activeParent.value,
+      this.bindings.i18n
+    );
 
     return (
       <ul part="parents" class="mt-3">
         {this.renderAllCategories()}
         {nonActiveParents.map((parent) => this.renderParent(parent))}
-        <li part="active-parent" class="parent-active">
-          {getFieldValueCaption(
-            this.field,
-            activeParent.value,
-            this.bindings.i18n
-          )}
-        </li>
+        <FacetValueLink
+          displayValue={activeParentDisplayValue}
+          numberOfResults={activeParent.numberOfResults}
+          isSelected={true}
+          i18n={this.bindings.i18n}
+          onClick={() => {
+            this.activeValueFocus.focusAfterSearch();
+            this.facet.deselectAll();
+          }}
+          searchQuery={this.facetState.facetSearch.query}
+          part="active-parent"
+          class="parent-active"
+          buttonRef={this.activeValueFocus.setElement}
+        >
+          <FacetValueLabelHighlight
+            displayValue={activeParentDisplayValue}
+            isSelected={true}
+          ></FacetValueLabelHighlight>
+        </FacetValueLink>
       </ul>
     );
   }
@@ -345,7 +377,10 @@ export class AtomicCategoryFacet
         numberOfResults={facetValue.numberOfResults}
         isSelected={isSelected}
         i18n={this.bindings.i18n}
-        onClick={() => this.facet.toggleSelect(facetValue)}
+        onClick={() => {
+          this.activeValueFocus.focusAfterSearch();
+          this.facet.toggleSelect(facetValue);
+        }}
         searchQuery={this.facetState.facetSearch.query}
       >
         <FacetValueLabelHighlight
@@ -377,7 +412,10 @@ export class AtomicCategoryFacet
             field={this.field}
             i18n={this.bindings.i18n}
             searchQuery={this.facetState.facetSearch.query}
-            onClick={() => this.facet.facetSearch.select(value)}
+            onClick={() => {
+              this.activeValueFocus.focusAfterSearch();
+              this.facet.facetSearch.select(value);
+            }}
           ></CategoryFacetSearchResult>
         ))}
       </ul>

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -39,8 +39,8 @@ import {registerFacetToStore} from '../../../utils/store';
 import {Button} from '../../common/button';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -160,14 +160,14 @@ export class AtomicCategoryFacet
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
-  @MaintainFocus()
-  protected showMoreFocus!: PersistentFocus;
+  @FocusTarget()
+  protected showMoreFocus!: FocusTargetController;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
-  @MaintainFocus()
-  protected activeValueFocus!: PersistentFocus;
+  @FocusTarget()
+  protected activeValueFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -228,9 +228,9 @@ export class AtomicCategoryFacet
           this.facet.deselectAll();
         }}
         headerRef={(header) => {
-          this.headerFocus.setElement(header);
+          this.headerFocus.setTarget(header);
           if (!this.hasParents) {
-            this.activeValueFocus.setElement(header);
+            this.activeValueFocus.setTarget(header);
           }
         }}
       ></FacetHeader>
@@ -353,7 +353,7 @@ export class AtomicCategoryFacet
           searchQuery={this.facetState.facetSearch.query}
           part="active-parent"
           class="parent-active"
-          buttonRef={this.activeValueFocus.setElement}
+          buttonRef={this.activeValueFocus.setTarget}
         >
           <FacetValueLabelHighlight
             displayValue={activeParentDisplayValue}
@@ -448,7 +448,7 @@ export class AtomicCategoryFacet
           }}
           canShowLessValues={this.facetState.canShowLessValues}
           canShowMoreValues={this.facetState.canShowMoreValues}
-          showMoreRef={this.showMoreFocus.setElement}
+          showMoreRef={this.showMoreFocus.setTarget}
         ></FacetShowMoreLess>
       </div>
     );

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -164,6 +164,9 @@ export class AtomicCategoryFacet
   protected showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
+  protected showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
   protected headerFocus!: FocusTargetController;
 
   @FocusTarget()
@@ -434,12 +437,16 @@ export class AtomicCategoryFacet
   }
 
   private renderShowMoreLess() {
+    if (this.facetState.canShowMoreValues) {
+      this.showLessFocus.disableForCurrentSearch();
+    }
     return (
       <div class={this.hasParents ? 'pl-9' : ''}>
         <FacetShowMoreLess
           label={this.label}
           i18n={this.bindings.i18n}
           onShowMore={() => {
+            this.showLessFocus.focusAfterSearch();
             this.facet.showMoreValues();
           }}
           onShowLess={() => {
@@ -449,6 +456,7 @@ export class AtomicCategoryFacet
           canShowLessValues={this.facetState.canShowLessValues}
           canShowMoreValues={this.facetState.canShowMoreValues}
           showMoreRef={this.showMoreFocus.setTarget}
+          showLessRef={this.showLessFocus.setTarget}
         ></FacetShowMoreLess>
       </div>
     );

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -37,8 +37,8 @@ import {
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -144,11 +144,11 @@ export class AtomicColorFacet
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
-  @MaintainFocus()
-  protected showMoreFocus!: PersistentFocus;
+  @FocusTarget()
+  protected showMoreFocus!: FocusTargetController;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -202,7 +202,7 @@ export class AtomicColorFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }
@@ -346,7 +346,7 @@ export class AtomicColorFacet
         }}
         canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
-        showMoreRef={this.showMoreFocus.setElement}
+        showMoreRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -147,6 +147,9 @@ export class AtomicColorFacet
   @MaintainFocus()
   protected showMoreFocus!: PersistentFocus;
 
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
+
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     const options: FacetOptions = {
@@ -192,10 +195,14 @@ export class AtomicColorFacet
       <FacetHeader
         i18n={this.bindings.i18n}
         label={this.label}
-        onClearFilters={() => this.facet.deselectAll()}
+        onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
+          this.facet.deselectAll();
+        }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -36,6 +36,10 @@ import {
 } from '../../../utils/field-utils';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -139,6 +143,9 @@ export class AtomicColorFacet
    */
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
+
+  @MaintainFocus()
+  protected showMoreFocus!: PersistentFocus;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -327,10 +334,12 @@ export class AtomicColorFacet
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
+        showMoreRef={this.showMoreFocus.setElement}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -145,13 +145,13 @@ export class AtomicColorFacet
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
   @FocusTarget()
-  protected showMoreFocus!: FocusTargetController;
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected showLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -148,6 +148,9 @@ export class AtomicColorFacet
   protected showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
+  protected showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
   protected headerFocus!: FocusTargetController;
 
   public initialize() {
@@ -333,11 +336,15 @@ export class AtomicColorFacet
   }
 
   private renderShowMoreLess() {
+    if (this.facetState.canShowMoreValues) {
+      this.showLessFocus.disableForCurrentSearch();
+    }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
+          this.showLessFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
@@ -347,6 +354,7 @@ export class AtomicColorFacet
         canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
         showMoreRef={this.showMoreFocus.setTarget}
+        showLessRef={this.showLessFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -39,8 +39,8 @@ import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -147,11 +147,11 @@ export class AtomicFacet
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
-  @MaintainFocus()
-  protected showMoreFocus!: PersistentFocus;
+  @FocusTarget()
+  protected showMoreFocus!: FocusTargetController;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({
@@ -216,7 +216,7 @@ export class AtomicFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }
@@ -377,7 +377,7 @@ export class AtomicFacet
         }}
         canShowMoreValues={this.facetState.canShowMoreValues}
         canShowLessValues={this.facetState.canShowLessValues}
-        showMoreRef={this.showMoreFocus.setElement}
+        showMoreRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -151,6 +151,9 @@ export class AtomicFacet
   protected showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
+  protected showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
   protected headerFocus!: FocusTargetController;
 
   private validateProps() {
@@ -364,11 +367,15 @@ export class AtomicFacet
   }
 
   private renderShowMoreLess() {
+    if (this.facetState.canShowMoreValues) {
+      this.showLessFocus.disableForCurrentSearch();
+    }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
+          this.showLessFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
@@ -378,6 +385,7 @@ export class AtomicFacet
         canShowMoreValues={this.facetState.canShowMoreValues}
         canShowLessValues={this.facetState.canShowLessValues}
         showMoreRef={this.showMoreFocus.setTarget}
+        showLessRef={this.showLessFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -148,13 +148,13 @@ export class AtomicFacet
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
   @FocusTarget()
-  protected showMoreFocus!: FocusTargetController;
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected showLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -150,6 +150,9 @@ export class AtomicFacet
   @MaintainFocus()
   protected showMoreFocus!: PersistentFocus;
 
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
+
   private validateProps() {
     new Schema({
       displayValuesAs: new StringValue({
@@ -206,10 +209,14 @@ export class AtomicFacet
       <FacetHeader
         i18n={this.bindings.i18n}
         label={this.label}
-        onClearFilters={() => this.facet.deselectAll()}
+        onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
+          this.facet.deselectAll();
+        }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -38,6 +38,10 @@ import {
 import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -142,6 +146,9 @@ export class AtomicFacet
    */
   @Prop() public injectionDepth = 1000;
   // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
+
+  @MaintainFocus()
+  protected showMoreFocus!: PersistentFocus;
 
   private validateProps() {
     new Schema({
@@ -358,10 +365,12 @@ export class AtomicFacet
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
-        canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
+        canShowLessValues={this.facetState.canShowLessValues}
+        showMoreRef={this.showMoreFocus.setElement}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -40,8 +40,8 @@ import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 interface NumericRangeWithLabel extends NumericRangeRequest {
@@ -152,8 +152,8 @@ export class AtomicNumericFacet
    */
   @Prop() public injectionDepth = 1000;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({
@@ -282,7 +282,7 @@ export class AtomicNumericFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -39,6 +39,10 @@ import {getFieldValueCaption} from '../../../utils/field-utils';
 import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 interface NumericRangeWithLabel extends NumericRangeRequest {
   label?: string;
@@ -147,6 +151,9 @@ export class AtomicNumericFacet
    * Minimum: `0`
    */
   @Prop() public injectionDepth = 1000;
+
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
 
   private validateProps() {
     new Schema({
@@ -265,6 +272,7 @@ export class AtomicNumericFacet
         i18n={this.bindings.i18n}
         label={this.label}
         onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
           if (this.filterState?.range) {
             this.filter?.clear();
             return;
@@ -274,6 +282,7 @@ export class AtomicNumericFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -153,7 +153,7 @@ export class AtomicNumericFacet
   @Prop() public injectionDepth = 1000;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -29,8 +29,8 @@ import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -137,8 +137,8 @@ export class AtomicRatingFacet
    */
   @Prop() public injectionDepth = 1000;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({
@@ -228,7 +228,7 @@ export class AtomicRatingFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -28,6 +28,10 @@ import Star from '../../../images/star.svg';
 import {Schema, StringValue} from '@coveo/bueno';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -133,6 +137,9 @@ export class AtomicRatingFacet
    */
   @Prop() public injectionDepth = 1000;
 
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
+
   private validateProps() {
     new Schema({
       displayValuesAs: new StringValue({constrainTo: ['checkbox', 'link']}),
@@ -214,10 +221,14 @@ export class AtomicRatingFacet
       <FacetHeader
         i18n={this.bindings.i18n}
         label={this.label}
-        onClearFilters={() => this.facet.deselectAll()}
+        onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
+          this.facet.deselectAll();
+        }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -138,7 +138,7 @@ export class AtomicRatingFacet
   @Prop() public injectionDepth = 1000;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   private validateProps() {
     new Schema({

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -26,6 +26,10 @@ import {BaseFacet} from '../facet-common';
 import Star from '../../../images/star.svg';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -124,6 +128,9 @@ export class AtomicRatingRangeFacet
    */
   @Prop() public injectionDepth = 1000;
 
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
+
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
     this.initializeFacet();
@@ -199,10 +206,14 @@ export class AtomicRatingRangeFacet
       <FacetHeader
         i18n={this.bindings.i18n}
         label={this.label}
-        onClearFilters={() => this.facet.deselectAll()}
+        onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
+          this.facet.deselectAll();
+        }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -27,8 +27,8 @@ import Star from '../../../images/star.svg';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -128,8 +128,8 @@ export class AtomicRatingRangeFacet
    */
   @Prop() public injectionDepth = 1000;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -213,7 +213,7 @@ export class AtomicRatingRangeFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -129,7 +129,7 @@ export class AtomicRatingRangeFacet
   @Prop() public injectionDepth = 1000;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -34,8 +34,8 @@ import {getFieldValueCaption} from '../../../utils/field-utils';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
 import {
-  MaintainFocus,
-  PersistentFocus,
+  FocusTarget,
+  FocusTargetController,
 } from '../../../utils/accessibility-utils';
 
 /**
@@ -119,8 +119,8 @@ export class AtomicTimeframeFacet
    */
   @Prop() public injectionDepth = 1000;
 
-  @MaintainFocus()
-  protected headerFocus!: PersistentFocus;
+  @FocusTarget()
+  protected headerFocus!: FocusTargetController;
 
   public initialize() {
     this.manualTimeframes = this.getManualTimeframes();
@@ -233,7 +233,7 @@ export class AtomicTimeframeFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
-        headerRef={this.headerFocus.setElement}
+        headerRef={this.headerFocus.setTarget}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -33,6 +33,10 @@ import dayjs from 'dayjs';
 import {getFieldValueCaption} from '../../../utils/field-utils';
 import {registerFacetToStore} from '../../../utils/store';
 import {Hidden} from '../../common/hidden';
+import {
+  MaintainFocus,
+  PersistentFocus,
+} from '../../../utils/accessibility-utils';
 
 /**
  * A facet is a list of values for a certain field occurring in the results.
@@ -114,6 +118,9 @@ export class AtomicTimeframeFacet
    * Minimum: `0`
    */
   @Prop() public injectionDepth = 1000;
+
+  @MaintainFocus()
+  protected headerFocus!: PersistentFocus;
 
   public initialize() {
     this.manualTimeframes = this.getManualTimeframes();
@@ -216,6 +223,7 @@ export class AtomicTimeframeFacet
         i18n={this.bindings.i18n}
         label={this.label}
         onClearFilters={() => {
+          this.headerFocus.focusAfterSearch();
           if (this.filterState?.range) {
             this.filter?.clear();
             return;
@@ -225,6 +233,7 @@ export class AtomicTimeframeFacet
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
+        headerRef={this.headerFocus.setElement}
       ></FacetHeader>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -120,7 +120,7 @@ export class AtomicTimeframeFacet
   @Prop() public injectionDepth = 1000;
 
   @FocusTarget()
-  protected headerFocus!: FocusTargetController;
+  private headerFocus!: FocusTargetController;
 
   public initialize() {
     this.manualTimeframes = this.getManualTimeframes();

--- a/packages/atomic/src/components/facets/facet-common.ts
+++ b/packages/atomic/src/components/facets/facet-common.ts
@@ -19,4 +19,7 @@ export interface FacetValueProps {
   isSelected: boolean;
   onClick(): void;
   searchQuery?: string;
+  class?: string;
+  part?: string;
+  buttonRef?: (element?: HTMLButtonElement) => void;
 }

--- a/packages/atomic/src/components/facets/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets/facet-header/facet-header.tsx
@@ -5,14 +5,17 @@ import CloseIcon from 'coveo-styleguide/resources/icons/svg/close.svg';
 import {i18n} from 'i18next';
 import {Button} from '../../common/button';
 
-export const FacetHeader: FunctionalComponent<{
+export interface FacetHeaderProps {
   i18n: i18n;
   label: string;
   numberOfSelectedValues: number;
   isCollapsed: boolean;
   onToggleCollapse(): void;
   onClearFilters?(): void;
-}> = (props) => {
+  headerRef?: (element?: HTMLButtonElement) => void;
+}
+
+export const FacetHeader: FunctionalComponent<FacetHeaderProps> = (props) => {
   const label = props.i18n.t(props.label);
   const expandFacet = props.i18n.t('expand-facet', {label});
   const collapseFacet = props.i18n.t('collapse-facet', {label});
@@ -33,6 +36,7 @@ export const FacetHeader: FunctionalComponent<{
       onClick={() => props.onToggleCollapse()}
       ariaExpanded={(!props.isCollapsed).toString()}
       text={label}
+      ref={props.headerRef}
     >
       <atomic-icon
         part="label-button-icon"

--- a/packages/atomic/src/components/facets/facet-show-more-less/facet-show-more-less.tsx
+++ b/packages/atomic/src/components/facets/facet-show-more-less/facet-show-more-less.tsx
@@ -11,6 +11,8 @@ interface FacetShowMoreProps {
   canShowMoreValues: boolean;
   onShowMore(): void;
   onShowLess(): void;
+  showMoreRef?: (element?: HTMLButtonElement) => void;
+  showLessRef?: (element?: HTMLButtonElement) => void;
 }
 
 export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
@@ -40,6 +42,7 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
         class={`${btnClasses} ${props.canShowLessValues ? '' : 'hidden'}`}
         aria-label={showLessFacetValues}
         onClick={() => props.onShowLess()}
+        ref={props.showLessRef}
       >
         <atomic-icon
           part="show-more-less-icon"
@@ -54,6 +57,7 @@ export const FacetShowMoreLess: FunctionalComponent<FacetShowMoreProps> = (
         class={`${btnClasses} ${props.canShowMoreValues ? '' : 'hidden'}`}
         aria-label={showMoreFacetValues}
         onClick={() => props.onShowMore()}
+        ref={props.showMoreRef}
       >
         <atomic-icon
           part="show-more-less-icon"

--- a/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
@@ -13,10 +13,10 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
   });
 
   return (
-    <li key={props.displayValue} class={props.class} part={props.part}>
+    <li key={props.displayValue} class={props.class}>
       <Button
         style="text-neutral"
-        part="value-link"
+        part={props.part ?? 'value-link'}
         onClick={() => props.onClick()}
         class="group w-full flex items-center px-2 py-2.5 text-left truncate no-outline"
         ariaPressed={props.isSelected.toString()}

--- a/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
@@ -13,7 +13,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
   });
 
   return (
-    <li key={props.displayValue}>
+    <li key={props.displayValue} class={props.class} part={props.part}>
       <Button
         style="text-neutral"
         part="value-link"
@@ -21,6 +21,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
         class="group w-full flex items-center px-2 py-2.5 text-left truncate no-outline"
         ariaPressed={props.isSelected.toString()}
         ariaLabel={ariaLabel}
+        ref={props.buttonRef}
       >
         {children}
         <span part="value-count" class="value-count">

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -23,19 +23,19 @@ export function AriaLiveRegion(regionName: string) {
   };
 }
 
-export interface PersistentFocus {
-  setElement(element: HTMLElement | undefined): void;
+export interface FocusTargetController {
+  setTarget(element: HTMLElement | undefined): void;
   focusAfterSearch(): void;
 }
 
-export function MaintainFocus() {
+export function FocusTarget() {
   return (component: InitializableComponent, setterName: string) => {
     const {componentWillLoad} = component;
 
     component.componentWillLoad = function () {
       componentWillLoad && componentWillLoad.call(this);
       const {componentDidRender} = this;
-      let maintainFocus = false;
+      let focusAfterSearch = false;
       let lastSearchId: string | undefined = undefined;
       let element: HTMLElement | undefined = undefined;
 
@@ -44,9 +44,9 @@ export function MaintainFocus() {
           return;
         }
         const searchId = bindings.engine.state.search.searchResponseId;
-        if (maintainFocus && searchId !== lastSearchId) {
+        if (focusAfterSearch && searchId !== lastSearchId) {
           setTimeout(() => element?.focus());
-          maintainFocus = false;
+          focusAfterSearch = false;
         }
         lastSearchId = searchId;
       }
@@ -59,17 +59,17 @@ export function MaintainFocus() {
         tryFocusElement(this.bindings);
       };
 
-      const focusMaintainer: PersistentFocus = {
-        setElement: (el) => {
+      const focusTargetController: FocusTargetController = {
+        setTarget: (el) => {
           el && (element = el);
           tryFocusElement(this.bindings);
         },
         focusAfterSearch: () => {
           lastSearchId = this.bindings.engine.state.search.searchResponseId;
-          maintainFocus = true;
+          focusAfterSearch = true;
         },
       };
-      this[setterName] = focusMaintainer;
+      this[setterName] = focusTargetController;
     };
   };
 }

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -1,4 +1,3 @@
-import {Bindings} from '..';
 import {UpdateLiveRegionEventArgs} from '../components/atomic-search-interface/atomic-aria-live';
 import {buildCustomEvent} from './event-utils';
 import {InitializableComponent} from './initialization-utils';
@@ -26,6 +25,7 @@ export function AriaLiveRegion(regionName: string) {
 export interface FocusTargetController {
   setTarget(element: HTMLElement | undefined): void;
   focusAfterSearch(): void;
+  disableForCurrentSearch(): void;
 }
 
 export function FocusTarget() {
@@ -39,35 +39,32 @@ export function FocusTarget() {
       let lastSearchId: string | undefined = undefined;
       let element: HTMLElement | undefined = undefined;
 
-      function tryFocusElement(bindings: Bindings) {
-        if (!element) {
-          return;
-        }
-        const searchId = bindings.engine.state.search.searchResponseId;
-        if (focusAfterSearch && searchId !== lastSearchId) {
-          setTimeout(() => element?.focus());
-          focusAfterSearch = false;
-        }
-        lastSearchId = searchId;
-      }
-
       this.componentDidRender = function () {
         componentDidRender && componentDidRender.call(this);
         if (!this.bindings) {
           return;
         }
-        tryFocusElement(this.bindings);
+        if (
+          focusAfterSearch &&
+          this.bindings.engine.state.search.searchResponseId !== lastSearchId
+        ) {
+          focusAfterSearch = false;
+          if (element) {
+            const el = element;
+            setTimeout(() => el.focus());
+          }
+        }
       };
 
       const focusTargetController: FocusTargetController = {
-        setTarget: (el) => {
-          el && (element = el);
-          tryFocusElement(this.bindings);
-        },
+        setTarget: (el) => el && (element = el),
         focusAfterSearch: () => {
           lastSearchId = this.bindings.engine.state.search.searchResponseId;
           focusAfterSearch = true;
         },
+        disableForCurrentSearch: () =>
+          this.bindings.engine.state.search.searchResponseId !== lastSearchId &&
+          (focusAfterSearch = false),
       };
       this[setterName] = focusTargetController;
     };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1075

In addition to E2E test that test focus, I added some other missing E2E tests.

I added a `FocusTarget` decorator, which allows us to define upcoming focus targets that may or may not exist yet. This utility should easily be reusable to improve accessibility in other components such as the pager. I recommend looking at [its usage](https://github.com/coveo/ui-kit/pull/1618/files#r774742155) before looking at its definition.

New behaviours:
* When pressing the "show less" button in any facet, the "show more" button is focused.
* When pressing the "show more" button in any facet, if there's no more "show more" button, the "show less" button is focused.
* When pressing the "clear filters" button in any facets, the header is focused.
* In a category facet, when pressing the "all categories" button, the header is focused.
* In a category facet, when selecting a facet search result, the active facet value is focused.
* ❗️The active category facet value is now displayed as a bold facet value (with the same indentation and font weight)
  * When pressed/clicked, it behaves exactly the same as the "All categories" button.
    * I did this because category facet values (and now also the active category facet value) are represented to screen readers as toggle switches. Logically, unselecting the currently active value should not activate another value.
  * When pressed, the header is focused.

Category facet comparison:
| before | after | after (while hovering active value) |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/54454747/147253307-5df81ac0-15d1-4ea6-8b5f-989472ed982b.png) | ![image](https://user-images.githubusercontent.com/54454747/147254103-1b2ca02f-06d3-470b-ad8e-685b96a7e173.png) | ![image](https://user-images.githubusercontent.com/54454747/147254256-3eeed396-3aa6-4033-bb78-bdd68bc47489.png) |

@johnnyCoveo in your opinion, is the new look & behaviour of the active facet value okay?