### PR TITLE
chore(headless): add deprecated tag

### DIFF
--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -75,7 +75,10 @@ export type {
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
 export {buildDocumentSuggestionList} from './controllers/document-suggestion-list/headless-document-suggestion-list';
 
-// Types exported for backward compatibility only.
+/**
+ * @deprecated
+ * Types exported for backward compatibility only.
+ */
 export type {
   DocumentSuggestionList as DocumentSuggestion,
   DocumentSuggestionListState as DocumentSuggestionState,


### PR DESCRIPTION
Just so they surface up when looking for things to clean up before next major headless release.
[Related slack thread](https://coveo.slack.com/archives/G016TA2G485/p1646070593061369?thread_ts=1646069124.589649&cid=G016TA2G485)