### PR TITLE
ci(cdn): deploy patch version to CDN

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -16,33 +16,11 @@
   },
   "ordered_phases": [
     {
-      "id": "deploy-headless-to-s3-latest",
+      "id": "deploy-headless-patch-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/headless/latest",
+        "directory": "proda/StaticCDN/headless/v$[HEADLESS_PATCH_VERSION]",
         "source": "packages/headless/dist/browser",
-        "parameters": {
-          "acl": "public-read"
-        }
-      }
-    },
-    {
-      "id": "deploy-atomic-to-s3-latest",
-      "s3": {
-        "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/latest",
-        "source": "packages/atomic/dist/atomic",
-        "parameters": {
-          "acl": "public-read"
-        }
-      }
-    },
-    {
-      "id": "deploy-atomic-headless-to-s3-latest",
-      "s3": {
-        "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/latest/headless",
-        "source": "packages/atomic/headless/dist/browser",
         "parameters": {
           "acl": "public-read"
         }
@@ -71,10 +49,21 @@
       }
     },
     {
-      "id": "deploy-atomic-minor-to-s3-version",
+      "id": "deploy-headless-to-s3-latest",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]",
+        "directory": "proda/StaticCDN/headless/latest",
+        "source": "packages/headless/dist/browser",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-patch-to-s3-version",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_PATCH_VERSION]",
         "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
@@ -82,11 +71,11 @@
       }
     },
     {
-      "id": "deploy-atomic-headless-minor-to-s3-version",
+      "id": "deploy-atomic-minor-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]/headless",
-        "source": "packages/atomic/headless/dist/browser",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]",
+        "source": "packages/atomic/dist/atomic",
         "parameters": {
           "acl": "public-read"
         }
@@ -104,10 +93,54 @@
       }
     },
     {
+      "id": "deploy-atomic-to-s3-latest",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/latest",
+        "source": "packages/atomic/dist/atomic",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-headless-patch-to-s3-version",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_PATCH_VERSION]/headless",
+        "source": "packages/atomic/headless/dist/browser",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-headless-minor-to-s3-version",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]/headless",
+        "source": "packages/atomic/headless/dist/browser",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
       "id": "deploy-atomic-headless-major-to-s3-version",
       "s3": {
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]/headless",
+        "source": "packages/atomic/headless/dist/browser",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-headless-to-s3-latest",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/latest/headless",
         "source": "packages/atomic/headless/dist/browser",
         "parameters": {
           "acl": "public-read"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,12 +52,15 @@ node('linux && docker') {
 
         (headlessMinor, headlessMajor) = (headless.version =~ semanticVersionRegex)[0]
         (atomicMinor, atomicMajor) = (atomic.version =~ semanticVersionRegex)[0]
+
         
         sh "deployment-package package create --with-deploy \
         --resolve HEADLESS_MINOR_VERSION=${headlessMinor} \
         --resolve HEADLESS_MAJOR_VERSION=${headlessMajor} \
         --resolve ATOMIC_MINOR_VERSION=${atomicMinor} \
         --resolve ATOMIC_MAJOR_VERSION=${atomicMajor} \
+        --resolve HEADLESS_PATCH_VERSION=${headless.version} \
+        --resolve ATOMIC_PATCH_VERSION=${atomic.version} \
         || true"
       }
     }


### PR DESCRIPTION
To allow [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) capabilities to our clients, we need to deploy patch versions to our CDN.

That way a link on a specific patch version can be "fixed", have its SHA-512 computed, and will not change over time.

As opposed to minor version, which could contain hotfix in the future.


@npushkarskii & @jpmarceau : Eventually (really not needed short term/not urgent), we should arrange for CDN links to be auto generated in our doc website for each release we do, similar to JSUI. 

For example with last release:
 
https://docs.coveo.com/en/m16b2503/javascript-search-framework/march-2022-release


https://coveord.atlassian.net/browse/KIT-1512