### PR TITLE
fix(atomic): fix color facet values in Safari 13

### DIFF
--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.pcss
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.pcss
@@ -8,8 +8,9 @@
   gap: var(--atomic-facet-boxes-gap, 0.5rem);
 }
 
-.value-box .value-label {
-  @apply w-full;
+.value-box .value-label,
+.value-box-count {
+  @apply w-full block;
 }
 
 .value-box.selected {

--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
@@ -18,7 +18,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
         style="outline-bg-neutral"
         part="value-box"
         onClick={() => props.onClick()}
-        class={`value-box box-border w-full h-full flex flex-col items-center p-2 group ${
+        class={`value-box box-border w-full h-full items-center p-2 group ${
           props.isSelected ? 'selected' : ''
         }`}
         ariaPressed={props.isSelected.toString()}
@@ -28,7 +28,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
         <span
           title={count}
           part="value-count"
-          class="text-neutral-dark truncate with-parentheses w-full text-sm mt-1"
+          class="value-box-count text-neutral-dark truncate with-parentheses w-full text-sm mt-1"
         >
           {count}
         </span>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1316

Before
![image](https://user-images.githubusercontent.com/4923043/148273000-091b0ed7-1b7c-46ed-8e59-4d61d35e872b.png)


After
<img width="344" alt="Screen Shot 2022-01-05 at 1 40 46 PM" src="https://user-images.githubusercontent.com/4923043/148272962-83d2df97-fbee-4e48-aa03-399b26fe8e04.png">

