### PR TITLE
fix(atomic): fixed focus when pressing a pager page button

### DIFF
--- a/packages/atomic/cypress/integration/pager-assertions.ts
+++ b/packages/atomic/cypress/integration/pager-assertions.ts
@@ -1,0 +1,7 @@
+import {PagerSelectors} from './pager-selectors';
+
+export function assertFocusActivePage() {
+  it('should focus on the active page', () => {
+    PagerSelectors.buttonActivePage().should('be.focused');
+  });
+}

--- a/packages/atomic/cypress/integration/pager-selectors.ts
+++ b/packages/atomic/cypress/integration/pager-selectors.ts
@@ -1,15 +1,11 @@
+export const pagerComponent = 'atomic-pager';
+
 export const PagerSelectors = {
-  pager: 'atomic-pager',
-  buttonNext: '[part="next-button"]',
-  buttonPrevious: '[part="previous-button"]',
+  pager: () => cy.get(pagerComponent),
+  shadow: () => PagerSelectors.pager().shadow(),
+  li: () => PagerSelectors.shadow().find('li'),
+  buttonNext: () => PagerSelectors.shadow().find('[part="next-button"]'),
+  buttonPrevious: () =>
+    PagerSelectors.shadow().find('[part="previous-button"]'),
+  buttonActivePage: () => PagerSelectors.shadow().find('[aria-current="page"]'),
 };
-
-export function createAliasLi() {
-  cy.get(PagerSelectors.pager).shadow().find('li').as('pagerLi');
-}
-
-export function createAliasNavigation() {
-  createAliasLi();
-  cy.get('@pagerLi').find(PagerSelectors.buttonPrevious).as('previousButton');
-  cy.get('@pagerLi').find(PagerSelectors.buttonNext).as('nextButton');
-}

--- a/packages/atomic/cypress/integration/pager.cypress.ts
+++ b/packages/atomic/cypress/integration/pager.cypress.ts
@@ -101,12 +101,12 @@ describe('Pager Test Suites', () => {
     });
   });
 
