### PR TITLE
fix(atomic): moved "view results" button on Android above the navigation bar

### DIFF
--- a/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
@@ -262,7 +262,7 @@ export class AtomicRefineModal implements InitializableComponent {
       <atomic-focus-trap active={isOpened}>
         <div
           part="container"
-          class={`w-screen h-screen fixed flex flex-col justify-between bg-background text-on-background left-0 top-0 z-10 ${
+          class={`fixed flex flex-col justify-between bg-background text-on-background left-0 top-0 right-0 bottom-0 z-10 ${
             isOpened
               ? 'animate-scaleUpRefineModal'
               : 'animate-slideDownRefineModal'


### PR DESCRIPTION
For whatever reason, it looks like `100vh` on Android includes the navigation bar.

# Before pics
| Pixel 4 Emulator — Chrome | OnePlus 9 Pro — Chrome | OnePlus 9 Pro — Firefox |
| --- | --- | --- |
|  ![Screenshot_1647266709](https://user-images.githubusercontent.com/54454747/158192324-aef119f1-00ed-4cdd-bc6a-9757dd994ca8.png) | ![Screenshot_2022-03-14-10-03-45-08_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/54454747/158192597-19aa5f23-24d7-4353-a019-c5cff23eb40c.jpg) | ![Screenshot_2022-03-14-10-03-20-55_3aea4af51f236e4932235fdada7d1643](https://user-images.githubusercontent.com/54454747/158192628-d6f48009-016a-4d12-9f0a-0288cda9ac15.jpg)  |

After fixing the issue, I tested on iOS as well to make sure I didn't break anything.

https://coveord.atlassian.net/browse/KIT-1366