### PR TITLE
fix(headless,atomic,quantic): typos for occurrences

### DIFF
--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
@@ -1,6 +1,6 @@
 import {
   doSortAlphanumeric,
-  doSortOccurences,
+  doSortOccurrences,
 } from '../../../utils/componentUtils';
 import {ResultListSelectors} from '../../result-list/result-list-selectors';
 import {CategoryFacetSelectors} from './category-facet-selectors';
@@ -120,12 +120,12 @@ export function assertLogFacetShowLess() {
   });
 }
 
-export function assertValuesSortedByOccurences() {
-  it('values should be ordered by occurences', () => {
+export function assertValuesSortedByOccurrences() {
+  it('values should be ordered by occurrences', () => {
     CategoryFacetSelectors.valueCount().as('categoryFacetAllValuesCount');
     cy.getTextOfAllElements('@categoryFacetAllValuesCount').then(
       (originalValues) => {
-        expect(originalValues).to.eql(doSortOccurences(originalValues));
+        expect(originalValues).to.eql(doSortOccurrences(originalValues));
       }
     );
   });

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -75,7 +75,7 @@ describe('Category Facet Test Suites', () => {
         CategoryFacetSelectors,
         categoryFacetLabel
       );
-      CategoryFacetAssertions.assertValuesSortedByOccurences();
+      CategoryFacetAssertions.assertValuesSortedByOccurrences();
     });
 
     describe('when selecting a value to go deeper one level (2nd level of the dataset)', () => {

--- a/packages/atomic/cypress/integration/facets/facet/facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet-assertions.ts
@@ -1,7 +1,7 @@
 import {TestFixture} from '../../../fixtures/test-fixture';
 import {
   doSortAlphanumeric,
-  doSortOccurences,
+  doSortOccurrences,
 } from '../../../utils/componentUtils';
 import {FacetSelectors} from './facet-selectors';
 
@@ -54,11 +54,11 @@ export function assertValuesSortedAlphanumerically() {
   });
 }
 
-export function assertValuesSortedByOccurences() {
-  it('values should be ordered by occurences', () => {
+export function assertValuesSortedByOccurrences() {
+  it('values should be ordered by occurrences', () => {
     FacetSelectors.valueCount().as('facetAllValuesCount');
     cy.getTextOfAllElements('@facetAllValuesCount').then((originalValues) => {
-      expect(originalValues).to.eql(doSortOccurences(originalValues));
+      expect(originalValues).to.eql(doSortOccurrences(originalValues));
     });
   });
 }

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -832,7 +832,7 @@ describe('Facet v1 Test Suites', () => {
         .init();
     });
 
-    FacetAssertions.assertValuesSortedByOccurences();
+    FacetAssertions.assertValuesSortedByOccurrences();
   });
 
   describe('when defining a value caption', () => {

--- a/packages/atomic/cypress/utils/componentUtils.ts
+++ b/packages/atomic/cypress/utils/componentUtils.ts
@@ -8,7 +8,7 @@ export function doSortAlphanumeric(originalValues: string[]) {
     .sort((first, second) => first.localeCompare(second));
 }
 
-export function doSortOccurences(originalValues: string[]) {
+export function doSortOccurrences(originalValues: string[]) {
   return originalValues
     .concat()
     .map((value) => parseInt(value.replaceAll(',', '')))

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet-options.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet-options.ts
@@ -82,7 +82,7 @@ export interface CategoryFacetOptions {
   /**
    * The criterion to use for sorting returned facet values.
    *
-   * @defaultValue `occurences`
+   * @defaultValue `occurrences`
    */
   sortCriteria?: CategoryFacetSortCriterion;
 }

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-actions.ts
@@ -79,7 +79,7 @@ export interface RegisterCategoryFacetActionCreatorPayload {
   /**
    * The criterion to use for sorting returned facet values.
    *
-   * @defaultValue `occurences`
+   * @defaultValue `occurrences`
    */
   sortCriteria?: CategoryFacetSortCriterion;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -95,7 +95,7 @@ export default class QuanticCategoryFacet extends LightningElement {
    * The sort criterion to apply to the returned facet values.
    * Possible values are:
    *   - `alphanumeric`: Filters are sorted in alphanumerical order.
-   *   - `occurrences`: Filters are sorted in descending order of number of occurences.
+   *   - `occurrences`: Filters are sorted in descending order of number of occurrences.
    * @api
    * @type {'alphanumeric' | 'occurrences'}
    * @defaultValue `'occurrences'`

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -72,7 +72,7 @@ export default class QuanticFacet extends LightningElement {
    * Possible values are:
    *   - `score`
    *   - `alphanumeric`
-   *   - `occurences`
+   *   - `occurrences`
    *   - `automatic`
    * @api
    * @type  {'score' | 'alphanumeric' | 'occurrences' | 'automatic'}


### PR DESCRIPTION
`occurrences` is spelled with 2 Rs