### PR TITLE
chore(quantic): fixing github actions quantic package test workflow

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -48,9 +48,6 @@ jobs:
             })
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Build Quantic project
-        working-directory: ./packages/quantic
-        run: npm run build
       - name: Create package version
         working-directory: ./packages/quantic
         run: |

--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -46,20 +46,14 @@ jobs:
               repo: context.repo.repo,
               run_id: context.runId
             })
-      - name: Install NPM dependencies
-        working-directory: ./packages/quantic
-        run: |
-          npm i -g typescript
-          npm i -g sfdx-cli
-          npm i
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Build Quantic project
         working-directory: ./packages/quantic
         run: npm run build
-      - name: Copy static resources
-        working-directory: ./packages/quantic
-        run: npm run copy:staticresources
       - name: Create package version
         working-directory: ./packages/quantic
         run: |
-          echo "$SFDX_AUTH_JWT_KEY" > server.key
-          node_modules/.bin/ts-node scripts/build/create-package.ts --remove-translations
+          echo "${{ env.SFDX_AUTH_JWT_KEY }}" > server.key
+          npx --no-install ts-node scripts/build/create-package.ts --remove-translations --ci
+          rm server.key


### PR DESCRIPTION
The github actions workflow that creates an **UNPUBLISHED** package has been broken since 1746. This workflow runs daily and is only to test that the current state of quantic in master can successfully be packaged so we can catch errors before real releases.

Anyway, this is an attempt to fix the issue. From what I can read [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) it seems manual or scheduled workflows can only be run when in the default branch so I don't think I can test this before merge. If i'm wrong please let me know.