### PR TITLE
docs(atomic): order stories by ID length

### DIFF
--- a/packages/atomic/.storybook/preview.js
+++ b/packages/atomic/.storybook/preview.js
@@ -22,6 +22,11 @@ export const decorators = [
 ];
 
 export const parameters = {
+  options: {
+    storySort: (firstStory, secondStory) => {
+      return firstStory[1].id.length - secondStory[1].id.length >= 0;
+    },
+  },
   controls: {expanded: true, hideNoControlsWarning: true},
   a11y: {
     element: 'atomic-search-interface',
@@ -33,7 +38,7 @@ export const parameters = {
   },
   previewTabs: {
     'storybook/docs/panel': {
-      hidden: true
-    }
-  }
+      hidden: true,
+    },
+  },
 };


### PR DESCRIPTION
Kind of a hack-ish fix for the problem we've had with storybook and atomic-smart-snippet, discussed internally on slack.

Essentially, when loading a story from the documentation website with `?path=/story/atomic-smart-snippet`, we end up loading `?path=/story/atomic-smart-snippet-suggestions--default-smart-snippet-suggestions` instead.

The root cause is that the full story identifier in Storybook is the component name (`atomic-smart-snippet`) + the story name itself (`default-smart-snippet`). Full ID to exactly load this story then becomes `atomic-smart-snippet--default-smart-snippet`. 

I first tried to make it so that the full ID is only the component name (ie: `atomic-smart-snippet`). I was not able to achieve this, and did not find anything in Storybook API that will allow that.

Instead I found out how Storybook internally "decides" which story to load when the ID is incomplete. It relies on a substring match on the list of sorted stories. And since `atomic-smart-snippet` matches for `atomic-smart-snippet-suggestions`, it's the one that gets picked.

By making the stories sorted by name length, then we know we always end up with the "exact" component name first.

🤷 

https://coveord.atlassian.net/browse/KIT-1766