### PR TITLE
fix(atomic): allow date input for Safari versions under 14

### DIFF
--- a/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
@@ -70,6 +70,9 @@ export class FacetDateInput {
     const inputClasses = 'input-primary p-2.5';
     const labelClasses = 'text-neutral-dark self-center';
 
+    const placeholder = 'yyyy-mm-dd';
+    const pattern = '^[12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$';
+
     return (
       <form
         class="grid gap-2 grid-cols-min-1fr mt-4 px-2"
@@ -93,7 +96,8 @@ export class FacetDateInput {
           ref={(ref) => (this.startRef = ref!)}
           class={inputClasses}
           aria-label={startAria}
-          placeholder="yyyy-mm-dd"
+          placeholder={placeholder}
+          pattern={pattern}
           required
           // API/Index minimum supported date
           min={this.formattedDateValue('1401-01-01')}
@@ -117,7 +121,8 @@ export class FacetDateInput {
           ref={(ref) => (this.endRef = ref!)}
           class={inputClasses}
           aria-label={endAria}
-          placeholder="yyyy-mm-dd"
+          placeholder={placeholder}
+          pattern={pattern}
           required
           min={this.formattedDateValue(this.start)}
           value={this.formattedDateValue(this.filterState.range?.end)}

--- a/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
@@ -93,13 +93,14 @@ export class FacetDateInput {
           ref={(ref) => (this.startRef = ref!)}
           class={inputClasses}
           aria-label={startAria}
+          placeholder="yyyy-mm-dd"
           required
           // API/Index minimum supported date
           min={this.formattedDateValue('1401-01-01')}
           max={this.formattedDateValue(this.end)}
           value={this.formattedDateValue(this.filterState.range?.start)}
           onInput={(e) =>
-            (this.start = (e.target as HTMLInputElement).valueAsDate!)
+            (this.start = new Date((e.target as HTMLInputElement).value))
           }
         />
         <label
@@ -116,11 +117,12 @@ export class FacetDateInput {
           ref={(ref) => (this.endRef = ref!)}
           class={inputClasses}
           aria-label={endAria}
+          placeholder="yyyy-mm-dd"
           required
           min={this.formattedDateValue(this.start)}
           value={this.formattedDateValue(this.filterState.range?.end)}
           onInput={(e) =>
-            (this.end = (e.target as HTMLInputElement).valueAsDate!)
+            (this.end = new Date((e.target as HTMLInputElement).value))
           }
         />
         <Button

--- a/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/facets/facet-date-input/facet-date-input.tsx
@@ -71,7 +71,8 @@ export class FacetDateInput {
     const labelClasses = 'text-neutral-dark self-center';
 
     const placeholder = 'yyyy-mm-dd';
-    const pattern = '^[12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$';
+    // Fallback for Safari < 14.1, date with format yyyy-mm-dd over 1400 (API limit)
+    const pattern = '^(1[4-9])\\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$';
 
     return (
       <form


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1112

Tested with BrowserStacks 
![Screen Shot 2022-01-04 at 4 10 34 PM](https://user-images.githubusercontent.com/4923043/148125002-dcbd1125-3782-49b2-96f1-6f08148112ac.png)

valueAsDate isn't supported, and I added a placeholder to inform the user of the correct date input format
