### PR TITLE
feat(headless): add insight numeric facet

### DIFF
--- a/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-facet.test.ts
@@ -1,0 +1,172 @@
+import {
+  NumericFacet,
+  buildInsightNumericFacet,
+  NumericFacetOptions,
+} from './headless-insight-numeric-facet';
+import {
+  MockInsightEngine,
+  buildMockInsightEngine,
+} from '../../../../../test/mock-engine';
+import {
+  deselectAllNumericFacetValues,
+  toggleSelectNumericFacetValue,
+} from '../../../../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
+import {buildMockNumericFacetValue} from '../../../../../test/mock-numeric-facet-value';
+import {buildMockNumericFacetRequest} from '../../../../../test/mock-numeric-facet-request';
+import {updateFacetOptions} from '../../../../../features/facet-options/facet-options-actions';
+import {NumericFacetValue} from '../../../../../features/facets/range-facets/numeric-facet-set/interfaces/response';
+import {deselectAllFacetValues} from '../../../../../features/facets/facet-set/facet-set-actions';
+import {updateRangeFacetSortCriterion} from '../../../../../features/facets/range-facets/generic/range-facet-actions';
+import {InsightAppState} from '../../../../../state/insight-app-state';
+import {buildMockInsightState} from '../../../../../test/mock-insight-state';
+import {executeSearch} from '../../../../../features/insight-search/insight-search-actions';
+
+describe('insight numeric facet', () => {
+  const facetId = '1';
+  let options: NumericFacetOptions;
+  let state: InsightAppState;
+  let engine: MockInsightEngine;
+  let numericFacet: NumericFacet;
+
+  function initNumericFacet() {
+    engine = buildMockInsightEngine({state});
+    numericFacet = buildInsightNumericFacet(engine, {options});
+  }
+
+  beforeEach(() => {
+    options = {
+      facetId,
+      field: 'created',
+      generateAutomaticRanges: true,
+    };
+
+    state = buildMockInsightState();
+    state.numericFacetSet[facetId] = buildMockNumericFacetRequest();
+
+    initNumericFacet();
+  });
+
+  describe('#toggleSelect', () => {
+    it('dispatches a toggleSelectNumericFacetValue with the passed value', () => {
+      const value = buildMockNumericFacetValue();
+      numericFacet.toggleSelect(value);
+
+      const action = toggleSelectNumericFacetValue({facetId, selection: value});
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('dispatches a search', () => {
+      const value = buildMockNumericFacetValue();
+      numericFacet.toggleSelect(value);
+
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+      expect(action).toBeTruthy();
+    });
+  });
+
+  describe('#deselectAll', () => {
+    beforeEach(() => numericFacet.deselectAll());
+
+    it('dispatches #deselectAllFacetValues with the facet id', () => {
+      expect(engine.actions).toContainEqual(deselectAllFacetValues(facetId));
+    });
+
+    it('dispatches a #updateFacetOptions action with #freezeFacetOrder true', () => {
+      expect(engine.actions).toContainEqual(
+        updateFacetOptions({freezeFacetOrder: true})
+      );
+    });
+
+    it('dispatches a search', () => {
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+
+      expect(engine.actions).toContainEqual(action);
+    });
+  });
+
+  describe('#sortBy', () => {
+    it('dispatches #updateRangeFacetSortCriterion', () => {
+      const criterion = 'descending';
+      numericFacet.sortBy(criterion);
+      const action = updateRangeFacetSortCriterion({facetId, criterion});
+
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('dispatches a #updateFacetOptions action with #freezeFacetOrder true', () => {
+      numericFacet.sortBy('descending');
+
+      expect(engine.actions).toContainEqual(
+        updateFacetOptions({freezeFacetOrder: true})
+      );
+    });
+
+    it('dispatches a search', () => {
+      numericFacet.sortBy('descending');
+
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+      expect(action).toBeTruthy();
+    });
+  });
+
+  function testCommonToggleSingleSelect(facetValue: () => NumericFacetValue) {
+    it('dispatches a #toggleSelect action with the passed facet value', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).toContainEqual(
+        toggleSelectNumericFacetValue({facetId, selection: facetValue()})
+      );
+    });
+
+    it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).toContainEqual(
+        updateFacetOptions({freezeFacetOrder: true})
+      );
+    });
+
+    it('dispatches a search', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+      expect(action).toBeTruthy();
+    });
+  }
+
+  describe('#toggleSingleSelect when the value state is "idle"', () => {
+    const facetValue = () => buildMockNumericFacetValue({state: 'idle'});
+
+    testCommonToggleSingleSelect(facetValue);
+
+    it('dispatches a #deselectAllFacetValues action', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).toContainEqual(
+        deselectAllNumericFacetValues(facetId)
+      );
+    });
+  });
+
+  describe('#toggleSingleSelect when the value state is not "idle"', () => {
+    const facetValue = () => buildMockNumericFacetValue({state: 'selected'});
+
+    testCommonToggleSingleSelect(facetValue);
+
+    it('does not dispatch a #deselectAllFacetValues action', () => {
+      numericFacet.toggleSingleSelect(facetValue());
+
+      expect(engine.actions).not.toContainEqual(
+        deselectAllNumericFacetValues(facetId)
+      );
+    });
+  });
+});

