### PR TITLE
feat(atomic): made result list outline and divider easily customizable

### DIFF
--- a/packages/atomic/src/components/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
@@ -28,6 +28,7 @@ import {randomID} from '../../../utils/utils';
  * The `atomic-folded-result-list` component is responsible for displaying folded query results, by applying one or more result templates for up to three layers (i.e., to the result, child and grandchild).
  *
  * @part result-list - The element containing every result of a result list
+ * @part outline - The element displaying an outline or a divider around a result
  */
 @Component({
   tag: 'atomic-folded-result-list',

--- a/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -26,6 +26,7 @@ import {randomID} from '../../../utils/utils';
  * The `atomic-result-list` component is responsible for displaying query results by applying one or more result templates.
  *
  * @part result-list - The element containing every result of a result list
+ * @part outline - The element displaying an outline or a divider around a result
  * @part result-list-grid-clickable-container - The parent of the result & the clickable link encompassing it, when results are displayed as a grid
  * @part result-list-grid-clickable - The clickable link encompassing the result when results are displayed as a grid
  * @part result-table - The element of the result table containing a heading and a body

--- a/packages/atomic/src/components/result-lists/grid-display-results.tsx
+++ b/packages/atomic/src/components/result-lists/grid-display-results.tsx
@@ -12,7 +12,7 @@ export const GridDisplayResults: FunctionalComponent<ResultsProps> = (
     });
 
     return (
-      <div part="result-list-grid-clickable-container">
+      <div part="result-list-grid-clickable-container outline">
         <LinkWithResultAnalytics
           part="result-list-grid-clickable"
           onSelect={() => interactiveResult.select()}

--- a/packages/atomic/src/components/result-lists/list-display-results.tsx
+++ b/packages/atomic/src/components/result-lists/list-display-results.tsx
@@ -8,6 +8,7 @@ export const ListDisplayResults: FunctionalComponent<ResultsProps> = (
     return (
       <atomic-result
         key={props.resultListCommon.getResultId(result, props.resultListState)}
+        part="outline"
         result={result}
         engine={props.bindings.engine}
         store={props.bindings.store}

--- a/packages/atomic/src/components/result-lists/result-list-common.pcss
+++ b/packages/atomic/src/components/result-lists/result-list-common.pcss
@@ -1,7 +1,7 @@
 @import './table-display.pcss';
 
 @define-mixin atomic-list-with-cards {
-  > * {
+  [part~='outline'] {
     border: 1px solid var(--atomic-neutral);
     padding: 1rem;
     border-radius: 1rem;
@@ -14,7 +14,7 @@
 
 @define-mixin atomic-list-with-dividers {
   &.density-comfortable {
-    > * {
+    [part~='outline'] {
       &::before {
         margin: 2rem 0;
       }
@@ -22,14 +22,14 @@
   }
 
   &.density-normal {
-    > * {
+    [part~='outline'] {
       &::before {
         margin: 1.5rem 0;
       }
     }
 
     @screen mobile-only {
-      > * {
+      [part~='outline'] {
         &::before {
           margin: 1.75rem 0;
         }
@@ -38,14 +38,14 @@
   }
 
   &.density-compact {
-    > * {
+    [part~='outline'] {
       &::before {
         margin: 1rem 0;
       }
     }
 
     @screen mobile-only {
-      > * {
+      [part~='outline'] {
         &::before {
           margin: 1.5rem 0;
         }
@@ -53,7 +53,7 @@
     }
   }
 
-  > * {
+  [part~='outline'] {
     &::before {
       display: block;
       content: ' ';
@@ -147,7 +147,7 @@
   }
 }
 
-[part='result-list-grid-clickable-container'] {
+[part~='outline'][part~='result-list-grid-clickable-container'] {
   position: relative;
 
   @screen desktop-only {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1646

While writing documentation, I realized that customizing the outline and the divider of the result list was complicated and unintuitive, and could easily be broken by our own changes.

I decided to work on this PR before finishing documentation because I wanted to establish how the outline and the divider are going to be customizable.

With this PR, the outline can now be customized like this:
```css
atomic-result-list::part(outline) {
  border-color: red;
}
```
![image](https://user-images.githubusercontent.com/54454747/169098254-78dabf29-893a-4317-b6ee-52af4c0de270.png)


And the divider like this:
```css
atomic-result-list::part(outline)::before {
  background-color: blue;
}
```
![image](https://user-images.githubusercontent.com/54454747/169098422-19f0fc7d-33c5-4857-a86d-70d4fb461ee8.png)

Alternately, I could also add a separate `divider` part just in case we end up with a weird DOM structure in the future.