### PR TITLE
feat(atomic): display count as compact number for facet values box

### DIFF
--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
@@ -6,7 +6,12 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
   props,
   children
 ) => {
+  const compactCount = new Intl.NumberFormat(props.i18n.language, {
+    notation: 'compact',
+  }).format(props.numberOfResults);
+
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
+
   const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
     count: props.numberOfResults,
@@ -31,7 +36,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
           class="value-box-count text-neutral-dark truncate w-full text-sm mt-1"
         >
           {props.i18n.t('between-parentheses', {
-            text: count,
+            text: compactCount,
           })}
         </span>
       </Button>


### PR DESCRIPTION
Display count for "box" facets as compact (or short) notation.

ie: 123,999,888-> 124M

Otherwise it gets silly pretty quickly since there's not a lot of horizontal space for each individual value.


<img width="373" alt="image" src="https://user-images.githubusercontent.com/1591893/160680399-2c990220-22c0-4abd-938d-949b5191c1bf.png">


https://coveord.atlassian.net/browse/KIT-1037