### PR TITLE
fix(atomic): improved focus trap detection

### DIFF
--- a/packages/atomic/src/components/common/atomic-focus-trap.tsx
+++ b/packages/atomic/src/components/common/atomic-focus-trap.tsx
@@ -1,5 +1,6 @@
 import {Component, Element, Listen, Prop, Watch} from '@stencil/core';
 import {getFirstFocusableDescendant} from '../../utils/accessibility-utils';
+import {getFocusedElement} from '../../utils/utils';
 
 function getParent(element: Element | ShadowRoot) {
   if (element.parentNode) {
@@ -86,7 +87,9 @@ export class AtomicFocusTrap {
       return;
     }
 
-    if (contains(this.host, e.target as Element)) {
+    const focusedElement = getFocusedElement();
+
+    if (focusedElement && contains(this.host, focusedElement)) {
       return;
     }
 

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -141,3 +141,13 @@ export function sanitizeStyle(style: string) {
   wrapperEl.innerHTML = purifiedOuterHTML;
   return wrapperEl.querySelector('style')?.innerHTML;
 }
+
+export function getFocusedElement(
+  rootElement: Document | ShadowRoot = document
+): Element | null {
+  const activeElement = rootElement.activeElement;
+  if (activeElement?.shadowRoot) {
+    return getFocusedElement(activeElement.shadowRoot) ?? activeElement;
+  }
+  return activeElement;
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1665

I spent 4 miserable hours trying to write cypress tests for this, but Cypress is extremely flaky with focus tests and the ShadowDOM.

The issue this PR fixes is that the event target and `document.activeElement` return a parent of the focused element instead of the focused element itself. Chrome and Firefox both expose different properties in the event that contain the correct element, but not the same as each-other, and I couldn't find one in Safari for iOS.

I found out that `activeElement` tends to reference an element with a ShadowDOM, and the ShadowDOM itself has another `activeElement` in its root.