### PR TITLE
fix(quantic): fix searchbox button style

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
@@ -45,19 +45,10 @@
               </template>
             </div>
             <template if:false={withoutSubmitButton}>
-              <div
-                class="searchbox__submit-button slds-button_brand"
-                onclick={onSubmit}
-              >
-                <lightning-button-icon
-                  title="Submit"
-                  id="fixed-text-addon-post"
-                  icon-class="searchbox__submit-button-icon"
-                  variant="bare-inverse"
-                  icon-name="utility:search"
-                  size="medium"
-                ></lightning-button-icon>
-              </div>
+                <button class="searchbox__submit-button slds-button slds-button_icon-inverse slds-button_icon-brand" title={labels.search} onclick={onSubmit}>
+                  <lightning-icon class="slds-current-color" size="x-small" icon-name="utility:search" alternative-text={labels.search} title={labels.search}></lightning-icon>
+                  <span class="slds-assistive-text">{labels.search}</span>
+                </button>
             </template>
           </div>
 

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.html
@@ -47,19 +47,10 @@
                   </template>
                 </div>
                 <template if:false={withoutSubmitButton}>
-                  <div
-                    class="searchbox__submit-button slds-button_brand"
-                    onclick={onSubmit}
-                  >
-                    <lightning-button-icon
-                      title="Submit"
-                      id="fixed-text-addon-post"
-                      icon-class="searchbox__submit-button-icon"
-                      variant="bare-inverse"
-                      icon-name="utility:search"
-                      size="medium"
-                    ></lightning-button-icon>
-                  </div>
+                  <button class="searchbox__submit-button slds-button slds-button_icon-inverse slds-button_icon-brand" title={labels.search} onclick={onSubmit}>
+                    <lightning-icon class="slds-current-color" size="x-small" icon-name="utility:search" alternative-text={labels.search} title={labels.search}></lightning-icon>
+                    <span class="slds-assistive-text">{labels.search}</span>
+                  </button>
                 </template>
               </div>
 

--- a/packages/quantic/force-app/main/default/lwc/searchBoxStyle/searchBoxStyle.css
+++ b/packages/quantic/force-app/main/default/lwc/searchBoxStyle/searchBoxStyle.css
@@ -6,6 +6,8 @@
   border-color: #e5e8e8;
   height: 48px;
   box-sizing: border-box;
+  border-radius: 0.25rem;
+  overflow: hidden;
 }
 
 .searchbox__input {
@@ -24,14 +26,15 @@
 }
 
 .searchbox__submit-button {
+  width: 46.75px;
+  border-radius: 0;
+  height: 100%;
+}
+
+.searchbox__submit-button:focus {
+  border: none;
   border-top-right-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
-  height: 100%;
-  width: 46.57px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
 }
 
 .searchbox__clear-button {
@@ -40,4 +43,8 @@
 
 .slds-input-has-icon .slds-input__icon.input__icon_cursor:not(button) {
   pointer-events: auto;
+}
+
+input[type="search"] {
+  -webkit-appearance: none;
 }

--- a/packages/quantic/scripts/build/util/sfdx.ts
+++ b/packages/quantic/scripts/build/util/sfdx.ts
@@ -23,7 +23,7 @@ export function sfdx<T = SfdxResponse>(command: string): Promise<T> {
       {
         cwd: process.cwd(),
         env: process.env,
-        maxBuffer: 1024 * 1024,
+        maxBuffer: 1024 * 1024 * 1.5,
       },
       (error, stdout) => {
         (error ? reject : resolve)(


### PR DESCRIPTION
Before
<img width="752" alt="Screen Shot 2022-02-15 at 2 42 25 PM" src="https://user-images.githubusercontent.com/16785453/154136821-5c8a7170-d30f-453b-a515-2a7b19a88fd9.png">

After
<img width="739" alt="Screen Shot 2022-02-15 at 2 42 46 PM" src="https://user-images.githubusercontent.com/16785453/154136845-e29e80b5-8916-4d78-b307-e0cd035fbb55.png">


Changed to make custom button as custom css doesn't collaborate well with SLDS LWC. This should keep us from getting messed up from changes introduced by salesforce.
Also added a CSS instruction to keep the styling on iOS, preventing the search input from getting the extra-rounded style.
