### PR TITLE
fix(quantic): not displaying suggestions when they are not among all the available options

### DIFF
--- a/packages/quantic/cypress/integration/case-classification/case-classification-expectations.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification-expectations.ts
@@ -5,6 +5,7 @@ import {
   CaseClassificationSelector,
   CaseClassificationSelectors,
 } from './case-classification-selectors';
+import {ConsoleExpectations} from '../console-expectations';
 
 function caseClassificationExpectations(selector: CaseClassificationSelector) {
   return {
@@ -168,4 +169,7 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
 
 export const CaseClassificationExpectations = {
   ...caseClassificationExpectations(CaseClassificationSelectors),
+  console: {
+    ...ConsoleExpectations,
+  },
 };

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -31,8 +31,12 @@ const invalidMaxSuggestionsError = (value: string | number) => {
 };
 const missingCoveoFieldNameError =
   'coveoFieldName is required, please set its value.';
-const nonCorrespondingSuggestionWarning = (value: string) => {
-  return `The value "${value}" was not found among all the options retrieved from Salesforce. Please confirm that the coveoFieldName corresponds to the correct sfFieldApiName.`;
+const nonCorrespondingSuggestionWarning = (
+  value: string,
+  coveoFieldName: string,
+  sfFieldApiName: string
+) => {
+  return `The value "${value}" was not found among all the options retrieved from Salesforce. Ensure that the Coveo field name "${coveoFieldName}" corresponds to the correct Salesforce field name "${sfFieldApiName}".`;
 };
 
 describe('quantic-case-classification', () => {
@@ -40,6 +44,7 @@ describe('quantic-case-classification', () => {
 
   const sfDefaultField = 'Priority';
   const coveoDefaultField = 'sfpriority';
+  const nonCorrespondingCoveoField = 'sforigin';
   const allOptions = [
     {id: '0', value: 'Very low', label: 'Very low'},
     {id: '1', value: 'Low', label: 'Low'},
@@ -825,7 +830,9 @@ describe('quantic-case-classification', () => {
           stubConsoleWarning(win);
         },
       });
-      configure();
+      configure({
+        coveoFieldName: nonCorrespondingCoveoField,
+      });
 
       scope('when loading the page', () => {
         Expect.numberOfInlineOptions(0);
@@ -835,7 +842,10 @@ describe('quantic-case-classification', () => {
       });
 
       scope('when fetching suggestions', () => {
-        mockCaseClassification(coveoDefaultField, nonCorrespondingSuggestions);
+        mockCaseClassification(
+          nonCorrespondingCoveoField,
+          nonCorrespondingSuggestions
+        );
         fetchClassifications();
         Expect.displaySelectTitle(false);
         Expect.displaySelectInput(true);
@@ -844,7 +854,11 @@ describe('quantic-case-classification', () => {
         nonCorrespondingSuggestions.forEach((suggestion: {value: string}) => {
           Expect.console.warning(
             true,
-            nonCorrespondingSuggestionWarning(suggestion.value)
+            nonCorrespondingSuggestionWarning(
+              suggestion.value,
+              nonCorrespondingCoveoField,
+              sfDefaultField
+            )
           );
         });
       });

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -40,7 +40,6 @@ describe('quantic-case-classification', () => {
 
   const sfDefaultField = 'Priority';
   const coveoDefaultField = 'sfpriority';
-  const defaultMaxSuggestions = 3;
   const allOptions = [
     {id: '0', value: 'Very low', label: 'Very low'},
     {id: '1', value: 'Low', label: 'Low'},
@@ -64,9 +63,7 @@ describe('quantic-case-classification', () => {
 
   describe('when using default options', () => {
     it('should render the component and all parts', () => {
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -124,9 +121,7 @@ describe('quantic-case-classification', () => {
 
   describe('when the suggestions are loading', () => {
     it('should display the loading spinner', () => {
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -155,9 +150,7 @@ describe('quantic-case-classification', () => {
 
   describe('when no suggestions are found', () => {
     it('should display only the select dropdown', () => {
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.numberOfInlineOptions(0);
@@ -567,9 +560,7 @@ describe('quantic-case-classification', () => {
   describe('when selecting a suggestion and then receiving new suggestions', () => {
     it('should keep the suggestion selected by the user', () => {
       const clickedIndex = 1;
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -628,9 +619,7 @@ describe('quantic-case-classification', () => {
   describe('when selecting a specific suggestion and then receiving new suggestions that does not contain the previously selected option', () => {
     it('should keep the suggestion selected by the user and display it in the select input', () => {
       const clickedIndex = 2;
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -688,9 +677,7 @@ describe('quantic-case-classification', () => {
   describe('when selecting an option from the select input and then fetching suggestions', () => {
     it('should keep the option selected by the user, display it in the select input and hide the suggestions', () => {
       const clickedIndex = 3;
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -730,9 +717,7 @@ describe('quantic-case-classification', () => {
 
   describe('when receiving new suggestions without changing the by default auto-selected suggestion', () => {
     it('should auto-select the suggestion with the highest confidence from the newly recieved suggestions', () => {
-      visitCaseClassification({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      visitCaseClassification({});
 
       scope('when loading the page', () => {
         Expect.displayLabel(true);
@@ -840,9 +825,7 @@ describe('quantic-case-classification', () => {
           stubConsoleWarning(win);
         },
       });
-      configure({
-        maxSuggestions: defaultMaxSuggestions,
-      });
+      configure();
 
       scope('when loading the page', () => {
         Expect.numberOfInlineOptions(0);

--- a/packages/quantic/cypress/integration/console-expectations.ts
+++ b/packages/quantic/cypress/integration/console-expectations.ts
@@ -3,6 +3,9 @@ import {ConsoleSelectors} from './console-selectors';
 export const ConsoleExpectations = {
   error: (hasError: boolean) =>
     ConsoleSelectors.error().should(hasError ? 'be.called' : 'not.be.called'),
-  warning: (hasError: boolean) =>
-    ConsoleSelectors.warn().should(hasError ? 'be.called' : 'not.be.called'),
+  warning: (hasError: boolean, message: string) =>
+    ConsoleSelectors.warn().should(
+      hasError ? 'be.calledWith' : 'not.be.calledWith',
+      message
+    ),
 };

--- a/packages/quantic/cypress/integration/document-suggestion/document.suggestion.expectations.ts
+++ b/packages/quantic/cypress/integration/document-suggestion/document.suggestion.expectations.ts
@@ -4,7 +4,6 @@ import {
   DocumentSuggestionSelector,
   DocumentSuggestionSelectors,
 } from './document-suggestion-selectors';
-import {ConsoleExpectations} from '../console-expectations';
 
 interface Fields {
   uri: string;

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
@@ -43,8 +43,8 @@ export default class QuanticCaseClassification extends LightningElement {
     if (error) {
       console.error('Error getting the picklist values');
     } else {
-      this.picklistValues = data;
       if (data) {
+        this.picklistValues = data;
         this.allOptionsReceived = true;
         if (!data.picklistFieldValues[this.sfFieldApiName]) {
           this.renderingError = `The Salesforce field API name "${this.sfFieldApiName}" is not found.`;
@@ -137,8 +137,8 @@ export default class QuanticCaseClassification extends LightningElement {
   lockedState = false;
   /** @type {boolean} */
   allOptionsReceived;
-  /** @type {Array<boolean>} */
-  loggedWarnings = [];
+  /** @type {Object} */
+  loggedInvalidFieldValueWarnings = {};
 
   connectedCallback() {
     this.validateProps();
@@ -314,9 +314,7 @@ export default class QuanticCaseClassification extends LightningElement {
           (option) => option.value === suggestion.value
         );
         if (!suggestionIncludedInOptions) {
-          this.logWarningOnce(
-            `The value "${suggestion.value}" was not found among all the options retrieved from Salesforce. Please confirm that the coveoFieldName corresponds to the correct sfFieldApiName.`
-          );
+          this.logInvalidFieldValueWarningOnce(suggestion.value);
         }
         return suggestionIncludedInOptions;
       })
@@ -415,10 +413,12 @@ export default class QuanticCaseClassification extends LightningElement {
     );
   }
 
-  logWarningOnce(message) {
-    if (!this.loggedWarnings[message]) {
-      this.loggedWarnings[message] = true;
-      console.warn(message);
+  logInvalidFieldValueWarningOnce(value) {
+    if (!this.loggedInvalidFieldValueWarnings[value]) {
+      this.loggedInvalidFieldValueWarnings[value] = true;
+      console.warn(
+        `The value "${value}" was not found among all the options retrieved from Salesforce. Please confirm that the coveoFieldName corresponds to the correct sfFieldApiName.`
+      );
     }
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
@@ -417,7 +417,7 @@ export default class QuanticCaseClassification extends LightningElement {
     if (!this.loggedInvalidFieldValueWarnings[value]) {
       this.loggedInvalidFieldValueWarnings[value] = true;
       console.warn(
-        `The value "${value}" was not found among all the options retrieved from Salesforce. Please confirm that the coveoFieldName corresponds to the correct sfFieldApiName.`
+        `The value "${value}" was not found among all the options retrieved from Salesforce. Ensure that the Coveo field name "${this.coveoFieldName}" corresponds to the correct Salesforce field name "${this.sfFieldApiName}".`
       );
     }
   }


### PR DESCRIPTION
[SVCC-466](https://coveord.atlassian.net/browse/SVCC-466)

### The problem:
Currently we always display the suggestions returned by our ML models even if the returned suggestions are not among all the available options retrieved from Salesforce. 

If a user for Example introduces `Priority` as the SF field name and `sfreason` as the Coveo field name, like that we having non corresponding SF field name and Coveo field name. in this case we dont want to display the suggestions cause they are not corresponding to the right field and to inform the user of this problem we want to log warnings to inform him.

### The fix:
Ignore suggestions that aren't part of the possible values retrieved from Salesforce and raise a warning when it happens.