### PR TITLE
docs: add function name to doc parser error message

### DIFF
--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -137,7 +137,14 @@ function getParamDescription(param: Parameter) {
   const description = emitAsTsDoc(nodes as unknown as readonly DocNode[]);
 
   if (!description) {
-    throw new Error(`No description found for param: ${param.name}`);
+    const location = /(^\w+)/.exec(
+      param.parameterTypeExcerpt.tokens[0].text
+    )?.[0];
+    throw new Error(
+      `No description found for param: ${param.name}${
+        location ? ` missing in ${location}` : ''
+      }`
+    );
   }
 
   return description;

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -141,8 +141,8 @@ function getParamDescription(param: Parameter) {
       param.parameterTypeExcerpt.tokens[0].text
     )?.[0];
     throw new Error(
-      `No description found for param: ${param.name}${
-        location ? ` missing in ${location}` : ''
+      `No description found for param: ${
+        location ? `'${param.name}' in ${location}` : param.name
       }`
     );
   }

--- a/packages/headless/doc-parser/src/entity-builder.ts
+++ b/packages/headless/doc-parser/src/entity-builder.ts
@@ -138,7 +138,7 @@ function getParamDescription(param: Parameter) {
 
   if (!description) {
     const location = /(^\w+)/.exec(
-      param.parameterTypeExcerpt.tokens[0].text
+      param.parameterTypeExcerpt.tokens?.[0].text
     )?.[0];
     throw new Error(
       `No description found for param: ${


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1577

instead of 
```
/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/entity-builder.ts:144
    throw new Error(`No description found for param: ${param.name}`);
          ^
Error: No description found for param: collection
    at getParamDescription (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/entity-builder.ts:144:11)
    at buildParamEntity (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/entity-builder.ts:57:16)
    at buildObjEntityFromParam (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:308:34)
    at resolveParameter (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:263:12)
    at /Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:198:5
    at Array.map (<anonymous>)
    at resolveMethodSignature (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:197:31)
    at /Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:75:14
    at Array.map (<anonymous>)
    at resolveMembers (/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/interface-resolver.ts:69:40)
lerna ERR! npm run doc:generate exited 1 in '@coveo/headless'
```

log:
```
/Users/liviarett/coveo/ui-kit/packages/headless/doc-parser/src/entity-builder.ts:143
    throw new Error(
          ^
Error: No description found for param: 'collection' in logShowMoreFoldedResults
```

I based it on one error that I had, hoping that `param.parameterTypeExcerpt.tokens[0].text` will always be the closest name we need. but let me know if this doesn't make sense