### PR TITLE
fix(atomic-angular): fix custom result templates for atomic angular

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/atomic-angular.module.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/atomic-angular.module.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* auto-generated angular module */
 import {CommonModule} from '@angular/common';
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {APP_INITIALIZER, ModuleWithProviders, NgModule, Provider} from '@angular/core';
 
         
 import {
@@ -134,10 +134,38 @@ AtomicTimeframeFacet
 ]
 
         
+const shimTemplates = ()=> {
+  // Angular's renderer will add children to a <template> instead of to its
+  // content. This shim will force any children added to a <template> to be
+  // added to its content instead.
+  // https://github.com/angular/angular/issues/15557
+  const nativeAppend = HTMLTemplateElement && HTMLTemplateElement.prototype && HTMLTemplateElement.prototype.appendChild;
+  if(!nativeAppend) {
+    return;
+  }
+  HTMLTemplateElement.prototype.appendChild = function<T extends Node>(
+    childNode: T
+  ) {
+    if (this.content) {
+      return this.content.appendChild(childNode);
+    } else {
+      return <T>nativeAppend.apply(this, [childNode]);
+    }
+  };
+}
+
+        
+const SHIM_TEMPLATES_PROVIDER: Provider = {
+  provide: APP_INITIALIZER,
+  multi: true,
+  useValue: shimTemplates
+}
+
+        
 @NgModule({
   declarations: DECLARATIONS,
   exports: DECLARATIONS,
-  providers: [],
+  providers: [SHIM_TEMPLATES_PROVIDER],
   imports: [CommonModule],
 })
 export class AtomicAngularModule {

--- a/packages/atomic/stencil-plugin/atomic-angular-module/index.ts
+++ b/packages/atomic/stencil-plugin/atomic-angular-module/index.ts
@@ -14,7 +14,7 @@ const dashToPascalCase = (str: string) =>
 const imports = `/* tslint:disable */
 /* auto-generated angular module */
 import {CommonModule} from '@angular/common';
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {APP_INITIALIZER, ModuleWithProviders, NgModule, Provider} from '@angular/core';
 `;
 
 const componentImports = (components: string[]) => `
@@ -33,11 +33,41 @@ ${components.join(',\n')}
 ]
 `;
 
+const shimTemplatesPrototype = `
+const shimTemplates = ()=> {
+  // Angular's renderer will add children to a <template> instead of to its
+  // content. This shim will force any children added to a <template> to be
+  // added to its content instead.
+  // https://github.com/angular/angular/issues/15557
+  const nativeAppend = HTMLTemplateElement && HTMLTemplateElement.prototype && HTMLTemplateElement.prototype.appendChild;
+  if(!nativeAppend) {
+    return;
+  }
+  HTMLTemplateElement.prototype.appendChild = function<T extends Node>(
+    childNode: T
+  ) {
+    if (this.content) {
+      return this.content.appendChild(childNode);
+    } else {
+      return <T>nativeAppend.apply(this, [childNode]);
+    }
+  };
+}
+`;
+
+const provider = `
+const SHIM_TEMPLATES_PROVIDER: Provider = {
+  provide: APP_INITIALIZER,
+  multi: true,
+  useValue: shimTemplates
+}
+`;
+
 const atomicAngularModule = `
 @NgModule({
   declarations: DECLARATIONS,
   exports: DECLARATIONS,
-  providers: [],
+  providers: [SHIM_TEMPLATES_PROVIDER],
   imports: [CommonModule],
 })
 export class AtomicAngularModule {
@@ -71,6 +101,8 @@ export function generateAngularModuleDefinition(options: {
         ${componentImports(componentClassNames)}
         ${defineCustomElements}
         ${declarations(componentClassNames)}
+        ${shimTemplatesPrototype}
+        ${provider}
         ${atomicAngularModule}
         `
       );

--- a/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
+++ b/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
@@ -25,12 +25,9 @@
       <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe>
     </atomic-timeframe-facet>
     <atomic-rating-facet field="ec_rating" label="Rating" numberOfIntervals="5"></atomic-rating-facet>
