### PR TITLE
fix(atomic): add facet results checks when a facet range has no values

### DIFF
--- a/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -28,7 +28,12 @@ import {FacetPlaceholder} from '../atomic-facet-placeholder/atomic-facet-placeho
 import {FacetContainer} from '../facet-container/facet-container';
 import {FacetHeader} from '../facet-header/facet-header';
 import {FacetValueLink} from '../facet-value-link/facet-value-link';
-import {BaseFacet, parseDependsOn, validateDependsOn} from '../facet-common';
+import {
+  BaseFacet,
+  parseDependsOn,
+  shouldDisplayInputForFacetRange,
+  validateDependsOn,
+} from '../facet-common';
 import {Timeframe} from '../atomic-timeframe/timeframe';
 import {FacetValueLabelHighlight} from '../facet-value-label-highlight/facet-value-label-highlight';
 import dayjs from 'dayjs';
@@ -384,16 +389,20 @@ export class AtomicTimeframeFacet
   }
 
   private get shouldRenderValues() {
-    const hasInputRange = !!this.filterState?.range;
-    return !hasInputRange && !!this.valuesToRender.length;
+    return !this.hasInputRange && !!this.valuesToRender.length;
+  }
+
+  private get hasInputRange() {
+    return !!this.filterState?.range;
   }
 
   private get shouldRenderInput() {
-    if (!this.withDatePicker) {
-      return false;
-    }
-
-    return this.searchStatusState.hasResults || !!this.filterState?.range;
+    return shouldDisplayInputForFacetRange({
+      hasInput: this.withDatePicker,
+      hasInputRange: this.hasInputRange,
+      searchStatusState: this.searchStatusState,
+      valuesToRender: this.valuesToRender,
+    });
   }
 
   public render() {

--- a/packages/atomic/src/components/facets/facet-common.spec.ts
+++ b/packages/atomic/src/components/facets/facet-common.spec.ts
@@ -1,0 +1,65 @@
+import {
+  buildSearchStatus,
+  NumericFacetValue,
+  SearchStatusState,
+} from '@coveo/headless';
+import {shouldDisplayInputForFacetRange} from './facet-common';
+
+describe('facet common', () => {
+  describe('shouldDisplayInputForFacetRange', () => {
+    it('should #display=false when there is no input', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: false,
+          hasInputRange: false,
+          searchStatusState: {hasResults: true} as SearchStatusState,
+          valuesToRender: [{}, {}] as NumericFacetValue[],
+        })
+      ).toBe(false);
+    });
+
+    it('should #display=true when there is an input range but no results', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: true,
+          hasInputRange: true,
+          searchStatusState: {hasResults: false} as SearchStatusState,
+          valuesToRender: [] as NumericFacetValue[],
+        })
+      ).toBe(true);
+    });
+
+    it('should #display=false there is no results', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: true,
+          hasInputRange: false,
+          searchStatusState: {hasResults: false} as SearchStatusState,
+          valuesToRender: [] as NumericFacetValue[],
+        })
+      ).toBe(false);
+    });
+
+    it('should #display=false there is no values to render', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: true,
+          hasInputRange: false,
+          searchStatusState: {hasResults: true} as SearchStatusState,
+          valuesToRender: [] as NumericFacetValue[],
+        })
+      ).toBe(false);
+    });
+
+    it('should #display=true there is values to render', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: true,
+          hasInputRange: false,
+          searchStatusState: {hasResults: true} as SearchStatusState,
+          valuesToRender: [{}, {}] as NumericFacetValue[],
+        })
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/atomic/src/components/facets/facet-common.ts
+++ b/packages/atomic/src/components/facets/facet-common.ts
@@ -16,6 +16,8 @@ import {
   FacetSortCriterion,
   CategoryFacetSortCriterion,
   RangeFacetSortCriterion,
+  NumericFacetValue,
+  DateFacetValue,
 } from '@coveo/headless';
 import {i18n} from 'i18next';
 
@@ -169,4 +171,31 @@ export function validateDependsOn(dependsOn: Record<string, string>) {
   if (Object.keys(dependsOn).length > 1) {
     throw "Depending on multiple facets isn't supported";
   }
+}
+
+export function shouldDisplayInputForFacetRange(facetRange: {
+  hasInput: boolean;
+  hasInputRange: boolean;
+  searchStatusState: SearchStatusState;
+  valuesToRender: NumericFacetValue[] | DateFacetValue[];
+}) {
+  const {hasInput, hasInputRange, searchStatusState, valuesToRender} =
+    facetRange;
+  if (!hasInput) {
+    return false;
+  }
+
+  if (hasInputRange) {
+    return true;
+  }
+
+  if (!searchStatusState.hasResults) {
+    return false;
+  }
+
+  if (!valuesToRender.length) {
+    return false;
+  }
+
+  return true;
 }


### PR DESCRIPTION
* Extract common logic for `shouldDisplayInput` for `numeric` and `timeframe` facet.
* When `numeric` facet is configured with `number-of-values=0`, create a headless facet only to verify if there's any results. It request only 1 value, with automatic range. The only thing we need is to verify if there's any facet results. We don't use it for display.


https://coveord.atlassian.net/browse/KIT-1458