### PR TITLE
ci(atomic-angular): add deploy alpha script

### DIFF
--- a/packages/atomic-angular/README.md
+++ b/packages/atomic-angular/README.md
@@ -14,6 +14,28 @@ Since Atomic Angular is built on top of the core [Atomic](https://docs.coveo.com
 
 However, there are still some special considerations.
 
+## Importing AtomicAngularModule
+
+In the module where you wish to make available Atomic Angular components, you must declare and import the `AtomicAngular` module.
+
+For example:
+
+```typescript
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {AtomicAngularModule} from '@coveo/atomic-angular';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, AtomicAngularModule],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+Once this is done, you will be able to reference all atomic components inside that module.
+
 ## Static Assets - Languages and SVGs
 
 For performance reasons, the generated JavaScript bundle does not automatically include static assets that are loaded on demand. This impacts language support, as well as the use of included SVG icons.

--- a/packages/atomic-angular/modify-package-json.js
+++ b/packages/atomic-angular/modify-package-json.js
@@ -1,0 +1,13 @@
+const {readFileSync, writeFileSync} = require('fs');
+const {resolve} = require('path');
+
+const packageJSONPath = resolve('./projects/atomic-angular/dist/package.json');
+
+const packageJSON = JSON.parse(readFileSync(packageJSONPath));
+if (!packageJSON.scripts) {
+  packageJSON.scripts = {};
+}
+packageJSON.scripts['npm:publish:alpha'] =
+  'node ../../../../../scripts/deploy/publish.js alpha';
+
+writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -4,8 +4,10 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build && npm run copy:assets",
-    "copy:assets": "ncp node_modules/@coveo/atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp node_modules/@coveo/atomic/dist/atomic/lang projects/atomic-angular/dist/lang"
+    "build": "ng build && npm run copy:assets && npm run npm:modify:dist",
+    "copy:assets": "ncp node_modules/@coveo/atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp node_modules/@coveo/atomic/dist/atomic/lang projects/atomic-angular/dist/lang",
+    "npm:publish:alpha": "npm --prefix projects/atomic-angular/dist run npm:publish:alpha",
+    "npm:modify:dist": "node modify-package-json.js"
   },
   "private": true,
   "dependencies": {

--- a/scripts/deploy/update-npm-tag.js
+++ b/scripts/deploy/update-npm-tag.js
@@ -1,12 +1,19 @@
 const {promisify} = require('util');
 const exec = promisify(require('child_process').exec);
 
-const packageDirs = ['atomic', 'auth', 'bueno', 'headless', 'atomic-react'];
+const packageDirs = [
+  'atomic',
+  'auth',
+  'bueno',
+  'headless',
+  'atomic-react',
+  'atomic-angular/projects/atomic-angular/dist',
+];
 
 async function main() {
   const requests = packageDirs
-    .map(dir => require(`../../packages/${dir}/package.json`))
-    .map(({name, version}) => updateNpmTag(name, version))
+    .map((dir) => require(`../../packages/${dir}/package.json`))
+    .map(({name, version}) => updateNpmTag(name, version));
 
   await Promise.all(requests);
 }
@@ -16,12 +23,14 @@ async function updateNpmTag(packageName, version) {
   const latestVersion = await getLatestVersion(packageName);
 
   if (!isGreaterThanLatestVersion(version, latestVersion)) {
-    console.log(`skipping tag update for ${packageName} because version "${version}" is not greater than latest version "${latestVersion}".`)
+    console.log(
+      `skipping tag update for ${packageName} because version "${version}" is not greater than latest version "${latestVersion}".`
+    );
     return;
   }
-  
+
   console.log(`updating ${packageName}@${version} to ${tag}.`);
-  await exec(`npm dist-tag add ${packageName}@${version} ${tag}`)
+  await exec(`npm dist-tag add ${packageName}@${version} ${tag}`);
 }
 
 async function getLatestVersion(packageName) {
@@ -32,12 +41,12 @@ async function getLatestVersion(packageName) {
 function isGreaterThanLatestVersion(version, latestVersion) {
   const candidate = parseVersion(version);
   const latest = parseVersion(latestVersion);
-  
+
   return isCandidateGreaterThanLatestVersion(candidate, latest, 0);
 }
 
 function parseVersion(version) {
-  return version.split('.').map(num => parseInt(num, 10));
+  return version.split('.').map((num) => parseInt(num, 10));
 }
 
 function isCandidateGreaterThanLatestVersion(candidate, latest, i) {


### PR DESCRIPTION
Angular is a bit special, since the `ng cli` tool generates a "project distribution" folder (`packages/atomic-angular/projects/atomic-angular/dist/**`) , which is what needs to be published (not the "root" package.json file at `packages/atomic-angular`)

So I've added a small script to build then modify the generated `package.json` with the needed script to `npm:publish:alpha` like other packages.

https://coveord.atlassian.net/browse/KIT-1427