### PR TITLE
fix(atomic): fixed focus when clearing a breadcrumb

### DIFF
--- a/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
+++ b/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
@@ -239,3 +239,15 @@ export function assertDisplayAllBreadcrumb(display: boolean) {
       .should(display ? 'not.exist' : 'exist');
   });
 }
+
+export function assertFocusBreadcrumb(index: number) {
+  it(`Should focus on the breadcrumb at index ${index}`, () => {
+    BreadboxSelectors.breadcrumbButton().eq(index).should('be.focused');
+  });
+}
+
+export function assertFocusClearAll() {
+  it('Should focus on the clear all button', () => {
+    BreadboxSelectors.clearAllButton().should('be.focused');
+  });
+}

--- a/packages/atomic/cypress/integration/breadbox/breadbox.cypress.ts
+++ b/packages/atomic/cypress/integration/breadbox/breadbox.cypress.ts
@@ -12,7 +12,11 @@ import {
   selectIdleCheckboxValueAt,
   selectIdleLinkValueAt,
 } from '../facets/facet-common-actions';
-import {addBreadbox, breadboxLabel} from './breadbox-actions';
+import {
+  addBreadbox,
+  breadboxLabel,
+  deselectBreadcrumbAtIndex,
+} from './breadbox-actions';
 import * as BreadboxAssertions from './breadbox-assertions';
 import * as CommonAssertions from '../common-assertions';
 import * as CommonFacetAssertions from '../facets/facet-common-assertions';
