### PR TITLE
fix(headless): prevent facetSearch from being sent in the search request

### DIFF
--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
@@ -35,7 +35,6 @@ import {
   search,
   facetOptions,
 } from '../../../../app/reducers';
-import {defaultFacetSearchOptions} from '../../../../features/facets/facet-search-set/facet-search-reducer-helpers';
 
 describe('category facet', () => {
   const facetId = '1';
@@ -94,7 +93,6 @@ describe('category facet', () => {
   it('registers a category facet with the passed options and default optional parameters', () => {
     const action = registerCategoryFacet({
       ...defaultCategoryFacetOptions,
-      facetSearch: {...defaultFacetSearchOptions},
       ...options,
       facetId,
     });

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
@@ -46,6 +46,7 @@ import {defaultFacetSearchOptions} from '../../../../features/facets/facet-searc
 import {CoreEngine} from '../../../../app/engine';
 import {isFacetLoadingResponseSelector} from '../../../../features/facets/facet-set/facet-set-selectors';
 import {isFacetEnabledSelector} from '../../../../features/facet-options/facet-options-selectors';
+import {omit} from '../../../../utils/utils';
 
 export type {
   CategoryFacetValue,
@@ -265,11 +266,15 @@ export function buildCoreCategoryFacet(
   const {dispatch} = engine;
 
   const facetId = determineFacetId(engine, props.options);
-  const options: Required<CategoryFacetOptions> = {
-    facetSearch: {...defaultFacetSearchOptions},
+  const registrationOptions = {
     ...defaultCategoryFacetOptions,
-    ...props.options,
+    ...omit('facetSearch', props.options),
+    field: props.options.field,
     facetId,
+  };
+  const options: Required<CategoryFacetOptions> = {
+    facetSearch: {...defaultFacetSearchOptions, ...props.options.facetSearch},
+    ...registrationOptions,
   };
 
   validateOptions(
@@ -290,7 +295,7 @@ export function buildCoreCategoryFacet(
   const getIsLoading = () => isFacetLoadingResponseSelector(engine.state);
   const getIsEnabled = () => isFacetEnabledSelector(engine.state, facetId);
 
-  dispatch(registerCategoryFacet(options));
+  dispatch(registerCategoryFacet(registrationOptions));
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
@@ -90,7 +90,8 @@ describe('facet', () => {
 
   it('registers a facet with the passed options and the default values of unspecified options', () => {
     const action = registerFacet({
-      ...options,
+      field: 'author',
+      sortCriteria: 'score',
       facetId,
       delimitingCharacter: '>',
       filterFacetCount: true,

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
@@ -50,6 +50,7 @@ import {loadReducerError} from '../../../../utils/errors';
 import {CoreEngine} from '../../../../app/engine';
 import {SearchThunkExtraArguments} from '../../../../app/search-thunk-extra-arguments';
 import {isFacetEnabledSelector} from '../../../../features/facet-options/facet-options-selectors';
+import {omit} from '../../../../utils/utils';
 
 export type {FacetOptions, FacetSearchOptions, FacetValueState};
 
@@ -298,11 +299,15 @@ export function buildCoreFacet(
   const controller = buildController(engine);
 
   const facetId = determineFacetId(engine, props.options);
-  const options: Required<FacetOptions> = {
-    facetSearch: {...defaultFacetSearchOptions},
+  const registrationOptions = {
     ...defaultFacetOptions,
-    ...props.options,
+    ...omit('facetSearch', props.options),
+    field: props.options.field,
     facetId,
+  };
+  const options: Required<FacetOptions> = {
+    facetSearch: {...defaultFacetSearchOptions, ...props.options.facetSearch},
+    ...registrationOptions,
   };
 
   validateOptions(engine, optionsSchema, options, 'buildFacet');
@@ -325,7 +330,7 @@ export function buildCoreFacet(
     return initialNumberOfValues < currentValues.length && hasIdleValues;
   };
 
-  dispatch(registerFacet(options));
+  dispatch(registerFacet(registrationOptions));
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.test.ts
@@ -39,7 +39,6 @@ import {
   configuration,
   search,
 } from '../../../app/reducers';
-import {defaultFacetSearchOptions} from '../../../features/facets/facet-search-set/facet-search-reducer-helpers';
 
 describe('category facet', () => {
   const facetId = '1';
@@ -97,7 +96,6 @@ describe('category facet', () => {
   it('registers a category facet with the passed options and default optional parameters', () => {
     const action = registerCategoryFacet({
       ...defaultCategoryFacetOptions,
-      facetSearch: {...defaultFacetSearchOptions},
       ...options,
       facetId,
     });

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -96,7 +96,8 @@ describe('facet', () => {
 
   it('registers a facet with the passed options and the default values of unspecified options', () => {
     const action = registerFacet({
-      ...options,
+      field: 'author',
+      sortCriteria: 'score',
       facetId,
       delimitingCharacter: '>',
       filterFacetCount: true,

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.test.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.test.ts
@@ -59,7 +59,8 @@ describe('facet', () => {
 
   it('registers a facet with the passed options and the default values of unspecified options', () => {
     const action = registerFacet({
-      ...options,
+      field: 'author',
+      sortCriteria: 'score',
       facetId,
       delimitingCharacter: '>',
       filterFacetCount: true,

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -34,3 +34,8 @@ export function encodedBtoa(stringToEncode: string) {
     encodeURI(stringToEncode)
   )!;
 }
+
+export function omit<T>(key: keyof T, obj: T) {
+  const {[key]: omitted, ...rest} = obj;
+  return rest;
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1753

I noticed that when investigating a maintenance case. IMO we shouldn't send parameters that aren't supposed to be there... What if one day facetSearch is an actual param? Would all the headless request instantly fail? Anyways that was my reasoning for this change 😄 