### PR TITLE
fix(auth): send organizationId as query string param during handshake

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -12,14 +12,14 @@ npm i @coveo/auth
 
 1. Configure a [SAML authentication provider](https://docs.coveo.com/en/91/#creating-a-search-api-saml-authentication-provider) on your organization.
 
-2. Instantiate the SAML client provided by this package in your web application.
+2. Inside your web application, instantiate the SAML client in this package.
 
-### Sample
+### Example
 ```
 import {buildSamlClient} from '@coveo/auth`;
 
-const organizationId = '<your organization id>';
-const provider = '<your configured SAML provider name>';
+const organizationId = '<organization id>';
+const provider = '<configured SAML auth provider name>';
 
 async function main() {
   const saml = buildSamlClient({organizationId, provider});
@@ -29,7 +29,7 @@ async function main() {
 
 main();
 ```
-### Sample with `@coveo/headless`
+### Example with `@coveo/headless`
 
 ```
 import {buildSamlClient} from '@coveo/auth`;
@@ -50,7 +50,11 @@ async function main() {
 
 main()
 ```
-React sample [available here](../samples/headless-react/src/pages/SamlPage.tsx).
+### Example with `@coveo/headless` and `React`
+
+- Code example [available here](../samples/headless-react/src/pages/SamlPage.tsx).
+
+## Reference
 
 ### `SamlClientOptions`
 

--- a/packages/auth/src/saml/saml-flow.test.ts
+++ b/packages/auth/src/saml/saml-flow.test.ts
@@ -72,14 +72,17 @@ describe('buildSamlFlow', () => {
   describe('#exchangeHandshakeToken', () => {
     describe('url hash contains handshake token', () => {
       beforeEach(() => {
+        options.organizationId = '1';
         options.location!.hash = `#t=All&sort=relevancy&handshake_token=${handshakeToken}`;
+
+        initSamlFlow();
       });
 
       it('sends a request with the token', () => {
         provider.exchangeHandshakeToken();
 
         expect(request).toHaveBeenCalledWith(
-          'https://platform.cloud.coveo.com/rest/search/v2/login/handshake/token',
+          `https://platform.cloud.coveo.com/rest/search/v2/login/handshake/token?organizationId=${options.organizationId}`,
           {
             method: 'POST',
             body: JSON.stringify({handshakeToken}),

--- a/packages/auth/src/saml/saml-flow.test.ts
+++ b/packages/auth/src/saml/saml-flow.test.ts
@@ -93,6 +93,17 @@ describe('buildSamlFlow', () => {
         );
       });
 
+      it('if the organization id has an unsafe url character, it encodes it', () => {
+        options.organizationId = '>';
+        initSamlFlow();
+
+        provider.exchangeHandshakeToken();
+        expect(request).toHaveBeenCalledWith(
+          'https://platform.cloud.coveo.com/rest/search/v2/login/handshake/token?organizationId=%3E',
+          expect.any(Object)
+        );
+      });
+
       it('url hash starts with handshake token param, it exchanges the token', () => {
         options.location!.hash = `#handshake_token=${handshakeToken}`;
         provider.exchangeHandshakeToken();

--- a/packages/auth/src/saml/saml-flow.ts
+++ b/packages/auth/src/saml/saml-flow.ts
@@ -33,18 +33,21 @@ export function buildSamlFlow(config: SamlFlowOptions): SamlFlow {
     },
 
     async exchangeHandshakeToken() {
-      const {location, history, request} = options;
+      const {organizationId, location, history, request} = options;
       const handshakeToken = getHandshakeToken(location);
       removeHandshakeToken(location, history);
 
       try {
-        const response = await request(`${api}/handshake/token`, {
-          method: 'POST',
-          body: JSON.stringify({handshakeToken}),
-          headers: {
-            'content-type': 'application/json; charset=UTF-8',
-          },
-        });
+        const response = await request(
+          `${api}/handshake/token?organizationId=${organizationId}`,
+          {
+            method: 'POST',
+            body: JSON.stringify({handshakeToken}),
+            headers: {
+              'content-type': 'application/json; charset=UTF-8',
+            },
+          }
+        );
         const data = await response.json();
         return data.token;
       } catch (e) {

--- a/packages/auth/src/saml/saml-flow.ts
+++ b/packages/auth/src/saml/saml-flow.ts
@@ -34,12 +34,13 @@ export function buildSamlFlow(config: SamlFlowOptions): SamlFlow {
 
     async exchangeHandshakeToken() {
       const {organizationId, location, history, request} = options;
+      const encodedOrgId = encodeURIComponent(organizationId);
       const handshakeToken = getHandshakeToken(location);
       removeHandshakeToken(location, history);
 
       try {
         const response = await request(
-          `${api}/handshake/token?organizationId=${organizationId}`,
+          `${api}/handshake/token?organizationId=${encodedOrgId}`,
           {
             method: 'POST',
             body: JSON.stringify({handshakeToken}),


### PR DESCRIPTION
In collaboration with the searchapi team, we wanted to remove the need to send an organizationId during the SAML handshake.
The goal was to make the handshake token necessary and sufficient.

However, [it turns out](https://coveord.atlassian.net/browse/SEARCHAPI-6571) that this is complex to change in the service.

This PR adjusts to send the org id during handshake.

https://coveord.atlassian.net/browse/KIT-1382