### PR TITLE
feat(atomic): add styling and states for children results and loading

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -593,13 +593,13 @@ export declare interface AtomicResult extends Components.AtomicResult {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['content', 'density', 'display', 'engine', 'image', 'imageSize', 'result']
+  inputs: ['classes', 'content', 'density', 'display', 'engine', 'image', 'imageSize', 'result']
 })
 @Component({
   selector: 'atomic-result',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['content', 'density', 'display', 'engine', 'image', 'imageSize', 'result']
+  inputs: ['classes', 'content', 'density', 'display', 'engine', 'image', 'imageSize', 'result']
 })
 export class AtomicResult {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -640,10 +640,10 @@ export namespace Components {
         "field": string;
     }
     interface AtomicResultPlaceholder {
-        "classes": string;
         "density": ResultDisplayDensity;
         "display": ResultDisplayLayout;
         "imageSize"?: ResultDisplayImageSize;
+        "isChild": boolean;
     }
     interface AtomicResultPrintableUri {
         /**
@@ -2086,10 +2086,10 @@ declare namespace LocalJSX {
         "field": string;
     }
     interface AtomicResultPlaceholder {
-        "classes"?: string;
         "density": ResultDisplayDensity;
         "display": ResultDisplayLayout;
         "imageSize"?: ResultDisplayImageSize;
+        "isChild"?: boolean;
     }
     interface AtomicResultPrintableUri {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -492,6 +492,7 @@ export namespace Components {
         "bindings": Bindings;
     }
     interface AtomicResult {
+        "classes": string;
         /**
           * The result content to display.
          */
@@ -537,9 +538,18 @@ export namespace Components {
     }
     interface AtomicResultChildren {
         /**
+          * The expected size of the image displayed in the children results.
+         */
+        "imageSize": ResultDisplayImageSize | null;
+        /**
           * Whether to inherit templates defined in a parent atomic-result-children. Only works for the second level of child nesting.
          */
         "inheritTemplates": boolean;
+        /**
+          * The copy for an empty result state.
+          * @defaultValue `No documents are related to this one.`
+         */
+        "noResultText": string;
     }
     interface AtomicResultChildrenTemplate {
         /**
@@ -630,6 +640,7 @@ export namespace Components {
         "field": string;
     }
     interface AtomicResultPlaceholder {
+        "classes": string;
         "density": ResultDisplayDensity;
         "display": ResultDisplayLayout;
         "imageSize"?: ResultDisplayImageSize;
@@ -1936,6 +1947,7 @@ declare namespace LocalJSX {
         "bindings": Bindings;
     }
     interface AtomicResult {
+        "classes"?: string;
         /**
           * The result content to display.
          */
@@ -1981,9 +1993,18 @@ declare namespace LocalJSX {
     }
     interface AtomicResultChildren {
         /**
+          * The expected size of the image displayed in the children results.
+         */
+        "imageSize"?: ResultDisplayImageSize | null;
+        /**
           * Whether to inherit templates defined in a parent atomic-result-children. Only works for the second level of child nesting.
          */
         "inheritTemplates"?: boolean;
+        /**
+          * The copy for an empty result state.
+          * @defaultValue `No documents are related to this one.`
+         */
+        "noResultText"?: string;
     }
     interface AtomicResultChildrenTemplate {
         /**
@@ -2065,6 +2086,7 @@ declare namespace LocalJSX {
         "field": string;
     }
     interface AtomicResultPlaceholder {
+        "classes"?: string;
         "density": ResultDisplayDensity;
         "display": ResultDisplayLayout;
         "imageSize"?: ResultDisplayImageSize;

--- a/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.pcss
+++ b/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.pcss
@@ -1,0 +1,25 @@
+@import '../../global/global.pcss';
+@import '../../global/mixins.pcss';
+
+@define-mixin display-density $max, $min {
+  .btn-text-primary {
+    margin-top: $min;
+
+    &.has-children {
+      margin-bottom: $min;
+    }
+  }
+}
+
+.btn-text-primary {
+  @mixin set-font-size var(--atomic-text-sm);
+}
+.density-compact {
+  @mixin display-density 1rem, 0.475rem;
+}
+.density-normal {
+  @mixin display-density 1.5rem, 0.875rem;
+}
+.density-comfortable {
+  @mixin display-density 1.75rem, 0.25rem;
+}

--- a/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.tsx
+++ b/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.tsx
@@ -42,6 +42,9 @@ export class AtomicLoadMoreChildrenResults {
   @Prop() public label = '';
 
   private getCollection() {
+    if (!this.result.raw.foldingcollection) {
+      return null;
+    }
     return this.foldedResultListState.results.find(
       (r) =>
         r.result.raw.foldingcollection === this.result.raw.foldingcollection
@@ -55,15 +58,15 @@ export class AtomicLoadMoreChildrenResults {
   }
 
   private hasMoreResults() {
-    return this.getCollection().moreResultsAvailable;
+    return this.getCollection()?.moreResultsAvailable;
   }
 
   private isLoading() {
-    return Boolean(this.getCollection().isLoadingMoreResults);
+    return Boolean(this.getCollection()?.isLoadingMoreResults);
   }
 
   private hasResults() {
-    return Boolean(this.getCollection().children.length);
+    return Boolean(this.getCollection()?.children.length);
   }
 
   private getButtonClass() {
@@ -81,7 +84,7 @@ export class AtomicLoadMoreChildrenResults {
   }
 
   public render() {
-    if (!this.foldedResultListState) {
+    if (!this.foldedResultListState || !this.getCollection()) {
       return null;
     }
 

--- a/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.tsx
+++ b/packages/atomic/src/components/atomic-load-more-children-results/atomic-load-more-children-results.tsx
@@ -2,9 +2,14 @@ import {Result, FoldedResultListState} from '@coveo/headless';
 import {Component, Element, h, Prop, State} from '@stencil/core';
 import {buildCustomEvent} from '../../utils/event-utils';
 import {Bindings, InitializeBindings} from '../../utils/initialization-utils';
+import {getResultDisplayClasses} from '../atomic-result/atomic-result-display-options';
 import {Button} from '../common/button';
 import {FoldedResultListStateContext} from '../result-lists/result-list-decorators';
-import {ResultContext} from '../result-template-components/result-template-decorators';
+import {
+  DisplayConfig,
+  ResultContext,
+  ResultDisplayConfigContext,
+} from '../result-template-components/result-template-decorators';
 
 /**
  * The `atomic-load-more-children-results` component allows to load the full collection for a folded result.
@@ -13,6 +18,8 @@ import {ResultContext} from '../result-template-components/result-template-decor
  */
 @Component({
   tag: 'atomic-load-more-children-results',
+  styleUrl: 'atomic-load-more-children-results.pcss',
+  shadow: true,
 })
 export class AtomicLoadMoreChildrenResults {
   @InitializeBindings() public bindings!: Bindings;
@@ -23,6 +30,9 @@ export class AtomicLoadMoreChildrenResults {
   @FoldedResultListStateContext()
   @State()
   private foldedResultListState!: FoldedResultListState;
+
+  @ResultDisplayConfigContext()
+  private displayConfig!: DisplayConfig;
 
   /**
    * The label for the button used to load more results.
@@ -52,18 +62,38 @@ export class AtomicLoadMoreChildrenResults {
     return Boolean(this.getCollection().isLoadingMoreResults);
   }
 
+  private hasResults() {
+    return Boolean(this.getCollection().children.length);
+  }
+
+  private getButtonClass() {
+    if (this.hasResults()) {
+      return 'has-children';
+    }
+    return '';
+  }
+  private getWrapperClass() {
+    return getResultDisplayClasses(
+      'list',
+      this.displayConfig.density,
+      this.displayConfig.imageSize
+    ).join(' ');
+  }
+
   public render() {
     if (!this.foldedResultListState) {
       return null;
     }
 
     return (
-      <div>
-        {this.hasMoreResults() && !this.isLoading() && (
+      <div class={this.getWrapperClass()}>
+        {this.hasMoreResults() && (
           <Button
+            part="button"
             style="text-primary"
             onClick={() => this.loadFullCollection()}
-            part="button"
+            class={this.getButtonClass()}
+            disabled={this.isLoading()}
           >
             {this.label || this.bindings.i18n.t('load-all-results')}
           </Button>

--- a/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.tsx
+++ b/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.tsx
@@ -21,9 +21,14 @@ export class AtomicResultPlaceholder {
   @Prop() display!: ResultDisplayLayout;
   @Prop() density!: ResultDisplayDensity;
   @Prop() imageSize?: ResultDisplayImageSize;
+  @Prop() classes = '';
 
   private getClasses() {
-    return getResultDisplayClasses(this.display, this.density, this.imageSize!);
+    return getResultDisplayClasses(
+      this.display,
+      this.density,
+      this.imageSize!
+    ).concat(this.classes);
   }
 
   private renderExcerptLine(width: string) {
@@ -45,9 +50,9 @@ export class AtomicResultPlaceholder {
   public render() {
     return (
       <div
-        class={`result-root with-sections animate-pulse ${this.getClasses().join(
-          ' '
-        )}`}
+        class={`result-root with-sections animate-pulse ${this.getClasses()
+          .join(' ')
+          .trim()}`}
       >
         <atomic-result-section-visual>
           <div class={placeholderClasses}></div>

--- a/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.tsx
+++ b/packages/atomic/src/components/atomic-result-placeholder/atomic-result-placeholder.tsx
@@ -21,14 +21,14 @@ export class AtomicResultPlaceholder {
   @Prop() display!: ResultDisplayLayout;
   @Prop() density!: ResultDisplayDensity;
   @Prop() imageSize?: ResultDisplayImageSize;
-  @Prop() classes = '';
+  @Prop() isChild = false;
 
   private getClasses() {
     return getResultDisplayClasses(
       this.display,
       this.density,
       this.imageSize!
-    ).concat(this.classes);
+    ).concat(this.isChild ? 'child-result' : '');
   }
 
   private renderExcerptLine(width: string) {

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -1,7 +1,36 @@
+@define-mixin atomic-children-desktop $max, $min {
+  &.child-result {
+    margin-bottom: $max;
+  }
+
+  atomic-result-section-children {
+    atomic-result-children::part(children-root) {
+      margin-top: $min;
+      padding: $max;
+    }
+
+    atomic-result-children::part(show-hide-button) {
+      margin-top: $min;
+      margin-bottom: $min;
+    }
+  }
+
+  atomic-result-placeholder {
+    margin-bottom: $max;
+  }
+}
+
 @define-mixin row-result-desktop {
   &.image-large.density-compact atomic-result-section-visual {
     width: 10.25rem;
     height: 10.25rem;
+  }
+
+  atomic-result-section-children {
+    atomic-result-children::part(children-root) {
+      border: 1px solid var(--atomic-neutral);
+      border-radius: 16px;
+    }
   }
 
   /* == Density styles == */
@@ -38,6 +67,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-desktop 1.75rem, 1.25rem;
   }
 
   &.density-normal {
@@ -73,6 +104,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-desktop 1.5rem, 0.875rem;
   }
 
   &.density-compact {
@@ -108,6 +141,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-desktop 1rem, 0.475rem;
   }
 
   /* == Image styles == */
@@ -120,8 +155,7 @@
       'visual emphasized      emphasized      emphasized'
       'visual excerpt         excerpt         excerpt'
       'visual bottom-metadata bottom-metadata bottom-metadata'
-      'visual .               .               .'
-      '.      children               .               .';
+      'visual children        children        children';
     grid-template-columns: minmax(0, min-content) auto 1fr auto;
     grid-template-rows: repeat(6, auto) minmax(0, 1fr);
   }
@@ -150,8 +184,7 @@
       'visual emphasized      emphasized      emphasized'
       'visual excerpt         excerpt         excerpt'
       'visual bottom-metadata bottom-metadata bottom-metadata'
-      'visual .               .               .'
-      '.      children               .               .';
+      'visual children        children        children';
     grid-template-columns: minmax(0, min-content) auto 1fr auto;
     grid-template-rows: repeat(6, auto) 1fr minmax(0, min-content);
 
@@ -168,7 +201,8 @@
       'title-metadata  title-metadata  title-metadata'
       'emphasized      emphasized      emphasized'
       'excerpt         excerpt         excerpt'
-      'bottom-metadata bottom-metadata bottom-metadata';
+      'bottom-metadata bottom-metadata bottom-metadata'
+      'children        children        children';
     grid-template-columns: auto 1fr auto;
     grid-template-rows: repeat(6, auto);
 

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-desktop.pcss
@@ -1,22 +1,22 @@
-@define-mixin atomic-children-desktop $max, $min {
+@define-mixin atomic-children-desktop $margin-small, $margin-small {
   &.child-result {
-    margin-bottom: $max;
+    margin-bottom: $margin-small;
   }
 
   atomic-result-section-children {
     atomic-result-children::part(children-root) {
-      margin-top: $min;
-      padding: $max;
+      margin-top: $margin-small;
+      padding: $margin-small;
     }
 
     atomic-result-children::part(show-hide-button) {
-      margin-top: $min;
-      margin-bottom: $min;
+      margin-top: $margin-small;
+      margin-bottom: $margin-small;
     }
   }
 
   atomic-result-placeholder {
-    margin-bottom: $max;
+    margin-bottom: $margin-small;
   }
 }
 

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -1,6 +1,34 @@
 @import '../../global/polyfills.pcss';
 
+@define-mixin atomic-children-mobile $max, $min {
+  atomic-result-section-children {
+    atomic-result-children::part(children-root) {
+      padding-top: $max;
+      margin-top: 1rem;
+      margin-left: -1rem;
+      margin-right: -1rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+
+    atomic-result-children::part(show-hide-button) {
+      margin-top: $min;
+      margin-bottom: $min;
+    }
+  }
+
+  atomic-result-placeholder {
+    margin-bottom: $max;
+  }
+}
+
 @define-mixin row-result-mobile {
+  atomic-result-section-children {
+    atomic-result-children::part(children-root) {
+      border-top: 1px solid var(--atomic-neutral);
+    }
+  }
+
   &.image-large.density-compact atomic-result-section-visual {
     width: 10.25rem;
     height: 10.25rem;
@@ -44,6 +72,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-mobile 1.75rem, 1.25rem;
   }
 
   &.density-normal {
@@ -83,6 +113,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-mobile 1.5rem, 0.875rem;
   }
 
   &.density-compact {
@@ -122,6 +154,8 @@
     atomic-result-section-title-metadata {
       margin-top: 0.475rem;
     }
+
+    @mixin atomic-children-mobile 1rem, 0.475rem;
   }
 
   /* == Image styles == */
@@ -134,7 +168,8 @@
       'emphasized'
       'excerpt'
       'bottom-metadata'
-      'actions';
+      'actions'
+      'children';
     grid-template-columns: 100%;
     grid-template-rows: repeat(8, auto);
 
@@ -155,7 +190,8 @@
       'visual          .'
       'excerpt         excerpt'
       'bottom-metadata bottom-metadata'
-      'actions         actions';
+      'actions         actions'
+      'children        children';
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: repeat(4, auto) 1fr repeat(3, auto);
 
@@ -175,7 +211,7 @@
       'visual          excerpt'
       'visual          bottom-metadata'
       'visual          actions'
-      'visual          .';
+      'visual          children';
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: repeat(7, auto) 1fr;
 
@@ -194,7 +230,8 @@
       'emphasized'
       'excerpt'
       'bottom-metadata'
-      'actions';
+      'actions'
+      'children';
     grid-template-columns: 100%;
     grid-template-rows: repeat(7, auto);
 

--- a/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result-row-mobile.pcss
@@ -1,6 +1,10 @@
 @import '../../global/polyfills.pcss';
 
 @define-mixin atomic-children-mobile $max, $min {
+  &.child-result {
+    margin-bottom: $max;
+  }
+
   atomic-result-section-children {
     atomic-result-children::part(children-root) {
       padding-top: $max;
@@ -193,7 +197,7 @@
       'actions         actions'
       'children        children';
     grid-template-columns: auto minmax(0, 1fr);
-    grid-template-rows: repeat(4, auto) 1fr repeat(3, auto);
+    grid-template-rows: repeat(4, auto) minmax(0, 1fr) repeat(3, auto);
 
     atomic-result-section-visual {
       width: 24vw;

--- a/packages/atomic/src/components/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/atomic-result/atomic-result.tsx
@@ -7,7 +7,10 @@ import {
   getResultDisplayClasses,
 } from './atomic-result-display-options';
 import {applyFocusVisiblePolyfill} from '../../utils/initialization-utils';
-import {ResultContextEvent} from '../result-template-components/result-template-decorators';
+import {
+  DisplayConfig,
+  ResultContextEvent,
+} from '../result-template-components/result-template-decorators';
 
 const resultSectionTags = [
   'atomic-result-section-visual',
@@ -68,11 +71,23 @@ export class AtomicResult {
    */
   @Prop() image: ResultDisplayImageSize = 'icon';
 
+  @Prop() classes = '';
+
   @Listen('atomic/resolveResult')
   public resolveResult(event: ResultContextEvent<FoldedResult | Result>) {
     event.preventDefault();
     event.stopPropagation();
     event.detail(this.result);
+  }
+
+  @Listen('atomic/resolveResultDisplayConfig')
+  public resolveResultDisplayConfig(event: ResultContextEvent<DisplayConfig>) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.detail({
+      density: this.density,
+      imageSize: this.imageSize!,
+    });
   }
 
   private containsSections() {
@@ -107,6 +122,9 @@ export class AtomicResult {
     );
     if (this.containsSections()) {
       classes.push('with-sections');
+    }
+    if (this.classes) {
+      classes.push(this.classes);
     }
     return classes;
   }

--- a/packages/atomic/src/components/result-lists/atomic-folded-result-list/atomic-folded-result-list.stories.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-folded-result-list/atomic-folded-result-list.stories.tsx
@@ -18,17 +18,85 @@ const {defaultModuleExport, exportedStory} = defaultStory(
     additionalChildMarkup: () => html`
       <atomic-result-template>
         <template>
-          <atomic-result-link></atomic-result-link>
-          <div style="padding-left: 15px; margin-top: 20px;">
-            <atomic-result-children>
-              <b slot="before-children">Related:</b>
+          <atomic-result-section-visual>
+            <atomic-result-image class="icon"></atomic-result-image>
+            <img src="https://picsum.photos/350" class="thumbnail" />
+          </atomic-result-section-visual>
+          <atomic-result-section-badges>
+            <atomic-field-condition must-match-sourcetype="Salesforce">
+              <atomic-result-badge
+                label="Salesforce"
+                class="salesforce-badge"
+              ></atomic-result-badge>
+            </atomic-field-condition>
+            <atomic-result-badge
+              icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
+            >
+              <atomic-result-multi-value-text
+                field="language"
+              ></atomic-result-multi-value-text>
+            </atomic-result-badge>
+            <atomic-field-condition must-match-is-recommendation="true">
+              <atomic-result-badge label="Recommended"></atomic-result-badge>
+            </atomic-field-condition>
+            <atomic-field-condition must-match-is-top-result="true">
+              <atomic-result-badge label="Top Result"></atomic-result-badge>
+            </atomic-field-condition>
+          </atomic-result-section-badges>
+          <atomic-result-section-title
+            ><atomic-result-link></atomic-result-link
+          ></atomic-result-section-title>
+          <atomic-result-section-excerpt
+            ><atomic-result-text field="excerpt"></atomic-result-text
+          ></atomic-result-section-excerpt>
+          <atomic-result-section-bottom-metadata>
+            <atomic-result-fields-list>
+              <atomic-field-condition class="field" if-defined="source">
+                <span class="field-label"
+                  ><atomic-text value="source"></atomic-text>:</span
+                >
+                <atomic-result-text field="source"></atomic-result-text>
+              </atomic-field-condition>
+            </atomic-result-fields-list>
+          </atomic-result-section-bottom-metadata>
+          <atomic-result-section-children>
+            <atomic-load-more-children-results></atomic-load-more-children-results>
+            <atomic-result-children image-size="icon">
+              <!-- CHILD -->
               <atomic-result-children-template>
+                <!-- CHILD TEMPLATE -->
                 <template>
-                  <atomic-result-link></atomic-result-link>
+                  <atomic-result-section-visual>
+                    <atomic-result-image class="icon"></atomic-result-image>
+                    <img src="https://picsum.photos/350" class="thumbnail" />
+                  </atomic-result-section-visual>
+                  <atomic-result-section-title
+                    ><atomic-result-link></atomic-result-link
+                  ></atomic-result-section-title>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
+                  <atomic-table-element label="Description">
+                    <atomic-result-section-excerpt>
+                      <atomic-result-text field="excerpt"></atomic-result-text>
+                    </atomic-result-section-excerpt>
+                  </atomic-table-element>
+                  <atomic-table-element label="author">
+                    <atomic-result-text field="author"></atomic-result-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="source">
+                    <atomic-result-text field="source"></atomic-result-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="language">
+                    <atomic-result-text field="language"></atomic-result-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="file-type">
+                    <atomic-result-text field="filetype"></atomic-result-text>
+                  </atomic-table-element>
                 </template>
               </atomic-result-children-template>
             </atomic-result-children>
-          </div>
+          </atomic-result-section-children>
         </template>
       </atomic-result-template>
     `,

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.pcss
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.pcss
@@ -1,0 +1,10 @@
+@import '../../../global/global.pcss';
+@import '../../../global/mixins.pcss';
+
+.show-hide-button {
+  @mixin set-font-size var(--atomic-text-sm);
+}
+
+.no-result-root {
+  color: var(--atomic-neutral-dark);
+}

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -162,16 +162,7 @@ export class AtomicResultChildren {
     );
   }
 
-  private showCollapseButton() {
-    const result = this.getResult();
-    return (
-      Boolean(result.children.length) &&
-      !result.isLoadingMoreResults &&
-      !result.moreResultsAvailable
-    );
-  }
-
-  private showChildrenWrapper() {
+  private shouldShowChildrenWrapper() {
     const result = this.getResult();
     if (!this.initialChildren.length && this.hideResults) return false;
     return (
@@ -200,12 +191,12 @@ export class AtomicResultChildren {
     if (result.isLoadingMoreResults) {
       components.push(
         <ListDisplayResultsPlaceholder
-          classes="child-result"
           resultsPerPageState={{
             numberOfResults: result.children.length || 2,
           }}
           density={this.displayConfig.density}
           imageSize={this.imageSize || this.displayConfig.imageSize}
+          isChild
         />
       );
     } else if (hasResults) {
@@ -226,24 +217,36 @@ export class AtomicResultChildren {
     return components;
   }
 
+  private renderCollapseButton() {
+    const result = this.getResult();
+    if (
+      Boolean(result.children.length) &&
+      !result.isLoadingMoreResults &&
+      !result.moreResultsAvailable
+    ) {
+      return null;
+    }
+    return (
+      <Button
+        part="show-hide-button"
+        class="show-hide-button"
+        style="text-primary"
+        onClick={() => (this.hideResults = !this.hideResults)}
+      >
+        {this.bindings.i18n.t(
+          this.hideResults ? 'show-all-results' : 'hide-all-results'
+        )}
+      </Button>
+    );
+  }
+
   public render() {
     if (!this.ready) return null;
     if (this.templateHasError) return <slot></slot>;
     return (
       <Host>
-        {this.showCollapseButton() && (
-          <Button
-            part="show-hide-button"
-            class="show-hide-button"
-            style="text-primary"
-            onClick={() => (this.hideResults = !this.hideResults)}
-          >
-            {this.bindings.i18n.t(
-              this.hideResults ? 'show-all-results' : 'hide-all-results'
-            )}
-          </Button>
-        )}
-        {this.showChildrenWrapper() && (
+        {this.renderCollapseButton()}
+        {this.shouldShowChildrenWrapper() && (
           <div part="children-root">{this.getComponents()}</div>
         )}
       </Host>

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -164,7 +164,9 @@ export class AtomicResultChildren {
 
   private shouldShowChildrenWrapper() {
     const result = this.getResult();
-    if (!this.initialChildren.length && this.hideResults) return false;
+    if (!this.initialChildren.length && this.hideResults) {
+        return false;
+    }
     return (
       Boolean(result.children.length) ||
       result.isLoadingMoreResults ||

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -5,16 +5,7 @@ import {
   Result,
   ResultTemplatesManager,
 } from '@coveo/headless';
-import {
-  Component,
-  Element,
-  State,
-  h,
-  Host,
-  Listen,
-  Prop,
-  FunctionalComponent,
-} from '@stencil/core';
+import {Component, Element, State, h, Listen, Prop, Host} from '@stencil/core';
 import {
   Bindings,
   InitializeBindings,
@@ -24,10 +15,15 @@ import {
   ResultContext,
   ChildTemplatesContext,
   ChildTemplatesContextEvent,
+  ResultDisplayConfigContext,
+  DisplayConfig,
 } from '../../result-template-components/result-template-decorators';
 import {ResultListCommon} from '../result-list-common';
 import {TemplateContent} from '../../result-templates/result-template-common';
 import {FoldedResultListStateContext} from '../result-list-decorators';
+import {ResultDisplayImageSize} from '../../atomic-result/atomic-result-display-options';
+import {ListDisplayResultsPlaceholder} from '../list-display-results-placeholder';
+import {Button} from '../../common/button';
 
 const childTemplateComponent = 'atomic-result-children-template';
 const componentTag = 'atomic-result-children';
@@ -37,9 +33,12 @@ const componentTag = 'atomic-result-children';
  * Includes two slots, "before-children" and "after-children", which allow for rendering content before and after the list of children,
  * only when children exist.
  * @internal
+ * @part no-result-root - The wrapper for the message when there are no results.
+ * @part show-hide-button - The button that allows to collapse or show all child results.
  */
 @Component({
   tag: 'atomic-result-children',
+  styleUrl: 'atomic-result-children.pcss',
   shadow: true,
 })
 export class AtomicResultChildren {
@@ -48,6 +47,8 @@ export class AtomicResultChildren {
   public templatesManager!: ResultTemplatesManager<TemplateContent>;
   @ResultContext({folded: true})
   private result!: FoldedResult;
+  @ResultDisplayConfigContext()
+  private displayConfig!: DisplayConfig;
 
   public resultListCommon?: ResultListCommon;
 
@@ -60,10 +61,26 @@ export class AtomicResultChildren {
   @State()
   private foldedResultListState!: FoldedResultListState;
 
+  @State()
+  private hideResults = false;
+
+  @State()
+  private showAllResults = false;
+
   /**
    * Whether to inherit templates defined in a parent atomic-result-children. Only works for the second level of child nesting.
    */
   @Prop() inheritTemplates = false;
+  /**
+   * The expected size of the image displayed in the children results.
+   */
+  @Prop({reflect: true}) imageSize: ResultDisplayImageSize | null = null;
+  /**
+   * The copy for an empty result state.
+   *
+   * @defaultValue `No documents are related to this one.`
+   */
+  @Prop() public noResultText = '';
 
   @Listen('atomic/resolveChildTemplates')
   public resolveChildTemplates(event: ChildTemplatesContextEvent) {
@@ -128,6 +145,9 @@ export class AtomicResultChildren {
         content={content}
         result={child}
         engine={this.bindings.engine}
+        density={this.displayConfig.density}
+        imageSize={this.imageSize || this.displayConfig.imageSize}
+        classes="child-result"
       ></atomic-result>
     );
   }
@@ -140,31 +160,85 @@ export class AtomicResultChildren {
     );
   }
 
+  private showCollapseButton() {
+    const result = this.getResult();
+    return (
+      Boolean(result.children.length) &&
+      !result.isLoadingMoreResults &&
+      !result.moreResultsAvailable
+    );
+  }
+
+  private showChildrenWrapper() {
+    const result = this.getResult();
+    return (
+      !this.hideResults &&
+      (Boolean(result.children.length) ||
+        result.isLoadingMoreResults ||
+        this.showAllResults)
+    );
+  }
+
+  public componentWillUpdate() {
+    if (this.getResult().isLoadingMoreResults && !this.showAllResults) {
+      this.showAllResults = true;
+    }
+  }
+
+  private getComponents() {
+    const components = [];
+    const result = this.getResult();
+    const hasResults = Boolean(result.children.length);
+    if (hasResults) {
+      components.push(<slot name="before-children"></slot>);
+    }
+    if (result.isLoadingMoreResults) {
+      components.push(
+        <ListDisplayResultsPlaceholder
+          classes="child-result"
+          resultsPerPageState={{
+            numberOfResults: result.children.length || 2,
+          }}
+          density={this.displayConfig.density}
+          imageSize={this.imageSize || this.displayConfig.imageSize}
+        />
+      );
+    } else if (hasResults) {
+      components.push(result.children.map((child) => this.renderChild(child)));
+    } else if (this.showAllResults) {
+      components.push(
+        <p part="no-result-root" class="no-result-root">
+          {this.noResultText || this.bindings.i18n.t('no-documents-related')}
+        </p>
+      );
+    }
+    if (hasResults) {
+      components.push(<slot name="after-children"></slot>);
+    }
+    return components;
+  }
+
   public render() {
     if (!this.ready) return null;
     if (this.templateHasError) return <slot></slot>;
-    const result = this.getResult();
-    if (result.children.length) {
-      return (
-        <Host>
-          <slot name="before-children"></slot>
-          {result.isLoadingMoreResults ? (
-            <Loading></Loading>
-          ) : (
-            result.children.map((child) => this.renderChild(child))
-          )}
-          <slot name="after-children"></slot>
-        </Host>
-      );
-    }
-    if (result.isLoadingMoreResults) {
-      return <Loading></Loading>;
-    }
-    return null;
+    return (
+      <Host>
+        {this.showCollapseButton() && (
+          <Button
+            part="show-hide-button"
+            class="show-hide-button"
+            style="text-primary"
+            onClick={() => (this.hideResults = !this.hideResults)}
+          >
+            {this.bindings.i18n.t(
+              this.hideResults ? 'show-all-results' : 'hide-all-results'
+            )}
+          </Button>
+        )}
+        {this.showChildrenWrapper() && (
+          <div part="children-root">{this.getComponents()}</div>
+        )}
+      </Host>
+    );
   }
 }
-
-const Loading: FunctionalComponent = () => {
-  // TODO:
-  return <p>Loading...</p>;
-};

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -186,7 +186,7 @@ export class AtomicResultChildren {
   private getComponents() {
     const components = [];
     const result = this.getResult();
-    const hasResults = Boolean(result.children.length);
+    const hasResults = result.children.length !== 0;
     if (hasResults) {
       components.push(<slot name="before-children"></slot>);
     }

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -165,7 +165,7 @@ export class AtomicResultChildren {
   private shouldShowChildrenWrapper() {
     const result = this.getResult();
     if (!this.initialChildren.length && this.hideResults) {
-        return false;
+      return false;
     }
     return (
       Boolean(result.children.length) ||
@@ -183,15 +183,14 @@ export class AtomicResultChildren {
     }
   }
 
+  private get hasResults() {
+    return this.getResult().children.length !== 0;
+  }
+
   private getComponents() {
-    const components = [];
     const result = this.getResult();
-    const hasResults = result.children.length !== 0;
-    if (hasResults) {
-      components.push(<slot name="before-children"></slot>);
-    }
     if (result.isLoadingMoreResults) {
-      components.push(
+      return (
         <ListDisplayResultsPlaceholder
           resultsPerPageState={{
             numberOfResults: result.children.length || 2,
@@ -201,28 +200,26 @@ export class AtomicResultChildren {
           isChild
         />
       );
-    } else if (hasResults) {
+    } else if (this.hasResults) {
       const children = this.hideResults
         ? this.initialChildren
         : result.children;
-      components.push(children.map((child) => this.renderChild(child)));
+      return children.map((child) => this.renderChild(child));
     } else if (this.showAllResults) {
-      components.push(
+      return (
         <p part="no-result-root" class="no-result-root">
           {this.noResultText || this.bindings.i18n.t('no-documents-related')}
         </p>
       );
     }
-    if (hasResults) {
-      components.push(<slot name="after-children"></slot>);
-    }
-    return components;
+    return null;
   }
 
   private renderCollapseButton() {
     const result = this.getResult();
     if (
       Boolean(result.children.length) &&
+      result.children.length !== this.initialChildren.length &&
       !result.isLoadingMoreResults &&
       !result.moreResultsAvailable
     ) {
@@ -234,7 +231,7 @@ export class AtomicResultChildren {
           onClick={() => (this.hideResults = !this.hideResults)}
         >
           {this.bindings.i18n.t(
-            this.hideResults ? 'show-all-results' : 'hide-all-results'
+            this.hideResults ? 'expand-results' : 'collapse-results'
           )}
         </Button>
       );
@@ -249,7 +246,11 @@ export class AtomicResultChildren {
       <Host>
         {this.renderCollapseButton()}
         {this.shouldShowChildrenWrapper() && (
-          <div part="children-root">{this.getComponents()}</div>
+          <div part="children-root">
+            {this.hasResults && <slot name="before-children"></slot>}
+            {this.getComponents()}
+            {this.hasResults && <slot name="after-children"></slot>}
+          </div>
         )}
       </Host>
     );

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -200,12 +200,14 @@ export class AtomicResultChildren {
           isChild
         />
       );
-    } else if (this.hasResults) {
+    }
+    if (this.hasResults) {
       const children = this.hideResults
         ? this.initialChildren
         : result.children;
       return children.map((child) => this.renderChild(child));
-    } else if (this.showAllResults) {
+    }
+    if (this.showAllResults) {
       return (
         <p part="no-result-root" class="no-result-root">
           {this.noResultText || this.bindings.i18n.t('no-documents-related')}

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -224,20 +224,20 @@ export class AtomicResultChildren {
       !result.isLoadingMoreResults &&
       !result.moreResultsAvailable
     ) {
-      return null;
+      return (
+        <Button
+          part="show-hide-button"
+          class="show-hide-button"
+          style="text-primary"
+          onClick={() => (this.hideResults = !this.hideResults)}
+        >
+          {this.bindings.i18n.t(
+            this.hideResults ? 'show-all-results' : 'hide-all-results'
+          )}
+        </Button>
+      );
     }
-    return (
-      <Button
-        part="show-hide-button"
-        class="show-hide-button"
-        style="text-primary"
-        onClick={() => (this.hideResults = !this.hideResults)}
-      >
-        {this.bindings.i18n.t(
-          this.hideResults ? 'show-all-results' : 'hide-all-results'
-        )}
-      </Button>
-    );
+    return null;
   }
 
   public render() {

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -82,6 +82,8 @@ export class AtomicResultChildren {
    */
   @Prop() public noResultText = '';
 
+  private initialChildren!: FoldedResult[];
+
   @Listen('atomic/resolveChildTemplates')
   public resolveChildTemplates(event: ChildTemplatesContextEvent) {
     event.preventDefault();
@@ -171,15 +173,18 @@ export class AtomicResultChildren {
 
   private showChildrenWrapper() {
     const result = this.getResult();
+    if (!this.initialChildren.length && this.hideResults) return false;
     return (
-      !this.hideResults &&
-      (Boolean(result.children.length) ||
-        result.isLoadingMoreResults ||
-        this.showAllResults)
+      Boolean(result.children.length) ||
+      result.isLoadingMoreResults ||
+      this.showAllResults
     );
   }
 
   public componentWillUpdate() {
+    if (this.getResult().children && !this.initialChildren) {
+      this.initialChildren = this.getResult().children;
+    }
     if (this.getResult().isLoadingMoreResults && !this.showAllResults) {
       this.showAllResults = true;
     }
@@ -204,7 +209,10 @@ export class AtomicResultChildren {
         />
       );
     } else if (hasResults) {
-      components.push(result.children.map((child) => this.renderChild(child)));
+      const children = this.hideResults
+        ? this.initialChildren
+        : result.children;
+      components.push(children.map((child) => this.renderChild(child)));
     } else if (this.showAllResults) {
       components.push(
         <p part="no-result-root" class="no-result-root">

--- a/packages/atomic/src/components/result-lists/list-display-results-placeholder.tsx
+++ b/packages/atomic/src/components/result-lists/list-display-results-placeholder.tsx
@@ -12,7 +12,7 @@ export const ListDisplayResultsPlaceholder: FunctionalComponent<
         density={props.density}
         display="list"
         imageSize={props.imageSize!}
-        classes={props.classes}
+        isChild={props.isChild}
       ></atomic-result-placeholder>
     )
   );

--- a/packages/atomic/src/components/result-lists/list-display-results-placeholder.tsx
+++ b/packages/atomic/src/components/result-lists/list-display-results-placeholder.tsx
@@ -12,6 +12,7 @@ export const ListDisplayResultsPlaceholder: FunctionalComponent<
         density={props.density}
         display="list"
         imageSize={props.imageSize!}
+        classes={props.classes}
       ></atomic-result-placeholder>
     )
   );

--- a/packages/atomic/src/components/result-lists/result-list-common.tsx
+++ b/packages/atomic/src/components/result-lists/result-list-common.tsx
@@ -37,6 +37,7 @@ interface DisplayOptions {
 }
 export interface ResultPlaceholderProps extends Omit<DisplayOptions, 'image'> {
   resultsPerPageState: ResultsPerPageState;
+  classes?: string;
 }
 export interface ResultsProps extends DisplayOptions {
   host: HTMLElement;

--- a/packages/atomic/src/components/result-lists/result-list-common.tsx
+++ b/packages/atomic/src/components/result-lists/result-list-common.tsx
@@ -37,7 +37,7 @@ interface DisplayOptions {
 }
 export interface ResultPlaceholderProps extends Omit<DisplayOptions, 'image'> {
   resultsPerPageState: ResultsPerPageState;
-  classes?: string;
+  isChild?: boolean;
 }
 export interface ResultsProps extends DisplayOptions {
   host: HTMLElement;

--- a/packages/atomic/src/components/result-template-components/result-template-decorators.tsx
+++ b/packages/atomic/src/components/result-template-components/result-template-decorators.tsx
@@ -1,6 +1,10 @@
 import {FoldedResult, Result, ResultTemplatesManager} from '@coveo/headless';
 import {ComponentInterface, getElement} from '@stencil/core';
 import {buildCustomEvent} from '../../utils/event-utils';
+import {
+  ResultDisplayDensity,
+  ResultDisplayImageSize,
+} from '../atomic-result/atomic-result-display-options';
 import {TemplateContent} from '../result-templates/result-template-common';
 
 export class MissingResultParentError extends Error {
@@ -138,6 +142,40 @@ export function ChildTemplatesContext() {
       const canceled = element.dispatchEvent(event);
       if (canceled) {
         this[resultVariable] = null;
+        return;
+      }
+      return componentWillRender && componentWillRender.call(this);
+    };
+  };
+}
+
+export type DisplayConfig = {
+  density: ResultDisplayDensity;
+  imageSize: ResultDisplayImageSize;
+};
+
+type ResultDisplayConfigContextEventHandler = (config: DisplayConfig) => void;
+export type ResultDisplayConfigContextEvent =
+  CustomEvent<ResultDisplayConfigContextEventHandler>;
+const resultDisplayConfigContextEventName = 'atomic/resolveResultDisplayConfig';
+
+/**
+ * A [StencilJS property decorator](https://stenciljs.com/) to fetch display properties for a result.
+ */
+export function ResultDisplayConfigContext() {
+  return (component: ComponentInterface, resultVariable: string) => {
+    const {componentWillRender} = component;
+    component.componentWillRender = function () {
+      const element = getElement(this);
+      const event = buildCustomEvent(
+        resultDisplayConfigContextEventName,
+        (config: DisplayConfig) => {
+          this[resultVariable] = config;
+        }
+      );
+
+      const canceled = element.dispatchEvent(event);
+      if (canceled) {
         return;
       }
       return componentWillRender && componentWillRender.call(this);

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -424,11 +424,11 @@
     "en": "Load all results",
     "fr": "Afficher tous les résultats"
   },
-  "show-all-results": {
+  "expand-results": {
     "en": "Expand results",
     "fr": "Afficher tous les résultats"
   },
-  "hide-all-results": {
+  "collapse-results": {
     "en": "Collapse results",
     "fr": "Cacher tous les résultats"
   },

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -425,11 +425,11 @@
     "fr": "Afficher tous les résultats"
   },
   "show-all-results": {
-    "en": "Show all results",
+    "en": "Expand results",
     "fr": "Afficher tous les résultats"
   },
   "hide-all-results": {
-    "en": "Hide all results",
+    "en": "Collapse results",
     "fr": "Cacher tous les résultats"
   },
   "no-documents-related": {

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -424,6 +424,18 @@
     "en": "Load all results",
     "fr": "Afficher tous les résultats"
   },
+  "show-all-results": {
+    "en": "Show all results",
+    "fr": "Afficher tous les résultats"
+  },
+  "hide-all-results": {
+    "en": "Hide all results",
+    "fr": "Cacher tous les résultats"
+  },
+  "no-documents-related": {
+    "en": "No documents are related to this one.",
+    "fr": "Aucun document associé à celui-ci."
+  },
   "in-seconds": {
     "en": "in {{count}} second",
     "fr": "en {{count}} seconde",

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -21,14 +21,6 @@
           organizationId: 'searchuisamples',
         });
 
-        const engine = searchInterface.engine;
-
-        const action = loadAdvancedSearchQueryActions(engine).updateAdvancedSearchQueries({
-          aq: '@source=iNaturalistTaxons',
-        });
-
-        engine.dispatch(action);
-
         // Trigger a first search
         searchInterface.executeFirstSearch();
       })();
@@ -84,7 +76,7 @@
           </atomic-layout-section>
           <atomic-layout-section section="results">
             <atomic-smart-snippet></atomic-smart-snippet>
-            <atomic-folded-result-list fields-to-include="snrating,sncost">
+            <atomic-folded-result-list fields-to-include="snrating,sncost" image-size="small">
               <atomic-result-template>
                 <template>
                   <style>
@@ -99,13 +91,8 @@
                     }
 
                     .thumbnail {
-                      display: none;
                       width: 100%;
                       height: 100%;
-                    }
-
-                    .icon {
-                      display: none;
                     }
 
                     .result-root.image-small .thumbnail,
@@ -128,7 +115,7 @@
                     }
                   </style>
                   <atomic-result-section-visual>
-                    <atomic-result-icon class="icon"></atomic-result-icon>
+                    <atomic-result-image class="icon"></atomic-result-image>
                     <img src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-badges>
@@ -221,24 +208,88 @@
                     <atomic-result-text field="filetype"></atomic-result-text>
                   </atomic-table-element>
                   <atomic-result-section-children>
-                    <atomic-result-children>
-                      <div style="margin-top: 15px; margin-bottom: 15px; font-weight: bold" slot="before-children">
-                        In this collection:
-                      </div>
+                    <atomic-load-more-children-results></atomic-load-more-children-results>
+                    <atomic-result-children image-size="icon">
                       <!-- CHILD -->
                       <atomic-result-children-template>
                         <!-- CHILD TEMPLATE -->
                         <template>
-                          <atomic-result-link></atomic-result-link>
-                          <div style="padding-left: 15px">
-                            <atomic-result-children inherit-templates> <!-- GRANDCHILD --> </atomic-result-children>
-                          </div>
+                          <style>
+                            .field {
+                              display: inline-flex;
+                              align-items: center;
+                            }
+
+                            .field-label {
+                              font-weight: bold;
+                              margin-right: 0.25rem;
+                            }
+
+                            .thumbnail {
+                              width: 100%;
+                              height: 100%;
+                            }
+
+                            .result-root.image-small .thumbnail,
+                            .result-root.image-large .thumbnail {
+                              display: inline-block;
+                            }
+
+                            .result-root.image-icon .icon {
+                              display: inline-block;
+                            }
+
+                            .result-root.image-small atomic-result-section-visual,
+                            .result-root.image-large atomic-result-section-visual {
+                              border-radius: var(--atomic-border-radius-xl);
+                            }
+
+                            .salesforce-badge::part(result-badge-element) {
+                              background-color: #44a1da;
+                              color: white;
+                            }
+                          </style>
+                          <atomic-result-section-visual>
+                            <atomic-result-image class="icon"></atomic-result-image>
+                            <img src="https://picsum.photos/350" class="thumbnail" />
+                          </atomic-result-section-visual>
+                          <atomic-result-section-title
+                            ><atomic-result-link></atomic-result-link
+                          ></atomic-result-section-title>
+                          <atomic-result-section-excerpt
+                            ><atomic-result-text field="excerpt"></atomic-result-text
+                          ></atomic-result-section-excerpt>
+                          <atomic-table-element label="Description">
+                            <atomic-result-section-title
+                              ><atomic-result-link></atomic-result-link
+                            ></atomic-result-section-title>
+                            <atomic-result-section-title-metadata>
+                              <atomic-field-condition class="field" if-defined="snrating">
+                                <atomic-result-rating field="snrating"></atomic-result-rating>
+                              </atomic-field-condition>
+                              <atomic-field-condition class="field" if-not-defined="snrating">
+                                <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
+                              </atomic-field-condition>
+                            </atomic-result-section-title-metadata>
+                            <atomic-result-section-excerpt>
+                              <atomic-result-text field="excerpt"></atomic-result-text>
+                            </atomic-result-section-excerpt>
+                          </atomic-table-element>
+                          <atomic-table-element label="author">
+                            <atomic-result-text field="author"></atomic-result-text>
+                          </atomic-table-element>
+                          <atomic-table-element label="source">
+                            <atomic-result-text field="source"></atomic-result-text>
+                          </atomic-table-element>
+                          <atomic-table-element label="language">
+                            <atomic-result-text field="language"></atomic-result-text>
+                          </atomic-table-element>
+                          <atomic-table-element label="file-type">
+                            <atomic-result-text field="filetype"></atomic-result-text>
+                          </atomic-table-element>
                         </template>
                       </atomic-result-children-template>
                     </atomic-result-children>
-                    <div style="margin-top: 15px">
-                      <atomic-load-more-children-results></atomic-load-more-children-results>
-                    </div>
                   </atomic-result-section-children>
                 </template>
               </atomic-result-template>


### PR DESCRIPTION
Couple pics:
<img width="1045" alt="Screenshot 2022-04-21 at 17 22 07" src="https://user-images.githubusercontent.com/30511433/164506377-7c32ca72-4c8b-41c5-a4b7-49cda3e04878.png">
<img width="376" alt="Screenshot 2022-04-21 at 17 22 36" src="https://user-images.githubusercontent.com/30511433/164506479-9b72e4be-72e4-4f49-a881-44dc7b03e63f.png">
<img width="358" alt="Screenshot 2022-04-21 at 17 23 12" src="https://user-images.githubusercontent.com/30511433/164506562-93df9dee-032d-4923-a055-4ce68bdde98b.png">


Vid: (I changed the copy from show/hide all to collapse/expand, but it needed a server restart)
https://user-images.githubusercontent.com/30511433/164505605-ab8fb516-d22a-45f7-b626-1cc0efea45cc.mov

