### PR TITLE
chore(quantic): read sfdx error JSON output from stdout instead of stderr

### DIFF
--- a/packages/quantic/scripts/build/util/sfdx.ts
+++ b/packages/quantic/scripts/build/util/sfdx.ts
@@ -27,7 +27,14 @@ export function sfdx<T = SfdxResponse>(command: string): Promise<T> {
       },
       (error, stdout) => {
         if (error) {
-          reject(error);
+          let jsonOutput;
+          try {
+            jsonOutput = JSON.parse(strip(stdout));
+          } catch (e) {
+            // The output is not JSON. The command most likely failed outside the SFDX CLI.
+          }
+
+          reject(jsonOutput || error);
         }
 
         resolve(stdout ? (JSON.parse(strip(stdout)) as T) : null);


### PR DESCRIPTION
[SVCC-2349](https://coveord.atlassian.net/browse/SVCC-2349)

Apparently a recent version of sfdx-cli introduced a change in the way errors are returned. Before, the error JSON response would be returned through stderr. It is now returned through stdout.

It prevented our deploy-community script from deploying on an existing scratch org.