### PR TITLE
fix(quantic): changed ... to expand from a A tag to a button

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.css
@@ -10,3 +10,7 @@
 .result-parenturi__container:last-child .result-parenturi__separator {
   display: none;
 }
+
+.expand-parenturi__container {
+  line-height: var(--lwc-lineHeightText, 1.5);
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -7,7 +7,7 @@
       <template for:each={foldedParents} for:item="parent">
         <div class="result-parenturi__container slds-grid slds-grid_vertical-align-center" key={parent.id}>
           <template if:true={parent.isFolded}>
-            <lightning-button variant="base" label="..." title="Expand URI parts" aria-label="Expand URI parts" onclick={expandParents}>...</lightning-button>
+            <button class="slds-button expand-parenturi__container" variant="base" label="..." title="Expand URI parts" aria-label="Expand URI parts" onclick={expandParents}>...</button>
           </template>
           <template if:false={parent.isFolded}>
             <a class={parent.classes} href={parent.uri} target={target}>{parent.name}</a>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -7,7 +7,7 @@
       <template for:each={foldedParents} for:item="parent">
         <div class="result-parenturi__container slds-grid slds-grid_vertical-align-center" key={parent.id}>
           <template if:true={parent.isFolded}>
-            <a onclick={expandParents}>...</a>
+            <lightning-button onclick={expandParents}>...</lightning-button>
           </template>
           <template if:false={parent.isFolded}>
             <a class={parent.classes} href={parent.uri} target={target}>{parent.name}</a>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -7,7 +7,7 @@
       <template for:each={foldedParents} for:item="parent">
         <div class="result-parenturi__container slds-grid slds-grid_vertical-align-center" key={parent.id}>
           <template if:true={parent.isFolded}>
-            <button class="slds-button expand-parenturi__container" variant="base" label="..." title="Expand URI parts" aria-label="Expand URI parts" onclick={expandParents}>...</button>
+            <button class="slds-button expand-parenturi__container" variant="base" label="..." title="Expand URI" aria-label="Expand URI" onclick={expandParents}>...</button>
           </template>
           <template if:false={parent.isFolded}>
             <a class={parent.classes} href={parent.uri} target={target}>{parent.name}</a>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -7,7 +7,7 @@
       <template for:each={foldedParents} for:item="parent">
         <div class="result-parenturi__container slds-grid slds-grid_vertical-align-center" key={parent.id}>
           <template if:true={parent.isFolded}>
-            <lightning-button onclick={expandParents}>...</lightning-button>
+            <lightning-button variant="base" label="..." title="Expand URI parts" aria-label="Expand URI parts" onclick={expandParents}>...</lightning-button>
           </template>
           <template if:false={parent.isFolded}>
             <a class={parent.classes} href={parent.uri} target={target}>{parent.name}</a>


### PR DESCRIPTION
[SVCC-2277](https://coveord.atlassian.net/browse/SVCC-2277)

Changed the clickable object from an A tag to a button as it does not redirect to another page. The mac screenreader now detects it as a expandable object