### PR TITLE
feat(atomic): change dayjs language when i18n language changes (Solution #2)

### DIFF
--- a/packages/atomic/.eslintrc.json
+++ b/packages/atomic/.eslintrc.json
@@ -10,6 +10,7 @@
   },
   "ignorePatterns": [
     "src/external-builds/**/*",
+    "src/components/atomic-search-interface/lang/**/*",
     "dist/**/*",
     "www/**/*",
     "loader/**/*",

--- a/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/atomic-search-interface/atomic-search-interface.tsx
@@ -194,7 +194,7 @@ export class AtomicSearchInterface {
       })
     );
 
-    loadDayjsLocale(this.language);
+    loadDayjsLocale(this.languageAssetPath, this.language);
     new Backend(this.i18n.services, this.i18nBackendOptions).read(
       this.language,
       'translation',
@@ -458,8 +458,12 @@ export class AtomicSearchInterface {
 
   private get i18nBackendOptions(): BackendOptions {
     return {
-      loadPath: `${getAssetPath(this.languageAssetsPath)}/{{lng}}.json`,
+      loadPath: `${this.languageAssetPath}/{{lng}}.json`,
     };
+  }
+
+  private get languageAssetPath() {
+    return getAssetPath(this.languageAssetsPath);
   }
 
   private async internalInitialization(initEngine: () => void) {
@@ -472,7 +476,7 @@ export class AtomicSearchInterface {
     }
     this.updateIconAssetsPath();
     initEngine();
-    loadDayjsLocale(this.language);
+    loadDayjsLocale(this.languageAssetPath, this.language);
     await this.i18nPromise;
     this.initComponents();
     this.initSearchStatus();

--- a/packages/atomic/src/utils/day-js-locales.ts
+++ b/packages/atomic/src/utils/day-js-locales.ts
@@ -1,41 +1,16 @@
 import dayjs from 'dayjs';
 
-const locales: Record<string, () => Promise<unknown>> = {
-  en: () => import('dayjs/locale/en'),
-  fr: () => import('dayjs/locale/fr'),
-  cs: () => import('dayjs/locale/cs'),
-  da: () => import('dayjs/locale/da'),
-  de: () => import('dayjs/locale/de'),
-  el: () => import('dayjs/locale/el'),
-  es: () => import('dayjs/locale/es'),
-  fi: () => import('dayjs/locale/fi'),
-  hu: () => import('dayjs/locale/hu'),
-  id: () => import('dayjs/locale/id'),
-  it: () => import('dayjs/locale/it'),
-  ja: () => import('dayjs/locale/ja'),
-  ko: () => import('dayjs/locale/ko'),
-  nl: () => import('dayjs/locale/nl'),
-  pl: () => import('dayjs/locale/pl'),
-  'pt-br': () => import('dayjs/locale/pt-br'),
-  ru: () => import('dayjs/locale/ru'),
-  sv: () => import('dayjs/locale/sv'),
-  th: () => import('dayjs/locale/th'),
-  tr: () => import('dayjs/locale/tr'),
-  'zh-cn': () => import('dayjs/locale/zh-cn'),
-  'zh-tw': () => import('dayjs/locale/zh-tw'),
-};
-
 const warn = (language: string) =>
   console.warn(`Cannot load dayjs locale file file for "${language}"`);
 
-export function loadDayjsLocale(language: string) {
-  if (!locales[language]) {
-    warn(language);
-    return;
-  }
-
+export async function loadDayjsLocale(
+  languageAssetPath: string,
+  language: string
+) {
   try {
-    locales[language]().then(() => dayjs.locale(language));
+    const module = await import(`${languageAssetPath}/dayjs/${language}.js`);
+    const locale = module.default;
+    dayjs.locale(locale);
   } catch (error) {
     warn(language);
   }

--- a/packages/samples/atomic-next/.eslintrc.json
+++ b/packages/samples/atomic-next/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "extends": "next/core-web-vitals",
-  "ignorePatterns": ["next.config.js"]
+  "ignorePatterns": ["next.config.js", "public"]
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1610

I'm not sure how to properly get the next/react sample working locally, what's the list of command to get
atomic -> atomic-react -> samples/atomic-react working?