### PR TITLE
fix(atomic): changed category facet lists to nested lists

### DIFF
--- a/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
+++ b/packages/atomic/src/components/facets/facet-value-link/facet-value-link.tsx
@@ -1,11 +1,12 @@
-import {FunctionalComponent, h} from '@stencil/core';
+import {FunctionalComponent, h, VNode} from '@stencil/core';
 import {Button} from '../../common/button';
 import {FacetValueProps} from '../facet-common';
 
-export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
-  props,
-  children
-) => {
+export const FacetValueLink: FunctionalComponent<
+  FacetValueProps & {
+    subList?: VNode[];
+  }
+> = (props, children) => {
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
   const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
@@ -31,6 +32,7 @@ export const FacetValueLink: FunctionalComponent<FacetValueProps> = (
           })}
         </span>
       </Button>
+      {props.subList}
     </li>
   );
 };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1677

This didn't really change anything with all the screen readers I tested, apart from VoiceOver on Mac OS with Firefox (not Safari), which read out the nesting level every time we focus on a button.

To avoid breaking existing implementations that might've used `display: flex` or `display: grid` on any of the parts, I added `display: contents` on every `ul` and `li` element whose sole purpose is nesting.

This change is slightly breaking, since:
* `[part="parents"]` now wraps `[part="values"]`
* `[part="parent-active"]` used to only wrap `[part="active-parent"]`, but now also wraps `[part="values"]`

I didn't add E2E tests yet, since this is a pretty big change and I don't want to waste time if we choose not to do this. If you guys like those changes, I'll add E2E tests and re-request reviews.

Visually, the component looks the exact same. Nothing has changed.

# Hierarchy comparison
![image](https://user-images.githubusercontent.com/54454747/170504933-9f1adf7e-7e47-4d88-8b71-210023669982.png)

## Before
* `ul[part="parents"]`
  * `li > button >` All categories
  * `li > button >` Computers & Tablets
  * `li > button >` Computer Accessories & Peripherals
  * `li > button >` Laptop Accessories
  * `li[part="parent-active"] > button >` Laptop Bags & Cases
* `ul[part="values"]`
  * `li > button >` Laptop Backpacks
  * `li > button >` Laptop Sleeves
  * `li > button >` Laptop Briefcases
  * `li > button >` Laptop Hard-Shell Cases
  * `li > button >` Laptop Messenger Bags

## After
* `ul[part="parents"] > li`
  * `button >` All categories
  * `ul > li`
    * `button >` Computers & Tablets
    * `ul > li`
      * `button >` Computer Accessories & Peripherals
      * `ul > li`
        * `button >` Laptop Accessories
        * `ul > li[part="parent-active"]`
          * `button >` Laptop Bags & Cases
          * `ul[part="values"]`
            * `li > button >` Laptop Backpacks
            * `li > button >` Laptop Sleeves
            * `li > button >` Laptop Briefcases
            * `li > button >` Laptop Hard-Shell Cases
            * `li > button >` Laptop Messenger Bags