### PR TITLE
fix(quantic): added optional chaining to searchbox

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
@@ -164,7 +164,7 @@ export default class QuanticSearchBox extends LightningElement {
   }
 
   showSuggestions() {
-    this.searchBox.showSuggestions();
+    this.searchBox?.showSuggestions();
     this.combobox?.classList.add('slds-is-open');
     this.combobox?.setAttribute('aria-expanded', 'true');
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.js
@@ -217,7 +217,7 @@ export default class QuanticStandaloneSearchBox extends NavigationMixin(
   }
 
   showSuggestions() {
-    this.standaloneSearchBox.showSuggestions();
+    this.standaloneSearchBox?.showSuggestions();
     this.combobox?.classList.add('slds-is-open');
     this.combobox?.setAttribute('aria-expanded', 'true');
   }


### PR DESCRIPTION
Clicking the search boxes before the engine is initialized causes an error that breaks the components.
Simple optional chaining fixes it.