### PR TITLE
docs(atomic): documentation for wrapper component + README for result templates

### DIFF
--- a/packages/atomic-react/README.md
+++ b/packages/atomic-react/README.md
@@ -33,21 +33,21 @@ It is important to respect the folder hierarchy, with SVG icons under the `asset
 
 ## Result templates
 
-Creating different type of results templates based on the type of content returned by the Coveo platform is a very common theme when building a Coveo search page.
+Rendering different types of result templates based on the type of content returned by the Coveo platform is very common when building a Coveo search page.
 
-The way to create result templates for an HTML project using the [core Atomic library](https://docs.coveo.com/en/atomic/latest/usage/create-a-result-list/) involves defining one or multiple `atomic-result-templates`, configured with HTML properties, adding conditions on the attributes and metadata of each results.
+The way to create result templates for an HTML project using the [core Atomic library](https://docs.coveo.com/en/atomic/latest/usage/create-a-result-list/) involves defining one or multiple `atomic-result-template` components, configured with HTML properties, adding conditions on the attributes and metadata of each results.
 
-Coupled with the [template](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) HTML tag, this works very well in a pure HTML project.
+Coupled with the [`<template>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) HTML tag, this works very well in a pure HTML project.
 
 However, this can be limiting and awkward to use in a React project using JSX.
 
-Atomic React expose an `AtomicResultList` component with a `template` props that can be used in a more straightforward manner when coupled with JSX.
+Atomic React exposes an `AtomicResultList` component with a `template` property that can be used in a more straightforward manner when coupled with JSX.
 
-The `template` property accept a function with a `Result` parameter, which can then be used to conditionnally render different templates based on properties and fields available on the result.
+The `template` property accepts a function with a `Result` parameter, which can then be used to conditionally render different templates based on properties and fields available in result items.
 
 The `template` function must then simply return a valid JSX Element.
 
-Here is an example of a fictitious search page, which define some premade templates for YouTube videos, as well as Salesforce cases:
+Here is an example of a fictitious search page, which defines some premade templates for YouTube videos, as well as Salesforce cases:
 
 ```jsx
 const MyResultTemplateForYouTubeVideos: React.FC<{result: Result}> = ({

--- a/packages/atomic-react/README.md
+++ b/packages/atomic-react/README.md
@@ -33,17 +33,21 @@ It is important to respect the folder hierarchy, with SVG icons under the `asset
 
 ## Result templates
 
-Creating different type of results templates based on the type of content returned for a particular query is a very common theme when build a Coveo search page.
+Creating different type of results templates based on the type of content returned by the Coveo platform is a very common theme when building a Coveo search page.
 
