### PR TITLE
chore(quantic): remove unnecessary check for github token

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -48,9 +48,6 @@ jobs:
             })
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Build Quantic project
-        working-directory: ./packages/quantic
-        run: npm run build
       - name: Create package version
         working-directory: ./packages/quantic
         run: |

--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -46,20 +46,14 @@ jobs:
               repo: context.repo.repo,
               run_id: context.runId
             })
-      - name: Install NPM dependencies
-        working-directory: ./packages/quantic
-        run: |
-          npm i -g typescript
-          npm i -g sfdx-cli
-          npm i
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Build Quantic project
         working-directory: ./packages/quantic
         run: npm run build
-      - name: Copy static resources
-        working-directory: ./packages/quantic
-        run: npm run copy:staticresources
       - name: Create package version
         working-directory: ./packages/quantic
         run: |
-          echo "$SFDX_AUTH_JWT_KEY" > server.key
-          node_modules/.bin/ts-node scripts/build/create-package.ts --remove-translations
+          echo "${{ env.SFDX_AUTH_JWT_KEY }}" > server.key
+          npx --no-install ts-node scripts/build/create-package.ts --remove-translations --ci
+          rm server.key

--- a/packages/quantic/scripts/build/create-package.ts
+++ b/packages/quantic/scripts/build/create-package.ts
@@ -23,7 +23,6 @@ interface Options {
 
 function ensureEnvVariables() {
   [
-    'GITHUB_TOKEN',
     'SFDX_AUTH_CLIENT_ID',
     'SFDX_AUTH_JWT_KEY',
     'SFDX_AUTH_JWT_USERNAME',


### PR DESCRIPTION
https://github.com/coveo/ui-kit/runs/5321152179?check_suite_focus=true
We got farther but this should fix it.. for real this time.

The GITHUB_TOKEN env variable is not necessary for creating unpublished packages.
It's only to create Discussion posts after a successful publish so I deem it non-critical.
If the env variable is missing the final step will fail but the release won't be cancelled outright.