### PR TITLE
fix(atomic): improved alignment of the "show more"/"show less" smart snippet caret

### DIFF
--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.pcss
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.pcss
@@ -21,8 +21,8 @@
     mask-image: linear-gradient(black, black var(--gradient-start), transparent 100%);
   }
 
-  atomic-icon {
-    vertical-align: bottom;
+  button atomic-icon {
+    @apply relative top-0.5;
   }
 
   .expanded {
@@ -32,8 +32,7 @@
     }
 
     button atomic-icon {
-      transform: scaleY(-1);
-      vertical-align: baseline;
+      @apply -scale-y-100 top-0;
     }
   }
 }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
@@ -106,7 +106,10 @@ export class AtomicSmartSnippetExpandableAnswer {
         part={this.expanded ? 'show-less-button' : 'show-more-button'}
       >
         {this.bindings.i18n.t(this.expanded ? 'show-less' : 'show-more')}
-        <atomic-icon icon={ArrowDown} class="w-3 ml-2"></atomic-icon>
+        <atomic-icon
+          icon={ArrowDown}
+          class="w-3 ml-2 align-baseline"
+        ></atomic-icon>
       </button>
     );
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1603

Already showed it to Johnny

# Before
<table>
<tr>
	<td>

![image](https://user-images.githubusercontent.com/54454747/166960553-0ec6392e-8c52-40da-87e5-12e90b9f2c27.png)
	<td>

![image](https://user-images.githubusercontent.com/54454747/166960570-46a4c0fd-d792-4dd7-be81-5c575ea4d612.png)
</table>

# After

<table>
<tr>
	<td>

![image](https://user-images.githubusercontent.com/54454747/166960682-d1958bce-b582-4d4a-b6fc-3cd76aad7488.png)
	<td>

![image](https://user-images.githubusercontent.com/54454747/166960700-4a9ec755-7126-402f-b20c-a8aa04ce5b6b.png)
</table>