### PR TITLE
chore: fix eslint warnings

### DIFF
--- a/packages/atomic/cypress/integration/facets/facet-common-actions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-actions.ts
@@ -1,4 +1,3 @@
-import {TestFixture} from '../../fixtures/test-fixture';
 import {
   BaseFacetSelector,
   FacetWithCheckboxSelector,

--- a/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
@@ -1,4 +1,3 @@
-import {TestFixture} from '../../fixtures/test-fixture';
 import {ComponentSelector, should} from '../common-assertions';
 
 export interface BaseFacetSelector extends ComponentSelector {

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-assertions.ts
@@ -1,4 +1,3 @@
-import {TestFixture} from '../../../fixtures/test-fixture';
 import {should} from '../../common-assertions';
 import {NumericFacetSelectors} from './numeric-facet-selectors';
 

--- a/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-assertions.ts
@@ -1,4 +1,3 @@
-import {TestFixture} from '../../../fixtures/test-fixture';
 import {
   BaseFacetSelector,
   FacetWithLinkSelector,

--- a/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet-assertions.ts
@@ -1,4 +1,3 @@
-import {TestFixture} from '../../../fixtures/test-fixture';
 import {should} from '../../common-assertions';
 import {TimeframeFacetSelectors} from './timeframe-facet-selectors';
 

--- a/packages/quantic/cypress/integration/result-quickview/result-quickview.cypress.ts
+++ b/packages/quantic/cypress/integration/result-quickview/result-quickview.cypress.ts
@@ -1,5 +1,5 @@
 import {configure} from '../../page-objects/configurator';
-import {InterceptAliases, interceptSearch} from '../../page-objects/search';
+import {interceptSearch} from '../../page-objects/search';
 import {ResultQuickviewExpectations as Expect} from './result-quickview-expectations';
 import {ResultQuickviewActions as Actions} from './result-quickview-actions';
 import {scope} from '../../reporters/detailed-collector';

--- a/packages/quantic/cypress/integration/result-template/result-template-actions.ts
+++ b/packages/quantic/cypress/integration/result-template/result-template-actions.ts
@@ -7,7 +7,7 @@ const resultTemplateActions = (selector: ResultTemplateSelector) => {
   return {
     appendChildren: (
       tagElement: string,
-      props: any = {},
+      props: Record<string, string> = {},
       innerHtml?: string
     ) => {
       selector


### PR DESCRIPTION
Fixed some warnings related to unused imports, and using the `any` type.

https://coveord.atlassian.net/browse/KIT-1400