### PR TITLE
ci: move snyk certifiers to staging

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -214,7 +214,7 @@
   },
   "deployment_config_version": 2,
   "certifiers": {
-    "dev": [
+    "stg": [
       {
         "system_certifier": "snyk"
       },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1768

It fails often cause npm versions aren't available yet