-    <atomic-rating-range-facet
-      field="ec_rating"
-      label="Rating range"
-      numberOfIntervals="5"
-      facetId="ec_rating_range"
-    ></atomic-rating-range-facet>
+    <atomic-rating-range-facet field="ec_rating" label="Rating range" numberOfIntervals="5" facetId="ec_rating_range">
+    </atomic-rating-range-facet>
+    <atomic-facet field="source"></atomic-facet>
   </atomic-facet-manager>
 
   <atomic-breadbox></atomic-breadbox>
@@ -47,27 +44,55 @@
   <div class="results">
     <atomic-did-you-mean></atomic-did-you-mean>
     <atomic-result-list
-      fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      fields-to-include="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      display="grid"
+      image-size="large"
     >
-      <!-- 
-            TODO: Result templates broken with angular
-            <atomic-result-template>
-                <template>
-                    <atomic-result-section-badges>
-                        <atomic-result-badge field="ec_brand"></atomic-result-badge>
-                    </atomic-result-section-badges>
-                    <atomic-result-section-visual>
-                        <atomic-result-image field="ec_images"></atomic-result-image>
-                    </atomic-result-section-visual>
-                    <atomic-result-section-title>
-                        <atomic-result-link></atomic-result-link>
-                    </atomic-result-section-title>
-                    <atomic-result-section-title-metadata>
-                        <atomic-result-rating field="ec_rating"></atomic-result-rating>
-                    </atomic-result-section-title-metadata>
-                </template>
-            </atomic-result-template> 
-            -->
+      <atomic-result-template>
+        <template>
+          <atomic-result-section-title>
+            <h2>
+              <atomic-result-link></atomic-result-link>
+            </h2>
+          </atomic-result-section-title>
+          <atomic-result-section-emphasized>
+            <atomic-result-number field="ec_price">
+              <atomic-format-currency currency="USD"></atomic-format-currency>
+            </atomic-result-number>
+          </atomic-result-section-emphasized>
+          <atomic-result-section-title-metadata>
+            <atomic-result-rating field="ec_rating"></atomic-result-rating>
+            <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
+          </atomic-result-section-title-metadata>
+          <atomic-result-section-badges>
+            <atomic-result-badge field="ec_brand"></atomic-result-badge>
+          </atomic-result-section-badges>
+          <atomic-result-section-visual>
+            <atomic-result-image field="ec_images" aria-hidden="true"></atomic-result-image>
+          </atomic-result-section-visual>
+          <atomic-result-section-excerpt>
+            <atomic-result-text field="ec_shortdesc"></atomic-result-text>
+          </atomic-result-section-excerpt>
+          <atomic-result-section-bottom-metadata>
+            <atomic-result-fields-list>
+              <atomic-field-condition class="field" if-defined="cat_platform">
+                <span class="field-label"> <atomic-text value="Platform"></atomic-text>: </span>
+                <atomic-result-text field="cat_platform"></atomic-result-text>
+              </atomic-field-condition>
+
+              <atomic-field-condition class="field" if-defined="cat_condition">
+                <span class="field-label"> <atomic-text value="Condition"></atomic-text>: </span>
+                <atomic-result-text field="cat_condition"></atomic-result-text>
+              </atomic-field-condition>
+
+              <atomic-field-condition class="field" if-defined="cat_categories">
+                <span class="field-label"> <atomic-text value="Tags"></atomic-text>: </span>
+                <atomic-result-multi-value-text field="cat_categories"></atomic-result-multi-value-text>
+              </atomic-field-condition>
+            </atomic-result-fields-list>
+          </atomic-result-section-bottom-metadata>
+        </template>
+      </atomic-result-template>
     </atomic-result-list>
     <div class="pagination">
       <atomic-load-more-results></atomic-load-more-results>


### PR DESCRIPTION
So, I struggled quite a bit on this one, going far down the rabbit hole of reading a lot about Angular `Content projection` , `ng-template`, `@ViewChild`, `@ContentChildren` etc. trying to understand how angular deals with the native `<template>` tag, and how I could workaround it.

Turns out it's due to a plain bug in angular, linked in the comment I added in `AtomicAngularModule`.

After this change, all the rest of the logic of result templates can stay exactly the same as the core Atomic library.


https://coveord.atlassian.net/browse/KIT-1404