### PR TITLE
fix(headless): adjust __require statements in node esm bundles

### DIFF
--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -175,6 +175,7 @@ function buildNodeConfig(options) {
   });
 }
 
+// https://github.com/coveo/ui-kit/issues/1616
 function adjustRequireImportsInNodeEsmBundles() {
   const paths = getNodeEsmBundlePaths();
   

--- a/packages/headless/esbuild.js
+++ b/packages/headless/esbuild.js
@@ -169,6 +169,11 @@ function buildNodeConfig(options) {
           __dirname,
           './node_modules/web-encoding/src/lib.cjs'
         ),
+        // https://github.com/coveo/ui-kit/issues/1616
+        'node-fetch': path.resolve(
+          __dirname,
+          './node_modules/node-fetch/lib/index.mjs'
+        )
       }),
     ],
     ...options,


### PR DESCRIPTION
~~Shot in the dark to try to fix [this issue](https://github.com/coveo/ui-kit/issues/1616). This is a work-around though because it seems like the issue is caused by webpack. TBD~~

**Problem**

In node esm bundles, esbuild replaces `require` statements import node built-ins with a custom `__require` function. When webpack encounters these statements, it does not know how to resolve the node built-ins and throws an error.

Here's the code for the custom `__require` function:
```js
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
}) : x)(function(x) {
  if (typeof require !== "undefined")
    return require.apply(this, arguments);
  throw new Error('Dynamic require of "' + x + '" is not supported');
});
```

**Work-around**

Using a regex to change instances of `__require` back to `require`. I will explore with the esbuild team if it would be possible to address at the bundler level.

https://coveord.atlassian.net/browse/KIT-1308