### PR TITLE
feat(headless): allow toggleSelectFacetValue to add new values

### DIFF
--- a/packages/atomic/src/pages/examples/headless.html
+++ b/packages/atomic/src/pages/examples/headless.html
@@ -29,7 +29,7 @@
 
       async function main() {
         await customElements.whenDefined('atomic-search-interface');
-        const searchInterface = document.querySelector('#search');
+        const searchInterface = document.querySelector('atomic-search-interface');
         await searchInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions-loader.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions-loader.ts
@@ -54,7 +54,7 @@ export interface FacetSetActionCreators {
   ): PayloadAction<RegisterFacetActionCreatorPayload>;
 
   /**
-   * Toggles a facet value.
+   * Toggles a facet value. If the value does not exist, it is added.
    *
    * @param payload - The action creator payload.
    * @returns A dispatchable action.

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -183,26 +183,33 @@ describe('facet-set slice', () => {
       expect(targetValue?.state).toBe('idle');
     });
 
-    it('adds new values', () => {
+    it('adds a new value before idle values when it does not exist', () => {
       const id = '1';
 
-      const facetValue = buildMockFacetValue({value: 'TED'});
+      const newFacetValue = buildMockFacetValue({
+        value: 'TED',
+        state: 'selected',
+      });
 
-      state[id] = buildMockFacetRequest({currentValues: []});
+      state[id] = buildMockFacetRequest({
+        currentValues: [
+          buildMockFacetValue({value: 'selected1', state: 'selected'}),
+          buildMockFacetValue({value: 'selected2', state: 'selected'}),
+          buildMockFacetValue({value: 'idle1', state: 'idle'}),
+          buildMockFacetValue({value: 'idle2', state: 'idle'}),
+        ],
+      });
 
       const action = toggleSelectFacetValue({
         facetId: id,
-        selection: facetValue,
+        selection: newFacetValue,
       });
-      const finalState = facetSetReducer(state, action);
 
-      const targetValue = finalState[id].currentValues.find(
-        (req) => req.value === facetValue.value
-      );
-      expect(targetValue).toEqual(facetValue);
+      const finalState = facetSetReducer(state, action);
+      expect(finalState[id].currentValues.indexOf(newFacetValue)).toBe(2);
     });
 
-    it('sets #freezeCurrentValues to true', () => {
+    it('sets #freezeCurrentValues to true when toggled value exists', () => {
       const id = '1';
 
       const facetValue = buildMockFacetValue({value: 'TED'});
@@ -217,6 +224,20 @@ describe('facet-set slice', () => {
       const finalState = facetSetReducer(state, action);
 
       expect(finalState[id].freezeCurrentValues).toBe(true);
+    });
+
+    it('does not #freezeCurrentValues to true when toggled value exists', () => {
+      const id = '1';
+
+      state[id] = buildMockFacetRequest({currentValues: []});
+
+      const action = toggleSelectFacetValue({
+        facetId: id,
+        selection: buildMockFacetValue({value: 'TED'}),
+      });
+      const finalState = facetSetReducer(state, action);
+
+      expect(finalState[id].freezeCurrentValues).toBe(false);
     });
 
     it('sets #preventAutoSelect to true', () => {

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -226,7 +226,7 @@ describe('facet-set slice', () => {
       expect(finalState[id].freezeCurrentValues).toBe(true);
     });
 
-    it('does not set #freezeCurrentValues to true when toggled value does not exists , () => {
+    it('does not set #freezeCurrentValues to true when toggled value does not exists', () => {
       const id = '1';
 
       state[id] = buildMockFacetRequest({currentValues: []});

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -226,7 +226,7 @@ describe('facet-set slice', () => {
       expect(finalState[id].freezeCurrentValues).toBe(true);
     });
 
-    it('does not #freezeCurrentValues to true when toggled value exists', () => {
+    it('does not set #freezeCurrentValues to true when toggled value exists', () => {
       const id = '1';
 
       state[id] = buildMockFacetRequest({currentValues: []});

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -226,7 +226,7 @@ describe('facet-set slice', () => {
       expect(finalState[id].freezeCurrentValues).toBe(true);
     });
 
-    it('does not set #freezeCurrentValues to true when toggled value exists does not', () => {
+    it('does not set #freezeCurrentValues to true when toggled value does not exists , () => {
       const id = '1';
 
       state[id] = buildMockFacetRequest({currentValues: []});

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -183,6 +183,25 @@ describe('facet-set slice', () => {
       expect(targetValue?.state).toBe('idle');
     });
 
+    it('adds new values', () => {
+      const id = '1';
+
+      const facetValue = buildMockFacetValue({value: 'TED'});
+
+      state[id] = buildMockFacetRequest({currentValues: []});
+
+      const action = toggleSelectFacetValue({
+        facetId: id,
+        selection: facetValue,
+      });
+      const finalState = facetSetReducer(state, action);
+
+      const targetValue = finalState[id].currentValues.find(
+        (req) => req.value === facetValue.value
+      );
+      expect(targetValue).toEqual(facetValue);
+    });
+
     it('sets #freezeCurrentValues to true', () => {
       const id = '1';
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -143,118 +143,127 @@ describe('facet-set slice', () => {
   });
 
   describe('dispatching #toggleSelectFacetValue with a registered facet id', () => {
-    it('sets the state of an idle value to selected', () => {
-      const id = '1';
+    const id = '1';
+    describe('when the facet value exists', () => {
+      it('sets the state of an idle value to selected', () => {
+        const facetValue = buildMockFacetValue({value: 'TED'});
+        const facetValueRequest = convertFacetValueToRequest(facetValue);
 
-      const facetValue = buildMockFacetValue({value: 'TED'});
-      const facetValueRequest = convertFacetValueToRequest(facetValue);
+        state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
 
-      state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: facetValue,
+        });
+        const finalState = facetSetReducer(state, action);
 
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: facetValue,
+        const targetValue = finalState[id].currentValues.find(
+          (req) => req.value === facetValue.value
+        );
+        expect(targetValue?.state).toBe('selected');
       });
-      const finalState = facetSetReducer(state, action);
 
-      const targetValue = finalState[id].currentValues.find(
-        (req) => req.value === facetValue.value
-      );
-      expect(targetValue?.state).toBe('selected');
+      it('sets the state of a selected value to idle', () => {
+        const facetValue = buildMockFacetValue({
+          value: 'TED',
+          state: 'selected',
+        });
+        const facetValueRequest = convertFacetValueToRequest(facetValue);
+
+        state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
+
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: facetValue,
+        });
+        const finalState = facetSetReducer(state, action);
+
+        const targetValue = finalState[id].currentValues.find(
+          (req) => req.value === facetValue.value
+        );
+        expect(targetValue?.state).toBe('idle');
+      });
+
+      it('sets #freezeCurrentValues to true', () => {
+        const facetValue = buildMockFacetValue({value: 'TED'});
+        const facetValueRequest = convertFacetValueToRequest(facetValue);
+
+        state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
+
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: facetValue,
+        });
+        const finalState = facetSetReducer(state, action);
+
+        expect(finalState[id].freezeCurrentValues).toBe(true);
+      });
+
+      it('sets #preventAutoSelect to true', () => {
+        const facetValue = buildMockFacetValue({value: 'TED'});
+        const facetValueRequest = convertFacetValueToRequest(facetValue);
+
+        state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
+
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: facetValue,
+        });
+        const finalState = facetSetReducer(state, action);
+
+        expect(finalState[id].preventAutoSelect).toBe(true);
+      });
     });
 
-    it('sets the state of a selected value to idle', () => {
-      const id = '1';
+    describe('when the facet value does not exists', () => {
+      it('replaces the first idle value with the new value', () => {
+        const newFacetValue = buildMockFacetValue({
+          value: 'TED',
+          state: 'selected',
+        });
 
-      const facetValue = buildMockFacetValue({value: 'TED', state: 'selected'});
-      const facetValueRequest = convertFacetValueToRequest(facetValue);
+        state[id] = buildMockFacetRequest({
+          currentValues: [
+            buildMockFacetValue({value: 'selected1', state: 'selected'}),
+            buildMockFacetValue({value: 'selected2', state: 'selected'}),
+            buildMockFacetValue({value: 'idle1', state: 'idle'}),
+            buildMockFacetValue({value: 'idle2', state: 'idle'}),
+          ],
+        });
 
-      state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: newFacetValue,
+        });
 
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: facetValue,
-      });
-      const finalState = facetSetReducer(state, action);
-
-      const targetValue = finalState[id].currentValues.find(
-        (req) => req.value === facetValue.value
-      );
-      expect(targetValue?.state).toBe('idle');
-    });
-
-    it('adds a new value before idle values when it does not exist', () => {
-      const id = '1';
-
-      const newFacetValue = buildMockFacetValue({
-        value: 'TED',
-        state: 'selected',
+        const finalState = facetSetReducer(state, action);
+        expect(finalState[id].currentValues.indexOf(newFacetValue)).toBe(2);
+        expect(finalState[id].currentValues.length).toBe(4);
       });
 
-      state[id] = buildMockFacetRequest({
-        currentValues: [
-          buildMockFacetValue({value: 'selected1', state: 'selected'}),
-          buildMockFacetValue({value: 'selected2', state: 'selected'}),
-          buildMockFacetValue({value: 'idle1', state: 'idle'}),
-          buildMockFacetValue({value: 'idle2', state: 'idle'}),
-        ],
+      it('does not set #freezeCurrentValues to true', () => {
+        state[id] = buildMockFacetRequest({currentValues: []});
+
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: buildMockFacetValue({value: 'TED'}),
+        });
+        const finalState = facetSetReducer(state, action);
+
+        expect(finalState[id].freezeCurrentValues).toBe(false);
       });
 
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: newFacetValue,
+      it('sets #preventAutoSelect to true', () => {
+        state[id] = buildMockFacetRequest({currentValues: []});
+
+        const action = toggleSelectFacetValue({
+          facetId: id,
+          selection: buildMockFacetValue({value: 'TED'}),
+        });
+        const finalState = facetSetReducer(state, action);
+
+        expect(finalState[id].preventAutoSelect).toBe(true);
       });
-
-      const finalState = facetSetReducer(state, action);
-      expect(finalState[id].currentValues.indexOf(newFacetValue)).toBe(2);
-    });
-
-    it('sets #freezeCurrentValues to true when toggled value exists', () => {
-      const id = '1';
-
-      const facetValue = buildMockFacetValue({value: 'TED'});
-      const facetValueRequest = convertFacetValueToRequest(facetValue);
-
-      state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
-
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: facetValue,
-      });
-      const finalState = facetSetReducer(state, action);
-
-      expect(finalState[id].freezeCurrentValues).toBe(true);
-    });
-
-    it('does not set #freezeCurrentValues to true when toggled value does not exists', () => {
-      const id = '1';
-
-      state[id] = buildMockFacetRequest({currentValues: []});
-
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: buildMockFacetValue({value: 'TED'}),
-      });
-      const finalState = facetSetReducer(state, action);
-
-      expect(finalState[id].freezeCurrentValues).toBe(false);
-    });
-
-    it('sets #preventAutoSelect to true', () => {
-      const id = '1';
-
-      const facetValue = buildMockFacetValue({value: 'TED'});
-      const facetValueRequest = convertFacetValueToRequest(facetValue);
-
-      state[id] = buildMockFacetRequest({currentValues: [facetValueRequest]});
-
-      const action = toggleSelectFacetValue({
-        facetId: id,
-        selection: facetValue,
-      });
-      const finalState = facetSetReducer(state, action);
-
-      expect(finalState[id].preventAutoSelect).toBe(true);
     });
   });
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -226,7 +226,7 @@ describe('facet-set slice', () => {
       expect(finalState[id].freezeCurrentValues).toBe(true);
     });
 
-    it('does not set #freezeCurrentValues to true when toggled value exists', () => {
+    it('does not set #freezeCurrentValues to true when toggled value exists does not', () => {
       const id = '1';
 
       state[id] = buildMockFacetRequest({currentValues: []});

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -85,7 +85,7 @@ export const facetSetReducer = createReducer(
           (req) => req.value === selection.value
         );
         if (!existingValue) {
-          insertValueBeforeIdleValues(facetRequest, selection);
+          insertNewValue(facetRequest, selection);
           return;
         }
 
@@ -189,14 +189,14 @@ export const facetSetReducer = createReducer(
         }
 
         const searchResultValue = buildSelectedFacetValueRequest(rawValue);
-        insertValueBeforeIdleValues(facetRequest, searchResultValue);
+        insertNewValue(facetRequest, searchResultValue);
         facetRequest.freezeCurrentValues = true;
         facetRequest.preventAutoSelect = true;
       });
   }
 );
 
-function insertValueBeforeIdleValues(
+function insertNewValue(
   facetRequest: FacetRequest,
   facetValue: FacetValueRequest
 ) {

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -79,16 +79,16 @@ export const facetSetReducer = createReducer(
           return;
         }
 
-        const targetValue = facetRequest.currentValues.find(
+        const existingValue = facetRequest.currentValues.find(
           (req) => req.value === selection.value
         );
 
-        if (!targetValue) {
-          return;
+        if (existingValue) {
+          const isSelected = existingValue.state === 'selected';
+          existingValue.state = isSelected ? 'idle' : 'selected';
+        } else {
+          facetRequest.currentValues.push(selection);
         }
-
-        const isSelected = targetValue.state === 'selected';
-        targetValue.state = isSelected ? 'idle' : 'selected';
 
         facetRequest.freezeCurrentValues = true;
         facetRequest.preventAutoSelect = true;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1388

To try it out with Atomic:

```html
<script type="module">
  import {loadFacetSetActions} from '/build/headless/headless.esm.js';
  async function main() {
    await customElements.whenDefined('atomic-search-interface');
    const searchInterface = document.querySelector(
      'atomic-search-interface'
    );
    await searchInterface.initialize({
      accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
      organizationId: 'searchuisamples',
    });

    const engine = searchInterface.engine;
    const action = loadFacetSetActions(engine).toggleSelectFacetValue({
      facetId: 'author',
      selection: {state: 'selected', value: 'helloooo'},
    });
    engine.dispatch(action);

    searchInterface.executeFirstSearch();
  }
  main();
</script>
```