### PR TITLE
test(atomic): decrease number of show more needed to fully expand facet

### DIFF
--- a/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
@@ -233,7 +233,13 @@ describe('Color Facet Test Suites', () => {
     describe('repeatedly until there\'s no more "Show more" button', () => {
       function setupRepeatShowMore() {
         new TestFixture()
-          .with(addColorFacet({field: colorFacetField, label: colorFacetLabel}))
+          .with(
+            addColorFacet({
+              field: colorFacetField,
+              label: colorFacetLabel,
+              'number-of-values': 25,
+            })
+          )
           .init();
         pressShowMoreUntilImpossible(ColorFacetSelectors);
       }

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -691,7 +691,9 @@ describe('Facet v1 Test Suites', () => {
 
     describe('repeatedly until there\'s no more "Show more" button', () => {
       function setupRepeatShowMore() {
-        new TestFixture().with(addFacet({field, label})).init();
+        new TestFixture()
+          .with(addFacet({field, label, 'number-of-values': 100}))
+          .init();
         pressShowMoreUntilImpossible(FacetSelectors);
       }
 


### PR DESCRIPTION
When "show more" is pressed, the number of displayed values increases by the initially configured number. The default value is 8, so if a facet has a lot of values, it will take several presses, increasing the chance of timing out.

The field used for the facet test had about ~130 values, so ~17 clicks are needed to fully expand.

```
1) Facet v1 Test Suites
       when selecting the "Show more" button
         repeatedly until there's no more "Show more" button
           verify rendering
             should focus on the show less button:
     AssertionError: Timed out retrying after 4000ms: expected '<button.btn-text-primary.flex.items-baseline.text-left.p-2.text-sm.max-w-full>' to be 'focused'
```

This PR adjusts the initial number of values so that the facet is fully expanded after one "show more" click.

One draw-back to point out is if the number of values decreases below the initial number, the tests would fail. This was always the case, but now the initial numbers are higher.



https://coveord.atlassian.net/browse/KIT-1340