### PR TITLE
fix: temporarily force git tags

### DIFF
--- a/scripts/deploy/bump-version.js
+++ b/scripts/deploy/bump-version.js
@@ -19,7 +19,7 @@ async function checkoutLatestMaster() {
 async function bumpVersionAndPush() {
   try {
     await exec(
-      `npx lerna version --conventional-commits --conventional-graduate --no-private --yes --exact`
+      `npx lerna version --conventional-commits --conventional-graduate --no-private --yes --exact --force-git-tag`
     );
   } catch (e) {
     console.error(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1719

Because of previous failures of last week, the tags were updated but the package not published, we need to temporarily override these tags https://github.com/coveo/ui-kit/runs/6865381088?check_suite_focus=true
I'll revert this right after