### PR TITLE
feat(atomic,headless): add more out of the box analytics configuration for atomic

### DIFF
--- a/packages/atomic/src/components/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/atomic-search-interface/analytics-config.spec.ts
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   getSampleSearchEngineConfiguration,
   SearchEngineConfiguration,
 } from '@coveo/headless';
-import {registerFacet} from '@coveo/headless/dist/definitions/features/facets/facet-set/facet-set-actions';
 import {createStore, ObservableMap} from '@stencil/store';
 import {
   AtomicStore,

--- a/packages/atomic/src/components/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/atomic-search-interface/analytics-config.spec.ts
@@ -1,0 +1,108 @@
+import {
+  getSampleSearchEngineConfiguration,
+  SearchEngineConfiguration,
+} from '@coveo/headless';
+import {registerFacet} from '@coveo/headless/dist/definitions/features/facets/facet-set/facet-set-actions';
+import {createStore, ObservableMap} from '@stencil/store';
+import {
+  AtomicStore,
+  initialStore,
+  registerFacetToStore,
+} from '../../utils/store';
+import {getAnalyticsConfig} from './analytics-config';
+
+describe('analyticsConfig', () => {
+  let config: SearchEngineConfiguration;
+  let store: ObservableMap<AtomicStore>;
+  const originalReferrer = document.referrer;
+  const setReferrer = (value: string) => {
+    Object.defineProperty(document, 'referrer', {value, configurable: true});
+  };
+
+  beforeEach(() => {
+    config = getSampleSearchEngineConfiguration();
+    store = createStore<AtomicStore>(initialStore());
+  });
+
+  afterEach(() => {
+    Object.defineProperty(document, 'referrer', {value: originalReferrer});
+  });
+
+  it('should provide out of the box values for analytics config', () => {
+    setReferrer('foo');
+    const resultingConfig = getAnalyticsConfig(config, true, store);
+    expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
+    expect(resultingConfig.originLevel3).toBe('foo');
+  });
+
+  it('merges provided engine analytics config', () => {
+    setReferrer('foo');
+    config.analytics = {
+      enabled: true,
+      originContext: 'something',
+      originLevel3: 'bar',
+    };
+    const resultingConfig = getAnalyticsConfig(config, false, store);
+    expect(resultingConfig.enabled).toBe(true);
+    expect(resultingConfig.originContext).toBe('something');
+    expect(resultingConfig.originLevel3).toBe('bar');
+  });
+
+  it('use existing analytics middleware if available', () => {
+    const analyticsClientMiddleware = (_: string, payload: any) => {
+      payload['foo'] = 'bar';
+      return payload;
+    };
+
+    config.analytics = {analyticsClientMiddleware};
+    const resultingConfig = getAnalyticsConfig(config, true, store);
+    const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+      buzz: 'bazz',
+    }) as any;
+    expect(out.foo).toBe('bar');
+  });
+
+  it('it augment analytics payload with Atomic version', () => {
+    const resultingConfig = getAnalyticsConfig(config, true, store);
+    const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+      customData: {},
+    }) as any;
+    expect(out.customData).toHaveProperty('coveoAtomicVersion');
+  });
+
+  it('it augment analytics payload with facet title, with any type of facet registered to the store', () => {
+    const resultingConfig = getAnalyticsConfig(config, true, store);
+    (
+      ['facets', 'numericFacets', 'dateFacets', 'categoryFacets'] as const
+    ).forEach((typeOfFacet) => {
+      registerFacetToStore(store, typeOfFacet, {
+        facetId: 'some_id',
+        label: 'This is a label',
+        element: jest.fn() as unknown as HTMLElement,
+      });
+
+      const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+        customData: {
+          facetId: 'some_id',
+          facetTitle: 'some_title',
+        },
+        facetState: [{title: 'some_title', id: 'some_id'}],
+      }) as any;
+      expect(out.customData.facetTitle).toBe('This is a label');
+      expect(out.facetState[0].title).toBe('This is a label');
+    });
+  });
+
+  it('it does not augment analytics payload with a facet title when a facet is unavailable from the store', () => {
+    const result = getAnalyticsConfig(config, true, store);
+    const out = result.analyticsClientMiddleware!('an_event', {
+      customData: {
+        facetId: 'some_id',
+        facetTitle: 'some_title',
+      },
+      facetState: [{title: 'some_title', id: 'some_id'}],
+    }) as any;
+    expect(out.customData.facetTitle).toBe('some_title');
+    expect(out.facetState[0].title).toBe('some_title');
+  });
+});

