### PR TITLE
ci: removed python cache

### DIFF
--- a/.github/actions/create-deployment-package/action.yml
+++ b/.github/actions/create-deployment-package/action.yml
@@ -6,7 +6,6 @@ runs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-        cache: 'pip'
     - name: Install deployment package
       shell: bash
       run: pip install --index-url https://pypi.dev.cloud.coveo.com/simple 'deployment-package==7.*'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1320

Because of the cache option, `setup-python` expected a `requirements.txt` file to use as its hash.