### PR TITLE
docs(headless): used location.replace instead of assign in redirect trigger doc

### DIFF
--- a/packages/samples/headless-react/src/components/triggers/redirection-trigger.class.tsx
+++ b/packages/samples/headless-react/src/components/triggers/redirection-trigger.class.tsx
@@ -29,7 +29,7 @@ export class RedirectionTrigger extends Component<{}, RedirectionTriggerState> {
       if (!this.controller.state.redirectTo) {
         return;
       }
-      window.location.href = this.controller.state.redirectTo;
+      window.location.replace(this.controller.state.redirectTo);
     });
   }
 

--- a/packages/samples/headless-react/src/components/triggers/redirection-trigger.fn.tsx
+++ b/packages/samples/headless-react/src/components/triggers/redirection-trigger.fn.tsx
@@ -17,7 +17,7 @@ export const RedirectionTrigger: FunctionComponent<
   const redirect = () => {
     setState(props.controller.state);
     if (state.redirectTo) {
-      window.location.href = controller.state.redirectTo!;
+      window.location.replace(controller.state.redirectTo);
     }
   };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1702

When testing in both Atomic and the headless-react sample, I noticed that using `location.href =` (equivalent of `location.assign()` caused a redirection to happen after the query was added to the URL, causing the back button to redirect us forward again whenever we press it.

I checked, and JSUI uses `location.assign`.