### PR TITLE
doc(headless): update headless doc links

### DIFF
--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
@@ -22,12 +22,12 @@ export type DateRangeInput = AbsoluteDate | RelativeDate;
 
 export interface DateRangeOptions {
   /**
-   * The starting value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/).
+   * The starting value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/search/search-date-facet-controller/relative-date-format/).
    */
   start: DateRangeInput;
 
   /**
-   * The ending value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/).
+   * The ending value for the date range. A date range can be either absolute or [relative](https://docs.coveo.com/en/headless/latest/reference/search/search-date-facet-controller/relative-date-format/).
    */
   end: DateRangeInput;
 

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
@@ -263,8 +263,8 @@ export function buildRelevanceInspector(
       engine.logger.warn(
         `For production environment, please specify the necessary fields either when instantiating a ResultList controller, or by dispatching a registerFieldsToInclude action.
         
-        https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#resultlistoptions
-        https://docs.coveo.com/en/headless/latest/reference/actions/field/#registerfieldstoinclude`
+        https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#resultlistoptions
+        https://docs.coveo.com/en/headless/latest/reference/search/actions/field/#registerfieldstoinclude`
       );
     },
   };

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
@@ -8,12 +8,12 @@ import {AnyFacetRequest} from '../../../generic/interfaces/generic-facet-request
  */
 export interface DateRangeRequest {
   /**
-   * The starting value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit".
+   * The starting value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/search/search-date-facet-controller/relative-date-format/) format "period-amount-unit".
    */
   start: string;
 
   /**
-   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/controllers/date-facet/relative-date-format/) format "period-amount-unit".
+   * The ending value for the date range, formatted as `YYYY/MM/DD@HH:mm:ss` or the [Relative Date](https://docs.coveo.com/en/headless/latest/reference/search/search-date-facet-controller/relative-date-format/) format "period-amount-unit".
    */
   end: string;
 

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
@@ -13,7 +13,7 @@ import inLabel from "@salesforce/label/c.quantic_InLabel";
  */
 export default class QuanticCategoryFacetValue extends LightningElement {
   /**
-   * The [facet value](https://docs.coveo.com/en/headless/latest/reference/controllers/category-facet/#categoryfacetvalue) to display.
+   * The [facet value](https://docs.coveo.com/en/headless/latest/reference/search/controllers/category-facet/#categoryfacetvalue) to display.
    * @api
    * @type {CategoryFacetValue} */
   @api item;

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -16,7 +16,7 @@ import LOCALE from '@salesforce/i18n/locale';
  */
 export default class QuanticFacetValue extends LightningElement {
   /**
-   * The [facet value](https://docs.coveo.com/en/headless/latest/reference/controllers/facet/#facetvalue) to display.
+   * The [facet value](https://docs.coveo.com/en/headless/latest/reference/search/controllers/facet/#facetvalue) to display.
    * @api
    * @type {FacetValueBase}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
@@ -21,7 +21,7 @@ export default class QuanticResult extends LightningElement {
    */
   @api engineId;
   /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result).
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result).
    * @api
    * @type {Result}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.js
@@ -19,7 +19,7 @@ export default class QuanticResultBadge extends LightningElement {
    */
   @api variant;
   /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result).
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result).
    * @api
    * @type {Result}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
@@ -21,7 +21,7 @@ const CHATTER='Chatter';
  */
 export default class QuanticResultLabel extends LightningElement {
   /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result) to use to infer label and icon.
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result) to use to infer label and icon.
    * @api
    * @type {Result}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -19,7 +19,7 @@ export default class QuanticResultLink extends LightningElement {
    */
   @api engineId;
   /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result).
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result).
    * @api
    * @type {Result}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
@@ -11,7 +11,7 @@ import {parseXML} from 'c/quanticUtils';
  */
 export default class QuanticResultPrintableUri extends LightningElement {
   /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/controllers/result-list/#result).
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result).
    * @api
    * @type {Result}
    */


### PR DESCRIPTION
Since the Headless documentation section was recently restructured, I had to update a few links here.