--- a/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
+++ b/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
@@ -4,40 +4,99 @@ import {
 } from '@coveo/headless';
 import {AnalyticsClientSendEventHook} from '@coveo/headless/node_modules/coveo.analytics';
 import {getAtomicEnvironment} from '../../global/environment';
+import {ObservableMap} from '@stencil/store';
+import {AtomicStore, getAllFacets} from '../../utils/store';
 
 type AnalyticsPayload = Parameters<AnalyticsClientSendEventHook>[1];
 
 export function getAnalyticsConfig(
   searchEngineConfig: SearchEngineConfiguration,
-  enabled: boolean
+  enabled: boolean,
+  store: ObservableMap<AtomicStore>
 ): AnalyticsConfiguration {
+  const analyticsClientMiddleware = (
+    event: string,
+    payload: AnalyticsPayload
+  ) => augmentAnalytics(event, payload, store, searchEngineConfig);
+
+  const outOfTheBoxConfig: AnalyticsConfiguration = {
+    analyticsClientMiddleware,
+    enabled,
+    documentLocation: document.location.href,
+    ...(document.referrer && {originLevel3: document.referrer}),
+  };
+
   if (searchEngineConfig.analytics) {
     return {
+      ...outOfTheBoxConfig,
       ...searchEngineConfig.analytics,
-      enabled,
-      analyticsClientMiddleware: (event, payload) =>
-        augmentAnalyticsWithAtomicVersion(
-          event,
-          payload,
-          searchEngineConfig.analytics?.analyticsClientMiddleware
-        ),
     };
   }
-
-  return {
-    enabled,
-    analyticsClientMiddleware: augmentAnalyticsWithAtomicVersion,
-  };
+  return outOfTheBoxConfig;
 }
 
