### PR TITLE
fix(headless): properly support authentication query parameter to use with SAML

### DIFF
--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.76.10",
       "license": "Apache-2.0",
       "dependencies": {
+        "@coveo/auth": "^1.5.2",
         "@coveo/bueno": "0.39.19",
         "@reduxjs/toolkit": "1.8.1",
         "@types/pino": "6.3.11",
@@ -1997,6 +1998,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@coveo/auth": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@coveo/auth/-/auth-1.5.2.tgz",
+      "integrity": "sha512-82I2/2lufI04OOqR2Nnys3UqC1RsqnbJM4H9yDDimKbxrIzazMu13jYQuAPDNkAMYT3nxza18MXyY70Qe9hICA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@coveo/bueno": {
       "version": "0.39.19",
@@ -14040,6 +14049,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@coveo/auth": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@coveo/auth/-/auth-1.5.2.tgz",
+      "integrity": "sha512-82I2/2lufI04OOqR2Nnys3UqC1RsqnbJM4H9yDDimKbxrIzazMu13jYQuAPDNkAMYT3nxza18MXyY70Qe9hICA=="
     },
     "@coveo/bueno": {
       "version": "0.39.19",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -43,6 +43,7 @@
     "pino-pretty": "^6.0.0"
   },
   "dependencies": {
+    "@coveo/auth": "^1.5.2",
     "@coveo/bueno": "0.39.19",
     "@reduxjs/toolkit": "1.8.1",
     "@types/pino": "6.3.11",

--- a/packages/headless/src/api/api-client-utils.ts
+++ b/packages/headless/src/api/api-client-utils.ts
@@ -5,11 +5,14 @@ import {
   SearchAPIErrorWithStatusCode,
   SearchAPIErrorWithExceptionInBody,
 } from './search/search-api-error-response';
+import {AuthenticationParam} from './search/search-api-params';
 
-export function pickNonBaseParams<Params extends BaseParam>(req: Params) {
+export function pickNonBaseParams<
+  Params extends BaseParam & AuthenticationParam
+>(req: Params) {
   // cheap version of _.omit
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {url, accessToken, organizationId, ...nonBase} = req;
+  const {url, accessToken, organizationId, authentication, ...nonBase} = req;
   return nonBase;
 }
 

--- a/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
@@ -1,4 +1,5 @@
 import {BaseParam, VisitorIDParam} from '../../../platform-service-params';
+import {AuthenticationParam} from '../../search-api-params';
 import {SearchRequest} from '../../search/search-request';
 
 export interface FacetSearchRequestOptions {
@@ -15,7 +16,8 @@ export interface FacetSearchRequestOptions {
 export interface BaseFacetSearchRequest
   extends FacetSearchRequestOptions,
     BaseParam,
-    VisitorIDParam {
+    VisitorIDParam,
+    AuthenticationParam {
   field: string;
   searchContext: SearchRequest;
   filterFacetCount: boolean;

--- a/packages/headless/src/api/search/facet-search/facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/facet-search-request.ts
@@ -1,6 +1,8 @@
 import {SpecificFacetSearchRequest} from './specific-facet-search/specific-facet-search-request';
 import {CategoryFacetSearchRequest} from './category-facet-search/category-facet-search-request';
 import {BaseParam} from '../../platform-service-params';
+import {AuthenticationParam} from '../search-api-params';
 
 export type FacetSearchRequest = BaseParam &
+  AuthenticationParam &
   (SpecificFacetSearchRequest | CategoryFacetSearchRequest);

--- a/packages/headless/src/api/search/html/html-request.ts
+++ b/packages/headless/src/api/search/html/html-request.ts
@@ -1,4 +1,5 @@
 import {BaseParam, VisitorIDParam} from '../../platform-service-params';
+import {AuthenticationParam} from '../search-api-params';
 
 export interface HtmlRequestOptions {
   uniqueId: string;
@@ -7,6 +8,7 @@ export interface HtmlRequestOptions {
 
 export type HtmlRequest = BaseParam &
   HtmlRequestOptions &
+  AuthenticationParam &
   VisitorIDParam & {
     enableNavigation: boolean;
     requestedOutputSize: number;

--- a/packages/headless/src/api/search/plan/plan-request.ts
+++ b/packages/headless/src/api/search/plan/plan-request.ts
@@ -6,6 +6,7 @@ import {
 } from '../../platform-service-params';
 import {
   AnalyticsParam,
+  AuthenticationParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,
@@ -20,4 +21,5 @@ export type PlanRequest = BaseParam &
   LocaleParam &
   TimezoneParam &
   VisitorIDParam &
-  AnalyticsParam;
+  AnalyticsParam &
+  AuthenticationParam;

--- a/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
+++ b/packages/headless/src/api/search/query-suggest/query-suggest-request.ts
@@ -7,6 +7,7 @@ import {
 import {
   ActionsHistoryParam,
   AnalyticsParam,
+  AuthenticationParam,
   PipelineParam,
   QueryParam,
   SearchHubParam,
@@ -22,6 +23,7 @@ export type QuerySuggestRequest = BaseParam &
   TimezoneParam &
   ActionsHistoryParam &
   VisitorIDParam &
+  AuthenticationParam &
   AnalyticsParam & {
     count: number;
   };

--- a/packages/headless/src/api/search/recommendation/recommendation-request.ts
+++ b/packages/headless/src/api/search/recommendation/recommendation-request.ts
@@ -8,6 +8,7 @@ import {
   ActionsHistoryParam,
   AdvancedQueryParam,
   AnalyticsParam,
+  AuthenticationParam,
   ConstantQueryParam,
   FieldsToIncludeParam,
   PipelineParam,
@@ -32,4 +33,5 @@ export type RecommendationRequest = BaseParam &
   LocaleParam &
   TimezoneParam &
   VisitorIDParam &
-  AnalyticsParam;
+  AnalyticsParam &
+  AuthenticationParam;

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -114,17 +114,28 @@ export interface ExcerptLength {
   excerptLength?: number;
 }
 
+export interface AuthenticationParam {
+  authentication?: string;
+}
+
 export const baseSearchRequest = (
-  req: BaseParam,
+  req: BaseParam & AuthenticationParam,
   method: HttpMethods,
   contentType: HTTPContentType,
   path: string
-) => ({
-  accessToken: req.accessToken,
-  method,
-  contentType,
-  url: `${req.url}${path}?${getOrganizationIdQueryParam(req)}`,
-});
+) => {
+  return {
+    accessToken: req.accessToken,
+    method,
+    contentType,
+    url: `${req.url}${path}?${getOrganizationIdQueryParam(req)}${
+      req.authentication ? `&${getAuthenticationQueryParam(req)}` : ''
+    }`,
+  };
+};
 
 export const getOrganizationIdQueryParam = (req: BaseParam) =>
   `organizationId=${req.organizationId}`;
+
+export const getAuthenticationQueryParam = (req: AuthenticationParam) =>
+  `authentication=${encodeURIComponent(req.authentication!)}`;

--- a/packages/headless/src/api/search/search/search-request.ts
+++ b/packages/headless/src/api/search/search/search-request.ts
@@ -12,6 +12,7 @@ import {
   ActionsHistoryParam,
   AdvancedQueryParam,
   AnalyticsParam,
+  AuthenticationParam,
   ConstantQueryParam,
   DisjunctionQueryParam,
   EnableDidYouMeanParam,
@@ -58,4 +59,5 @@ export type SearchRequest = BaseParam &
   TimezoneParam &
   AnalyticsParam &
   ExcerptLength &
-  ActionsHistoryParam;
+  ActionsHistoryParam &
+  AuthenticationParam;

--- a/packages/headless/src/app/search-engine/search-engine-configuration.ts
+++ b/packages/headless/src/app/search-engine/search-engine-configuration.ts
@@ -1,10 +1,13 @@
-import {RecordValue, Schema} from '@coveo/bueno';
+import {ArrayValue, RecordValue, Schema} from '@coveo/bueno';
 import {
   PostprocessFacetSearchResponseMiddleware,
   PostprocessQuerySuggestResponseMiddleware,
   PostprocessSearchResponseMiddleware,
 } from '../../api/search/search-api-client-middleware';
-import {nonEmptyString} from '../../utils/validate-payload';
+import {
+  nonEmptyString,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 import {
   engineConfigurationDefinitions,
   EngineConfiguration,
@@ -51,6 +54,12 @@ export interface SearchConfigurationOptions {
    */
   timezone?: string;
   /**
+   * Specifies the name of the authentication providers to use to perform queries.
+   *
+   * See [SAML Authentication](https://docs.coveo.com/en/91/).
+   */
+  authenticationProviders?: string[];
+  /**
    * Allows for augmenting a search response before the state is updated.
    */
   preprocessSearchResponseMiddleware?: PostprocessSearchResponseMiddleware;
@@ -76,6 +85,10 @@ export const searchEngineConfigurationSchema =
         searchHub: nonEmptyString,
         locale: nonEmptyString,
         timezone: nonEmptyString,
+        authenticationProviders: new ArrayValue({
+          required: false,
+          each: requiredNonEmptyString,
+        }),
       },
     }),
   });

--- a/packages/headless/src/app/search-engine/search-engine.test.ts
+++ b/packages/headless/src/app/search-engine/search-engine.test.ts
@@ -1,86 +1,126 @@
+import {buildSamlClient} from '@coveo/auth';
 import {enableDebug} from '../../features/debug/debug-actions';
 import {setSearchHub} from '../../features/search-hub/search-hub-actions';
 import {
   buildSearchEngine,
+  buildSearchEngineWithSamlAuthentication,
   SearchEngine,
   SearchEngineOptions,
 } from './search-engine';
 import {getSampleSearchEngineConfiguration} from './search-engine-configuration';
+jest.mock('@coveo/auth');
 
-describe('buildSearchEngine', () => {
-  let options: SearchEngineOptions;
+describe('searchEngine', () => {
   let engine: SearchEngine;
+  describe('buildSearchEngine', () => {
+    let options: SearchEngineOptions;
 
-  function initEngine() {
-    engine = buildSearchEngine(options);
-  }
-
-  beforeEach(() => {
-    options = {
-      configuration: getSampleSearchEngineConfiguration(),
-      loggerOptions: {level: 'silent'},
-    };
-
-    initEngine();
-  });
-
-  it('passing an invalid searchHub throws', () => {
-    options.configuration.search!.searchHub = '';
-    expect(initEngine).toThrow();
-  });
-
-  it('passing an invalid pipeline throws', () => {
-    options.configuration.search!.pipeline = '';
-    expect(initEngine).toThrow();
-  });
-
-  it('exposes an #executeFirstSearch method', () => {
-    expect(engine.executeFirstSearch).toBeTruthy();
-  });
-
-  it('is possible to change the search hub', () => {
-    const initialSearchHub = engine.state.searchHub;
-    engine.dispatch(setSearchHub('newHub'));
-    expect(engine.state.searchHub).not.toBe(initialSearchHub);
-  });
-
-  it('is possible to toggle debug mode', () => {
-    expect(engine.state.debug).toBe(false);
-    engine.dispatch(enableDebug());
-    expect(engine.state.debug).toBe(true);
-  });
-
-  describe('when passing a search configuration', () => {
-    const pipeline = 'newPipe';
-    const searchHub = 'newHub';
-    const locale = 'fr';
-    const timezone = 'Africa/Johannesburg';
+    function initEngine() {
+      engine = buildSearchEngine(options);
+    }
 
     beforeEach(() => {
-      options.configuration.search = {
-        pipeline,
-        searchHub,
-        locale,
-        timezone,
+      options = {
+        configuration: getSampleSearchEngineConfiguration(),
+        loggerOptions: {level: 'silent'},
       };
 
       initEngine();
     });
 
-    it('sets the pipeline correctly', () => {
-      expect(engine.state.pipeline).toBe(pipeline);
+    it('passing an invalid searchHub throws', () => {
+      options.configuration.search!.searchHub = '';
+      expect(initEngine).toThrow();
     });
 
-    it('sets the searchHub correctly', () => {
-      expect(engine.state.searchHub).toBe(searchHub);
+    it('passing an invalid pipeline throws', () => {
+      options.configuration.search!.pipeline = '';
+      expect(initEngine).toThrow();
     });
 
-    it('sets the searchHub correctly', () => {
-      expect(engine.state.configuration.search.locale).toBe(locale);
+    it('exposes an #executeFirstSearch method', () => {
+      expect(engine.executeFirstSearch).toBeTruthy();
     });
 
-    it('sets the timezone correctly', () => {
-      expect(engine.state.configuration.search.timezone).toBe(timezone);
+    it('is possible to change the search hub', () => {
+      const initialSearchHub = engine.state.searchHub;
+      engine.dispatch(setSearchHub('newHub'));
+      expect(engine.state.searchHub).not.toBe(initialSearchHub);
+    });
+
+    it('is possible to toggle debug mode', () => {
+      expect(engine.state.debug).toBe(false);
+      engine.dispatch(enableDebug());
+      expect(engine.state.debug).toBe(true);
+    });
+
+    describe('when passing a search configuration', () => {
+      const pipeline = 'newPipe';
+      const searchHub = 'newHub';
+      const locale = 'fr';
+      const timezone = 'Africa/Johannesburg';
+
+      beforeEach(() => {
+        options.configuration.search = {
+          pipeline,
+          searchHub,
+          locale,
+          timezone,
+        };
+
+        initEngine();
+      });
+
+      it('sets the pipeline correctly', () => {
+        expect(engine.state.pipeline).toBe(pipeline);
+      });
+
+      it('sets the searchHub correctly', () => {
+        expect(engine.state.searchHub).toBe(searchHub);
+      });
+
+      it('sets the searchHub correctly', () => {
+        expect(engine.state.configuration.search.locale).toBe(locale);
+      });
+
+      it('sets the timezone correctly', () => {
+        expect(engine.state.configuration.search.timezone).toBe(timezone);
+      });
+    });
+  });
+
+  describe('buildSearchEngineWithSamlAuthentication', () => {
+    beforeAll(() => {
+      (buildSamlClient as jest.Mock).mockImplementation(() => ({
+        authenticate: () => Promise.resolve('theToken'),
+      }));
+    });
+
+    it('sets the authentication provider and token correctly', async () => {
+      engine = await buildSearchEngineWithSamlAuthentication({
+        configuration: {
+          organizationId: 'theOrg',
+          provider: 'theProvider',
+        },
+      });
+
+      expect(engine.state.configuration.search.authenticationProviders[0]).toBe(
+        'theProvider'
+      );
+      expect(engine.state.configuration.accessToken).toBe('theToken');
+    });
+
+    it('passes down generic engine options correctly', async () => {
+      engine = await buildSearchEngineWithSamlAuthentication({
+        configuration: {
+          organizationId: 'theOrg',
+          provider: 'theProvider',
+          analytics: {enabled: false},
+          search: {
+            pipeline: 'thePipeline',
+          },
+        },
+      });
     });
   });
 });

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -4,7 +4,7 @@ import {
   validatePayload,
   requiredNonEmptyString,
 } from '../../utils/validate-payload';
-import {BooleanValue, Value} from '@coveo/bueno';
+import {ArrayValue, BooleanValue, Value} from '@coveo/bueno';
 import {IRuntimeEnvironment} from 'coveo.analytics';
 
 const originSchemaOnConfigUpdate = () => nonEmptyString;
@@ -63,6 +63,12 @@ export interface UpdateSearchConfigurationActionCreatorPayload {
    * The [tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) identifier of the time zone of the user.
    */
   timezone?: string;
+  /**
+   * Specifies the name of the authentication providers to use to perform queries.
+   *
+   * See [SAML Authentication](https://docs.coveo.com/en/91/).
+   */
+  authenticationProviders?: string[];
 }
 
 export const updateSearchConfiguration = createAction(
@@ -74,6 +80,10 @@ export const updateSearchConfiguration = createAction(
       searchHub: nonEmptyString,
       timezone: nonEmptyString,
       locale: nonEmptyString,
+      authenticationProviders: new ArrayValue({
+        required: false,
+        each: requiredNonEmptyString,
+      }),
     })
 );
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -27,6 +27,7 @@ describe('configuration slice', () => {
       apiBaseUrl: `${url}/rest/search/v2`,
       locale: 'en-US',
       timezone: 'Africa/Johannesburg',
+      authenticationProviders: [],
     },
     analytics: {
       enabled: true,
@@ -213,6 +214,7 @@ describe('configuration slice', () => {
           apiBaseUrl: 'http://test.com/search',
           locale: 'fr-CA',
           timezone: 'Africa/Johannesburg',
+          authenticationProviders: ['theProvider'],
         },
       };
 
@@ -223,6 +225,7 @@ describe('configuration slice', () => {
             apiBaseUrl: 'http://test.com/search',
             locale: 'fr-CA',
             timezone: 'Africa/Johannesburg',
+            authenticationProviders: ['theProvider'],
           })
         )
       ).toEqual(expectedState);
@@ -235,6 +238,7 @@ describe('configuration slice', () => {
           apiBaseUrl: 'http://test.com/search',
           locale: 'fr-CA',
           timezone: 'Africa/Johannesburg',
+          authenticationProviders: ['theNewProvider'],
         },
       };
 
@@ -245,6 +249,7 @@ describe('configuration slice', () => {
             apiBaseUrl: 'http://test.com/search',
             locale: 'fr-CA',
             timezone: 'Africa/Johannesburg',
+            authenticationProviders: ['theNewProvider'],
           })
         )
       ).toEqual(expectedState);

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -75,6 +75,10 @@ export const configurationReducer = createReducer(
         if (action.payload.timezone) {
           state.search.timezone = action.payload.timezone;
         }
+        if (action.payload.authenticationProviders) {
+          state.search.authenticationProviders =
+            action.payload.authenticationProviders;
+        }
       })
       .addCase(updateAnalyticsConfiguration, (state, action) => {
         if (!isNullOrUndefined(action.payload.enabled)) {

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -41,6 +41,12 @@ export interface ConfigurationState {
      * By default, the timezone will be [guessed](https://day.js.org/docs/en/timezone/guessing-user-timezone).
      */
     timezone: string;
+    /**
+     * Specifies the name of the authentication providers to use to perform queries.
+     *
+     * See [SAML Authentication](https://docs.coveo.com/en/91/).
+     */
+    authenticationProviders: string[];
   };
   /**
    * The global headless engine Usage Analytics API configuration.
@@ -123,6 +129,7 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     apiBaseUrl: `${platformUrl()}${searchAPIEndpoint}`,
     locale: 'en-US',
     timezone: dayjs.tz.guess(),
+    authenticationProviders: [],
   },
   analytics: {
     enabled: true,

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-request-builder.ts
@@ -22,6 +22,10 @@ export const buildCategoryFacetSearchRequest = async (
     url: state.configuration.search.apiBaseUrl,
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
+    ...(state.configuration.search.authenticationProviders.length && {
+      authentication:
+        state.configuration.search.authenticationProviders.join(','),
+    }),
     basePath,
     captions,
     numberOfValues,

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
@@ -18,6 +18,10 @@ export const buildSpecificFacetSearchRequest = async (
     url: state.configuration.search.apiBaseUrl,
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
+    ...(state.configuration.search.authenticationProviders && {
+      authentication:
+        state.configuration.search.authenticationProviders.join(','),
+    }),
     captions,
     numberOfValues,
     query: newQuery,

--- a/packages/headless/src/features/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-actions.ts
@@ -175,5 +175,8 @@ export const buildQuerySuggestRequest = async (
       ...(s.configuration.analytics.enabled &&
         (await fromAnalyticsStateToAnalyticsParams(s.configuration.analytics))),
     }),
+    ...(s.configuration.search.authenticationProviders.length && {
+      authentication: s.configuration.search.authenticationProviders.join(','),
+    }),
   };
 };

--- a/packages/headless/src/features/recommendation/recommendation-actions.ts
+++ b/packages/headless/src/features/recommendation/recommendation-actions.ts
@@ -108,4 +108,7 @@ export const buildRecommendationRequest = async (
   }),
   ...(s.configuration.analytics.enabled &&
     (await fromAnalyticsStateToAnalyticsParams(s.configuration.analytics))),
+  ...(s.configuration.search.authenticationProviders.length && {
+    authentication: s.configuration.search.authenticationProviders.join(','),
+  }),
 });

--- a/packages/headless/src/features/result-preview/result-preview-request-builder.ts
+++ b/packages/headless/src/features/result-preview/result-preview-request-builder.ts
@@ -31,5 +31,8 @@ export async function buildResultPreviewRequest(
     q,
     ...options,
     requestedOutputSize: options.requestedOutputSize || 0,
+    ...(search.authenticationProviders.length && {
+      authentication: search.authenticationProviders.join(','),
+    }),
   };
 }

--- a/packages/headless/src/features/search-and-folding/search-and-folding-request.ts
+++ b/packages/headless/src/features/search-and-folding/search-and-folding-request.ts
@@ -67,5 +67,9 @@ export const buildSearchAndFoldingLoadCollectionRequest = async (
       !isNullOrUndefined(state.excerptLength.length) && {
         excerptLength: state.excerptLength.length,
       }),
+    ...(state.configuration.search.authenticationProviders.length && {
+      authentication:
+        state.configuration.search.authenticationProviders.join(','),
+    }),
   };
 };

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -138,5 +138,9 @@ export const buildPlanRequest = async (
       (await fromAnalyticsStateToAnalyticsParams(
         state.configuration.analytics
       ))),
+    ...(state.configuration.search.authenticationProviders.length && {
+      authentication:
+        state.configuration.search.authenticationProviders.join(','),
+    }),
   };
 };

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -15,6 +15,7 @@ export type {
 export {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
+  buildSearchEngineWithSamlAuthentication,
 } from './app/search-engine/search-engine';
 
 export type {CoreEngine, ExternalEngineOptions} from './app/engine';

--- a/packages/samples/headless-react/src/pages/SamlPage.tsx
+++ b/packages/samples/headless-react/src/pages/SamlPage.tsx
@@ -1,36 +1,36 @@
-import {buildSamlClient, SamlClientOptions} from '@coveo/auth';
-import {buildSearchEngine} from '@coveo/headless';
+import {SamlClientOptions} from '@coveo/auth';
+import {
+  buildSearchEngineWithSamlAuthentication,
+  SearchEngine,
+} from '@coveo/headless';
 import {useEffect, useState, PropsWithChildren} from 'react';
 import {AppContext} from '../context/engine';
 
 export function SamlPage(props: PropsWithChildren<SamlClientOptions>) {
-  const [accessToken, setAccessToken] = useState('');
-  const saml = buildSamlClient(props);
+  const [engine, setEngine] = useState<SearchEngine | null>(null);
 
   useEffect(() => {
-    getToken();
+    getEngine();
   }, []);
 
-  if (!accessToken) {
+  if (!engine) {
     return null;
   }
 
-  async function getToken() {
+  async function getEngine() {
     try {
-      const token = await saml.authenticate();
-      setAccessToken(token);
+      setEngine(
+        await buildSearchEngineWithSamlAuthentication({
+          configuration: {
+            organizationId: props.organizationId,
+            provider: props.provider,
+          },
+        })
+      );
     } catch (e) {
       console.error(e);
     }
   }
-
-  const engine = buildSearchEngine({
-    configuration: {
-      organizationId: props.organizationId,
-      accessToken,
-      renewAccessToken: saml.authenticate,
-    },
-  });
 
   return (
     <AppContext.Provider value={{engine}}>{props.children}</AppContext.Provider>


### PR DESCRIPTION
When using SAML authentication, we need to send the `authentication` query parameter to the API.

This parameter needs to contain the name(s) of the security identity provider to use to resolve the identity of the end user. 

Without this query parameter, it means the user is essentially anonymous/not authenticated as far as the search API is concerned.

I've also added a new `buildSearchEngineWithSamlAuthentication` function to Headless, which takes care of wiring the `accessToken`, `provider`, and `renewAccessToken` function automatically for the implementers.
 

https://coveord.atlassian.net/browse/KIT-1800