### PR TITLE
ci: add atomic-angular package tag

### DIFF
--- a/scripts/deploy/update-npm-tag.js
+++ b/scripts/deploy/update-npm-tag.js
@@ -6,7 +6,8 @@ const packageDirs = [
   'auth',
   'bueno',
   'headless',
-  'atomic-react'
+  'atomic-react',
+  'atomic-angular/projects/atomic-angular'
 ];
 
 async function main() {


### PR DESCRIPTION
This is something I had reverted last time I tried to do a release since the path was incorrect. Angular is "special" in how component library are packaged, with a projects subfolder.

I did a test run of the script locally and it should work next release 🤞  

https://coveord.atlassian.net/browse/KIT-1442