### PR TITLE
feat(atomic): Implement keyboard navigation between panels in search box suggestions

### DIFF
--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -59,7 +59,8 @@ export class AtomicSearchBox {
   private searchBox!: SearchBox | StandaloneSearchBox;
   private id!: string;
   private inputRef!: HTMLInputElement;
-  private listRefs: HTMLElement[] = [];
+  private leftPanelRef: HTMLElement | undefined;
+  private rightPanelRef: HTMLElement | undefined;
   private querySetActions!: QuerySetActionCreators;
   private pendingSuggestionEvents: SearchBoxSuggestionsEvent[] = [];
   private suggestions: SearchBoxSuggestions[] = [];
@@ -212,8 +213,9 @@ export class AtomicSearchBox {
     }
 
     return (
-      this.listRefs[0]?.querySelector(`#${this.activeDescendant}`) ||
-      this.listRefs[1]?.querySelector(`#${this.activeDescendant}`)
+      this.leftPanelRef?.querySelector(`#${this.activeDescendant}`) ||
+      this.rightPanelRef?.querySelector(`#${this.activeDescendant}`) ||
+      null
     );
   }
 
@@ -251,11 +253,13 @@ export class AtomicSearchBox {
   }
 
   private get panelInFocus() {
-    return (
-      this.listRefs.find((ref) =>
-        ref?.contains(this.activeDescendantElement)
-      ) || this.listRefs.find((panel) => panel)
-    );
+    if (this.leftPanelRef?.contains(this.activeDescendantElement)) {
+      return this.leftPanelRef;
+    }
+    if (this.rightPanelRef?.contains(this.activeDescendantElement)) {
+      return this.rightPanelRef;
+    }
+    return this.leftPanelRef || this.rightPanelRef;
   }
 
   private getSuggestionElements(suggestions: SearchBoxSuggestions[]) {
@@ -293,7 +297,7 @@ export class AtomicSearchBox {
     this.updateQueryFromSuggestion();
   }
 
-  private focusPanel(panel: HTMLElement) {
+  private focusPanel(panel: HTMLElement | undefined) {
     if (this.panelInFocus === panel) {
       return;
     }
@@ -460,11 +464,11 @@ export class AtomicSearchBox {
         break;
       case 'ArrowRight':
         e.preventDefault();
-        this.focusPanel(this.listRefs[1]);
+        this.focusPanel(this.rightPanelRef);
         break;
       case 'ArrowLeft':
         e.preventDefault();
-        this.focusPanel(this.listRefs[0]);
+        this.focusPanel(this.leftPanelRef);
         break;
     }
   }
@@ -596,7 +600,7 @@ export class AtomicSearchBox {
             el?.replaceChildren(item.content);
           }
         }}