@@ -140,6 +144,35 @@ describe('Breadbox Test Suites', () => {
       BreadboxAssertions.assertCategoryPathInBreadcrumb(selectedPath);
       BreadboxAssertions.assertDisplayBreadcrumbClearIcon();
       BreadboxAssertions.assertBreadcrumbDisplayLength(3);
+    });
+  });
+
+  describe('when selecting 3 facet values', () => {
+    beforeEach(() => {
+      setupBreadboxWithMultipleFacets();
+      for (let i = 0; i < 3; i++) {
+        selectIdleCheckboxValueAt(FacetSelectors, 0);
+        cy.wait(TestFixture.interceptAliases.Search);
+        cy.wait(TestFixture.interceptAliases.UA);
+      }
+    });
+
+    describe('when clearing the second breadcrumb', () => {
+      beforeEach(() => {
+        deselectBreadcrumbAtIndex(1);
+        cy.wait(TestFixture.interceptAliases.Search);
+      });
+
+      BreadboxAssertions.assertFocusBreadcrumb(1);
+    });
+
+    describe('when clearing the last breadcrumb', () => {
+      beforeEach(() => {
+        deselectBreadcrumbAtIndex(2);
+        cy.wait(TestFixture.interceptAliases.Search);
+      });
+
+      BreadboxAssertions.assertFocusClearAll();
     });
   });
 

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -71,7 +71,7 @@ export class AtomicBreadbox implements InitializableComponent {
   @State() private isCollapsed = true;
 
   @FocusTarget()
-  private breadcrumbRemovedFocus!: FocusTargetController;
+  private breadcrumbFocus!: FocusTargetController;
 
   public initialize() {
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
@@ -174,14 +174,14 @@ export class AtomicBreadbox implements InitializableComponent {
           title={`${breadcrumb.label}: ${fullValue}`}
           onClick={() => {
             if (this.numberOfBreadcrumbs > 1) {
-              this.breadcrumbRemovedFocus.focusAfterSearch();
+              this.breadcrumbFocus.focusAfterSearch();
             }
             this.lastRemovedBreadcrumbIndex = index;
             breadcrumb.deselect();
           }}
           ref={
             this.lastRemovedBreadcrumbIndex === index
-              ? this.breadcrumbRemovedFocus.setTarget
+              ? this.breadcrumbFocus.setTarget
               : undefined
           }
         >
@@ -266,9 +266,7 @@ export class AtomicBreadbox implements InitializableComponent {
           class="p-2 btn-pill"
           ariaLabel={this.bindings.i18n.t('clear-all-filters')}
           onClick={() => this.breadcrumbManager.deselectAll()}
-          ref={
-            isFocusTarget ? this.breadcrumbRemovedFocus.setTarget : undefined
-          }
+          ref={isFocusTarget ? this.breadcrumbFocus.setTarget : undefined}
         ></Button>
       </li>
     );

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -17,6 +17,10 @@ import {Button} from '../common/button';
 import CloseIcon from 'coveo-styleguide/resources/icons/svg/close.svg';
 import {getFieldValueCaption} from '../../utils/field-utils';
 import {Hidden} from '../common/hidden';
+import {
+  FocusTarget,
+  FocusTargetController,
+} from '../../utils/accessibility-utils';
 
 interface Breadcrumb {
   facetId: string;
@@ -51,6 +55,8 @@ export class AtomicBreadbox implements InitializableComponent {
   private resizeObserver?: ResizeObserver;
   private showMore!: HTMLButtonElement;
   private showLess!: HTMLButtonElement;
+  private lastRemovedBreadcrumbIndex = 0;
+  private numberOfBreadcrumbs = 0;
   facetManager!: FacetManager;
 
   @Element() private host!: HTMLElement;
@@ -63,6 +69,9 @@ export class AtomicBreadbox implements InitializableComponent {
   public facetManagerState!: FacetManagerState;
   @State() public error!: Error;
   @State() private isCollapsed = true;
+
+  @FocusTarget()
+  private breadcrumbRemovedFocus!: FocusTargetController;
 
   public initialize() {
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
@@ -148,7 +157,7 @@ export class AtomicBreadbox implements InitializableComponent {
     return ellipsedPath.join(SEPARATOR);
   }
 
-  private renderBreadcrumb(breadcrumb: Breadcrumb) {
+  private renderBreadcrumb(breadcrumb: Breadcrumb, index: number) {
     const fullValue = Array.isArray(breadcrumb.formattedValue)
       ? breadcrumb.formattedValue.join(SEPARATOR)
       : breadcrumb.formattedValue;
@@ -163,7 +172,18 @@ export class AtomicBreadbox implements InitializableComponent {
           style="outline-bg-neutral"
           class="py-2 px-3 flex items-center btn-pill group"
           title={`${breadcrumb.label}: ${fullValue}`}
-          onClick={() => breadcrumb.deselect()}
+          onClick={() => {
+            if (this.numberOfBreadcrumbs > 1) {
+              this.breadcrumbRemovedFocus.focusAfterSearch();
+            }
+            this.lastRemovedBreadcrumbIndex = index;
+            breadcrumb.deselect();
+          }}
+          ref={
+            this.lastRemovedBreadcrumbIndex === index
+              ? this.breadcrumbRemovedFocus.setTarget
+              : undefined
+          }
         >
           <span
             part="breadcrumb-label"
@@ -235,6 +255,8 @@ export class AtomicBreadbox implements InitializableComponent {
   }
 
   private renderClearAll() {
+    const isFocusTarget =
+      this.lastRemovedBreadcrumbIndex === this.numberOfBreadcrumbs;
     return (
       <li key="clear-all">
         <Button
@@ -244,6 +266,9 @@ export class AtomicBreadbox implements InitializableComponent {
           class="p-2 btn-pill"
           ariaLabel={this.bindings.i18n.t('clear-all-filters')}
           onClick={() => this.breadcrumbManager.deselectAll()}
+          ref={
+            isFocusTarget ? this.breadcrumbRemovedFocus.setTarget : undefined
+          }
         ></Button>
       </li>
     );
@@ -328,9 +353,12 @@ export class AtomicBreadbox implements InitializableComponent {
       const indexB = this.facetManagerState.facetIds.indexOf(b.facetId);
       return indexA - indexB;
     });
+    this.numberOfBreadcrumbs = sortedBreadcrumbs.length;
 
     return [
-      sortedBreadcrumbs.map((breadcrumb) => this.renderBreadcrumb(breadcrumb)),
+      sortedBreadcrumbs.map((breadcrumb, i) =>
+        this.renderBreadcrumb(breadcrumb, i)
+      ),
       this.isCollapsed && this.renderShowMore(),
       !this.isCollapsed && this.renderShowLess(),
       this.renderClearAll(),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1084

Removing a breadcrumb selects the next breadcrumb, or the "clear all" button.

Focus is still lost when removing the last breadcrumb or pressing "clear all". Maintaining focus when that happens would require adding a lot of logic to find what's the next focusable element in the DOM (or adding a package such as [tabbable](https://www.npmjs.com/package/tabbable)). We'll see if Deque deems it important.