### PR TITLE
fix(headless): add dedicated context controller for recommendation & product-recommendations engines

### DIFF
--- a/packages/headless/src/controllers/product-recommendations/context/headless-product-recommendations-context.test.ts
+++ b/packages/headless/src/controllers/product-recommendations/context/headless-product-recommendations-context.test.ts
@@ -1,0 +1,22 @@
+import {
+  buildContext,
+  Context,
+} from './headless-product-recommendations-context';
+import {
+  buildMockProductRecommendationsAppEngine,
+  MockProductRecommendationEngine,
+} from '../../../test/mock-engine';
+
+describe('Context', () => {
+  let context: Context;
+  let engine: MockProductRecommendationEngine;
+
+  beforeEach(() => {
+    engine = buildMockProductRecommendationsAppEngine();
+    context = buildContext(engine);
+  });
+
+  it('initializes properly', () => {
+    expect(context.state.values).toEqual({});
+  });
+});

--- a/packages/headless/src/controllers/product-recommendations/context/headless-product-recommendations-context.ts
+++ b/packages/headless/src/controllers/product-recommendations/context/headless-product-recommendations-context.ts
@@ -1,0 +1,22 @@
+import {
+  ContextPayload,
+  ContextValue,
+} from '../../../features/context/context-state';
+import {
+  buildCoreContext,
+  Context,
+  ContextState,
+} from '../../core/context/headless-core-context';
+import {ProductRecommendationEngine} from '../../../app/product-recommendation-engine/product-recommendation-engine';
+
+export type {Context, ContextState, ContextPayload, ContextValue};
+
+/**
+ * Creates a `Context` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @returns A `Context` controller instance.
+ */
+export function buildContext(engine: ProductRecommendationEngine): Context {
+  return buildCoreContext(engine);
+}

--- a/packages/headless/src/controllers/recommendation/context/headless-recommendation-context.test.ts
+++ b/packages/headless/src/controllers/recommendation/context/headless-recommendation-context.test.ts
@@ -1,0 +1,19 @@
+import {buildContext, Context} from './headless-recommendation-context';
+import {
+  buildMockRecommendationAppEngine,
+  MockRecommendationEngine,
+} from '../../../test/mock-engine';
+
+describe('Context', () => {
+  let context: Context;
+  let engine: MockRecommendationEngine;
+
+  beforeEach(() => {
+    engine = buildMockRecommendationAppEngine();
+    context = buildContext(engine);
+  });
+
+  it('initializes properly', () => {
+    expect(context.state.values).toEqual({});
+  });
+});

--- a/packages/headless/src/controllers/recommendation/context/headless-recommendation-context.ts
+++ b/packages/headless/src/controllers/recommendation/context/headless-recommendation-context.ts
@@ -1,0 +1,22 @@
+import {
+  ContextPayload,
+  ContextValue,
+} from '../../../features/context/context-state';
+import {
+  buildCoreContext,
+  Context,
+  ContextState,
+} from '../../core/context/headless-core-context';
+import {RecommendationEngine} from '../../../app/recommendation-engine/recommendation-engine';
+
+export type {Context, ContextState, ContextPayload, ContextValue};
+
+/**
+ * Creates a `Context` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @returns A `Context` controller instance.
+ */
+export function buildContext(engine: RecommendationEngine): Context {
+  return buildCoreContext(engine);
+}

--- a/packages/headless/src/product-recommendation.index.ts
+++ b/packages/headless/src/product-recommendation.index.ts
@@ -88,7 +88,7 @@ export type {
   ContextValue,
   ContextPayload,
 } from './controllers/context/headless-context';
-export {buildContext} from './controllers/context/headless-context';
+export {buildContext} from './controllers/product-recommendations/context/headless-product-recommendations-context';
 
 export type {
   DictionaryFieldContext,

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -52,7 +52,7 @@ export type {
   ContextValue,
   ContextPayload,
 } from './controllers/context/headless-context';
-export {buildContext} from './controllers/context/headless-context';
+export {buildContext} from './controllers/recommendation/context/headless-recommendation-context';
 
 export type {
   DictionaryFieldContext,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1640

was already the case for product listing, but not the other engines