### PR TITLE
fix(atomic): improved aria label for rating facet values

### DIFF
--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -250,6 +250,9 @@ export class AtomicRatingFacet
   }
 
   private formatFacetValue(facetValue: NumericFacetValue) {
+    if (facetValue.start === this.maxValueInIndex) {
+      return this.bindings.i18n.t('stars-only', {count: facetValue.start});
+    }
     return this.bindings.i18n.t('stars', {
       count: facetValue.start,
       max: this.maxValueInIndex,

--- a/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -237,9 +237,8 @@ export class AtomicRatingRangeFacet
 
   private formatFacetValue(facetValue: NumericFacetValue) {
     if (facetValue.start === this.maxValueInIndex) {
-      return this.bindings.i18n.t('stars', {
+      return this.bindings.i18n.t('stars-only', {
         count: facetValue.start,
-        max: this.maxValueInIndex,
       });
     }
     return this.bindings.i18n.t('stars-range', {

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -1261,6 +1261,10 @@
     "en": "{{count}} stars out of {{max}}",
     "fr": "{{count}} étoiles sur {{max}}"
   },
+  "stars-only": {
+    "en": "only {{count}} stars out of {{count}}",
+    "fr": "seulement {{count}} étoiles sur {{count}}"
+  },
   "stars-range": {
     "en": "{{value}} to {{count}} stars",
     "fr": "{{value}} à {{count}} étoiles"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1793

For every facet value where "Only" is displayed, I added "only" in the aria label.

<table>
<tr>
	<td>

![image](https://user-images.githubusercontent.com/54454747/175994469-113e6a74-3e23-43ee-9725-855e474a4232.png)
	<td>

Rating facet labels:
* Inclusion filter on only 5 stars out of 5; 205 results
* Inclusion filter on 4 stars out of 5; 1163 results
* Inclusion filter on 3 stars out of 5; 146 results
* Inclusion filter on 2 stars out of 5; 25 results
* Inclusion filter on one star out of 5; 16 results
<tr>
	<td>

![image](https://user-images.githubusercontent.com/54454747/175994546-39337f61-9e60-42cf-9118-55849397d77a.png)
	<td>

Rating range facet labels:
* Inclusion filter on only 5 stars out of 5; 205 results
* Inclusion filter on 4 to 5 stars; 1361 results
* Inclusion filter on 3 to 5 stars; 1503 results
* Inclusion filter on 2 to 5 stars; 1528 results
* Inclusion filter on 1 to 5 stars; 1544 results
</table>