### PR TITLE
fix(atomic): hid modals when they were never opened

### DIFF
--- a/packages/atomic/src/components/search/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-modal/atomic-modal.tsx
@@ -136,7 +136,7 @@ export class AtomicModal implements InitializableComponent {
               part="container"
               class={`flex flex-col justify-between bg-background text-on-background ${
                 this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
-              } ${this.wasEverOpened ? '' : 'animation-skip'}`}
+              } ${this.wasEverOpened ? '' : 'invisible'}`}
               onAnimationEnd={() => this.animationEnded.emit()}
               ref={(ref) => (this.animatableContainer = ref)}
             >

--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -117,9 +117,4 @@
     @apply shadow;
     --tw-shadow: 0px -2px 8px rgba(229, 232, 232, 0.75);
   }
-
-  .animation-skip {
-    animation-duration: 0s;
-    animation-fill-mode: forwards;
-  }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1778

There was a glitch when opening the dev tools and closing them which showed the top of the refine modal at the bottom of the screen.