### PR TITLE
feat(atomic): make grid result <a> a sibling instead of parent

### DIFF
--- a/packages/atomic/src/components/atomic-result/atomic-result.pcss
+++ b/packages/atomic/src/components/atomic-result/atomic-result.pcss
@@ -23,6 +23,11 @@
       }
     }
     &.display-grid {
+      a,
+      button {
+        position: relative;
+      }
+
       &.image-large {
         @screen desktop-only {
           @mixin cell-result-desktop;

--- a/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -25,7 +25,7 @@ import {ResultListCommon, ResultRenderingFunction} from '../result-list-common';
  * The `atomic-result-list` component is responsible for displaying query results by applying one or more result templates.
  *
  * @part result-list - The element containing every result of a result list
- * @part result-list-grid-parent - The parent of the result & the clickable link encompassing it, when results are displayed as a grid
+ * @part result-list-grid-clickable-container - The parent of the result & the clickable link encompassing it, when results are displayed as a grid
  * @part result-list-grid-clickable - The clickable link encompassing the result when results are displayed as a grid
  * @part result-table - The element of the result table containing a heading and a body
  * @part result-table-heading - The element containing the row of cells in the result table's heading

--- a/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -25,7 +25,8 @@ import {ResultListCommon, ResultRenderingFunction} from '../result-list-common';
  * The `atomic-result-list` component is responsible for displaying query results by applying one or more result templates.
  *
  * @part result-list - The element containing every result of a result list
- * @part result-list-grid-clickable - The clickable result when results are displayed as a grid
+ * @part result-list-grid-parent - The parent of the result & the clickable link encompassing it, when results are displayed as a grid
+ * @part result-list-grid-clickable - The clickable link encompassing the result when results are displayed as a grid
  * @part result-table - The element of the result table containing a heading and a body
  * @part result-table-heading - The element containing the row of cells in the result table's heading
  * @part result-table-heading-row - The element containing cells of the result table's heading

--- a/packages/atomic/src/components/result-lists/grid-display-results.tsx
+++ b/packages/atomic/src/components/result-lists/grid-display-results.tsx
@@ -12,7 +12,7 @@ export const GridDisplayResults: FunctionalComponent<ResultsProps> = (
     });
 
     return (
-      <div part="result-list-grid-parent">
+      <div part="result-list-grid-clickable-container">
         <LinkWithResultAnalytics
           part="result-list-grid-clickable"
           onSelect={() => interactiveResult.select()}

--- a/packages/atomic/src/components/result-lists/grid-display-results.tsx
+++ b/packages/atomic/src/components/result-lists/grid-display-results.tsx
@@ -12,14 +12,16 @@ export const GridDisplayResults: FunctionalComponent<ResultsProps> = (
     });
 
     return (
-      <LinkWithResultAnalytics
-        part="result-list-grid-clickable"
-        onSelect={() => interactiveResult.select()}
-        onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
-        onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
-        href={props.resultListCommon.getUnfoldedResult(result).clickUri}
-        target="_self"
-      >
+      <div part="result-list-grid-parent">
+        <LinkWithResultAnalytics
+          part="result-list-grid-clickable"
+          onSelect={() => interactiveResult.select()}
+          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
+          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
+          href={props.resultListCommon.getUnfoldedResult(result).clickUri}
+          target="_self"
+          title={props.resultListCommon.getUnfoldedResult(result).title}
+        />
         <atomic-result
           key={props.resultListCommon.getResultId(
             result,
@@ -32,7 +34,7 @@ export const GridDisplayResults: FunctionalComponent<ResultsProps> = (
           imageSize={props.imageSize}
           content={props.getContentOfResultTemplate(result)}
         ></atomic-result>
-      </LinkWithResultAnalytics>
+      </div>
     );
   });
 };

--- a/packages/atomic/src/components/result-lists/result-list-common.pcss
+++ b/packages/atomic/src/components/result-lists/result-list-common.pcss
@@ -75,7 +75,6 @@
 
 [part='result-list-grid-parent'] {
   position: relative;
-  cursor: pointer;
 }
 
 [part='result-list-grid-clickable'] {
@@ -84,7 +83,6 @@
   bottom: 0;
   right: 0;
   left: 0;
-  pointer-events: none;
 }
 
 .list-wrapper.placeholder {

--- a/packages/atomic/src/components/result-lists/result-list-common.pcss
+++ b/packages/atomic/src/components/result-lists/result-list-common.pcss
@@ -147,7 +147,7 @@
   }
 }
 
-[part='result-list-grid-parent'] {
+[part='result-list-grid-clickable-container'] {
   position: relative;
 
   @screen desktop-only {

--- a/packages/atomic/src/components/result-lists/result-list-common.pcss
+++ b/packages/atomic/src/components/result-lists/result-list-common.pcss
@@ -73,9 +73,18 @@
   }
 }
 
-a[part='result-list-grid-clickable'] {
-  display: grid;
-  text-decoration: none;
+[part='result-list-grid-parent'] {
+  position: relative;
+  cursor: pointer;
+}
+
+[part='result-list-grid-clickable'] {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  pointer-events: none;
 }
 
 .list-wrapper.placeholder {
@@ -160,6 +169,8 @@ a[part='result-list-grid-clickable'] {
     grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
 
     atomic-result {
+      height: 100%;
+      box-sizing: border-box;
       border: 1px solid transparent;
       padding: 1rem;
       border-radius: 1rem;

--- a/packages/atomic/src/components/result-lists/result-list-common.pcss
+++ b/packages/atomic/src/components/result-lists/result-list-common.pcss
@@ -73,18 +73,6 @@
   }
 }
 
-[part='result-list-grid-parent'] {
-  position: relative;
-}
-
-[part='result-list-grid-clickable'] {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  left: 0;
-}
-
 .list-wrapper.placeholder {
   atomic-result {
     display: none;
@@ -159,16 +147,11 @@
   }
 }
 
-.list-root.display-grid {
-  display: grid;
-  justify-content: space-evenly;
+[part='result-list-grid-parent'] {
+  position: relative;
 
   @screen desktop-only {
-    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
-
-    atomic-result {
-      height: 100%;
-      box-sizing: border-box;
+    & {
       border: 1px solid transparent;
       padding: 1rem;
       border-radius: 1rem;
@@ -178,6 +161,29 @@
         box-shadow: 0px 10px 25px var(--atomic-neutral);
       }
     }
+  }
+}
+
+[part='result-list-grid-clickable'] {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.list-root.display-grid {
+  display: grid;
+  justify-content: space-evenly;
+
+  atomic-result {
+    height: 100%;
+    box-sizing: border-box;
+  }
+
+  @screen desktop-only {
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
 
     &.density-comfortable {
       grid-row-gap: 4rem;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1574

Why? https://html.spec.whatwg.org/#the-a-element

> [Transparent](https://html.spec.whatwg.org/#transparent), but there must be no [interactive content](https://html.spec.whatwg.org/#interactive-content-2) descend[a](https://html.spec.whatwg.org/#the-a-element)nt, a element descendant, or descendant with the [tabindex](https://html.spec.whatwg.org/#attr-tabindex) attribute specified.

Inspired by https://css-tricks.com/nested-links/ & https://inclusive-components.design/cards/