### PR TITLE
test(atomic): add cypress tests for atomic-query-error 

### DIFF
--- a/packages/atomic/cypress/integration/query-error-selectors.ts
+++ b/packages/atomic/cypress/integration/query-error-selectors.ts
@@ -1,0 +1,12 @@
+export const queryErrorComponent = 'atomic-query-error';
+export const QueryErrorSelectors = {
+  shadow: () => cy.get(queryErrorComponent).shadow(),
+  moreInfoBtn: () =>
+    QueryErrorSelectors.shadow().find('[part="more-info-btn"]'),
+  moreInfoMessage: () =>
+    QueryErrorSelectors.shadow().find('[part="error-info"]'),
+  icon: () => QueryErrorSelectors.shadow().find('atomic-icon'),
+  errorTitle: () => QueryErrorSelectors.shadow().find('[part="title"]'),
+  errorDescription: () =>
+    QueryErrorSelectors.shadow().find('[part="description"]'),
+};

--- a/packages/atomic/cypress/integration/query-error.cypress.ts
+++ b/packages/atomic/cypress/integration/query-error.cypress.ts
@@ -1,6 +1,7 @@
 import {TestFixture} from '../fixtures/test-fixture';
 import {addQueryError} from './query-error-actions';
 import * as CommonAssertions from './common-assertions';
+import {QueryErrorSelectors} from './query-error-selectors';
 
 describe('Query Error Test Suites', () => {
   describe("when there's an error", () => {
@@ -9,5 +10,32 @@ describe('Query Error Test Suites', () => {
     });
 
     CommonAssertions.assertAriaLiveMessage('wrong');
+
+    it('should display an error title', () => {
+      QueryErrorSelectors.errorTitle()
+        .should('exist')
+        .should('be.visible')
+        .contains('Something went wrong');
+    });
+
+    it('should display an error description', () => {
+      QueryErrorSelectors.errorDescription()
+        .should('exist')
+        .should('be.visible')
+        .contains('If the problem persists contact the administrator.');
+    });
+
+    it('should display an icon', () => {
+      QueryErrorSelectors.icon().should('exist').should('be.visible');
+    });
+
+    it('should render a show more info button that displays error information on click', () => {
+      QueryErrorSelectors.moreInfoMessage().should('not.exist');
+
+      QueryErrorSelectors.moreInfoBtn().should('exist').click();
+      QueryErrorSelectors.moreInfoMessage()
+        .should('exist')
+        .contains('statusText": "I\'m a Teapot"');
+    });
   });
 });


### PR DESCRIPTION
Not as much tests as I would have liked. Turns out it's pretty complex to get Cypress to return the exact error message shape that Headless ultimately looks at to "unwrap" the API errors and resurface that all the way up to the UI element.

So I just tested the minimum stuff, and not each individual possible error messages.

https://coveord.atlassian.net/browse/KIT-1185