### PR TITLE
fix(headless): fix search ID generation for results-per-page controller

### DIFF
--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.test.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.test.ts
@@ -11,7 +11,7 @@ import {
   registerNumberOfResults,
   updateNumberOfResults,
 } from '../../features/pagination/pagination-actions';
-import {executeSearch} from '../../features/search/search-actions';
+import {fetchPage} from '../../features/search/search-actions';
 import {createMockState} from '../../test/mock-state';
 import {buildMockPagination} from '../../test/mock-pagination';
 import {configuration, pagination} from '../../app/reducers';
@@ -80,11 +80,11 @@ describe('ResultsPerPage', () => {
     expect(engine.actions).toContainEqual(updateNumberOfResults(num));
   });
 
-  it('calling #set executes a search', () => {
+  it('calling #set executes a fetchPage', () => {
     resultsPerPage.set(10);
 
     const action = engine.actions.find(
-      (a) => a.type === executeSearch.pending.type
+      (a) => a.type === fetchPage.pending.type
     );
     expect(action).toBeTruthy();
   });

--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
@@ -1,7 +1,7 @@
 import {configuration, pagination} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {logPagerResize} from '../../features/pagination/pagination-analytics-actions';
-import {executeSearch} from '../../features/search/search-actions';
+import {fetchPage} from '../../features/search/search-actions';
 import {
   ConfigurationSection,
   PaginationSection,
@@ -51,7 +51,7 @@ export function buildResultsPerPage(
 
     set(num: number) {
       coreController.set(num);
-      dispatch(executeSearch(logPagerResize()));
+      dispatch(fetchPage(logPagerResize()));
     },
   };
 }


### PR DESCRIPTION
Similar to: https://github.com/coveo/ui-kit/pull/1938

Forgot to change the dispatched action for results-per-page.

https://coveord.atlassian.net/browse/KIT-1597