### PR TITLE
ci(headless,atomic): use github artifacts to store build output on bump

### DIFF
--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -3,10 +3,17 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      deployWithNoVersionBump:
+        description: 'Start deploy even if last commit is not a version bump'
+        type: boolean
+        required: false
+
 jobs:
   allow-workflow:
     name: 'Allow workflow'
-    if: "startsWith(github.event.head_commit.message, '[Version Bump]')"
+    if: "startsWith(github.event.head_commit.message, '[Version Bump]') || ${{ github.event.inputs.deployWithNoVersionBump == 'true' }}"
     runs-on: ubuntu-latest
     steps:
       - run: echo "Workflow allowed to start"
@@ -37,7 +44,7 @@ jobs:
           name: artifacts-atomic
           path: |
             packages/atomic/dist
-            
+
       - name: Archive build artifacts Atomic Storybook
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publishbot.yml
+++ b/.github/workflows/publishbot.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   allow-workflow:
-    name: "Allow workflow"
+    name: 'Allow workflow'
     if: "startsWith(github.event.head_commit.message, '[Version Bump]')"
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +23,28 @@ jobs:
       - run: npm run npm:publish:alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Archive build artifacts Headless
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-headless
+          path: |
+            packages/headless/dist
+
+      - name: Archive build artifacts Atomic
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-atomic
+          path: |
+            packages/atomic/dist
+            
+      - name: Archive build artifacts Atomic Storybook
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts-atomic-storybook
+          path: |
+            packages/atomic/storybook-static
+
   deploy:
     name: 'Deploy the package'
     needs: npm-publish
@@ -31,7 +53,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifacts-headless
+          path: packages/headless/dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifacts-atomic
+          path: packages/atomic/dist
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifacts-atomic-storybook
+          path: packages/atomic/storybook-static
+
       - run: rm -rf veracode && mkdir veracode
       - run: mkdir veracode/auth
       - run: cp -R packages/auth/src packages/auth/package.json packages/auth/package-lock.json veracode/auth


### PR DESCRIPTION
Tentative to remove the "setup" ( `./.github/actions/setup` ) from executing in self hosted runner.

Instead of trying to clone, install dependencies (disk space failure here), and rebuild, use artifacts from the built packages.

I'm not 100% sure this will work 🤷 🎲 

Because of this, I added a manual workflow dispatch to be able to test more easily.

I will remove it once I can confirm that it works properly.

https://coveord.atlassian.net/browse/KIT-1436