### PR TITLE
feat(quantic): Fix Breadcrumb values for screen readers

### DIFF
--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-expectations.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-expectations.ts
@@ -51,6 +51,14 @@ function baseBreadcrumbManagerExpectations(
         .contains(value)
         .logDetail(`should have the value "${value}" at first value`);
     },
+    firstBreadcrumbAltTextContains: (value: string) => {
+      selector
+        .firstbreadcrumbAltText()
+        .contains(value)
+        .logDetail(
+          `should have the "${value}" as slds-assistive-text at first value`
+        );
+    },
     displayShowMore: (display: boolean) => {
       selector
         .showMoreButton()

--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-selectors.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-selectors.ts
@@ -7,6 +7,7 @@ export interface BreadcrumbSelector extends ComponentSelector {
   values: () => CypressSelector;
   showMoreButton: () => CypressSelector;
   firstbreadcrumbValueLabel: () => CypressSelector;
+  firstbreadcrumbAltText: () => CypressSelector;
 }
 
 interface BreadcrumbManagerSelector extends ComponentSelector {
@@ -24,6 +25,10 @@ const FacetBreadcrumbSelectors: BreadcrumbSelector = {
   values: () => FacetBreadcrumbSelectors.get().find('c-quantic-pill'),
   firstbreadcrumbValueLabel: () =>
     FacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
+  firstbreadcrumbAltText: () =>
+    FacetBreadcrumbSelectors.get()
+      .find('lightning-icon > .slds-assistive-text')
+      .first(),
   showMoreButton: () =>
     FacetBreadcrumbSelectors.get().find('.breadcrumb-manager__more-button'),
 };
@@ -37,6 +42,10 @@ const NumericFacetBreadcrumbSelectors: BreadcrumbSelector = {
   values: () => NumericFacetBreadcrumbSelectors.get().find('c-quantic-pill'),
   firstbreadcrumbValueLabel: () =>
     NumericFacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
+  firstbreadcrumbAltText: () =>
+    NumericFacetBreadcrumbSelectors.get()
+      .find('lightning-icon > .slds-assistive-text')
+      .first(),
   showMoreButton: () =>
     NumericFacetBreadcrumbSelectors.get().find(
       '.breadcrumb-manager__more-button'
@@ -54,6 +63,10 @@ const CategoryFacetBreadcrumbSelectors: BreadcrumbSelector = {
     CategoryFacetBreadcrumbSelectors.get()
       .find('.pill__text-container')
       .first(),
+  firstbreadcrumbAltText: () =>
+    CategoryFacetBreadcrumbSelectors.get()
+      .find('lightning-icon > .slds-assistive-text')
+      .first(),
 };
 
 const DateFacetBreadcrumbSelectors: BreadcrumbSelector = {
@@ -63,6 +76,10 @@ const DateFacetBreadcrumbSelectors: BreadcrumbSelector = {
   values: () => DateFacetBreadcrumbSelectors.get().find('c-quantic-pill'),
   firstbreadcrumbValueLabel: () =>
     DateFacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
+  firstbreadcrumbAltText: () =>
+    DateFacetBreadcrumbSelectors.get()
+      .find('lightning-icon > .slds-assistive-text')
+      .first(),
   showMoreButton: () =>
     DateFacetBreadcrumbSelectors.get().find('.breadcrumb-manager__more-button'),
 };

--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager.cypress.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager.cypress.ts
@@ -11,6 +11,7 @@ describe('quantic-breadcrumb-manager', () => {
   const numericField = 'ytlikecount';
   const dateField = 'date';
   const categoryField = 'geographicalhierarchy';
+  const clearActionName = 'Clear';
 
   interface BreadcrumbOptions {
     categoryDivider: string;
@@ -85,6 +86,7 @@ describe('quantic-breadcrumb-manager', () => {
       });
 
       scope('when selecting values in time frame facet', () => {
+        const dateFacetName = 'Date';
         const timeframeLabel1 = 'Past 6 months';
         const timeframeLabel2 = 'Past 10 years';
         Expect.dateFacetBreadcrumb.displayBreadcrumb(false);
@@ -94,10 +96,13 @@ describe('quantic-breadcrumb-manager', () => {
 
         Expect.dateFacetBreadcrumb.displayBreadcrumb(true);
         Expect.dateFacetBreadcrumb.displayLabel(true);
-        Expect.dateFacetBreadcrumb.labelContains('Date');
+        Expect.dateFacetBreadcrumb.labelContains(dateFacetName);
         Expect.dateFacetBreadcrumb.numberOfValues(1);
         Expect.dateFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           timeframeLabel1
+        );
+        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextContains(
+          `${dateFacetName} ${clearActionName}`
         );
 
         Actions.timeframeFacet.selectValue(timeframeLabel2);
@@ -120,6 +125,7 @@ describe('quantic-breadcrumb-manager', () => {
 
       scope('when selecting values in category facet', () => {
         const path = ['North America', 'Canada', 'British Columbia'];
+        const categoryFacetName = 'Country';
 
         Expect.categoryFacetBreadcrumb.displayBreadcrumb(false);
 
@@ -128,11 +134,14 @@ describe('quantic-breadcrumb-manager', () => {
 
         Expect.categoryFacetBreadcrumb.displayBreadcrumb(true);
         Expect.categoryFacetBreadcrumb.displayLabel(true);
-        Expect.categoryFacetBreadcrumb.labelContains('Country');
+        Expect.categoryFacetBreadcrumb.labelContains(categoryFacetName);
         Expect.categoryFacetBreadcrumb.displayValues(true);
         Expect.categoryFacetBreadcrumb.numberOfValues(1);
         Expect.categoryFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           path[0]
+        );
+        Expect.categoryFacetBreadcrumb.firstBreadcrumbAltTextContains(
+          `${categoryFacetName} ${clearActionName}`
         );
 
         Actions.categoryFacet.selectChildValue(path[1]);
@@ -217,13 +226,17 @@ describe('quantic-breadcrumb-manager', () => {
         Expect.facetBreadcrumb.numberOfValues(1);
         Expect.facetBreadcrumb.firstBreadcrumbValueLabelContains(fileType);
 
+        const dateFacetName = 'Date';
         Expect.dateFacetBreadcrumb.displayBreadcrumb(true);
         Expect.dateFacetBreadcrumb.displayLabel(true);
-        Expect.dateFacetBreadcrumb.labelContains('Date');
+        Expect.dateFacetBreadcrumb.labelContains(dateFacetName);
         Expect.dateFacetBreadcrumb.displayValues(true);
         Expect.dateFacetBreadcrumb.numberOfValues(1);
         Expect.dateFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           'Past 6 months'
+        );
+        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextContains(
+          `${dateFacetName} ${clearActionName}`
         );
         Expect.categoryFacetBreadcrumb.displayBreadcrumb(true);
         Expect.categoryFacetBreadcrumb.displayLabel(true);

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -9,7 +9,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value.value} alt-text={breadcrumbValue.value.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -26,7 +26,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.formattedValue} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -42,7 +42,7 @@
               <span class="slds-col breadcrumb-manager__field-name">{breadcrumbValue.label}{labels.colon} </span>
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <li class="breadcrumb__container">
-                  <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
+                  <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumbValue.label} action-name={labels.clear}></c-quantic-pill>
                 </li>
               </ul>
             </li>
@@ -53,7 +53,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value} alt-text={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -12,6 +12,7 @@ import {I18nUtils, RelativeDateFormatter, Store} from 'c/quanticUtils';
 
 import nMore from '@salesforce/label/c.quantic_NMore';
 import clearAllFilters from '@salesforce/label/c.quantic_ClearAllFilters';
+import clear from '@salesforce/label/c.quantic_Clear';
 import colon from '@salesforce/label/c.quantic_Colon';
 
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
@@ -71,6 +72,7 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   labels = {
     nMore,
+    clear,
     clearAllFilters,
     colon
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
@@ -1,6 +1,6 @@
 <template>
-  <a class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small" onclick={deselect}>
+  <button class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small slds-button" onclick={deselect}>
     <span class="slds-nowrap pill__text-container slds-truncate">{label}</span>
-    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={altText} size="xx-small"></lightning-icon>
-  </a>
+    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={alternativeText} size="xx-small"></lightning-icon>
+  </button>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
@@ -20,8 +20,28 @@ export default class QuanticPill extends LightningElement {
    * @type {string}
    */
   @api altText;
+  /**
+   * The name of the group if applicable related to the button (for screen readers).
+   * @api
+   * @type {string}
+   */
+  @api groupName;
+  /**
+   * The name of the action if applicable when the button is clicked (for screen readers).
+   * @api
+   * @type {string}
+   */
+  @api actionName;
   
   deselect() {
     this.dispatchEvent(new CustomEvent('deselect'));
+  }
+
+  get alternativeText() {
+    let label = this.altText;
+    if(this.groupName && this.actionName) {
+      label = `${this.groupName} ${this.actionName}`;
+    }
+    return label;
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2271

The breadcrumb values are now accessible when pressing TAB:
![image](https://user-images.githubusercontent.com/2488155/179857824-57e14656-f52b-4aa4-bded-e495aabfa8b2.png)

And the text that is said when reaching this value with screen readers has been fixed:

It was : `facetValue facetValue` being said
Now it is: `facetValue facetName clear button` that is being said.