### PR TITLE
chore(quantic): updated graphql typing

### DIFF
--- a/packages/quantic/scripts/build/util/github.ts
+++ b/packages/quantic/scripts/build/util/github.ts
@@ -45,7 +45,7 @@ export async function createDiscussion(
     },
   });
   const query = `
-    mutation createDiscussion($repositoryId: String!, $categoryId: String!,  $title: String!, $body: String!) {
+    mutation createDiscussion($repositoryId: ID!, $categoryId: ID!,  $title: String!, $body: String!) {
       createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
         discussion {
           id


### PR DESCRIPTION
The typing for these params was either changed or is newly enforced. Either way, this fixes it so the quantic release discussion post can be done automatically again.