### PR TITLE
doc(atomic): external component selector option

### DIFF
--- a/packages/atomic/src/components/atomic-external/atomic-external.tsx
+++ b/packages/atomic/src/components/atomic-external/atomic-external.tsx
@@ -6,14 +6,15 @@ import {
 } from '../../utils/initialization-utils';
 /**
  * The `atomic-external` component allows components defined outside of the `atomic-search-interface` to initialize.
- *
- * @part selector - The CSS selector that identifies the `atomic-search-interface` component with which to initialize the external components.
  */
 @Component({
   tag: 'atomic-external',
   shadow: false,
 })
 export class AtomicExternal {
+  /**
+   * The CSS selector that identifies the `atomic-search-interface` component with which to initialize the external components.
+   */
   @Prop() selector = 'atomic-search-interface';
   @Listen('atomic/initializeComponent')
   public handleInitialization(event: InitializeEvent) {

--- a/packages/atomic/src/components/atomic-external/atomic-external.tsx
+++ b/packages/atomic/src/components/atomic-external/atomic-external.tsx
@@ -5,7 +5,9 @@ import {
   initializeEventName,
 } from '../../utils/initialization-utils';
 /**
- * The `atomic-external` component allows components defined outside of the `atomic-search-interface` to initialize .
+ * The `atomic-external` component allows components defined outside of the `atomic-search-interface` to initialize.
+ *
+ * @part selector - The CSS selector that identifies the `atomic-search-interface` component with which to initialize the external components.
  */
 @Component({
   tag: 'atomic-external',


### PR DESCRIPTION
Added a doc string for the external component selector option.
Seems to generate correctly, but let me know if I made some kind of syntax mistake, it's been a while since I played in this project.
<img width="1054" alt="Screen Shot 2022-01-13 at 10 03 24 AM" src="https://user-images.githubusercontent.com/39384459/149375352-68c886b8-4793-41c4-abbf-e1ef24dabdf3.png">
