### PR TITLE
fix(quantic): initialized callback executing more than once fixed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -132,13 +132,13 @@ export default class QuanticSearchInterface extends LightningElement {
         );
         if (!redirectData) {
           engine.executeFirstSearch();
-          return;
-        }
-        window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
-        const {value, analytics} = JSON.parse(redirectData);
+        } else {
+          window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
+          const {value, analytics} = JSON.parse(redirectData);
   
-        engine.dispatch(updateQuery({q: value}));
-        engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
+          engine.dispatch(updateQuery({q: value}));
+          engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
+        }
       }
       this.initialized = true;
     }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -119,29 +119,30 @@ export default class QuanticSearchInterface extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    if (!this.initialized) {
-      const {updateQuery} = CoveoHeadless.loadQueryActions(engine);
-
-      if (!this.disableStateInUrl) {
-        this.initUrlManager(engine);
-      }
-  
-      if (!this.skipFirstSearch) {
-        const redirectData = window.localStorage.getItem(
-          STANDALONE_SEARCH_BOX_STORAGE_KEY
-        );
-        if (!redirectData) {
-          engine.executeFirstSearch();
-        } else {
-          window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
-          const {value, analytics} = JSON.parse(redirectData);
-  
-          engine.dispatch(updateQuery({q: value}));
-          engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
-        }
-      }
-      this.initialized = true;
+    if (this.initialized) {
+      return;
     }
+    const {updateQuery} = CoveoHeadless.loadQueryActions(engine);
+
+    if (!this.disableStateInUrl) {
+      this.initUrlManager(engine);
+    }
+
+    if (!this.skipFirstSearch) {
+      const redirectData = window.localStorage.getItem(
+        STANDALONE_SEARCH_BOX_STORAGE_KEY
+      );
+      if (!redirectData) {
+        engine.executeFirstSearch();
+      } else {
+        window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
+        const {value, analytics} = JSON.parse(redirectData);
+
+        engine.dispatch(updateQuery({q: value}));
+        engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
+      }
+    }
+    this.initialized = true;
   };
 
   get fragment() {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -139,9 +139,8 @@ export default class QuanticSearchInterface extends LightningElement {
   
         engine.dispatch(updateQuery({q: value}));
         engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
-
-        this.initialized = true;
       }
+      this.initialized = true;
     }
   };
 


### PR DESCRIPTION
### Bug:
[SFINT-4494](https://coveord.atlassian.net/browse/SFINT-4494)
Adding a new Quantic component to the page after the first initialization of the search interface is triggering the execution of the the initialization loop for a second time causing by this a weird behaviour by the Quantic Facets: the facet values are deleted after selecting one value.

### Expected behaviour:
The initialization loop should run only once and the facets should work as expected after adding them after the first execution of the the initialization loop.

### Source of the problem:
`buildUrlManager` headless controller is called in each initialization loop, building this controller is triggering the dispatch of the following action [restoreSearchParameters](https://github.com/coveo/ui-kit/blob/7640744168e5c46d5b2e5bd578e9ac899d975602/packages/headless/src/features/facets/facet-set/facet-set-slice.ts#L59) , which is causing the deletion of the facet values.



https://user-images.githubusercontent.com/86681870/164709896-866fa84d-ceec-43db-817e-e33da3909d3e.mov

