### PR TITLE
fix(headless): replace qa by stg

### DIFF
--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -94,7 +94,7 @@ export class PlatformClient {
 
 type PlatformCombination =
   | {env: 'dev'; region: 'us' | 'eu'}
-  | {env: 'qa'; region: 'us' | 'eu'}
+  | {env: 'stg'; region: 'us'}
   | {env: 'hipaa'; region: 'us'}
   | {env: 'prod'; region: 'us' | 'eu' | 'au'};
 

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -22,7 +22,7 @@ function analyticsUrlFromPlatformUrl(
   organizationId: string
 ) {
   const isCoveoPlatformURL =
-    /^https:\/\/platform(dev|qa|hipaa)?(-)?(eu|au)?\.cloud\.coveo\.com/.test(
+    /^https:\/\/platform(dev|stg|hipaa)?(-)?(eu|au)?\.cloud\.coveo\.com/.test(
       platformUrl
     );
   if (isCoveoPlatformURL) {

--- a/packages/headless/src/test/platform-url.ts
+++ b/packages/headless/src/test/platform-url.ts
@@ -1,5 +1,5 @@
 export type TestedRegion = 'us' | 'au' | 'eu';
-export type TestedEnvironment = 'dev' | 'qa' | 'prod' | 'hipaa';
+export type TestedEnvironment = 'dev' | 'stg' | 'prod' | 'hipaa';
 
 export interface TestedPlatformURL {
   region?: TestedRegion;
@@ -68,24 +68,17 @@ export const allValidPlatformCombination: () => TestedPlatformURL[] = () => [
   },
   {
     region: 'us',
-    environment: 'qa',
-    platform: 'https://platformqa.cloud.coveo.com',
-    search: 'https://platformqa.cloud.coveo.com/rest/search/v2',
-    analytics: 'https://analyticsqa.cloud.coveo.com/rest/ua',
+    environment: 'stg',
+    platform: 'https://platformstg.cloud.coveo.com',
+    search: 'https://platformstg.cloud.coveo.com/rest/search/v2',
+    analytics: 'https://analyticsstg.cloud.coveo.com/rest/ua',
   },
   {
     region: undefined,
-    environment: 'qa',
-    platform: 'https://platformqa.cloud.coveo.com',
-    search: 'https://platformqa.cloud.coveo.com/rest/search/v2',
-    analytics: 'https://analyticsqa.cloud.coveo.com/rest/ua',
-  },
-  {
-    region: 'eu',
-    environment: 'qa',
-    platform: 'https://platformqa-eu.cloud.coveo.com',
-    search: 'https://platformqa-eu.cloud.coveo.com/rest/search/v2',
-    analytics: 'https://analyticsqa-eu.cloud.coveo.com/rest/ua',
+    environment: 'stg',
+    platform: 'https://platformstg.cloud.coveo.com',
+    search: 'https://platformstg.cloud.coveo.com/rest/search/v2',
+    analytics: 'https://analyticsstg.cloud.coveo.com/rest/ua',
   },
   {
     region: 'us',


### PR DESCRIPTION
Replaced QA by STG.
There's no stg in EU, so I removed this combination from the test, tho I reckon the code doesn't check for bad combinations.