### PR TITLE
test(atomic): make test stable using the old setup 

### DIFF
--- a/packages/atomic/cypress/integration/search-box.cypress.ts
+++ b/packages/atomic/cypress/integration/search-box.cypress.ts
@@ -57,21 +57,6 @@ describe('Search Box Test Suites', () => {
         .init();
     }
 
-    function setupWithRecentQueries() {
-      new TestFixture()
-        .with(setRecentQueries(numOfRecentQueries))
-        .with(
-          addSearchBox({
-            recentQueries: {
-              maxWithoutQuery: maxRecentQueriesWithoutQuery,
-              maxWithQuery: numOfRecentQueries,
-            },
-            props: {'number-of-queries': numOfRecentQueries},
-          })
-        )
-        .init();
-    }
-
     describe('without input', () => {
       const expectedSum =
         maxSuggestionsWithoutQuery + maxRecentQueriesWithoutQuery;
@@ -121,12 +106,10 @@ describe('Search Box Test Suites', () => {
 
       describe('after focusing a suggestion with the keyboard', () => {
         before(() => {
-          setupWithRecentQueries();
-          setInputText();
+          setupWithSuggestionsAndRecentQueries();
 
-          SearchBoxSelectors.inputBox()
-            .focus()
-            .type('{downarrow}{downarrow}{downarrow}');
+          const downKeys = Array(9).fill('{downarrow}').join('');
+          SearchBoxSelectors.inputBox().type(`Rec${downKeys}`, {delay: 200});
         });
 
         SearchBoxAssertions.assertHasText('Recent query 1');


### PR DESCRIPTION
I think I turned all the stones ...

I commented out all code that is clearing suggestions. Still, I saw suggestions being cleared in cypress. So, I think the test code is at fault.

One way to make it work™️ is to slow down the typing. At 200ms, I did not see any failing attempts locally. At 150ms, they still occasionally happened.

Since this solution relies on delays, it is not as stable as the initial PR, so I put the changes in a separate branch,
