### PR TITLE
refactor(headless): remove dependency on #q property in querysuggest slice

### DIFF
--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -241,7 +241,8 @@ describe('search api client', () => {
     it(`when calling SearchAPIClient.querySuggest
     should call PlatformClient.call with the right options`, async () => {
       const id = 'someid123';
-      const qs = buildMockQuerySuggest({id, q: 'some query', count: 11});
+      const qs = buildMockQuerySuggest({id, count: 11});
+      state.querySet[id] = 'some query';
       state.querySuggest[id] = qs;
 
       const req = await buildQuerySuggestRequest(id, state);
@@ -257,7 +258,7 @@ describe('search api client', () => {
         }/querySuggest?${getOrganizationIdQueryParam(req)}`,
         logger,
         requestParams: {
-          q: state.querySuggest[id]!.q,
+          q: state.querySet[id],
           count: state.querySuggest[id]!.count,
           context: state.context.contextValues,
           pipeline: state.pipeline,

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -23,9 +23,10 @@ import {getVisitorID, historyStore} from '../../api/analytics/analytics';
 import {QuerySuggestSuccessResponse} from '../../api/search/query-suggest/query-suggest-response';
 
 export type StateNeededByQuerySuggest = ConfigurationSection &
-  QuerySetSection &
   QuerySuggestionSection &
-  Partial<ContextSection & PipelineSection & SearchHubSection>;
+  Partial<
+    QuerySetSection & ContextSection & PipelineSection & SearchHubSection
+  >;
 
 const idDefinition = {
   id: requiredNonEmptyString,
@@ -156,7 +157,10 @@ export const buildQuerySuggestRequest = async (
     organizationId: s.configuration.organizationId,
     url: s.configuration.search.apiBaseUrl,
     count: s.querySuggest[id]!.count,
-    q: s.querySet[id],
+    /**
+     * @deprecated - Adjust `StateNeededByQuerySuggest` to make `querySet` required in v2.
+     */
+    q: s.querySet?.[id],
     locale: s.configuration.search.locale,
     timezone: s.configuration.search.timezone,
     actionsHistory: s.configuration.analytics.enabled

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.test.ts
@@ -3,7 +3,6 @@ import {QuerySuggestCompletion} from '../../api/search/query-suggest/query-sugge
 import {
   clearQuerySuggest,
   fetchQuerySuggestions,
-  FetchQuerySuggestionsThunkReturn,
   registerQuerySuggest,
   selectQuerySuggestion,
 } from './query-suggest-actions';
@@ -187,34 +186,28 @@ describe('querySuggest slice', () => {
       const responseId = 'response-uuid';
       const completions = getCompletions();
       const fetchQuerySuggestionsFulfilledAction =
-        fetchQuerySuggestions.fulfilled(
-          buildMockFetchQuerySuggestionsResponse(),
-          '',
-          {
-            id,
-          }
-        );
+        buildFetchQuerySuggestFullfilledAction();
 
       fetchQuerySuggestionsFulfilledAction.meta.requestId = 'the_right_id';
 
-      function buildMockFetchQuerySuggestionsResponse(): FetchQuerySuggestionsThunkReturn {
-        return {
-          completions,
-          id,
-          responseId,
-          q: 'abc',
-        };
-      }
-
-      it('when fetchQuerySuggestions has an invalid id, it does not throw', () => {
-        const id = 'invalid id';
-        const action = fetchQuerySuggestions.fulfilled(
-          buildMockFetchQuerySuggestionsResponse(),
+      function buildFetchQuerySuggestFullfilledAction() {
+        return fetchQuerySuggestions.fulfilled(
+          {
+            completions,
+            id,
+            responseId,
+            q: 'abc',
+          },
           '',
           {
             id,
           }
         );
+      }
+
+      it('when fetchQuerySuggestions has an id that is not a key of the set, it does not throw', () => {
+        const action = buildFetchQuerySuggestFullfilledAction();
+        action.meta.arg.id = 'invalid id';
 
         expect(() => querySuggestReducer(state, action)).not.toThrow();
       });

--- a/packages/headless/src/features/query-suggest/query-suggest-slice.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-slice.ts
@@ -52,7 +52,7 @@ export const querySuggestReducer = createReducer(
           return;
         }
 
-        const {q} = querySuggest;
+        const {q} = action.payload;
         if (q) {
           querySuggest.partialQueries.push(
             q.replace(/;/, encodeURIComponent(';'))

--- a/packages/headless/src/features/query-suggest/query-suggest-state.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-state.ts
@@ -17,7 +17,7 @@ export interface QuerySuggestState {
   /**
    * The partial basic query expression for which query suggestions were requested (e.g., `cov`).
    *
-   * @deprecated This property will be removed because it duplicates the values in the "querySet" slice. To access the value, please use "engine.state.querySet[id]".
+   * @deprecated The next major version will remove this property because it duplicates the values in the "querySet" slice. To access the value, please use "engine.state.querySet[id]".
    */
   q: string;
   /**

--- a/packages/headless/src/features/query-suggest/query-suggest-state.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-state.ts
@@ -16,6 +16,8 @@ export interface QuerySuggestState {
   responseId: string;
   /**
    * The partial basic query expression for which query suggestions were requested (e.g., `cov`).
+   *
+   * @deprecated This property will be removed because it duplicates the values in the "querySet" slice. To access the value, please use "engine.state.querySet[id]".
    */
   q: string;
   /**


### PR DESCRIPTION
There's some code that's needed to ensure the `q` property in the query suggest slice stays in sync with the `q` in the query set. The duplication is not needed though and can be stream-lined.

This PR takes the first step. It removes the dependency on the `q` property and deprecates it. It does not remove the duplicate reducer code and unit tests though to not change the behavior in case anyone is reading the `q` property. We would do this just before headless v2 is released.

https://coveord.atlassian.net/browse/KIT-674