### PR TITLE
fix(quantic): improvement of the display behaviour of the suggestions

### DIFF
--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -634,23 +634,26 @@ describe('quantic-case-classification', () => {
         Expect.displaySelectInput(true);
       });
 
-      scope('when fetching suggestions', () => {
-        const suggestionsCount = 3;
-        const firstSuggestionIndex = 0;
+      scope(
+        'when fetching suggestions and getting a firt set of suggestions',
+        () => {
+          const suggestionsCount = 3;
+          const firstSuggestionIndex = 0;
 
-        mockCaseClassification(
-          coveoDefaultField,
-          allOptions.slice(0, suggestionsCount)
-        );
-        fetchClassifications();
-        Expect.displaySelectTitle(true);
-        Expect.displaySelectInput(false);
-        Expect.numberOfSuggestions(suggestionsCount);
-        Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
-        Expect.numberOfInlineOptions(0);
-        Expect.logClickedSuggestion(firstSuggestionIndex, true);
-        Expect.correctValue(allOptions[firstSuggestionIndex].value);
-      });
+          mockCaseClassification(
+            coveoDefaultField,
+            allOptions.slice(0, suggestionsCount)
+          );
+          fetchClassifications();
+          Expect.displaySelectTitle(true);
+          Expect.displaySelectInput(false);
+          Expect.numberOfSuggestions(suggestionsCount);
+          Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
+          Expect.numberOfInlineOptions(0);
+          Expect.logClickedSuggestion(firstSuggestionIndex, true);
+          Expect.correctValue(allOptions[firstSuggestionIndex].value);
+        }
+      );
 
       scope('when selecting a suggestion', () => {
         Actions.clickSuggestion(clickedIndex);
@@ -662,20 +665,42 @@ describe('quantic-case-classification', () => {
         Expect.correctValue(allOptions[clickedIndex].value);
       });
 
-      scope('when fetching suggestions again', () => {
-        const suggestionsCount = 1;
+      scope(
+        'when fetching suggestions and getting a different set of suggestions',
+        () => {
+          const suggestionsCount = 1;
 
-        mockCaseClassification(
-          coveoDefaultField,
-          allOptions.slice(0, suggestionsCount)
-        );
-        fetchClassifications();
-        Expect.displaySelectTitle(false);
-        Expect.displaySelectInput(false);
-        Expect.numberOfSuggestions(0);
-        Expect.numberOfInlineOptions(0);
-        Expect.correctValue(allOptions[clickedIndex].value);
-      });
+          mockCaseClassification(
+            coveoDefaultField,
+            allOptions.slice(0, suggestionsCount)
+          );
+          fetchClassifications();
+          Expect.displaySelectTitle(false);
+          Expect.displaySelectInput(false);
+          Expect.numberOfSuggestions(0);
+          Expect.numberOfInlineOptions(0);
+          Expect.correctValue(allOptions[clickedIndex].value);
+        }
+      );
+
+      scope(
+        'when fetching suggestions and getting again the first set of suggestions',
+        () => {
+          const suggestionsCount = 3;
+
+          mockCaseClassification(
+            coveoDefaultField,
+            allOptions.slice(0, suggestionsCount)
+          );
+          fetchClassifications();
+          Expect.displaySelectTitle(true);
+          Expect.displaySelectInput(false);
+          Expect.numberOfSuggestions(suggestionsCount);
+          Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
+          Expect.numberOfInlineOptions(0);
+          Expect.correctValue(allOptions[clickedIndex].value);
+        }
+      );
     });
   });
 

--- a/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/integration/case-classification/case-classification.cypress.ts
@@ -635,7 +635,7 @@ describe('quantic-case-classification', () => {
       });
 
       scope(
-        'when fetching suggestions and getting a firt set of suggestions',
+        'when fetching suggestions and getting a first set of suggestions',
         () => {
           const suggestionsCount = 3;
           const firstSuggestionIndex = 0;

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
@@ -200,6 +200,9 @@ export default class QuanticCaseClassification extends LightningElement {
         if (!this.isSuggestion(value) && this.isMoreOptionsVisible) {
           this.hideSuggestions = true;
           this.showSelect();
+        } else {
+          this.hideSuggestions = false;
+          this.hideSelect();
         }
         this.setFieldValue(value, true);
       }
@@ -329,6 +332,14 @@ export default class QuanticCaseClassification extends LightningElement {
    */
   showSelect() {
     this._isSelectVisible = true;
+  }
+
+  /**
+   * Hides the select input.
+   * @returns {void}
+   */
+  hideSelect() {
+    this._isSelectVisible = false;
   }
 
   /**


### PR DESCRIPTION
[SFINT-4428](https://coveord.atlassian.net/browse/SFINT-4428)
## What is wrong?
Steps to reproduce:

1. The user types the subject/description of his case.
2. Some suggestions appears and the user selects one of the suggestions.
3. The user updates the subject/description triggering new suggestions that do not include the value selected by the user.
4. The suggestions are not displayed and the value selected by the user is persisted and displayed in the select dropdown.
5. The user updates the subject/description triggering new suggestions that do include the value selected by the user.
6. The value suggestions are still not displayed and the the value selected by the user is still displayed in the select input which is not the behaviour we want.


https://user-images.githubusercontent.com/86681870/158168302-3344522e-2003-4e22-a37e-8fdea69f6690.mov




## What is the correct behaviour?
In the step 6 we want to display again the suggestions and display the value selected by the user as a selected suggestion and not in the select dropdown.


https://user-images.githubusercontent.com/86681870/158168886-103b0a1d-9f85-4d2a-b717-02a7bd7ff9f1.mov




