### PR TITLE
fix(atomic): clone child nodes for inherited templates in children

### DIFF
--- a/packages/atomic/cypress/integration/result-list/folded-result-list-actions.ts
+++ b/packages/atomic/cypress/integration/result-list/folded-result-list-actions.ts
@@ -4,6 +4,7 @@ import {
   resultChildrenTemplateComponent,
 } from './folded-result-list-selectors';
 import {resultLinkComponent} from './result-components/result-link-selectors';
+import {resultSectionTags} from './result-list-selectors';
 
 export function buildResultTopChild(children?: HTMLElement): HTMLElement[] {
   return [
@@ -17,12 +18,17 @@ export function buildResultChildren(grandChildren?: HTMLElement): HTMLElement {
   const childrenTemplate = generateComponentHTML(
     resultChildrenTemplateComponent
   );
+  const sectionEl = generateComponentHTML(resultSectionTags.title);
   const link = generateComponentHTML(resultLinkComponent);
   const template = generateComponentHTML('template') as HTMLTemplateElement;
-  template.content.appendChild(link);
+  sectionEl.appendChild(link);
+  template.content.appendChild(sectionEl);
 
   if (grandChildren) {
-    template.content.appendChild(grandChildren);
+    const childrenSectionEL = generateComponentHTML(resultSectionTags.children);
+    childrenSectionEL.appendChild(grandChildren);
+
+    template.content.appendChild(childrenSectionEL);
   }
 
   childrenTemplate.appendChild(template);

--- a/packages/atomic/cypress/integration/result-list/folded-result-list.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/folded-result-list.cypress.ts
@@ -2,6 +2,7 @@ import {generateComponentHTML, TestFixture} from '../../fixtures/test-fixture';
 import {
   addFoldedResultList,
   buildTemplateWithoutSections,
+  buildTemplateWithSections,
 } from './result-list-actions';
 import {
   buildResultChildren,
@@ -115,7 +116,10 @@ describe('Folded Result List Component', () => {
         .with(setSource)
         .with(
           addFoldedResultList(
-            buildTemplateWithoutSections(buildResultTopChild(resultChildren))
+            buildTemplateWithSections({
+              title: generateComponentHTML(resultLinkComponent),
+              children: buildResultChildren(resultChildren),
+            })
           )
         )
         .init();

--- a/packages/atomic/cypress/integration/result-list/result-list-selectors.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list-selectors.ts
@@ -6,7 +6,8 @@ export type ResultSection =
   | 'titleMetadata'
   | 'emphasized'
   | 'excerpt'
-  | 'bottomMetadata';
+  | 'bottomMetadata'
+  | 'children';
 
 export const resultSectionTags: Record<ResultSection, string> = {
   visual: 'atomic-result-section-visual',
@@ -17,6 +18,7 @@ export const resultSectionTags: Record<ResultSection, string> = {
   emphasized: 'atomic-result-section-emphasized',
   excerpt: 'atomic-result-section-excerpt',
   bottomMetadata: 'atomic-result-section-bottom-metadata',
+  children: 'atomic-result-section-children',
 };
 
 export const resultComponent = 'atomic-result';

--- a/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -135,7 +135,7 @@ export class AtomicResultChildren {
         el.tagName.toLowerCase() !== componentTag &&
         !el.querySelector(componentTag)
     );
-    fragment.append(...children.map((c) => c.cloneNode()));
+    fragment.append(...children.map((c) => c.cloneNode(true)));
     return fragment;
   }
 

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -287,6 +287,9 @@
                           <atomic-table-element label="file-type">
                             <atomic-result-text field="filetype"></atomic-result-text>
                           </atomic-table-element>
+                          <atomic-result-section-children>
+                            <atomic-result-children inherit-templates> </atomic-result-children>
+                          </atomic-result-section-children>
                         </template>
                       </atomic-result-children-template>
                     </atomic-result-children>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1645

When using sections, grandchildren weren't actually rendering anything because when I cloned the children for inherited templates, I only got the top level stuff, meaning that we would render the `*-section` component, but nothing that was inside it