### PR TITLE
fix(atomic): fixed smart snippet show more/show less issue when rotating screen

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -2339,7 +2339,7 @@ declare namespace LocalJSX {
     interface AtomicSmartSnippetAnswer {
         "htmlContent": string;
         "innerStyle"?: string;
-        "onAtomic/smartSnippet/answerRendered"?: (event: CustomEvent<{height: number}>) => void;
+        "onAnswerRendered"?: (event: CustomEvent<{height: number}>) => void;
     }
     interface AtomicSmartSnippetExpandableAnswer {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -2339,7 +2339,7 @@ declare namespace LocalJSX {
     interface AtomicSmartSnippetAnswer {
         "htmlContent": string;
         "innerStyle"?: string;
-        "onAnswerRendered"?: (event: CustomEvent<{height: number}>) => void;
+        "onAnswerSizeUpdated"?: (event: CustomEvent<{height: number}>) => void;
     }
     interface AtomicSmartSnippetExpandableAnswer {
         /**

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-answer.tsx
@@ -1,4 +1,12 @@
-import {Component, h, Prop, Event, EventEmitter, Host} from '@stencil/core';
+import {
+  Component,
+  h,
+  Prop,
+  Event,
+  EventEmitter,
+  Host,
+  Listen,
+} from '@stencil/core';
 import {sanitize} from 'dompurify';
 import {sanitizeStyle} from '../../utils/utils';
 
@@ -15,14 +23,23 @@ export class AtomicSmartSnippetAnswer {
   @Prop({reflect: true}) htmlContent!: string;
   @Prop({reflect: true}) innerStyle?: string;
 
-  @Event({
-    eventName: 'atomic/smartSnippet/answerRendered',
-  })
+  @Event({bubbles: false})
   private answerRendered!: EventEmitter<{height: number}>;
   private wrapperElement?: HTMLElement;
+  private isRendering = true;
+
+  public componentWillRender() {
+    this.isRendering = true;
+  }
 
   public componentDidRender() {
-    this.answerRendered.emit({height: this.wrapperElement!.scrollHeight});
+    this.isRendering = false;
+    this.emitCurrentHeight();
+  }
+
+  @Listen('resize', {target: 'window'})
+  public windowResized() {
+    this.emitCurrentHeight();
   }
 
   private get sanitizedStyle() {
@@ -30,6 +47,13 @@ export class AtomicSmartSnippetAnswer {
       return undefined;
     }
     return sanitizeStyle(this.innerStyle);
+  }
+
+  private emitCurrentHeight() {
+    if (this.isRendering) {
+      return;
+    }
+    this.answerRendered.emit({height: this.wrapperElement!.scrollHeight});
   }
 
   private renderStyle() {

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
@@ -64,7 +64,7 @@ export class AtomicSmartSnippetExpandableAnswer {
     this.smartSnippet = buildSmartSnippet(this.bindings.engine);
   }
 
-  public answerRendered(event: CustomEvent<{height: number}>) {
+  public answerSizeUpdated(event: CustomEvent<{height: number}>) {
     const {height} = event.detail;
     this.host.style.setProperty('--full-height', `${height}px`);
     this.showButton = height > this.maximumHeight;
@@ -85,7 +85,7 @@ export class AtomicSmartSnippetExpandableAnswer {
           exportparts="answer"
           htmlContent={this.smartSnippetState.answer}
           innerStyle={this.snippetStyle}
-          onAnswerRendered={(e) => this.answerRendered(e)}
+          onAnswerSizeUpdated={(e) => this.answerSizeUpdated(e)}
         ></atomic-smart-snippet-answer>
       </div>
     );

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
@@ -3,7 +3,7 @@ import {
   SmartSnippet,
   SmartSnippetState,
 } from '@coveo/headless';
-import {h, Component, State, Prop, Element, Listen} from '@stencil/core';
+import {h, Component, State, Prop, Element} from '@stencil/core';
 import ArrowDown from '../../images/arrow-down.svg';
 import {
   InitializeBindings,
@@ -64,7 +64,6 @@ export class AtomicSmartSnippetExpandableAnswer {
     this.smartSnippet = buildSmartSnippet(this.bindings.engine);
   }
 
-  @Listen('atomic/smartSnippet/answerRendered')
   public answerRendered(event: CustomEvent<{height: number}>) {
     const {height} = event.detail;
     this.host.style.setProperty('--full-height', `${height}px`);
@@ -86,6 +85,7 @@ export class AtomicSmartSnippetExpandableAnswer {
           exportparts="answer"
           htmlContent={this.smartSnippetState.answer}
           innerStyle={this.snippetStyle}
+          onAnswerRendered={(e) => this.answerRendered(e)}
         ></atomic-smart-snippet-answer>
       </div>
     );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1604

The "show more" button in smart snippet only appears when there's not enough room vertically to display the snippet. 

Prior to this PR, the height of the content of the snippet was only evaluated when the snippet was initially rendered. However, the height varies when the size of the screen changes, such as when a mobile device's orientation is changed.