### PR TITLE
test(atomic-react): improve stability of atomic-react smoke tests

### DIFF
--- a/packages/samples/headless-react/cypress/integration/atomic-react/smoke-test.cypress.ts
+++ b/packages/samples/headless-react/cypress/integration/atomic-react/smoke-test.cypress.ts
@@ -1,4 +1,14 @@
-describe('smoke test', () => {
+describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
+  // Context: https://stackoverflow.com/a/50387233
+  // This is a benign error that can be safely ignored
+  const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+  Cypress.on('uncaught:exception', (err) => {
+    if (resizeObserverLoopErrRe.test(err.message)) {
+      return false;
+    }
+    return true;
+  });
+
   it('should load', () => {
     cy.visit('http://localhost:3000/atomic-react').wait(1000);
     cy.get('atomic-search-box')

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -36,7 +36,7 @@
     "ssr:build": "npm run build && npm run build:server",
     "ssr:start": "node ./build/server/server/server.js",
     "copy:assets": "ncp node_modules/@coveo/atomic-react/dist/assets public/assets && ncp node_modules/@coveo/atomic-react/dist/lang public/lang",
-    "link:atomic-react": "pushd ../../atomic-react && npm link ../samples/headless-react/node_modules/react/",
+    "link:atomic-react": "cd ../../atomic-react && npm link ../samples/headless-react/node_modules/react/",
     "cypress:open": "cypress open"
   },
   "browserslist": {

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -28,14 +28,16 @@
   },
   "scripts": {
     "prepublishOnly": "exit 1",
-    "dev": "npm run copy:assets && react-scripts start",
+    "dev": "npm run copy:assets && npm run link:atomic-react && react-scripts start",
     "build": "tsc --noEmit",
     "build:server": "tsc --project ./tsconfig.server.json",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "ssr:build": "npm run build && npm run build:server",
     "ssr:start": "node ./build/server/server/server.js",
-    "copy:assets": "ncp node_modules/@coveo/atomic-react/dist/assets public/assets && ncp node_modules/@coveo/atomic-react/dist/lang public/lang"
+    "copy:assets": "ncp node_modules/@coveo/atomic-react/dist/assets public/assets && ncp node_modules/@coveo/atomic-react/dist/lang public/lang",
+    "link:atomic-react": "pushd ../../atomic-react && npm link ../samples/headless-react/node_modules/react/",
+    "cypress:open": "cypress open"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
* Add a script to `npm link` local react instance when running the samples in dev
* Add a larger viewport for the smoke tests, I can't be bothered with making the sample responsive on all devices :D 
* The regex check on the resize observer, from the google search I've done, seems to be what many people recommend, as it is apparently a benign error that is reported by Chrome. And cypress will automatically fail on any console error being thrown.

Now, I'm not sure what actually causes this error to happen. I suspect a deeper performance issue in Atomic as a whole (nothing to do with Atomic React), that simply (sometimes) gets triggered in the "full commerce page sample" because it uses many components. But I don't think the performance issue is critical. Just not as good as it could be in a perfect world, I guess.

So, I propose just shoving it under the rug for now.

https://coveord.atlassian.net/browse/KIT-1389