### PR TITLE
feat(commerce): add a context controller for the product listings engine

### DIFF
--- a/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
@@ -6,6 +6,7 @@ import {
   PlatformClientCallOptions,
 } from '../../platform-client';
 import {SortCriterion} from '../../../features/sort/sort';
+import {ContextPayload} from '../../../controllers/product-listing/context/headless-product-listing-context';
 export interface ProductListingsParam
   extends ProductListingBaseParam,
     ProductListingRequestParam {}
@@ -29,6 +30,7 @@ export interface ProductListingRequestParam {
     options?: FacetOptions;
   };
   sort?: SortCriterion;
+  userContext?: ContextPayload;
 }
 
 /**

--- a/packages/headless/src/controllers/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/context/headless-context.test.ts
@@ -3,13 +3,6 @@ import {
   buildMockSearchAppEngine,
   MockSearchEngine,
 } from '../../test/mock-engine';
-import {Action} from 'redux';
-import {
-  setContext,
-  addContext,
-  removeContext,
-} from '../../features/context/context-actions';
-import {contextReducer} from '../../features/context/context-slice';
 
 describe('Context', () => {
   let context: Context;
@@ -20,33 +13,7 @@ describe('Context', () => {
     context = buildContext(engine);
   });
 
-  const expectContainAction = (action: Action) => {
-    const found = engine.actions.find((a) => a.type === action.type);
-    expect(engine.actions).toContainEqual(found);
-  };
-
   it('initializes properly', () => {
     expect(context.state.values).toEqual({});
-  });
-
-  it('it adds the correct reducers to engine', () => {
-    expect(engine.addReducers).toHaveBeenCalledWith({
-      context: contextReducer,
-    });
-  });
-
-  it('setContext dispatches #setContext', () => {
-    context.set({foo: ['bar']});
-    expectContainAction(setContext);
-  });
-
-  it('addContext dispatches #addContext', () => {
-    context.add('foo', ['bar']);
-    expectContainAction(addContext);
-  });
-
-  it('removeContext dispatches #removeContext', () => {
-    context.remove('foo');
-    expectContainAction(removeContext);
   });
 });

--- a/packages/headless/src/controllers/context/headless-context.ts
+++ b/packages/headless/src/controllers/context/headless-context.ts
@@ -18,25 +18,5 @@ export type {Context, ContextState, ContextPayload, ContextValue};
  * @returns A `Context` controller instance.
  */
 export function buildContext(engine: SearchEngine): Context {
-  const context = buildCoreContext(engine);
-
-  return {
-    ...context,
-
-    get state() {
-      return context.state;
-    },
-
-    set(contextPayload: ContextPayload) {
-      context.set(contextPayload);
-    },
-
-    add(contextKey: string, contextValue: ContextValue) {
-      context.add(contextKey, contextValue);
-    },
-
-    remove(key: string) {
-      context.remove(key);
-    },
-  };
+  return buildCoreContext(engine);
 }

--- a/packages/headless/src/controllers/core/context/headless-core-context.test.ts
+++ b/packages/headless/src/controllers/core/context/headless-core-context.test.ts
@@ -1,0 +1,52 @@
+import {buildCoreContext, Context} from './headless-core-context';
+import {
+  buildMockSearchAppEngine,
+  MockSearchEngine,
+} from '../../../test/mock-engine';
+import {Action} from 'redux';
+import {
+  setContext,
+  addContext,
+  removeContext,
+} from '../../../features/context/context-actions';
+import {contextReducer} from '../../../features/context/context-slice';
+
+describe('Context', () => {
+  let context: Context;
+  let engine: MockSearchEngine;
+
+  beforeEach(() => {
+    engine = buildMockSearchAppEngine();
+    context = buildCoreContext(engine);
+  });
+
+  const expectContainAction = (action: Action) => {
+    const found = engine.actions.find((a) => a.type === action.type);
+    expect(engine.actions).toContainEqual(found);
+  };
+
+  it('initializes properly', () => {
+    expect(context.state.values).toEqual({});
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      context: contextReducer,
+    });
+  });
+
+  it('setContext dispatches #setContext', () => {
+    context.set({foo: ['bar']});
+    expectContainAction(setContext);
+  });
+
+  it('addContext dispatches #addContext', () => {
+    context.add('foo', ['bar']);
+    expectContainAction(addContext);
+  });
+
+  it('removeContext dispatches #removeContext', () => {
+    context.remove('foo');
+    expectContainAction(removeContext);
+  });
+});

