### PR TITLE
fix(atomic): fix regression on deprecated image prop for result list

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-list-actions.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list-actions.ts
@@ -55,8 +55,9 @@ export const addFieldValueInResponse =
   };
 
 export const addResultList =
-  (template?: HTMLElement) => (fixture: TestFixture) => {
-    const resultList = generateComponentHTML(resultListComponent);
+  (template?: HTMLElement, props = {}) =>
+  (fixture: TestFixture) => {
+    const resultList = generateComponentHTML(resultListComponent, props);
     if (template) {
       resultList.appendChild(template);
     }

--- a/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
+++ b/packages/atomic/cypress/integration/result-list/result-list.cypress.ts
@@ -197,3 +197,32 @@ configs.forEach(({componentSelectors, componentTag, addResultFn, title}) => {
     });
   });
 });
+
+describe('deprecated image prop on result-list', () => {
+  it('should use image prop if defined', () => {
+    new TestFixture()
+      .with(addResultList(undefined, {image: 'large'}))
+      .withoutFirstAutomaticSearch()
+      .init();
+
+    ResultListSelectors.shadow().find('.image-large').should('exist');
+  });
+
+  it('should use image-size prop if defined', () => {
+    new TestFixture()
+      .with(addResultList(undefined, {'image-size': 'small'}))
+      .withoutFirstAutomaticSearch()
+      .init();
+
+    ResultListSelectors.shadow().find('.image-small').should('exist');
+  });
+  it('should prioritize image-size over image prop if both are defined', () => {
+    new TestFixture()
+      .with(addResultList(undefined, {'image-size': 'small', image: 'large'}))
+      .withoutFirstAutomaticSearch()
+      .init();
+
+    ResultListSelectors.shadow().find('.image-small').should('exist');
+    ResultListSelectors.shadow().find('.image-large').should('not.exist');
+  });
+});

--- a/packages/atomic/package-lock.json
+++ b/packages/atomic/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "@coveo/atomic",
-      "version": "1.59.0",
+      "version": "1.60.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/bueno": "0.34.10",
-        "@coveo/headless": "1.66.0",
+        "@coveo/bueno": "0.34.11",
+        "@coveo/headless": "1.66.1",
         "@salesforce-ux/design-system": "^2.16.1",
         "@stencil/core": "2.15.2",
         "@stencil/store": "1.5.0",
@@ -1949,17 +1949,17 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.34.10",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.10.tgz",
-      "integrity": "sha512-+fOFr42VYQh95XJ0ralScaz65ncCVB9yag74N3AkLs3Xr1zwvjac6nU4l3XuHjeHBt2ECPst2qcNjWnB44jPjQ=="
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.11.tgz",
+      "integrity": "sha512-O2I24rXSu6c+INQWbdFirqtFBHFVTuHG64pl8OKzkmIJjWqNtEdrg5DZ23lfL5ZJFVNAt+PdW5Au85WUyuNXcg=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.0.tgz",
-      "integrity": "sha512-PDdrwcQN3ee4j9Qzm7RTLlB58Tw/3zvdIHNfLf99SZwCime6TPyMYEPpNckg0NyGpkpt1Q3+PgYIaoJVTNUtWQ==",
+      "version": "1.66.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.1.tgz",
+      "integrity": "sha512-pUcAdy7eqo2rQzY69Fn4xz3MCIA1YkC4oYWajIglNIeTygkAXBwnkXjmsfZbnvKyPbo5JjvD3bD1usC0ellb2Q==",
       "dependencies": {
-        "@coveo/bueno": "0.34.10",
-        "@reduxjs/toolkit": "^1.5.0",
+        "@coveo/bueno": "0.34.11",
+        "@reduxjs/toolkit": "^1.8.1",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
         "abab": "^2.0.5",
@@ -1974,7 +1974,7 @@
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
         "ts-debounce": "^3.0.0",
-        "web-encoding": "^1.1.4"
+        "web-encoding": "1.1.4"
       },
       "peerDependencies": {
         "encoding": "^0.1.13",
@@ -27985,9 +27985,9 @@
       }
     },
     "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.4.tgz",
+      "integrity": "sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==",
       "dependencies": {
         "util": "^0.12.3"
       },
