### PR TITLE
fix(atomic): fix extra facet count spacing when switching to French language

### DIFF
--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -1164,7 +1164,7 @@
   },
   "between-parentheses": {
     "en": "({{text}})",
-    "fr": "(\u00A0{{text}}\u00A0)"
+    "fr": "({{text}})"
   },
   "smart-snippet": {
     "en": "Potential answer to your question",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1602

Altered the locales.json file "between-parentheses" attribute which would add unnecessary spacing inside facet counts when switching to French.