### PR TITLE
fix(atomic): improved accessibility for printable uri

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-components/result-printable-uri.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-components/result-printable-uri.cypress.ts
@@ -175,6 +175,7 @@ describe('Result Printable Uri Component', () => {
         ResultPrintableUriSelectors.ellipsisButton().click();
         ResultPrintableUriSelectors.ellipsisButton().should('not.exist');
         ResultPrintableUriSelectors.links().should('have.length.above', 3);
+        ResultPrintableUriSelectors.links().eq(3).should('be.focused');
       });
 
       CommonAssertions.assertAccessibility(

--- a/packages/atomic/src/components/result-link/result-link.tsx
+++ b/packages/atomic/src/components/result-link/result-link.tsx
@@ -8,10 +8,11 @@ export interface ResultLinkProps {
   target: string;
   part?: string;
   title?: string;
+  ref?: (elm?: HTMLAnchorElement) => void;
 }
 
 export const LinkWithResultAnalytics: FunctionalComponent<ResultLinkProps> = (
-  {href, interactiveResult, target, part, title},
+  {href, interactiveResult, target, part, title, ref},
   children
 ) => {
   const stopPropagationAndProcess = (e: Event, process: () => void) => {
@@ -38,6 +39,7 @@ export const LinkWithResultAnalytics: FunctionalComponent<ResultLinkProps> = (
         stopPropagationAndProcess(e, interactiveResult.cancelPendingSelect)
       }
       target={target}
+      ref={ref}
     >
       {children}
     </a>

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -699,6 +699,10 @@
     "en": "Source",
     "fr": "Source"
   },
+  "printable-uri": {
+    "en": "Source path of the result",
+    "fr": "Chemin source du résultat"
+  },
   "collapsed-uri-parts": {
     "en": "Collapsed URI parts",
     "fr": "Segments d'URI réduits"

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -25,6 +25,7 @@ export function AriaLiveRegion(regionName: string) {
 export interface FocusTargetController {
   setTarget(element: HTMLElement | undefined): void;
   focusAfterSearch(): void;
+  focusOnNextTarget(): void;
   disableForCurrentSearch(): void;
 }
 
@@ -36,6 +37,7 @@ export function FocusTarget() {
       componentWillLoad && componentWillLoad.call(this);
       const {componentDidRender} = this;
       let focusAfterSearch = false;
+      let focusOnNextTarget = false;
       let lastSearchId: string | undefined = undefined;
       let element: HTMLElement | undefined = undefined;
 
@@ -57,10 +59,22 @@ export function FocusTarget() {
       };
 
       const focusTargetController: FocusTargetController = {
-        setTarget: (el) => el && (element = el),
+        setTarget: (el) => {
+          if (!el) {
+            return;
+          }
+          element = el;
+          if (focusOnNextTarget) {
+            focusOnNextTarget = false;
+            element.focus();
+          }
+        },
         focusAfterSearch: () => {
           lastSearchId = this.bindings.engine.state.search.searchResponseId;
           focusAfterSearch = true;
+        },
+        focusOnNextTarget: () => {
+          focusOnNextTarget = true;
         },
         disableForCurrentSearch: () =>
           this.bindings.engine.state.search.searchResponseId !== lastSearchId &&


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1076

* Added a label to the printable URI as a whole
* Made the expand button focus on the first newly revealed value
* Added a role to separators