### PR TITLE
fix(atomic): removed search box focus when pressing search button

### DIFF
--- a/packages/atomic/cypress/integration/search-box.cypress.ts
+++ b/packages/atomic/cypress/integration/search-box.cypress.ts
@@ -107,7 +107,6 @@ describe('Search Box Test Suites', () => {
             cy.wait(TestFixture.interceptAliases.Search);
           });
 
-          SearchBoxAssertions.assertFocusSearchBox();
           SearchBoxAssertions.assertHasText('Recent query 1');
         });
       });

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -22,11 +22,7 @@ import {
   SearchBoxSuggestionsBindings,
   SearchBoxSuggestionsEvent,
 } from '../search-box-suggestions/suggestions-common';
-import {
-  AriaLiveRegion,
-  FocusTarget,
-  FocusTargetController,
-} from '../../utils/accessibility-utils';
+import {AriaLiveRegion} from '../../utils/accessibility-utils';
 
 /**
  * The `atomic-search-box` component creates a search box with built-in support for suggestions.

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -75,9 +75,6 @@ export class AtomicSearchBox {
   @AriaLiveRegion('search-box')
   protected ariaMessage!: string;
 
-  @FocusTarget()
-  private inputFocus!: FocusTargetController;
-
   public initialize() {
     this.id = randomID('atomic-search-box-');
     this.querySetActions = loadQuerySetActions(this.bindings.engine);
@@ -299,10 +296,7 @@ export class AtomicSearchBox {
     return (
       <input
         part="input"
-        ref={(el) => {
-          this.inputRef = el as HTMLInputElement;
-          this.inputFocus.setTarget(el);
-        }}
+        ref={(el) => (this.inputRef = el as HTMLInputElement)}
         role="combobox"
         aria-autocomplete="both"
         aria-haspopup="true"
@@ -418,7 +412,6 @@ export class AtomicSearchBox {
         part="submit-button"
         ariaLabel={this.bindings.i18n.t('search')}
         onClick={() => {
-          this.inputFocus.focusAfterSearch();
           this.searchBox.submit();
           this.clearSuggestionElements();
         }}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1342

I originally added this because I expected it to improve the experience with screen readers a bit, but now I don't see why I thought this was a good idea. Focusing on the search box causes the search suggestions to open.