### PR TITLE
fix(headless): rework pagination logic to reuse existing searchResponseId

### DIFF
--- a/packages/headless/src/api/analytics/analytics.test.ts
+++ b/packages/headless/src/api/analytics/analytics.test.ts
@@ -138,7 +138,22 @@ describe('analytics', () => {
       );
     });
 
-    it('when search is provided, #getSearchUID returns the correct id', () => {
+    it('when #searchResponseId is provided, #getSearchUID returns the correct id', () => {
+      const searchUid = 'test';
+      const state = {
+        ...baseState,
+        search: buildMockSearchState({
+          searchResponseId: searchUid,
+          response: buildMockSearchResponse({
+            searchUid: 'another_id',
+          }),
+        }),
+      };
+      const provider = new AnalyticsProvider(state);
+      expect(provider.getSearchUID()).toEqual(searchUid);
+    });
+
+    it('when #searchResponseId is not provided, #getSearchUID returns the correct id', () => {
       const searchUid = 'test';
       const state = {
         ...baseState,

--- a/packages/headless/src/api/analytics/analytics.ts
+++ b/packages/headless/src/api/analytics/analytics.ts
@@ -77,6 +77,7 @@ export class AnalyticsProvider implements SearchPageClientProvider {
 
   public getSearchUID() {
     return (
+      this.state.search?.searchResponseId ||
       this.state.search?.response.searchUid ||
       this.state.recommendation?.searchUid ||
       this.state.productListing?.responseId ||

--- a/packages/headless/src/controllers/pager/headless-pager.test.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Pager,
   PagerOptions,
@@ -8,7 +9,7 @@ import {
   buildMockSearchAppEngine,
   MockSearchEngine,
 } from '../../test/mock-engine';
-import {executeSearch} from '../../features/search/search-actions';
+import {fetchPage} from '../../features/search/search-actions';
 
 describe('Pager', () => {
   let engine: MockSearchEngine;
@@ -41,21 +42,21 @@ describe('Pager', () => {
     expect(pager.state.currentPages.length).toBe(5);
   });
 
-  it('#selectPage dispatches #executeSearch', () => {
+  it('#selectPage dispatches #fetchPage', () => {
     pager.selectPage(2);
-    const action = engine.findAsyncAction(executeSearch.pending);
+    const action = engine.findAsyncAction(fetchPage.pending);
     expect(action).toBeTruthy();
   });
 
-  it('#nextPage dispatches #executeSearch', () => {
+  it('#nextPage dispatches #fetchPage', () => {
     pager.nextPage();
-    const action = engine.findAsyncAction(executeSearch.pending);
+    const action = engine.findAsyncAction(fetchPage.pending);
     expect(action).toBeTruthy();
   });
 
-  it('#previousPage dispatches #executeSearch', () => {
+  it('#previousPage dispatches #fetchPage', () => {
     pager.previousPage();
-    const action = engine.findAsyncAction(executeSearch.pending);
+    const action = engine.findAsyncAction(fetchPage.pending);
     expect(engine.actions).toContainEqual(action);
   });
 });

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -1,4 +1,4 @@
-import {executeSearch} from '../../features/search/search-actions';
+import {fetchPage} from '../../features/search/search-actions';
 import {
   logPageNumber,
   logPageNext,
@@ -39,17 +39,17 @@ export function buildPager(
 
     selectPage(page: number) {
       pager.selectPage(page);
-      dispatch(executeSearch(logPageNumber()));
+      dispatch(fetchPage(logPageNumber()));
     },
 
     nextPage() {
       pager.nextPage();
-      dispatch(executeSearch(logPageNext()));
+      dispatch(fetchPage(logPageNext()));
     },
 
     previousPage() {
       pager.previousPage();
-      dispatch(executeSearch(logPagePrevious()));
+      dispatch(fetchPage(logPagePrevious()));
     },
   };
 }

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -11,6 +11,7 @@ import {
   fetchMoreResults,
   StateNeededByExecuteSearch,
   fetchFacetValues,
+  fetchPage,
 } from './search-actions';
 
 /**
@@ -73,6 +74,32 @@ export interface SearchActionCreators {
       ClientThunkExtraArguments<SearchAPIClient>
     >
   >;
+
+  /**
+   * Creates an action that executes a search query to fetch a new page of results.
+   *
+   * @example
+   *
+   * ```js
+   * const {logPagerNext} = loadSearchAnalyticsActions(engine);
+   * const {fetchPage} = loadSearchActions(engine);
+   *
+   * engine.dispatch(fetchPage(logPagerNext()));
+   * ```
+   *
+   * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadSearchAnalyticsActions` for possible values.
+   * @returns A dispatchable action.
+   */
+  fetchPage(
+    analyticsSearchAction: SearchAction
+  ): AsyncThunkAction<
+    ExecuteSearchThunkReturn,
+    SearchAction,
+    AsyncThunkOptions<
+      StateNeededByExecuteSearch,
+      ClientThunkExtraArguments<SearchAPIClient>
+    >
+  >;
 }
 
 /**
@@ -87,5 +114,6 @@ export function loadSearchActions(engine: SearchEngine): SearchActionCreators {
     executeSearch,
     fetchMoreResults,
     fetchFacetValues,
+    fetchPage,
   };
 }

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -194,6 +194,40 @@ export const executeSearch = createAsyncThunk<
   }
 );
 
+export const fetchPage = createAsyncThunk<
+  ExecuteSearchThunkReturn,
+  SearchAction,
+  AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+>(
+  'search/fetchPage',
+  async (
+    analyticsAction: SearchAction,
+    {getState, dispatch, rejectWithValue, extra}
+  ) => {
+    const state = getState();
+    addEntryInActionsHistory(state);
+    const fetched = await fetchFromAPI(
+      extra.apiClient,
+      state,
+      await buildSearchRequest(state)
+    );
+
+    if (isErrorResponse(fetched.response)) {
+      dispatch(logQueryError(fetched.response.error));
+      return rejectWithValue(fetched.response.error);
+    }
+
+    dispatch(snapshot(extractHistory(state)));
+    return {
+      ...fetched,
+      response: fetched.response.success,
+      automaticallyCorrected: false,
+      originalQuery: getOriginalQuery(state),
+      analyticsAction,
+    };
+  }
+);
+
 export const fetchMoreResults = createAsyncThunk<
   ExecuteSearchThunkReturn,
   void,

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -3,6 +3,7 @@ import {
   executeSearch,
   fetchFacetValues,
   fetchMoreResults,
+  fetchPage,
 } from './search-actions';
 import {getSearchInitialState, SearchState} from './search-state';
 
@@ -56,6 +57,9 @@ export const searchReducer = createReducer(
     builder.addCase(fetchMoreResults.rejected, (state, action) =>
       handleRejectedSearch(state, action)
     );
+    builder.addCase(fetchPage.rejected, (state, action) =>
+      handleRejectedSearch(state, action)
+    );
     builder.addCase(executeSearch.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);
       state.results = action.payload.response.results;
@@ -65,11 +69,16 @@ export const searchReducer = createReducer(
       handleFulfilledSearch(state, action);
       state.results = [...state.results, ...action.payload.response.results];
     });
+    builder.addCase(fetchPage.fulfilled, (state, action) => {
+      handleFulfilledSearch(state, action);
+      state.results = action.payload.response.results;
+    });
     builder.addCase(fetchFacetValues.fulfilled, (state, action) => {
       state.response.facets = action.payload.response.facets;
       state.response.searchUid = action.payload.response.searchUid;
     });
     builder.addCase(executeSearch.pending, handlePendingSearch);
     builder.addCase(fetchMoreResults.pending, handlePendingSearch);
+    builder.addCase(fetchPage.pending, handlePendingSearch);
   }
 );


### PR DESCRIPTION
Problem was:

1. Execute a search, get search response ID, log an analytics search event.
2. Click on a result, analytics click event is linked to search response ID generated at step # 1, everything is good so far.
3. Use the pager to go to next page, execute a new query, get a new search response ID, update the results set/response/search ID. Log a custom event (not a search, since from the end user perspective, it's not a new search, it's just a continuation of the same query performed on step # 1)
4. Click on a new result, analytics click event is linked to search response ID generated at step # 3. Since at step # 3 we never log a search event, but a custom event, this means that click is flagged as incoherent by Usage Analytics, since there is no accompanying search event.

Now, this problem was actually also present for everything that loaded more result: "Load more" button, infinite scrolling, pagination, and facet load more values because in `AnalyticsClient` we were not using the correct `searchResponseId` property when available.

For load more/infinite scrolling/facet fetch more, there was nothing more to fix than using the correct property in `AnalyticsClient`.

For pagination, we used the standard `executeSearch` action, which means we had no way of differentiating between a "new search" and "fetching a new page" from an end user perspective.

For this, I added a `fetchPage` action, which does the same thing as `executeSearch`, but without the code needed to handle did you mean feature.

Hope that makes sense !

https://coveord.atlassian.net/browse/KIT-1573