### PR TITLE
fix(atomic): prevent ResizeObserver from crashing Safari 12

### DIFF
--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -48,7 +48,7 @@ const ELLIPSIS = '...';
 export class AtomicBreadbox implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
   private breadcrumbManager!: BreadcrumbManager;
-  private resizeObserver!: ResizeObserver;
+  private resizeObserver?: ResizeObserver;
   private showMore!: HTMLButtonElement;
   private showLess!: HTMLButtonElement;
   facetManager!: FacetManager;
@@ -67,12 +67,15 @@ export class AtomicBreadbox implements InitializableComponent {
   public initialize() {
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
     this.facetManager = buildFacetManager(this.bindings.engine);
-    this.resizeObserver = new ResizeObserver(() => this.adaptBreadcrumbs());
-    this.resizeObserver.observe(this.host.parentElement!);
+
+    if (window.ResizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => this.adaptBreadcrumbs());
+      this.resizeObserver.observe(this.host.parentElement!);
+    }
   }
 
   public disconnectedCallback() {
-    this.resizeObserver.disconnect();
+    this.resizeObserver?.disconnect();
   }
 
   private get breadcrumbs() {

--- a/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-fields-list/atomic-result-fields-list.tsx
@@ -21,8 +21,10 @@ export class AtomicResultFieldsList {
   @Element() private host!: HTMLElement;
 
   public connectedCallback() {
-    this.resizeObserver = new ResizeObserver(() => this.update());
-    this.resizeObserver.observe(this.host.parentElement!);
+    if (window.ResizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => this.update());
+      this.resizeObserver.observe(this.host.parentElement!);
+    }
   }
 
   public disconnectedCallback() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1317

Prevent's crashing component and displaying an error to the console. It's quite an old version for the web 2018. The downside will be not adapting the breadcrumb/field list to be on one line.

Side note: css parts selectors don't work in Safari 12 😱 