### PR TITLE
fix(atomic): hid breadcrumb icon from screen readers

### DIFF
--- a/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/atomic-breadbox/atomic-breadbox.tsx
@@ -202,6 +202,7 @@ export class AtomicBreadbox implements InitializableComponent {
             part="breadcrumb-clear"
             class="w-2.5 h-2.5 ml-2 mt-px"
             icon={CloseIcon}
+            aria-hidden="true"
           ></atomic-icon>
         </Button>
       </li>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1662

Each screen reader I tested already ignored the icon. This fix corresponds with recommendations I saw from multiple articles online.

Screen readers I tested:
* VoiceOver for Mac OS
* VoiceOver for iOS
* TalkBack for Android
* JAWS for Windows
* NVDA for Windows
