### PR TITLE
feat(case-assist): add JSDoc support

### DIFF
--- a/packages/headless/config/api-extractor/case-assist.json
+++ b/packages/headless/config/api-extractor/case-assist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./base.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/definitions/case-assist.index.d.ts",
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/temp/case-assist.api.json"
+  }
+}

--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -12,6 +12,7 @@ import {
   Engine,
   resolveEngine,
 } from './src/headless-export-resolvers/engine-resolver';
+import {caseAssistUseCase} from './use-cases/case-assist';
 import {productListingUseCase} from './use-cases/product-listing';
 import {productRecommendationUseCase} from './use-cases/product-recommendation';
 import {recommendationUseCase} from './use-cases/recommendation';
@@ -51,6 +52,11 @@ const useCases: UseCase[] = [
     name: 'product-listing',
     entryFile: 'temp/product-listing.api.json',
     config: productListingUseCase,
+  },
+  {
+    name: 'case-assist',
+    entryFile: 'temp/case-assist.api.json',
+    config: caseAssistUseCase,
   },
 ];
 

--- a/packages/headless/doc-parser/use-cases/case-assist.ts
+++ b/packages/headless/doc-parser/use-cases/case-assist.ts
@@ -1,0 +1,43 @@
+import {ActionLoaderConfiguration} from '../src/headless-export-resolvers/action-loader-resolver';
+import {ControllerConfiguration} from '../src/headless-export-resolvers/controller-resolver';
+import {EngineConfiguration} from '../src/headless-export-resolvers/engine-resolver';
+
+const controllers: ControllerConfiguration[] = [
+  {
+    initializer: 'buildCaseInput',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildCaseField',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildCaseAssistQuickview',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildDocumentSuggestionList',
+    samplePaths: {},
+  },
+];
+
+const actionLoaders: ActionLoaderConfiguration[] = [
+  {
+    initializer: 'loadCaseInputActions',
+  },
+  {
+    initializer: 'loadCaseFieldActions',
+  },
+  {
+    initializer: 'loadDocumentSuggestionActions',
+  },
+  {
+    initializer: 'loadCaseAssistAnalyticsActions',
+  },
+];
+
+const engine: EngineConfiguration = {
+  initializer: 'buildCaseAssistEngine',
+};
+
+export const caseAssistUseCase = {controllers, actionLoaders, engine};

--- a/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-response.ts
+++ b/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-response.ts
@@ -1,7 +1,7 @@
 /**
  * Defines document suggestion result.
  */
