### PR TITLE
ci: added registry to npm publish GHA step

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,22 @@
 name: "Setup & build"
 description: "Setup node, install dependencies & build"
+inputs:
+  with-registry:
+    description: Whether we should use the npmjs.org registry
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v2
+    - if: ${{ inputs.with-registry != 'true' }}
+      uses: actions/setup-node@v2
       with:
         node-version-file: '.nvmrc'
+    - if: ${{ inputs.with-registry == 'true' }}
+      uses: actions/setup-node@v2
+      with:
+        node-version-file: '.nvmrc'
+        registry-url: 'https://registry.npmjs.org'
     - uses: actions/cache@v2
       id: build-cache
       with:

--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
+        with:
+          with-registry: 'true'
       - run: npm config set loglevel verbose --global
       - run: npm run npm:publish:alpha
         env:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1303

I think the publish step may be silently failing because the registry is missing. In the [official documentation](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages), the registry is added. In the old Jenkinsfile, the registry was also added.