### PR TITLE
fix(headless): restoreSearchParameters action deletes the unselected values of the standard facet

### DIFF
--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -580,13 +580,21 @@ describe('facet-set slice', () => {
     it(`when a facet is found in the #f payload,
     it sets #currentValues to the selected values in the payload`, () => {
       const facetId = 'author';
-      state[facetId] = buildMockFacetRequest();
-
+      const valueA = buildMockFacetValueRequest({value: 'a'});
+      const valueB = buildMockFacetValueRequest({value: 'b'});
+      state[facetId] = buildMockFacetRequest({
+        currentValues: [valueA, valueB],
+      });
       const f = {[facetId]: ['a']};
       const finalState = facetSetReducer(state, restoreSearchParameters({f}));
-
-      const value = buildMockFacetValueRequest({value: 'a', state: 'selected'});
-      expect(finalState[facetId].currentValues).toEqual([value]);
+      const selectedValue = buildMockFacetValueRequest({
+        value: 'a',
+        state: 'selected',
+      });
+      expect(finalState[facetId].currentValues).toEqual([
+        selectedValue,
+        valueB,
+      ]);
     });
 
     it(`when the number of values in the payload is greater than the number of values on the request,
@@ -612,12 +620,14 @@ describe('facet-set slice', () => {
     });
 
     it(`when a facet is not found in the #f payload,
-    it deselects all values by setting #currentValues to an empty array`, () => {
+    it deselects all values by setting the state of each facet value in #currentValues to idle`, () => {
       const currentValues = [buildMockFacetValueRequest({state: 'selected'})];
       state['author'] = buildMockFacetRequest({currentValues});
 
       const finalState = facetSetReducer(state, restoreSearchParameters({}));
-      expect(finalState['author'].currentValues).toEqual([]);
+      expect(finalState['author'].currentValues).toEqual([
+        buildMockFacetValueRequest(),
+      ]);
     });
 
     it('sets #preventAutoSelect to true on facets with at least one value selected', () => {

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -62,12 +62,18 @@ export const facetSetReducer = createReducer(
 
         facetIds.forEach((id) => {
           const request = state[id];
-          const values = f[id] || [];
+          const selectedValues = f[id] || [];
+          const unselectedValues = request.currentValues.filter(
+            (facetValue) => !selectedValues.includes(facetValue.value)
+          );
 
-          request.currentValues = values.map(buildSelectedFacetValueRequest);
-          request.preventAutoSelect = values.length > 0;
+          request.currentValues = [
+            ...selectedValues.map(buildSelectedFacetValueRequest),
+            ...unselectedValues.map(buildUnselectedFacetValueRequest),
+          ];
+          request.preventAutoSelect = selectedValues.length > 0;
           request.numberOfValues = Math.max(
-            values.length,
+            selectedValues.length,
             request.numberOfValues
           );
         });
@@ -268,4 +274,10 @@ export function convertFacetValueToRequest(
 
 function buildSelectedFacetValueRequest(value: string): FacetValueRequest {
   return {value, state: 'selected'};
+}
+
+function buildUnselectedFacetValueRequest(
+  facetValue: FacetValueRequest
+): FacetValueRequest {
+  return {...facetValue, state: 'idle'};
 }


### PR DESCRIPTION
The goal of this PR is to figure out if the behaviour I will describe in this description is a bug or not and to answer the following question: **Why when we restore the search parameters we only set the selected facet values and we ignore the unselected values in the facet-set?**

### The problem:
After executing the first search,  building a url manager controller and selecting a value from a standard facet is causing the deletion of all the other values in this standard facet.

https://user-images.githubusercontent.com/86681870/172202709-d1b8849d-2aec-4957-987d-ca30518d61ce.mov

**Why this is happening?**

This is happening because of the following two steps:

1. Building a url manager controller:
When  building a url manager controller by calling `buildUrlManager` we also build a search parameter manager by calling `buildSearchParameterManager`.
When executing `buildSearchParameterManager` we dispatch a `restoreSearchParameters` action.
In [facet-set-slice.ts](https://github.com/coveo/ui-kit/blob/af7d9c59d3d11a682dbac22260c715d9b2667f21/packages/headless/src/features/facets/facet-set/facet-set-slice.ts#L59-L74)  we can see the code executed when this action is dispatched.
We set `state[facetId].currentValues `to the list of selected values. If there is no selected values `state[facetId].currentValues` will be an empty array.

2. Selecting a value from the standard facet:
When selecting a value from a standard value the `toggleSelectFacetValue` action is dispatched. you can find [here](https://github.com/coveo/ui-kit/blob/af7d9c59d3d11a682dbac22260c715d9b2667f21/packages/headless/src/features/facets/facet-set/facet-set-slice.ts#L75-L96) the code executed when this action is executed.
We first check if the facet value selected exists in the `state[facetId].currentValues`.
Since in step 1 we saw that `state[facetId].currentValues`  is an empty array now because of the `restoreSearchParameters action` the selected value will not be found so we enter to this [if block](https://github.com/coveo/ui-kit/blob/af7d9c59d3d11a682dbac22260c715d9b2667f21/packages/headless/src/features/facets/facet-set/facet-set-slice.ts#L88) and we just insert the selected value which will result the behaviour shown in the screen recording above.


### The potential fix if this a bug:
I just updated the piece of code executed when the `restoreSearchParameters` action is dispatched in facet-set-slice.ts. 
The update is to indeed affect the selected values to `state[facetId].currentValues` but also to keep the unselectedValues.
After all thats the goal of the restoreSearchParameters action, just to update the selected facet values, right?


https://user-images.githubusercontent.com/86681870/172207978-3091089d-125a-47c7-832c-71b7e7c146ec.mov



