### PR TITLE
fix(headless): relevance inspector fetchFieldsDescription rename interface & enable by default

### DIFF
--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.test.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.test.ts
@@ -17,6 +17,7 @@ import {
   enableFetchAllFields,
   fetchFieldsDescription,
 } from '../../features/fields/fields-actions';
+import {buildMockFieldDescription} from '../../test/mock-field-description';
 
 describe('RelevanceInspector', () => {
   let engine: MockSearchEngine;
@@ -143,6 +144,18 @@ describe('RelevanceInspector', () => {
       userIdentities: responseWithDebug.userIdentities,
       rankingExpressions: responseWithDebug.rankingExpressions,
       fieldsDescription: [],
+    });
+  });
+
+  it('should return the fieldsDecription correctly, when debug is enabled', () => {
+    const state = createMockState();
+    state.debug = true;
+    state.fields.fieldsDescription = [buildMockFieldDescription()];
+    engine = buildMockSearchAppEngine({state});
+    relevanceInspector = buildRelevanceInspector(engine);
+
+    expect(relevanceInspector.state).toMatchObject({
+      fieldsDescription: state.fields.fieldsDescription,
     });
   });
 });

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.test.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.test.ts
@@ -106,9 +106,15 @@ describe('RelevanceInspector', () => {
     expect(engine.actions).toContainEqual(disableFetchAllFields());
   });
 
-  it(`when calling fetchFieldsDescription()
+  it(`when calling fetchFieldsDescription() with debug disabled
+  it should dispatch an "enableDebug" action`, () => {
+    relevanceInspector.fetchFieldsDescription();
+    expect(engine.actions).toContainEqual(enableDebug());
+  });
+
+  it(`when calling fetchFieldsDescription() 
   it should dispatch an "fetchFieldsDescription" action`, () => {
-    relevanceInspector.fetchFieldDescriptions();
+    relevanceInspector.fetchFieldsDescription();
     expect(engine.findAsyncAction(fetchFieldsDescription.pending)).toBeTruthy();
   });
 

--- a/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
+++ b/packages/headless/src/controllers/relevance-inspector/headless-relevance-inspector.ts
@@ -67,9 +67,13 @@ export interface RelevanceInspectorInitialState {
  */
 export interface RelevanceInspector extends Controller {
   /**
-   * Fetch the description of all fields available from the index.
+   * @deprecated Use `fetchFieldsDescription` instead.
    */
   fetchFieldDescriptions(): void;
+  /**
+   * Fetch the description of all fields available from the index.
+   */
+  fetchFieldsDescription(): void;
   /**
    * Fetch all fields available from the index on each individual results.
    */
@@ -126,9 +130,15 @@ export interface RelevanceInspectorState {
   rankingExpressions?: QueryRankingExpression[];
 
   /**
-   * The description of all fields available in the index.
+   * @deprecated Use `fieldDescriptions`.
    */
   fieldDescriptions?: FieldDescription[];
+
+  /**
+   * The description of all fields available in the index.
+   */
+  fieldsDescription?: FieldDescription[];
+
   /**
    * Whether fields debugging is enabled, returning all fields available on query results.
    */
@@ -257,7 +267,8 @@ export function buildRelevanceInspector(
       dispatch(disableFetchAllFields());
     },
 
-    fetchFieldDescriptions() {
+    fetchFieldsDescription() {
+      !this.state.isEnabled && dispatch(enableDebug());
       dispatch(fetchFieldsDescription());
       warnProductionEnvironment('fieldsDescription');
       engine.logger.warn(
@@ -266,6 +277,10 @@ export function buildRelevanceInspector(
         https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#resultlistoptions
         https://docs.coveo.com/en/headless/latest/reference/search/actions/field/#registerfieldstoinclude`
       );
+    },
+
+    fetchFieldDescriptions() {
+      this.fetchFieldsDescription();
     },
   };
 }

--- a/packages/samples/headless-react/src/components/relevance-inspector/relevance-inspector.class.tsx
+++ b/packages/samples/headless-react/src/components/relevance-inspector/relevance-inspector.class.tsx
@@ -64,7 +64,7 @@ export class RelevanceInspector extends Component<{}, RelevanceInspectorState> {
             }
           />
         </label>
-        <button onClick={() => this.controller.fetchFieldDescriptions()}>
+        <button onClick={() => this.controller.fetchFieldsDescription()}>
           {' '}
           Retrieve fields description
         </button>

--- a/packages/samples/headless-react/src/components/relevance-inspector/relevance-inspector.fn.tsx
+++ b/packages/samples/headless-react/src/components/relevance-inspector/relevance-inspector.fn.tsx
@@ -44,7 +44,7 @@ export const RelevanceInspector: FunctionComponent<RelevanceInspectorProps> = (
           }
         />
       </label>
-      <button onClick={() => controller.fetchFieldDescriptions()}>
+      <button onClick={() => controller.fetchFieldsDescription()}>
         {' '}
         Retrieve fields description
       </button>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1416

fieldsDescription or fieldDescriptions, since it's an array of fields I went for the former.
Currently it's a bit confusing. parts of the code have either naming. Now for the relevance inspector everything is fieldsDescription and the rest has been deprecated.