@@ -30155,17 +30155,17 @@
       "optional": true
     },
     "@coveo/bueno": {
-      "version": "0.34.10",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.10.tgz",
-      "integrity": "sha512-+fOFr42VYQh95XJ0ralScaz65ncCVB9yag74N3AkLs3Xr1zwvjac6nU4l3XuHjeHBt2ECPst2qcNjWnB44jPjQ=="
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.11.tgz",
+      "integrity": "sha512-O2I24rXSu6c+INQWbdFirqtFBHFVTuHG64pl8OKzkmIJjWqNtEdrg5DZ23lfL5ZJFVNAt+PdW5Au85WUyuNXcg=="
     },
     "@coveo/headless": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.0.tgz",
-      "integrity": "sha512-PDdrwcQN3ee4j9Qzm7RTLlB58Tw/3zvdIHNfLf99SZwCime6TPyMYEPpNckg0NyGpkpt1Q3+PgYIaoJVTNUtWQ==",
+      "version": "1.66.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.1.tgz",
+      "integrity": "sha512-pUcAdy7eqo2rQzY69Fn4xz3MCIA1YkC4oYWajIglNIeTygkAXBwnkXjmsfZbnvKyPbo5JjvD3bD1usC0ellb2Q==",
       "requires": {
-        "@coveo/bueno": "0.34.10",
-        "@reduxjs/toolkit": "^1.5.0",
+        "@coveo/bueno": "0.34.11",
+        "@reduxjs/toolkit": "^1.8.1",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
         "abab": "^2.0.5",
@@ -30180,7 +30180,7 @@
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
         "ts-debounce": "^3.0.0",
-        "web-encoding": "^1.1.4"
+        "web-encoding": "1.1.4"
       },
       "dependencies": {
         "@reduxjs/toolkit": {
@@ -50464,9 +50464,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.4.tgz",
+      "integrity": "sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==",
       "requires": {
         "@zxing/text-encoding": "0.9.0",
         "util": "^0.12.3"

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -651,7 +651,7 @@ export namespace Components {
         /**
           * The expected size of the image displayed in the results.
          */
-        "imageSize"?: ResultDisplayImageSize;
+        "imageSize": ResultDisplayImageSize;
         /**
           * Sets a rendering function to bypass the standard HTML template mechanism for rendering results. You can use this function while working with web frameworks that don't use plain HTML syntax, e.g., React, Angular or Vue.  Do not use this method if you integrate Atomic in a plain HTML deployment.
           * @param render

--- a/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -89,11 +89,14 @@ export class AtomicResultList implements InitializableComponent {
   /**
    * The expected size of the image displayed in the results.
    */
-  @Prop({reflect: true}) imageSize?: ResultDisplayImageSize;
+  @Prop({reflect: true}) imageSize: ResultDisplayImageSize = 'icon';
   /**
    * @deprecated use `imageSize` instead.
    */
   @Prop({reflect: true}) image: ResultDisplayImageSize = 'icon';
+
+  // to remove when `image` prop is removed;
+  private propToUseForImageSize: 'image' | 'imageSize' = 'imageSize';
 
   /**
    * Sets a rendering function to bypass the standard HTML template mechanism for rendering results.
@@ -108,6 +111,16 @@ export class AtomicResultList implements InitializableComponent {
   ) {
     this.renderingFunction = render;
     this.assignRenderingFunctionIfPossible();
+  }
+
+  connectedCallback() {
+    // to remove when `image` prop is removed;
+    if (this.host.hasAttribute('image')) {
+      this.propToUseForImageSize = 'image';
+    }
+    if (this.host.hasAttribute('image-size')) {
+      this.propToUseForImageSize = 'imageSize';
+    }
   }
 
   @Listen('scroll', {target: 'window'})
@@ -159,7 +172,7 @@ export class AtomicResultList implements InitializableComponent {
       host: this.host,
       display: this.display,
       density: this.density,
-      imageSize: this.imageSize,
+      imageSize: this.determineImageSize,
       templateHasError: this.templateHasError,
       resultListState: this.resultListState,
       resultsPerPageState: this.resultsPerPageState,
@@ -175,5 +188,12 @@ export class AtomicResultList implements InitializableComponent {
       this.resultListCommon.renderingFunction = this
         .renderingFunction as ResultRenderingFunction;
     }
+  }
+
+  private get determineImageSize() {
+    if (this.propToUseForImageSize === 'image') {
+      return this.image;
+    }
+    return this.imageSize;
   }
 }

--- a/packages/atomic/src/components/result-lists/result-list-common.tsx
+++ b/packages/atomic/src/components/result-lists/result-list-common.tsx
@@ -211,7 +211,7 @@ export class ResultListCommon {
     isLoading: boolean,
     displayPlaceholders: boolean
   ): string {
-    const classes = getResultDisplayClasses(display, density, imageSize!);
+    const classes = getResultDisplayClasses(display, density, imageSize);
     if (firstSearchExecuted && isLoading) {
       classes.push('loading');
     }

--- a/packages/quantic/package-lock.json
+++ b/packages/quantic/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@coveo/quantic",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/headless": "1.66.0"
+        "@coveo/headless": "1.66.1"
       },
       "devDependencies": {
         "@ckeditor/jsdoc-plugins": "25.4.5",
@@ -2173,17 +2173,17 @@
       }
     },
     "node_modules/@coveo/bueno": {
-      "version": "0.34.10",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.10.tgz",
-      "integrity": "sha512-+fOFr42VYQh95XJ0ralScaz65ncCVB9yag74N3AkLs3Xr1zwvjac6nU4l3XuHjeHBt2ECPst2qcNjWnB44jPjQ=="
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.11.tgz",
+      "integrity": "sha512-O2I24rXSu6c+INQWbdFirqtFBHFVTuHG64pl8OKzkmIJjWqNtEdrg5DZ23lfL5ZJFVNAt+PdW5Au85WUyuNXcg=="
     },
     "node_modules/@coveo/headless": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.0.tgz",
-      "integrity": "sha512-PDdrwcQN3ee4j9Qzm7RTLlB58Tw/3zvdIHNfLf99SZwCime6TPyMYEPpNckg0NyGpkpt1Q3+PgYIaoJVTNUtWQ==",
+      "version": "1.66.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.1.tgz",
+      "integrity": "sha512-pUcAdy7eqo2rQzY69Fn4xz3MCIA1YkC4oYWajIglNIeTygkAXBwnkXjmsfZbnvKyPbo5JjvD3bD1usC0ellb2Q==",
       "dependencies": {
-        "@coveo/bueno": "0.34.10",
-        "@reduxjs/toolkit": "^1.5.0",
+        "@coveo/bueno": "0.34.11",
+        "@reduxjs/toolkit": "^1.8.1",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
         "abab": "^2.0.5",
@@ -2198,7 +2198,7 @@
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
         "ts-debounce": "^3.0.0",
-        "web-encoding": "^1.1.4"
+        "web-encoding": "1.1.4"
       },
       "peerDependencies": {
         "encoding": "^0.1.13",
@@ -3746,9 +3746,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-6pNQnkL2Uk9SbRUb12BFminLPhrPab1euNzVl1eh+Q7+X8+JGMw8vgKUfQRlGZesmcd+8fByQMZBaoOAEozJsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.8.2.tgz",
+      "integrity": "sha512-0fP+mY/APCRoVuaf4YqOlSar6xe5rsnKq1oApoknMVDE4jCTN/eVqOkE5/lGOEcS+EB2MNM+HFz/8lcR6+gY3Q==",
       "dev": true,
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
@@ -15439,9 +15439,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-      "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA=="
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -24855,9 +24855,9 @@
       "dev": true
     },
     "node_modules/keyv": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.2.8.tgz",
-      "integrity": "sha512-IZZo6krhHWPhgsP5mBkEdPopVPN/stgCnBVuqi6dda/Nm5mDTOSVTrFMkWqlJsDum+B0YSe887tNxdjDWkO7aQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.2.9.tgz",
+      "integrity": "sha512-vqRBrN4xQHud7UMAGzGGFbt96MtGB9pb0OOg8Dhtq5RtiswCb1pCFq878iqC4hdeOP6eDPnCoFxA+2TXx427Ow==",
       "dev": true,
       "dependencies": {
         "compress-brotli": "^1.3.8",
@@ -28089,13 +28089,13 @@
       }
     },
     "node_modules/npm-registry-fetch/node_modules/make-fetch-happen": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-      "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.4.tgz",
+      "integrity": "sha512-hU1w68PqfH7FdMgjbiziJoACY0edlbIZ0CyKnpcEruVdCjsUrN+qoenOCIayNqVBK7toSWwbDxvQlrhH0gjRdg==",
       "dev": true,
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.0.2",
+        "cacache": "^16.1.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -37077,9 +37077,9 @@
       }
     },
     "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.4.tgz",
+      "integrity": "sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==",
       "dependencies": {
         "util": "^0.12.3"
       },
@@ -39708,17 +39708,17 @@
       "optional": true
     },
     "@coveo/bueno": {
-      "version": "0.34.10",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.10.tgz",
-      "integrity": "sha512-+fOFr42VYQh95XJ0ralScaz65ncCVB9yag74N3AkLs3Xr1zwvjac6nU4l3XuHjeHBt2ECPst2qcNjWnB44jPjQ=="
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.34.11.tgz",
+      "integrity": "sha512-O2I24rXSu6c+INQWbdFirqtFBHFVTuHG64pl8OKzkmIJjWqNtEdrg5DZ23lfL5ZJFVNAt+PdW5Au85WUyuNXcg=="
     },
     "@coveo/headless": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.0.tgz",
-      "integrity": "sha512-PDdrwcQN3ee4j9Qzm7RTLlB58Tw/3zvdIHNfLf99SZwCime6TPyMYEPpNckg0NyGpkpt1Q3+PgYIaoJVTNUtWQ==",
+      "version": "1.66.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-1.66.1.tgz",
+      "integrity": "sha512-pUcAdy7eqo2rQzY69Fn4xz3MCIA1YkC4oYWajIglNIeTygkAXBwnkXjmsfZbnvKyPbo5JjvD3bD1usC0ellb2Q==",
       "requires": {
-        "@coveo/bueno": "0.34.10",
-        "@reduxjs/toolkit": "^1.5.0",
+        "@coveo/bueno": "0.34.11",
+        "@reduxjs/toolkit": "^1.8.1",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
         "abab": "^2.0.5",
@@ -39733,7 +39733,7 @@
         "redux-mock-store": "^1.5.4",
         "redux-thunk": "^2.3.0",
         "ts-debounce": "^3.0.0",
-        "web-encoding": "^1.1.4"
+        "web-encoding": "1.1.4"
       }
     },
     "@cspotcode/source-map-consumer": {
@@ -40988,9 +40988,9 @@
       }
     },
     "@oclif/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-6pNQnkL2Uk9SbRUb12BFminLPhrPab1euNzVl1eh+Q7+X8+JGMw8vgKUfQRlGZesmcd+8fByQMZBaoOAEozJsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.8.2.tgz",
+      "integrity": "sha512-0fP+mY/APCRoVuaf4YqOlSar6xe5rsnKq1oApoknMVDE4jCTN/eVqOkE5/lGOEcS+EB2MNM+HFz/8lcR6+gY3Q==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
@@ -50788,9 +50788,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-      "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA=="
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -58152,9 +58152,9 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.2.8.tgz",
-      "integrity": "sha512-IZZo6krhHWPhgsP5mBkEdPopVPN/stgCnBVuqi6dda/Nm5mDTOSVTrFMkWqlJsDum+B0YSe887tNxdjDWkO7aQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.2.9.tgz",
+      "integrity": "sha512-vqRBrN4xQHud7UMAGzGGFbt96MtGB9pb0OOg8Dhtq5RtiswCb1pCFq878iqC4hdeOP6eDPnCoFxA+2TXx427Ow==",
       "dev": true,
       "requires": {
         "compress-brotli": "^1.3.8",
@@ -62766,13 +62766,13 @@
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.1.3",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-          "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+          "version": "10.1.4",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.4.tgz",
+          "integrity": "sha512-hU1w68PqfH7FdMgjbiziJoACY0edlbIZ0CyKnpcEruVdCjsUrN+qoenOCIayNqVBK7toSWwbDxvQlrhH0gjRdg==",
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
-            "cacache": "^16.0.2",
+            "cacache": "^16.1.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
@@ -67754,9 +67754,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.4.tgz",
+      "integrity": "sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==",
       "requires": {
         "@zxing/text-encoding": "0.9.0",
         "util": "^0.12.3"


### PR DESCRIPTION
The deprecated `image` prop (but not yet removed) stopped working since it was not passed down to `resultListCommon`.

I also did changes so that `imageSize` is not `undefined` by default, and then internally resolved to `icon` in resultListCommon, as a fallback when not provided.

This helps documentation and various tool. We should pay special attention to not reproduce this pattern in new components/refactor: 

When we hide the default value of a prop from the `@Prop()` Stencil decorator, it means users have to guess what ends up happening internally, VS just being able to read it (or be informed by their IDE).

https://coveord.atlassian.net/browse/KIT-1642