-function augmentAnalyticsWithAtomicVersion(
+function augmentAnalytics(
   event: string,
   payload: AnalyticsPayload,
-  existingMiddleware?: AnalyticsConfiguration['analyticsClientMiddleware']
+  store: ObservableMap<AtomicStore>,
+  config: SearchEngineConfiguration
 ) {
-  const out = existingMiddleware ? existingMiddleware(event, payload) : payload;
-  if (out.customData) {
-    out.customData.coveoAtomicVersion = getAtomicEnvironment().version;
+  let result = augmentWithExternalMiddleware(event, payload, config);
+  result = augmentAnalyticsWithAtomicVersion(result);
+  result = augmentAnalyticsWithFacetTitles(result, store);
+  return result;
+}
+
+function augmentWithExternalMiddleware(
+  event: string,
+  payload: AnalyticsPayload,
+  config: SearchEngineConfiguration
+) {
+  if (config.analytics?.analyticsClientMiddleware) {
+    return config.analytics.analyticsClientMiddleware(event, payload);
   }
-  return out;
+  return payload;
+}
+
+function augmentAnalyticsWithAtomicVersion(payload: AnalyticsPayload) {
+  if (payload.customData) {
+    payload.customData.coveoAtomicVersion = getAtomicEnvironment().version;
+  }
+  return payload;
+}
+
+function augmentAnalyticsWithFacetTitles(
+  payload: AnalyticsPayload,
+  store: ObservableMap<AtomicStore>
+) {
+  const allFacets = getAllFacets(store);
+  const getAtomicFacetLabelOrOriginalTitle = (
+    facetId: string,
+    originalTitle: string
+  ) => (allFacets[facetId] ? allFacets[facetId].label : originalTitle);
+
+  if (payload.facetState) {
+    payload.facetState = payload.facetState.map(
+      (analyticsFacetState: {id: string; title: string}) => {
+        const {id, title: originalTitle} = analyticsFacetState;
+        return {
+          ...analyticsFacetState,
+          title: getAtomicFacetLabelOrOriginalTitle(id, originalTitle),
+        };
+      }
+    );
+  }
+
+  if (
+    payload.customData &&
+    payload.customData.facetTitle &&
+    payload.customData.facetId &&
+    payload.customData.facetTitle
+  ) {
+    payload.customData.facetTitle = getAtomicFacetLabelOrOriginalTitle(
+      payload.customData.facetId,
+      payload.customData.facetTitle
+    );
+  }
+  return payload;
 }

--- a/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
+++ b/packages/atomic/src/components/atomic-search-interface/analytics-config.ts
@@ -19,7 +19,7 @@ export function getAnalyticsConfig(
     payload: AnalyticsPayload
   ) => augmentAnalytics(event, payload, store, searchEngineConfig);
 
-  const outOfTheBoxConfig: AnalyticsConfiguration = {
+  const defaultConfiguration: AnalyticsConfiguration = {
     analyticsClientMiddleware,
     enabled,
     documentLocation: document.location.href,
@@ -28,11 +28,11 @@ export function getAnalyticsConfig(
 
   if (searchEngineConfig.analytics) {
     return {
-      ...outOfTheBoxConfig,
+      ...defaultConfiguration,
       ...searchEngineConfig.analytics,
     };
   }
-  return outOfTheBoxConfig;
+  return defaultConfiguration;
 }
 
 function augmentAnalytics(

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -297,7 +297,11 @@ export class AtomicSearchInterface {
 
   private initEngine(options: InitializationOptions) {
     const searchConfig = this.getSearchConfiguration(options);
-    const analyticsConfig = getAnalyticsConfig(options, this.analytics);
+    const analyticsConfig = getAnalyticsConfig(
+      options,
+      this.analytics,
+      this.store
+    );
     try {
       this.engine = buildSearchEngine({
         configuration: {

--- a/packages/atomic/src/utils/store.ts
+++ b/packages/atomic/src/utils/store.ts
@@ -75,3 +75,10 @@ function isInDocument(element: Node) {
 export const getFacetElements = (store: ObservableMap<AtomicStore>) => {
   return store.state.facetElements.filter((element) => isInDocument(element));
 };
+
+export const getAllFacets = (store: ObservableMap<AtomicStore>) => ({
+  ...store.state.facets,
+  ...store.state.dateFacets,
+  ...store.state.categoryFacets,
+  ...store.state.numericFacets,
+});

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -101,11 +101,12 @@ export interface AnalyticsParam {
   analytics?: {
     clientId: string;
     deviceId?: string;
-    pageId: string;
+    pageId?: string;
     clientTimestamp: string;
     documentReferrer: string;
     originContext: string;
-    userDisplayName: string;
+    userDisplayName?: string;
+    documentLocation?: string;
   };
 }
 

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -108,6 +108,10 @@ export interface AnalyticsConfiguration {
    * Specifies the user display name for the usage analytics logs.
    */
   userDisplayName?: string;
+  /**
+   * Specifies the URL of the current page or component.
+   */
+  documentLocation?: string;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -123,6 +123,10 @@ export interface UpdateAnalyticsConfigurationActionCreatorPayload {
    * Specifies the user display name for the usage analytics logs.
    */
   userDisplayName?: string;
+  /**
+   * Specifies the URL of the current page or component.
+   */
+  documentLocation?: string;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;
@@ -140,6 +144,7 @@ export const updateAnalyticsConfiguration = createAction(
       anonymous: new BooleanValue({default: false}),
       deviceId: nonEmptyString,
       userDisplayName: nonEmptyString,
+      documentLocation: nonEmptyString,
     })
 );
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -37,6 +37,7 @@ describe('configuration slice', () => {
       anonymous: false,
       deviceId: 'Chrome',
       userDisplayName: 'Someone',
+      documentLocation: 'http://hello.world.com',
     },
   };
 
@@ -142,6 +143,7 @@ describe('configuration slice', () => {
           anonymous: true,
           deviceId: 'wozz',
           userDisplayName: 'wazz',
+          documentLocation: 'http://somewhere.com',
         },
       };
       expect(
@@ -156,6 +158,7 @@ describe('configuration slice', () => {
             anonymous: true,
             deviceId: 'wozz',
             userDisplayName: 'wazz',
+            documentLocation: 'http://somewhere.com',
           })
         )
       ).toEqual(expectedState);
@@ -173,6 +176,7 @@ describe('configuration slice', () => {
           anonymous: true,
           deviceId: 'wozz',
           userDisplayName: 'wazz',
+          documentLocation: 'http://somewhere.com',
         },
       };
 
@@ -188,6 +192,7 @@ describe('configuration slice', () => {
             anonymous: true,
             deviceId: 'wozz',
             userDisplayName: 'wazz',
+            documentLocation: 'http://somewhere.com',
           })
         )
       ).toEqual(expectedState);

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -105,6 +105,9 @@ export const configurationReducer = createReducer(
         if (!isNullOrUndefined(action.payload.userDisplayName)) {
           state.analytics.userDisplayName = action.payload.userDisplayName;
         }
+        if (!isNullOrUndefined(action.payload.documentLocation)) {
+          state.analytics.documentLocation = action.payload.documentLocation;
+        }
       })
       .addCase(disableAnalytics, (state) => {
         state.analytics.enabled = false;

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -106,6 +106,10 @@ export interface AnalyticsState {
    * Specifies the user display name for the usage analytics logs.
    */
   userDisplayName: string;
+  /**
+   * Specifies the URL of the current page or component.
+   */
+  documentLocation: string;
 }
 
 export const searchAPIEndpoint = '/rest/search/v2';
@@ -129,6 +133,7 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     anonymous: false,
     deviceId: '',
     userDisplayName: '',
+    documentLocation: '',
   },
 });
 
@@ -138,12 +143,13 @@ export const fromAnalyticsStateToAnalyticsParams = async (
   return {
     analytics: {
       clientId: await getVisitorID(),
-      deviceId: s.deviceId,
-      pageId: getPageID(),
       clientTimestamp: new Date().toISOString(),
       documentReferrer: s.originLevel3,
       originContext: s.originContext,
-      userDisplayName: s.userDisplayName,
+      ...(s.userDisplayName && {userDisplayName: s.userDisplayName}),
+      ...(s.documentLocation && {documentLocation: s.documentLocation}),
+      ...(s.deviceId && {deviceId: s.deviceId}),
+      ...(getPageID() && {pageId: getPageID()}),
     },
   };
 };

--- a/packages/headless/src/test/mock-analytics-state.ts
+++ b/packages/headless/src/test/mock-analytics-state.ts
@@ -12,6 +12,7 @@ export function buildMockAnalyticsState(
     deviceId: '',
     originContext: '',
     userDisplayName: '',
+    documentLocation: '',
     ...config,
   };
 }


### PR DESCRIPTION
Most notably `documentLocation`, `documentReferrer`, which Headless cannot determine itself (needs to be in a browser context).

Added auto resolving of Facet title (Headless does not contain the notion of facet label: it's purely a UI option).

Some minor changes in Headless for analytics parameters: Instead of sending an empty string when a value is un-available, simply don't send anything.

https://coveord.atlassian.net/browse/KIT-1623