### PR TITLE
feat(atomic): make assets and language available for atomic-react

### DIFF
--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -9,12 +9,13 @@
     "directory": "packages/atomic-react"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile",
+    "build": "npm run clean && npm run compile && npm run copy:assets",
     "dev": "npm link ../samples/headless-react/node_modules/react",
     "clean": "rm -rf dist",
     "compile": "npm run tsc",
     "tsc": "tsc -p .",
-    "npm:publish:alpha": "node ../../scripts/deploy/publish.js alpha"
+    "npm:publish:alpha": "node ../../scripts/deploy/publish.js alpha",
+    "copy:assets": "ncp node_modules/@coveo/atomic/dist/atomic/assets dist/assets && ncp node_modules/@coveo/atomic/dist/atomic/lang dist/lang "
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -29,6 +30,7 @@
     "@types/node": "^15.12.2",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
+    "ncp": "^2.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/samples/headless-react/.gitignore
+++ b/packages/samples/headless-react/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+
+public/assets
+public/lang

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -28,13 +28,14 @@
   },
   "scripts": {
     "prepublishOnly": "exit 1",
-    "dev": "react-scripts start",
+    "dev": "npm run copy:assets && react-scripts start",
     "build": "tsc --noEmit",
     "build:server": "tsc --project ./tsconfig.server.json",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "ssr:build": "npm run build && npm run build:server",
-    "ssr:start": "node ./build/server/server/server.js"
+    "ssr:start": "node ./build/server/server/server.js",
+    "copy:assets": "ncp node_modules/@coveo/atomic-react/dist/assets public/assets && ncp node_modules/@coveo/atomic-react/dist/lang public/lang"
   },
   "browserslist": {
     "production": [
@@ -47,5 +48,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "ncp": "^2.0.0"
   }
 }


### PR DESCRIPTION
For all external assets (things that may not be loaded ahead of times by our components), project using Atomic-react (and all other output target we will support- Angular, Vue, etc), the embedding project has to make available `lang` (translation) and `assets` (bunch of SVG)  in whatever represent their "public" web server folder.

For example, in our sample headless-react package built with create react app, this means making all files available in the `public` folder.

This is a gotcha that we will need to document clearly for our users ! 

If they don't copy `node_modules/@coveo/atomic-react/dist/lang` to some publicly available folder on their server, it means that the language dictionary will be empty by default (english won't even load) and for all strings you would only see the "key", and not the associated value.

Another approach would be to arrange for english to be loaded eagerly, so that it's at least always there without our users having to configure or copy any files.

But, it would mean that when they start to use other translation file, things would start to fail in the same manner as described above. It would also be an obvious hit to the bundle size.

So I think in this case, I prefer to fail right away, and have some good explanation and instruction in our README and documentation.

However, once that's done, it's extremely trivial to change the language of the interface, with a simple prop : 
```jsx
<AtomicSearchInterface language="fr">
  [...]
</AtomicSearchInterface>
```

https://coveord.atlassian.net/browse/KIT-1332