### PR TITLE
Fix(Headless, Quantic): Sending the correct analytics event when clicking on the title of the Quickview of a document suggestion

### DIFF
--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -58,3 +58,10 @@ export type {
   DocumentSuggestionListState as DocumentSuggestionState,
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
 export {buildDocumentSuggestionList as buildDocumentSuggestion} from './controllers/document-suggestion-list/headless-document-suggestion-list';
+
+export type {
+  CaseAssistInteractiveResult,
+  CaseAssistInteractiveResultOptions,
+  CaseAssistInteractiveResultProps,
+} from './controllers/document-suggestion-list/case-assist-headless-interactive-result';
+export {buildCaseAssistInteractiveResult} from './controllers/document-suggestion-list/case-assist-headless-interactive-result';

--- a/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
+++ b/packages/headless/src/controllers/core/interactive-result/headless-core-interactive-result.ts
@@ -1,9 +1,9 @@
 import {configuration} from '../../../app/reducers';
-import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {loadReducerError} from '../../../utils/errors';
 import {ConfigurationSection} from '../../../state/state-sections';
 import {Result} from '../../../api/search/search/result';
 import {debounce} from 'ts-debounce';
+import {CoreEngine} from '../../..';
 
 export interface InteractiveResultCoreOptions {
   /**
@@ -72,7 +72,7 @@ export interface InteractiveResultCore {
  * @returns A controller core instance.
  */
 export function buildInteractiveResultCore(
-  engine: SearchEngine,
+  engine: CoreEngine,
   props: InteractiveResultCoreProps,
   action: () => void
 ): InteractiveResultCore {
@@ -104,8 +104,8 @@ export function buildInteractiveResultCore(
 }
 
 function loadInteractiveResultCoreReducers(
-  engine: SearchEngine
-): engine is SearchEngine<ConfigurationSection> {
+  engine: CoreEngine
+): engine is CoreEngine<ConfigurationSection> {
   engine.addReducers({configuration});
   return true;
 }

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
@@ -1,0 +1,76 @@
+import {Result} from '../../api/search/search/result';
+import {configuration} from '../../app/reducers';
+import {buildDocumentSuggestionClickThunk} from '../../features/case-assist/case-assist-analytics-actions';
+import {buildMockResult} from '../../test';
+import {
+  buildMockCaseAssistEngine,
+  MockCaseAssistEngine,
+} from '../../test/mock-engine';
+import {
+  buildCaseAssistInteractiveResult,
+  CaseAssistInteractiveResult,
+} from './case-assist-headless-interactive-result';
+
+describe('InteractiveResult', () => {
+  let engine: MockCaseAssistEngine;
+  let mockResult: Result;
+  let interactiveResult: CaseAssistInteractiveResult;
+  let logDocumentOpenPendingActionType: string;
+
+  const resultStringParams = {
+    title: 'title',
+    uri: 'uri',
+    printableUri: 'printable-uri',
+    clickUri: 'click-uri',
+    uniqueId: 'unique-id',
+    excerpt: 'exceprt',
+    firstSentences: 'first-sentences',
+    flags: 'flags',
+  };
+
+  function initializeInteractiveResult(delay?: number) {
+    const result = (mockResult = buildMockResult(resultStringParams));
+    logDocumentOpenPendingActionType = buildDocumentSuggestionClickThunk(
+      mockResult.uniqueId
+    ).pending.type;
+    interactiveResult = buildCaseAssistInteractiveResult(engine, {
+      options: {result, selectionDelay: delay},
+    });
+  }
+
+  function findLogDocumentAction() {
+    return (
+      engine.actions.find(
+        (action) => action.type === logDocumentOpenPendingActionType
+      ) ?? null
+    );
+  }
+
+  function expectLogDocumentActionPending() {
+    const action = findLogDocumentAction();
+    expect(action).toEqual(
+      buildDocumentSuggestionClickThunk(mockResult.uniqueId).pending(
+        action!.meta.requestId
+      )
+    );
+  }
+
+  beforeEach(() => {
+    engine = buildMockCaseAssistEngine();
+    initializeInteractiveResult();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({configuration});
+  });
+
+  it('when calling select(), logs documentOpen', () => {
+    interactiveResult.select();
+    expectLogDocumentActionPending();
+  });
+});

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
@@ -51,11 +51,6 @@ describe('InteractiveResult', () => {
   beforeEach(() => {
     engine = buildMockCaseAssistEngine();
     initializeInteractiveResult();
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   it('it adds the correct reducers to engine', () => {

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.test.ts
@@ -1,6 +1,6 @@
 import {Result} from '../../api/search/search/result';
 import {configuration} from '../../app/reducers';
-import {buildDocumentSuggestionClickThunk} from '../../features/case-assist/case-assist-analytics-actions';
+import {buildDocumentSuggestionOpenThunk} from '../../features/case-assist/case-assist-analytics-actions';
 import {buildMockResult} from '../../test';
 import {
   buildMockCaseAssistEngine,
@@ -18,19 +18,12 @@ describe('InteractiveResult', () => {
   let logDocumentOpenPendingActionType: string;
 
   const resultStringParams = {
-    title: 'title',
-    uri: 'uri',
-    printableUri: 'printable-uri',
-    clickUri: 'click-uri',
     uniqueId: 'unique-id',
-    excerpt: 'exceprt',
-    firstSentences: 'first-sentences',
-    flags: 'flags',
   };
 
   function initializeInteractiveResult(delay?: number) {
     const result = (mockResult = buildMockResult(resultStringParams));
-    logDocumentOpenPendingActionType = buildDocumentSuggestionClickThunk(
+    logDocumentOpenPendingActionType = buildDocumentSuggestionOpenThunk(
       mockResult.uniqueId
     ).pending.type;
     interactiveResult = buildCaseAssistInteractiveResult(engine, {
@@ -49,7 +42,7 @@ describe('InteractiveResult', () => {
   function expectLogDocumentActionPending() {
     const action = findLogDocumentAction();
     expect(action).toEqual(
-      buildDocumentSuggestionClickThunk(mockResult.uniqueId).pending(
+      buildDocumentSuggestionOpenThunk(mockResult.uniqueId).pending(
         action!.meta.requestId
       )
     );

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
@@ -1,0 +1,48 @@
+import {CaseAssistEngine} from '../../case-assist.index';
+import {logDocumentSuggestionClick} from '../../features/case-assist/case-assist-analytics-actions';
+import {
+  buildInteractiveResultCore,
+  InteractiveResultCore,
+  InteractiveResultCoreOptions,
+  InteractiveResultCoreProps,
+} from '../core/interactive-result/headless-core-interactive-result';
+
+export interface CaseAssistInteractiveResultOptions
+  extends InteractiveResultCoreOptions {}
+
+export interface CaseAssistInteractiveResultProps
+  extends InteractiveResultCoreProps {
+  /**
+   * The options for the `InteractiveResult` controller.
+   * */
+  options: CaseAssistInteractiveResultOptions;
+}
+
+/**
+ * The `InteractiveResult` controller provides an interface for triggering desirable side effects, such as logging UA events to the Coveo Platform, when a user selects a query result.
+ */
+export interface CaseAssistInteractiveResult extends InteractiveResultCore {}
+
+/**
+ * Creates a `CaseAssistInteractiveResult` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `CaseAssistInteractiveResult` properties.
+ * @returns A `CaseAssistInteractiveResult` controller instance.
+ */
+export function buildCaseAssistInteractiveResult(
+  engine: CaseAssistEngine,
+  props: CaseAssistInteractiveResultProps
+): CaseAssistInteractiveResult {
+  let wasOpened = false;
+
+  const logAnalyticsIfNeverOpened = () => {
+    if (wasOpened) {
+      return;
+    }
+    wasOpened = true;
+    engine.dispatch(logDocumentSuggestionClick(props.options.result.uniqueId));
+  };
+
+  return buildInteractiveResultCore(engine, props, logAnalyticsIfNeverOpened);
+}

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
@@ -1,5 +1,5 @@
 import {CaseAssistEngine} from '../../case-assist.index';
-import {logDocumentSuggestionClick} from '../../features/case-assist/case-assist-analytics-actions';
+import {logDocumentSuggestionOpen} from '../../features/case-assist/case-assist-analytics-actions';
 import {
   buildInteractiveResultCore,
   InteractiveResultCore,
@@ -41,7 +41,7 @@ export function buildCaseAssistInteractiveResult(
       return;
     }
     wasOpened = true;
-    engine.dispatch(logDocumentSuggestionClick(props.options.result.uniqueId));
+    engine.dispatch(logDocumentSuggestionOpen(props.options.result.uniqueId));
   };
 
   return buildInteractiveResultCore(engine, props, logAnalyticsIfNeverOpened);

--- a/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/case-assist-headless-interactive-result.ts
@@ -13,13 +13,13 @@ export interface CaseAssistInteractiveResultOptions
 export interface CaseAssistInteractiveResultProps
   extends InteractiveResultCoreProps {
   /**
-   * The options for the `InteractiveResult` controller.
+   * The options for the `CaseAssistInteractiveResult` controller.
    * */
   options: CaseAssistInteractiveResultOptions;
 }
 
 /**
- * The `InteractiveResult` controller provides an interface for triggering desirable side effects, such as logging UA events to the Coveo Platform, when a user selects a query result.
+ * The `CaseAssistInteractiveResult` controller provides an interface for triggering desirable side effects, such as logging UA events to the Coveo Platform, when a user selects a query result.
  */
 export interface CaseAssistInteractiveResult extends InteractiveResultCore {}
 

--- a/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
@@ -68,15 +68,20 @@ export const logClassificationClick = (classificationId: string) =>
       })
   )();
 
-export const logDocumentSuggestionClick = (suggestionId: string) =>
-  makeCaseAssistAnalyticsAction(
+export const logDocumentSuggestionClick = (suggestionId: string) => {
+  return buildDocumentSuggestionClickThunk(suggestionId)();
+};
+
+export const buildDocumentSuggestionClickThunk = (suggestionId: string) => {
+  return makeCaseAssistAnalyticsAction(
     'analytics/caseAssist/documentSuggestion/click',
     (client, state) =>
       client.logSelectDocumentSuggestion({
         suggestion: caseAssistDocumentSuggestionSelector(state, suggestionId),
         ticket: caseAssistCaseSelector(state),
       })
-  )();
+  );
+};
 
 export const logQuickviewDocumentSuggestionClick = (suggestionId: string) => {
   return buildQuickviewDocumentSuggestionClickThunk(suggestionId)();

--- a/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-actions.ts
@@ -68,20 +68,15 @@ export const logClassificationClick = (classificationId: string) =>
       })
   )();
 
-export const logDocumentSuggestionClick = (suggestionId: string) => {
-  return buildDocumentSuggestionClickThunk(suggestionId)();
-};
-
-export const buildDocumentSuggestionClickThunk = (suggestionId: string) => {
-  return makeCaseAssistAnalyticsAction(
+export const logDocumentSuggestionClick = (suggestionId: string) =>
+  makeCaseAssistAnalyticsAction(
     'analytics/caseAssist/documentSuggestion/click',
     (client, state) =>
       client.logSelectDocumentSuggestion({
         suggestion: caseAssistDocumentSuggestionSelector(state, suggestionId),
         ticket: caseAssistCaseSelector(state),
       })
-  );
-};
+  )();
 
 export const logQuickviewDocumentSuggestionClick = (suggestionId: string) => {
   return buildQuickviewDocumentSuggestionClickThunk(suggestionId)();
@@ -97,6 +92,26 @@ export const buildQuickviewDocumentSuggestionClickThunk = (
         suggestion: caseAssistDocumentSuggestionSelector(
           state,
           suggestionId,
+          true
+        ),
+        ticket: caseAssistCaseSelector(state),
+      })
+  );
+};
+
+export const logDocumentSuggestionOpen = (suggestionId: string) => {
+  return buildDocumentSuggestionOpenThunk(suggestionId)();
+};
+
+export const buildDocumentSuggestionOpenThunk = (suggestionId: string) => {
+  return makeCaseAssistAnalyticsAction(
+    'analytics/caseAssist/documentSuggestion/click',
+    (client, state) =>
+      client.logSelectDocumentSuggestion({
+        suggestion: caseAssistDocumentSuggestionSelector(
+          state,
+          suggestionId,
+          false,
           true
         ),
         ticket: caseAssistCaseSelector(state),

--- a/packages/headless/src/features/case-assist/case-assist-analytics-selectors.test.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-selectors.test.ts
@@ -268,6 +268,28 @@ describe('case assist analytics selectors', () => {
       });
     });
 
+    it('should return the document suggestion matching the specified ID with the field openDocument when the openDocument parameter is set to true', () => {
+      const suggestion = caseAssistDocumentSuggestionSelector(
+        buildStateWithDocumentSuggestions(),
+        'document-id',
+        false,
+        true
+      );
+
+      expect(suggestion).toMatchObject({
+        responseId: 'last-document-suggestion-response-id',
+        suggestionId: 'document-id',
+        openDocument: true,
+        suggestion: {
+          documentPosition: 0,
+          documentTitle: 'My Document',
+          documentUri: 'http://my.document.uri',
+          documentUriHash: 'document-uri-hash',
+          documentUrl: 'http://my.document.uri/clickable',
+        },
+      });
+    });
+
     it('should throw when the document suggestion is not found', () => {
       expect(() =>
         caseAssistDocumentSuggestionSelector(

--- a/packages/headless/src/features/case-assist/case-assist-analytics-selectors.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-selectors.ts
@@ -108,7 +108,8 @@ export const caseAssistCaseClassificationSelector = (
 export const caseAssistDocumentSuggestionSelector = (
   state: Partial<CaseAssistAppState>,
   suggestionId: string,
-  fromQuickview = false
+  fromQuickview = false,
+  openDocument = false
 ) => {
   let suggestionIdx;
   const suggestion = state.documentSuggestion?.documents.find((s, idx) => {
@@ -139,6 +140,9 @@ export const caseAssistDocumentSuggestionSelector = (
 
   if (fromQuickview) {
     return {...result, fromQuickview};
+  }
+  if (openDocument) {
+    return {...result, openDocument};
   }
   return result;
 };

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -1,8 +1,4 @@
 <template>
-  <template if:true={showQuickview}>
-    <c-quantic-search-interface engine-id={searchEngineId}>
-    </c-quantic-search-interface>
-  </template>
   <template if:true={loading}>
     <div class="loading-holder">
       <lightning-spinner alternative-text={labels.loading}></lightning-spinner>

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -3,10 +3,6 @@
     <div class="error-message slds-text-color_destructive">{renderingError}</div>
   </template>
   <template if:false={renderingError}>
-    <template if:true={showQuickview}>
-      <c-quantic-search-interface engine-id={searchEngineId}>
-      </c-quantic-search-interface>
-    </template>
     <template if:true={loading}>
       <div class="loading-holder">
         <lightning-spinner alternative-text={labels.loading}></lightning-spinner>

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -14,7 +14,7 @@ import noSuggestions from '@salesforce/label/c.quantic_NoSuggestions';
  *
  * @category Case Assist
  * @example
- * <c-quantic-document-suggestion engine-id={engineId} search-engine-id={searchEngineId} max-documents="5"></c-quantic-document-suggestion>
+ * <c-quantic-document-suggestion engine-id={engineId} max-documents="5"></c-quantic-document-suggestion>
  */
 export default class QuanticDocumentSuggestion extends LightningElement {
   labels = {
@@ -28,13 +28,6 @@ export default class QuanticDocumentSuggestion extends LightningElement {
    * @type {string}
    */
   @api engineId;
-  /**
-   * The ID of the search engine instance the component registers to, this is used to instantiate the search interface to be able to show the quick view.
-   * @api
-   * @type {string}
-   * @defaultValue `'search-engine'`
-   */
-  @api searchEngineId = 'search-engine';
   /**
    * Whether or not we want to disply the quick view for the document suggestions.
    * @api

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -31,7 +31,7 @@ export default class QuanticDocumentSuggestion extends LightningElement {
    */
   @api engineId;
   /**
-   * Whether or not we want to disply the quick view for the document suggestions.
+   * Whether or not we want to dispaly the quick view for the document suggestions.
    * @api
    * @type {boolean}
    * @defaultValue `false`

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -31,7 +31,7 @@ export default class QuanticDocumentSuggestion extends LightningElement {
    */
   @api engineId;
   /**
-   * Whether or not we want to dispaly the quick view for the document suggestions.
+   * Whether or not we want to display the quick view for the document suggestions.
    * @api
    * @type {boolean}
    * @defaultValue `false`

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -33,7 +33,7 @@ export default class QuanticResultLink extends LightningElement {
    *   - `_top`: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
    * @api
    * @type {string}
-   * @defaultValue `'_self'`
+   * @defaultValue `'_blank'`
    */
   @api target = '_blank';
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -33,9 +33,9 @@ export default class QuanticResultLink extends LightningElement {
    *   - `_top`: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
    * @api
    * @type {string}
-   * @defaultValue `'_blank'`
+   * @defaultValue `'_self'`
    */
-  @api target = '_blank';
+  @api target = '_self';
   /**
    * Indicates the use case where this component is used.
    * @api

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -48,13 +48,11 @@ export default class QuanticResultLink extends LightningElement {
   engine;
 
   connectedCallback() {
-    getHeadlessEnginePromise(this.engineId)
-      .then((engine) => {
-        this.initialize(engine);
-      })
-      .catch((error) => {
-        console.error(error.message);
-      });
+    getHeadlessEnginePromise(this.engineId).then((engine) => {
+      this.initialize(engine);
+    }).catch((error) => {
+      console.error(error.message);
+    });
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -23,7 +23,7 @@ export default class QuanticResultLink extends LightningElement {
    * @api
    * @type {Result}
    */
-  @api result
+  @api result;
   /**
    * Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>).
    * The following keywords have special meanings for where to load the URL:
@@ -35,17 +35,26 @@ export default class QuanticResultLink extends LightningElement {
    * @type {string}
    * @defaultValue `'_self'`
    */
-  @api target = '_self';
+  @api target = '_blank';
+  /**
+   * Indicates the use case where this component is used.
+   * @api
+   * @type {'search'|'case-assist'}
+   * @defaultValue `'search'`
+   */
+  @api useCase = 'search';
 
   /** @type {SearchEngine} */
   engine;
 
   connectedCallback() {
-    getHeadlessEnginePromise(this.engineId).then((engine) => {
-      this.initialize(engine);
-    }).catch((error) => {
-      console.error(error.message);
-    });
+    getHeadlessEnginePromise(this.engineId)
+      .then((engine) => {
+        this.initialize(engine);
+      })
+      .catch((error) => {
+        console.error(error.message);
+      });
   }
 
   /**
@@ -57,7 +66,9 @@ export default class QuanticResultLink extends LightningElement {
       this.engine,
       this.result,
       this.template,
-      CoveoHeadless.buildInteractiveResult
+      this.useCase === 'case-assist'
+        ? CoveoHeadlessCaseAssist.buildCaseAssistInteractiveResult
+        : CoveoHeadless.buildInteractiveResult
     );
-  }
+  };
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -25,7 +25,7 @@
                 <c-quantic-result-label result={result} icon-only></c-quantic-result-label>
               </div>
               <div class="slds-truncate quickview__result-title">
-                <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
+                <c-quantic-result-link use-case={useCase} result={result} engine-id={engineId}></c-quantic-result-link>
               </div>
             </div>
             <div class="slds-truncate slds-text-align_right quickview__result-date slds-col_bump-left">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -25,7 +25,7 @@
                 <c-quantic-result-label result={result} icon-only></c-quantic-result-label>
               </div>
               <div class="slds-truncate quickview__result-title">
-                <c-quantic-result-link use-case={useCase} result={result} engine-id={engineId}></c-quantic-result-link>
+                <c-quantic-result-link target="_blank" use-case={useCase} result={result} engine-id={engineId}></c-quantic-result-link>
               </div>
             </div>
             <div class="slds-truncate slds-text-align_right quickview__result-date slds-col_bump-left">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -125,7 +125,9 @@ export default class QuanticResultQuickview extends LightningElement {
   openQuickview() {
     this.isQuickviewOpen = true;
     this.quickview.fetchResultContent();
-    this.addRecentResult();
+    if(this.useCase !== 'case-assist'){
+      this.addRecentResult();
+    }
   }
 
   addRecentResult() {


### PR DESCRIPTION
### For the Case Assist use case we needed to dispatch a different analytics event when the user clicks on the title of a document suggestion in a Quickview comparing to the click event sent when being in a search use case. 


### Changes made in Headless:
- New controller `buildCaseAssistInteractiveResult` created. this controller will take care of sending the correct analytics events when the user clicks on the title of a document suggestion in a quickview.
- New analytic action created `logDocumentSuggestionOpen`, this action dispatch a `suggestion_click` event with metadata indicating that the click was made to open the document suggestion after clicking on its title from the quickview.

### Changes made in Quantic:
- The QuanticResultLink calls the  buildCaseAssistInteractiveResult controller when being used in a Case Assist use case.
- The value of target in the QuanticResultLink  when used in the QuanticResultQuickview updated to be "_blank" instead of "_self", to open the link in a new tab instead of opening it in the same tab.


https://user-images.githubusercontent.com/86681870/154520589-127b9dd1-5af4-45d8-9159-6cee53bc750f.mov