--- a/packages/headless/src/controllers/core/context/headless-core-context.ts
+++ b/packages/headless/src/controllers/core/context/headless-core-context.ts
@@ -1,0 +1,96 @@
+import {
+  buildController,
+  Controller,
+} from '../../controller/headless-controller';
+import {
+  ContextPayload,
+  ContextValue,
+} from '../../../features/context/context-state';
+import {
+  setContext,
+  addContext,
+  removeContext,
+} from '../../../features/context/context-actions';
+import {ContextSection} from '../../../state/state-sections';
+import {context} from '../../../app/reducers';
+import {loadReducerError} from '../../../utils/errors';
+import {CoreEngine} from '../../../app/engine';
+
+export type {ContextPayload, ContextValue};
+
+/**
+ * The `Context` controller injects [custom contextual information](https://docs.coveo.com/en/399/) into the search requests and usage analytics search events sent from a search interface.
+ */
+export interface Context extends Controller {
+  /**
+   * Sets the context for the query. This replaces any existing context with the new one.
+   *
+   *  @param context - The context to set for the query.
+   */
+  set(context: ContextPayload): void;
+
+  /**
+   * Adds (or, if one is already present, replaces) a new context key-value pair.
+   *
+   * @param contextKey - The context key to add.
+   * @param contextValue - The context value to add.
+   */
+  add(contextKey: string, contextValue: ContextValue): void;
+
+  /**
+   * Removes a context key from the query.
+   * @param key - The context key to remove.
+   */
+  remove(key: string): void;
+
+  /**
+   * The state of the `Context` controller.
+   */
+  state: ContextState;
+}
+
+export interface ContextState {
+  /**
+   * An object holding the context keys and their values.
+   */
+  values: Record<string, ContextValue>;
+}
+
+export function buildCoreContext(engine: CoreEngine): Context {
+  if (!loadContextReducers(engine)) {
+    throw loadReducerError;
+  }
+
+  const controller = buildController(engine);
+  const {dispatch} = engine;
+  const getState = () => engine.state;
+
+  return {
+    ...controller,
+
+    get state() {
+      return {
+        values: getState().context.contextValues,
+      };
+    },
+
+    set(context: ContextPayload) {
+      dispatch(setContext(context));
+    },
+
+    add(contextKey: string, contextValue: ContextValue) {
+      dispatch(addContext({contextKey, contextValue}));
+    },
+
+    remove(key: string) {
+      dispatch(removeContext(key));
+    },
+  };
+}
+
+function loadContextReducers(
+  engine: CoreEngine
+): engine is CoreEngine<ContextSection> {
+  engine.addReducers({context});
+  return true;
+}

--- a/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.test.ts
+++ b/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.test.ts
@@ -1,0 +1,19 @@
+import {buildContext, Context} from './headless-product-listing-context';
+import {
+  buildMockProductListingEngine,
+  MockProductListingEngine,
+} from '../../../test/mock-engine';
+
+describe('Context', () => {
+  let context: Context;
+  let engine: MockProductListingEngine;
+
+  beforeEach(() => {
+    engine = buildMockProductListingEngine();
+    context = buildContext(engine);
+  });
+
+  it('initializes properly', () => {
+    expect(context.state.values).toEqual({});
+  });
+});

--- a/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.ts
+++ b/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.ts
@@ -1,13 +1,13 @@
 import {
   ContextPayload,
   ContextValue,
-} from '../../features/context/context-state';
-import {SearchEngine} from '../../app/search-engine/search-engine';
+} from '../../../features/context/context-state';
+import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 import {
   buildCoreContext,
   Context,
   ContextState,
-} from '../core/context/headless-core-context';
+} from '../../core/context/headless-core-context';
 
 export type {Context, ContextState, ContextPayload, ContextValue};
 