--- a/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-facet.ts
+++ b/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-facet.ts
@@ -1,0 +1,101 @@
+import {NumericRangeRequest} from '../../../../../features/facets/range-facets/numeric-facet-set/interfaces/request';
+import {NumericFacetValue} from '../../../../../features/facets/range-facets/numeric-facet-set/interfaces/response';
+import {
+  ConfigurationSection,
+  NumericFacetSection,
+  SearchSection,
+} from '../../../../../state/state-sections';
+import {
+  configuration,
+  numericFacetSet,
+  search,
+} from '../../../../../app/reducers';
+import {loadReducerError} from '../../../../../utils/errors';
+import {getAnalyticsActionForToggleRangeFacetSelect} from '../../../../../features/facets/range-facets/generic/range-facet-utils';
+import {
+  buildCoreNumericFacet,
+  buildNumericRange,
+  NumericFacet,
+  NumericFacetOptions,
+  NumericFacetProps,
+  NumericFacetState,
+  NumericRangeOptions,
+} from '../../../../core/facets/range-facet/numeric-facet/headless-core-numeric-facet';
+import {RangeFacetSortCriterion} from '../../../../../features/facets/range-facets/generic/interfaces/request';
+import {InsightEngine} from '../../../../../app/insight-engine/insight-engine';
+import {executeSearch} from '../../../../../features/insight-search/insight-search-actions';
+import {
+  logFacetClearAll,
+  logFacetUpdateSort,
+} from '../../../../../features/facets/facet-set/facet-set-insight-analytics-actions';
+
+export type {
+  NumericRangeOptions,
+  NumericRangeRequest,
+  NumericFacetValue,
+  NumericFacetOptions,
+  NumericFacetProps,
+  NumericFacet,
+  NumericFacetState,
+};
+export {buildNumericRange};
+
+/**
+ * Creates a `NumericFacet` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `NumericFacet` properties.
+ * @returns A `NumericFacet` controller instance.
+ */
+export function buildInsightNumericFacet(
+  engine: InsightEngine,
+  props: NumericFacetProps
+): NumericFacet {
+  if (!loadNumericFacetReducers(engine)) {
+    throw loadReducerError;
+  }
+
+  const coreController = buildCoreNumericFacet(engine, props);
+  const dispatch = engine.dispatch;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+
+    deselectAll() {
+      coreController.deselectAll();
+      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+    },
+
+    sortBy(criterion: RangeFacetSortCriterion) {
+      coreController.sortBy(criterion);
+      dispatch(
+        executeSearch(logFacetUpdateSort({facetId: getFacetId(), criterion}))
+      );
+    },
+
+    toggleSelect: (selection: NumericFacetValue) => {
+      coreController.toggleSelect(selection);
+      dispatch(
+        executeSearch(
+          getAnalyticsActionForToggleRangeFacetSelect(getFacetId(), selection)
+        )
+      );
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+      };
+    },
+  };
+}
+
+function loadNumericFacetReducers(
+  engine: InsightEngine
+): engine is InsightEngine<
+  NumericFacetSection & ConfigurationSection & SearchSection
+> {
+  engine.addReducers({numericFacetSet, configuration, search});
+  return true;
+}

