### PR TITLE
fix(Quantic): showQuickview property updated to be hideQuickview in quanticDocumentSuggestion

### DIFF
--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.html
@@ -7,7 +7,7 @@
 
     <c-quantic-case-assist-interface case-assist-id={caseAssistId} engine-id={config.engineId} slot="preview">
       <c-quantic-document-suggestion engine-id={config.engineId} search-engine-id={config.searchEngineId}
-        max-documents={config.maxDocuments} fetch-on-init={config.fetchOnInit} show-quickview={config.showQuickview}
+        max-documents={config.maxDocuments} fetch-on-init={config.fetchOnInit} hide-quickview={config.showQuickview}
         number-of-auto-opened-documents={config.numberOfAutoOpenedDocuments}>
         <c-action-send-rating slot="actions"></c-action-send-rating>
       </c-quantic-document-suggestion>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.js
@@ -38,10 +38,10 @@ export default class ExampleQuanticDocumentSuggestion extends LightningElement {
       defaultValue: false,
     },
     {
-      attribute: 'showQuickview',
-      label: 'Show quickview',
+      attribute: 'hideQuickview',
+      label: 'Hide quickview',
       description:
-        'Whether or not we want to display the quick view for the document suggestions.',
+        'Whether or not we want to hide the quick view for the document suggestions.',
       defaultValue: false,
     },
     {

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -3,7 +3,7 @@
     <div class="error-message slds-text-color_destructive">{renderingError}</div>
   </template>
   <template if:false={renderingError}>
-    <template if:true={showQuickview}>
+    <template if:false={hideQuickview}>
       <c-quantic-search-interface engine-id={searchEngineId}>
       </c-quantic-search-interface>
     </template>
@@ -30,7 +30,7 @@
                     ">
                     <p class="excerpt">{it.value.excerpt}</p>
                     <div class="row slds-var-p-top_medium">
-                      <template if:true={showQuickview}>
+                      <template if:false={hideQuickview}>
                         <c-quantic-result-quickview use-case="case-assist" engine-id={engineId}
                           preview-button-icon="utility:new_window" preview-button-label="Show more"
                           preview-button-variant="outline-brand" result={it.value}>

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -38,12 +38,12 @@ export default class QuanticDocumentSuggestion extends LightningElement {
    */
   @api searchEngineId = 'search-engine';
   /**
-   * Whether or not we want to display the quick view for the document suggestions.
+   * Whether or not we want to hide the quick view for the document suggestions.
    * @api
    * @type {boolean}
    * @defaultValue `false`
    */
-  @api showQuickview = false;
+  @api hideQuickview = false;
   /**
    * Whether or not we want to fetch suggestions when initializing this component.
    * @api


### PR DESCRIPTION
## showQuickview property updated to be hideQuickview in the quanticDocumentSuggestion.

- ### This change was identified as a breaking change, and we want to decide how  to handle that.


- ### This PR will stay in draft until we decide if we want to accept this change or not, if the change is accepted I'll go ahead and update the functional tests impacted by this and I'll open the PR.