### PR TITLE
feat(atomic): improved ripple animation speed

### DIFF
--- a/packages/atomic/src/global/ripple.pcss
+++ b/packages/atomic/src/global/ripple.pcss
@@ -3,7 +3,7 @@
   pointer-events: none;
   transform: scale(0);
   border-radius: 50%;
-  animation: ripple 700ms linear;
+  animation: ripple var(--animation-duration) linear;
 }
 
 .ripple-relative {

--- a/packages/atomic/src/utils/ripple.ts
+++ b/packages/atomic/src/utils/ripple.ts
@@ -10,7 +10,7 @@ const RIPPLE = 'ripple';
 
 function getAnimationDurationInMilliseconds(radiusPixels: number) {
   // A 318px wide button has a duration of 700ms.
-  return Math.cbrt(radiusPixels) / 0.007739287879;
+  return Math.cbrt(radiusPixels) * 129.21;
 }
 
 function setPositionRelativeIfStatic(element: Element) {

--- a/packages/atomic/src/utils/ripple.ts
+++ b/packages/atomic/src/utils/ripple.ts
@@ -8,6 +8,11 @@ interface RippleOptions {
 
 const RIPPLE = 'ripple';
 
+function getAnimationDurationInMilliseconds(radiusPixels: number) {
+  // A 318px wide button has a duration of 700ms.
+  return Math.cbrt(radiusPixels) / 0.007739287879;
+}
+
 function setPositionRelativeIfStatic(element: Element) {
   if (getComputedStyle(element).position === 'static') {
     element.classList.add('ripple-relative');
@@ -34,6 +39,10 @@ export function createRipple(event: MouseEvent, options: RippleOptions) {
   ripple.style.width = ripple.style.height = `${diameter}px`;
   ripple.style.left = `${event.clientX - (left + radius)}px`;
   ripple.style.top = `${event.clientY - (top + radius)}px`;
+  ripple.style.setProperty(
+    '--animation-duration',
+    `${getAnimationDurationInMilliseconds(radius)}ms`
+  );
   button.prepend(ripple);
   cleanupAnimationOnFinish(ripple);
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1596

Live demo: https://r1kvvq.csb.app/#q=atlas%20data%20lake

I changed the ripple animation duration of each component so they are based off the radius of the ripple.