### PR TITLE
feat(atomic): add part and hideIf to suggestions

### DIFF
--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -419,12 +419,27 @@ export class AtomicSearchBox {
     this.ariaMessage = '';
   }
 
+  private makeSuggestionPart(isSelected: boolean, customPart = '') {
+    let part = 'suggestion';
+    if (isSelected) {
+      part += ' active-suggestion';
+    }
+    if (customPart) {
+      part += ` ${customPart}`;
+    }
+    return part;
+  }
+
   private renderSuggestion(
     suggestion: SearchBoxSuggestionElement,
-    index: number
+    index: number,
+    lastIndex: number
   ) {
     const id = `${this.id}-suggestion-${index}`;
     const isSelected = id === this.activeDescendant;
+    if (suggestion.hideIf?.(index === lastIndex)) {
+      return null;
+    }
     return (
       <li
         id={id}
@@ -432,7 +447,7 @@ export class AtomicSearchBox {
         aria-selected={`${isSelected}`}
         key={suggestion.key}
         data-query={suggestion.query}
-        part={isSelected ? 'active-suggestion suggestion' : 'suggestion'}
+        part={this.makeSuggestionPart(isSelected, suggestion.part)}
         class={`flex px-4 h-10 items-center text-neutral-dark hover:bg-neutral-light cursor-pointer first:rounded-t-md last:rounded-b-md ${
           isSelected ? 'bg-neutral-light' : ''
         }`}
@@ -467,7 +482,11 @@ export class AtomicSearchBox {
         }`}
       >
         {this.suggestionElements.map((suggestion, index) =>
-          this.renderSuggestion(suggestion, index)
+          this.renderSuggestion(
+            suggestion,
+            index,
+            this.suggestionElements.length - 1
+          )
         )}
       </ul>
     );

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -122,16 +122,18 @@ export class AtomicSearchBoxRecentQueries {
       key: 'recent-query-clear',
       content: (
         <div class="flex justify-between w-full">
-          <span class="font-bold">
+          <span class="font-bold" part="recent-query-title">
             {this.bindings.i18n.t('recent-searches')}
           </span>
-          <span>{this.bindings.i18n.t('clear')}</span>
+          <span part="recent-query-clear">{this.bindings.i18n.t('clear')}</span>
         </div>
       ),
       onSelect: () => {
         this.recentQueriesList.clear();
         this.bindings.triggerSuggestions();
       },
+      part: 'recent-query-header',
+      hideIf: (isLast: boolean) => isLast,
     };
   }
 

--- a/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
@@ -7,8 +7,10 @@ import {closest} from '../../utils/utils';
 export interface SearchBoxSuggestionElement {
   key: string;
   query?: string;
+  part?: string;
   onSelect(): void;
   content: Element | VNode;
+  hideIf?(isLast: boolean): boolean;
 }
 
 export interface SearchBoxSuggestions {

--- a/packages/atomic/src/pages/examples/suggestions.html
+++ b/packages/atomic/src/pages/examples/suggestions.html
@@ -21,7 +21,7 @@
           suggestions = [];
 
           renderSuggestions(bindings) {
-            return this.suggestions.map((suggestion) => {
+            return this.suggestions.slice(0, 4).map((suggestion) => {
               const content = document.createElement('div');
               content.innerText = suggestion;
               return {
@@ -82,7 +82,7 @@
         <atomic-layout-section section="search">
           <atomic-search-box suggestion-timeout="1000">
             <custom-suggestions></custom-suggestions>
-            <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+            <atomic-search-box-query-suggestions icon="../assets/magnifier.svg"> </atomic-search-box-query-suggestions>
           </atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="main">


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-162

This adds parts to the recent queries header to make it more customisable. I also noticed that this was happening:
![Screenshot 2022-05-11 at 12 43 35](https://user-images.githubusercontent.com/30511433/167850265-9ef9cfb1-78ab-4380-ab78-35b6214143e1.png)
7
so had an idea to add a `hideIf` function to the suggestion, which we can later build upon if we need to