-        {...(isSuggestionElement(item) && {
+        {...(hasQuery && {
           role: 'option',
           'data-query': item.query,
           'aria-selected': `${isSelected}`,
@@ -641,7 +645,7 @@ export class AtomicSearchBox {
             part="suggestions suggestions-left"
             aria-label={this.bindings.i18n.t('query-suggestion-list')}
             ref={(el) => {
-              this.listRefs[0] = el!;
+              this.leftPanelRef = el!;
             }}
             class="flex-grow"
           >
@@ -660,7 +664,7 @@ export class AtomicSearchBox {
             part="suggestions suggestions-right"
             aria-label={this.bindings.i18n.t('query-suggestion-list')}
             ref={(el) => {
-              this.listRefs[1] = el!;
+              this.rightPanelRef = el!;
             }}
             class="flex-grow"
           >

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -68,6 +68,7 @@ export class AtomicSearchBox {
   @State()
   private searchBoxState!: SearchBoxState | StandaloneSearchBoxState;
   @State() public error!: Error;
+  @State() private suggestedQuery = '';
   @State() private isExpanded = false;
   @State() private activeDescendant = '';
   @State() private previousActiveDescendantElement: HTMLLIElement | null = null;
@@ -178,6 +179,7 @@ export class AtomicSearchBox {
       isStandalone: !!this.redirectionUrl,
       searchBoxController: this.searchBox,
       numberOfQueries: this.numberOfQueries,
+      suggestedQuery: () => this.suggestedQuery,
       clearSuggestions: () => this.clearSuggestions(),
       triggerSuggestions: () => this.triggerSuggestions(),
       getSuggestions: () => this.suggestions,
@@ -585,6 +587,7 @@ export class AtomicSearchBox {
         }}
         onMouseOver={() => {
           if (isSuggestionElement(item) && item.query) {
+            this.updateActiveDescendant(id);
             this.updateSuggestedQuery(item.query);
           }
         }}
@@ -615,6 +618,7 @@ export class AtomicSearchBox {
         )
       )
     );
+    this.suggestedQuery = q;
     this.updateSuggestionElements();
   }
 

--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -586,8 +586,8 @@ export class AtomicSearchBox {
           this.clearSuggestions();
         }}
         onMouseOver={() => {
+          this.updateActiveDescendant(id);
           if (isSuggestionElement(item) && item.query) {
-            this.updateActiveDescendant(id);
             this.updateSuggestedQuery(item.query);
           }
         }}

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -3,6 +3,7 @@ import {buildInstantResults, InstantResults, Result} from '@coveo/headless';
 
 import {
   dispatchSearchBoxSuggestionsEvent,
+  cleanUpString,
   SearchBoxSuggestionItem,
   SearchBoxSuggestions,
   SearchBoxSuggestionsBindings,
@@ -41,8 +42,8 @@ export class AtomicSearchBoxRecentQueries {
     const results = this.instantResults.state.results.length
       ? this.instantResults.state.results
       : this.results;
-    return results.map((result, i) => ({
-      key: `instant-result-${i}`,
+    return results.map((result: Result) => ({
+      key: `instant-result-${cleanUpString(result.title)}`,
       query: '',
       content: <div class="flex items-center break-all">{result.title}</div>,
       onSelect: () => {

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -39,6 +39,9 @@ export class AtomicSearchBoxRecentQueries {
   }
 
   private renderItems(): SearchBoxSuggestionItem[] {
+    if (!this.bindings.suggestedQuery()) {
+      return [];
+    }
     const results = this.instantResults.state.results.length
       ? this.instantResults.state.results
       : this.results;

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -3,11 +3,11 @@ import {buildInstantResults, InstantResults, Result} from '@coveo/headless';
 
 import {
   dispatchSearchBoxSuggestionsEvent,
-  cleanUpString,
   SearchBoxSuggestionItem,
   SearchBoxSuggestions,
   SearchBoxSuggestionsBindings,
 } from '../suggestions-common';
+import {cleanUpString} from '../../../utils/string-utils';
 
 /**
  * The `atomic-search-box-instant-results` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of instant results behavior.

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -17,7 +17,7 @@ import {
   tag: 'atomic-search-box-instant-results',
   shadow: true,
 })
-export class AtomicSearchBoxRecentQueries {
+export class AtomicSearchBoxInstantResults {
   private bindings!: SearchBoxSuggestionsBindings;
 
   @Element() private host!: HTMLElement;

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
@@ -8,6 +8,7 @@ import {QuerySuggestionSection} from '@coveo/headless/dist/definitions/state/sta
 import {Component, Element, Prop, State, h} from '@stencil/core';
 import {
   dispatchSearchBoxSuggestionsEvent,
+  cleanUpString,
   SearchBoxSuggestionElement,
   SearchBoxSuggestions,
   SearchBoxSuggestionsBindings,
@@ -114,7 +115,7 @@ export class AtomicSearchBoxQuerySuggestions {
           )}
         </div>
       ),
-      key: `qs-${suggestion.rawValue}`,
+      key: `qs-${cleanUpString(suggestion.rawValue)}`,
       query: suggestion.rawValue,
       onSelect: () => {
         this.bindings.searchBoxController.selectSuggestion(suggestion.rawValue);

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
@@ -8,11 +8,11 @@ import {QuerySuggestionSection} from '@coveo/headless/dist/definitions/state/sta
 import {Component, Element, Prop, State, h} from '@stencil/core';
 import {
   dispatchSearchBoxSuggestionsEvent,
-  cleanUpString,
   SearchBoxSuggestionElement,
   SearchBoxSuggestions,
   SearchBoxSuggestionsBindings,
 } from '../suggestions-common';
+import {cleanUpString} from '../../../utils/string-utils';
 
 /**
  * The `atomic-search-box-query-suggestions` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of query suggestion behavior.

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -7,6 +7,7 @@ import {
 import {Component, Element, Prop, State, h} from '@stencil/core';
 import {
   dispatchSearchBoxSuggestionsEvent,
+  cleanUpString,
   SearchBoxDividerElement,
   SearchBoxSuggestionElement,
   SearchBoxSuggestionItem,
@@ -156,7 +157,7 @@ export class AtomicSearchBoxRecentQueries {
   private renderItem(value: string): SearchBoxSuggestionElement {
     const query = this.bindings.searchBoxController.state.value;
     return {
-      key: `recent-${value}`,
+      key: `recent-${cleanUpString(value)}`,
       query: value,
       content: (
         <div class="flex items-center break-all">

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -7,7 +7,6 @@ import {
 import {Component, Element, Prop, State, h} from '@stencil/core';
 import {
   dispatchSearchBoxSuggestionsEvent,
-  cleanUpString,
   SearchBoxDividerElement,
   SearchBoxSuggestionElement,
   SearchBoxSuggestionItem,
@@ -16,6 +15,7 @@ import {
 } from '../suggestions-common';
 import {once} from '../../../utils/utils';
 import {SafeStorage, StorageItems} from '../../../utils/local-storage-utils';
+import {cleanUpString} from '../../../utils/string-utils';
 
 /**
  * The `atomic-search-box-recent-queries` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of recent query suggestions.

--- a/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
@@ -38,9 +38,10 @@ export interface SearchBoxSuggestionsBindings extends Bindings {
   isStandalone: boolean;
   searchBoxController: SearchBox;
   numberOfQueries: number;
+  suggestedQuery(): string;
   clearSuggestions(): void;
   triggerSuggestions(): void;
-  getSuggestions: () => SearchBoxSuggestions[];
+  getSuggestions(): SearchBoxSuggestions[];
 }
 
 export const dispatchSearchBoxSuggestionsEvent = (

--- a/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
@@ -72,11 +72,3 @@ export function isDividerElement(
 ): el is SearchBoxDividerElement {
   return !('query' in el);
 }
-
-export function cleanUpString(str: string) {
-  return str
-    .match(/(\d|\w|\s)+/g)
-    ?.join('')
-    .replace(/\s/g, '-')
-    .toLocaleLowerCase();
-}

--- a/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/search-box-suggestions/suggestions-common.ts
@@ -71,3 +71,11 @@ export function isDividerElement(
 ): el is SearchBoxDividerElement {
   return !('query' in el);
 }
+
+export function cleanUpString(str: string) {
+  return str
+    .match(/(\d|\w|\s)+/g)
+    ?.join('')
+    .replace(/\s/g, '-')
+    .toLocaleLowerCase();
+}

--- a/packages/atomic/src/utils/string-utils.ts
+++ b/packages/atomic/src/utils/string-utils.ts
@@ -1,3 +1,11 @@
 export function regexEncode(value: string): string {
   return value.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
 }
+
+export function cleanUpString(str: string) {
+  return str
+    .match(/(\d|\w|\s)+/g)
+    ?.join('')
+    .replace(/\s/g, '-')
+    .toLocaleLowerCase();
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1689

Here is a video of the navigation:
https://user-images.githubusercontent.com/30511433/171474146-ae9f7c88-a972-4d83-bdd6-3c57445f0f19.mov

A few screenshots of the aria stuff for ease of review:
`combobox` input
<img width="1187" alt="Screenshot 2022-06-01 at 15 17 57" src="https://user-images.githubusercontent.com/30511433/171474649-0e80ff60-5ec6-4ce6-baae-675ecf8a7f3e.png">
`listbox` div
<img width="1223" alt="Screenshot 2022-06-01 at 15 18 44" src="https://user-images.githubusercontent.com/30511433/171474769-a79a7f99-7daa-4d50-8767-cafd7c57e91c.png">

`option` list item when there is a query, default value (listitem?) when there isn't one, which includes dividers (`query === undefined`) and instant results (`query === ''`)
<img width="1295" alt="Screenshot 2022-06-01 at 15 20 02" src="https://user-images.githubusercontent.com/30511433/171475022-19872385-154e-4ab1-9db3-05ab6abfe805.png">
<img width="1386" alt="Screenshot 2022-06-01 at 15 20 41" src="https://user-images.githubusercontent.com/30511433/171475118-3dddb495-db86-41d7-884d-d7a4ffe65c7b.png">

