### PR TITLE
feat(atomic-react): improve localization configuration for atomic-react

### DIFF
--- a/packages/atomic-react/README.md
+++ b/packages/atomic-react/README.md
@@ -211,7 +211,7 @@ const MyPage = () => {
 
 ## Localization (i18n)
 
-AtomicReact offers an optional callback to allow to localize the search interface, as described here: https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/
+The Atomic React search interface component exposes an optional `localization` option, which takes a callback function that lets you handle [localization](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/).
 
 ```jsx
 <AtomicSearchInterface

--- a/packages/atomic-react/README.md
+++ b/packages/atomic-react/README.md
@@ -208,3 +208,17 @@ const MyPage = () => {
   );
 };
 ```
+
+## Localization (i18n)
+
+AtomicReact offers an optional callback to allow to localize the search interface, as described here: https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/
+
+```jsx
+<AtomicSearchInterface
+  localization={(i18n) => {
+    i18n.addResourceBundle('en', 'translation', {
+      search: "I'm feeling lucky!",
+    });
+  }}
+></AtomicSearchInterface>
+```

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -30,9 +30,9 @@ interface WrapperProps extends Omit<JSX.AtomicSearchInterface, 'i18n'> {
    */
   theme?: string | 'none';
   /**
-   * An optional callback that can be used to control the localization of the interface.
+   * An optional callback that lets you control the interface localization.
    *
-   * The function receive the search interface 18n instance, which can then be leveraged as described here : https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/
+   * The function receives the search interface 18n instance, which you can then modify (see [Localization](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/)).
    *
    */
   localization?: (i18n: i18n) => void;

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef} from 'react';
-import type {JSX} from '@coveo/atomic';
+import type {JSX, i18n} from '@coveo/atomic';
 import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
@@ -10,7 +10,7 @@ type ExecuteSearch = HTMLAtomicSearchInterfaceElement['executeFirstSearch'];
 /**
  * The properties of the AtomicSearchInterface component
  */
-interface WrapperProps extends JSX.AtomicSearchInterface {
+interface WrapperProps extends Omit<JSX.AtomicSearchInterface, 'i18n'> {
   /**
    * An optional callback function that can be used to control the execution of the first query.
    *
@@ -29,13 +29,23 @@ interface WrapperProps extends JSX.AtomicSearchInterface {
    * Read more about theming and visual customization here : https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/
    */
   theme?: string | 'none';
+  /**
+   * An optional callback that can be used to control the localization of the interface.
+   *
+   * The function receive the search interface 18n instance, which can then be leveraged as described here : https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/
+   *
+   */
+  localization?: (i18n: i18n) => void;
 }
 
-const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'theme'>> = {
+const DefaultProps: Required<
+  Pick<WrapperProps, 'onReady' | 'theme' | 'localization'>
+> = {
   onReady: (executeFirstSearch) => {
     return executeFirstSearch();
   },
   theme: 'coveo',
+  localization: () => {},
 };
 
 /**
@@ -52,7 +62,7 @@ export const SearchInterfaceWrapper = (
       configuration: getSampleSearchEngineConfiguration(),
     });
   }
-  const {engine, theme, onReady, ...allOtherProps} = mergedProps;
+  const {engine, theme, localization, onReady, ...allOtherProps} = mergedProps;
   const searchInterfaceRef = useRef<HTMLAtomicSearchInterfaceElement>(null);
   if (theme !== 'none') {
     import(`@coveo/atomic/dist/atomic/themes/${theme}.css`);
@@ -61,6 +71,7 @@ export const SearchInterfaceWrapper = (
   useEffect(() => {
     const searchInterfaceAtomic = searchInterfaceRef.current!;
     searchInterfaceAtomic.initialize(engine.state.configuration).then(() => {
+      localization(searchInterfaceAtomic.i18n);
       onReady(
         searchInterfaceAtomic.executeFirstSearch.bind(searchInterfaceAtomic)
       );

--- a/packages/atomic/src/index.ts
+++ b/packages/atomic/src/index.ts
@@ -1,4 +1,5 @@
 export {Components, JSX} from './components';
+export type {i18n} from 'i18next';
 
 export {bindLogDocumentOpenOnResult} from './utils/result-utils';
 


### PR DESCRIPTION
Was originally reported from Coveo discuss.

Getting a reference to the 18n instance on the search interface is kind of awkward to do in React otherwise.

https://coveord.atlassian.net/browse/KIT-1461