### PR TITLE
fix(atomic): made facet values focus when pressing show more/show less

### DIFF
--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
@@ -181,6 +181,12 @@ export function assertDisplayAllCategoriesButton(display: boolean) {
   });
 }
 
+export function assertFocusFirstChildValue() {
+  it('should focus on the first value', () => {
+    CategoryFacetSelectors.childValue().first().should('be.focused');
+  });
+}
+
 export function assertFocusActiveParent() {
   it('should focus on the active parent', () => {
     CategoryFacetSelectors.activeParentValue().should('be.focused');

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -385,7 +385,7 @@ describe('Category Facet Test Suites', () => {
           CategoryFacetSelectors,
           true
         );
-        CommonFacetAssertions.assertFocusShowLess(CategoryFacetSelectors);
+        CategoryFacetAssertions.assertFocusFirstChildValue();
       });
 
       describe('verify analytics', () => {
@@ -412,7 +412,7 @@ describe('Category Facet Test Suites', () => {
             CategoryFacetSelectors,
             false
           );
-          CommonFacetAssertions.assertFocusShowMore(CategoryFacetSelectors);
+          CategoryFacetAssertions.assertFocusFirstChildValue();
         });
 
         describe('verify analytics', () => {

--- a/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
@@ -226,7 +226,7 @@ describe('Color Facet Test Suites', () => {
       ColorFacetAssertions.assertNumberOfIdleBoxValues(
         colorFacetDefaultNumberOfValues * 2
       );
-      CommonFacetAssertions.assertFocusShowMore(ColorFacetSelectors);
+      CommonFacetAssertions.assertFocusFirstBoxValue(ColorFacetSelectors);
     });
     describe('verify analytics', () => {
       before(setupSelectShowMore);
@@ -258,7 +258,7 @@ describe('Color Facet Test Suites', () => {
           ColorFacetSelectors,
           true
         );
-        CommonFacetAssertions.assertFocusShowLess(ColorFacetSelectors);
+        CommonFacetAssertions.assertFocusFirstBoxValue(ColorFacetSelectors);
       });
     });
 

--- a/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
@@ -27,6 +27,13 @@ export interface FacetWithLinkSelector extends ComponentSelector {
   idleLinkValueLabel: () => Cypress.Chainable<JQuery<HTMLElement>>;
 }
 
+export interface FacetWithBoxSelector extends ComponentSelector {
+  selectedBoxValue: () => Cypress.Chainable<JQuery<HTMLElement>>;
+  idleBoxValue: () => Cypress.Chainable<JQuery<HTMLElement>>;
+  boxValueWithText: (text: string) => Cypress.Chainable<JQuery<HTMLElement>>;
+  idleBoxValueLabel: () => Cypress.Chainable<JQuery<HTMLElement>>;
+}
+
 export interface FacetWithSearchSelector extends ComponentSelector {
   searchInput: () => Cypress.Chainable<JQuery<HTMLElement>>;
   searchClearButton: () => Cypress.Chainable<JQuery<HTMLElement>>;
@@ -287,18 +294,20 @@ export function assertFocusHeader(BaseFacetSelector: BaseFacetSelector) {
   });
 }
 
-export function assertFocusShowMore(
-  FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector
+export function assertFocusFirstCheckboxValue(
+  FacetWithShowMoreLessSelector: FacetWithCheckboxSelector
 ) {
-  it('should focus on the show more button', () => {
-    FacetWithShowMoreLessSelector.showMoreButton().should('be.focused');
+  it('should focus on the first value', () => {
+    FacetWithShowMoreLessSelector.idleCheckboxValue()
+      .first()
+      .should('be.focused');
   });
 }
 
-export function assertFocusShowLess(
-  FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector
+export function assertFocusFirstBoxValue(
+  FacetWithShowMoreLessSelector: FacetWithBoxSelector
 ) {
-  it('should focus on the show less button', () => {
-    FacetWithShowMoreLessSelector.showLessButton().should('be.focused');
+  it('should focus on the first value', () => {
+    FacetWithShowMoreLessSelector.idleBoxValue().first().should('be.focused');
   });
 }

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -665,7 +665,7 @@ describe('Facet v1 Test Suites', () => {
         FacetSelectors,
         defaultNumberOfValues * 2
       );
-      CommonFacetAssertions.assertFocusShowMore(FacetSelectors);
+      CommonFacetAssertions.assertFocusFirstCheckboxValue(FacetSelectors);
     });
 
     describe('verify analytics', () => {
@@ -689,7 +689,7 @@ describe('Facet v1 Test Suites', () => {
           false
         );
         CommonFacetAssertions.assertDisplayShowLessButton(FacetSelectors, true);
-        CommonFacetAssertions.assertFocusShowLess(FacetSelectors);
+        CommonFacetAssertions.assertFocusFirstCheckboxValue(FacetSelectors);
       });
     });
 

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -192,10 +192,7 @@ export class AtomicCategoryFacet
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
   @FocusTarget()
-  private showMoreFocus!: FocusTargetController;
-
-  @FocusTarget()
-  private showLessFocus!: FocusTargetController;
+  private showMoreLessFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -422,7 +419,10 @@ export class AtomicCategoryFacet
     );
   }
 
-  private renderValue(facetValue: CategoryFacetValue) {
+  private renderValue(
+    facetValue: CategoryFacetValue,
+    isShowMoreLessFocusTarget: boolean
+  ) {
     const displayValue = getFieldValueCaption(
       this.field,
       facetValue.value,
@@ -440,6 +440,9 @@ export class AtomicCategoryFacet
           this.facet.toggleSelect(facetValue);
         }}
         searchQuery={this.facetState.facetSearch.query}
+        buttonRef={(element) =>
+          isShowMoreLessFocusTarget && this.showMoreLessFocus.setTarget(element)
+        }
       >
         <FacetValueLabelHighlight
           displayValue={displayValue}
@@ -456,7 +459,9 @@ export class AtomicCategoryFacet
 
     return (
       <ul part="values" class={this.hasParents ? 'pl-9' : 'mt-3'}>
-        {this.facetState.values.map((value) => this.renderValue(value))}
+        {this.facetState.values.map((value, i) =>
+          this.renderValue(value, i === 0)
+        )}
       </ul>
     );
   }
@@ -492,26 +497,21 @@ export class AtomicCategoryFacet
   }
 
   private renderShowMoreLess() {
-    if (this.facetState.canShowMoreValues) {
-      this.showMoreFocus.disableForCurrentSearch();
-    }
     return (
       <div class={this.hasParents ? 'pl-9' : ''}>
         <FacetShowMoreLess
           label={this.label}
           i18n={this.bindings.i18n}
           onShowMore={() => {
-            this.showMoreFocus.focusAfterSearch();
+            this.showMoreLessFocus.focusAfterSearch();
             this.facet.showMoreValues();
           }}
           onShowLess={() => {
-            this.showLessFocus.focusAfterSearch();
+            this.showMoreLessFocus.focusAfterSearch();
             this.facet.showLessValues();
           }}
           canShowLessValues={this.facetState.canShowLessValues}
           canShowMoreValues={this.facetState.canShowMoreValues}
-          showMoreRef={this.showLessFocus.setTarget}
-          showLessRef={this.showMoreFocus.setTarget}
         ></FacetShowMoreLess>
       </div>
     );

--- a/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -492,7 +492,7 @@ export class AtomicCategoryFacet
 
   private renderShowMoreLess() {
     if (this.facetState.canShowMoreValues) {
-      this.showLessFocus.disableForCurrentSearch();
+      this.showMoreFocus.disableForCurrentSearch();
     }
     return (
       <div class={this.hasParents ? 'pl-9' : ''}>
@@ -500,17 +500,17 @@ export class AtomicCategoryFacet
           label={this.label}
           i18n={this.bindings.i18n}
           onShowMore={() => {
-            this.showLessFocus.focusAfterSearch();
+            this.showMoreFocus.focusAfterSearch();
             this.facet.showMoreValues();
           }}
           onShowLess={() => {
-            this.showMoreFocus.focusAfterSearch();
+            this.showLessFocus.focusAfterSearch();
             this.facet.showLessValues();
           }}
           canShowLessValues={this.facetState.canShowLessValues}
           canShowMoreValues={this.facetState.canShowMoreValues}
-          showMoreRef={this.showMoreFocus.setTarget}
-          showLessRef={this.showLessFocus.setTarget}
+          showMoreRef={this.showLessFocus.setTarget}
+          showLessRef={this.showMoreFocus.setTarget}
         ></FacetShowMoreLess>
       </div>
     );

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -392,24 +392,24 @@ export class AtomicColorFacet
 
   private renderShowMoreLess() {
     if (this.facetState.canShowMoreValues) {
-      this.showLessFocus.disableForCurrentSearch();
+      this.showMoreFocus.disableForCurrentSearch();
     }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showLessFocus.focusAfterSearch();
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showMoreFocus.focusAfterSearch();
+          this.showLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
-        showMoreRef={this.showMoreFocus.setTarget}
-        showLessRef={this.showLessFocus.setTarget}
+        showMoreRef={this.showLessFocus.setTarget}
+        showLessRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -178,10 +178,7 @@ export class AtomicColorFacet
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
   @FocusTarget()
-  private showMoreFocus!: FocusTargetController;
-
-  @FocusTarget()
-  private showLessFocus!: FocusTargetController;
+  private showMoreLessFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -295,7 +292,11 @@ export class AtomicColorFacet
     );
   }
 
-  private renderValue(facetValue: FacetValue, onClick: () => void) {
+  private renderValue(
+    facetValue: FacetValue,
+    onClick: () => void,
+    isShowMoreLessFocusTarget: boolean
+  ) {
     const displayValue = getFieldValueCaption(
       this.facetId!,
       facetValue.value,
@@ -314,6 +315,10 @@ export class AtomicColorFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
+            buttonRef={(element) =>
+              isShowMoreLessFocusTarget &&
+              this.showMoreLessFocus.setTarget(element)
+            }
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -331,6 +336,10 @@ export class AtomicColorFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
+            buttonRef={(element) =>
+              isShowMoreLessFocusTarget &&
+              this.showMoreLessFocus.setTarget(element)
+            }
           >
             <div
               part={`value-${partValueWithDisplayValue} value-${partValueWithAPIValue} default-color-value`}
@@ -365,22 +374,23 @@ export class AtomicColorFacet
 
   private renderValues() {
     return this.renderValuesContainer(
-      this.facetState.values.map((value) =>
-        this.renderValue(value, () => this.facet.toggleSelect(value))
+      this.facetState.values.map((value, i) =>
+        this.renderValue(value, () => this.facet.toggleSelect(value), i === 0)
       )
     );
   }
 
   private renderSearchResults() {
     return this.renderValuesContainer(
-      this.facetState.facetSearch.values.map((value) =>
+      this.facetState.facetSearch.values.map((value, i) =>
         this.renderValue(
           {
             state: 'idle',
             numberOfResults: value.count,
             value: value.rawValue,
           },
-          () => this.facet.facetSearch.select(value)
+          () => this.facet.facetSearch.select(value),
+          i === 0
         )
       ),
       this.facetState.facetSearch.query
@@ -399,25 +409,20 @@ export class AtomicColorFacet
   }
 
   private renderShowMoreLess() {
-    if (this.facetState.canShowMoreValues) {
-      this.showMoreFocus.disableForCurrentSearch();
-    }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showMoreFocus.focusAfterSearch();
+          this.showMoreLessFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showLessFocus.focusAfterSearch();
+          this.showMoreLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowLessValues={this.facetState.canShowLessValues}
         canShowMoreValues={this.facetState.canShowMoreValues}
-        showMoreRef={this.showLessFocus.setTarget}
-        showLessRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -178,10 +178,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
   @FocusTarget()
-  private showMoreFocus!: FocusTargetController;
-
-  @FocusTarget()
-  private showLessFocus!: FocusTargetController;
+  private showMoreLessFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -302,7 +299,11 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
     );
   }
 
-  private renderValue(facetValue: FacetValue, onClick: () => void) {
+  private renderValue(
+    facetValue: FacetValue,
+    onClick: () => void,
+    isShowMoreLessFocusTarget: boolean
+  ) {
     const displayValue = getFieldValueCaption(
       this.field,
       facetValue.value,
@@ -319,6 +320,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
+            buttonRef={(element) =>
+              isShowMoreLessFocusTarget &&
+              this.showMoreLessFocus.setTarget(element)
+            }
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -336,6 +341,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
+            buttonRef={(element) =>
+              isShowMoreLessFocusTarget &&
+              this.showMoreLessFocus.setTarget(element)
+            }
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -353,6 +362,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
+            buttonRef={(element) =>
+              isShowMoreLessFocusTarget &&
+              this.showMoreLessFocus.setTarget(element)
+            }
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -377,11 +390,14 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
 
   private renderValues() {
     return this.renderValuesContainer(
-      this.facetState.values.map((value) =>
-        this.renderValue(value, () =>
-          this.displayValuesAs === 'link'
-            ? this.facet.toggleSingleSelect(value)
-            : this.facet.toggleSelect(value)
+      this.facetState.values.map((value, i) =>
+        this.renderValue(
+          value,
+          () =>
+            this.displayValuesAs === 'link'
+              ? this.facet.toggleSingleSelect(value)
+              : this.facet.toggleSelect(value),
+          i === 0
         )
       )
     );
@@ -399,7 +415,8 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
           () =>
             this.displayValuesAs === 'link'
               ? this.facet.facetSearch.singleSelect(value)
-              : this.facet.facetSearch.select(value)
+              : this.facet.facetSearch.select(value),
+          false
         )
       )
     );
@@ -417,25 +434,20 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   }
 
   private renderShowMoreLess() {
-    if (this.facetState.canShowMoreValues) {
-      this.showMoreFocus.disableForCurrentSearch();
-    }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showMoreFocus.focusAfterSearch();
+          this.showMoreLessFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showLessFocus.focusAfterSearch();
+          this.showMoreLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowMoreValues={this.facetState.canShowMoreValues}
         canShowLessValues={this.facetState.canShowLessValues}
-        showMoreRef={this.showLessFocus.setTarget}
-        showLessRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/facets/atomic-facet/atomic-facet.tsx
@@ -418,24 +418,24 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
 
   private renderShowMoreLess() {
     if (this.facetState.canShowMoreValues) {
-      this.showLessFocus.disableForCurrentSearch();
+      this.showMoreFocus.disableForCurrentSearch();
     }
     return (
       <FacetShowMoreLess
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showLessFocus.focusAfterSearch();
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showMoreFocus.focusAfterSearch();
+          this.showLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowMoreValues={this.facetState.canShowMoreValues}
         canShowLessValues={this.facetState.canShowLessValues}
-        showMoreRef={this.showMoreFocus.setTarget}
-        showLessRef={this.showLessFocus.setTarget}
+        showMoreRef={this.showLessFocus.setTarget}
+        showLessRef={this.showMoreFocus.setTarget}
       ></FacetShowMoreLess>
     );
   }

--- a/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
+++ b/packages/atomic/src/components/facets/facet-value-box/facet-value-box.tsx
@@ -28,6 +28,7 @@ export const FacetValueBox: FunctionalComponent<FacetValueProps> = (
         }`}
         ariaPressed={props.isSelected.toString()}
         ariaLabel={ariaLabel}
+        ref={props.buttonRef}
       >
         {children}
         <span

--- a/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -34,6 +34,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
             : 'border border-neutral-dark'
         }`}
         aria-label={ariaLabel}
+        ref={props.buttonRef}
       >
         <atomic-icon
           class={`w-3/5 svg-checkbox ${props.isSelected ? 'block' : 'hidden'}`}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1680

Ideally, when we press "show more", I think the first new value should be selected. However, in some (few) cases, values are sorted and therefor the new and old values are mixed together, which could make this behaviour weird and unintuitive.