### PR TITLE
fix(headless): add warning on missing permanentid

### DIFF
--- a/packages/headless/src/features/analytics/analytics-utils.test.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.test.ts
@@ -3,6 +3,7 @@ import {buildMockResult} from '../../test';
 import {createMockRecommendationState} from '../../test/mock-recommendation-state';
 import {buildMockResultWithFolding} from '../../test/mock-result-with-folding';
 import {
+  documentIdentifier,
   partialDocumentInformation,
   partialRecommendationInformation,
 } from './analytics-utils';
@@ -135,6 +136,40 @@ describe('analytics-utils', () => {
         state
       );
       expect(documentPosition).toBe(1);
+    });
+  });
+
+  describe('documentIdentifier', () => {
+    it('should extract permanentid properly if available on a result', () => {
+      const result = buildMockResult();
+      result.raw.permanentid = 'qwerty';
+      expect(documentIdentifier(result)).toMatchObject({
+        contentIDKey: 'permanentid',
+        contentIDValue: 'qwerty',
+      });
+    });
+
+    it('should return an empty string if permanentid is not available on a result', () => {
+      const result = buildMockResult();
+      delete result.raw.permanentid;
+      expect(documentIdentifier(result)).toMatchObject({
+        contentIDKey: 'permanentid',
+        contentIDValue: '',
+      });
+    });
+
+    it('should log an error permanentid is not available on a result', () => {
+      const spyConsole = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const result = buildMockResult();
+      delete result.raw.permanentid;
+
+      documentIdentifier(result);
+
+      expect(spyConsole).toHaveBeenCalled();
+      spyConsole.mockRestore();
     });
   });
 });

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -223,8 +223,14 @@ function buildPartialDocumentInformation(
 }
 
 export const documentIdentifier = (result: Result): DocumentIdentifier => {
+  if (!result.raw.permanentid) {
+    console.warn(
+      'Missing field permanentid on result. This might cause many issues with your Coveo deployment. See https://docs.coveo.com/en/1913 and https://docs.coveo.com/en/1640 for more information.',
+      result
+    );
+  }
   return {
-    contentIDKey: '@permanentid',
+    contentIDKey: 'permanentid',
     contentIDValue: result.raw.permanentid || '',
   };
 };


### PR DESCRIPTION
Original discussion: https://discuss.coveo.com/t/log-click-events-default-contentidkey-values-permanentid-vs-permanentid-vs-urihash/7356/6

https://coveord.atlassian.net/browse/KIT-1430