### PR TITLE
fix(quantic): fix standalone searchbox init attribute and timeframe facet tests

### DIFF
--- a/packages/quantic/cypress/integration/document-suggestion/document-suggestion.cypress.ts
+++ b/packages/quantic/cypress/integration/document-suggestion/document-suggestion.cypress.ts
@@ -11,6 +11,10 @@ import {sendRating} from '../../page-objects/actions/action-send-rating';
 import allDocuments from '../../fixtures/documentSuggestions.json';
 import similarDocuments from '../../fixtures/similarDocumentSuggestions.json';
 import {fetchSuggestions} from '../../page-objects/actions/action-get-suggestions';
+import {
+  InterceptAliases,
+  interceptResultHtmlContent,
+} from '../../page-objects/search';
 
 interface DocumentSuggestionOptions {
   maxDocuments: number;
@@ -40,6 +44,7 @@ describe('quantic-document-suggestion', () => {
     options: Partial<DocumentSuggestionOptions> = {}
   ) {
     interceptCaseAssist();
+    interceptResultHtmlContent();
     cy.visit(pageUrl);
     configure(options);
   }
@@ -391,6 +396,7 @@ describe('quantic-document-suggestion', () => {
         const clickIndex = 0;
 
         Actions.openQuickview(clickIndex);
+        cy.wait(InterceptAliases.ResultHtml);
         Expect.logClickingSuggestion(clickIndex, allDocuments, true);
         Actions.closeQuickview();
       });

--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -21,13 +21,13 @@ describe('quantic-timeframe-facet', () => {
   const pageUrl = 's/quantic-timeframe-facet';
 
   const validRange = {
-    start: '2000-01-01',
-    end: '2000-12-31',
+    start: '1/1/2000',
+    end: '12/31/2000',
     filter: '2000/01/01@00:00:00..2000/12/31@23:59:59',
   };
   const invalidRange = {
-    start: '2000-12-31',
-    end: '2000-01-01',
+    start: '12/31/2000',
+    end: '1/1/2000',
     filter: '2000/12/31@00:00:00..2000/01/01@23:59:59',
   };
 
@@ -308,7 +308,7 @@ describe('quantic-timeframe-facet', () => {
 
           Expect.numberOfValidationErrors(1);
           Expect.validationError(
-            'Your entry does not match the allowed format yyyy-MM-dd.'
+            'Your entry does not match the allowed format M/d/yyyy.'
           );
         });
 
@@ -317,7 +317,7 @@ describe('quantic-timeframe-facet', () => {
 
           Expect.numberOfValidationErrors(1);
           Expect.validationError(
-            'Your entry does not match the allowed format yyyy-MM-dd.'
+            'Your entry does not match the allowed format M/d/yyyy.'
           );
         });
 

--- a/packages/quantic/cypress/integration/result-quickview/result-quickview.cypress.ts
+++ b/packages/quantic/cypress/integration/result-quickview/result-quickview.cypress.ts
@@ -1,5 +1,8 @@
 import {configure} from '../../page-objects/configurator';
-import {interceptSearch} from '../../page-objects/search';
+import {
+  interceptSearch,
+  mockResultHtmlContent,
+} from '../../page-objects/search';
 import {ResultQuickviewExpectations as Expect} from './result-quickview-expectations';
 import {ResultQuickviewActions as Actions} from './result-quickview-actions';
 import {scope} from '../../reporters/detailed-collector';
@@ -10,17 +13,6 @@ interface ResultQuickviewOptions {
   previewButtonIcon: string;
   previewButtonLabel: string;
   previewButtonVariant: string;
-}
-
-function mockResultHtmlContent(tag: string, innerHtml?: string) {
-  cy.intercept('POST', '**/rest/search/v2/html?*', (req) => {
-    req.continue((res) => {
-      const element = document.createElement(tag);
-      element.innerHTML = innerHtml ? innerHtml : 'this is a response';
-      res.body = element;
-      res.send();
-    });
-  });
 }
 
 describe('quantic-result-quickview', () => {

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -38,6 +38,7 @@ export const InterceptAliases = {
   QuerySuggestions: '@coveoQuerySuggest',
   Search: '@coveoSearch',
   FacetSearch: '@coveoFacetSearch',
+  ResultHtml: '@coveoResultHtml',
 };
 
 export const routeMatchers = {
@@ -45,6 +46,7 @@ export const routeMatchers = {
   querySuggest: '**/rest/search/v2/querySuggest?*',
   search: '**/rest/search/v2?*',
   facetSearch: '**/rest/search/v2/facet?*',
+  html: '**/rest/search/v2/html?*',
 };
 
 export function interceptSearch() {
@@ -142,4 +144,22 @@ export function mockSearchNoResults() {
       res.send();
     });
   }).as(InterceptAliases.Search.substring(1));
+}
+
+export function interceptResultHtmlContent() {
+  cy.intercept('POST', routeMatchers.html).as(
+    InterceptAliases.ResultHtml.substring(1)
+  );
+}
+
+export function mockResultHtmlContent(tag: string, innerHtml?: string) {
+  cy.intercept('POST', routeMatchers.html, (req) => {
+    req.alias = InterceptAliases.ResultHtml.substring(1);
+    req.continue((res) => {
+      const element = document.createElement(tag);
+      element.innerHTML = innerHtml ? innerHtml : 'this is a response';
+      res.body = element;
+      res.send();
+    });
+  });
 }

--- a/packages/quantic/force-app/examples/main/lwc/eventListener/eventListener.html
+++ b/packages/quantic/force-app/examples/main/lwc/eventListener/eventListener.html
@@ -1,7 +1,7 @@
 <template>
   <template if:true={expectsEvents}>
     <div class="slds-m-bottom_small">
-      <lightning-card title="Events">
+      <c-quantic-card-container title="Events">
         <template for:each={events} for:item="event">
           <div key={event.type} class="slds-card__body_inner">
             <div class="grid slds-grid_vertical-align-center slds-m-bottom_xx-small">
@@ -20,7 +20,7 @@
             </div>
           </div>
         </template>
-      </lightning-card>
+      </c-quantic-card-container>
     </div>
   </template>
 

--- a/packages/quantic/force-app/examples/main/lwc/exampleLayout/exampleLayout.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleLayout/exampleLayout.html
@@ -4,11 +4,11 @@
 
   <div class="slds-grid slds-wrap slds-gutters_direct slds-m-top_large">
     <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-2 slds-large-size_1-of-2">
-      <lightning-card title="Configuration">
+      <c-quantic-card-container title="Configuration">
         <div class="slds-card__body_inner">
           <slot name="configuration">Configuration Slot</slot>
         </div>
-      </lightning-card>
+      </c-quantic-card-container>
 
       <div class="slds-m-vertical_large">
         <a href="/examples">Return to examples</a>
@@ -17,11 +17,11 @@
     <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-2 slds-large-size_1-of-2">
       <template if:true={showPreview}>
         <c-event-listener expected-events={expectedEvents}>
-          <lightning-card title="Preview">
-            <div class="slds-card__body_inner">
+          <c-quantic-card-container title="Preview">
+            <div class="slds-card__body_inner slds-p-bottom_small">
               <slot name="preview">Preview Slot</slot>
             </div>
-          </lightning-card>
+          </c-quantic-card-container>
         </c-event-listener>
       </template>
     </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
@@ -96,6 +96,8 @@ export default class QuanticStandaloneSearchBox extends NavigationMixin(
   standaloneSearchBox;
   /** @type {Function} */
   unsubscribe;
+  /** @type {boolean} */
+  isInitialized;
 
   /** @type {Suggestion[]} */
   get suggestions() {
@@ -116,9 +118,11 @@ export default class QuanticStandaloneSearchBox extends NavigationMixin(
   }
 
   renderedCallback() {
-    initializeWithHeadless(this, this.standaloneEngineId, this.initialize).then(() => {
-      this.input.setAttribute('is-initialized', 'true');
-    });
+    initializeWithHeadless(this, this.standaloneEngineId, this.initialize);
+    if (!this.isInitialized && !!this.standaloneSearchBox && !!this.input) {
+      this.input?.setAttribute('is-initialized', 'true');
+      this.isInitialized = true;
+    }
   }
 
   @wire(CurrentPageReference)

--- a/packages/quantic/package-lock.json
+++ b/packages/quantic/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@coveo/quantic",
-      "version": "1.8.7",
+      "version": "1.8.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/headless": "^1.46.1"
+        "@coveo/headless": "^1.46.3"
       },
       "devDependencies": {
         "@ckeditor/jsdoc-plugins": "^25.4.4",
@@ -22,7 +22,7 @@
         "@types/wait-on": "5.3.1",
         "chalk": "4.1.2",
         "change-case": "4.1.2",
-        "cypress": "^9.2.0",
+        "cypress": "^9.5.0",
         "dotenv": "^10.0.0",
         "eslint": "7.32.0",
         "eslint-plugin-cypress": "2.12.1",
@@ -2114,16 +2114,16 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.2.tgz",
-      "integrity": "sha512-ER0QX5oWj6eQea/itLHypWWmWAvnAmdEHACYPDKAnj2e34RFjkTTRegZPTfEnHgZDK+RXMLYtgatX+/dwuU/Tg=="
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.3.tgz",
+      "integrity": "sha512-J+Nzw0QqcA7yh87PSzLhsz8tq4Iq0T/b+NesoHYDJSI2Cjfwj33VMgXTakb7QynLTLG5VaplxeLZ4xwkENqELQ=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.46.1.tgz",
-      "integrity": "sha512-+3OzvP1MqhhHKfALQsUME6Xzk3BExhvcfBC4UriPgYx9oY1+MXMYKcfKvoDlI2Miozq0wvzaV0JEfzDC9ayD4A==",
+      "version": "1.46.3",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.46.3.tgz",
+      "integrity": "sha512-gvdoRX8sLFbZMUIdig7ZHKrrCqmHGdNokHt30NARHxdasBlNVstcv+30bIPUq0/ANg/9+Bnq8U8GmxcomPK4DQ==",
       "dependencies": {
-        "@coveo/bueno": "^0.34.2",
+        "@coveo/bueno": "^0.34.3",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -8654,9 +8654,9 @@
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
-      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "node_modules/@types/sizzle": {
@@ -10723,19 +10723,18 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
-        "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
       "engines": {
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "^1.1.2"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -11896,25 +11895,26 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz",
-      "integrity": "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -11938,10 +11938,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -11982,6 +11982,21 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/cypress/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cypress/node_modules/supports-color": {
@@ -25573,16 +25588,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -30666,16 +30671,6 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated"
     },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -30696,12 +30691,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -33880,16 +33869,16 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.2.tgz",
-      "integrity": "sha512-ER0QX5oWj6eQea/itLHypWWmWAvnAmdEHACYPDKAnj2e34RFjkTTRegZPTfEnHgZDK+RXMLYtgatX+/dwuU/Tg=="
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.3.tgz",
+      "integrity": "sha512-J+Nzw0QqcA7yh87PSzLhsz8tq4Iq0T/b+NesoHYDJSI2Cjfwj33VMgXTakb7QynLTLG5VaplxeLZ4xwkENqELQ=="
     },
     "@coveo/headless": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.46.1.tgz",
-      "integrity": "sha512-+3OzvP1MqhhHKfALQsUME6Xzk3BExhvcfBC4UriPgYx9oY1+MXMYKcfKvoDlI2Miozq0wvzaV0JEfzDC9ayD4A==",
+      "version": "1.46.3",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.46.3.tgz",
+      "integrity": "sha512-gvdoRX8sLFbZMUIdig7ZHKrrCqmHGdNokHt30NARHxdasBlNVstcv+30bIPUq0/ANg/9+Bnq8U8GmxcomPK4DQ==",
       "requires": {
-        "@coveo/bueno": "^0.34.2",
+        "@coveo/bueno": "^0.34.3",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
@@ -39306,9 +39295,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
-      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -40911,13 +40900,12 @@
       }
     },
     "cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
+        "colors": "1.4.0",
         "string-width": "^4.2.0"
       }
     },
@@ -41873,24 +41861,25 @@
       }
     },
     "cypress": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz",
-      "integrity": "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -41914,10 +41903,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -41947,6 +41936,15 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "supports-color": {
@@ -52493,12 +52491,6 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -56583,24 +56575,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
-      }
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -50,7 +50,7 @@
     "@types/wait-on": "5.3.1",
     "chalk": "4.1.2",
     "change-case": "4.1.2",
-    "cypress": "^9.2.0",
+    "cypress": "^9.5.0",
     "dotenv": "^10.0.0",
     "eslint": "7.32.0",
     "eslint-plugin-cypress": "2.12.1",


### PR DESCRIPTION
The logic to set the initialized attribute was flawed in that it wasn't executing after the rendering of the input element. The proposed solution follows the [LWC recommendation](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.create_lifecycle_hooks_rendered) for executing code once on a rendering cycle.

Running the tests locally also showed consistent failures in the timeframe facet tests. Curious why it isn't failing elsewhere but it runs successfully locally with these changes