-The way to create result templates for an HTML project using the [core Atomic library](https://docs.coveo.com/en/atomic/latest/usage/create-a-result-list/) involves defining one or multiple `atomic-result-templates`, configured with HTML based conditions on the attributes and properties of each results, coupled with the [template](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) HTML tag.
+The way to create result templates for an HTML project using the [core Atomic library](https://docs.coveo.com/en/atomic/latest/usage/create-a-result-list/) involves defining one or multiple `atomic-result-templates`, configured with HTML properties, adding conditions on the attributes and metadata of each results.
 
-While this works very well in an pure HTML based deployment, this can be limiting to use in a React based project using JSX.
+Coupled with the [template](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) HTML tag, this works very well in a pure HTML project.
 
-Atomic React expose an `AtomicResultList` component with a `template` props that can be used in a more straightforward manner when dealing with JSX.
+However, this can be limiting and awkward to use in a React project using JSX.
+
+Atomic React expose an `AtomicResultList` component with a `template` props that can be used in a more straightforward manner when coupled with JSX.
 
 The `template` property accept a function with a `Result` parameter, which can then be used to conditionnally render different templates based on properties and fields available on the result.
 
 The `template` function must then simply return a valid JSX Element.
+
+Here is an example of a fictitious search page, which define some premade templates for YouTube videos, as well as Salesforce cases:
 
 ```jsx
 const MyResultTemplateForYouTubeVideos: React.FC<{result: Result}> = ({
@@ -115,6 +119,7 @@ const MyResultTemplateFunction = (result: Result) => {
   if (result.raw.filetype === 'YoutubeVideo') {
     return <MyResultTemplateForYouTubeVideos result={result} />;
   }
+
   if (result.raw.objecttype === 'Case') {
     return <MyResultTemplateForSalesforceCases result={result} />;
   }

--- a/packages/atomic-react/src/components/ResultListWrapper.tsx
+++ b/packages/atomic-react/src/components/ResultListWrapper.tsx
@@ -9,8 +9,8 @@ import ReactDOMServer from 'react-dom/server';
  */
 interface WrapperProps extends AtomicJSX.AtomicResultList {
   /**
-   * A template function that receives a result parameter,
-   * that can be used to conditionally render different type of result templates based on properties of the result,.
+   * A template function that receives a result parameter.
+   * It can be used to conditionally render different type of result templates based on the properties of each result.
    */
   template: (result: Result) => JSX.Element;
 }

--- a/packages/atomic-react/src/components/ResultListWrapper.tsx
+++ b/packages/atomic-react/src/components/ResultListWrapper.tsx
@@ -9,7 +9,7 @@ import ReactDOMServer from 'react-dom/server';
  */
 interface WrapperProps extends AtomicJSX.AtomicResultList {
   /**
-   * A template function that receives a result parameter.
+   * A template function that takes a result item and outputs its target rendering as a JSX element.
    * It can be used to conditionally render different type of result templates based on the properties of each result.
    */
   template: (result: Result) => JSX.Element;

--- a/packages/atomic-react/src/components/ResultListWrapper.tsx
+++ b/packages/atomic-react/src/components/ResultListWrapper.tsx
@@ -4,10 +4,23 @@ import type {Result} from '@coveo/atomic/headless';
 import {AtomicResultList} from './stencil-generated';
 import ReactDOMServer from 'react-dom/server';
 
+/**
+ * The properties of the AtomicResultList component
+ */
 interface WrapperProps extends AtomicJSX.AtomicResultList {
+  /**
+   * A template function that receives a result parameter,
+   * that can be used to conditionally render different type of result templates based on properties of the result,.
+   */
   template: (result: Result) => JSX.Element;
 }
 
+/**
+ * This component serves as a wrapper for the core AtomicResultList.
+ *
+ * @param props
+ * @returns
+ */
 export const ResultListWrapper: React.FC<WrapperProps> = (props) => {
   const {template, ...otherProps} = props;
   const resultListRef = useRef<HTMLAtomicResultListElement>(null);

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -7,8 +7,27 @@ import {
 import {AtomicSearchInterface} from './stencil-generated/index';
 
 type ExecuteSearch = HTMLAtomicSearchInterfaceElement['executeFirstSearch'];
+/**
+ * The properties of the AtomicSearchInterface component
+ */
 interface WrapperProps extends JSX.AtomicSearchInterface {
+  /**
+   * An optional callback function that can be used to control the execution of the first query.
+   *
+   * If not provided, a default function will be used, to execute the first query immediately after initialization.
+   */
   onReady?: (executeFirstSearch: ExecuteSearch) => Promise<void>;
+  /**
+   * An optional `theme` property can be set in order to load one of the premade Coveo theme.
+   *
+   * Currently, possible values are`coveo`, `accessible` and `none`.
+   *
+   * - `coveo` is the default theme, and will be used if no value is provided. It consist of a set of color that matches the Coveo brand.
+   * - `accessible` is a high contrast theme, best suited for implementations where web accessibility is important.
+   * - `none` means that no premade theme will be loaded. You will have to provide the theme yourself.
+   *
+   * Read more about theming and visual customization here : https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/
+   */
   theme?: string | 'none';
 }
 
@@ -19,6 +38,11 @@ const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'theme'>> = {
   theme: 'coveo',
 };
 
+/**
+ * This component serves as a wrapper for the core AtomicSearchInterface
+ * @param props
+ * @returns
+ */
 export const SearchInterfaceWrapper = (
   props: React.PropsWithChildren<WrapperProps>
 ) => {

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -18,13 +18,13 @@ interface WrapperProps extends JSX.AtomicSearchInterface {
    */
   onReady?: (executeFirstSearch: ExecuteSearch) => Promise<void>;
   /**
-   * An optional `theme` property can be set in order to load one of the premade Coveo theme.
+   * An optional `theme` property can be set in order to load one of the premade Coveo themes.
    *
-   * Possible values are `coveo`, `accessible` and `none`.
+   * Possible values are:
    *
-   * - `coveo` is the default theme, and will be used if no value is provided. It consist of a set of color that matches the Coveo brand.
-   * - `accessible` is a high contrast theme, best suited for implementations where web accessibility is important.
-   * - `none` means that no premade theme will be loaded. You will have to provide the theme yourself.
+   * - `coveo`: the default theme, used if no value is provided. It consists of a set of colors that match the Coveo brand.
+   * - `accessible`: a high contrast theme, best suited for implementations where web accessibility is important.
+   * - `none`: no premade theme will be loaded. You will have to provide the theme yourself.
    *
    * Read more about theming and visual customization here : https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/
    */
@@ -39,7 +39,7 @@ const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'theme'>> = {
 };
 
 /**
- * This component serves as a wrapper for the core AtomicSearchInterface
+ * This component serves as a wrapper for the core AtomicSearchInterface.
  * @param props
  * @returns
  */

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -14,13 +14,13 @@ interface WrapperProps extends JSX.AtomicSearchInterface {
   /**
    * An optional callback function that can be used to control the execution of the first query.
    *
-   * If not provided, a default function will be used, to execute the first query immediately after initialization.
+   * If not provided, a default function will be used, which execute the first query immediately after initialization.
    */
   onReady?: (executeFirstSearch: ExecuteSearch) => Promise<void>;
   /**
    * An optional `theme` property can be set in order to load one of the premade Coveo theme.
    *
-   * Currently, possible values are`coveo`, `accessible` and `none`.
+   * Possible values are `coveo`, `accessible` and `none`.
    *
    * - `coveo` is the default theme, and will be used if no value is provided. It consist of a set of color that matches the Coveo brand.
    * - `accessible` is a high contrast theme, best suited for implementations where web accessibility is important.


### PR DESCRIPTION
@jpmarceau : This is essentially what will need to be documented for Atomic React (everything that appears in the README), and resurfaced on our doc website.

As of this moment, there is not other difference from the basic Atomic library.

https://coveord.atlassian.net/browse/KIT-1360