### PR TITLE
fix(quantic): fixed double search on timeframe facet clear

### DIFF
--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -1,5 +1,6 @@
 import {configure} from '../../../page-objects/configurator';
 import {
+  captureBaselineNumberOfRequests,
   InterceptAliases,
   interceptSearch,
   interceptSearchIndefinitely,
@@ -9,6 +10,7 @@ import {scope} from '../../../reporters/detailed-collector';
 
 import {TimeframeFacetExpectations as Expect} from './timeframe-facet-expectations';
 import {TimeframeFacetActions as Actions} from './timeframe-facet-actions';
+import {SearchExpectations} from '../../search-expectations';
 
 interface TimeframeFacetOptions {
   field: string;
@@ -100,8 +102,13 @@ describe('quantic-timeframe-facet', () => {
       });
 
       scope('when clearing filter', () => {
+        captureBaselineNumberOfRequests(InterceptAliases.Search);
+
         Actions.clearFilter();
 
+        cy.wait(InterceptAliases.Search);
+
+        SearchExpectations.numberOfSearchRequests(1);
         Expect.numberOfSelectedValues(0);
         Expect.urlHashIsEmpty();
         Expect.displayClearButton(false);
@@ -268,10 +275,13 @@ describe('quantic-timeframe-facet', () => {
       });
 
       scope('when clearing filter', () => {
+        captureBaselineNumberOfRequests(InterceptAliases.Search);
+
         Actions.clearFilter();
 
         cy.wait(InterceptAliases.Search);
 
+        SearchExpectations.numberOfSearchRequests(1);
         Expect.displayClearButton(false);
         Expect.displayValues(true);
         Expect.urlHashIsEmpty();
@@ -299,8 +309,12 @@ describe('quantic-timeframe-facet', () => {
 
           Expect.numberOfValidationErrors(0);
 
+          captureBaselineNumberOfRequests(InterceptAliases.Search);
+
           Actions.clearFilter();
           cy.wait(InterceptAliases.Search);
+
+          SearchExpectations.numberOfSearchRequests(1);
         });
 
         scope('invalid start date format', () => {

--- a/packages/quantic/cypress/integration/search-expectations.ts
+++ b/packages/quantic/cypress/integration/search-expectations.ts
@@ -1,4 +1,4 @@
-import {InterceptAliases} from '../page-objects/search';
+import {baselineAlias, InterceptAliases} from '../page-objects/search';
 
 export const SearchExpectations = {
   sortedBy: (sortCriteria: string) => {
@@ -22,6 +22,14 @@ export const SearchExpectations = {
         expression,
         `search request constant query expression should be '${expression}'`
       );
+    });
+  },
+
+  numberOfSearchRequests: (expected: number) => {
+    cy.get(baselineAlias).then((baseline) => {
+      cy.get(`${InterceptAliases.Search}.all`)
+        .should('have.length', Number(baseline) + expected)
+        .logDetail(`should send ${expected} search requests`);
     });
   },
 };

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -18,6 +18,8 @@ function paramsInclude(superset: RequestParams, subset: RequestParams) {
   }, true);
 }
 
+export const baselineAlias = '@baseline';
+
 export const InterceptAliases = {
   UA: {
     Facet: {
@@ -181,4 +183,10 @@ export function interceptQuerySuggestWithParam(
       req.alias = alias.substring(1);
     }
   });
+}
+
+export function captureBaselineNumberOfRequests(interceptAlias: string) {
+  cy.get(`${interceptAlias}.all`).then((calls) =>
+    cy.wrap(calls.length).as(baselineAlias.substring(1))
+  );
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -483,13 +483,14 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   clearSelections() {
-    if (this.withDatePicker) {
+    this._showValues = true;
+
+    if (this.withDatePicker && this.dateFilter?.state.range) {
       this.dateFilter.clear();
       this.disableRangeValidation();
+      return;
     }
     this.facet.deselectAll();
-
-    this._showValues = true;
   }
 
   /**


### PR DESCRIPTION
Clearing the filters on the Quantic Timeframe Facet would trigger two search requests due to the filter.clear action dispatching a search as well as the facet.deselectAll.
Now we only execute one or the other depending on if the filter is set using the filter or a selected timeframe.

[SVCC-550](https://coveord.atlassian.net/browse/SVCC-550)