### PR TITLE
feat(atomic-angular): copy static assets for distribution

### DIFF
--- a/packages/atomic-angular/package-lock.json
+++ b/packages/atomic-angular/package-lock.json
@@ -31,6 +31,7 @@
         "karma-coverage": "~2.1.0",
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "~1.7.0",
+        "ncp": "^2.0.0",
         "ng-packagr": "^13.0.0",
         "typescript": "~4.5.2"
       }
@@ -13140,6 +13141,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true,
+      "bin": {
+        "ncp": "bin/ncp"
       }
     },
     "node_modules/needle": {
@@ -29248,6 +29258,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true
     },
     "needle": {
       "version": "2.9.1",

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build"
+    "build": "ng build && npm run copy:assets",
+    "copy:assets": "ncp node_modules/@coveo/atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp node_modules/@coveo/atomic/dist/atomic/lang projects/atomic-angular/dist/lang"
   },
   "private": true,
   "dependencies": {
@@ -31,6 +32,7 @@
     "karma-coverage": "~2.1.0",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "~1.7.0",
+    "ncp": "^2.0.0",
     "ng-packagr": "^13.0.0",
     "typescript": "~4.5.2"
   }

--- a/packages/samples/angular/.gitignore
+++ b/packages/samples/angular/.gitignore
@@ -36,6 +36,8 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
+/src/lang
+/src/assets/*.svg
 
 # System files
 .DS_Store

--- a/packages/samples/angular/angular.json
+++ b/packages/samples/angular/angular.json
@@ -22,7 +22,7 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": ["src/favicon.ico", "src/assets", "src/lang"],
             "styles": [
               "./node_modules/@coveo/atomic/dist/atomic/themes/coveo.css",
               "src/styles.css"
@@ -87,7 +87,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": ["src/favicon.ico", "src/assets", "src/lang"],
             "styles": ["src/styles.css"],
             "scripts": []
           }

--- a/packages/samples/angular/package-lock.json
+++ b/packages/samples/angular/package-lock.json
@@ -28,6 +28,7 @@
         "@angular/compiler-cli": "~13.1.0",
         "@types/jasmine": "~3.10.0",
         "@types/node": "^12.11.1",
+        "ncp": "^2.0.0",
         "typescript": "~4.5.2"
       }
     },
@@ -12925,6 +12926,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true,
+      "bin": {
+        "ncp": "bin/ncp"
       }
     },
     "node_modules/needle": {
@@ -28733,6 +28743,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true
     },
     "needle": {
       "version": "2.9.1",

--- a/packages/samples/angular/package.json
+++ b/packages/samples/angular/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "npm link ../../atomic-angular/projects/atomic-angular/dist/ && ng serve",
-    "watch": "ng build --watch --configuration development"
+    "start": "npm run link:local && npm run copy:assets && ng serve",
+    "watch": "ng build --watch --configuration development",
+    "link:local": "npm link ../../atomic-angular/projects/atomic-angular/dist/",
+    "copy:assets": "ncp node_modules/@coveo/atomic-angular/assets src/assets && ncp node_modules/@coveo/atomic-angular/lang src/lang"
   },
   "private": true,
   "dependencies": {
@@ -28,6 +30,7 @@
     "@angular/compiler-cli": "~13.1.0",
     "@types/jasmine": "~3.10.0",
     "@types/node": "^12.11.1",
+    "ncp": "^2.0.0",
     "typescript": "~4.5.2"
   }
 }


### PR DESCRIPTION
Similar to Atomic React, we need to make it easy to copy and redistribute the static assets.

I will cover the angular specific stuff in the README on my next task, and this will also be explained on our doc site.


https://coveord.atlassian.net/browse/KIT-1405