### PR TITLE
feat(atomic): added heading-level prop to facets

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -50,13 +50,13 @@ export declare interface AtomicCategoryFacet extends Components.AtomicCategoryFa
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['basePath', 'delimitingCharacter', 'dependsOn', 'facetId', 'field', 'filterByBasePath', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['basePath', 'delimitingCharacter', 'dependsOn', 'facetId', 'field', 'filterByBasePath', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-category-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['basePath', 'delimitingCharacter', 'dependsOn', 'facetId', 'field', 'filterByBasePath', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['basePath', 'delimitingCharacter', 'dependsOn', 'facetId', 'field', 'filterByBasePath', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicCategoryFacet {
   protected el: HTMLElement;
@@ -71,13 +71,13 @@ export declare interface AtomicColorFacet extends Components.AtomicColorFacet {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-color-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicColorFacet {
   protected el: HTMLElement;
@@ -153,13 +153,13 @@ export declare interface AtomicFacet extends Components.AtomicFacet {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicFacet {
   protected el: HTMLElement;
@@ -423,13 +423,13 @@ export declare interface AtomicNumericFacet extends Components.AtomicNumericFace
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'rangeAlgorithm', 'sortCriteria', 'withInput']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'rangeAlgorithm', 'sortCriteria', 'withInput']
 })
 @Component({
   selector: 'atomic-numeric-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'rangeAlgorithm', 'sortCriteria', 'withInput']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'rangeAlgorithm', 'sortCriteria', 'withInput']
 })
 export class AtomicNumericFacet {
   protected el: HTMLElement;
@@ -533,13 +533,13 @@ export declare interface AtomicRatingFacet extends Components.AtomicRatingFacet 
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
 })
 @Component({
   selector: 'atomic-rating-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
+  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
 })
 export class AtomicRatingFacet {
   protected el: HTMLElement;
@@ -554,13 +554,13 @@ export declare interface AtomicRatingRangeFacet extends Components.AtomicRatingR
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
+  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
 })
 @Component({
   selector: 'atomic-rating-range-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
+  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'icon', 'injectionDepth', 'isCollapsed', 'label', 'maxValueInIndex', 'minValueInIndex', 'numberOfIntervals']
 })
 export class AtomicRatingRangeFacet {
   protected el: HTMLElement;
@@ -1444,13 +1444,13 @@ export declare interface AtomicTimeframeFacet extends Components.AtomicTimeframe
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'withDatePicker']
+  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'withDatePicker']
 })
 @Component({
   selector: 'atomic-timeframe-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'isCollapsed', 'label', 'withDatePicker']
+  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'withDatePicker']
 })
 export class AtomicTimeframeFacet {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -51,6 +51,10 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
+        /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
         "injectionDepth": number;
@@ -96,6 +100,10 @@ export namespace Components {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount": boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
@@ -154,6 +162,10 @@ export namespace Components {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount": boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
@@ -352,6 +364,10 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
+        /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
         "injectionDepth": number;
@@ -435,6 +451,10 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
+        /**
           * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
          */
         "icon": string;
@@ -480,6 +500,10 @@ export namespace Components {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount": boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
         /**
           * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
          */
@@ -1032,6 +1056,10 @@ export namespace Components {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount": boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel": number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
@@ -1649,6 +1677,10 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
+        /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
         "injectionDepth"?: number;
@@ -1694,6 +1726,10 @@ declare namespace LocalJSX {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount"?: boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
@@ -1752,6 +1788,10 @@ declare namespace LocalJSX {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount"?: boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
@@ -1948,6 +1988,10 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
+        /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */
         "injectionDepth"?: number;
@@ -2032,6 +2076,10 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
+        /**
           * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
          */
         "icon"?: string;
@@ -2077,6 +2125,10 @@ declare namespace LocalJSX {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount"?: boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
         /**
           * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
          */
@@ -2611,6 +2663,10 @@ declare namespace LocalJSX {
           * Whether to exclude the parents of folded results when estimating the result count for each facet value.
          */
         "filterFacetCount"?: boolean;
+        /**
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+         */
+        "headingLevel"?: number;
         /**
           * The maximum number of results to scan in the index to ensure that the facet lists all potential facet values. Note: A high injectionDepth may negatively impact the facet request performance. Minimum: `0` Default: `1000`
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -51,7 +51,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -101,7 +101,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -163,7 +163,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -364,7 +364,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -451,7 +451,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -501,7 +501,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -944,7 +944,7 @@ export namespace Components {
          */
         "collapsedHeight": number;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.
          */
         "headingLevel": number;
         /**
@@ -985,7 +985,7 @@ export namespace Components {
     }
     interface AtomicSmartSnippetSuggestions {
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the "People also ask" heading over the snippets, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the "People also ask" heading over the snippets, from 1 to 5.
          */
         "headingLevel": number;
         /**
@@ -1057,7 +1057,7 @@ export namespace Components {
          */
         "filterFacetCount": boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel": number;
         /**
@@ -1677,7 +1677,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -1727,7 +1727,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -1789,7 +1789,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -1988,7 +1988,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -2076,7 +2076,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -2126,7 +2126,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**
@@ -2544,7 +2544,7 @@ declare namespace LocalJSX {
          */
         "collapsedHeight"?: number;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.
          */
         "headingLevel"?: number;
         /**
@@ -2592,7 +2592,7 @@ declare namespace LocalJSX {
     }
     interface AtomicSmartSnippetSuggestions {
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the "People also ask" heading over the snippets, from 1 to 5.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the "People also ask" heading over the snippets, from 1 to 5.
          */
         "headingLevel"?: number;
         /**
@@ -2664,7 +2664,7 @@ declare namespace LocalJSX {
          */
         "filterFacetCount"?: boolean;
         /**
-          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.  We recommend setting this property in order to improve accessibility.
+          * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
          */
         "headingLevel"?: number;
         /**

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
@@ -68,9 +68,6 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
 
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the "People also ask" heading over the snippets, from 1 to 5.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
 

--- a/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -70,8 +70,6 @@ export class AtomicSmartSnippet implements InitializableComponent {
 
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the question at the top of the snippet, from 1 to 5.
-   *
-   * We recommend setting this property in order to improve accessibility.
    */
   @Prop({reflect: true}) public headingLevel = 0;
 

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -153,6 +153,13 @@ export class AtomicCategoryFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -274,6 +281,7 @@ export class AtomicCategoryFacet
           this.facetState.hasActiveValues && this.isCollapsed ? 1 : 0
         }
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         onClearFilters={() => {
           this.headerFocus.focusAfterSearch();

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -154,9 +154,6 @@ export class AtomicCategoryFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -140,9 +140,6 @@ export class AtomicColorFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -139,6 +139,13 @@ export class AtomicColorFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -255,6 +262,7 @@ export class AtomicColorFacet
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -140,6 +140,13 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -263,6 +270,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -141,9 +141,6 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -150,6 +150,13 @@ export class AtomicNumericFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -334,6 +341,7 @@ export class AtomicNumericFacet
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -151,9 +151,6 @@ export class AtomicNumericFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -133,6 +133,13 @@ export class AtomicRatingFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -274,6 +281,7 @@ export class AtomicRatingFacet
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -134,9 +134,6 @@ export class AtomicRatingFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -124,9 +124,6 @@ export class AtomicRatingRangeFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -123,6 +123,13 @@ export class AtomicRatingRangeFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -269,6 +276,7 @@ export class AtomicRatingRangeFacet
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -114,6 +114,13 @@ export class AtomicTimeframeFacet
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
+   * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
+   *
+   * We recommend setting this property in order to improve accessibility.
+   *
+   */
+  @Prop({reflect: true}) public headingLevel = 0;
+  /**
    * Whether to exclude the parents of folded results when estimating the result count for each facet value.
    */
   @Prop({reflect: true}) public filterFacetCount = true;
@@ -282,6 +289,7 @@ export class AtomicTimeframeFacet
         }}
         numberOfSelectedValues={this.numberOfSelectedValues}
         isCollapsed={this.isCollapsed}
+        headingLevel={this.headingLevel}
         onToggleCollapse={() => (this.isCollapsed = !this.isCollapsed)}
         headerRef={this.headerFocus.setTarget}
       ></FacetHeader>

--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -115,9 +115,6 @@ export class AtomicTimeframeFacet
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading over the facet, from 1 to 6.
-   *
-   * We recommend setting this property in order to improve accessibility.
-   *
    */
   @Prop({reflect: true}) public headingLevel = 0;
   /**

--- a/packages/atomic/src/components/facets/facet-common.ts
+++ b/packages/atomic/src/components/facets/facet-common.ts
@@ -33,7 +33,8 @@ export type BaseFacet<FacetType extends AnyFacetType> = {
   NumberOfIntervalsProp<FacetType> &
   SortCriterionProp<FacetType> &
   DisplayValuesAsProp &
-  CollapsedProp;
+  CollapsedProp &
+  HeadingLevelProp;
 
 type PropsOnAllFacets = {
   facetId?: string;
@@ -87,6 +88,8 @@ type DisplayValuesAsProp = {
 };
 
 type CollapsedProp = {isCollapsed?: boolean};
+
+type HeadingLevelProp = {headingLevel?: number};
 
 export interface FacetValueProps {
   i18n: i18n;

--- a/packages/atomic/src/components/facets/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets/facet-header/facet-header.tsx
@@ -11,7 +11,7 @@ export interface FacetHeaderProps {
   label: string;
   numberOfSelectedValues: number;
   isCollapsed: boolean;
-  headingLevel?: number;
+  headingLevel: number;
   onToggleCollapse(): void;
   onClearFilters?(): void;
   headerRef?: (element?: HTMLButtonElement) => void;
@@ -39,7 +39,7 @@ export const FacetHeader: FunctionalComponent<FacetHeaderProps> = (props) => {
       ariaExpanded={(!props.isCollapsed).toString()}
       ref={props.headerRef}
     >
-      <Heading level={props.headingLevel ?? 0} class="truncate">
+      <Heading level={props.headingLevel} class="truncate">
         {label}
       </Heading>
       <atomic-icon

--- a/packages/atomic/src/components/facets/facet-header/facet-header.tsx
+++ b/packages/atomic/src/components/facets/facet-header/facet-header.tsx
@@ -4,12 +4,14 @@ import ArrowBottomIcon from 'coveo-styleguide/resources/icons/svg/arrow-bottom-r
 import CloseIcon from 'coveo-styleguide/resources/icons/svg/close.svg';
 import {i18n} from 'i18next';
 import {Button} from '../../common/button';
+import {Heading} from '../../common/heading';
 
 export interface FacetHeaderProps {
   i18n: i18n;
   label: string;
   numberOfSelectedValues: number;
   isCollapsed: boolean;
+  headingLevel?: number;
   onToggleCollapse(): void;
   onClearFilters?(): void;
   headerRef?: (element?: HTMLButtonElement) => void;
@@ -35,9 +37,11 @@ export const FacetHeader: FunctionalComponent<FacetHeaderProps> = (props) => {
       title={props.isCollapsed ? expandFacet : collapseFacet}
       onClick={() => props.onToggleCollapse()}
       ariaExpanded={(!props.isCollapsed).toString()}
-      text={label}
       ref={props.headerRef}
     >
+      <Heading level={props.headingLevel ?? 0} class="truncate">
+        {label}
+      </Heading>
       <atomic-icon
         part="label-button-icon"
         class="w-3 self-center shrink-0 ml-4"

--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -319,10 +319,16 @@
           field="ec_category"
           label="Category"
           delimiting-character="|"
+          heading-level="2"
           with-search
         ></atomic-category-facet>
-        <atomic-facet field="ec_brand" label="Brand"></atomic-facet>
-        <atomic-numeric-facet field="cat_review_count" label="Amount of reviews" display-values-as="link">
+        <atomic-facet field="ec_brand" label="Brand" heading-level="2"></atomic-facet>
+        <atomic-numeric-facet
+          field="cat_review_count"
+          label="Amount of reviews"
+          display-values-as="link"
+          heading-level="2"
+        >
           <atomic-numeric-range start="0" end="150" label="Few"></atomic-numeric-range>
           <atomic-numeric-range start="150" end="650" label="A moderate amount"></atomic-numeric-range>
           <atomic-numeric-range start="650" end="999999999" label="A lot"></atomic-numeric-range>
@@ -332,11 +338,12 @@
           label="Color"
           number-of-values="6"
           sort-criteria="occurrences"
+          heading-level="2"
         ></atomic-color-facet>
-        <atomic-numeric-facet field="ec_price" label="Cost" with-input="integer">
+        <atomic-numeric-facet field="ec_price" label="Cost" with-input="integer" heading-level="2">
           <atomic-format-currency currency="USD"></atomic-format-currency>
         </atomic-numeric-facet>
-        <atomic-timeframe-facet label="Listed within" with-date-picker>
+        <atomic-timeframe-facet label="Listed within" with-date-picker heading-level="2">
           <atomic-timeframe unit="hour"></atomic-timeframe>
           <atomic-timeframe unit="day"></atomic-timeframe>
           <atomic-timeframe unit="week"></atomic-timeframe>
@@ -345,12 +352,18 @@
           <atomic-timeframe unit="year"></atomic-timeframe>
           <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe>
         </atomic-timeframe-facet>
-        <atomic-rating-facet field="ec_rating" label="Rating" number-of-intervals="5"> </atomic-rating-facet>
+        <atomic-rating-facet
+          field="ec_rating"
+          label="Rating"
+          number-of-intervals="5"
+          heading-level="2"
+        ></atomic-rating-facet>
         <atomic-rating-range-facet
           facet-id="ec_rating_range"
           field="ec_rating"
           label="Rating Range"
           number-of-intervals="5"
+          heading-level="2"
         >
         </atomic-rating-range-facet>
       </atomic-facet-manager>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1676

The alternative was to recommend implementers to add a heading before each facet, but that would cause screen readers to repeat the same heading twice, so I prefer to do this. This also follows the same pattern as for the smart snippet.

When no heading level is set, the only side-effect of this change is that the `span` in headings is now a `div`.