### PR TITLE
Fix(Headless): prevent caseField and caseInput from reseting when being already registered 

### DIFF
--- a/packages/headless/src/controllers/case-field/headless-case-field.test.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../features/case-field/case-field-actions';
 import {getCaseFieldInitialState} from '../../features/case-field/case-field-state';
 import {fetchDocumentSuggestions} from '../../features/document-suggestion/document-suggestion-actions';
+import {buildMockCaseAssistState} from '../../test/mock-case-assist-state';
 import {
   buildMockCaseAssistEngine,
   MockCaseAssistEngine,
@@ -53,6 +54,24 @@ describe('Case Field', () => {
 
   it('building a case field registers the case field in the state', () => {
     expect(engine.actions).toContainEqual(
+      registerCaseField({fieldName: testFieldName, fieldValue: ''})
+    );
+  });
+
+  it('building a case field that was already registered does not register the case field again', () => {
+    engine = buildMockCaseAssistEngine({
+      state: {
+        ...buildMockCaseAssistState(),
+        caseField: {
+          ...getCaseFieldInitialState(),
+          fields: {
+            [testFieldName]: {value: '', suggestions: []},
+          },
+        },
+      },
+    });
+    initCaseField();
+    expect(engine.actions).not.toContainEqual(
       registerCaseField({fieldName: testFieldName, fieldValue: ''})
     );
   });

--- a/packages/headless/src/controllers/case-field/headless-case-field.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.ts
@@ -116,7 +116,9 @@ export function buildCaseField(
     return engine.state;
   };
 
-  if (!getState().caseField?.fields?.[options.field]) {
+  const isRegistered = getState().caseField?.fields?.[options.field];
+
+  if (!isRegistered) {
     dispatch(
       registerCaseField({
         fieldName: options.field,

--- a/packages/headless/src/controllers/case-field/headless-case-field.ts
+++ b/packages/headless/src/controllers/case-field/headless-case-field.ts
@@ -112,16 +112,18 @@ export function buildCaseField(
     'buildCaseField'
   ) as Required<CaseFieldOptions>;
 
-  dispatch(
-    registerCaseField({
-      fieldName: options.field,
-      fieldValue: '',
-    })
-  );
-
   const getState = () => {
     return engine.state;
   };
+
+  if (!getState().caseField?.fields?.[options.field]) {
+    dispatch(
+      registerCaseField({
+        fieldName: options.field,
+        fieldValue: '',
+      })
+    );
+  }
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/case-input/headless-case-input.test.ts
+++ b/packages/headless/src/controllers/case-input/headless-case-input.test.ts
@@ -17,6 +17,7 @@ import {
 import {updateCaseInput} from '../../features/case-input/case-input-actions';
 import {fetchCaseClassifications} from '../../features/case-field/case-field-actions';
 import {fetchDocumentSuggestions} from '../../features/document-suggestion/document-suggestion-actions';
+import {buildMockCaseAssistState} from '../../test/mock-case-assist-state';
 
 describe('Case Input', () => {
   let engine: MockCaseAssistEngine;
@@ -49,6 +50,23 @@ describe('Case Input', () => {
 
   it('building a case input registers the input field in the state', () => {
     expect(engine.actions).toContainEqual(
+      updateCaseInput({fieldName: testFieldName, fieldValue: ''})
+    );
+  });
+
+  it('building a case input that was already registered does not register the input field again', () => {
+    engine = buildMockCaseAssistEngine({
+      state: {
+        ...buildMockCaseAssistState(),
+        caseInput: {
+          [testFieldName]: {
+            value: '',
+          },
+        },
+      },
+    });
+    initCaseInput();
+    expect(engine.actions).not.toContainEqual(
       updateCaseInput({fieldName: testFieldName, fieldValue: ''})
     );
   });

--- a/packages/headless/src/controllers/case-input/headless-case-input.ts
+++ b/packages/headless/src/controllers/case-input/headless-case-input.ts
@@ -95,12 +95,14 @@ export function buildCaseInput(
 
   const fieldName = props.options.field;
 
-  dispatch(
-    updateCaseInput({
-      fieldName: fieldName,
-      fieldValue: '',
-    })
-  );
+  if (!getState().caseInput?.[fieldName]) {
+    dispatch(
+      updateCaseInput({
+        fieldName: fieldName,
+        fieldValue: '',
+      })
+    );
+  }
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/case-input/headless-case-input.ts
+++ b/packages/headless/src/controllers/case-input/headless-case-input.ts
@@ -94,8 +94,9 @@ export function buildCaseInput(
   validateCaseInputOptions(engine, props.options);
 
   const fieldName = props.options.field;
+  const isRegistered = getState().caseInput?.[fieldName];
 
-  if (!getState().caseInput?.[fieldName]) {
+  if (!isRegistered) {
     dispatch(
       updateCaseInput({
         fieldName: fieldName,


### PR DESCRIPTION
### The Problem: 
- Calling the **buildCaseField** function of a field that was already registered  will reset its value to an empty string and its suggestions to an empty array.
- Calling the **buildCaseInput** function of a field that was already registered  will reset its value to an empty string.

### The Fix:
- Conditions added to check if the field is registered or not before registering it again.