### PR TITLE
fix(atomic): made smart snippet wait for answer to be rendered

### DIFF
--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -4,6 +4,7 @@ import {
   InitializeBindings,
   Bindings,
   BindStateToController,
+  RemainHiddenUntilDescendantsRendered,
 } from '../../utils/initialization-utils';
 import {
   buildSmartSnippet,
@@ -99,6 +100,9 @@ export class AtomicSmartSnippet implements InitializableComponent {
   @Prop({reflect: true}) snippetStyle?: string;
 
   @State() feedbackSent = false;
+
+  @RemainHiddenUntilDescendantsRendered()
+  private remainHiddenUntilDescendantsRendered!: () => void;
 
   public initialize() {
     this.smartSnippet = buildSmartSnippet(this.bindings.engine);
@@ -214,6 +218,7 @@ export class AtomicSmartSnippet implements InitializableComponent {
     if (!this.smartSnippetState.answerFound) {
       return <Hidden></Hidden>;
     }
+    this.remainHiddenUntilDescendantsRendered();
 
     return (
       <aside>

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -290,4 +290,26 @@ export function DeferUntilRender() {
   };
 }
 
+export function RemainHiddenUntilDescendantsRendered() {
+  return (component: ComponentInterface, methodName: string) => {
+    const {componentDidRender} = component;
+
+    component[methodName] = function () {
+      const element = getElement(this);
+      if (!element.classList.contains('atomic-hidden')) {
+        return;
+      }
+      element.style.visibility = 'hidden';
+      element.style.position = 'absolute';
+    };
+
+    component.componentDidRender = function () {
+      const element = getElement(this);
+      element.style.visibility = '';
+      element.style.position = '';
+      return componentDidRender && componentDidRender.call(this);
+    };
+  };
+}
+
 export type I18nState = Record<string, (variables?: TOptions) => string>;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1525

The answer part of the snippet takes a bit longer to render than the rest (about 120ms more on my laptop). Originally, I assumed this was due to it rendering twice in order to estimate the height of the snippet, but adding logic to only render once did not fix the issue, so I stashed that fix. My guess is that setting `innerHTML` causes the delay.

My solution was to wait for `componentDidRender` to be called before revealing the smart snippet component. I expected the `componentDidRender` lifecycle event to be called too early due to the above issue with the answer rendering twice, but that didn't turn out to be the case.