### PR TITLE
fix(atomic): hid atomic-did-you-mean when there's no correction

### DIFF
--- a/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -7,6 +7,7 @@ import {
   InitializeBindings,
 } from '../../utils/initialization-utils';
 import escape from 'escape-html';
+import {Hidden} from '../common/hidden';
 
 /**
  * The `atomic-did-you-mean` component is responsible for handling query corrections. When a query returns no result but finds a possible query correction, the component either suggests the correction or automatically triggers a new query with the suggested term.
@@ -89,7 +90,7 @@ export class AtomicDidYouMean implements InitializableComponent {
 
   public render() {
     if (!this.didYouMeanState.hasQueryCorrection) {
-      return;
+      return <Hidden></Hidden>;
     }
 
     if (this.didYouMeanState.wasAutomaticallyCorrected) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1607

When there was no correction, the element was empty but still had `display: block`, which meant it could still have a margin (which it did, when it was inside the status section).