### PR TITLE
feat(atomic): Segmented facets styled partially

### DIFF
--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
@@ -18,8 +18,12 @@
   @apply w-full;
 }
 
+.value-label {
+  @apply group-hover:!text-primary-light;
+}
+
 .value-box {
-  @apply hover:border-blue-400 rounded-none;
+  @apply hover:!border-primary-light hover:!bg-background rounded-none p-2;
 }
 
 .value-box-count {
@@ -27,9 +31,9 @@
 }
 
 .value-box.selected {
-  @apply border-blue-600;
+  @apply border-primary;
 }
 
 .value-box.selected .value-label {
-  @apply text-blue-600 font-normal;
+  @apply text-primary font-normal;
 }

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
@@ -1,0 +1,16 @@
+@import '../../../global/global.pcss';
+@import '../facet-common.pcss';
+@import '../facet-search/facet-search.pcss';
+
+.box-container {
+  @apply flex items-stretch inline-block;
+}
+
+.value-box .value-label,
+.value-box-count {
+  @apply w-full;
+}
+
+.value-box.selected {
+  box-shadow: 0 0 0 1px var(--atomic-primary);
+}

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
@@ -5,12 +5,12 @@
   @apply flex items-stretch;
 }
 
-.box-container li:first-child .value-box:first-child {
-  border-radius: 3px 0px 0px 3px;
+.box-container li:first-child .value-box {
+  border-radius: var(--atomic-border-radius) 0px 0px var(--atomic-border-radius);
 }
 
-.box-container li:last-child .value-box:last-child {
-  border-radius: 0px 3px 3px 0px;
+.box-container li:last-child .value-box {
+  border-radius: 0px var(--atomic-border-radius) var(--atomic-border-radius) 0px;
 }
 
 .value-box .value-label,
@@ -18,12 +18,12 @@
   @apply w-full;
 }
 
-.value-label {
-  @apply group-hover:!text-primary-light;
+.value-box .value-label {
+  @apply group-hover:text-primary-light;
 }
 
-.value-box {
-  @apply hover:!border-primary-light hover:!bg-background rounded-none p-2;
+.box-container .value-box {
+  @apply hover:border-primary-light rounded-none p-2 border-2;
 }
 
 .value-box-count {

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
@@ -1,9 +1,16 @@
 @import '../../../global/global.pcss';
 @import '../facet-common.pcss';
-@import '../facet-search/facet-search.pcss';
 
 .box-container {
   @apply flex items-stretch inline-block;
+}
+
+.box-container li:first-child .value-box:first-child {
+  border-radius: 5px 0px 0px 5px;
+}
+
+.box-container li:last-child .value-box:last-child {
+  border-radius: 0px 5px 5px 0px;
 }
 
 .value-box .value-label,
@@ -11,6 +18,18 @@
   @apply w-full;
 }
 
+.value-box {
+  @apply hover:border-blue-400 rounded-none;
+}
+
+.value-box-count {
+  @apply pl-1;
+}
+
 .value-box.selected {
-  box-shadow: 0 0 0 1px var(--atomic-primary);
+  @apply border-blue-600;
+}
+
+.value-box.selected .value-label {
+  @apply text-blue-600 font-normal;
 }

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.pcss
@@ -2,15 +2,15 @@
 @import '../facet-common.pcss';
 
 .box-container {
-  @apply flex items-stretch inline-block;
+  @apply flex items-stretch;
 }
 
 .box-container li:first-child .value-box:first-child {
-  border-radius: 5px 0px 0px 5px;
+  border-radius: 3px 0px 0px 3px;
 }
 
 .box-container li:last-child .value-box:last-child {
-  border-radius: 0px 5px 5px 0px;
+  border-radius: 0px 3px 3px 0px;
 }
 
 .value-box .value-label,

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
@@ -72,7 +72,7 @@ export class AtomicSegmentedFacet
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time more values are shown.
    */
-  @Prop({reflect: true}) public numberOfValues = 6;
+  @Prop({reflect: true}) public numberOfValues = 8;
   /**
    * The sort criterion to apply to the returned facet values.
    * Possible values are 'score', 'alphanumeric', 'occurrences', and 'automatic'.
@@ -143,6 +143,11 @@ export class AtomicSegmentedFacet
   }
 
   public render() {
-    return this.renderValues();
+    return (
+      <div class="flex">
+        <b class="inline-block my-3 mr-2">{this.label}</b>
+        {this.renderValues()}
+      </div>
+    );
   }
 }

--- a/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
@@ -72,7 +72,7 @@ export class AtomicSegmentedFacet
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time more values are shown.
    */
-  @Prop({reflect: true}) public numberOfValues = 8;
+  @Prop({reflect: true}) public numberOfValues = 6;
   /**
    * The sort criterion to apply to the returned facet values.
    * Possible values are 'score', 'alphanumeric', 'occurrences', and 'automatic'.


### PR DESCRIPTION
- Completed the basic styling for the segmented facets. 
- Count is displayed by default and can be hidden using parts
- Created subtasks for the remaining styling to be done.

Segmented facets look like this for now: 

<img width="698" alt="Screen Shot 2022-05-26 at 5 35 31 PM" src="https://user-images.githubusercontent.com/97299176/170585881-918bc775-ed97-437c-9f32-3a5d806e738b.png">

Update:

- First and last facets have rounded edges
- Increased padding between count and facet value
- Different shades of blue on border between hover/selected facet state
<img width="809" alt="Screen Shot 2022-05-30 at 9 19 31 AM" src="https://user-images.githubusercontent.com/97299176/171000791-2d5f4e2b-3d3b-4678-9fd3-6997184880f3.png">





https://coveord.atlassian.net/browse/KIT-1667