### PR TITLE
ci(snyk): fix snyk code config to use one path

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -164,38 +164,8 @@
     "no_scan": false,
     "configurations": [
       {
-        "path": "packages/bueno",
-        "project_name": "bueno",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/auth",
-        "project_name": "auth",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/headless",
-        "project_name": "headless-engine",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/quantic",
-        "project_name": "quantic",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/atomic",
-        "project_name": "atomic",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/atomic-react",
-        "project_name": "atomic-react",
-        "org": "coveo-jsui"
-      },
-      {
-        "path": "packages/atomic-angular",
-        "project_name": "atomic-angular",
+        "path": ".",
+        "project_name": "coveo/ui-kit",
         "org": "coveo-jsui"
       }
     ]


### PR DESCRIPTION
Otherwise the `.dcignore` file at the root of the repo gets, well, ignored.

https://coveord.atlassian.net/browse/KIT-1463