### PR TITLE
docs(atomic): removed heading from table description column

### DIFF
--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -426,7 +426,7 @@
                 </atomic-result-fields-list>
               </atomic-result-section-bottom-metadata>
               <atomic-table-element label="Description">
-                <h2><atomic-result-link></atomic-result-link></h2>
+                <atomic-result-link></atomic-result-link>
               </atomic-table-element>
               <atomic-table-element label="Price">
                 <atomic-result-number field="ec_price">


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1675

After I'm done with all accessibility issues, I will update the accessibility doc and look at the list of commits that modified `commerce-full.html`