### PR TITLE
fix(atomic): possible @coveo/headless version mismatch

### DIFF
--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -19,7 +19,7 @@ async function checkoutLatestMaster() {
 async function bumpVersionAndPush() {
   try {
     await exec(
-      `npx lerna version --conventional-commits --conventional-graduate --no-private --yes`
+      `npx lerna version --conventional-commits --conventional-graduate --no-private --yes --exact`
     );
   } catch (e) {
     console.error(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1515

[**See this related PR for samples**](https://github.com/ThibodeauJF/atomic-cli-v1.25/pull/1/files)

### Root problem
When installing @coveo/atomic, @coveo/headless is both a “subpackage” (@coveo/atomic/headless) and a dependency (@coveo/headless).

### Stemming issues
1. Both versions can have a possible mismatch
2. The typescript of Atomic’s Headless points to @coveo/headless instead of @coveo/atomic/headless. <img width="566" alt="Screen Shot 2022-03-30 at 8 58 15 AM" src="https://user-images.githubusercontent.com/4923043/160917982-d60866c9-d602-416f-84a8-039e6eee9318.png">
3. You start getting completions for both packages in VS code, because of the dependency. Not a big deal, but can be a bit annoying. <img width="808" alt="Screen Shot 2022-03-30 at 8 30 06 AM" src="https://user-images.githubusercontent.com/4923043/160918002-c67729c7-cf80-4aa8-8257-10614de55f5d.png">
4. Using the CDN & npm packages could also lead to version mismatches.

### Solutions
1. For **issue # 1**, by using lerna’s --exact option, it will ensure that the exact version is installed for our packages https://github.com/lerna/lerna/tree/main/commands/version#--exact
2. For **issue # 4**, there should be no major issues when building custom components with a different Atomic & Headless patch version, but there may be some internal bugs if it’s using different minor version (we should specify in the doc to stick to the same minor when using an hybrid CDN/NPM setup, and perhaps advise against it entirely). To fix this in the CLI project, we could either:
    1. Ensure the CDN path fits the installed minor (e.g. I have @coveo/atomic@1.34.2 installed, CDN should be https://static.cloud.coveo.com/atomic/v1.34/atomic.esm.js
    2. Remove the hybrid mode and use the installed @coveo/atomic build (personally favoring that option, see PR)
3. For **issues # 2 & # 3**, removing @coveo/atomic/headless from NPM in our next major bump and only keeping it for the CDN is a possible fix. This will make better use of NPM without workaround when using NPM. A doc change will be required.
4. For **issue # 2** replacing the path “@coveo/headless” with “@coveo/atomic/headless” in our declaration files for the Atomic package could do it.
5. For **issue # 2** now in the CLI project, use a different path in the tsconfig mapping @coveo/headless to Atomic’s (see PR)

We could go for **fixes # 1, # 2, (# 4 or # 5)** for now and perhaps **fix # 3** when we bump?