--- a/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-filter.test.ts
+++ b/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-filter.test.ts
@@ -1,0 +1,99 @@
+import {buildMockNumericFacetRequest} from '../../../../../test/mock-numeric-facet-request';
+import {
+  buildInsightNumericFilter,
+  NumericFilter,
+  NumericFilterInitialState,
+  NumericFilterOptions,
+} from './headless-insight-numeric-filter';
+import {updateNumericFacetValues} from '../../../../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
+import {buildMockNumericFacetValue} from '../../../../../test/mock-numeric-facet-value';
+import {updateFacetOptions} from '../../../../../features/facet-options/facet-options-actions';
+import {
+  buildMockInsightEngine,
+  MockInsightEngine,
+} from '../../../../../test/mock-engine';
+import {InsightAppState} from '../../../../../state/insight-app-state';
+import {buildMockInsightState} from '../../../../../test/mock-insight-state';
+import {executeSearch} from '../../../../../features/insight-search/insight-search-actions';
+
+describe('insight numeric filter', () => {
+  const facetId = '1';
+  let options: NumericFilterOptions;
+  let initialState: NumericFilterInitialState | undefined;
+  let state: InsightAppState;
+  let engine: MockInsightEngine;
+  let numericFacet: NumericFilter;
+
+  function initNumericFilter() {
+    engine = buildMockInsightEngine({state});
+    numericFacet = buildInsightNumericFilter(engine, {options, initialState});
+  }
+
+  beforeEach(() => {
+    initialState = undefined;
+
+    options = {
+      facetId,
+      field: 'created',
+    };
+
+    state = buildMockInsightState();
+    state.numericFacetSet[facetId] = buildMockNumericFacetRequest();
+
+    initNumericFilter();
+  });
+
+  describe('#setRange', () => {
+    it('dispatches a updateNumericFacetValues with the passed value', () => {
+      const value = buildMockNumericFacetValue({});
+      numericFacet.setRange(value);
+
+      const action = updateNumericFacetValues({
+        facetId,
+        values: [
+          {
+            ...value,
+            state: 'selected',
+            numberOfResults: 0,
+            endInclusive: true,
+          },
+        ],
+      });
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('dispatches a search', () => {
+      const value = buildMockNumericFacetValue();
+      numericFacet.setRange(value);
+
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+      expect(action).toBeTruthy();
+    });
+  });
+
+  describe('#clear', () => {
+    beforeEach(() => numericFacet.clear());
+
+    it('dispatches #updateNumericFacetValues with the facet id and an empty array', () => {
+      expect(engine.actions).toContainEqual(
+        updateNumericFacetValues({facetId, values: []})
+      );
+    });
+
+    it('dispatches a #updateFacetOptions action with #freezeFacetOrder true', () => {
+      expect(engine.actions).toContainEqual(
+        updateFacetOptions({freezeFacetOrder: true})
+      );
+    });
+
+    it('dispatches a search', () => {
+      const action = engine.actions.find(
+        (a) => a.type === executeSearch.pending.type
+      );
+
+      expect(engine.actions).toContainEqual(action);
+    });
+  });
+});

--- a/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-filter.ts
+++ b/packages/headless/src/controllers/insight/facets/range-facet/numeric-facet/headless-insight-numeric-filter.ts
@@ -1,0 +1,92 @@
+import {
+  ConfigurationSection,
+  NumericFacetSection,
+  SearchSection,
+} from '../../../../../state/state-sections';
+import {loadReducerError} from '../../../../../utils/errors';
+import {
+  configuration,
+  numericFacetSet,
+  search,
+} from '../../../../../app/reducers';
+
+import {
+  NumericFilterOptions,
+  NumericFilterInitialState,
+  NumericFilterRange,
+  NumericFilterProps,
+  NumericFilterState,
+  NumericFilter,
+  buildCoreNumericFilter,
+} from '../../../../core/facets/range-facet/numeric-facet/headless-core-numeric-filter';
+import {InsightEngine} from '../../../../../app/insight-engine/insight-engine';
+import {
+  logFacetClearAll,
+  logFacetSelect,
+} from '../../../../../features/facets/facet-set/facet-set-insight-analytics-actions';
+import {executeSearch} from '../../../../../features/insight-search/insight-search-actions';
+
+export type {
+  NumericFilterOptions,
+  NumericFilterInitialState,
+  NumericFilterRange,
+  NumericFilterProps,
+  NumericFilterState,
+  NumericFilter,
+};
+
+/**
+ * Creates a `NumericFilter` controller instance.
+ * @param engine - The headless engine.
+ * @param props - The configurable `NumericFilter` controller properties.
+ * @returns A `NumericFilter` controller instance.
+ */
+export function buildInsightNumericFilter(
+  engine: InsightEngine,
+  props: NumericFilterProps
+): NumericFilter {
+  if (!loadNumericFilterReducer(engine)) {
+    throw loadReducerError;
+  }
+
+  const coreController = buildCoreNumericFilter(engine, props);
+  const {dispatch} = engine;
+  const getFacetId = () => coreController.state.facetId;
+
+  return {
+    ...coreController,
+    clear: () => {
+      coreController.clear();
+      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+    },
+    setRange: (range) => {
+      const success = coreController.setRange(range);
+      if (success) {
+        dispatch(
+          executeSearch(
+            logFacetSelect({
+              facetId: getFacetId(),
+              facetValue: `${range.start}..${range.end}`,
+            })
+          )
+        );
+      }
+      return success;
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+      };
+    },
+  };
+}
+
+function loadNumericFilterReducer(
+  engine: InsightEngine
+): engine is InsightEngine<
+  NumericFacetSection & ConfigurationSection & SearchSection
+> {
+  engine.addReducers({numericFacetSet, configuration, search});
+  return true;
+}

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -15,6 +15,7 @@ import {
   FacetSection,
   InsightCaseContextSection,
   InsightConfigurationSection,
+  NumericFacetSection,
   PaginationSection,
   QuerySection,
   SearchSection,
@@ -45,6 +46,7 @@ export type StateNeededByExecuteSearch = ConfigurationSection &
       SearchSection &
       QuerySection &
       FacetSection &
+      NumericFacetSection &
       PaginationSection
   >;
 
@@ -206,7 +208,10 @@ const buildInsightSearchRequest = (
     url: state.configuration.platformUrl,
     insightId: state.insightConfiguration.insightId,
     q: state.query?.q,
-    facets: getFacetRequests(state.facetSet),
+    facets: getFacetRequests({
+      ...state.facetSet,
+      ...state.numericFacetSet,
+    }),
     caseContext: state.insightCaseContext?.caseContext,
     ...(state.pagination && {
       firstResult: state.pagination.firstResult,

--- a/packages/headless/src/state/insight-app-state.ts
+++ b/packages/headless/src/state/insight-app-state.ts
@@ -14,6 +14,7 @@ import {
   FacetOptionsSection,
   QuerySuggestionSection,
   QuerySetSection,
+  NumericFacetSection,
 } from './state-sections';
 
 export type InsightSearchParametersState = QuerySection &
@@ -32,4 +33,5 @@ export type InsightAppState = InsightSearchParametersState &
   FacetSearchSection &
   FacetOptionsSection &
   QuerySetSection &
-  QuerySuggestionSection;
+  QuerySuggestionSection &
+  NumericFacetSection;

--- a/packages/headless/src/test/mock-insight-state.ts
+++ b/packages/headless/src/test/mock-insight-state.ts
@@ -2,6 +2,7 @@ import {getConfigurationInitialState} from '../features/configuration/configurat
 import {getFacetOptionsInitialState} from '../features/facet-options/facet-options-state';
 import {getFacetSearchSetInitialState} from '../features/facets/facet-search-set/specific/specific-facet-search-set-state';
 import {getFacetSetInitialState} from '../features/facets/facet-set/facet-set-state';
+import {getNumericFacetSetInitialState} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-set-state';
 import {getInsightConfigurationInitialState} from '../features/insight-configuration/insight-configuration-state';
 import {getInsightInterfaceInitialState} from '../features/insight-interface/insight-interface-state';
 import {getInsightCaseContextSearchInitialState} from '../features/insight-search/insight-case-context-state';
@@ -33,6 +34,7 @@ export function buildMockInsightState(
     facetOptions: getFacetOptionsInitialState(),
     querySet: getQuerySetInitialState(),
     querySuggest: getQuerySuggestSetInitialState(),
+    numericFacetSet: getNumericFacetSetInitialState(),
     ...config,
   };
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2205

This PR adds the numeric facet controller for the insight use case. The numeric filter controller is also included.