### PR TITLE
feat(headless): adds a link to the usage article about highlighting

### DIFF
--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -53,7 +53,8 @@ export interface SearchBoxProps {
 }
 
 /**
- * The `SearchBox` headless controller offers a high-level interface for designing a common search box UI controller.
+ * The `SearchBox` headless controller offers a high-level interface for designing a common search box UI controller 
+ * with [highlighting for query suggestions](https://docs.coveo.com/en/headless/latest/usage/highlighting/).
  */
 export interface SearchBox extends Controller {
   /**


### PR DESCRIPTION
it's a follow-up to this PR: https://github.com/coveo/doc_jekyll-public-site/pull/6709 