### PR TITLE
fix(atomic): prevent search box "enter" from submitting twice

### DIFF
--- a/packages/atomic/cypress/integration/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/integration/search-box/search-box.cypress.ts
@@ -9,6 +9,7 @@ import * as CommonAssertions from '../common-assertions';
 import * as SearchBoxAssertions from './search-box-assertions';
 import {addQuerySummary} from '../query-summary-actions';
 import * as QuerySummaryAssertions from '../query-summary-assertions';
+import {RouteAlias} from '../../utils/setupComponent';
 
 const setSuggestions = (count: number) => () => {
   cy.intercept(
@@ -144,6 +145,21 @@ describe('Search Box Test Suites', () => {
     CommonAssertions.assertAriaLiveMessage(' no ');
   });
 
+  describe('with a basic search box', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(addSearchBox())
+        .with(addQuerySummary())
+        .withoutFirstAutomaticSearch()
+        .init();
+      SearchBoxSelectors.inputBox().click();
+      SearchBoxSelectors.inputBox().type('test{enter}', {force: true});
+      cy.wait(RouteAlias.analytics);
+    });
+
+    CommonAssertions.assertConsoleError(false);
+  });
+
   describe('with disableSearch set to true', () => {
     beforeEach(() => {
       new TestFixture()
@@ -159,5 +175,6 @@ describe('Search Box Test Suites', () => {
     SearchBoxAssertions.assertHasSuggestionsCount(0);
     SearchBoxAssertions.assertHasText('test');
     QuerySummaryAssertions.assertHasPlaceholder();
+    CommonAssertions.assertConsoleError(false);
   });
 });

--- a/packages/atomic/src/components/common/search-box/clear-button.tsx
+++ b/packages/atomic/src/components/common/search-box/clear-button.tsx
@@ -2,18 +2,15 @@ import ClearIcon from 'coveo-styleguide/resources/icons/svg/clear.svg';
 import {FunctionalComponent, h} from '@stencil/core';
 import {Button, ButtonProps} from '../button';
 import {AnyBindings} from '../interface/bindings';
-import {SearchBox} from '@coveo/headless';
 
 interface Props extends Partial<ButtonProps> {
   bindings: AnyBindings;
-  searchBox: SearchBox;
   inputRef: HTMLInputElement | null;
 }
 
 export const ClearButton: FunctionalComponent<Props> = ({
   inputRef,
   bindings,
-  searchBox,
   onClick,
   ...defaultButtonProps
 }) => (
@@ -22,7 +19,6 @@ export const ClearButton: FunctionalComponent<Props> = ({
     part="clear-button"
     class="w-8 h-8 mr-1.5 text-neutral-dark"
     onClick={() => {
-      searchBox.clear();
       onClick?.();
       inputRef?.focus();
     }}

--- a/packages/atomic/src/components/common/search-box/search-input.tsx
+++ b/packages/atomic/src/components/common/search-box/search-input.tsx
@@ -1,5 +1,4 @@
 import {JSXBase} from '@stencil/core/internal';
-import {SearchBox, SearchBoxState} from '@coveo/headless';
 import {FunctionalComponent, h} from '@stencil/core';
 import {AnyBindings} from '../interface/bindings';
 import {ClearButton} from './clear-button';
@@ -8,27 +7,24 @@ interface Props extends JSXBase.InputHTMLAttributes<HTMLInputElement> {
   inputRef: HTMLInputElement;
   loading: boolean;
   bindings: AnyBindings;
-  state: SearchBoxState;
-  searchBox: SearchBox;
-  disabled: boolean;
+  value: string;
   ariaOwns?: string;
   isExpanded?: string;
   activeDescendant?: string;
+  onClear(): void;
 }
 
 export const SearchInput: FunctionalComponent<Props> = ({
   inputRef,
   loading,
   bindings,
-  state,
-  searchBox,
-  disabled,
   onKeyDown,
+  value,
+  onClear,
   ...defaultInputProps
 }) => (
   <div class="grow flex items-center">
     <input
-      value={state.value}
       part="input"
       aria-label={bindings.i18n.t('search-box')}
       aria-autocomplete="both"
@@ -41,17 +37,9 @@ export const SearchInput: FunctionalComponent<Props> = ({
       class="h-full outline-none bg-transparent w-0 grow px-4 py-3.5 text-neutral-dark placeholder-neutral-dark text-lg"
       onKeyDown={(e) => {
         onKeyDown?.(e);
-        if (disabled) {
-          return;
-        }
-
-        switch (e.key) {
-          case 'Enter':
-            searchBox.submit();
-            break;
-        }
       }}
       {...defaultInputProps}
+      value={value}
     />
     {loading && (
       <span
@@ -59,11 +47,11 @@ export const SearchInput: FunctionalComponent<Props> = ({
         class="loading w-5 h-5 rounded-full bg-gradient-to-r animate-spin mr-3 grid place-items-center"
       ></span>
     )}
-    {!loading && state.value && (
+    {!loading && value && (
       <ClearButton
         inputRef={inputRef}
         bindings={bindings}
-        searchBox={searchBox}
+        onClick={() => onClear()}
       />
     )}
   </div>

--- a/packages/atomic/src/components/common/search-box/submit-button.tsx
+++ b/packages/atomic/src/components/common/search-box/submit-button.tsx
@@ -2,16 +2,13 @@ import SearchIcon from 'coveo-styleguide/resources/icons/svg/search.svg';
 import {FunctionalComponent, h} from '@stencil/core';
 import {Button, ButtonProps} from '../button';
 import {AnyBindings} from '../interface/bindings';
-import {SearchBox} from '@coveo/headless';
 
 interface Props extends Partial<ButtonProps> {
   bindings: AnyBindings;
-  searchBox: SearchBox;
 }
 
 export const SubmitButton: FunctionalComponent<Props> = ({
   bindings,
-  searchBox,
   onClick,
   ...defaultButtonProps
 }) => (
@@ -21,7 +18,6 @@ export const SubmitButton: FunctionalComponent<Props> = ({
     part="submit-button"
     ariaLabel={bindings.i18n.t('search')}
     onClick={() => {
-      searchBox.submit();
       onClick?.();
     }}
     {...defaultButtonProps}

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.tsx
@@ -63,6 +63,18 @@ export class AtomicInsightSearchBox {
     });
   }
 
+  private onKeyDown(e: KeyboardEvent) {
+    if (this.disableSearch) {
+      return;
+    }
+
+    switch (e.key) {
+      case 'Enter':
+        this.searchBox.submit();
+        break;
+    }
+  }
+
   public render() {
     return (
       <SearchBoxWrapper disabled={this.disableSearch}>
@@ -71,9 +83,9 @@ export class AtomicInsightSearchBox {
           loading={this.searchBoxState.isLoading}
           ref={(el) => (this.inputRef = el as HTMLInputElement)}
           bindings={this.bindings}
-          state={this.searchBoxState}
-          searchBox={this.searchBox}
-          disabled={this.disableSearch}
+          value={this.searchBoxState.value}
+          onKeyDown={(e) => this.onKeyDown(e)}
+          onClear={() => this.searchBox.clear()}
           onInput={(e) => {
             this.searchBox.updateText((e.target as HTMLInputElement).value);
           }}
@@ -81,7 +93,7 @@ export class AtomicInsightSearchBox {
         <SubmitButton
           bindings={this.bindings}
           disabled={this.disableSearch}
-          searchBox={this.searchBox}
+          onClick={() => this.searchBox.submit()}
         />
       </SearchBoxWrapper>
     );

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -701,13 +701,12 @@ export class AtomicSearchBox {
           loading={this.searchBoxState.isLoading}
           ref={(el) => (this.inputRef = el as HTMLInputElement)}
           bindings={this.bindings}
-          searchBox={this.searchBox}
-          state={this.searchBoxState}
-          disabled={this.disableSearch}
+          value={this.searchBoxState.value}
           onFocus={() => this.onFocus()}
           onInput={(e) => this.onInput((e.target as HTMLInputElement).value)}
           onBlur={() => this.clearSuggestions()}
           onKeyDown={(e) => this.onKeyDown(e)}
+          onClear={() => this.searchBox.clear()}
           aria-owns={this.popupId}
           aria-expanded={`${this.isExpanded}`}
           aria-activedescendant={this.activeDescendant}
@@ -716,7 +715,7 @@ export class AtomicSearchBox {
         <SubmitButton
           bindings={this.bindings}
           disabled={this.disableSearch}
-          searchBox={this.searchBox}
+          onClick={() => this.searchBox.submit()}
         />
       </SearchBoxWrapper>,
       !this.suggestions.length && (

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -12,7 +12,12 @@
       async function main() {
         await customElements.whenDefined('atomic-insight-interface');
         const insightInterface = document.querySelector('atomic-insight-interface');
-        await insightInterface.initialize({});
+        await insightInterface.initialize({
+          // TODO: update org with an insight supported one
+          insightId: 'test',
+          accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+          organizationId: 'searchuisamples',
+        });
 
         insightInterface.executeFirstSearch();
       }
@@ -32,7 +37,9 @@
   <body>
     <button id="widget-view">Toggle widget view</button>
     <div id="wrapper">
-      <atomic-insight-interface> </atomic-insight-interface>
+      <atomic-insight-interface>
+        <atomic-insight-search-box></atomic-insight-search-box>
+      </atomic-insight-interface>
     </div>
     <script src="../header.js" type="text/javascript"></script>
     <script type="text/javascript">

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -195,7 +195,11 @@
         </atomic-layout-section>
         <atomic-layout-section section="main">
           <atomic-segmented-facet-scrollable>
-            <atomic-segmented-facet field="objecttype" number-of-values="20"></atomic-segmented-facet>
+            <atomic-segmented-facet
+              facet-id="segment"
+              field="objecttype"
+              number-of-values="20"
+            ></atomic-segmented-facet>
           </atomic-segmented-facet-scrollable>
           <atomic-layout-section section="status">
             <atomic-breadbox></atomic-breadbox>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1867

I'm aware the insight feature/refactor isn't fully done yet, but because of this early bug I basically made the functional components agnostic of the headless search box type & we're not passing down the controller which will sometimes be of type insight, sometimes commerce, etc...