### PR TITLE
fix(quantic): added escape util for showing query in rich-text

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
@@ -77,10 +77,10 @@ export default class QuanticDidYouMean extends LightningElement {
   }
 
   get noResultsLabel() {
-    return I18nUtils.format(this.labels.noResultsFor, I18nUtils.getTextBold(this.originalQuery));
+    return I18nUtils.format(this.labels.noResultsFor, I18nUtils.getTextBold(I18nUtils.escapeHTML(this.originalQuery)));
   }
 
   get correctedQueryLabel() {
-    return I18nUtils.format(this.labels.queryCorrectedTo, I18nUtils.getTextBold(this.correctedQuery));
+    return I18nUtils.format(this.labels.queryCorrectedTo, I18nUtils.getTextBold(I18nUtils.escapeHTML(this.correctedQuery)));
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -111,7 +111,7 @@ export default class QuanticNoResults extends LightningElement {
 
   get noResultsTitleLabel() {
     if (this.query) {
-      return I18nUtils.format(this.labels.noResultsForTitle, I18nUtils.getTextBold(this.query));
+      return I18nUtils.format(this.labels.noResultsForTitle, I18nUtils.getTextBold(I18nUtils.escapeHTML(this.query)));
     }
     return this.labels.noResultsTitle;
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
@@ -93,7 +93,7 @@ export default class QuanticSummary extends LightningElement {
   get noResultsLabel() {
     return I18nUtils.format(
         this.hasQuery ? this.labels.noResultsFor : this.labels.noResults,
-        I18nUtils.getTextBold(this.query));
+        I18nUtils.getTextBold(I18nUtils.escapeHTML(this.query)));
   }
 
   get summaryLabel() {
@@ -104,6 +104,6 @@ export default class QuanticSummary extends LightningElement {
       this.labels[labelName],
       I18nUtils.getTextWithDecorator(this.range, '<b class="summary__range">', '</b>'),
       I18nUtils.getTextWithDecorator(this.total, '<b class="summary__total">', '</b>'),
-      I18nUtils.getTextWithDecorator(this.query, '<b class="summary__query">', '</b>'));
+      I18nUtils.getTextWithDecorator(I18nUtils.escapeHTML(this.query), '<b class="summary__query">', '</b>'));
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -84,7 +84,7 @@ describe('c/quanticUtils', () => {
       });
 
       it('should escape html anchor tags', () => {
-        let htmlWithTags = '<a src="http:.//www.sketchysite.com"></a>';
+        let htmlWithTags = '<a src="http://www.sketchysite.com"></a>';
       
         expect(I18nUtils.escapeHTML(htmlWithTags)).toBe("&lt;a src=\"http:.//www.sketchysite.com\"&gt;&lt;/a&gt;");
       });

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -86,7 +86,7 @@ describe('c/quanticUtils', () => {
       it('should escape html anchor tags', () => {
         let htmlWithTags = '<a src="http://www.sketchysite.com"></a>';
       
-        expect(I18nUtils.escapeHTML(htmlWithTags)).toBe("&lt;a src=\"http:.//www.sketchysite.com\"&gt;&lt;/a&gt;");
+        expect(I18nUtils.escapeHTML(htmlWithTags)).toBe("&lt;a src=\"http://www.sketchysite.com\"&gt;&lt;/a&gt;");
       });
     });
   });

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -75,5 +75,19 @@ describe('c/quanticUtils', () => {
         expect(I18nUtils.format(testString, test, buddy)).toBe('this is a test string, buddy.');
       });
     });
+
+    describe('escapeHTML', () => {
+      it('should escape html tags', () => {
+        let htmlWithTags = '<div>test string</div>';
+      
+        expect(I18nUtils.escapeHTML(htmlWithTags)).toBe('&lt;div&gt;test string&lt;/div&gt;');
+      });
+
+      it('should escape html anchor tags', () => {
+        let htmlWithTags = '<a src="http:.//www.sketchysite.com"></a>';
+      
+        expect(I18nUtils.escapeHTML(htmlWithTags)).toBe("&lt;a src=\"http:.//www.sketchysite.com\"&gt;&lt;/a&gt;");
+      });
+    });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -154,12 +154,22 @@ export class I18nUtils {
   }
 
   /**
-   *
    * @param {Date} date
    */
   static formatDate(date) {
     const result = new Intl.DateTimeFormat(LOCALE).format(date);
     return result;
+  }
+
+  /**
+   * @param {string} html 
+   * @returns {string}
+   */
+  static escapeHTML(html) {
+    var escape = document.createElement('textarea');
+    escape.textContent = html;
+    // eslint-disable-next-line @lwc/lwc/no-inner-html
+    return escape.innerHTML;
   }
 }
 


### PR DESCRIPTION
`lightning-formatted-rich-text` which we use for bolding renders html in a query. I added a util that uses html <textarea> escaping in a clever way so the queries are displayed properly.

Before
<img width="704" alt="Screen Shot 2022-01-17 at 10 26 45 AM" src="https://user-images.githubusercontent.com/16785453/149797328-12e87416-d04e-4d9f-ab2a-26fc865801c3.png">
<img width="695" alt="Screen Shot 2022-01-17 at 10 26 31 AM" src="https://user-images.githubusercontent.com/16785453/149797331-166e33e7-4a4f-4759-a0ce-7c784708c4fd.png">

After
<img width="570" alt="Screen Shot 2022-01-17 at 10 25 36 AM" src="https://user-images.githubusercontent.com/16785453/149797355-719b8e3e-359a-4d81-993e-bff9b9ad6ed2.png">
<img width="629" alt="Screen Shot 2022-01-17 at 10 25 55 AM" src="https://user-images.githubusercontent.com/16785453/149797333-d782ee84-f376-408f-810c-9ca904eab7b3.png">
<img width="638" alt="Screen Shot 2022-01-17 at 10 25 44 AM" src="https://user-images.githubusercontent.com/16785453/149797357-fe11152d-c0ca-4709-a2b6-888994a0e999.png">

