### PR TITLE
feat(atomic): allow to add children inside atomic-result-children

### DIFF
--- a/packages/atomic/src/components/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/atomic-result-children/atomic-result-children.tsx
@@ -1,4 +1,4 @@
-import {Component, Element, State, h} from '@stencil/core';
+import {Component, Element, State, h, Host} from '@stencil/core';
 import {
   buildResultTemplatesManager,
   FoldedResult,
@@ -68,21 +68,28 @@ export class AtomicResultChildren {
     if (!this.ready) return null;
     if (this.templateHasError) return <slot></slot>;
     if (this.result.children.length) {
-      return this.result.children.map((child) => {
-        const content = this.childrenResultsTemplatesManager.selectTemplate(
-          child.result
-        );
-        if (content) {
-          return (
-            <atomic-result
-              content={content}
-              result={child}
-              engine={this.bindings.engine}
-            ></atomic-result>
-          );
-        }
-        return null;
-      });
+      // TODO: definitely document this in KIT-1519 amd KIT-1520
+      return (
+        <Host>
+          <slot name="before-children"></slot>
+          {this.result.children.map((child) => {
+            const content = this.childrenResultsTemplatesManager.selectTemplate(
+              child.result
+            );
+            if (content) {
+              return (
+                <atomic-result
+                  content={content}
+                  result={child}
+                  engine={this.bindings.engine}
+                ></atomic-result>
+              );
+            }
+            return null;
+          })}
+          <slot name="after-children"></slot>
+        </Host>
+      );
     }
     return null;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1535

so we could add something like
![Screenshot 2022-04-01 at 17 59 22](https://user-images.githubusercontent.com/30511433/161308886-db0ee7bd-8711-4e18-bcdb-35695c805fa9.png)
only when there are children
![Screenshot 2022-04-01 at 17 59 29](https://user-images.githubusercontent.com/30511433/161308903-d2840c93-4dfd-43a6-a2dc-45b40ed701d5.png)
 