### PR TITLE
feat(atomic): refactored atomic-modal mobile/desktop look to fullscreen true/false prop

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -307,6 +307,7 @@ export namespace Components {
     }
     interface AtomicModal {
         "close": () => void;
+        "fullscreen": boolean;
         "isOpen": boolean;
         "source"?: HTMLElement;
     }
@@ -1789,6 +1790,7 @@ declare namespace LocalJSX {
     }
     interface AtomicModal {
         "close"?: () => void;
+        "fullscreen"?: boolean;
         "isOpen"?: boolean;
         "onAnimationEnded"?: (event: CustomEvent<never>) => void;
         "source"?: HTMLElement;

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
@@ -13,13 +13,13 @@ atomic-focus-trap {
   grid-area: modal;
 }
 
-:host(.opened) {
+:host(.open) {
   [part='backdrop'] {
     @apply pointer-events-auto;
   }
 }
 
-:host(.opened.dialog) {
+:host(.open.dialog) {
   [part='backdrop'] {
     background-color: rgba(40, 40, 40, 0.8);
   }

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
@@ -35,23 +35,12 @@ atomic-focus-trap {
       '. modal .'
       '. .     .';
 
-    grid-template-columns: 1fr auto 1fr;
-    @screen desktop-only {
-      grid-template-rows: 1fr auto 3fr;
-    }
-    @screen mobile-only {
-      grid-template-rows: 0 auto 0;
-    }
+    grid-template-columns: 1fr min(30rem, 100%) 1fr;
+    grid-template-rows: 1fr auto 3fr;
   }
 
   [part='container'] {
     @apply rounded;
-
-    @screen desktop-only {
-      min-width: 30rem;
-      max-width: 100vw;
-      max-height: 100vh;
-    }
   }
 
   [part='header-wrapper'] {

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
@@ -40,7 +40,7 @@ atomic-focus-trap {
   }
 
   [part='container'] {
-    @apply rounded;
+    @apply rounded shadow;
   }
 
   [part='header-wrapper'] {
@@ -64,7 +64,6 @@ atomic-focus-trap {
 :host(.fullscreen) {
   [part='container'] {
     @apply absolute inset-0;
-    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
   }
 
   [part='header-wrapper'] {
@@ -76,6 +75,6 @@ atomic-focus-trap {
   }
 
   [part='footer-wrapper'] {
-    @apply shadow-lg px-6 py-4;
+    @apply shadow-t-lg px-6 py-4;
   }
 }

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
@@ -2,25 +2,6 @@
 
 [part='backdrop'] {
   @apply pointer-events-none;
-
-  @screen desktop-only {
-    @apply grid place-items-center;
-    grid-template-areas:
-      '. .     .'
-      '. modal .'
-      '. .     .';
-    grid-template-columns: 1fr auto 1fr;
-    grid-template-rows: 1fr auto 3fr;
-
-    transition: background-color 500ms ease-in-out;
-    &.opened {
-      background-color: rgba(40, 40, 40, 0.8);
-    }
-  }
-
-  &.opened {
-    @apply pointer-events-auto;
-  }
 }
 
 atomic-focus-trap {
@@ -30,53 +11,80 @@ atomic-focus-trap {
 [part='container'] {
   @apply overflow-hidden;
   grid-area: modal;
+}
 
-  @screen mobile-only {
+:host(.opened) {
+  [part='backdrop'] {
+    @apply pointer-events-auto;
+  }
+}
+
+:host(.opened.dialog) {
+  [part='backdrop'] {
+    background-color: rgba(40, 40, 40, 0.8);
+  }
+}
+
+:host(.dialog) {
+  [part='backdrop'] {
+    @apply grid place-items-center;
+    grid-template-areas:
+      '. .     .'
+      '. modal .'
+      '. .     .';
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: 1fr auto 3fr;
+
+    transition: background-color 500ms ease-in-out;
+  }
+
+  [part='container'] {
+    @apply rounded;
+
+    @screen desktop-only {
+      min-width: 30rem;
+      max-width: 100vw;
+      max-height: 100vh;
+    }
+
+    @screen mobile-only {
+      @apply fixed inset-6;
+    }
+  }
+
+  [part='header-wrapper'] {
+    @apply px-6 py-4;
+  }
+
+  [part='header'] {
+    @apply font-bold;
+  }
+
+  [part='body-wrapper'] {
+    @apply p-6;
+  }
+
+  [part='footer-wrapper'] {
+    @apply bg-neutral-light;
+    padding: 1rem 1.125rem;
+  }
+}
+
+:host(.fullscreen) {
+  [part='container'] {
     @apply absolute inset-0;
     box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
   }
 
-  @screen desktop-only {
-    @apply rounded;
-    min-width: 30rem;
-    max-width: 100vw;
-    max-height: 100vh;
-  }
-}
-
-[part='header-wrapper'] {
-  @screen mobile-only {
+  [part='header-wrapper'] {
     @apply p-6;
   }
 
-  @screen desktop-only {
-    @apply px-6 py-4;
-  }
-}
-
-[part='header'] {
-  @screen desktop-only {
-    @apply font-bold;
-  }
-}
-
-[part='body-wrapper'] {
-  @screen mobile-only {
+  [part='body-wrapper'] {
     @apply px-6 pt-8 pb-5;
   }
 
-  @screen desktop-only {
-    @apply p-6;
-  }
-}
-
-[part='footer-wrapper'] {
-  @screen mobile-only {
+  [part='footer-wrapper'] {
     @apply shadow-lg px-6 py-4;
-  }
-
-  @screen desktop-only {
-    @apply bg-neutral-light;
-    padding: 1rem 1.125rem;
   }
 }

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.pcss
@@ -27,15 +27,21 @@ atomic-focus-trap {
 
 :host(.dialog) {
   [part='backdrop'] {
-    @apply grid place-items-center;
+    @apply grid p-6;
+    transition: background-color 500ms ease-in-out;
+
     grid-template-areas:
       '. .     .'
       '. modal .'
       '. .     .';
-    grid-template-columns: 1fr auto 1fr;
-    grid-template-rows: 1fr auto 3fr;
 
-    transition: background-color 500ms ease-in-out;
+    grid-template-columns: 1fr auto 1fr;
+    @screen desktop-only {
+      grid-template-rows: 1fr auto 3fr;
+    }
+    @screen mobile-only {
+      grid-template-rows: 0 auto 0;
+    }
   }
 
   [part='container'] {
@@ -45,10 +51,6 @@ atomic-focus-trap {
       min-width: 30rem;
       max-width: 100vw;
       max-height: 100vh;
-    }
-
-    @screen mobile-only {
-      @apply fixed inset-6;
     }
   }
 

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
@@ -7,6 +7,7 @@ import {
   Watch,
   Event,
   EventEmitter,
+  Host,
 } from '@stencil/core';
 import {
   Bindings,
@@ -43,6 +44,7 @@ export class AtomicModal implements InitializableComponent {
 
   @State() public error!: Error;
 
+  @Prop({mutable: true}) fullscreen = false;
   @Prop({mutable: true}) source?: HTMLElement;
   @Prop({reflect: true, mutable: true}) isOpen = false;
   @Prop({mutable: true}) close: () => void = () => (this.isOpen = false);
@@ -76,6 +78,19 @@ export class AtomicModal implements InitializableComponent {
     this.source?.focus();
   }
 
+  private getClasses() {
+    const classes: string[] = [];
+    if (this.isOpen) {
+      classes.push('opened');
+    }
+    if (this.fullscreen) {
+      classes.push('fullscreen');
+    } else {
+      classes.push('dialog');
+    }
+    return classes;
+  }
+
   public componentWillRender() {
     this.wasEverOpened ||= this.isOpen;
   }
@@ -90,55 +105,55 @@ export class AtomicModal implements InitializableComponent {
     }
 
     return (
-      <div
-        part="backdrop"
-        class={`fixed left-0 top-0 right-0 bottom-0 z-10 ${
-          this.isOpen ? 'opened' : ''
-        }`}
-        onClick={(e) => e.target === e.currentTarget && this.close()}
-      >
-        <atomic-focus-trap
-          active={this.isOpen}
-          role="dialog"
-          aria-modal={this.isOpen.toString()}
-          aria-labelledby={this.headerId}
+      <Host class={this.getClasses().join(' ')}>
+        <div
+          part="backdrop"
+          class="fixed left-0 top-0 right-0 bottom-0 z-10"
+          onClick={(e) => e.target === e.currentTarget && this.close()}
         >
-          <article
-            part="container"
-            class={`flex flex-col justify-between bg-background text-on-background ${
-              this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
-            }`}
-            onAnimationEnd={() => this.animationEnded.emit()}
+          <atomic-focus-trap
+            active={this.isOpen}
+            role="dialog"
+            aria-modal={this.isOpen.toString()}
+            aria-labelledby={this.headerId}
           >
-            <header part="header-wrapper" class="flex flex-col items-center">
+            <article
+              part="container"
+              class={`flex flex-col justify-between bg-background text-on-background ${
+                this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
+              }`}
+              onAnimationEnd={() => this.animationEnded.emit()}
+            >
+              <header part="header-wrapper" class="flex flex-col items-center">
+                <div
+                  part="header"
+                  class="flex justify-between text-xl w-full max-w-lg"
+                  id={this.headerId}
+                >
+                  <slot name="header"></slot>
+                </div>
+              </header>
+              <hr part="header-ruler" class="border-neutral"></hr>
               <div
-                part="header"
-                class="flex justify-between text-xl w-full max-w-lg"
-                id={this.headerId}
+                part="body-wrapper"
+                class="overflow-auto grow flex flex-col items-center w-full"
               >
-                <slot name="header"></slot>
+                <div part="body" class="w-full max-w-lg">
+                  <slot name="body"></slot>
+                </div>
               </div>
-            </header>
-            <hr part="header-ruler" class="border-neutral"></hr>
-            <div
-              part="body-wrapper"
-              class="overflow-auto grow flex flex-col items-center w-full"
-            >
-              <div part="body" class="w-full max-w-lg">
-                <slot name="body"></slot>
-              </div>
-            </div>
-            <footer
-              part="footer-wrapper"
-              class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
-            >
-              <div part="footer" class="w-full max-w-lg">
-                <slot name="footer"></slot>
-              </div>
-            </footer>
-          </article>
-        </atomic-focus-trap>
-      </div>
+              <footer
+                part="footer-wrapper"
+                class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
+              >
+                <div part="footer" class="w-full max-w-lg">
+                  <slot name="footer"></slot>
+                </div>
+              </footer>
+            </article>
+          </atomic-focus-trap>
+        </div>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
@@ -81,7 +81,7 @@ export class AtomicModal implements InitializableComponent {
   private getClasses() {
     const classes: string[] = [];
     if (this.isOpen) {
-      classes.push('opened');
+      classes.push('open');
     }
     if (this.fullscreen) {
       classes.push('fullscreen');

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
@@ -108,7 +108,7 @@ export class AtomicModal implements InitializableComponent {
       <Host class={this.getClasses().join(' ')}>
         <div
           part="backdrop"
-          class="fixed left-0 top-0 right-0 bottom-0 z-10"
+          class="fixed left-0 top-0 right-0 bottom-0 z-[9999]"
           onClick={(e) => e.target === e.currentTarget && this.close()}
         >
           <atomic-focus-trap

--- a/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/atomic-modal/atomic-modal.tsx
@@ -44,7 +44,7 @@ export class AtomicModal implements InitializableComponent {
 
   @State() public error!: Error;
 
-  @Prop({mutable: true}) fullscreen = false;
+  @Prop({reflect: true, mutable: true}) fullscreen = false;
   @Prop({mutable: true}) source?: HTMLElement;
   @Prop({reflect: true, mutable: true}) isOpen = false;
   @Prop({mutable: true}) close: () => void = () => (this.isOpen = false);

--- a/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
@@ -243,6 +243,7 @@ export class AtomicRefineModal implements InitializableComponent {
   public render() {
     return (
       <atomic-modal
+        fullscreen={true}
         isOpen={this.isOpen}
         source={this.openButton}
         close={() => (this.isOpen = false)}

--- a/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/atomic-refine-modal/atomic-refine-modal.tsx
@@ -243,7 +243,7 @@ export class AtomicRefineModal implements InitializableComponent {
   public render() {
     return (
       <atomic-modal
-        fullscreen={true}
+        fullscreen
         isOpen={this.isOpen}
         source={this.openButton}
         close={() => (this.isOpen = false)}

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.pcss
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.pcss
@@ -1,29 +1,18 @@
 @import '../../global/global.pcss';
 
-[part='reason-title'],
-[part='details-title'] {
-  @screen mobile-only {
-    @apply text-2xl;
-  }
+[part='buttons'] {
+  @apply flex justify-end;
 
   @screen desktop-only {
-    @apply text-lg;
+    @apply gap-2;
   }
-}
 
-[part='cancel-button'] {
-  @apply text-primary;
+  @screen mobile-only {
+    @apply gap-4;
+  }
 }
 
 [part='cancel-button'],
 [part='submit-button'] {
-  @apply flex justify-center;
-
-  @screen mobile-only {
-    @apply text-lg leading-6 p-3;
-  }
-
-  @screen desktop-only {
-    @apply text-sm leading-4 p-2;
-  }
+  @apply flex justify-center text-sm leading-4 p-2;
 }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.pcss
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.pcss
@@ -1,14 +1,14 @@
 @import '../../global/global.pcss';
 
-[part='buttons'] {
-  @apply flex justify-end;
+[part='reason'] {
+  @apply text-base leading-4 text-neutral-dark;
 
   @screen desktop-only {
-    @apply gap-2;
+    @apply mt-2;
   }
 
   @screen mobile-only {
-    @apply gap-4;
+    @apply mt-4;
   }
 }
 

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
@@ -230,6 +230,7 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
 
     return (
       <atomic-modal
+        fullscreen={false}
         source={this.source}
         isOpen={this.isOpen}
         close={() => this.close()}

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
@@ -36,6 +36,7 @@ import {updateBreakpoints} from '../../utils/replace-breakpoint';
  * @part body - The body of the modal, between the header and the footer.
  * @part form - The wrapper around the reason and details.
  * @part reason-title - The title above the reason radio buttons.
+ * @part reason - A wrapper around the radio button and the label of a reason.
  * @part reason-radio - A radio button representing a reason.
  * @part reason-label - A label linked to a radio button representing a reason.
  * @part details-title - The title above the details input.
@@ -141,7 +142,7 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
           {this.bindings.i18n.t('smart-snippet-feedback-select-reason')}
         </legend>
         {options.map(({id, localeKey, correspondingAnswer}) => (
-          <div key={id} class="text-base leading-4 text-neutral-dark mt-2">
+          <div key={id} part="reason">
             <input
               part="reason-radio"
               type="radio"
@@ -209,7 +210,7 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
 
   private renderFooter() {
     return (
-      <div part="buttons" slot="footer">
+      <div part="buttons" slot="footer" class="flex justify-end gap-2">
         <Button
           part="cancel-button"
           style="outline-neutral"

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-feedback-modal.tsx
@@ -134,7 +134,10 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
 
     return (
       <fieldset>
-        <legend part="reason-title" class="font-bold text-on-background">
+        <legend
+          part="reason-title"
+          class="font-bold text-on-background text-lg"
+        >
           {this.bindings.i18n.t('smart-snippet-feedback-select-reason')}
         </legend>
         {options.map(({id, localeKey, correspondingAnswer}) => (
@@ -168,7 +171,10 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
 
     return (
       <fieldset>
-        <legend part="details-title" class="font-bold text-on-background">
+        <legend
+          part="details-title"
+          class="font-bold text-on-background text-lg"
+        >
           {this.bindings.i18n.t('smart-snippet-feedback-details')}
         </legend>
         <textarea
@@ -203,10 +209,11 @@ export class AtomicSmartSnippetFeedbackModal implements InitializableComponent {
 
   private renderFooter() {
     return (
-      <div part="buttons" slot="footer" class="flex justify-end gap-2">
+      <div part="buttons" slot="footer">
         <Button
           part="cancel-button"
           style="outline-neutral"
+          class="text-primary"
           onClick={() => this.close()}
         >
           {this.bindings.i18n.t('cancel')}

--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -108,7 +108,8 @@
     cursor: inherit;
   }
 
-  .shadow-lg {
+  .shadow-t-lg {
+    @apply shadow;
     --tw-shadow: 0px -2px 8px rgba(229, 232, 232, 0.75);
   }
 }

--- a/packages/atomic/src/pages/examples/modal.html
+++ b/packages/atomic/src/pages/examples/modal.html
@@ -18,13 +18,20 @@
           organizationId: 'searchuisamples',
         });
 
+        const fullscreenCheckbox = document.getElementById('checkbox-fullscreen');
         const openModalButton = document.getElementById('btn-open-modal');
         const closeModalButton = document.getElementById('btn-done');
         const modal = document.getElementById('modal');
         modal.source = openModalButton;
 
+        function updateFullscreen() {
+          modal.setAttribute('fullscreen', `${fullscreenCheckbox.checked}`);
+        }
+
+        fullscreenCheckbox.addEventListener('change', () => updateFullscreen());
         openModalButton.addEventListener('click', () => modal.setAttribute('is-open', 'true'));
         closeModalButton.addEventListener('click', () => modal.setAttribute('is-open', 'false'));
+        updateFullscreen();
       })();
     </script>
   </head>
@@ -32,6 +39,7 @@
   <body>
     <atomic-search-interface>
       <button id="btn-open-modal">Open modal</button>
+      <input type="checkbox" id="checkbox-fullscreen" /><label for="checkbox-fullscreen">Fullscreen</label>
       <atomic-modal id="modal">
         <div slot="header">This is a title</div>
         <div slot="body">This is the body</div>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1587

Prior to this PR, the `atomic-modal` had a "desktop" look (which is what we generally saw for the `atomic-smart-snippet-feedback-modal` component), and it had a mobile look (which is what we always saw for the `atomic-refine-modal` component).

In this PR, a boolean `fullscreen` prop was added to `atomic-modal`. The desktop look was mapped to the value `false` and the mobile look was mapped to the value `true`.

# `atomic-smart-snippet-feedback-modal`
Uses `<atomic-modal fullscreen={false} ...>...</atomic-modal>`

## Desktop
![image](https://user-images.githubusercontent.com/54454747/166293190-602762dd-2370-4802-b1c7-7ab818a47e05.png)

## Mobile
![image](https://user-images.githubusercontent.com/54454747/166293214-7926b1ff-0a3c-45bc-9247-bea686f142a7.png)

# `atomic-refine-modal` (mobile)
Uses `<atomic-modal fullscreen={true} ...>...</atomic-modal>`

![image](https://user-images.githubusercontent.com/54454747/166290687-ff6d2a8f-637f-456c-94b4-d607968bc12b.png)
