### PR TITLE
fix(atomic): improved search box aria label

### DIFF
--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -54,8 +54,8 @@
     "zh-TW": "無標題"
   },
   "search-box": {
-    "en": "Insert a query. Press enter to send.",
-    "fr": "Insérer une requête. Appuyez sur Entrée pour envoyer."
+    "en": "Input field to perform a search. Insert a query. Press enter to send.",
+    "fr": "Champ de texte pour performer une recherche. Insérer une requête. Appuyez sur Entrée pour envoyer."
   },
   "facet-search": {
     "en": "Search for values in the {{label}} facet",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1792

The reported issue specified that the word "Search" isn't part of the aria label.

I decided to test this with the 5 screen readers we usually support, here's what they say when we focus on the search box:
* JAWS (Windows):
> 5 search suggestions are available. Input field to perform a search. Insert a query. Press enter to send. edit combo expanded. Search. To set the value use the Arrow keys or type the value.
* NVDA (Windows):
> Input field to perform a search. Insert a query. Press enter to send. combo box expanded has auto complete editable Search blank 
* TalkBack (Android):
> Collapsed, edit box. Input field to perform a search. Insert a query. Press enter to send. Search. Double-tap to edit text. Editing options, actions available, use tap with three fingers to view.
* VoiceOver (iOS):
> Input field to perform a search. Insert a query. Press enter to send. Search. Combobox. Menu popup. Collapsed. Double-tap to expand.
* VoiceOver (macOS):
> Input field to perform a search. Insert a query. Press enter to send. Menu pop up Menu pop-up Combo box, 5 search suggestions available. You are currently on a Menu pop-up combo box, inside of web content. Type text or, to display a list of choices, press Control-Option-Space. To exit this web area, press Control-Option-Shift-Up Arrow

I think this label is still an improvement, because the label is most often the first thing pronounced, and I think this new label conveys sooner and more clearly that a search box is focused.