### PR TITLE
feat(atomic): additional control over outgoing i18n locales requests

### DIFF
--- a/packages/atomic/cypress/integration/search-interface.cypress.ts
+++ b/packages/atomic/cypress/integration/search-interface.cypress.ts
@@ -60,7 +60,7 @@ describe('Search Interface Component', () => {
 
     it('should default back to english when language unavailable', () => {
       setLanguageAndWait('fr');
-      setLanguageAndWait('nope');
+      setLanguage('jo');
 
       QuerySummarySelectors.text().should('contain', 'Results');
     });
@@ -69,12 +69,28 @@ describe('Search Interface Component', () => {
       setLanguageAndWait('es-ES');
 
       QuerySummarySelectors.text().should('contain', 'Resultados');
+      cy.get(TestFixture.consoleAliases.error).should('not.be.called');
+    });
+
+    it('should not log an error to the console when fetching non-existing languages', () => {
+      setLanguageAndWait('es-ES');
+      setLanguage('jo');
+
+      cy.get(TestFixture.consoleAliases.error).should('not.be.called');
     });
 
     it('should work with lowercase regions', () => {
       setLanguageAndWait('zh-tw');
 
       QuerySummarySelectors.text().should('contain', '結果數');
+    });
+
+    it('should support adding a non-existing language', () => {
+      setTranslation('jo', 'showing-results-of', 'hello');
+      setLanguage('jo');
+      cy.wait(200);
+
+      QuerySummarySelectors.text().should('contain', 'hello');
     });
 
     it('should support changing a translation value without overriding other strings', () => {

--- a/packages/atomic/scripts/copy-dayjs-locales.js
+++ b/packages/atomic/scripts/copy-dayjs-locales.js
@@ -1,9 +1,7 @@
 const util = require('util');
 const fs = require('fs');
-const rm = util.promisify(fs.rm);
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
-const mkdir = util.promisify(fs.mkdir);
 
 function getI18nLocaleKey(key) {
   if (!key.includes('-')) {
@@ -30,8 +28,6 @@ async function copyDayjsLocales() {
 
   const generatedPath = 'src/generated';
   const dayjsLocaleDataPath = `${generatedPath}/dayjs-locales-data.ts`;
-  await rm(generatedPath, {recursive: true, force: true});
-  await mkdir(generatedPath);
   await writeFile(dayjsLocaleDataPath, fileContent);
 }
 

--- a/packages/atomic/scripts/create-generated-folder.js
+++ b/packages/atomic/scripts/create-generated-folder.js
@@ -1,0 +1,12 @@
+const util = require('util');
+const fs = require('fs');
+const rm = util.promisify(fs.rm);
+const mkdir = util.promisify(fs.mkdir);
+
+async function createGeneratedFolder() {
+  const generatedPath = 'src/generated';
+  await rm(generatedPath, {recursive: true, force: true});
+  await mkdir(generatedPath);
+}
+
+createGeneratedFolder();

--- a/packages/atomic/scripts/split-locales.js
+++ b/packages/atomic/scripts/split-locales.js
@@ -37,6 +37,20 @@ async function splitLocales() {
       JSON.stringify(localeData)
     );
   });
+
+  saveAvailableLocales(localesMap);
+}
+
+async function saveAvailableLocales(localesMap) {
+  const generatedPath = 'src/generated';
+  const localesArray = Object.entries(localesMap).map(
+    ([localeKey]) => localeKey.toLowerCase()
+  );
+
+  await writeFile(
+    `${generatedPath}/availableLocales.json`,
+    JSON.stringify(localesArray)
+  );
 }
 
 splitLocales();

--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -6,6 +6,7 @@
     "experimentalDecorators": true,
     "lib": ["dom", "es2020"],
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "module": "esnext",
     // create-react-app compatibility
     // https://github.com/facebook/create-react-app/issues/9468#issuecomment-692963920


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1773

I'll merge this one after https://github.com/coveo/ui-kit/pull/2140 not to cause you too much issues @olamothe 

Basically this PR allows us to do 2 things:
1. Not request locales files (e.g. en.json) which we know we don't have (new script to pull all available locales in a json at build time)
2. Not request locales files for other namespace than the "translation" one which is the default (we we're doing it for other namespaces such as caption-filetype)