### PR TITLE
fix(quantic): added missing optional chaining

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
@@ -39,7 +39,7 @@ export default class QuanticCaseAssistInterface extends LightningElement {
 
   connectedCallback() {
     loadDependencies(this, HeadlessBundleNames.caseAssist).then(() => {
-      if (!getHeadlessBindings(this.engineId).engine) {
+      if (!getHeadlessBindings(this.engineId)?.engine) {
         getHeadlessConfiguration().then((data) => {
           if (data) {
             this.engineOptions = {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -82,7 +82,7 @@ export default class QuanticSearchInterface extends LightningElement {
 
   connectedCallback() {
     loadDependencies(this).then(() => {
-      if (!getHeadlessBindings(this.engineId).engine) {
+      if (!getHeadlessBindings(this.engineId)?.engine) {
         getHeadlessConfiguration().then((data) => {
           if (data) {
             this.engineOptions = {


### PR DESCRIPTION
A brave SE tried to instantiate a quantic-search-interface without any quantic components in it. It crashed due to an unsafe evaluation.
Optional chaining to the rescue.