### PR TITLE
feat(atomic): added analytics & highlighting to smart snippet suggestions

### DIFF
--- a/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
@@ -28,7 +28,9 @@ export function assertAnswerBottomMargin(
 }
 
 export function assertlogOpenSmartSnippetSuggestionsSource(log: boolean) {
-  it.skip(`${should(log)} log a openSmartSnippetSource click event`, () => {
+  it(`${should(
+    log
+  )} log a openSmartSnippetSuggestionSource click event`, () => {
     if (log) {
       cy.expectClickEvent('openSmartSnippetSuggestionSource');
     } else {

--- a/packages/atomic/cypress/integration/smart-snippet-suggestions.cypress.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions.cypress.ts
@@ -11,6 +11,7 @@ import {
   addSmartSnippetSuggestions,
   addSmartSnippetSuggestionsDefaultOptions,
 } from './smart-snippet-suggestions-actions';
+import {AnalyticsTracker} from '../utils/analyticsUtils';
 
 const {remSize, relatedQuestions: defaultRelatedQuestions} =
   addSmartSnippetSuggestionsDefaultOptions;
@@ -263,6 +264,17 @@ describe('Smart Snippet Suggestions Test Suites', () => {
     SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsSource(
       true
     );
+
+    describe('then clicking the snippet url with the same snippet', () => {
+      beforeEach(() => {
+        AnalyticsTracker.reset();
+        SmartSnippetSuggestionsSelectors.sourceUrl().first().rightclick();
+      });
+
+      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsSource(
+        false
+      );
+    });
 
     describe('then getting a new snippet and clicking on the title again', () => {
       beforeEach(() => {

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-source.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-source.tsx
@@ -6,6 +6,7 @@ import {
   State,
   EventEmitter,
   Event,
+  Host,
 } from '@stencil/core';
 import {Result} from '@coveo/headless';
 import {LinkWithResultAnalytics} from '../result-link/result-link';
@@ -46,7 +47,7 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
 
   render() {
     return (
-      <section aria-label={this.bindings.i18n.t('smart-snippet-source')}>
+      <Host>
         <LinkWithResultAnalytics
           title={this.source.clickUri}
           href={this.source.clickUri}
@@ -63,7 +64,7 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
           title={this.source.title}
           href={this.source.clickUri}
           target="_self"
-          className="block mb-6"
+          className="block"
           part="source-title"
           onSelect={() => this.selectSource.emit()}
           onBeginDelayedSelect={() => this.beginDelayedSelectSource.emit()}
@@ -74,7 +75,7 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
             default="no-title"
           ></atomic-result-text>
         </LinkWithResultAnalytics>
-      </section>
+      </Host>
     );
   }
 }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
@@ -173,9 +173,9 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
         part="footer"
         aria-label={this.bindings.i18n.t('smart-snippet-source')}
       >
-        {relatedQuestion.source && (
+        {
           <atomic-smart-snippet-source
-            source={relatedQuestion.source}
+            source={source}
             onSelectSource={() =>
               this.smartSnippetQuestionsList.selectSource(
                 relatedQuestion.questionAnswerId
@@ -192,7 +192,7 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
               )
             }
           ></atomic-smart-snippet-source>
-        )}
+        }
       </footer>
     );
   }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
@@ -18,7 +18,6 @@ import {Heading} from '../common/heading';
 import {Button} from '../common/button';
 import {randomID} from '../../utils/utils';
 import {waitUntilAppLoaded} from '../../utils/store';
-import {LinkWithResultAnalytics} from '../result-link/result-link';
 
 /**
  * The `atomic-smart-snippet-suggestions-suggestions` component displays an accordion of questions related to the query with their corresponding answers.

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
@@ -8,7 +8,6 @@ import {
 import ArrowRight from '../../images/arrow-right.svg';
 import ArrowDown from '../../images/arrow-down.svg';
 import {
-  buildInteractiveResult,
   buildSmartSnippetQuestionsList,
   SmartSnippetQuestionsList,
   SmartSnippetQuestionsListState,
@@ -18,7 +17,6 @@ import {Hidden} from '../common/hidden';
 import {Heading} from '../common/heading';
 import {Button} from '../common/button';
 import {randomID} from '../../utils/utils';
-import {LinkWithResultAnalytics} from '../result-link/result-link';
 
 /**
  * The `atomic-smart-snippet-suggestions-suggestions` component displays an accordion of questions related to the query with their corresponding answers.
@@ -170,36 +168,31 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
     if (!source) {
       return [];
     }
-    const interactiveResult = buildInteractiveResult(this.bindings.engine!, {
-      options: {result: source},
-    });
     return (
       <footer
         part="footer"
         aria-label={this.bindings.i18n.t('smart-snippet-source')}
       >
-        <LinkWithResultAnalytics
-          title={source.clickUri}
-          href={source.clickUri}
-          target="_self"
-          part="source-url"
-          onSelect={() => interactiveResult.select()}
-          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
-          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
-        >
-          {source.clickUri}
-        </LinkWithResultAnalytics>
-        <LinkWithResultAnalytics
-          title={source.title}
-          href={source.clickUri}
-          target="_self"
-          part="source-title"
-          onSelect={() => interactiveResult.select()}
-          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
-          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
-        >
-          {source.title}
-        </LinkWithResultAnalytics>
+        {relatedQuestion.source && (
+          <atomic-smart-snippet-source
+            source={relatedQuestion.source}
+            onSelectSource={() =>
+              this.smartSnippetQuestionsList.selectSource(
+                relatedQuestion.questionAnswerId
+              )
+            }
+            onBeginDelayedSelectSource={() =>
+              this.smartSnippetQuestionsList.beginDelayedSelectSource(
+                relatedQuestion.questionAnswerId
+              )
+            }
+            onCancelPendingSelectSource={() =>
+              this.smartSnippetQuestionsList.cancelPendingSelectSource(
+                relatedQuestion.questionAnswerId
+              )
+            }
+          ></atomic-smart-snippet-source>
+        )}
       </footer>
     );
   }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.pcss
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.pcss
@@ -7,9 +7,9 @@
 }
 
 [part='source-title'] {
-  @apply mb-6;
   @mixin link-style;
   @mixin set-font-size var(--atomic-text-2xl);
+  @apply mb-6;
 }
 
 footer {

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.pcss
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.pcss
@@ -1,12 +1,13 @@
 @import '../../global/global.pcss';
 @import '../../global/mixins.pcss';
 
-[part='source-url'] a {
+[part='source-url'] {
   @mixin link-style;
   @mixin set-font-size var(--atomic-text-base);
 }
 
 [part='source-title'] {
+  @apply mb-6;
   @mixin link-style;
   @mixin set-font-size var(--atomic-text-2xl);
 }

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -198,7 +198,10 @@ export class AtomicSmartSnippet implements InitializableComponent {
         >
           {this.renderQuestion()}
           {this.renderContent()}
-          <footer part="footer">
+          <footer
+            part="footer"
+            aria-label={this.bindings.i18n.t('smart-snippet-source')}
+          >
             {this.smartSnippetState.source && (
               <atomic-smart-snippet-source
                 source={this.smartSnippetState.source}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1636

# Smart Snippet footer DOM
![image](https://user-images.githubusercontent.com/54454747/168336510-f02fb0d4-8f3e-4f9a-9b74-4a287414177d.png)

# Smart Snippet Suggestions footer DOM
![image](https://user-images.githubusercontent.com/54454747/168336709-df712026-99ec-4d8e-882e-16890259a7b1.png)

For some reason, VoiceOver for Mac OS announced the source of the smart snippet as a footer, but announced the source of the smart snippet suggestions as content information. Both are valid IMO.

Thanks to @mbenkirane-coveo for the highlighting!