### PR TITLE
fix(atomic): hide instant results on mobile on page resize

### DIFF
--- a/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/atomic-search-box/atomic-search-box.tsx
@@ -661,20 +661,19 @@ export class AtomicSearchBox {
   }
 
   private async updateSuggestedQuery(suggestedQuery: string) {
-    if (!isMobile(this.bindings.store)) {
-      await Promise.allSettled(
-        this.suggestions.map((suggestion) =>
-          promiseTimeout(
-            suggestion.onSuggestedQueryChange
-              ? suggestion.onSuggestedQueryChange(suggestedQuery)
-              : Promise.resolve(),
-            this.suggestionTimeout
-          )
+    const query = isMobile(this.bindings.store) ? '' : suggestedQuery;
+    await Promise.allSettled(
+      this.suggestions.map((suggestion) =>
+        promiseTimeout(
+          suggestion.onSuggestedQueryChange
+            ? suggestion.onSuggestedQueryChange(query)
+            : Promise.resolve(),
+          this.suggestionTimeout
         )
-      );
-      this.suggestedQuery = suggestedQuery;
-      this.updateSuggestionElements(suggestedQuery);
-    }
+      )
+    );
+    this.suggestedQuery = query;
+    this.updateSuggestionElements(query);
   }
 
   private renderPanel(

--- a/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -26,6 +26,7 @@ import {
   ResultDisplayLayout,
 } from '../../atomic-result/atomic-result-display-options';
 import {Button} from '../../common/button';
+import {isMobile} from '../../../utils/store';
 
 /**
  * The `atomic-search-box-instant-results` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of instant results behavior.
@@ -93,7 +94,7 @@ export class AtomicSearchBoxInstantResults implements BaseResultList {
   }
 
   private renderItems(): SearchBoxSuggestionElement[] {
-    if (!this.bindings.suggestedQuery()) {
+    if (!this.bindings.suggestedQuery() || isMobile(this.bindings.store)) {
       return [];
     }
     const results = this.instantResults.state.results.length


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1750

This is what happens when you start already on mobile (because I don't update the suggested query when on mobile, no results ever show)
https://user-images.githubusercontent.com/30511433/174060378-fb951f15-910a-427f-be0e-0da3475fe297.mov

However when you resize to mobile, we currently don't update the suggested query, which means that the render function in instant results still shows results for it.
https://user-images.githubusercontent.com/30511433/174060458-05678805-f3cc-495a-862b-2acc92c10762.mov

So I did two things here: update the state of the search box for mobile (clearing the suggested query), but also make sure that the render function doesn't return anything for mobile

