### PR TITLE
feat(atomic): added custom styling to smart snippet answer

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -1185,13 +1185,13 @@ export declare interface AtomicSmartSnippet extends Components.AtomicSmartSnippe
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['collapsedHeight', 'headingLevel', 'maximumHeight']
+  inputs: ['collapsedHeight', 'headingLevel', 'maximumHeight', 'snippetStyle']
 })
 @Component({
   selector: 'atomic-smart-snippet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['collapsedHeight', 'headingLevel', 'maximumHeight']
+  inputs: ['collapsedHeight', 'headingLevel', 'maximumHeight', 'snippetStyle']
 })
 export class AtomicSmartSnippet {
   protected el: HTMLElement;

--- a/packages/atomic/cypress/integration/smart-snippet.cypress.ts
+++ b/packages/atomic/cypress/integration/smart-snippet.cypress.ts
@@ -1,4 +1,5 @@
 import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
+import {toArray} from '../utils/arrayUtils';
 import {SmartSnippetSelectors} from './smart-snippet-selectors';
 import * as CommonAssertions from './common-assertions';
 import * as SmartSnippetAssertions from './smart-snippet-assertions';
@@ -26,7 +27,9 @@ interface AddSmartSnippetOptions {
     'heading-level'?: number;
     'maximum-height'?: number;
     'collapsed-height'?: number;
+    'snippet-style'?: string;
   };
+  content?: HTMLElement | HTMLElement[];
   question?: string;
   answer?: string;
   sourceTitle?: string;
@@ -36,9 +39,14 @@ interface AddSmartSnippetOptions {
 const addSmartSnippet =
   (options: AddSmartSnippetOptions = {}) =>
   (fixture: TestFixture) => {
+    const element = generateComponentHTML(
+      'atomic-smart-snippet',
+      options.props
+    );
+    element.append(...toArray(options.content ?? []));
     fixture
       .withStyle(`html { font-size: ${remSize}px; }`)
-      .withElement(generateComponentHTML('atomic-smart-snippet', options.props))
+      .withElement(element)
       .withCustomResponse((response) => {
         const [result] = response.results;
         result.title = options.sourceTitle ?? defaultSourceTitle;
@@ -307,5 +315,52 @@ describe('Smart Snippet Test Suites', () => {
     SmartSnippetAssertions.assertLikeButtonChecked(false);
     SmartSnippetAssertions.assertDislikeButtonChecked(true);
     SmartSnippetAssertions.assertThankYouBanner(true);
+  });
+
+  describe('with custom styling in a template element', () => {
+    before(() => {
+      const styleEl = generateComponentHTML('style');
+      styleEl.innerHTML = `
+        b {
+          color: rgb(84, 170, 255);
+        }
+      `;
+      const templateEl = generateComponentHTML(
+        'template'
+      ) as HTMLTemplateElement;
+      templateEl.content.appendChild(styleEl);
+      new TestFixture().with(addSmartSnippet({content: templateEl})).init();
+    });
+
+    it('applies the styling to the rendered snippet', () => {
+      SmartSnippetSelectors.answer()
+        .find('b')
+        .invoke('css', 'color')
+        .should('equal', 'rgb(84, 170, 255)');
+    });
+  });
+
+  describe('with custom styling in an attribute', () => {
+    before(() => {
+      const style = `
+        b {
+          color: rgb(84, 170, 255);
+        }
+      `;
+      new TestFixture()
+        .with(
+          addSmartSnippet({
+            props: {'snippet-style': style},
+          })
+        )
+        .init();
+    });
+
+    it('applies the styling to the rendered snippet', () => {
+      SmartSnippetSelectors.answer()
+        .find('b')
+        .invoke('css', 'color')
+        .should('equal', 'rgb(84, 170, 255)');
+    });
   });
 });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -812,7 +812,7 @@ export namespace Components {
          */
         "collapsedHeight": number;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.  You can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
          */
         "headingLevel": number;
         /**
@@ -820,7 +820,7 @@ export namespace Components {
          */
         "maximumHeight": number;
         /**
-          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```  Alternatively, you can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
+          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```
          */
         "snippetStyle"?: string;
     }
@@ -2209,7 +2209,7 @@ declare namespace LocalJSX {
          */
         "collapsedHeight"?: number;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.  You can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
          */
         "headingLevel"?: number;
         /**
@@ -2217,7 +2217,7 @@ declare namespace LocalJSX {
          */
         "maximumHeight"?: number;
         /**
-          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```  Alternatively, you can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
+          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```
          */
         "snippetStyle"?: string;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -819,9 +819,14 @@ export namespace Components {
           * The maximum height (in pixels) a snippet can have before the component truncates it and displays a "show more" button.
          */
         "maximumHeight": number;
+        /**
+          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```  Alternatively, you can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
+         */
+        "snippetStyle"?: string;
     }
     interface AtomicSmartSnippetAnswer {
         "htmlContent": string;
+        "innerStyle"?: string;
     }
     interface AtomicSmartSnippetExpandableAnswer {
         /**
@@ -832,6 +837,10 @@ export namespace Components {
           * The maximum height (in pixels) a snippet can have before the component truncates it and displays a "show more" button.
          */
         "maximumHeight": number;
+        /**
+          * Sets the style of the snippet.  Example: ```ts expandableAnswer.snippetStyle = `   b {     color: blue;   } `; ```
+         */
+        "snippetStyle"?: string;
     }
     interface AtomicSortDropdown {
     }
@@ -2207,9 +2216,14 @@ declare namespace LocalJSX {
           * The maximum height (in pixels) a snippet can have before the component truncates it and displays a "show more" button.
          */
         "maximumHeight"?: number;
+        /**
+          * Sets the style of the snippet.  Example: ```ts smartSnippet.snippetStyle = `   b {     color: blue;   } `; ```  Alternatively, you can style the snippet by inserting a template element like this: ```html <atomic-smart-snippet>   <template>     <style>       b {         color: blue;       }     </style>   </template> </atomic-smart-snippet> ```
+         */
+        "snippetStyle"?: string;
     }
     interface AtomicSmartSnippetAnswer {
         "htmlContent": string;
+        "innerStyle"?: string;
         "onAtomic/smartSnippet/answerRendered"?: (event: CustomEvent<{height: number}>) => void;
     }
     interface AtomicSmartSnippetExpandableAnswer {
@@ -2221,6 +2235,10 @@ declare namespace LocalJSX {
           * The maximum height (in pixels) a snippet can have before the component truncates it and displays a "show more" button.
          */
         "maximumHeight"?: number;
+        /**
+          * Sets the style of the snippet.  Example: ```ts expandableAnswer.snippetStyle = `   b {     color: blue;   } `; ```
+         */
+        "snippetStyle"?: string;
     }
     interface AtomicSortDropdown {
     }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-answer.tsx
@@ -1,5 +1,6 @@
-import {Component, h, Prop, Event, EventEmitter} from '@stencil/core';
+import {Component, h, Prop, Event, EventEmitter, Host} from '@stencil/core';
 import {sanitize} from 'dompurify';
+import {sanitizeStyle} from '../../utils/utils';
 
 /**
  * @internal
@@ -11,6 +12,7 @@ import {sanitize} from 'dompurify';
 })
 export class AtomicSmartSnippetAnswer {
   @Prop({reflect: true}) htmlContent!: string;
+  @Prop({reflect: true}) innerStyle?: string;
 
   @Event({
     eventName: 'atomic/smartSnippet/answerRendered',
@@ -22,7 +24,23 @@ export class AtomicSmartSnippetAnswer {
     this.answerRendered.emit({height: this.wrapperElement!.scrollHeight});
   }
 
-  public render() {
+  private get sanitizedStyle() {
+    if (!this.innerStyle) {
+      return undefined;
+    }
+    return sanitizeStyle(this.innerStyle);
+  }
+
+  private renderStyle() {
+    const style = this.sanitizedStyle;
+    if (!style) {
+      return;
+    }
+    // deepcode ignore ReactSetInnerHtml: Defined by implementer and sanitized by dompurify
+    return <style innerHTML={style}></style>;
+  }
+
+  private renderContent() {
     return (
       <div class="wrapper" ref={(element) => (this.wrapperElement = element)}>
         {/* deepcode ignore ReactSetInnerHtml: Sanitized by back-end + dompurify */}
@@ -34,6 +52,15 @@ export class AtomicSmartSnippetAnswer {
           class="margin"
         ></div>
       </div>
+    );
+  }
+
+  public render() {
+    return (
+      <Host>
+        {this.renderStyle()}
+        {this.renderContent()}
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
@@ -37,6 +37,19 @@ export class AtomicSmartSnippetExpandableAnswer {
    * When the answer is partly hidden, how much of its height (in pixels) should be visible.
    */
   @Prop({reflect: true}) collapsedHeight = 180;
+  /**
+   * Sets the style of the snippet.
+   *
+   * Example:
+   * ```ts
+   * expandableAnswer.snippetStyle = `
+   *   b {
+   *     color: blue;
+   *   }
+   * `;
+   * ```
+   */
+  @Prop({reflect: true}) snippetStyle?: string;
 
   @State() showButton = true;
 
@@ -72,6 +85,7 @@ export class AtomicSmartSnippetExpandableAnswer {
         <atomic-smart-snippet-answer
           exportparts="answer"
           htmlContent={this.smartSnippetState.answer}
+          innerStyle={this.snippetStyle}
         ></atomic-smart-snippet-answer>
       </div>
     );

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -58,6 +58,19 @@ export class AtomicSmartSnippet implements InitializableComponent {
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.
    *
    * We recommend setting this property in order to improve accessibility.
+   *
+   * You can style the snippet by inserting a template element like this:
+   * ```html
+   * <atomic-smart-snippet>
+   *   <template>
+   *     <style>
+   *       b {
+   *         color: blue;
+   *       }
+   *     </style>
+   *   </template>
+   * </atomic-smart-snippet>
+   * ```
    */
   @Prop({reflect: true}) public headingLevel = 0;
 
@@ -79,19 +92,6 @@ export class AtomicSmartSnippet implements InitializableComponent {
    *     color: blue;
    *   }
    * `;
-   * ```
-   *
-   * Alternatively, you can style the snippet by inserting a template element like this:
-   * ```html
-   * <atomic-smart-snippet>
-   *   <template>
-   *     <style>
-   *       b {
-   *         color: blue;
-   *       }
-   *     </style>
-   *   </template>
-   * </atomic-smart-snippet>
    * ```
    */
   @Prop({reflect: true}) snippetStyle?: string;

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import {getAssetPath} from '@stencil/core';
 import {NODE_TYPES} from '@stencil/core/mock-doc';
+import {sanitize} from 'dompurify';
 
 /**
  * Returns a function that can be executed only once
@@ -95,4 +96,16 @@ export function elementHasAncestorTag(
   if (!parentElement) return false;
   if (parentElement.tagName === tagName.toUpperCase()) return true;
   return elementHasAncestorTag(parentElement, tagName);
+}
+
+export function sanitizeStyle(style: string) {
+  const purifiedOuterHTML = sanitize(`<style>${style}</style>`, {
+    ALLOWED_TAGS: ['style'],
+    ALLOWED_ATTR: [],
+    FORCE_BODY: true,
+  });
+  const wrapperEl = document.createElement('div');
+  // deepcode ignore ReactSetInnerHtml: sanitized by dompurify
+  wrapperEl.innerHTML = purifiedOuterHTML;
+  return wrapperEl.querySelector('style')?.innerHTML;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1499

Follow-up to https://github.com/coveo/ui-kit/pull/1854/files, but improved.

This adds custom styling to smart snippet answers by doing the following:
```html
<atomic-smart-snippet>
  <template>
    <style>
      b { color: red; }
    </style>
  </template>
</atomic-smart-snippet>
```

This also adds a prop which can be used as an alternative in frameworks like React, Angular or Vue.