### PR TITLE
fix(atomic): made screen readers skip colon in "filters" and "sort by"

### DIFF
--- a/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
+++ b/packages/atomic/cypress/integration/breadbox/breadbox-assertions.ts
@@ -77,7 +77,7 @@ export function assertCategoryPathInBreadcrumb(path: string[]) {
 
   it(`should display the selected path "${joinedPath}" in the breadcrumbs`, () => {
     BreadboxSelectors.breadcrumbButton().contains(
-      `${categoryFacetLabel}${joinedPath}`
+      `${categoryFacetLabel}:${joinedPath}`
     );
   });
 }
@@ -85,7 +85,7 @@ export function assertCategoryPathInBreadcrumb(path: string[]) {
 function assertBreadcrumbValueText(facetSelector: string, facetLabel: string) {
   cy.getTextOfAllElements(facetSelector).then((facetValues) => {
     facetValues.forEach((element: string) => {
-      BreadboxSelectors.breadcrumbButton().contains(`${facetLabel}${element}`);
+      BreadboxSelectors.breadcrumbButton().contains(`${facetLabel}:${element}`);
     });
   });
 }

--- a/packages/atomic/cypress/integration/no-results.cypress.ts
+++ b/packages/atomic/cypress/integration/no-results.cypress.ts
@@ -45,7 +45,7 @@ describe('No Results Test Suites', () => {
     it('text content should match', () => {
       cy.get(tag)
         .shadow()
-        .find('[part="no-results"] .quotations')
+        .find('[part="no-results"] [part="highlight"]')
         .should('contain.text', 'gahaiusdhgaiuewjfsf');
     });
   });

--- a/packages/atomic/cypress/utils/componentUtils.ts
+++ b/packages/atomic/cypress/utils/componentUtils.ts
@@ -9,11 +9,11 @@ export function doSortAlphanumeric(originalValues: string[]) {
 }
 
 export function doSortOccurrences(originalValues: string[]) {
+  const getNumericalValue = (value: string) =>
+    parseInt(value.replaceAll(/[,()]/g, ''));
   return originalValues
     .concat()
-    .map((value) => parseInt(value.replaceAll(',', '')))
-    .sort((a, b) => b - a)
-    .map((value) => value.toLocaleString('en'));
+    .sort((a, b) => getNumericalValue(b) - getNumericalValue(a));
 }
 
 export const aliasNoAtSignBuilder = (aliasWithAtSign: IAlias) => {

--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -187,9 +187,9 @@ export class AtomicBreadbox implements InitializableComponent {
         >
           <span
             part="breadcrumb-label"
-            class="max-w-snippet truncate with-colon text-neutral-dark mr-0.5 group-hover:text-primary group-focus:text-primary"
+            class="max-w-snippet truncate text-neutral-dark mr-0.5 group-hover:text-primary group-focus:text-primary"
           >
-            {breadcrumb.label}
+            {this.bindings.i18n.t('with-colon', {text: breadcrumb.label})}
           </span>
           <span
             part="breadcrumb-value"
@@ -370,8 +370,10 @@ export class AtomicBreadbox implements InitializableComponent {
 
     return (
       <div class="text-on-background text-sm flex">
-        <span part="label" class="font-bold p-2 pl-0 with-colon">
-          {this.bindings.i18n.t('filters')}
+        <span part="label" class="font-bold p-2 pl-0">
+          {this.bindings.i18n.t('with-colon', {
+            text: this.bindings.i18n.t('filters'),
+          })}
         </span>
         <div class="relative flex-grow">
           <ul

--- a/packages/atomic/src/components/atomic-no-results/atomic-no-results.tsx
+++ b/packages/atomic/src/components/atomic-no-results/atomic-no-results.tsx
@@ -65,7 +65,10 @@ export class AtomicNoResults {
   }
 
   private wrapHighlight(content: string) {
-    return `<span class="font-bold quotations" part="highlight">${content}</span>`;
+    return `<span class="font-bold" part="highlight">${this.bindings.i18n.t(
+      'between-quotations',
+      {text: content}
+    )}</span>`;
   }
 
   private renderMagnifyingGlass() {

--- a/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
@@ -232,10 +232,12 @@ export class AtomicRefineModal implements InitializableComponent {
           <span class="truncate mr-1">
             {this.bindings.i18n.t('view-results')}
           </span>
-          <span class="with-parentheses">
-            {this.querySummaryState.total.toLocaleString(
-              this.bindings.i18n.language
-            )}
+          <span>
+            {this.bindings.i18n.t('between-parentheses', {
+              text: this.querySummaryState.total.toLocaleString(
+                this.bindings.i18n.language
+              ),
+            })}
           </span>
         </Button>
       </div>

--- a/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
+++ b/packages/atomic/src/components/atomic-sort-dropdown/atomic-sort-dropdown.tsx
@@ -109,11 +109,13 @@ export class AtomicSortDropdown implements InitializableComponent {
   private renderLabel() {
     return (
       <label
-        class="m-2 font-bold text-sm with-colon cursor-pointer"
+        class="m-2 font-bold text-sm cursor-pointer"
         part="label"
         htmlFor={this.id}
       >
-        {this.bindings.i18n.t('sort-by')}
+        {this.bindings.i18n.t('with-colon', {
+          text: this.bindings.i18n.t('sort-by'),
+        })}
       </label>
     );
   }

--- a/packages/atomic/src/components/facets/category-facet-search-result/category-facet-search-result.tsx
+++ b/packages/atomic/src/components/facets/category-facet-search-result/category-facet-search-result.tsx
@@ -74,7 +74,9 @@ export const CategoryFacetSearchResult: FunctionalComponent<CategoryFacetSearchR
               searchQuery={searchQuery}
             ></FacetValueLabelHighlight>
             <span part="value-count" class="value-count">
-              {count}
+              {i18n.t('between-parentheses', {
+                text: count,
+              })}
             </span>
           </div>
           <div

--- a/packages/atomic/src/components/facets/color-facet-checkbox/color-facet-checkbox.tsx
+++ b/packages/atomic/src/components/facets/color-facet-checkbox/color-facet-checkbox.tsx
@@ -40,7 +40,9 @@ export const ColorFacetCheckbox: FunctionalComponent<FacetValueProps> = (
       >
         {children}
         <span part="value-count" class="value-count">
-          {count}
+          {props.i18n.t('between-parentheses', {
+            text: count,
+          })}
         </span>
       </label>
     </li>

--- a/packages/atomic/src/components/facets/facet-common.pcss
+++ b/packages/atomic/src/components/facets/facet-common.pcss
@@ -1,3 +1,3 @@
 .value-count {
-  @apply ml-1.5 text-neutral-dark with-parentheses;
+  @apply ml-1.5 text-neutral-dark;
 }

--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
@@ -28,9 +28,11 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
         <span
           title={count}
           part="value-count"
-          class="value-box-count text-neutral-dark truncate with-parentheses w-full text-sm mt-1"
+          class="value-box-count text-neutral-dark truncate w-full text-sm mt-1"
         >
-          {count}
+          {props.i18n.t('between-parentheses', {
+            text: count,
+          })}
         </span>
       </Button>
     </li>

--- a/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -50,7 +50,9 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
       >
         {children}
         <span part="value-count" class="value-count">
-          {count}
+          {props.i18n.t('between-parentheses', {
+            text: count,
+          })}
         </span>
       </label>
     </li>

--- a/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
@@ -26,7 +26,9 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
       >
         {children}
         <span part="value-count" class="value-count">
-          {count}
+          {props.i18n.t('between-parentheses', {
+            text: count,
+          })}
         </span>
       </Button>
     </li>

--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -84,10 +84,6 @@
     content: ')';
   }
 
-  .with-colon::after {
-    content: ':';
-  }
-
   .quotations::before,
   .quotations::after {
     content: '"';

--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -76,19 +76,6 @@
     border: none;
   }
 
-  .with-parentheses::before {
-    content: '(';
-  }
-
-  .with-parentheses::after {
-    content: ')';
-  }
-
-  .quotations::before,
-  .quotations::after {
-    content: '"';
-  }
-
   .no-outline {
     @apply focus-visible:outline-none;
   }

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -1129,5 +1129,13 @@
   "with-colon": {
     "en": "{{text}}:",
     "fr": "{{text}}\u00A0:"
+  },
+  "between-quotations": {
+    "en": "\"{{text}}\"",
+    "fr": "«\u00A0{{text}}\u00A0»"
+  },
+  "between-parentheses": {
+    "en": "({{text}})",
+    "fr": "(\u00A0{{text}}\u00A0)"
   }
 }

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -1125,5 +1125,9 @@
   "stars-range": {
     "en": "{{value}} to {{count}} stars",
     "fr": "{{value}} à {{count}} étoiles"
+  },
+  "with-colon": {
+    "en": "{{text}}:",
+    "fr": "{{text}}\u00A0:"
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1087

In the case of "filter:" at-least, the colon (`:`) symbol being inside a `::after` caused screen readers to select it individually. In the first commit, I extracted the colon symbol out of `::after` blocks.

In the second commit (so I can revert it if you guys think it's too out-of-scope), I did the same thing for parentheses (which are notably used in every facet) and quotation marks. I didn't spot accessibility issues with those, these changes are mostly preventive. As a bonus, those are all localized, now.