### PR TITLE
feat(atomic): added -checked part to checkbox facets

### DIFF
--- a/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
@@ -18,10 +18,14 @@ export const FacetSelectors = {
     return this.shadow().find('[part="placeholder"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"][part~="value-checkbox-checked"][aria-checked="true"]'
+    );
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"]:not([part~="value-checkbox-checked"])[aria-checked="false"]'
+    );
   },
   checkboxValueWithText(text: string) {
     return this.shadow()

--- a/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet-selectors.ts
@@ -18,17 +18,17 @@ export const FacetSelectors = {
     return this.shadow().find('[part="placeholder"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
   },
   checkboxValueWithText(text: string) {
     return this.shadow()
       .find(`[part="value-label"]:contains("${text}")`)
       .parent()
       .parent()
-      .find('[part="value-checkbox"]');
+      .find('[part~="value-checkbox"]');
   },
   idleCheckboxValueLabel() {
     return this.idleCheckboxValue().parent().find('[part="value-label"]');

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
@@ -16,17 +16,17 @@ export const NumericFacetSelectors = {
     return this.shadow().find('[part="placeholder"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
   },
   checkboxValueWithText(text: string) {
     return this.shadow()
       .find(`[part="value-label"]:contains("${text}")`)
       .parent()
       .parent()
-      .find('[part="value-checkbox"]');
+      .find('[part~="value-checkbox"]');
   },
   idleCheckboxValueLabel() {
     return this.idleCheckboxValue().parent().find('[part="value-label"]');

--- a/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
@@ -16,10 +16,14 @@ export const NumericFacetSelectors = {
     return this.shadow().find('[part="placeholder"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"][part~="value-checkbox-checked"][aria-checked="true"]'
+    );
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"]:not([part~="value-checkbox-checked"])[aria-checked="false"]'
+    );
   },
   checkboxValueWithText(text: string) {
     return this.shadow()

--- a/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-selectors.ts
@@ -33,10 +33,14 @@ export const RatingFacetSelectors = {
     return this.shadow().find('[part="value-rating"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"][part~="value-checkbox-checked"][aria-checked="true"]'
+    );
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find(
+      '[part~="value-checkbox"]:not([part~="value-checkbox-checked"])[aria-checked="false"]'
+    );
   },
   checkboxValueWithText(text: string) {
     return this.shadow()

--- a/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-selectors.ts
+++ b/packages/atomic/cypress/integration/facets/rating-facet/rating-facet-selectors.ts
@@ -33,17 +33,17 @@ export const RatingFacetSelectors = {
     return this.shadow().find('[part="value-rating"]');
   },
   selectedCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="true"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="true"]');
   },
   idleCheckboxValue() {
-    return this.shadow().find('[part="value-checkbox"][aria-checked="false"]');
+    return this.shadow().find('[part~="value-checkbox"][aria-checked="false"]');
   },
   checkboxValueWithText(text: string) {
     return this.shadow()
       .find(`[part="value-rating"][aria-label="${text}"]`)
       .parent()
       .parent()
-      .find('[part="value-checkbox"]');
+      .find('[part~="value-checkbox"]');
   },
   idleCheckboxValueLabel() {
     return this.idleCheckboxValue().parent().find('[part="value-rating"]');

--- a/packages/atomic/src/components/common/checkbox.tsx
+++ b/packages/atomic/src/components/common/checkbox.tsx
@@ -1,0 +1,62 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import Tick from '../../images/checkbox.svg';
+
+export interface CheckboxProps {
+  checked: boolean;
+  onToggle(checked: boolean): void;
+  key?: string | number;
+  id?: string;
+  class?: string;
+  text?: string;
+  part?: string;
+  ariaLabel?: string;
+  ariaCurrent?: string;
+  ref?(element?: HTMLElement): void;
+  onMouseDown?(evt: MouseEvent): void;
+}
+
+export const Checkbox: FunctionalComponent<CheckboxProps> = (props) => {
+  const partName = props.part ?? 'checkbox';
+
+  const classNames = [
+    'w-4 h-4 grid place-items-center rounded no-outline hover:border-primary-light focus-visible:border-primary-light',
+  ];
+  const parts = [partName];
+  if (props.checked) {
+    classNames.push(
+      'selected bg-primary hover:bg-primary-light focus-visible:bg-primary-light'
+    );
+    parts.push(`${partName}-checked`);
+  } else {
+    classNames.push('border border-neutral-dark');
+    parts.push(`${partName}-unchecked`);
+  }
+  if (props.class) {
+    classNames.push(props.class);
+  }
+
+  const attributes = {
+    key: props.key,
+    id: props.id,
+    class: classNames.join(' '),
+    part: parts.join(' '),
+    'aria-checked': props.checked.toString(),
+    'aria-label': props.ariaLabel ?? props.text,
+    value: props.text,
+    ref: props.ref,
+  };
+
+  return (
+    <button
+      {...attributes}
+      role="checkbox"
+      onClick={() => props.onToggle?.(!props.checked)}
+      onMouseDown={(e) => props.onMouseDown?.(e)}
+    >
+      <atomic-icon
+        class={`w-3/5 svg-checkbox ${props.checked ? 'block' : 'hidden'}`}
+        icon={Tick}
+      ></atomic-icon>
+    </button>
+  );
+};

--- a/packages/atomic/src/components/common/checkbox.tsx
+++ b/packages/atomic/src/components/common/checkbox.tsx
@@ -29,7 +29,6 @@ export const Checkbox: FunctionalComponent<CheckboxProps> = (props) => {
     parts.push(`${partName}-checked`);
   } else {
     classNames.push('border border-neutral-dark');
-    parts.push(`${partName}-unchecked`);
   }
   if (props.class) {
     classNames.push(props.class);

--- a/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -71,6 +71,8 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  * @part value-* - The dynamic part name used to customize a facet value. The `*` is a syntactical placeholder for a specific facet value. For example, if the component's `field` property is set to 'filetype' and your source has a `YouTubeVideo` file type, the part would be targeted like this: `atomic-color-facet::part(value-YouTubeVideo)...`.
  *
  * @part value-box - The facet value when display is 'box'.
+ * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  *
  * @part show-more - The show more results button.

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -72,7 +72,6 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
- * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  * @part value-box - The facet value when display is 'box'.

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -71,6 +71,8 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  * @part value-count - The facet value count, common for all displays.
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  * @part value-box - The facet value when display is 'box'.

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -74,7 +74,6 @@ interface NumericRangeWithLabel extends NumericRangeRequest {
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
- * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  *

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -73,6 +73,8 @@ interface NumericRangeWithLabel extends NumericRangeRequest {
  * @part value-count - The facet value count, common for all displays.
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  *

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -55,7 +55,6 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
- * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  *

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -54,6 +54,8 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  * @part value-rating - The facet value rating, common for all displays.
  *
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
+ * @part value-checkbox-unchecked - The unchecked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  *

--- a/packages/atomic/src/components/search/facets/color-facet-checkbox/color-facet-checkbox.tsx
+++ b/packages/atomic/src/components/search/facets/color-facet-checkbox/color-facet-checkbox.tsx
@@ -23,7 +23,9 @@ export const ColorFacetCheckbox: FunctionalComponent<FacetValueProps> = (
       <button
         id={id}
         role="checkbox"
-        part={`value-${partValue}`}
+        part={`value-checkbox value-${partValue}${
+          props.isSelected ? ' value-checkbox-checked' : ''
+        }`}
         onClick={() => props.onClick()}
         onMouseDown={(e) =>
           createRipple(e, {color: 'neutral', parent: labelRef})

--- a/packages/atomic/src/components/search/facets/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/search/facets/facet-value-checkbox/facet-value-checkbox.pcss
@@ -5,7 +5,7 @@
   width: var(--atomic-facet-checkbox-size, 16px);
   height: var(--atomic-facet-checkbox-size, 16px);
 
-  @apply absolute z-1 left-2 grid place-items-center rounded no-outline hover:border-primary-light focus-visible:border-primary-light;
+  @apply absolute z-1 left-2;
 }
 
 .value-checkbox + label {

--- a/packages/atomic/src/components/search/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/search/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -1,8 +1,8 @@
 import {FunctionalComponent, h} from '@stencil/core';
 import {createRipple} from '../../../../utils/ripple';
 import {randomID} from '../../../../utils/utils';
+import {Checkbox} from '../../../common/checkbox';
 import {FacetValueProps} from '../facet-common';
-import Checkbox from '../../../../images/checkbox.svg';
 
 export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
   props,
@@ -19,28 +19,18 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
 
   return (
     <li key={props.displayValue} class="relative flex items-center">
-      <button
+      <Checkbox
         id={id}
-        role="checkbox"
+        checked={props.isSelected}
+        onToggle={() => props.onClick()}
         part="value-checkbox"
-        onClick={() => props.onClick()}
+        class="value-checkbox"
+        ariaLabel={ariaLabel}
+        ref={props.buttonRef}
         onMouseDown={(e) =>
           createRipple(e, {color: 'neutral', parent: labelRef})
         }
-        aria-checked={props.isSelected.toString()}
-        class={`value-checkbox ${
-          props.isSelected
-            ? 'selected bg-primary'
-            : 'border border-neutral-dark'
-        }`}
-        aria-label={ariaLabel}
-        ref={props.buttonRef}
-      >
-        <atomic-icon
-          class={`w-3/5 svg-checkbox ${props.isSelected ? 'block' : 'hidden'}`}
-          icon={Checkbox}
-        ></atomic-icon>
-      </button>
+      />
       <label
         ref={(ref) => (labelRef = ref!)}
         htmlFor={id}


### PR DESCRIPTION
I extracted the facet value's checkbox into an accessible Checkbox functional component. `:checked` doesn't work since this is not a real checkbox.

I also changed the background color of checkboxes when hovered, so that they are accessible even when standalone. It doesn't look any worse than before in a facet value IMO.

When the checkbox is checked, the part `PART-checked` is added.

# Standalone
Checked:
<img width="33" alt="image" src="https://user-images.githubusercontent.com/54454747/180296719-386af499-c8fa-4a61-a3fa-f2c4f7501bce.png">
Checked & hovered:
<img width="37" alt="image" src="https://user-images.githubusercontent.com/54454747/180296745-2819f3e3-23b0-4b33-bbe4-9dd785f34eac.png">

# Facet value
Checked:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/54454747/180296816-dcc4f06c-d556-46b3-9ad9-010ebf4e3054.png">
Checked & hovered:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/54454747/180296883-afc682f6-1d66-4886-ab6b-5c8b14969192.png">


https://coveord.atlassian.net/browse/KIT-1868