-export interface DocumentSuggestion {
+export interface DocumentSuggestionResponse {
   clickUri: string;
   excerpt: string;
   fields: Record<string, string | number | boolean | string[]>;
@@ -16,7 +16,7 @@ export interface DocumentSuggestion {
  * See https://platform.cloud.coveo.com/docs?urls.primaryName=Customer%20Service#/Suggestions/getSuggestDocument
  */
 export interface GetDocumentSuggestionsResponse {
-  documents: DocumentSuggestion[];
+  documents: DocumentSuggestionResponse[];
   totalCount: number;
   responseId: string;
 }

--- a/packages/headless/src/app/case-assist-engine/case-assist-engine-configuration.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine-configuration.ts
@@ -17,7 +17,7 @@ export interface CaseAssistEngineConfiguration extends EngineConfiguration {
    */
   caseAssistId: string;
   /**
-   * The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+   * The locale of the current user. Must comply with IETF’s [BCP 47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) definition.
    *
    * Notes:
    *  Coveo Machine Learning models use this information to provide contextually relevant output.

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -67,10 +67,18 @@ export type {Result} from './api/search/search/result';
 export type {Raw} from './api/search/search/raw';
 export type {HighlightKeyword} from './utils/highlight';
 
-export type {DocumentSuggestion} from './api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
+export type {DocumentSuggestionResponse} from './api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
 
 export type {
   DocumentSuggestionList,
   DocumentSuggestionListState,
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
 export {buildDocumentSuggestionList} from './controllers/document-suggestion-list/headless-document-suggestion-list';
+
+// Types exported for backward compatibility only.
+export type {
+  DocumentSuggestionList as DocumentSuggestion,
+  DocumentSuggestionListState as DocumentSuggestionState,
+} from './controllers/document-suggestion-list/headless-document-suggestion-list';
+
+export {buildDocumentSuggestionList as buildDocumentSuggestion} from './controllers/document-suggestion-list/headless-document-suggestion-list';

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -34,6 +34,7 @@ export type {
   CaseInput,
   CaseInputOptions,
   CaseInputProps,
+  UpdateFetchOptions,
 } from './controllers/case-input/headless-case-input';
 export {buildCaseInput} from './controllers/case-input/headless-case-input';
 
@@ -42,9 +43,18 @@ export type {
   CaseField,
   CaseFieldOptions,
   CaseFieldProps,
+  UpdateCaseFieldFetchOptions,
 } from './controllers/case-field/headless-case-field';
 export {buildCaseField} from './controllers/case-field/headless-case-field';
 
+export type {CaseFieldSuggestion} from './features/case-field/case-field-state';
+
+export type {
+  QuickviewCore,
+  QuickviewCoreOptions,
+  QuickviewCoreProps,
+  QuickviewCoreState,
+} from './controllers/core/quickview/headless-core-quickview';
 export type {
   CaseAssistQuickviewState,
   CaseAssistQuickview,
@@ -53,8 +63,14 @@ export type {
 } from './controllers/quickview/case-assist-headless-quickview';
 export {buildCaseAssistQuickview} from './controllers/quickview/case-assist-headless-quickview';
 
+export type {Result} from './api/search/search/result';
+export type {Raw} from './api/search/search/raw';
+export type {HighlightKeyword} from './utils/highlight';
+
+export type {DocumentSuggestion} from './api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
+
 export type {
-  DocumentSuggestionList as DocumentSuggestion,
-  DocumentSuggestionListState as DocumentSuggestionState,
+  DocumentSuggestionList,
+  DocumentSuggestionListState,
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
-export {buildDocumentSuggestionList as buildDocumentSuggestion} from './controllers/document-suggestion-list/headless-document-suggestion-list';
+export {buildDocumentSuggestionList} from './controllers/document-suggestion-list/headless-document-suggestion-list';

--- a/packages/headless/src/controllers/document-suggestion-list/headless-document-suggestion-list.ts
+++ b/packages/headless/src/controllers/document-suggestion-list/headless-document-suggestion-list.ts
@@ -17,7 +17,7 @@ import {
 } from '../../app/reducers';
 import {loadReducerError} from '../../utils/errors';
 import {CaseAssistAPIErrorStatusResponse} from '../../api/service/case-assist/case-assist-api-client';
-import {DocumentSuggestion} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
+import {DocumentSuggestionResponse} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
 
 /**
  * The `DocumentSuggestion` controller is responsible for getting document suggestions using case information present in the state.
@@ -45,7 +45,7 @@ export interface DocumentSuggestionListState {
   /**
    * The retrieved document suggestions.
    */
-  documents: DocumentSuggestion[];
+  documents: DocumentSuggestionResponse[];
 }
 
 /**

--- a/packages/headless/src/features/case-assist/case-assist-analytics-actions-loader.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-actions-loader.ts
@@ -15,37 +15,71 @@ import {
   logQuickviewDocumentSuggestionClick,
 } from './case-assist-analytics-actions';
 
+/**
+ * The Case Assist analytics action creators.
+ */
 export interface CaseAssistAnalyticsActionCreators {
+  /**
+   * Creates a Case Assist event for when the user enters the interface.
+   *
+   * @returns A dispatchable action.
+   */
   logCaseStart(): AsyncThunkAction<
     void,
     void,
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user moves to the next stage.
+   *
+   * @returns A dispatchable action.
+   */
   logCaseNextStage(): AsyncThunkAction<
     void,
     void,
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user creates a case.
+   *
+   * @returns A dispatchable action.
+   */
   logCreateCase(): AsyncThunkAction<
     void,
     void,
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the case is solved.
+   *
+   * @returns A dispatchable action.
+   */
   logSolveCase(): AsyncThunkAction<
     void,
     void,
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user leaves.
+   *
+   * @returns A dispatchable action.
+   */
   logAbandonCase(): AsyncThunkAction<
     void,
     void,
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user updates a field.
+   *
+   * @param fieldName - The target field name.
+   * @returns A dispatchable action.
+   */
   logUpdateCaseField(
     fieldName: string
   ): AsyncThunkAction<
@@ -54,6 +88,12 @@ export interface CaseAssistAnalyticsActionCreators {
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user selects a classification suggestion.
+   *
+   * @param classificationId - The unique identifier of the target classification.
+   * @returns A dispatchable action.
+   */
   logClassificationClick(
     classificationId: string
   ): AsyncThunkAction<
@@ -62,6 +102,12 @@ export interface CaseAssistAnalyticsActionCreators {
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user selects a document suggestion.
+   *
+   * @param suggestionId - The unique identifier of the target document.
+   * @returns A dispatchable action.
+   */
   logDocumentSuggestionClick(
     suggestionId: string
   ): AsyncThunkAction<
@@ -70,6 +116,12 @@ export interface CaseAssistAnalyticsActionCreators {
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user previews a document suggestion from the quickview.
+   *
+   * @param suggestionId - The unique identifier of the target document.
+   * @returns A dispatchable action.
+   */
   logQuickviewDocumentSuggestionClick(
     suggestionId: string
   ): AsyncThunkAction<
@@ -78,6 +130,13 @@ export interface CaseAssistAnalyticsActionCreators {
     AsyncThunkAnalyticsOptions<StateNeededByCaseAssistAnalytics>
   >;
 
+  /**
+   * Creates a Case Assist event for when the user rates a document suggestion.
+   *
+   * @param suggestionId - The unique identifier of the target document.
+   * @param rating - The rating.
+   * @returns A dispatchable action.
+   */
   logDocumentSuggestionRating(
     suggestionId: string,
     rating: number
@@ -88,10 +147,15 @@ export interface CaseAssistAnalyticsActionCreators {
   >;
 }
 
+/**
+ * Loads the case assist analytics actions.
+ * @param engine The case assist engine.
+ * @returns The available analytics actions.
+ */
 export function loadCaseAssistAnalyticsActions(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _engine: CaseAssistEngine
+  engine: CaseAssistEngine
 ): CaseAssistAnalyticsActionCreators {
+  engine.addReducers({});
   return {
     logCaseStart,
     logCaseNextStage,

--- a/packages/headless/src/features/document-suggestion/document-suggestion-slice.test.ts
+++ b/packages/headless/src/features/document-suggestion/document-suggestion-slice.test.ts
@@ -1,5 +1,5 @@
 import {
-  DocumentSuggestion,
+  DocumentSuggestionResponse,
   GetDocumentSuggestionsResponse,
 } from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
 import {fetchDocumentSuggestions} from './document-suggestion-actions';
@@ -11,7 +11,7 @@ import {
 
 describe('document suggestion slice', () => {
   let state: DocumentSuggestionState;
-  const mockDocument: DocumentSuggestion = {
+  const mockDocument: DocumentSuggestionResponse = {
     clickUri: 'www.clikuri.com',
     title: 'Mock Document',
     excerpt: 'This is a dang good mock document.',

--- a/packages/headless/src/features/document-suggestion/document-suggestion-state.ts
+++ b/packages/headless/src/features/document-suggestion/document-suggestion-state.ts
@@ -1,5 +1,5 @@
 import {CaseAssistAPIErrorStatusResponse} from '../../api/service/case-assist/case-assist-api-client';
-import {DocumentSuggestion} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
+import {DocumentSuggestionResponse} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response';
 
 export const getDocumentSuggestionInitialState =
   (): DocumentSuggestionState => ({
@@ -34,5 +34,5 @@ export interface DocumentSuggestionState {
   /**
    * The retrieved document suggestions.
    */
-  documents: DocumentSuggestion[];
+  documents: DocumentSuggestionResponse[];
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -102,7 +102,7 @@ export default class QuanticDocumentSuggestion extends LightningElement {
   initialize = (engine) => {
     this.engine = engine;
     this.documentSuggestion =
-      CoveoHeadlessCaseAssist.buildDocumentSuggestion(engine);
+      CoveoHeadlessCaseAssist.buildDocumentSuggestionList(engine);
     this.unsubscribeDocumentSuggestion = this.documentSuggestion.subscribe(() =>
       this.updateDocumentSuggestionState()
     );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-470

This PR makes the JSDoc available for the case assist use case in Headless.

The end result was tested by generating both the Headless and Quantic documentation in the online documentation repository.