@@ -17,7 +17,7 @@ export type {Context, ContextState, ContextPayload, ContextValue};
  * @param engine - The headless engine.
  * @returns A `Context` controller instance.
  */
-export function buildContext(engine: SearchEngine): Context {
+export function buildContext(engine: ProductListingEngine): Context {
   const context = buildCoreContext(engine);
 
   return {

--- a/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.ts
+++ b/packages/headless/src/controllers/product-listing/context/headless-product-listing-context.ts
@@ -18,25 +18,5 @@ export type {Context, ContextState, ContextPayload, ContextValue};
  * @returns A `Context` controller instance.
  */
 export function buildContext(engine: ProductListingEngine): Context {
-  const context = buildCoreContext(engine);
-
-  return {
-    ...context,
-
-    get state() {
-      return context.state;
-    },
-
-    set(contextPayload: ContextPayload) {
-      context.set(contextPayload);
-    },
-
-    add(contextKey: string, contextValue: ContextValue) {
-      context.add(contextKey, contextValue);
-    },
-
-    remove(key: string) {
-      context.remove(key);
-    },
-  };
+  return buildCoreContext(engine);
 }

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -3,6 +3,7 @@ import {isErrorResponse} from '../../api/search/search-api-client';
 import {
   CategoryFacetSection,
   ConfigurationSection,
+  ContextSection,
   DateFacetSection,
   FacetOptionsSection,
   FacetOrderSection,
@@ -76,7 +77,8 @@ export type StateNeededByFetchProductListing = ConfigurationSection &
       CategoryFacetSection &
       DateFacetSection &
       FacetOptionsSection &
-      FacetOrderSection
+      FacetOrderSection &
+      ContextSection
   >;
 
 export interface FetchProductListingThunkReturn {
@@ -150,6 +152,9 @@ export const buildProductListingRequest = async (
     }),
     ...((state.sort?.by || SortBy.Relevance) !== SortBy.Relevance && {
       sort: state.sort,
+    }),
+    ...(state.context && {
+      userContext: state.context.contextValues,
     }),
   };
 };

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -162,3 +162,11 @@ export type {
   NumericFilterInitialState,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
 export {buildNumericFilter} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
+
+export type {
+  Context,
+  ContextState,
+  ContextPayload,
+  ContextValue,
+} from './controllers/product-listing/context/headless-product-listing-context';
+export {buildContext} from './controllers/product-listing/context/headless-product-listing-context';

--- a/packages/headless/src/state/product-listing-app-state.ts
+++ b/packages/headless/src/state/product-listing-app-state.ts
@@ -2,6 +2,7 @@ import {
   CategoryFacetSearchSection,
   CategoryFacetSection,
   ConfigurationSection,
+  ContextSection,
   DateFacetSection,
   FacetOptionsSection,
   FacetOrderSection,
@@ -26,4 +27,5 @@ export type ProductListingAppState = ConfigurationSection &
   FacetOrderSection &
   StructuredSortSection &
   PaginationSection &
-  VersionSection;
+  VersionSection &
+  ContextSection;

--- a/packages/headless/src/test/mock-product-listing-state.ts
+++ b/packages/headless/src/test/mock-product-listing-state.ts
@@ -11,6 +11,7 @@ import {getPaginationInitialState} from '../features/pagination/pagination-state
 import {getSortInitialState} from '../features/sort/sort-state';
 import {getFacetSearchSetInitialState} from '../features/facets/facet-search-set/specific/specific-facet-search-set-state';
 import {getCategoryFacetSearchSetInitialState} from '../features/facets/facet-search-set/category/category-facet-search-set-state';
+import {getContextInitialState} from '../features/context/context-state';
 
 export function buildMockProductListingState(
   config: Partial<ProductListingAppState> = {}
@@ -29,6 +30,7 @@ export function buildMockProductListingState(
     numericFacetSet: getNumericFacetSetInitialState(),
     pagination: getPaginationInitialState(),
     version: 'unit-testing-version',
+    context: getContextInitialState(),
     ...config,
   };
 }


### PR DESCRIPTION
Add a context controller to give custom context information through the product listings engine.

[COM-1459](https://coveord.atlassian.net/browse/COM-1459)