-  describe('when selecting page 3', () => {
+  describe('when selecting page 5', () => {
     beforeEach(() => {
       new TestFixture()
         .withElement(generateComponentHTML(pagerComponent))
         .init();
-      PagerSelectors.li().find('button[aria-label="Page 3"]').click();
+      PagerSelectors.li().find('button[aria-label="Page 5"]').click();
       cy.wait(TestFixture.interceptAliases.Search);
     });
 

--- a/packages/atomic/cypress/integration/pager.cypress.ts
+++ b/packages/atomic/cypress/integration/pager.cypress.ts
@@ -5,7 +5,9 @@ import {
   shouldRenderErrorComponent,
   buildTestUrl,
 } from '../utils/setupComponent';
-import {createAliasNavigation, PagerSelectors} from './pager-selectors';
+import {pagerComponent, PagerSelectors} from './pager-selectors';
+import * as PagerAssertions from './pager-assertions';
+import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
 
 describe('Pager Test Suites', () => {
   function setupPager(attributes = '') {
@@ -14,20 +16,20 @@ describe('Pager Test Suites', () => {
 
   function componentLoaded(numberOfPages: number) {
     const totalLi = numberOfPages + 2;
-    cy.get('@pagerLi').get(PagerSelectors.pager).should('be.visible');
-    cy.get('@pagerLi')
+    PagerSelectors.pager().should('be.visible');
+    PagerSelectors.li()
       .find('button')
       .contains(numberOfPages.toString())
       .should('be.visible');
-    cy.get('@previousButton').should('be.visible');
-    cy.get('@nextButton').should('be.visible');
-    cy.get('@pagerLi').its('length').should('eq', totalLi);
-    cy.checkA11y(PagerSelectors.pager);
+    PagerSelectors.buttonPrevious().should('be.visible');
+    PagerSelectors.buttonNext().should('be.visible');
+    PagerSelectors.li().its('length').should('eq', totalLi);
+    cy.checkA11y(pagerComponent);
   }
 
   function checkPagerSelected(pageNumber: string, selected: boolean) {
     const isContain = selected ? 'contain' : 'not.contain';
-    cy.get('@pagerLi')
+    PagerSelectors.li()
       .contains(pageNumber)
       .should('have.attr', 'part')
       .and(isContain, 'active-page-button');
@@ -45,7 +47,6 @@ describe('Pager Test Suites', () => {
   describe('Default Pager', () => {
     beforeEach(() => {
       setupPager();
-      createAliasNavigation();
     });
 
     it('should load and pass automated accessibility', () => {
@@ -53,7 +54,7 @@ describe('Pager Test Suites', () => {
     });
 
     it('should go to next page and log UA on button next', async () => {
-      cy.get('@nextButton').click();
+      PagerSelectors.buttonNext().click();
       checkPagerSelected('2', true);
       checkPagerSelected('1', false);
       validateUrlhash(2);
@@ -66,8 +67,8 @@ describe('Pager Test Suites', () => {
     });
 
     it('should go to previous page and log UA on button previous', async () => {
-      cy.get('@nextButton').click();
-      cy.get('@previousButton').click();
+      PagerSelectors.buttonNext().click();
+      PagerSelectors.buttonPrevious().click();
 
       checkPagerSelected('1', true);
       checkPagerSelected('2', false);
@@ -81,7 +82,7 @@ describe('Pager Test Suites', () => {
     });
 
     it('should go to page 3 and log UA on button Pager', async () => {
-      cy.get('@pagerLi').find('button').contains('3').click();
+      PagerSelectors.li().find('button').contains('3').click();
       checkPagerSelected('3', true);
       checkPagerSelected('1', false);
       validateUrlhash(3);
@@ -94,10 +95,22 @@ describe('Pager Test Suites', () => {
     });
 
     it('should load more numbers when click 5', () => {
-      cy.get('@pagerLi').find('button').contains('5').click();
+      PagerSelectors.li().find('button').contains('5').click();
       checkPagerSelected('5', true);
       checkPagerSelected('6', false);
     });
+  });
+
+  describe('when selecting page 3', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .withElement(generateComponentHTML(pagerComponent))
+        .init();
+      PagerSelectors.li().find('button[aria-label="Page 3"]').click();
+      cy.wait(TestFixture.interceptAliases.Search);
+    });
+
+    PagerAssertions.assertFocusActivePage();
   });
 
   describe('Pager should load from url', () => {
@@ -105,8 +118,7 @@ describe('Pager Test Suites', () => {
       cy.visit(buildTestUrl('firstResult=20'));
       injectComponent('<atomic-pager></atomic-pager>');
       cy.wait(1000);
-      createAliasNavigation();
-      cy.get('@pagerLi').get(PagerSelectors.pager).should('be.visible');
+      PagerSelectors.pager().should('be.visible');
       checkPagerSelected('3', true);
     });
   });
@@ -114,25 +126,22 @@ describe('Pager Test Suites', () => {
   describe('Option numberOfPages ', () => {
     it('should render when prop is a number', () => {
       setupPager('number-of-pages=10');
-      createAliasNavigation();
       componentLoaded(10);
     });
 
     it('should render when prop is a number_string ', () => {
       setupPager('number-of-pages="8"');
-      createAliasNavigation();
       componentLoaded(8);
     });
 
     it('should fallback to number when prop contains number&character', () => {
       setupPager('number-of-pages="9k3"');
-      createAliasNavigation();
       componentLoaded(9);
     });
 
     it('should render an error when the prop is not in the list of numberOfPages', () => {
       setupPager('number-of-pages="-5"');
-      shouldRenderErrorComponent(PagerSelectors.pager);
+      shouldRenderErrorComponent(pagerComponent);
     });
   });
 });

--- a/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
@@ -1,4 +1,4 @@
-import {createAliasNavigation, PagerSelectors} from '../pager-selectors';
+import {pagerComponent, PagerSelectors} from '../pager-selectors';
 import {withAnySectionnableResultList} from './result-list-utils';
 import {
   resultListComponent,
@@ -38,9 +38,8 @@ describe('Result List Component', () => {
     beforeEach(() => {
       new TestFixture()
         .with(addResultList())
-        .withElement(generateComponentHTML(PagerSelectors.pager))
+        .withElement(generateComponentHTML(pagerComponent))
         .init();
-      createAliasNavigation();
     });
 
     it('should update the results', () => {
@@ -50,7 +49,7 @@ describe('Result List Component', () => {
         firstResultHtml = element[0].innerHTML;
       });
 
-      cy.get('@nextButton').click();
+      PagerSelectors.buttonNext().click();
       cy.wait(500);
 
       ResultListSelectors.firstResult().should((element) => {

--- a/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/atomic-pager/atomic-pager.tsx
@@ -15,6 +15,10 @@ import {
 } from '../../utils/initialization-utils';
 import ArrowRight from '../../images/arrow-right.svg';
 import {Button} from '../common/button';
+import {
+  FocusTarget,
+  FocusTargetController,
+} from '../../utils/accessibility-utils';
 
 /**
  * The `atomic-pager` provides buttons that allow the end user to navigate through the different result pages.
@@ -52,6 +56,9 @@ export class AtomicPager implements InitializableComponent {
    * Specifies how many page buttons to display in the pager.
    */
   @Prop() numberOfPages = 5;
+
+  @FocusTarget()
+  private activePage!: FocusTargetController;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
@@ -112,6 +119,10 @@ export class AtomicPager implements InitializableComponent {
 
   private buildPage(page: number) {
     const isSelected = this.pager.isCurrentPage(page);
+    const parts = ['page-button'];
+    if (isSelected) {
+      parts.push('active-page-button');
+    }
     return (
       <li>
         <Button
@@ -121,10 +132,12 @@ export class AtomicPager implements InitializableComponent {
           onClick={() => {
             this.pager.selectPage(page);
             this.scrollToTop();
+            this.activePage.focusAfterSearch();
           }}
           class={`btn-page ${isSelected ? 'selected' : ''}`}
-          part={`page-button ${isSelected && 'active-page-button'}`}
+          part={parts.join(' ')}
           text={page.toLocaleString(this.bindings.i18n.language)}
+          ref={isSelected ? this.activePage.setTarget : undefined}
         ></Button>
       </li>
     );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1078

If pages "1, 2, 3, 4, 5" are displayed, pressing page 5 shifts the displayed pages to "3, 4, 5, 6, 7", but the focus would stay on the last button (page 7), which is confusing when using a screen reader. With this change, the focus would be moved to page 5, so it stays on the same page they just pressed.