### PR TITLE
feat(atomic): network improvements

### DIFF
--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -342,7 +342,6 @@ export class AtomicSearchInterface {
       lng: this.language,
       fallbackLng: false,
       backend: this.i18nBackendOptions,
-      initImmediate: false,
     });
   }
 
@@ -446,9 +445,9 @@ export class AtomicSearchInterface {
       );
       return;
     }
-    await this.i18nPromise;
     this.updateIconAssetsPath();
     initEngine();
+    await this.i18nPromise;
     this.initComponents();
     this.initSearchStatus();
     this.initUrlManager();

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -337,10 +337,11 @@ export class AtomicSearchInterface {
   }
 
   private initI18n() {
+    const isLanguageComplete = ['en', 'fr'].includes(this.language);
     return this.i18n.use(Backend).init({
       debug: this.logLevel === 'debug',
       lng: this.language,
-      fallbackLng: false,
+      fallbackLng: isLanguageComplete ? false : 'en',
       backend: this.i18nBackendOptions,
     });
   }

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -132,6 +132,10 @@ export class AtomicSearchInterface {
     setCoveoGlobal();
   }
 
+  public async componentWillLoad() {
+    return await this.initI18n();
+  }
+
   @Watch('searchHub')
   @Watch('pipeline')
   public updateSearchConfiguration() {
@@ -166,18 +170,16 @@ export class AtomicSearchInterface {
 
   @Watch('language')
   public updateLanguage() {
-    if (!this.engineIsCreated(this.engine)) {
-      return;
+    if (this.engineIsCreated(this.engine)) {
+      const {updateSearchConfiguration} = loadSearchConfigurationActions(
+        this.engine
+      );
+      this.engine.dispatch(
+        updateSearchConfiguration({
+          locale: this.language,
+        })
+      );
     }
-
-    const {updateSearchConfiguration} = loadSearchConfigurationActions(
-      this.engine
-    );
-    this.engine.dispatch(
-      updateSearchConfiguration({
-        locale: this.language,
-      })
-    );
 
     new Backend(this.i18n.services, this.i18nBackendOptions).read(
       this.language,
@@ -337,7 +339,7 @@ export class AtomicSearchInterface {
     return this.i18n.use(Backend).init({
       debug: this.logLevel === 'debug',
       lng: this.language,
-      fallbackLng: ['en'],
+      fallbackLng: false,
       backend: this.i18nBackendOptions,
     });
   }
@@ -444,7 +446,6 @@ export class AtomicSearchInterface {
     }
     this.updateIconAssetsPath();
     initEngine();
-    await this.initI18n();
     this.initComponents();
     this.initSearchStatus();
     this.initUrlManager();

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -171,16 +171,18 @@ export class AtomicSearchInterface {
 
   @Watch('language')
   public updateLanguage() {
-    if (this.engineIsCreated(this.engine)) {
-      const {updateSearchConfiguration} = loadSearchConfigurationActions(
-        this.engine
-      );
-      this.engine.dispatch(
-        updateSearchConfiguration({
-          locale: this.language,
-        })
-      );
+    if (!this.engineIsCreated(this.engine)) {
+      return;
     }
+
+    const {updateSearchConfiguration} = loadSearchConfigurationActions(
+      this.engine
+    );
+    this.engine.dispatch(
+      updateSearchConfiguration({
+        locale: this.language,
+      })
+    );
 
     new Backend(this.i18n.services, this.i18nBackendOptions).read(
       this.language,
@@ -238,7 +240,7 @@ export class AtomicSearchInterface {
   /**
    * Initializes the connection with the headless search engine using options for `accessToken` (required), `organizationId` (required), `renewAccessToken`, and `platformUrl`.
    */
-  @Method() public async initialize(options: InitializationOptions) {
+  @Method() public initialize(options: InitializationOptions) {
     return this.internalInitialization(() => this.initEngine(options));
   }
 
@@ -246,7 +248,7 @@ export class AtomicSearchInterface {
    * Initializes the connection with an already preconfigured headless search engine, as opposed to the `initialize` method which will internally create a new search engine instance.
    *
    */
-  @Method() public async initializeWithSearchEngine(engine: SearchEngine) {
+  @Method() public initializeWithSearchEngine(engine: SearchEngine) {
     return this.internalInitialization(() => (this.engine = engine));
   }
 
@@ -254,7 +256,7 @@ export class AtomicSearchInterface {
    *
    * Executes the first search and logs the interface load event to analytics, after initializing connection to the headless search engine.
    */
-  @Method() public async executeFirstSearch() {
+  @Method() public executeFirstSearch() {
     if (!this.engineIsCreated(this.engine)) {
       return;
     }

--- a/packages/atomic/src/components/result-lists/result-list-common.tsx
+++ b/packages/atomic/src/components/result-lists/result-list-common.tsx
@@ -12,7 +12,6 @@ import {
   ResultListProps,
   EcommerceDefaultFieldsToInclude,
 } from '@coveo/headless';
-import {identity} from 'lodash';
 import {Bindings} from '../../utils/initialization-utils';
 import {
   ResultDisplayDensity,
@@ -167,7 +166,9 @@ export class ResultListCommon {
     const templates = (
       includeDefaultTemplate ? [this.makeDefaultTemplate()] : []
     ).concat(
-      customTemplates.filter(identity) as ResultTemplate<DocumentFragment>[]
+      customTemplates.filter(
+        (template) => template
+      ) as ResultTemplate<DocumentFragment>[]
     );
 
     this.resultTemplatesManager.registerTemplates(...templates);

--- a/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.tsx
+++ b/packages/atomic/src/components/result-template-components/atomic-result-image/atomic-result-image.tsx
@@ -53,6 +53,12 @@ export class AtomicResultImage implements InitializableComponent {
       return;
     }
 
-    return <img alt={`${this.field} image`} src={filterProtocol(url)} />;
+    return (
+      <img
+        alt={`${this.field} image`}
+        src={filterProtocol(url)}
+        loading="lazy"
+      />
+    );
   }
 }

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -116,7 +116,7 @@
                   </style>
                   <atomic-result-section-visual>
                     <atomic-result-image class="icon"></atomic-result-image>
-                    <img src="https://picsum.photos/350" class="thumbnail" />
+                    <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-badges>
                     <atomic-field-condition must-match-sourcetype="Salesforce">
@@ -251,7 +251,7 @@
                           </style>
                           <atomic-result-section-visual>
                             <atomic-result-image class="icon"></atomic-result-image>
-                            <img src="https://picsum.photos/350" class="thumbnail" />
+                            <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                           </atomic-result-section-visual>
                           <atomic-result-section-title
                             ><atomic-result-link></atomic-result-link

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -211,7 +211,7 @@
               <atomic-result-template must-match-sourcetype="YouTube">
                 <template>
                   <atomic-result-section-visual image-size="small">
-                    <img src="https://picsum.photos/350" class="thumbnail" />
+                    <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
                   <atomic-result-section-excerpt
@@ -264,7 +264,7 @@
                   </style>
                   <atomic-result-section-visual>
                     <atomic-result-icon class="icon"></atomic-result-icon>
-                    <img src="https://picsum.photos/350" class="thumbnail" />
+                    <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-badges>
                     <atomic-field-condition must-match-sourcetype="Salesforce">

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -1,5 +1,4 @@
 import {ComponentInterface, getElement} from '@stencil/core';
-import {mapValues} from 'lodash';
 import {camelToKebab, kebabToCamel} from './utils';
 
 interface MapPropOptions {
@@ -45,8 +44,12 @@ export function mapAttributesToProp(
 }
 
 function stringMapToStringArrayMap(map: Record<string, string>) {
-  return mapValues(map, (value) =>
-    value.split(',').map((subValue) => subValue.trim())
+  return Object.entries(map).reduce(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key]: value.split(',').map((subValue) => subValue.trim()),
+    }),
+    {}
   );
 }
 

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
@@ -17,7 +17,7 @@
       <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
     </h3>
     <div slot="visual" class="slds-size_1-of-1 slds-medium-size_1-of-4 slds-large-size_1-of-4 slds-p-right_x-small slds-m-top_xx-small slds-m-bottom_x-small">
-      <img style="border-radius: 4px; border: none;" src={videoThumbnail}></img>
+      <img loading="lazy" style="border-radius: 4px; border: none;" src={videoThumbnail}></img>
     </div>
     <div slot="excerpt">
       {result.Excerpt}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1620

First set of performance improvements

1. Start loading i18n configured language sooner, before `initialize` is called
2. Only load configured language for i18n, don't load fallback language (e.g. if "fr", "en.json" was still loaded)
3. Remove lodash imports (should only be used as a dev dep), saves ~97kb
4. Use loading="lazy" on `img` tags