### PR TITLE
test(atomic): attempt to improve breadbox test stability

### DIFF
--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -1,6 +1,7 @@
 import {CyHttpMessages} from 'cypress/types/net-stubbing';
 import {i18n} from 'i18next';
 import {SearchResponseSuccess} from '../../../headless/dist/definitions/api/search/search/search-response';
+import {AnalyticsTracker, AnyEventRequest} from '../utils/analyticsUtils';
 import {buildTestUrl} from '../utils/setupComponent';
 
 export type SearchResponseModifierPredicate = (
@@ -136,6 +137,15 @@ export class TestFixture {
 
       if (this.disabledAnalytics) {
         searchInterfaceComponent.setAttribute('analytics', 'false');
+      } else {
+        AnalyticsTracker.reset();
+        cy.intercept(
+          {
+            method: 'POST',
+            url: '**/rest/ua/v15/analytics/*',
+          },
+          (request) => AnalyticsTracker.push(request.body as AnyEventRequest)
+        );
       }
 
       if (this.responseModifiers.length) {

--- a/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
+++ b/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
@@ -13,6 +13,7 @@ import {label} from '../facets/facet/facet-actions';
 import {timeframeFacetLabel} from '../facets/timeframe-facet/timeframe-facet-action';
 import {colorFacetLabel} from '../facets/color-facet/color-facet-actions';
 import {categoryFacetLabel} from '../facets/category-facet/category-facet-actions';
+import {AnalyticsTracker} from '../../utils/analyticsUtils';
 
 export function assertDisplayBreadcrumb(display: boolean) {
   it(`${should(display)} display the breadcrumb`, () => {
@@ -214,13 +215,10 @@ export function assertLogBreadcrumbCategoryFacet(field: string) {
 
 export function assertLogBreadcrumbClearAll() {
   it('should log the breadcrumb facet clearAll to UA', () => {
-    cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
-      const analyticsBody = intercept.request.body;
-      expect(analyticsBody).to.have.property(
-        'actionCause',
-        'breadcrumbResetAll'
-      );
-    });
+    expect(AnalyticsTracker.getLastSearchEvent()).to.have.property(
+      'actionCause',
+      'breadcrumbResetAll'
+    );
   });
 }
 

--- a/packages/atomic/cypress/integration/breadbox/breadbox.cypress.ts
+++ b/packages/atomic/cypress/integration/breadbox/breadbox.cypress.ts
@@ -37,6 +37,7 @@ import {
 } from '../facets/timeframe-facet/timeframe-facet-action';
 import {TimeframeFacetSelectors} from '../facets/timeframe-facet/timeframe-facet-selectors';
 import {NumericFacetSelectors} from '../facets/numeric-facet/numeric-facet-selectors';
+import {waitUntilNextSearchRendered} from '../common-actions';
 
 describe('Breadbox Test Suites', () => {
   function setupBreadboxWithMultipleFacets() {
@@ -57,11 +58,9 @@ describe('Breadbox Test Suites', () => {
     function setupBreadboxWithSelectedFacetAndNumericFacet() {
       setupBreadboxWithMultipleFacets();
       selectIdleCheckboxValueAt(NumericFacetSelectors, selectionIndex);
-      cy.wait(TestFixture.interceptAliases.UA);
-      cy.wait(TestFixture.interceptAliases.Search);
+      waitUntilNextSearchRendered();
       selectIdleCheckboxValueAt(FacetSelectors, selectionIndex);
-      cy.wait(TestFixture.interceptAliases.Search);
-      cy.wait(TestFixture.interceptAliases.UA);
+      waitUntilNextSearchRendered();
     }
 
     describe('verify rendering', () => {
@@ -85,7 +84,7 @@ describe('Breadbox Test Suites', () => {
       function setupClearAllBreadcrumb() {
         setupBreadboxWithSelectedFacetAndNumericFacet();
         BreadboxSelectors.clearAllButton().click();
-        cy.wait(TestFixture.interceptAliases.Search);
+        waitUntilNextSearchRendered();
       }
 
       describe('verify rendering', () => {
@@ -119,14 +118,11 @@ describe('Breadbox Test Suites', () => {
       const selectionIndex = 0;
       setupBreadboxWithMultipleFacets();
       selectChildValueAt(canadaHierarchyIndex[0]);
-      cy.wait(TestFixture.interceptAliases.Search);
-      cy.wait(TestFixture.interceptAliases.UA);
+      waitUntilNextSearchRendered();
       selectIdleLinkValueAt(TimeframeFacetSelectors, selectionIndex);
-      cy.wait(TestFixture.interceptAliases.Search);
-      cy.wait(TestFixture.interceptAliases.UA);
+      waitUntilNextSearchRendered();
       selectIdleBoxValueAt(selectionIndex);
-      cy.wait(TestFixture.interceptAliases.Search);
-      cy.wait(TestFixture.interceptAliases.UA);
+      waitUntilNextSearchRendered();
     }
     describe('verify rendering', () => {
       before(setupBreadboxWithDifferentTypeSelectedFacet);
@@ -148,12 +144,10 @@ describe('Breadbox Test Suites', () => {
     function setupSelectedMulitpleFacets() {
       setupBreadboxWithMultipleFacets();
       FacetSelectors.showMoreButton().click();
-      cy.wait(TestFixture.interceptAliases.Search);
-      cy.wait(TestFixture.interceptAliases.UA);
+      waitUntilNextSearchRendered();
       index.forEach((i: number) => {
         selectIdleCheckboxValueAt(FacetSelectors, i);
-        cy.wait(TestFixture.interceptAliases.Search);
-        cy.wait(TestFixture.interceptAliases.UA);
+        waitUntilNextSearchRendered();
       });
     }
 

--- a/packages/atomic/cypress/integration/common-actions.ts
+++ b/packages/atomic/cypress/integration/common-actions.ts
@@ -1,0 +1,53 @@
+function observeRecursively(
+  element: Node,
+  callback: (mutations: MutationRecord[]) => void,
+  isAlreadyObserved = false
+): () => void {
+  const disconnectCallbacks: (() => void)[] = [];
+  if (!isAlreadyObserved) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        Array.from(mutation.addedNodes).forEach((node) => {
+          disconnectCallbacks.push(observeRecursively(node, callback, true));
+        });
+        callback(mutations);
+      });
+    });
+    observer.observe(element, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true,
+    });
+    disconnectCallbacks.push(() => observer.disconnect());
+  }
+  if ((element as HTMLElement).shadowRoot) {
+    disconnectCallbacks.push(
+      observeRecursively((element as HTMLElement).shadowRoot!, callback, false)
+    );
+  }
+  Array.from(element.childNodes).forEach((child) =>
+    disconnectCallbacks.push(observeRecursively(child, callback, true))
+  );
+  return () => disconnectCallbacks.forEach((disconnect) => disconnect());
+}
+
+export function waitUntilNextSearchRendered() {
+  cy.wrap(
+    new Promise<void>((resolve) => {
+      cy.get('atomic-search-interface').then(([searchInterface]) => {
+        const lastSearchResponseId =
+          searchInterface.engine?.state.search.searchResponseId;
+        const disconnect = observeRecursively(searchInterface, () => {
+          if (
+            searchInterface.engine?.state.search.searchResponseId !==
+            lastSearchResponseId
+          ) {
+            disconnect();
+            resolve();
+          }
+        });
+      });
+    })
+  );
+}

--- a/packages/atomic/cypress/support/commands.ts
+++ b/packages/atomic/cypress/support/commands.ts
@@ -6,7 +6,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Chainable<Subject> {
       getAnalyticsAt(selector: string, order: number): Chainable<unknown>;
-      getTextOfAllElements(selector: string): Chainable<unknown>;
+      getTextOfAllElements(selector: string): Chainable<string[]>;
       // https://github.com/cypress-io/cypress-documentation/issues/108
       state(key: string): CypressRequest[];
       shouldBeCalled(urlPart: string, timesCalled: number): Chainable<unknown>;

--- a/packages/atomic/cypress/utils/analyticsUtils.ts
+++ b/packages/atomic/cypress/utils/analyticsUtils.ts
@@ -1,0 +1,87 @@
+import {CoveoAnalyticsClient} from '@coveo/headless/node_modules/coveo.analytics';
+import {findLast} from './arrayUtils';
+
+export type SearchEventRequest = Parameters<
+  CoveoAnalyticsClient['sendSearchEvent']
+>[0];
+
+export type ClickEventRequest = Parameters<
+  CoveoAnalyticsClient['sendClickEvent']
+>[0];
+
+export type CustomEventRequest = Parameters<
+  CoveoAnalyticsClient['sendCustomEvent']
+>[0];
+
+export type AnyEventRequest =
+  | SearchEventRequest
+  | ClickEventRequest
+  | CustomEventRequest;
+
+function isSearchEventRequest(
+  request: AnyEventRequest
+): request is SearchEventRequest {
+  return 'actionCause' in request;
+}
+
+function isClickEventRequest(
+  request: AnyEventRequest
+): request is ClickEventRequest {
+  return 'documentUri' in request;
+}
+
+function isCustomEventRequest(
+  request: AnyEventRequest
+): request is CustomEventRequest {
+  return 'eventType' in request;
+}
+
+const analyticsEventsKey = '_analyticsEvents';
+
+interface WindowWithAnalytics extends Window {
+  [analyticsEventsKey]?: AnyEventRequest[];
+}
+
+export class AnalyticsTracker {
+  private static get window() {
+    return window as WindowWithAnalytics;
+  }
+
+  private static get analytics() {
+    return (this.window[analyticsEventsKey] =
+      this.window[analyticsEventsKey] ?? []);
+  }
+
+  private static set analytics(analytics: AnyEventRequest[]) {
+    this.window[analyticsEventsKey] = analytics;
+  }
+
+  static push(request: AnyEventRequest) {
+    this.analytics.push(request);
+  }
+
+  static reset() {
+    this.analytics = [];
+  }
+
+  static getLastSearchEvent() {
+    return findLast(
+      this.analytics,
+      isSearchEventRequest
+    ) as SearchEventRequest | null;
+  }
+
+  static getLastClickEvent() {
+    return findLast(
+      this.analytics,
+      isClickEventRequest
+    ) as ClickEventRequest | null;
+  }
+
+  static getLastCustomEvent() {
+    return findLast(
+      this.analytics,
+      isCustomEventRequest
+    ) as CustomEventRequest | null;
+  }
+}

--- a/packages/atomic/cypress/utils/arrayUtils.ts
+++ b/packages/atomic/cypress/utils/arrayUtils.ts
@@ -1,3 +1,12 @@
 export function toArray<T>(values: T | T[]): T[] {
   return Array.isArray(values) ? values : [values];
 }
+
+export function findLast<T>(values: T[], predicate: (value: T) => boolean) {
+  for (let i = values.length - 1; i >= 0; i--) {
+    if (predicate(values[i])) {
+      return values[i];
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1322

I don't have an exact idea as to what causes the stability issue of some tests such as Breadbox's. I logged the failed tests from various components in the JIRA above. In this PR, I'm mostly working towards my intuition and trying to solve only one test suite. If this PR gets approved, I will open a second PR to replicate those changes on other test suites.

# My intuition (for breadbox)
I believe the breadbox tests may be failing because of a race condition. I suspect that `cy.wait` on a search event may be calling the next step too quickly before components had the time to re-render, and some checkboxes may be ticked on elements that are being (or about to be) re-rendered.

Part of what's giving me this intuition is the following screenshot from a failed test in the CI, where two checkboxes should be checked but only the first one was actually checked:
<details>
<summary>screenshot</summary>

![Breadbox Test Suites -- when selecting a standard facet and a numeric facet -- verify rendering -- should display the selected checkbox facets in the breadcrumbs (failed)](https://user-images.githubusercontent.com/54454747/148600615-27bc21db-a585-4e55-b625-6fb475b4aaf8.png)
</details>

# My solutions
1. Instead of relying on `cy.wait` finishing after the render, I introduced a new function called `waitUntilNextSearchRendered`. This function looks at the current `searchResponseId`, creates a `MutationObserver`, and resolves after a mutation happened with a different `searchResponseId`.
2. Since analytics also relied on a `cy.wait`, which I doubt would be consistently called after a re-render,I introduced a `AnalyticsTracker` static class, which logs all analytics events and allows us to look at the most recent event. `TestFixture` takes care of resetting it and intercepting analytics events.