### PR TITLE
chore(quantic): fixed flaky facet search tests

### DIFF
--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -116,6 +116,23 @@ export function mockNoMoreFacetValues(field: string) {
   }).as(InterceptAliases.Search.substring(1));
 }
 
+export function mockFacetSearchSingleValue(queryString: string) {
+  cy.intercept('POST', routeMatchers.facetSearch, (req) => {
+    req.continue((res) => {
+      res.body.values = [
+        {
+          displayValue: queryString,
+          path: [],
+          rawValue: queryString,
+          count: 1,
+        },
+      ];
+      res.body.moreValuesAvailable = false;
+      res.send();
+    });
+  }).as(InterceptAliases.FacetSearch.substring(1));
+}
+
 export function extractFacetValues(
   response: CyHttpMessages.IncomingResponse | undefined
 ) {


### PR DESCRIPTION
A couple facet tests were failing as they expected 'account' facet search to yield only one result.
Instead of relying on a changing index I decided to intercept the facetSearch request and mock the response.

To mock the facet search request response to have only one value:
- Added mock function
- Added mock test setup function
- Moved the concerned tests into their on `it` blocks as, unfortunately cypress doesn't allow you to restore intercepts and overwriting them is messy and doesn't work great either.