### PR TITLE
fix(atomic,headless): clear standalone search box state when redirecting

### DIFF
--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -162,8 +162,11 @@ export class AtomicSearchBox {
     this.pendingSuggestionEvents = [];
   }
 
-  public componentDidUpdate() {
-    if (!('redirectTo' in this.searchBoxState)) {
+  public componentWillUpdate() {
+    if (
+      !('redirectTo' in this.searchBoxState) ||
+      !('reset' in this.searchBox)
+    ) {
       return;
     }
 
@@ -176,6 +179,7 @@ export class AtomicSearchBox {
     const storage = new SafeStorage();
     storage.setJSON(StorageItems.STANDALONE_SEARCH_BOX_DATA, data);
 
+    this.searchBox.reset();
     window.location.href = redirectTo;
   }
 

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -13,6 +13,7 @@ import {
   registerStandaloneSearchBox,
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
+  resetStandaloneSearchBox,
 } from '../../features/standalone-search-box-set/standalone-search-box-set-actions';
 import {StandaloneSearchBoxAnalytics} from '../../features/standalone-search-box-set/standalone-search-box-set-state';
 import {
@@ -50,6 +51,11 @@ export interface StandaloneSearchBox extends SearchBox {
    * Triggers a redirection.
    */
   submit(): void;
+
+  /**
+   * Reset a standalone search box's state. To be dispatched on SPAs after the redirection has been triggered.
+   */
+  reset(): void;
 
   /**
    * A scoped and simplified part of the headless state that is relevant to the `StandaloneSearchBox` controller.
@@ -125,6 +131,10 @@ export function buildStandaloneSearchBox(
       dispatch(updateAnalyticsToOmniboxFromLink({id, metadata}));
 
       this.submit();
+    },
+
+    reset() {
+      dispatch(resetStandaloneSearchBox({id}));
     },
 
     submit() {

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
@@ -12,6 +12,8 @@ import {
   updateAnalyticsToOmniboxFromLink,
   UpdateAnalyticsToOmniboxFromLinkActionCreatorPayload,
   StateNeededForRedirect,
+  resetStandaloneSearchBox,
+  ResetStandaloneSearchBoxActionCreatorPayload,
 } from './standalone-search-box-set-actions';
 
 export type {
@@ -34,6 +36,16 @@ export interface StandaloneSearchBoxSetActionCreators {
   registerStandaloneSearchBox(
     payload: RegisterStandaloneSearchBoxActionCreatorPayload
   ): PayloadAction<RegisterStandaloneSearchBoxActionCreatorPayload>;
+
+  /**
+   * Reset a standalone search box's state. To be dispatched on SPAs after the redirection has been triggered.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  resetStandaloneSearchBox(
+    payload: ResetStandaloneSearchBoxActionCreatorPayload
+  ): PayloadAction<ResetStandaloneSearchBoxActionCreatorPayload>;
 
   /**
    * Preprocesses the query for the current headless state, and retrieves a redirection URL if a redirect trigger was fired in the query pipeline.
@@ -86,5 +98,6 @@ export function loadStandaloneSearchBoxSetActions(
     fetchRedirectUrl,
     updateAnalyticsToSearchFromLink,
     updateAnalyticsToOmniboxFromLink,
+    resetStandaloneSearchBox,
   };
 }

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -43,6 +43,21 @@ export const registerStandaloneSearchBox = createAction(
     })
 );
 
+export interface ResetStandaloneSearchBoxActionCreatorPayload {
+  /**
+   * The standalone search box id.
+   */
+  id: string;
+}
+
+export const resetStandaloneSearchBox = createAction(
+  'standaloneSearchBox/reset',
+  (payload: ResetStandaloneSearchBoxActionCreatorPayload) =>
+    validatePayload(payload, {
+      id: requiredNonEmptyString,
+    })
+);
+
 export interface UpdateAnalyticsToSearchFromLinkActionCreatorPayload {
   /**
    * The standalone search box id.

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.test.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.test.ts
@@ -5,6 +5,7 @@ import {
   registerStandaloneSearchBox,
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
+  resetStandaloneSearchBox,
 } from './standalone-search-box-set-actions';
 import {standaloneSearchBoxSetReducer} from './standalone-search-box-set-slice';
 import {StandaloneSearchBoxSetState} from './standalone-search-box-set-state';
@@ -43,6 +44,24 @@ describe('standalone search box slice', () => {
       const finalState = standaloneSearchBoxSetReducer(state, action);
 
       expect(state[id]).toEqual(finalState[id]);
+    });
+  });
+
+  describe('#resetStandaloneSearchBox', () => {
+    it('when the id exists, it resets the state except for the "defaultRedirectionUrl"', () => {
+      state[id]!.redirectTo = '/newpage';
+      state[id]!.defaultRedirectionUrl = '/newpage';
+      const action = resetStandaloneSearchBox({id});
+      const finalState = standaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState[id]).toEqual(
+        buildMockStandaloneSearchBoxEntry({defaultRedirectionUrl: '/newpage'})
+      );
+    });
+
+    it('when the id does not exist, it does not throw', () => {
+      const action = resetStandaloneSearchBox({id: 'invalid'});
+      expect(() => standaloneSearchBoxSetReducer(state, action)).not.toThrow();
     });
   });
 

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -2,6 +2,7 @@ import {createReducer} from '@reduxjs/toolkit';
 import {
   fetchRedirectUrl,
   registerStandaloneSearchBox,
+  resetStandaloneSearchBox,
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
 } from './standalone-search-box-set-actions';
@@ -22,6 +23,17 @@ export const standaloneSearchBoxSetReducer = createReducer(
         }
 
         state[id] = buildStandaloneSearchBoxEntry(redirectionUrl);
+      })
+      .addCase(resetStandaloneSearchBox, (state, action) => {
+        const {id} = action.payload;
+        const searchBox = state[id];
+
+        if (searchBox) {
+          state[id] = buildStandaloneSearchBoxEntry(
+            searchBox.defaultRedirectionUrl
+          );
+          return;
+        }
       })
       .addCase(fetchRedirectUrl.pending, (state, action) => {
         const searchBox = state[action.meta.arg.id];


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1821

I don't think clearing the search box **query** it's relevant to the SPA use case since you probably keep the same atomic component & the same controller (original reason why **redirectTo** was not reset in the first place).