### PR TITLE
fix(quantic): update date format in tests

### DIFF
--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -23,13 +23,13 @@ describe('quantic-timeframe-facet', () => {
   const pageUrl = 's/quantic-timeframe-facet';
 
   const validRange = {
-    start: '2000-01-01',
-    end: '2000-12-31',
+    start: '01/01/2000',
+    end: '31/12/2000',
     filter: '2000/01/01@00:00:00..2000/12/31@23:59:59',
   };
   const invalidRange = {
-    start: '2000-12-31',
-    end: '2000-01-01',
+    start: '31/12/2000',
+    end: '01/01/2000',
     filter: '2000/12/31@00:00:00..2000/01/01@23:59:59',
   };
 
@@ -322,7 +322,7 @@ describe('quantic-timeframe-facet', () => {
 
           Expect.numberOfValidationErrors(1);
           Expect.validationError(
-            'Your entry does not match the allowed format yyyy-MM-dd.'
+            'Your entry does not match the allowed format dd/MM/yyyy.'
           );
         });
 
@@ -331,7 +331,7 @@ describe('quantic-timeframe-facet', () => {
 
           Expect.numberOfValidationErrors(1);
           Expect.validationError(
-            'Your entry does not match the allowed format yyyy-MM-dd.'
+            'Your entry does not match the allowed format dd/MM/yyyy.'
           );
         });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2352

This PR fixes the date format in the Quantic Timeframe facet tests to match the community locale. It seems that the Lightning date picker component is now honoring the setting.