### PR TITLE
fix(quantic): corner case addressed in the QuanticTabBar component

### DIFF
--- a/packages/quantic/cypress/integration/tab-bar/tab-bar.cypress.ts
+++ b/packages/quantic/cypress/integration/tab-bar/tab-bar.cypress.ts
@@ -148,4 +148,25 @@ describe('quantic-tab-bar', () => {
       });
     });
   });
+
+  describe('when a tab containing the same expression as another tab is selected from the dropdown list', () => {
+    it('should correctly select the tab', () => {
+      cy.viewport(extraSmallViewportWidth, 900);
+      visitPage();
+
+      scope('when loading the page', () => {
+        Expect.displayedTabsEqual([TAB_1]);
+        Expect.tabsInDropdownEqual([TAB_2, TAB_3, TAB_4]);
+        Expect.activeTabContains(TAB_1);
+      });
+
+      scope('when selecting the tab', () => {
+        Actions.openDropdown();
+        Expect.displayDropdown(true);
+        Actions.selectTabFromDropdown(TAB_4);
+        Expect.displayedTabsEqual([TAB_4]);
+        Expect.tabsInDropdownEqual([TAB_1, TAB_2, TAB_3]);
+      });
+    });
+  });
 });

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.html
@@ -8,7 +8,7 @@
         <c-quantic-tab label="Tab 1" engine-id={engineId} is-active></c-quantic-tab>
         <c-quantic-tab label="Tab 2" engine-id={engineId} expression="@sfkbid"></c-quantic-tab>
         <c-quantic-tab label="Tab 3" engine-id={engineId} expression="@jisourcetype"></c-quantic-tab>
-        <c-quantic-tab label="Tab 4" engine-id={engineId} expression="@objecttype==Knowledge"></c-quantic-tab>
+        <c-quantic-tab label="Tab 4" engine-id={engineId} expression="@sfkbid"></c-quantic-tab>
       </c-quantic-tab-bar>
     </c-quantic-search-interface>
   </c-example-layout>

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
@@ -6,16 +6,17 @@
         class="tab-bar_more-button slds-tabs_default__item slds-tabs_default__overflow-button slds-is-absolute slds-p-right_none slds-p-left_none"
         title={labels.moreTabs} role="presentation">
         <div class={dropdownClasses}>
-          <button class="slds-button slds-var-p-horizontal_small" aria-haspopup="true" onclick={toggleDropdown}>{moreButtonLabel}
-            <lightning-icon
-              class={moreButtonIconClasses}
-              icon-name={arrowIconName} size="xx-small" aria-hidden="true"></lightning-icon>
+          <button class="slds-button slds-var-p-horizontal_small" aria-haspopup="true"
+            onclick={toggleDropdown}>{moreButtonLabel}
+            <lightning-icon class={moreButtonIconClasses} icon-name={arrowIconName} size="xx-small" aria-hidden="true">
+            </lightning-icon>
           </button>
           <div class="slds-dropdown slds-dropdown_right">
             <ul class="slds-dropdown__list slds-dropdown_length-with-icon-10" role="menu">
               <template for:each={tabsInDropdown} for:item="tab">
-                <li class="slds-dropdown__item" role="presentation" key={tab.value}>
-                  <a role="menuitem" tabindex={optionTabIndex} onclick={handleDropdownTabSelect} data-value={tab.value}>
+                <li class="slds-dropdown__item" role="presentation" key={tab.id}>
+                  <a role="menuitem" tabindex={optionTabIndex} onclick={handleDropdownTabSelect} data-value={tab.value}
+                    data-label={tab.label}>
                     <span class="slds-truncate" title={tab.label}>{tab.label}</span>
                   </a>
                 </li>

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -59,7 +59,8 @@ export default class QuanticTabBar extends LightningElement {
    * @returns {void}
    */
   updateDropdownOptions() {
-    this.tabsInDropdown = this.overflowingTabs.map((el) => ({
+    this.tabsInDropdown = this.overflowingTabs.map((el, index) => ({
+      id: index,
       // @ts-ignore
       label: el.label,
       // @ts-ignore
@@ -319,9 +320,10 @@ export default class QuanticTabBar extends LightningElement {
   handleDropdownTabSelect = (event) => {
     event.stopPropagation();
     const targetValue = event.currentTarget.getAttribute('data-value');
+    const targetLabel = event.currentTarget.getAttribute('data-label');
     const clickedtab = this.overflowingTabs.find(
       // @ts-ignore
-      (tab) => tab.expression === targetValue
+      (tab) => tab.expression === targetValue && tab.label === targetLabel
     );
     // @ts-ignore
     clickedtab?.select();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4546
When a tab containing the same expression as another tab is selected from the drop-down list:
In the following the Tab2 has the same expression as Tab4

#### Before:

https://user-images.githubusercontent.com/86681870/176433899-6a06798b-2550-4830-98bb-ea693a1a1b7f.mov

#### After:

https://user-images.githubusercontent.com/86681870/176433923-c3767569-c8de-477f-b3d4-2d7717b14fc4.mov

