### PR TITLE
fix(headless, quantic):  Update analytics events sent when auto selecting the classification with the highest confidence

### DIFF
--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -81,7 +81,7 @@ describe('Case Field', () => {
       };
     });
 
-    it('dispatches a #logClassificationClick action', () => {
+    it('dispatches a #logClassificationClick action when value is a suggestion', () => {
       field.update('suggested value');
 
       expect(engine.actions).toContainEqual(

--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -119,7 +119,7 @@ describe('Case Field', () => {
       );
     });
 
-    it('does not dispatche a #logCaseFieldUpdate analytics action when the autoSelection parameter is set to true', () => {
+    it('does not dispatch a #logCaseFieldUpdate analytics action when the autoSelection parameter is set to true', () => {
       field.update(testValue, undefined, true);
 
       expect(engine.actions).not.toContainEqual(

--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -81,7 +81,7 @@ describe('Case Field', () => {
       };
     });
 
-    it('dispatches a #logClassificationClick action when value is a suggestion', () => {
+    it('dispatches a #logClassificationClick action when value is a suggestion and autoSelection is falsy ', () => {
       field.update('suggested value');
 
       expect(engine.actions).toContainEqual(
@@ -101,6 +101,16 @@ describe('Case Field', () => {
       );
     });
 
+    it('does not dispatch a #logClassificationClick action when value is a suggestion but autoSelection is truthy', () => {
+      field.update(testValue, undefined, true);
+
+      expect(engine.actions).not.toContainEqual(
+        expect.objectContaining({
+          type: 'analytics/caseAssist/classification/click/pending',
+        })
+      );
+    });
+
     it('dispatches a #updateCaseField action with the passed field value', () => {
       field.update(testValue);
 
@@ -109,10 +119,20 @@ describe('Case Field', () => {
       );
     });
 
-    it('dispatches a #logCaseFieldUpdate analytics action', () => {
+    it('dispatches a #logCaseFieldUpdate analytics action when autoSelection is falsy', () => {
       field.update(testValue);
 
       expect(engine.actions).toContainEqual(
+        expect.objectContaining({
+          type: 'analytics/caseAssist/case/field/update/pending',
+        })
+      );
+    });
+
+    it('does not dispatch a #logCaseFieldUpdate analytics action when autoSelection is truthy', () => {
+      field.update(testValue, undefined, true);
+
+      expect(engine.actions).not.toContainEqual(
         expect.objectContaining({
           type: 'analytics/caseAssist/case/field/update/pending',
         })

--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -81,7 +81,7 @@ describe('Case Field', () => {
       };
     });
 
-    it('dispatches a #logClassificationClick action when value is a suggestion and autoSelection is falsy', () => {
+    it('dispatches a #logClassificationClick action', () => {
       field.update('suggested value');
 
       expect(engine.actions).toContainEqual(
@@ -101,16 +101,6 @@ describe('Case Field', () => {
       );
     });
 
-    it('does not dispatch a #logClassificationClick action when value is a suggestion but autoSelection is truthy', () => {
-      field.update(testValue, undefined, true);
-
-      expect(engine.actions).not.toContainEqual(
-        expect.objectContaining({
-          type: 'analytics/caseAssist/classification/click/pending',
-        })
-      );
-    });
-
     it('dispatches a #updateCaseField action with the passed field value', () => {
       field.update(testValue);
 
@@ -119,7 +109,7 @@ describe('Case Field', () => {
       );
     });
 
-    it('dispatches a #logCaseFieldUpdate analytics action when autoSelection is falsy', () => {
+    it('dispatches a #logCaseFieldUpdate analytics action', () => {
       field.update(testValue);
 
       expect(engine.actions).toContainEqual(
@@ -129,7 +119,7 @@ describe('Case Field', () => {
       );
     });
 
-    it('does not dispatch a #logCaseFieldUpdate analytics action when autoSelection is truthy', () => {
+    it('does not dispatche a #logCaseFieldUpdate analytics action when the autoSelection parameter is set to true', () => {
       field.update(testValue, undefined, true);
 
       expect(engine.actions).not.toContainEqual(

--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -81,7 +81,7 @@ describe('Case Field', () => {
       };
     });
 
-    it('dispatches a #logClassificationClick action when value is a suggestion and autoSelection is falsy ', () => {
+    it('dispatches a #logClassificationClick action when value is a suggestion and autoSelection is falsy', () => {
       field.update('suggested value');
 
       expect(engine.actions).toContainEqual(

--- a/packages/headless/src/controllers/case-field/headless-case-field.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.ts
@@ -74,7 +74,11 @@ export interface CaseField extends Controller {
    * @param value - The field value to set.
    * @param updatesToFetch - A set of flags dictating whether to fetch case assist data after updating the field value.
    */
-  update(value: string, updatesToFetch?: UpdateCaseFieldFetchOptions): void;
+  update(
+    value: string,
+    updatesToFetch?: UpdateCaseFieldFetchOptions,
+    autoSelection?: boolean
+  ): void;
 
   /**
    * A scoped and simplified part of the headless state that is relevant to the `CaseField` controller.
@@ -142,12 +146,16 @@ export function buildCaseField(
       };
     },
 
-    update(value: string, updatesToFetch?: UpdateCaseFieldFetchOptions) {
+    update(
+      value: string,
+      updatesToFetch?: UpdateCaseFieldFetchOptions,
+      autoSelection?: boolean
+    ) {
       const suggestionId = getState().caseField?.fields?.[
         options.field
       ]?.suggestions?.find((s) => s.value === value)?.id;
 
-      if (suggestionId) {
+      if (!autoSelection && suggestionId) {
         dispatch(logClassificationClick(suggestionId));
       }
 
@@ -158,7 +166,9 @@ export function buildCaseField(
         })
       );
 
-      dispatch(logUpdateCaseField(options.field));
+      if (!autoSelection) {
+        dispatch(logUpdateCaseField(options.field));
+      }
 
       updatesToFetch?.caseClassifications &&
         dispatch(fetchCaseClassifications());

--- a/packages/headless/src/controllers/case-field/headless-case-field.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.ts
@@ -9,6 +9,7 @@ import {
   documentSuggestion,
 } from '../../app/reducers';
 import {
+  logAutoSelectCaseField,
   logClassificationClick,
   logUpdateCaseField,
 } from '../../features/case-assist/case-assist-analytics-actions';
@@ -155,8 +156,10 @@ export function buildCaseField(
         options.field
       ]?.suggestions?.find((s) => s.value === value)?.id;
 
-      if (!autoSelection && suggestionId) {
-        dispatch(logClassificationClick(suggestionId));
+      if (suggestionId) {
+        autoSelection
+          ? dispatch(logAutoSelectCaseField(suggestionId))
+          : dispatch(logClassificationClick(suggestionId));
       }
 
       dispatch(

--- a/packages/headless/src/controllers/case-field/headless-case-field.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.ts
@@ -166,9 +166,7 @@ export function buildCaseField(
         })
       );
 
-      if (!autoSelection) {
-        dispatch(logUpdateCaseField(options.field));
-      }
+      !autoSelection && dispatch(logUpdateCaseField(options.field));
 
       updatesToFetch?.caseClassifications &&
         dispatch(fetchCaseClassifications());

--- a/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
@@ -55,6 +55,20 @@ export const logUpdateCaseField = (fieldName: string) =>
       })
   )();
 
+export const logAutoSelectCaseField = (classificationId: string) =>
+  makeCaseAssistAnalyticsAction(
+    'analytics/caseAssist/classification/click',
+    (client, state) =>
+      client.logSelectFieldSuggestion({
+        suggestion: caseAssistCaseClassificationSelector(
+          state,
+          classificationId,
+          true
+        ),
+        ticket: caseAssistCaseSelector(state),
+      })
+  )();
+
 export const logClassificationClick = (classificationId: string) =>
   makeCaseAssistAnalyticsAction(
     'analytics/caseAssist/classification/click',

--- a/packages/headless/src/features/case-assist/case-assist-analytics-selectors.test.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-selectors.test.ts
@@ -217,6 +217,25 @@ describe('case assist analytics selectors', () => {
       });
     });
 
+    it('should return the classification matching the specified ID with the field autoSelection when the autoSelection parameter is set to true', () => {
+      const classification = caseAssistCaseClassificationSelector(
+        buildStateWithCaseField(),
+        'service-suggestion-id',
+        true
+      );
+
+      expect(classification).toMatchObject({
+        autoSelection: true,
+        classificationId: 'service-suggestion-id',
+        responseId: 'last-response-id',
+        fieldName: 'category',
+        classification: {
+          value: 'service',
+          confidence: 0.765,
+        },
+      });
+    });
+
     it('should throw when the classification is not found', () => {
       expect(() =>
         caseAssistCaseClassificationSelector(

--- a/packages/headless/src/features/case-assist/case-assist-analytics-selectors.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-selectors.ts
@@ -72,7 +72,8 @@ export const caseAssistCustomCaseFieldValuesSelector = (
 
 export const caseAssistCaseClassificationSelector = (
   state: Partial<CaseAssistAppState>,
-  classificationId: string
+  classificationId: string,
+  autoSelection = false
 ) => {
   const classificationFieldName = Object.keys(
     state?.caseField?.fields ?? {}
@@ -94,7 +95,7 @@ export const caseAssistCaseClassificationSelector = (
     (suggestion) => suggestion.id === classificationId
   );
 
-  return {
+  const result = {
     classificationId: classification?.id ?? '',
     responseId: state.caseField?.status.lastResponseId ?? '',
     fieldName: classificationFieldName,
@@ -103,6 +104,11 @@ export const caseAssistCaseClassificationSelector = (
       confidence: classification?.confidence ?? 0,
     },
   };
+
+  if (autoSelection) {
+    return {...result, autoSelection};
+  }
+  return result;
 };
 
 export const caseAssistDocumentSuggestionSelector = (

--- a/packages/quantic/cypress/integration/case-classification/case-classification-expectations.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification-expectations.ts
@@ -43,7 +43,7 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
         .logDetail(`${should(display)} display the loading spinner`);
     },
 
-    displayRenderingError: (display: boolean, error) => {
+    displayRenderingError: (display: boolean, error: string) => {
       selector
         .renderingError()
         .should(display ? 'exist' : 'not.exist')
@@ -139,7 +139,7 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
         .logDetail('should log the "ticket_field_update" UA event');
     },
 
-    logClickedSuggestion: (index: number) => {
+    logClickedSuggestion: (index: number, autoSelection = false) => {
       cy.wait(InterceptAliases.UA.ClassificationClick)
         .then((interception) => {
           const analyticsBody = interception.request.body;
@@ -147,6 +147,12 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
             .suggestedOptionInput(index)
             .invoke('attr', 'data-suggestion-id')
             .should('eq', analyticsBody.svc_action_data.classificationId);
+          if (autoSelection) {
+            expect(analyticsBody.svc_action_data).to.have.property(
+              'autoSelection',
+              true
+            );
+          }
         })
         .logDetail('should log the "ticket_classification_click" UA event');
     },

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -70,6 +70,7 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 3;
+        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -81,7 +82,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
         Expect.numberOfInlineOptions(0);
-        Expect.logClickedSuggestion(0, true);
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
       });
 
       scope('when selecting a suggestion', () => {
@@ -181,6 +182,7 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
+        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -189,7 +191,7 @@ describe('quantic-case-classification', () => {
         fetchClassifications();
         Expect.displaySelectTitle(false);
         Expect.numberOfSuggestions(1);
-        Expect.logClickedSuggestion(0, true);
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
         Expect.numberOfInlineOptions(0);
         Expect.displaySelectInput(false);
         Expect.displaySelectTitle(true);
@@ -298,6 +300,7 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
+        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -308,7 +311,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
-        Expect.logClickedSuggestion(0, true);
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
       });
 
       scope('when selecting a suggestion', () => {
@@ -351,6 +354,7 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
+        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -361,7 +365,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
-        Expect.logClickedSuggestion(0, true);
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
       });
     });
   });

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -81,6 +81,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
         Expect.numberOfInlineOptions(0);
+        Expect.logClickedSuggestion(0, true);
       });
 
       scope('when selecting a suggestion', () => {
@@ -188,6 +189,7 @@ describe('quantic-case-classification', () => {
         fetchClassifications();
         Expect.displaySelectTitle(false);
         Expect.numberOfSuggestions(1);
+        Expect.logClickedSuggestion(0, true);
         Expect.numberOfInlineOptions(0);
         Expect.displaySelectInput(false);
         Expect.displaySelectTitle(true);
@@ -306,6 +308,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
+        Expect.logClickedSuggestion(0, true);
       });
 
       scope('when selecting a suggestion', () => {
@@ -358,6 +361,7 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
+        Expect.logClickedSuggestion(0, true);
       });
     });
   });

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -414,6 +414,7 @@ describe('quantic-case-classification', () => {
           allOptions.slice(0, suggestionsCount)
         );
         fetchClassifications();
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
         Expect.displaySelectTitle(true);
         Expect.displaySelectInput(false);
         Expect.numberOfSuggestions(suggestionsCount);

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -70,7 +70,6 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 3;
-        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -82,11 +81,6 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
         Expect.numberOfInlineOptions(0);
-        Expect.logClickedSuggestion(firstSuggestionIndex);
-        Expect.logUpdatedClassificationFromSuggestion(
-          coveoDefaultField,
-          firstSuggestionIndex
-        );
       });
 
       scope('when selecting a suggestion', () => {
@@ -186,7 +180,6 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
-        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -198,11 +191,6 @@ describe('quantic-case-classification', () => {
         Expect.numberOfInlineOptions(0);
         Expect.displaySelectInput(false);
         Expect.displaySelectTitle(true);
-        Expect.logClickedSuggestion(firstSuggestionIndex);
-        Expect.logUpdatedClassificationFromSuggestion(
-          coveoDefaultField,
-          firstSuggestionIndex
-        );
       });
 
       scope('when selecting an option from the select input', () => {
@@ -308,7 +296,6 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
-        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -319,11 +306,6 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
-        Expect.logClickedSuggestion(firstSuggestionIndex);
-        Expect.logUpdatedClassificationFromSuggestion(
-          coveoDefaultField,
-          firstSuggestionIndex
-        );
       });
 
       scope('when selecting a suggestion', () => {
@@ -366,7 +348,6 @@ describe('quantic-case-classification', () => {
 
       scope('when fetching suggestions', () => {
         const suggestionsCount = 2;
-        const firstSuggestionIndex = 0;
 
         mockCaseClassification(
           coveoDefaultField,
@@ -377,11 +358,6 @@ describe('quantic-case-classification', () => {
         Expect.numberOfSuggestions(suggestionsCount);
         Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
         Expect.displaySelectInput(false);
-        Expect.logClickedSuggestion(firstSuggestionIndex);
-        Expect.logUpdatedClassificationFromSuggestion(
-          coveoDefaultField,
-          firstSuggestionIndex
-        );
       });
     });
   });
@@ -433,11 +409,6 @@ describe('quantic-case-classification', () => {
         Expect.displaySelectTitle(true);
         Expect.displaySelectInput(false);
         Expect.numberOfSuggestions(suggestionsCount);
-        Expect.logClickedSuggestion(firstSuggestionIndex);
-        Expect.logUpdatedClassificationFromSuggestion(
-          coveoDefaultField,
-          firstSuggestionIndex
-        );
         Actions.clickSuggestion(firstSuggestionIndex);
         Expect.logDeselect(coveoDefaultField);
         Actions.reportValidity();

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
@@ -169,8 +169,7 @@ export default class QuanticCaseClassification extends LightningElement {
       this.renderingError = `${this.maxSuggestions} is an invalid maximum number of suggestions. A positive integer was expected.`;
     }
     if (!this.coveoFieldName) {
-      this.renderingError =
-        'coveoFieldName is required, please set its value.';
+      this.renderingError = 'coveoFieldName is required, please set its value.';
     }
   }
 
@@ -190,7 +189,7 @@ export default class QuanticCaseClassification extends LightningElement {
         const value = this.classifications.length
           ? this.classifications[0].value
           : '';
-        this.setFieldValue(value);
+        this.setFieldValue(value, true);
       }
     }
   }
@@ -349,8 +348,8 @@ export default class QuanticCaseClassification extends LightningElement {
    * Set the current value and update the state.
    * @returns {void}
    */
-  setFieldValue(value) {
-    this.field.update(value);
+  setFieldValue(value, autoSelection) {
+    this.field.update(value, undefined, autoSelection);
     this._value = value;
   }
 }


### PR DESCRIPTION
[SVCC-456](https://coveord.atlassian.net/browse/SVCC-456)
### What is wrong?
On the first time loading the case classification component (no interaction by user yet), this component already send 2 UA events : `svc_action: "ticket_classification_click"`  & `svc_action: "ticket_field_update"`.
This is happening because from the Quantic side we automatically select the classification with highest confidence when fetching classifications. .

### What is the correct behaviour?

When a value is auto-selected because it has the highest confidence, we should send a "ticket_classification_click" with metadata identifying it as an automatic selection.

#### The Quantic Case Classification component:

https://user-images.githubusercontent.com/86681870/154517620-3da46c16-fb86-4606-9ee9-f951a9c6e330.mov



