### PR TITLE
feat(quantic): update Quantic components to work with different engines

### DIFF
--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -78,6 +78,8 @@ export type {
 } from './controllers/document-suggestion-list/headless-document-suggestion-list';
 export {buildDocumentSuggestionList} from './controllers/document-suggestion-list/headless-document-suggestion-list';
 
+export {buildCaseAssistInteractiveResult as buildInteractiveResult} from './controllers/document-suggestion-list/case-assist-headless-interactive-result';
+
 /**
  * @deprecated
  * Types exported for backward compatibility only.

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -64,6 +64,7 @@ export type {
   CaseAssistQuickviewOptions,
   CaseAssistQuickviewProps,
 } from './controllers/quickview/case-assist-headless-quickview';
+export {buildCaseAssistQuickview as buildQuickview} from './controllers/quickview/case-assist-headless-quickview';
 export {buildCaseAssistQuickview} from './controllers/quickview/case-assist-headless-quickview';
 
 export type {Result} from './api/search/search/result';

--- a/packages/quantic/docs/jsdoc-guidelines.md
+++ b/packages/quantic/docs/jsdoc-guidelines.md
@@ -25,8 +25,9 @@ Events fired from this component should be defined using the `@fires` tag.
 
 Each component should be given one or more category values using the `@category` tag from one of the following cateogories:
 
-- **Search**: Components pertaining to the Search use-case.
-- **Case Assist**: Components pertaining to the Case Assist use-case.
+- **Search**: Components pertaining to the Search use case.
+- **Case Assist**: Components pertaining to the Case Assist use case.
+- **Insight Panel**: Components pertaining to the Insight Panel use case
 - **Result Template**: Components meant to be used within result templates.
 - **Utility**: Components providing a generic utility without pertaining to any specific Coveo Headless use-case.
   If there are more than one relevant category, each should be specified with its own tag.

--- a/packages/quantic/docs/template/lwc-json/publish.js
+++ b/packages/quantic/docs/template/lwc-json/publish.js
@@ -1,6 +1,6 @@
 /**
  * @overview Builds a tree-like JSON string from the LWC doclet data.
- * @version 0.0.1 
+ * @version 0.0.1
  */
 'use strict';
 
@@ -10,13 +10,11 @@ const xmlToJson = require('xml2json').toJson;
 const dump = require('jsdoc/util/dumper').dump;
 
 function formatType(type) {
-  return type
-    ? (type.names.length === 1 ? type.names[0] : type.names)
-    : '';
+  return type ? (type.names.length === 1 ? type.names[0] : type.names) : '';
 }
 
 function formatBooleanParam(boolParam) {
-  return typeof boolParam === 'boolean' ? boolParam : ''
+  return typeof boolParam === 'boolean' ? boolParam : '';
 }
 
 function parseFunction(element, parentNode) {
@@ -34,7 +32,7 @@ function parseFunction(element, parentNode) {
     virtual: !!element.virtual,
     description: element.description || '',
     parameters: [],
-    examples: []
+    examples: [],
   };
 
   parentNode.functions.push(thisFunction);
@@ -42,7 +40,7 @@ function parseFunction(element, parentNode) {
   if (element.returns) {
     thisFunction.returns = {
       type: formatType(element.returns[0].type),
-      description: element.returns[0].description || ''
+      description: element.returns[0].description || '',
     };
   }
 
@@ -88,10 +86,10 @@ function parseMember(element, parentNode) {
     required: !element.defaultvalue && !isTagDefined(element, 'optional'),
     defaultValue: element.defaultvalue || '',
     type: element.type?.names?.join('|') || '',
-  }
+  };
   if (prop.type.name === 'function') {
-    prop.type.params = element.params || '',
-      prop.type.returns = element.returns || ''
+    (prop.type.params = element.params || ''),
+      (prop.type.returns = element.returns || '');
   }
   parentNode.properties.push(prop);
 }
@@ -104,21 +102,26 @@ function getMetadata(element) {
 }
 
 function getComponentCategories(element) {
-  const categories = element.tags?.filter((tag) => tag.originalTitle === 'category');
-  return categories ? categories.map(category => category.value) : [];
+  const categories = element.tags?.filter(
+    (tag) => tag.originalTitle === 'category'
+  );
+  return categories ? categories.map((category) => category.value) : [];
 }
 
 const categoryMap = {
   search: 'Search',
   resultTemplate: 'Result Template',
   caseAssist: 'Case Assist',
-  utility: 'Utility'
-}
+  utility: 'Utility',
+  insightPanel: 'Insight Panel',
+};
 
 function parseClass(element, parentNode, childNodes) {
   if (!parentNode.components) {
     parentNode.components = {};
-    Object.keys(categoryMap).forEach(key => parentNode.components[key] = []);
+    Object.keys(categoryMap).forEach(
+      (key) => (parentNode.components[key] = [])
+    );
   }
 
   element.xmlMeta = getMetadata(element).LightningComponentBundle;
@@ -133,15 +136,21 @@ function parseClass(element, parentNode, childNodes) {
     xmlMeta: {
       apiVersion: element.xmlMeta?.apiVersion || '',
       isExposed: element.xmlMeta?.isExposed,
-      targets: element.xmlMeta?.targets?.target || []
-    }
+      targets: element.xmlMeta?.targets?.target || [],
+    },
   };
 
-  const categoryKeys = Object.keys(categoryMap).filter(key => thisClass.categories.includes(categoryMap[key]));
+  const categoryKeys = Object.keys(categoryMap).filter((key) =>
+    thisClass.categories.includes(categoryMap[key])
+  );
   if (!categoryKeys.length) {
-    throw new Error(`JsDoc parsing FAILED: Invalid or missing category value(s) on component ${thisClass.name}.`);
+    throw new Error(
+      `JsDoc parsing FAILED: Invalid or missing category value(s) on component ${thisClass.name}.`
+    );
   }
-  categoryKeys.forEach(categoryKey => parentNode.components[categoryKey].push(thisClass));
+  categoryKeys.forEach((categoryKey) =>
+    parentNode.components[categoryKey].push(thisClass)
+  );
 
   if (element.examples) {
     for (let i = 0, len = element.examples.length; i < len; i++) {
@@ -166,7 +175,7 @@ function parseClass(element, parentNode, childNodes) {
 function graft(parentNode, childNodes, parentLongname) {
   childNodes
     .filter(function (element) {
-      return (element.memberof === parentLongname);
+      return element.memberof === parentLongname;
     })
     .forEach(function (element, _index) {
       switch (element.kind) {
@@ -189,15 +198,16 @@ function graft(parentNode, childNodes, parentLongname) {
 exports.publish = function (data, opts) {
   let root = {};
 
-  data({ undocumented: true }).remove();
+  data({undocumented: true}).remove();
   const docs = data().get();
 
   graft(root, docs);
 
   if (opts.destination === 'console') {
     console.log(dump(root));
-  }
-  else {
-    console.log('This template only supports output to the console. Use the option "-d console" when you run JSDoc.');
+  } else {
+    console.log(
+      'This template only supports output to the console. Use the option "-d console" when you run JSDoc.'
+    );
   }
 };

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -1,8 +1,4 @@
-import {
-  LightningElement,
-  track,
-  api
-} from 'lwc';
+import {LightningElement, track, api} from 'lwc';
 import {
   registerComponentForInit,
   initializeWithHeadless,
@@ -27,6 +23,7 @@ import colon from '@salesforce/label/c.quantic_Colon';
 /**
  * The `QuanticBreadcrumbManager` component creates breadcrumbs that display a summary of the currently active facet values.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-breadcrumb-manager engine-id={engineId} category-divider=";" collapse-threshold="4"></c-quantic-breadcrumb-manager>
  */
@@ -44,7 +41,7 @@ export default class QuanticBreadcrumbManager extends LightningElement {
    * @defaultValue `'/'`
    */
   @api categoryDivider = '/';
-  /** 
+  /**
    * Maximum number of displayed breadcrumb values. When more values are selected, additional values appear under the "More" button.
    * @api
    * @type {Number}
@@ -74,8 +71,8 @@ export default class QuanticBreadcrumbManager extends LightningElement {
     nMore,
     clear,
     clearAllFilters,
-    colon
-  }
+    colon,
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -90,8 +87,10 @@ export default class QuanticBreadcrumbManager extends LightningElement {
    */
   initialize = (engine) => {
     this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
-    this.unsubscribe = this.breadcrumbManager.subscribe(() => this.updateState());
-  }
+    this.unsubscribe = this.breadcrumbManager.subscribe(() =>
+      this.updateState()
+    );
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
@@ -99,9 +98,12 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   updateState() {
     this.facetBreadcrumbs = this.breadcrumbManager.state.facetBreadcrumbs;
-    this.categoryFacetBreadcrumbs = this.breadcrumbManager.state.categoryFacetBreadcrumbs;
-    this.numericFacetBreadcrumbs = this.breadcrumbManager.state.numericFacetBreadcrumbs;
-    this.dateFacetBreadcrumbs = this.breadcrumbManager.state.dateFacetBreadcrumbs;
+    this.categoryFacetBreadcrumbs =
+      this.breadcrumbManager.state.categoryFacetBreadcrumbs;
+    this.numericFacetBreadcrumbs =
+      this.breadcrumbManager.state.numericFacetBreadcrumbs;
+    this.dateFacetBreadcrumbs =
+      this.breadcrumbManager.state.dateFacetBreadcrumbs;
     this.hasBreadcrumbs = this.breadcrumbManager.state.hasBreadcrumbs;
   }
 
@@ -115,11 +117,11 @@ export default class QuanticBreadcrumbManager extends LightningElement {
     return {
       ...breadcrumb,
       label: data ? data[breadcrumb.field]?.label : breadcrumb.field,
-      values: (breadcrumb.values.map(range => ({
+      values: breadcrumb.values.map((range) => ({
         ...range,
         value: `${range.value.start} - ${range.value.end}`,
         formattedValue: data[breadcrumb.field]?.format(range.value),
-      })))
+      })),
     };
   }
 
@@ -136,18 +138,20 @@ export default class QuanticBreadcrumbManager extends LightningElement {
   }
 
   /**
-   * 
-   * @param {DateFacetValue} dateRange 
+   *
+   * @param {DateFacetValue} dateRange
    */
   formatDateRange(dateRange) {
     try {
       const startDate = CoveoHeadless.deserializeRelativeDate(dateRange.start);
       const endDate = CoveoHeadless.deserializeRelativeDate(dateRange.end);
-      
+
       return new RelativeDateFormatter().formatRange(startDate, endDate);
     } catch (err) {
       // handle it as a fixed date range
-      return `${this.formatDate(dateRange.start)} - ${this.formatDate(dateRange.end)}`;
+      return `${this.formatDate(dateRange.start)} - ${this.formatDate(
+        dateRange.end
+      )}`;
     }
   }
 
@@ -161,13 +165,13 @@ export default class QuanticBreadcrumbManager extends LightningElement {
     return {
       ...breadcrumb,
       label: data ? data[breadcrumb.field]?.label : breadcrumb.field,
-      values: breadcrumb.values.map(range => ({
+      values: breadcrumb.values.map((range) => ({
         ...range,
         value: data[breadcrumb.field]?.format(range.value),
-      }))
+      })),
     };
   }
-  
+
   formatFacetBreadcrumbValue(breadcrumb) {
     const data = getFromStore(this.engineId, Store.facetTypes.FACETS);
     return {
@@ -188,54 +192,80 @@ export default class QuanticBreadcrumbManager extends LightningElement {
   }
 
   getBreadcrumbValuesCollapsed(breadcrumb) {
-    return ({
+    return {
       ...breadcrumb,
       values: breadcrumb.values.slice(0, this.collapseThreshold),
       showMoreButton: true,
-      showMoreButtonText: I18nUtils.format(this.labels.nMore, breadcrumb.values.length - this.collapseThreshold),
+      showMoreButtonText: I18nUtils.format(
+        this.labels.nMore,
+        breadcrumb.values.length - this.collapseThreshold
+      ),
       expandButtonClick: () => {
-        this.expandedBreadcrumbFieldsState = [...this.expandedBreadcrumbFieldsState, breadcrumb.field];
-      }
-    });
+        this.expandedBreadcrumbFieldsState = [
+          ...this.expandedBreadcrumbFieldsState,
+          breadcrumb.field,
+        ];
+      },
+    };
   }
 
   getShouldCollapseBreadcrumbValues(breadcrumb) {
     this.resetExpandedBreadcrumbFieldState(breadcrumb);
-    return breadcrumb.values.length > this.collapseThreshold && !this.expandedBreadcrumbFieldsState.includes(breadcrumb.field);
+    return (
+      breadcrumb.values.length > this.collapseThreshold &&
+      !this.expandedBreadcrumbFieldsState.includes(breadcrumb.field)
+    );
   }
 
   getBreadcrumbValues(breadcrumb) {
-    return (this.getShouldCollapseBreadcrumbValues(breadcrumb) ?
-      this.getBreadcrumbValuesCollapsed(breadcrumb) :
-      breadcrumb);
+    return this.getShouldCollapseBreadcrumbValues(breadcrumb)
+      ? this.getBreadcrumbValuesCollapsed(breadcrumb)
+      : breadcrumb;
   }
 
   get facetBreadcrumbValues() {
-    const facetBreadcrumbsToDisplay = this.facetBreadcrumbs?.map(breadcrumb =>this.formatFacetBreadcrumbValue(breadcrumb)) || [];
-    return facetBreadcrumbsToDisplay.map(breadcrumb => this.getBreadcrumbValues(breadcrumb));
+    const facetBreadcrumbsToDisplay =
+      this.facetBreadcrumbs?.map((breadcrumb) =>
+        this.formatFacetBreadcrumbValue(breadcrumb)
+      ) || [];
+    return facetBreadcrumbsToDisplay.map((breadcrumb) =>
+      this.getBreadcrumbValues(breadcrumb)
+    );
   }
 
   get numericFacetBreadcrumbsValues() {
-    const numericFacetBreadcrumbsToDisplay = this.numericFacetBreadcrumbs.map(breadcrumb =>this.formatRangeBreadcrumbValue(breadcrumb)) || [];
-    return numericFacetBreadcrumbsToDisplay.map(breadcrumb => this.getBreadcrumbValues(breadcrumb));
+    const numericFacetBreadcrumbsToDisplay =
+      this.numericFacetBreadcrumbs.map((breadcrumb) =>
+        this.formatRangeBreadcrumbValue(breadcrumb)
+      ) || [];
+    return numericFacetBreadcrumbsToDisplay.map((breadcrumb) =>
+      this.getBreadcrumbValues(breadcrumb)
+    );
   }
 
   get categoryFacetBreadcrumbsValues() {
     const data = getFromStore(this.engineId, Store.facetTypes.CATEGORYFACETS);
-    return this.categoryFacetBreadcrumbs.map(breadcrumb => {
-      const breadcrumbValues = this.formatCategoryBreadcrumbValue(breadcrumb);
-      return {
-        facetId: breadcrumb.facetId,
-        field: breadcrumb.field,
-        label: data ? data[breadcrumb.field]?.label : breadcrumb.field,
-        deselect: breadcrumb.deselect,
-        value: breadcrumbValues.join(` ${this.categoryDivider} `)
-      };
-    }) || [];
+    return (
+      this.categoryFacetBreadcrumbs.map((breadcrumb) => {
+        const breadcrumbValues = this.formatCategoryBreadcrumbValue(breadcrumb);
+        return {
+          facetId: breadcrumb.facetId,
+          field: breadcrumb.field,
+          label: data ? data[breadcrumb.field]?.label : breadcrumb.field,
+          deselect: breadcrumb.deselect,
+          value: breadcrumbValues.join(` ${this.categoryDivider} `),
+        };
+      }) || []
+    );
   }
 
   get dateFacetBreadcrumbsValues() {
-    const dateFacetBreadcrumbsToDisplay = this.dateFacetBreadcrumbs.map(breadcrumb => this.formatDateRangeBreadcrumbValue(breadcrumb)) || [];
-    return dateFacetBreadcrumbsToDisplay.map(breadcrumb => this.getBreadcrumbValues(breadcrumb));
+    const dateFacetBreadcrumbsToDisplay =
+      this.dateFacetBreadcrumbs.map((breadcrumb) =>
+        this.formatDateRangeBreadcrumbValue(breadcrumb)
+      ) || [];
+    return dateFacetBreadcrumbsToDisplay.map((breadcrumb) =>
+      this.getBreadcrumbValues(breadcrumb)
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -3,6 +3,7 @@ import {
   registerComponentForInit,
   initializeWithHeadless,
   getFromStore,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, RelativeDateFormatter, Store} from 'c/quanticUtils';
 
@@ -86,7 +87,9 @@ export default class QuanticBreadcrumbManager extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
+    this.breadcrumbManager = getHeadlessBundle(
+      this.engineId
+    ).buildBreadcrumbManager(engine);
     this.unsubscribe = this.breadcrumbManager.subscribe(() =>
       this.updateState()
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -146,8 +146,12 @@ export default class QuanticBreadcrumbManager extends LightningElement {
    */
   formatDateRange(dateRange) {
     try {
-      const startDate = CoveoHeadless.deserializeRelativeDate(dateRange.start);
-      const endDate = CoveoHeadless.deserializeRelativeDate(dateRange.end);
+      const startDate = getHeadlessBundle(
+        this.engineId
+      ).deserializeRelativeDate(dateRange.start);
+      const endDate = getHeadlessBundle(this.engineId).deserializeRelativeDate(
+        dateRange.end
+      );
 
       return new RelativeDateFormatter().formatRange(startDate, endDate);
     } catch (err) {

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
@@ -61,7 +61,8 @@ export default class QuanticCaseAssistInterface extends LightningElement {
               this.engineOptions,
               CoveoHeadlessCaseAssist.buildCaseAssistEngine,
               this.engineId,
-              this
+              this,
+              CoveoHeadlessCaseAssist
             );
             setInitializedCallback(this.initialize, this.engineId);
           }

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -1,5 +1,10 @@
 import {api, LightningElement, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless, registerToStore, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  registerComponentForInit,
+  initializeWithHeadless,
+  registerToStore,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 import {I18nUtils, regexEncode, Store} from 'c/quanticUtils';
 
 import clear from '@salesforce/label/c.quantic_Clear';
@@ -24,6 +29,7 @@ import expandFacet from '@salesforce/label/c.quantic_ExpandFacet';
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criterion (e.g., number of occurrences).
  * A `QuanticCategoryFacet` displays field values in a browsable, hierarchical fashion.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-category-facet engine-id={engineId} facet-id="myfacet" field="geographicalhierarchy" label="Country" base-path="Africa,Togo,Lome" no-filter-by-base-path delimiting-character="/" number-of-values="5" is-collapsed></c-quantic-category-facet>
  */
@@ -34,7 +40,7 @@ export default class QuanticCategoryFacet extends LightningElement {
    * @type {string}
    */
   @api engineId;
-  /** 
+  /**
    * A unique identifier for the facet.
    * Defaults to the `field` value.
    * @api
@@ -73,7 +79,7 @@ export default class QuanticCategoryFacet extends LightningElement {
    * @api
    * @type {boolean}
    * @defaultValue `false
-   */  
+   */
   @api noFilterFacetCount = false;
   /**
    * The character that separates the values of the target multi-value field.
@@ -87,7 +93,7 @@ export default class QuanticCategoryFacet extends LightningElement {
    * The number of values to request for this facet.
    * Also determines the number of additional values to request each time more values are shown.
    * @api
-   * @type {number} 
+   * @type {number}
    * @defaultValue `8`
    */
   @api numberOfValues = 8;
@@ -134,11 +140,11 @@ export default class QuanticCategoryFacet extends LightningElement {
     'numberOfValues',
     'sortCriteria',
     'withSearch',
-  ]
+  ];
 
   /** @type {CategoryFacetState} */
   @track state;
-  
+
   /** @type {CategoryFacet} */
   facet;
   /** @type {SearchStatus} */
@@ -155,7 +161,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   input;
   /** @type {AnyHeadless} */
   headless;
- 
+
   labels = {
     clear,
     showMore,
@@ -168,7 +174,7 @@ export default class QuanticCategoryFacet extends LightningElement {
     noMatchesFor,
     collapseFacet,
     expandFacet,
-  }
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -198,9 +204,11 @@ export default class QuanticCategoryFacet extends LightningElement {
       options: {
         field: this.field,
         facetId: this.facetId ?? this.field,
-        facetSearch: this.withSearch ? {
-          numberOfValues: Number(this.numberOfValues)
-        } : undefined,
+        facetSearch: this.withSearch
+          ? {
+              numberOfValues: Number(this.numberOfValues),
+            }
+          : undefined,
         delimitingCharacter: this.delimitingCharacter,
         basePath: this.basePath?.length ? this.basePath.split(',') : [],
         filterByBasePath: !this.noFilterByBasePath,
@@ -213,13 +221,16 @@ export default class QuanticCategoryFacet extends LightningElement {
     registerToStore(this.engineId, Store.facetTypes.CATEGORYFACETS, {
       label: this.label,
       facetId: this.facet.state.facetId,
-      element: this.template.host
+      element: this.template.host,
     });
-  }
+  };
 
   updateState() {
     this.state = this.facet?.state;
-    this.showPlaceholder = this.searchStatus?.state?.isLoading && !this.searchStatus?.state?.hasError && !this.searchStatus?.state?.firstSearchExecuted;
+    this.showPlaceholder =
+      this.searchStatus?.state?.isLoading &&
+      !this.searchStatus?.state?.hasError &&
+      !this.searchStatus?.state?.firstSearchExecuted;
   }
 
   get values() {
@@ -235,7 +246,9 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get canShowMore() {
-    return this.facet && this.state?.canShowMoreValues && !this.isFacetSearchActive;
+    return (
+      this.facet && this.state?.canShowMoreValues && !this.isFacetSearchActive
+    );
   }
 
   get canShowLess() {
@@ -264,7 +277,7 @@ export default class QuanticCategoryFacet extends LightningElement {
       index: index,
       numberOfResults: result.count,
       path: result.path,
-      localizedPath: this.buildPath(result.path) ,
+      localizedPath: this.buildPath(result.path),
       highlightedResult: this.highlightResult(
         result.displayValue,
         this.input?.value
@@ -281,11 +294,11 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get showMoreFacetValuesLabel() {
-    return I18nUtils.format(this.labels.showMoreFacetValues, this.label)
+    return I18nUtils.format(this.labels.showMoreFacetValues, this.label);
   }
 
   get showLessFacetValuesLabel() {
-    return I18nUtils.format(this.labels.showLessFacetValues, this.label)
+    return I18nUtils.format(this.labels.showLessFacetValues, this.label);
   }
 
   get moreMatchesForLabel() {
@@ -305,7 +318,9 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   get actionButtonLabel() {
-    const label = this.isCollapsed ? this.labels.expandFacet : this.labels.collapseFacet;
+    const label = this.isCollapsed
+      ? this.labels.expandFacet
+      : this.labels.collapseFacet;
     return I18nUtils.format(label, this.label);
   }
 
@@ -332,7 +347,7 @@ export default class QuanticCategoryFacet extends LightningElement {
         displayValue: item.value,
         rawValue: item.value,
         count: item.numberOfResults,
-        path: item.path
+        path: item.path,
       });
     } else {
       this.facet.toggleSelect(item);
@@ -343,7 +358,9 @@ export default class QuanticCategoryFacet extends LightningElement {
   getItemFromValue(value) {
     const facetValues = [...this.values, ...this.nonActiveParents];
     // @ts-ignore
-    return (this.isFacetSearchActive ? this.facetSearchResults : facetValues).find((item) => item.value === value);
+    return (
+      this.isFacetSearchActive ? this.facetSearchResults : facetValues
+    ).find((item) => item.value === value);
   }
 
   preventDefault(evt) {
@@ -377,7 +394,7 @@ export default class QuanticCategoryFacet extends LightningElement {
   }
 
   clearInput() {
-    if(this.input) {
+    if (this.input) {
       this.input.value = '';
     }
     this.facet.facetSearch.updateText('');
@@ -395,11 +412,11 @@ export default class QuanticCategoryFacet extends LightningElement {
    * @param {string[]} path
    */
   buildPath(path) {
-    if(!path.length) {
+    if (!path.length) {
       return this.labels.allCategories;
-    } 
-    if(path.length > 2) {
-      path = path.slice(0, 1).concat("...", ...path.slice(-1));
+    }
+    if (path.length > 2) {
+      path = path.slice(0, 1).concat('...', ...path.slice(-1));
     }
     return path.join('/');
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -1,5 +1,5 @@
 import {api, LightningElement, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless, registerToStore} from 'c/quanticHeadlessLoader';
+import {registerComponentForInit, initializeWithHeadless, registerToStore, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 import {I18nUtils, regexEncode, Store} from 'c/quanticUtils';
 
 import clear from '@salesforce/label/c.quantic_Clear';
@@ -153,6 +153,8 @@ export default class QuanticCategoryFacet extends LightningElement {
   collapseIconName = 'utility:dash';
   /** @type {HTMLInputElement} */
   input;
+  /** @type {AnyHeadless} */
+  headless;
  
   labels = {
     clear,
@@ -186,12 +188,13 @@ export default class QuanticCategoryFacet extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
 
-    this.facet = CoveoHeadless.buildCategoryFacet(engine, {
+    this.facet = this.headless.buildCategoryFacet(engine, {
       options: {
         field: this.field,
         facetId: this.facetId ?? this.field,

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.js
@@ -357,10 +357,11 @@ export default class QuanticCategoryFacet extends LightningElement {
 
   getItemFromValue(value) {
     const facetValues = [...this.values, ...this.nonActiveParents];
-    // @ts-ignore
     return (
-      this.isFacetSearchActive ? this.facetSearchResults : facetValues
-    ).find((item) => item.value === value);
+      (this.isFacetSearchActive ? this.facetSearchResults : facetValues)
+        // @ts-ignore
+        .find((item) => item.value === value)
+    );
   }
 
   preventDefault(evt) {

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
@@ -1,6 +1,6 @@
 import {api, LightningElement} from 'lwc';
 
-import inLabel from "@salesforce/label/c.quantic_InLabel";
+import inLabel from '@salesforce/label/c.quantic_InLabel';
 
 /** @typedef {import("coveo").CategoryFacetValue} CategoryFacetValue */
 
@@ -8,6 +8,7 @@ import inLabel from "@salesforce/label/c.quantic_InLabel";
  * The `QuanticCategoryFacetValue` component is used by a `QuanticCategoryFacet` component to display a formatted facet value, path to that value and the number of results with that value.
  * @fires CustomEvent#selectvalue
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-category-facet-value onselectvalue={onSelect} item={result} is-search-result active-parent></c-quantic-category-facet-value>
  */
@@ -24,14 +25,14 @@ export default class QuanticCategoryFacetValue extends LightningElement {
    * @defaultValue `false`
    */
   @api isSearchResult = false;
-  /** 
+  /**
    * Whether the value is an active parent node.
    * @api
    * @type {boolean}
    * @defaultValue `false`
    */
   @api activeParent = false;
-  /** 
+  /**
    * Whether the value is a non-active parent node.
    * @api
    * @type {boolean}
@@ -40,8 +41,8 @@ export default class QuanticCategoryFacetValue extends LightningElement {
   @api nonActiveParent = false;
 
   labels = {
-    inLabel
-  }
+    inLabel,
+  };
 
   get categoryFacetLiClass() {
     return this.activeParent ? 'slds-var-m-left_large slds-grid' : 'slds-grid';
@@ -50,17 +51,18 @@ export default class QuanticCategoryFacetValue extends LightningElement {
   get facetValue() {
     return this.item.value;
   }
-  
+
   /**
    * @param {Event} evt
    */
   onSelect(evt) {
     evt.preventDefault();
-    this.dispatchEvent(new CustomEvent(
-      'selectvalue', {
-      detail: {
-        value: this.facetValue
-      }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('selectvalue', {
+        detail: {
+          value: this.facetValue,
+        },
+      })
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.js
@@ -3,6 +3,7 @@ import {
   registerComponentForInit,
   initializeWithHeadless,
   registerToStore,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, fromSearchApiDate, Store} from 'c/quanticUtils';
 import LOCALE from '@salesforce/i18n/locale';
@@ -105,6 +106,8 @@ export default class QuanticDateFacet extends LightningElement {
   unsubscribe;
   /** @type {Function} */
   unsubscribeSearchStatus;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     clearFilter,
@@ -125,12 +128,13 @@ export default class QuanticDateFacet extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
 
-    this.facet = CoveoHeadless.buildDateFacet(engine, {
+    this.facet = this.headless.buildDateFacet(engine, {
       options: {
         field: this.field,
         numberOfValues: Number(this.numberOfValues),

--- a/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
@@ -1,5 +1,5 @@
 import { api, LightningElement, track } from 'lwc';
-import { initializeWithHeadless, registerComponentForInit } from 'c/quanticHeadlessLoader';
+import { getHeadlessBundle, initializeWithHeadless, registerComponentForInit } from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import didYouMean from '@salesforce/label/c.quantic_DidYouMean';
@@ -38,6 +38,8 @@ export default class QuanticDidYouMean extends LightningElement {
   unsubscribe;
   /** @type {DidYouMean} */
   didYouMean;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     didYouMean,
@@ -57,7 +59,8 @@ export default class QuanticDidYouMean extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.didYouMean = CoveoHeadless.buildDidYouMean(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.didYouMean = this.headless.buildDidYouMean(engine);
     this.unsubscribe = this.didYouMean.subscribe(() => this.updateState());
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.js
@@ -1,5 +1,9 @@
-import { api, LightningElement, track } from 'lwc';
-import { getHeadlessBundle, initializeWithHeadless, registerComponentForInit } from 'c/quanticHeadlessLoader';
+import {api, LightningElement, track} from 'lwc';
+import {
+  getHeadlessBundle,
+  initializeWithHeadless,
+  registerComponentForInit,
+} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import didYouMean from '@salesforce/label/c.quantic_DidYouMean';
@@ -14,6 +18,7 @@ import queryCorrectedTo from '@salesforce/label/c.quantic_QueryCorrectedTo';
  * The `QuanticDidYouMean` component is responsible for handling query corrections.
  * When a query returns no result but finds a possible query correction, the component either suggests the correction or automatically triggers a new query with the suggested term.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-did-you-mean engine-id={engineId}></c-quantic-did-you-mean>
  */
@@ -45,12 +50,12 @@ export default class QuanticDidYouMean extends LightningElement {
     didYouMean,
     noResultsFor,
     queryCorrectedTo,
-  }
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
   }
-  
+
   renderedCallback() {
     initializeWithHeadless(this, this.engineId, this.initialize);
   }
@@ -62,7 +67,7 @@ export default class QuanticDidYouMean extends LightningElement {
     this.headless = getHeadlessBundle(this.engineId);
     this.didYouMean = this.headless.buildDidYouMean(engine);
     this.unsubscribe = this.didYouMean.subscribe(() => this.updateState());
-  }
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
@@ -70,7 +75,8 @@ export default class QuanticDidYouMean extends LightningElement {
 
   updateState() {
     this.hasQueryCorrection = this.didYouMean.state.hasQueryCorrection;
-    this.wasAutomaticallyCorrected = this.didYouMean.state.wasAutomaticallyCorrected;
+    this.wasAutomaticallyCorrected =
+      this.didYouMean.state.wasAutomaticallyCorrected;
     this.originalQuery = this.didYouMean.state.originalQuery;
     this.correctedQuery = this.didYouMean.state.queryCorrection.correctedQuery;
   }
@@ -80,10 +86,16 @@ export default class QuanticDidYouMean extends LightningElement {
   }
 
   get noResultsLabel() {
-    return I18nUtils.format(this.labels.noResultsFor, I18nUtils.getTextBold(I18nUtils.escapeHTML(this.originalQuery)));
+    return I18nUtils.format(
+      this.labels.noResultsFor,
+      I18nUtils.getTextBold(I18nUtils.escapeHTML(this.originalQuery))
+    );
   }
 
   get correctedQueryLabel() {
-    return I18nUtils.format(this.labels.queryCorrectedTo, I18nUtils.getTextBold(I18nUtils.escapeHTML(this.correctedQuery)));
+    return I18nUtils.format(
+      this.labels.queryCorrectedTo,
+      I18nUtils.getTextBold(I18nUtils.escapeHTML(this.correctedQuery))
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -27,7 +27,7 @@
                     <p class="excerpt">{it.value.excerpt}</p>
                     <div class="row slds-var-p-top_medium">
                       <template if:true={showQuickview}>
-                        <c-quantic-result-quickview use-case="case-assist" engine-id={engineId}
+                        <c-quantic-result-quickview engine-id={engineId}
                           preview-button-icon="utility:new_window" preview-button-label={labels.readMore}
                           preview-button-variant="outline-brand" result={it.value}>
                           <slot slot="footer" name="quickview-footer" data-doc-id={it.value.uniqueId}></slot>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -4,6 +4,7 @@ import {
   registerComponentForInit,
   initializeWithHeadless,
   registerToStore,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, regexEncode, Store} from 'c/quanticUtils';
 
@@ -151,6 +152,8 @@ export default class QuanticFacet extends LightningElement {
   unsubscribeSearchStatus;
   /** @type {HTMLInputElement} */
   input;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     showMore,
@@ -179,7 +182,8 @@ export default class QuanticFacet extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
@@ -195,7 +199,7 @@ export default class QuanticFacet extends LightningElement {
       filterFacetCount: !this.noFilterFacetCount,
       injectionDepth: Number(this.injectionDepth),
     };
-    this.facet = CoveoHeadless.buildFacet(engine, {options});
+    this.facet = this.headless.buildFacet(engine, {options});
     this.unsubscribe = this.facet.subscribe(() => this.updateState());
     registerToStore(this.engineId, Store.facetTypes.FACETS, {
       label: this.label,

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.js
@@ -1,4 +1,3 @@
-
 import {LightningElement, track, api} from 'lwc';
 import {
   registerComponentForInit,
@@ -30,6 +29,7 @@ import expandFacet from '@salesforce/label/c.quantic_ExpandFacet';
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criterion (e.g., number of occurrences).
  * A `QuanticFacet` displays a facet of the results for the current query.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-facet engine-id={engineId} facet-id="myFacet" field="filetype" label="File Type" number-of-values="5" sort-criteria="occurrences" no-search display-values-as="link" is-collapsed></c-quantic-facet>
  */
@@ -40,7 +40,7 @@ export default class QuanticFacet extends LightningElement {
    * @type {string}
    */
   @api engineId;
-  /** 
+  /**
    * A unique identifier for the facet.
    * Defaults to the facet field.
    * @api
@@ -135,11 +135,11 @@ export default class QuanticFacet extends LightningElement {
     'displayValuesAs',
     'noFilterFacetCount',
     'injectionDepth',
-  ]
+  ];
 
   /** @type {FacetState} */
   @track state;
-  
+
   /** @type {Facet} */
   facet;
   /** @type {SearchStatus} */
@@ -192,9 +192,11 @@ export default class QuanticFacet extends LightningElement {
       field: this.field,
       sortCriteria: this.sortCriteria,
       numberOfValues: Number(this.numberOfValues),
-      facetSearch: this.noSearch ? undefined : {
-        numberOfValues: Number(this.numberOfValues)
-      },
+      facetSearch: this.noSearch
+        ? undefined
+        : {
+            numberOfValues: Number(this.numberOfValues),
+          },
       facetId: this.facetId ?? this.field,
       filterFacetCount: !this.noFilterFacetCount,
       injectionDepth: Number(this.injectionDepth),
@@ -204,9 +206,9 @@ export default class QuanticFacet extends LightningElement {
     registerToStore(this.engineId, Store.facetTypes.FACETS, {
       label: this.label,
       facetId: this.facet.state.facetId,
-      element: this.template.host
+      element: this.template.host,
     });
-  }
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
@@ -215,17 +217,22 @@ export default class QuanticFacet extends LightningElement {
 
   updateState() {
     this.state = this.facet?.state;
-    this.showPlaceholder = this.searchStatus?.state?.isLoading && !this.searchStatus?.state?.hasError && !this.searchStatus?.state?.firstSearchExecuted;
+    this.showPlaceholder =
+      this.searchStatus?.state?.isLoading &&
+      !this.searchStatus?.state?.hasError &&
+      !this.searchStatus?.state?.firstSearchExecuted;
   }
 
   get values() {
-    return this.state?.values
-      .filter((value) => value.numberOfResults || value.state === 'selected')
-      .map((v) => ({
-        ...v,
-        checked: v.state === 'selected',
-        highlightedResult: v.value,
-      })) || [];
+    return (
+      this.state?.values
+        .filter((value) => value.numberOfResults || value.state === 'selected')
+        .map((v) => ({
+          ...v,
+          checked: v.state === 'selected',
+          highlightedResult: v.value,
+        })) || []
+    );
   }
 
   get query() {
@@ -304,7 +311,9 @@ export default class QuanticFacet extends LightningElement {
   }
 
   get actionButtonLabel() {
-    const label = this.isCollapsed ? this.labels.expandFacet : this.labels.collapseFacet;
+    const label = this.isCollapsed
+      ? this.labels.expandFacet
+      : this.labels.collapseFacet;
     return I18nUtils.format(label, this.label);
   }
 
@@ -313,7 +322,7 @@ export default class QuanticFacet extends LightningElement {
   }
 
   get isDisplayAsLink() {
-    return this.displayValuesAs === 'link'
+    return this.displayValuesAs === 'link';
   }
 
   get numberOfSelectedValues() {
@@ -322,8 +331,14 @@ export default class QuanticFacet extends LightningElement {
 
   get clearFilterLabel() {
     if (this.hasActiveValues) {
-      const labelName = I18nUtils.getLabelNameWithCount('clearFilter', this.numberOfSelectedValues);
-      return `${I18nUtils.format(this.labels[labelName], this.numberOfSelectedValues)}`;
+      const labelName = I18nUtils.getLabelNameWithCount(
+        'clearFilter',
+        this.numberOfSelectedValues
+      );
+      return `${I18nUtils.format(
+        this.labels[labelName],
+        this.numberOfSelectedValues
+      )}`;
     }
     return '';
   }
@@ -345,7 +360,9 @@ export default class QuanticFacet extends LightningElement {
   }
 
   getItemFromValue(value) {
-    return (this.isFacetSearchActive ? this.facetSearchResults : this.values).find((item) => item.value === value);
+    return (
+      this.isFacetSearchActive ? this.facetSearchResults : this.values
+    ).find((item) => item.value === value);
   }
 
   /**
@@ -403,7 +420,7 @@ export default class QuanticFacet extends LightningElement {
   }
 
   clearInput() {
-    if(this.input) {
+    if (this.input) {
       this.input.value = '';
     }
     this.facet.facetSearch.updateText('');
@@ -414,6 +431,9 @@ export default class QuanticFacet extends LightningElement {
       return result;
     }
     const regex = new RegExp(`(${regexEncode(query)})`, 'i');
-    return result.replace(regex, '<b class="facet__search-result_highlight">$1</b>');
+    return result.replace(
+      regex,
+      '<b class="facet__search-result_highlight">$1</b>'
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
@@ -143,8 +143,8 @@ export default class QuanticFacetManager extends LightningElement {
       return;
     }
 
-    // @ts-ignore
     const payload = this.facets.map((f) => ({
+      // @ts-ignore
       facetId: f.dataset.facetId,
       payload: f,
     }));

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
@@ -11,9 +11,10 @@ import {api, LightningElement} from 'lwc';
 
 /**
  * The `QuanticFacetManager` component acts as a container component allowing facets to be reordered dynamically as search queries are performed.
- * 
+ *
  * An item template element can be assigned to the `itemTemplate` slot allowing to customize the element that wraps each facet.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-facet-manager engine-id={engineId}>
  *   <c-quantic-facet engine-id={engineId} field="type"></c-quantic-facet>
@@ -104,9 +105,11 @@ export default class QuanticFacetManager extends LightningElement {
   }
 
   getFacetsFromSlot() {
-    const isFacetManager = (tagName) => /-quantic-facet-manager$/i.test(tagName);
-    return Array.from(this.querySelectorAll('*'))
-      .filter((element) => isFacetManager(element.parentElement.tagName));
+    const isFacetManager = (tagName) =>
+      /-quantic-facet-manager$/i.test(tagName);
+    return Array.from(this.querySelectorAll('*')).filter((element) =>
+      isFacetManager(element.parentElement.tagName)
+    );
   }
 
   moveFacetsToHost() {
@@ -141,7 +144,10 @@ export default class QuanticFacetManager extends LightningElement {
     }
 
     // @ts-ignore
-    const payload = this.facets.map((f) => ({facetId: f.dataset.facetId, payload: f}));
+    const payload = this.facets.map((f) => ({
+      facetId: f.dataset.facetId,
+      payload: f,
+    }));
     const sortedFacets = this.facetManager.sort(payload).map((f) => f.payload);
 
     sortedFacets.forEach((sortedFacet) => {

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetManager/quanticFacetManager.js
@@ -1,4 +1,5 @@
 import {
+  getHeadlessBundle,
   initializeWithHeadless,
   registerComponentForInit,
 } from 'c/quanticHeadlessLoader';
@@ -42,6 +43,8 @@ export default class QuanticFacetManager extends LightningElement {
   searchStatus;
   /** @type {Function} */
   unsubscribeSearchStatus;
+  /** @type {AnyHeadless} */
+  headless;
 
   itemTemplate;
 
@@ -64,14 +67,15 @@ export default class QuanticFacetManager extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
+    this.headless = getHeadlessBundle(this.engineId);
     this.resolveItemTemplate();
     this.moveFacetsToHost();
 
-    this.facetManager = CoveoHeadless.buildFacetManager(engine);
+    this.facetManager = this.headless.buildFacetManager(engine);
     this.unsubscribeFacetManager = this.facetManager.subscribe(() =>
       this.updateFacetManagerState()
     );
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateSearchStatusState()
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -11,6 +11,7 @@ import LOCALE from '@salesforce/i18n/locale';
  * The `QuanticFacetValue` component is used by a facet component to display a formatted facet value and the number of results with that value.
  * @fires CustomEvent#selectvalue
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-facet-value onselectvalue={onSelect} item={result} is-checked={result.checked} display-as-link={displayAsLink} formatting-function={formattingFunction}></c-quantic-facet-value>
  */
@@ -35,7 +36,7 @@ export default class QuanticFacetValue extends LightningElement {
    * @defaultValue `false`
    */
   @api displayAsLink = false;
-  /** 
+  /**
    * A function used to format the displayed value.
    * @api
    * @type {Function}
@@ -63,11 +64,12 @@ export default class QuanticFacetValue extends LightningElement {
    */
   onSelect(evt) {
     evt.preventDefault();
-    this.dispatchEvent(new CustomEvent(
-      'selectvalue', {
-      detail: {
-        value: this.formattedFacetValue
-      }
-    }));
+    this.dispatchEvent(
+      new CustomEvent('selectvalue', {
+        detail: {
+          value: this.formattedFacetValue,
+        },
+      })
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
@@ -321,6 +321,24 @@ function getHeadlessBundle(engineId) {
   return window.coveoHeadless[engineId]?.bundle ?? CoveoHeadless;
 }
 
+/**
+ * Gets whether the specified engine is using the expected bundle.
+ * @param {string} engineId - The engine ID.
+ * @param {string} expectedBundleName - The expected headless bundle name.
+ * @returns 
+ */
+function isHeadlessBundle(engineId, expectedBundleName) {
+  let expectedBundle;
+  try {
+    expectedBundle = headlessBundles[expectedBundleName]?.bundle();
+  } catch (e) {
+    // Attempting to load a bundle for a different case will fail
+    // unless both bundles are loaded at the same time.
+  }
+
+  return getHeadlessBundle(engineId) === expectedBundle;
+}
+
 
 export {
   loadDependencies,
@@ -337,4 +355,5 @@ export {
   HeadlessBundleNames,
   getAllFacetsFromStore,
   getHeadlessBundle,
+  isHeadlessBundle,
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -12,6 +12,13 @@ import getHeadlessConfiguration from '@salesforce/apex/InsightController.getHead
 /** @typedef {import("coveo").InsightEngine} InsightEngine */
 /** @typedef {import("coveo").InsightEngineOptions} InsightEngineOptions */
 
+/**
+ * The `QuanticInsightInterface` component handles the headless insight engine configuration.
+ * A single instance should be used for each instance of the Coveo Headless insight engine.
+ * @category Insight Panel
+ * @example
+ * <c-quantic-insight-interface engine-id={engineId} insight-id={insightId}></c-quantic-insight-interface>
+ */
 export default class QuanticInsightInterface extends LightningElement {
   /**
    * @api

--- a/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.js
@@ -4,6 +4,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticModal` is a container component that displays slotted content in a modal. This component handles the animation logic, exposes methods to open and close the modal, offers the option to open the modal in full screen or just to cover the search interface, and exposes a set of slots to fully customize the modal content.
  *
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-modal full-screen animation="slideToLeft">
  *   <div slot="header">Modal Header</div>
@@ -14,8 +15,8 @@ import {LightningElement, api} from 'lwc';
 export default class QuanticModal extends LightningElement {
   animations = {
     slideToLeft: 'slideToLeft',
-    slideToTop: 'slideToTop'
-  }
+    slideToTop: 'slideToTop',
+  };
 
   /**
    * Indicates whether the modal will be opened in full screen.
@@ -42,10 +43,13 @@ export default class QuanticModal extends LightningElement {
   }
 
   validateProps() {
-    if (this.animation !== this.animations.slideToLeft && this.animation !== this.animations.slideToTop) {
+    if (
+      this.animation !== this.animations.slideToLeft &&
+      this.animation !== this.animations.slideToTop
+    ) {
       this.renderingError = `"${this.animation}" is an invalid value for the animation property. animation can only be set to "${this.animations.slideToTop}" or "${this.animations.slideToLeft}".`;
     }
-    if ( typeof(this.fullScreen)!== 'boolean' ){
+    if (typeof this.fullScreen !== 'boolean') {
       this.renderingError = `"${this.fullScreen}" is an invalid value for the full-screen property. full-screen can only be set to a boolean value.`;
     }
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -1,5 +1,5 @@
 import {api, LightningElement, track} from 'lwc';
-import {initializeWithHeadless, registerComponentForInit} from 'c/quanticHeadlessLoader';
+import {getHeadlessBundle, initializeWithHeadless, registerComponentForInit} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import noResultsForTitle from '@salesforce/label/c.quantic_NoResultsForTitle';
@@ -60,6 +60,8 @@ export default class QuanticNoResults extends LightningElement {
   unsubscribeQuerySummary;
   /** @type {Function} */
   unsubscribeBreadcrumbsManager;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     noResultsTitle,
@@ -81,10 +83,11 @@ export default class QuanticNoResults extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
-    this.historyManager = CoveoHeadless.buildHistoryManager(engine);
-    this.querySummary = CoveoHeadless.buildQuerySummary(engine);
-    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
+    this.historyManager = this.headless.buildHistoryManager(engine);
+    this.querySummary = this.headless.buildQuerySummary(engine);
+    this.breadcrumbManager = this.headless.buildBreadcrumbManager(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
     this.unsubscribeHistoryManager = this.historyManager.subscribe(() => this.updateState());
     this.unsubscribeQuerySummary = this.querySummary.subscribe(() => this.updateState());

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -1,5 +1,5 @@
 import {api, LightningElement, track} from 'lwc';
-import {getHeadlessBundle, initializeWithHeadless, registerComponentForInit} from 'c/quanticHeadlessLoader';
+import {initializeWithHeadless, registerComponentForInit} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import noResultsForTitle from '@salesforce/label/c.quantic_NoResultsForTitle';
@@ -60,8 +60,6 @@ export default class QuanticNoResults extends LightningElement {
   unsubscribeQuerySummary;
   /** @type {Function} */
   unsubscribeBreadcrumbsManager;
-  /** @type {AnyHeadless} */
-  headless;
 
   labels = {
     noResultsTitle,
@@ -83,11 +81,10 @@ export default class QuanticNoResults extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.headless = getHeadlessBundle(this.engineId);
-    this.searchStatus = this.headless.buildSearchStatus(engine);
-    this.historyManager = this.headless.buildHistoryManager(engine);
-    this.querySummary = this.headless.buildQuerySummary(engine);
-    this.breadcrumbManager = this.headless.buildBreadcrumbManager(engine);
+    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.historyManager = CoveoHeadless.buildHistoryManager(engine);
+    this.querySummary = CoveoHeadless.buildQuerySummary(engine);
+    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
     this.unsubscribeHistoryManager = this.historyManager.subscribe(() => this.updateState());
     this.unsubscribeQuerySummary = this.querySummary.subscribe(() => this.updateState());

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -421,8 +421,8 @@ export default class QuanticNumericFacet extends LightningElement {
     evt.preventDefault();
 
     this.setValidityParameters();
-    // @ts-ignore
     const allValid = this.allInputs.reduce(
+      // @ts-ignore
       (validSoFar, inputCmp) => validSoFar && inputCmp.reportValidity(),
       true
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -3,7 +3,8 @@ import {
   registerComponentForInit,
   initializeWithHeadless,
   getHeadlessBindings,
-  registerToStore
+  registerToStore,
+  getHeadlessBundle
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, Store} from 'c/quanticUtils';
 import LOCALE from '@salesforce/i18n/locale';
@@ -156,6 +157,8 @@ export default class QuanticNumericFacet extends LightningElement {
   unsubscribeFilter;
   /** @type {Function} */
   unsubscribeSearchStatus;
+  /** @type {AnyHeadless} */
+  headless;
 
   /** @type {string} */
   start;
@@ -193,7 +196,8 @@ export default class QuanticNumericFacet extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
@@ -204,7 +208,7 @@ export default class QuanticNumericFacet extends LightningElement {
     if(this.withInput) {
       this.initializeFilter(engine);
     }
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
     registerToStore(this.engineId, Store.facetTypes.NUMERICFACETS, {
       label: this.label,
@@ -218,7 +222,7 @@ export default class QuanticNumericFacet extends LightningElement {
    * @param {import("coveo").SearchEngine} engine
    */
   initializeFacet(engine) {
-    this.facet = CoveoHeadless.buildNumericFacet(engine, {
+    this.facet = this.headless.buildNumericFacet(engine, {
       options: {
         field: this.field,
         generateAutomaticRanges: true,
@@ -236,7 +240,7 @@ export default class QuanticNumericFacet extends LightningElement {
    * @param {import("coveo").SearchEngine} engine
    */
   initializeFilter(engine) {
-    this.numericFilter = CoveoHeadless.buildNumericFilter(engine, {
+    this.numericFilter = this.headless.buildNumericFilter(engine, {
       options: {
         field: this.field,
         facetId: this.facet?.state.facetId ? `${this.facet.state.facetId}_input` : undefined
@@ -400,7 +404,7 @@ export default class QuanticNumericFacet extends LightningElement {
 
     if(this.numberOfValues > 0) {
       const engine = getHeadlessBindings(this.engineId).engine;
-      engine.dispatch(CoveoHeadless.loadNumericFacetSetActions(engine).deselectAllNumericFacetValues(this.facet.state.facetId));
+      engine.dispatch(this.headless.loadNumericFacetSetActions(engine).deselectAllNumericFacetValues(this.facet.state.facetId));
     }
     
     this.numericFilter.setRange({

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -4,7 +4,7 @@ import {
   initializeWithHeadless,
   getHeadlessBindings,
   registerToStore,
-  getHeadlessBundle
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, Store} from 'c/quanticUtils';
 import LOCALE from '@salesforce/i18n/locale';
@@ -13,12 +13,12 @@ import clearFilter from '@salesforce/label/c.quantic_ClearFilter';
 import clearFilter_plural from '@salesforce/label/c.quantic_ClearFilter_plural';
 import collapseFacet from '@salesforce/label/c.quantic_CollapseFacet';
 import expandFacet from '@salesforce/label/c.quantic_ExpandFacet';
-import min from "@salesforce/label/c.quantic_Min";
-import max from "@salesforce/label/c.quantic_Max";
-import numberInputMinimum from "@salesforce/label/c.quantic_NumberInputMinimum";
-import numberInputMaximum from "@salesforce/label/c.quantic_NumberInputMaximum";
-import apply from "@salesforce/label/c.quantic_Apply";
-import numberInputApply from "@salesforce/label/c.quantic_NumberInputApply";
+import min from '@salesforce/label/c.quantic_Min';
+import max from '@salesforce/label/c.quantic_Max';
+import numberInputMinimum from '@salesforce/label/c.quantic_NumberInputMinimum';
+import numberInputMaximum from '@salesforce/label/c.quantic_NumberInputMaximum';
+import apply from '@salesforce/label/c.quantic_Apply';
+import numberInputApply from '@salesforce/label/c.quantic_NumberInputApply';
 import messageWhenRangeOverflow from '@salesforce/label/c.quantic_MessageWhenRangeOverflow';
 import messageWhenRangeUnderflow from '@salesforce/label/c.quantic_MessageWhenRangeUnderflow';
 
@@ -33,6 +33,7 @@ import messageWhenRangeUnderflow from '@salesforce/label/c.quantic_MessageWhenRa
 /**
  * The `QuanticNumericFacet` component displays facet values as numeric ranges.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-numeric-facet engine-id={engineId} facet-id="myfacet" field="ytlikecount" label="Youtube Likes" numberOfValues="5" sort-criteria="descending" range-algorithm="even" formatting-function={myFormattingFunction} is-collapsed></c-quantic-numeric-facet>
  */
@@ -43,7 +44,7 @@ export default class QuanticNumericFacet extends LightningElement {
    * @type {string}
    */
   @api engineId;
-  /** 
+  /**
    * A unique identifier for the facet.
    * @api
    * @type {string}
@@ -95,11 +96,10 @@ export default class QuanticNumericFacet extends LightningElement {
    * @param {NumericFacetValue} item
    * @returns {string}
    */
-  @api formattingFunction = (item) => `${new Intl.NumberFormat(LOCALE).format(
-    item.start
-  )} - ${new Intl.NumberFormat(LOCALE).format(
-    item.end
-  )}`;
+  @api formattingFunction = (item) =>
+    `${new Intl.NumberFormat(LOCALE).format(
+      item.start
+    )} - ${new Intl.NumberFormat(LOCALE).format(item.end)}`;
   /**
    * Whether this facet should contain an input allowing users to set custom ranges.
    * Depending on the field, the input can allow either decimal or integer values.
@@ -132,7 +132,7 @@ export default class QuanticNumericFacet extends LightningElement {
     'sortCriteria',
     'rangeAlgorithm',
     'withInput',
-  ]
+  ];
 
   /** @type {NumericFacetState} */
   @track state;
@@ -140,8 +140,8 @@ export default class QuanticNumericFacet extends LightningElement {
   @track filterState = {
     isLoading: false,
     enabled: true,
-    facetId: undefined
-  }
+    facetId: undefined,
+  };
 
   /** @type {NumericFacet} */
   facet;
@@ -181,7 +181,7 @@ export default class QuanticNumericFacet extends LightningElement {
     apply,
     numberInputApply,
     messageWhenRangeOverflow,
-    messageWhenRangeUnderflow
+    messageWhenRangeUnderflow,
   };
 
   connectedCallback() {
@@ -202,21 +202,23 @@ export default class QuanticNumericFacet extends LightningElement {
       this.updateState()
     );
 
-    if(this.numberOfValues > 0) {
+    if (this.numberOfValues > 0) {
       this.initializeFacet(engine);
     }
-    if(this.withInput) {
+    if (this.withInput) {
       this.initializeFilter(engine);
     }
     this.searchStatus = this.headless.buildSearchStatus(engine);
-    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
+    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
+      this.updateState()
+    );
     registerToStore(this.engineId, Store.facetTypes.NUMERICFACETS, {
       label: this.label,
       facetId: this.facet?.state.facetId ?? this.field,
       format: this.formattingFunction,
-      element: this.template.host
+      element: this.template.host,
     });
-  }
+  };
 
   /**
    * @param {import("coveo").SearchEngine} engine
@@ -230,10 +232,9 @@ export default class QuanticNumericFacet extends LightningElement {
         rangeAlgorithm: this.rangeAlgorithm,
         numberOfValues: Number(this.numberOfValues),
         facetId: this.facetId ?? this.field,
-      }
+      },
     });
     this.unsubscribe = this.facet.subscribe(() => this.updateState());
-    
   }
 
   /**
@@ -243,10 +244,14 @@ export default class QuanticNumericFacet extends LightningElement {
     this.numericFilter = this.headless.buildNumericFilter(engine, {
       options: {
         field: this.field,
-        facetId: this.facet?.state.facetId ? `${this.facet.state.facetId}_input` : undefined
-      }
+        facetId: this.facet?.state.facetId
+          ? `${this.facet.state.facetId}_input`
+          : undefined,
+      },
     });
-    this.unsubscribeFilter = this.numericFilter.subscribe(() => this.updateFilterState());
+    this.unsubscribeFilter = this.numericFilter.subscribe(() =>
+      this.updateFilterState()
+    );
   }
 
   disconnectedCallback() {
@@ -257,7 +262,10 @@ export default class QuanticNumericFacet extends LightningElement {
 
   updateState() {
     this.state = this.facet?.state;
-    this.showPlaceholder = this.searchStatus?.state?.isLoading && !this.searchStatus?.state?.hasError && !this.searchStatus?.state?.firstSearchExecuted;
+    this.showPlaceholder =
+      this.searchStatus?.state?.isLoading &&
+      !this.searchStatus?.state?.hasError &&
+      !this.searchStatus?.state?.firstSearchExecuted;
   }
 
   updateFilterState() {
@@ -281,7 +289,7 @@ export default class QuanticNumericFacet extends LightningElement {
   }
 
   get step() {
-    return this.withInput ==='integer' ? '1' : 'any';
+    return this.withInput === 'integer' ? '1' : 'any';
   }
 
   /** @returns {HTMLInputElement} */
@@ -307,28 +315,45 @@ export default class QuanticNumericFacet extends LightningElement {
   }
 
   get actionButtonLabel() {
-    const label = this.isCollapsed ? this.labels.expandFacet : this.labels.collapseFacet;
+    const label = this.isCollapsed
+      ? this.labels.expandFacet
+      : this.labels.collapseFacet;
     return I18nUtils.format(label, this.label);
   }
 
   get numberOfSelectedValues() {
-    return this.filterState?.range ? 1 : this.state.values.filter(({state}) => state === 'selected').length;
+    return this.filterState?.range
+      ? 1
+      : this.state.values.filter(({state}) => state === 'selected').length;
   }
 
   get showValues() {
-    return !this.searchStatus?.state?.hasError && !this.filterState?.range && !!this.values.length;
+    return (
+      !this.searchStatus?.state?.hasError &&
+      !this.filterState?.range &&
+      !!this.values.length
+    );
   }
 
   get clearFilterLabel() {
     if (this.hasActiveValues) {
-      const labelName = I18nUtils.getLabelNameWithCount('clearFilter', this.numberOfSelectedValues);
-      return `${I18nUtils.format(this.labels[labelName], this.numberOfSelectedValues)}`;
+      const labelName = I18nUtils.getLabelNameWithCount(
+        'clearFilter',
+        this.numberOfSelectedValues
+      );
+      return `${I18nUtils.format(
+        this.labels[labelName],
+        this.numberOfSelectedValues
+      )}`;
     }
     return '';
   }
 
   get shouldRenderInput() {
-    return this.withInput && this.searchStatus?.state?.hasResults || !!this.filterState?.range;
+    return (
+      (this.withInput && this.searchStatus?.state?.hasResults) ||
+      !!this.filterState?.range
+    );
   }
 
   get shouldRenderValues() {
@@ -354,22 +379,24 @@ export default class QuanticNumericFacet extends LightningElement {
     this.inputMax.required = false;
   }
 
-  /** 
+  /**
    * @param {CustomEvent<{value: string}>} evt
    */
   onSelectValue(evt) {
-    const item = this.values.find((value) => this.formattingFunction(value) === evt.detail.value);
+    const item = this.values.find(
+      (value) => this.formattingFunction(value) === evt.detail.value
+    );
     this.facet.toggleSelect(item);
   }
 
   clearSelections() {
-    if(this.filterState?.range) {
+    if (this.filterState?.range) {
       this.numericFilter.clear();
     }
     this.facet?.deselectAll();
-    if(this.withInput) {
+    if (this.withInput) {
       this.resetValidityParameters();
-    
+
       this.allInputs.forEach((input) => {
         // @ts-ignore
         input.checkValidity();
@@ -389,27 +416,34 @@ export default class QuanticNumericFacet extends LightningElement {
 
   /**
    * @param {Event} evt
-  */
+   */
   onApply(evt) {
     evt.preventDefault();
 
     this.setValidityParameters();
     // @ts-ignore
-    const allValid = this.allInputs.reduce((validSoFar, inputCmp) => validSoFar && inputCmp.reportValidity(), true);
+    const allValid = this.allInputs.reduce(
+      (validSoFar, inputCmp) => validSoFar && inputCmp.reportValidity(),
+      true
+    );
     this.resetValidityParameters();
 
     if (!allValid) {
       return;
     }
 
-    if(this.numberOfValues > 0) {
+    if (this.numberOfValues > 0) {
       const engine = getHeadlessBindings(this.engineId).engine;
-      engine.dispatch(this.headless.loadNumericFacetSetActions(engine).deselectAllNumericFacetValues(this.facet.state.facetId));
+      engine.dispatch(
+        this.headless
+          .loadNumericFacetSetActions(engine)
+          .deselectAllNumericFacetValues(this.facet.state.facetId)
+      );
     }
-    
+
     this.numericFilter.setRange({
       start: this.inputMin ? Number(this.inputMin.value) : undefined,
-      end: this.inputMax ? Number(this.inputMax.value) : undefined
+      end: this.inputMax ? Number(this.inputMax.value) : undefined,
     });
   }
 
@@ -449,7 +483,7 @@ export default class QuanticNumericFacet extends LightningElement {
   get customMessageOverflow() {
     return I18nUtils.format(this.labels.messageWhenRangeOverflow, this.max);
   }
-  
+
   get customMessageUnderflow() {
     return I18nUtils.format(this.labels.messageWhenRangeUnderflow, this.min);
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
@@ -1,5 +1,9 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  registerComponentForInit,
+  initializeWithHeadless,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 
 import next from '@salesforce/label/c.quantic_Next';
 import previous from '@salesforce/label/c.quantic_Previous';
@@ -10,6 +14,7 @@ import previous from '@salesforce/label/c.quantic_Previous';
 /**
  * The `QuanticPager` provides buttons that allow the end user to navigate through the different result pages.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-pager engine-id={engineId} number-of-pages="4"></c-quantic-pager>
  */
@@ -31,7 +36,7 @@ export default class QuanticPager extends LightningElement {
   /** @type {number[]} */
   @track currentPages = [];
   /** @type {boolean}*/
-  @track hasResults
+  @track hasResults;
 
   /** @type {Pager} */
   pager;
@@ -50,8 +55,8 @@ export default class QuanticPager extends LightningElement {
 
   labels = {
     next,
-    previous
-  }
+    previous,
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -69,12 +74,14 @@ export default class QuanticPager extends LightningElement {
     this.pager = this.headless.buildPager(engine, {
       options: {
         numberOfPages: Number(this.numberOfPages),
-      }
+      },
     });
     this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribe = this.pager.subscribe(() => this.updateState());
-    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
-  }
+    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
+      this.updateState()
+    );
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
@@ -115,7 +122,7 @@ export default class QuanticPager extends LightningElement {
   get currentPagesObjects() {
     return this.currentPages.map((page) => ({
       number: page,
-      selected: page === this.currentPage
+      selected: page === this.currentPage,
     }));
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.js
@@ -1,5 +1,5 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless} from 'c/quanticHeadlessLoader';
+import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 
 import next from '@salesforce/label/c.quantic_Next';
 import previous from '@salesforce/label/c.quantic_Previous';
@@ -45,6 +45,8 @@ export default class QuanticPager extends LightningElement {
   hasNext;
   /** @type {number} */
   currentPage = 1;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     next,
@@ -63,12 +65,13 @@ export default class QuanticPager extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.pager = CoveoHeadless.buildPager(engine, {
+    this.headless = getHeadlessBundle(this.engineId);
+    this.pager = this.headless.buildPager(engine, {
       options: {
         numberOfPages: Number(this.numberOfPages),
       }
     });
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribe = this.pager.subscribe(() => this.updateState());
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/quanticRefineModalContent.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/quanticRefineModalContent.js
@@ -1,5 +1,5 @@
 import {LightningElement, api} from 'lwc';
-import {getAllFacetsFromStore} from 'c/quanticHeadlessLoader';
+import {getAllFacetsFromStore, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 import {
   initializeWithHeadless,
   registerComponentForInit,
@@ -53,6 +53,8 @@ export default class QuanticRefineModalContent extends LightningElement {
   data;
   /** @type {boolean} */
   hasActiveFilters = false;
+  /** @type {AnyHeadless} */
+  headless;
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -71,8 +73,9 @@ export default class QuanticRefineModalContent extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
-    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
+    this.breadcrumbManager = this.headless.buildBreadcrumbManager(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.gatherFacets()
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/quanticRefineModalContent.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/quanticRefineModalContent.js
@@ -1,5 +1,8 @@
 import {LightningElement, api} from 'lwc';
-import {getAllFacetsFromStore, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  getAllFacetsFromStore,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 import {
   initializeWithHeadless,
   registerComponentForInit,
@@ -27,6 +30,7 @@ import QuanticTimeframeFacet from 'c/quanticTimeframeFacet';
  * The `QuanticRefineModalContent` component displays a copy of the search interface facets and sort components. This component is intended to be displayed inside the Quantic Modal to assure the responsiveness when the search interface is displayed on smaller screens.
  *
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-refine-modal-content engine-id={engineId} hide-sort></c-quantic-refine-modal-content>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
@@ -1,5 +1,6 @@
 import {LightningElement, api} from 'lwc';
 import {
+  getHeadlessBundle,
   initializeWithHeadless,
   registerComponentForInit,
 } from 'c/quanticHeadlessLoader';
@@ -67,6 +68,8 @@ export default class QuanticRefineToggle extends LightningElement {
   activeFiltersCount = 0;
   /** @type {string} */
   modalId = 'refineModal';
+  /** @type {AnyHeadless} */
+  headless;
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -80,8 +83,9 @@ export default class QuanticRefineToggle extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.querySummary = CoveoHeadless.buildQuerySummary(engine);
-    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.querySummary = this.headless.buildQuerySummary(engine);
+    this.breadcrumbManager = this.headless.buildBreadcrumbManager(engine);
 
     this.unsubscribeQuerySummary = this.querySummary.subscribe(() =>
       this.updateTotalResults()

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
@@ -21,6 +21,7 @@ import viewResults from '@salesforce/label/c.quantic_ViewResults';
 /**
  * The `QuanticRefineToggle` component displays a button that is used to open the refine modal.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-refine-toggle engine-id={engineId} hide-sort full-screen>
  *   <div slot="refine-title">Custom Title</div>

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
@@ -1,7 +1,7 @@
 // @ts-ignore
 import defaultTemplate from './quanticResult.html';
 
-import {LightningElement, api, track} from "lwc";
+import {LightningElement, api, track} from 'lwc';
 import {TimeSpan} from 'c/quanticUtils';
 
 /** @typedef {import("coveo").Result} Result */
@@ -10,6 +10,7 @@ import {TimeSpan} from 'c/quanticUtils';
 /**
  * The `QuanticResult` component is used internally by the `QuanticResultList` component.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-result engine-id={engineId} result={result} result-templates-manager={resultTemplatesManager}></c-quantic-result>
  */
@@ -44,7 +45,7 @@ export default class QuanticResult extends LightningElement {
   }
 
   get videoThumbnail() {
-    return `http://img.youtube.com/vi/${this.result.raw.ytvideoid}/mqdefault.jpg`
+    return `http://img.youtube.com/vi/${this.result.raw.ytvideoid}/mqdefault.jpg`;
   }
 
   get videoSourceId() {
@@ -52,7 +53,10 @@ export default class QuanticResult extends LightningElement {
   }
 
   get videoTimeSpan() {
-    return new TimeSpan(this.result.raw.ytvideoduration, false).getCleanHHMMSS();
+    return new TimeSpan(
+      this.result.raw.ytvideoduration,
+      false
+    ).getCleanHHMMSS();
   }
 
   onHasPreview = (evt) => {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -1,5 +1,5 @@
 import {LightningElement, api} from 'lwc';
-import {getHeadlessEnginePromise} from 'c/quanticHeadlessLoader';
+import {getHeadlessBundle, getHeadlessEnginePromise} from 'c/quanticHeadlessLoader';
 import {ResultUtils} from 'c/quanticUtils';
 
 /** @typedef {import("coveo").Result} Result */
@@ -40,12 +40,15 @@ export default class QuanticResultLink extends LightningElement {
    * Indicates the use case where this component is used.
    * @api
    * @type {'search'|'case-assist'}
+   * @deprecated The component uses the same Headless bundle as the interface it is bound to.
    * @defaultValue `'search'`
    */
   @api useCase = 'search';
 
   /** @type {SearchEngine} */
   engine;
+  /** @type {AnyHeadless} */
+  headless;
 
   connectedCallback() {
     getHeadlessEnginePromise(this.engineId).then((engine) => {
@@ -59,14 +62,13 @@ export default class QuanticResultLink extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
+    this.headless = getHeadlessBundle(this.engineId);
     this.engine = engine;
     ResultUtils.bindClickEventsOnResult(
       this.engine,
       this.result,
       this.template,
-      this.useCase === 'case-assist'
-        ? CoveoHeadlessCaseAssist.buildCaseAssistInteractiveResult
-        : CoveoHeadless.buildInteractiveResult
+      this.headless.buildInteractiveResult
     );
   };
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -1,5 +1,5 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless} from 'c/quanticHeadlessLoader';
+import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 
 /** @typedef {import("coveo").Result} Result */
 /** @typedef {import("coveo").ResultList} ResultList */
@@ -47,6 +47,8 @@ export default class QuanticResultList extends LightningElement {
   unsubscribeResultsPerPage;
   /** @type {ResultTemplatesManager} */
   resultTemplatesManager;
+  /** @type {AnyHeadless} */
+  headless;
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -60,20 +62,21 @@ export default class QuanticResultList extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.resultsPerPage = CoveoHeadless.buildResultsPerPage(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.resultsPerPage = this.headless.buildResultsPerPage(engine);
     this.unsubscribeResultsPerPage = this.resultsPerPage.subscribe(() => this.updateState());
 
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
 
-    this.resultList = CoveoHeadless.buildResultList(engine, {
+    this.resultList = this.headless.buildResultList(engine, {
       options: {
         fieldsToInclude: this.fields
       }
     });
-    this.resultTemplatesManager = CoveoHeadless.buildResultTemplatesManager(
+    this.resultTemplatesManager = this.headless.buildResultTemplatesManager(
       engine
     );
     this.registerTemplates();

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -1,5 +1,9 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  registerComponentForInit,
+  initializeWithHeadless,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 
 /** @typedef {import("coveo").Result} Result */
 /** @typedef {import("coveo").ResultList} ResultList */
@@ -12,6 +16,7 @@ import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} fro
  * The `QuanticResultList` component is responsible for displaying query results by applying one or more result templates.
  * @fires CustomEvent#registerresulttemplates
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-result-list engine-id={engineId} fields-to-include="objecttype,gdfiletitle"></c-quantic-result-list>
  */
@@ -28,7 +33,8 @@ export default class QuanticResultList extends LightningElement {
    * @type {string}
    * @defaultValue `'date,author,source,language,filetype,parents,sfknowledgearticleid'`
    */
-  @api fieldsToInclude = 'date,author,source,language,filetype,parents,sfknowledgearticleid';
+  @api fieldsToInclude =
+    'date,author,source,language,filetype,parents,sfknowledgearticleid';
 
   /** @type {ResultListState}*/
   @track state;
@@ -64,7 +70,9 @@ export default class QuanticResultList extends LightningElement {
   initialize = (engine) => {
     this.headless = getHeadlessBundle(this.engineId);
     this.resultsPerPage = this.headless.buildResultsPerPage(engine);
-    this.unsubscribeResultsPerPage = this.resultsPerPage.subscribe(() => this.updateState());
+    this.unsubscribeResultsPerPage = this.resultsPerPage.subscribe(() =>
+      this.updateState()
+    );
 
     this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
@@ -73,15 +81,14 @@ export default class QuanticResultList extends LightningElement {
 
     this.resultList = this.headless.buildResultList(engine, {
       options: {
-        fieldsToInclude: this.fields
-      }
+        fieldsToInclude: this.fields,
+      },
     });
-    this.resultTemplatesManager = this.headless.buildResultTemplatesManager(
-      engine
-    );
+    this.resultTemplatesManager =
+      this.headless.buildResultTemplatesManager(engine);
     this.registerTemplates();
     this.unsubscribe = this.resultList.subscribe(() => this.updateState());
-  }
+  };
 
   registerTemplates() {
     this.dispatchEvent(
@@ -101,7 +108,11 @@ export default class QuanticResultList extends LightningElement {
   updateState() {
     this.state = this.resultList?.state;
     this.numberOfResults = this.resultsPerPage?.state?.numberOfResults;
-    this.showPlaceholder = this.searchStatus?.state?.isLoading && !this.searchStatus?.state?.hasError && !this.searchStatus?.state?.firstSearchExecuted && !!this.numberOfResults;
+    this.showPlaceholder =
+      this.searchStatus?.state?.isLoading &&
+      !this.searchStatus?.state?.hasError &&
+      !this.searchStatus?.state?.firstSearchExecuted &&
+      !!this.numberOfResults;
   }
 
   get fields() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -25,7 +25,7 @@
                 <c-quantic-result-label result={result} icon-only></c-quantic-result-label>
               </div>
               <div class="slds-truncate quickview__result-title">
-                <c-quantic-result-link target="_blank" use-case={useCase} result={result} engine-id={engineId}></c-quantic-result-link>
+                <c-quantic-result-link target="_blank" result={result} engine-id={engineId}></c-quantic-result-link>
               </div>
             </div>
             <div class="slds-text-align_right quickview__result-date slds-col_bump-left">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
@@ -1,5 +1,9 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  registerComponentForInit,
+  initializeWithHeadless,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 
 /** @typedef {import("coveo").SearchStatus} SearchStatus */
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
@@ -8,6 +12,7 @@ import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} fro
 /**
  * The `QuanticResultsPerPage` component determines how many results to display per page.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-results-per-page engine-id={engineId} choices-displayed="5,10,20" initial-choice="5"></c-quantic-results-per-page>
  */
@@ -34,7 +39,7 @@ export default class QuanticResultsPerPage extends LightningElement {
   @api initialChoice = 10;
 
   /** @type {boolean}*/
-  @track hasResults
+  @track hasResults;
   /** @type {number[]} */
   @track choices = [];
 
@@ -50,7 +55,7 @@ export default class QuanticResultsPerPage extends LightningElement {
   unsubscribeSearchStatus;
   /** @type {AnyHeadless} */
   headless;
-  
+
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
   }
@@ -67,12 +72,16 @@ export default class QuanticResultsPerPage extends LightningElement {
     this.choices = this.parseChoicesDisplayed();
     this.validateInitialChoice();
     this.resultsPerPage = this.headless.buildResultsPerPage(engine, {
-      initialState: {numberOfResults: Number(this.initialChoice) ?? this.choices[0]},
+      initialState: {
+        numberOfResults: Number(this.initialChoice) ?? this.choices[0],
+      },
     });
     this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribe = this.resultsPerPage.subscribe(() => this.updateState());
-    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
-  }
+    this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
+      this.updateState()
+    );
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
@@ -88,7 +97,9 @@ export default class QuanticResultsPerPage extends LightningElement {
     return this.choicesDisplayed.split(',').map((choice) => {
       const parsedChoice = parseInt(choice, 10);
       if (isNaN(parsedChoice)) {
-        throw new Error(`The choice value "${choice}" from the "choicesDisplayed" option is not a number.`);
+        throw new Error(
+          `The choice value "${choice}" from the "choicesDisplayed" option is not a number.`
+        );
       }
       return parsedChoice;
     });
@@ -96,14 +107,16 @@ export default class QuanticResultsPerPage extends LightningElement {
 
   validateInitialChoice() {
     if (!this.choices.includes(Number(this.initialChoice))) {
-      throw new Error(`The "initialChoice" option value "${this.initialChoice}" is not included in the "choicesDisplayed" option "${this.choicesDisplayed}".`);
+      throw new Error(
+        `The "initialChoice" option value "${this.initialChoice}" is not included in the "choicesDisplayed" option "${this.choicesDisplayed}".`
+      );
     }
   }
 
   get choicesObjects() {
     return this.choices.map((choice) => ({
       value: choice,
-      selected: choice === this.currentResultsPerPageValue
+      selected: choice === this.currentResultsPerPageValue,
     }));
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.js
@@ -1,5 +1,5 @@
 import {LightningElement, api, track} from 'lwc';
-import {registerComponentForInit, initializeWithHeadless} from 'c/quanticHeadlessLoader';
+import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 
 /** @typedef {import("coveo").SearchStatus} SearchStatus */
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
@@ -48,6 +48,8 @@ export default class QuanticResultsPerPage extends LightningElement {
   unsubscribe;
   /** @type {Function} */
   unsubscribeSearchStatus;
+  /** @type {AnyHeadless} */
+  headless;
   
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -61,12 +63,13 @@ export default class QuanticResultsPerPage extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
+    this.headless = getHeadlessBundle(this.engineId);
     this.choices = this.parseChoicesDisplayed();
     this.validateInitialChoice();
-    this.resultsPerPage = CoveoHeadless.buildResultsPerPage(engine, {
+    this.resultsPerPage = this.headless.buildResultsPerPage(engine, {
       initialState: {numberOfResults: Number(this.initialChoice) ?? this.choices[0]},
     });
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribe = this.resultsPerPage.subscribe(() => this.updateState());
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
@@ -5,7 +5,7 @@ import {
   getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 
-import { keys } from 'c/quanticUtils';
+import {keys} from 'c/quanticUtils';
 
 import search from '@salesforce/label/c.quantic_Search';
 import clear from '@salesforce/label/c.quantic_Clear';
@@ -23,16 +23,16 @@ const CLASS_WITHOUT_SUBMIT =
 /**
  * The `QuanticSearchBox` component creates a search box with built-in support for query suggestions.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-search-box engine-id={engineId} placeholder="Enter a query..." without-submit-button number-of-suggestions="8"></c-quantic-search-box>
  */
 export default class QuanticSearchBox extends LightningElement {
-
   labels = {
     search,
     clear,
   };
-  
+
   /**
    * The ID of the engine instance the component registers to.
    * @api
@@ -88,7 +88,7 @@ export default class QuanticSearchBox extends LightningElement {
       },
     });
     this.unsubscribe = this.searchBox.subscribe(() => this.updateState());
-  }
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -114,11 +114,13 @@ export default class QuanticSearchBox extends LightningElement {
   }
 
   get suggestions() {
-    return this.searchBox?.state.suggestions.map((s, index) => ({
-      key: index,
-      rawValue: s.rawValue,
-      value: s.highlightedValue,
-    })) ?? [];
+    return (
+      this.searchBox?.state.suggestions.map((s, index) => ({
+        key: index,
+        rawValue: s.rawValue,
+        value: s.highlightedValue,
+      })) ?? []
+    );
   }
 
   /**
@@ -156,7 +158,9 @@ export default class QuanticSearchBox extends LightningElement {
   }
 
   get searchBoxInputClass() {
-    return this.withoutSubmitButton ? 'slds-input searchbox__input' : 'slds-input searchbox__input searchbox__input-with-button';
+    return this.withoutSubmitButton
+      ? 'slds-input searchbox__input'
+      : 'slds-input searchbox__input searchbox__input-with-button';
   }
 
   get suggestionsOpen() {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.js
@@ -2,6 +2,7 @@ import {LightningElement, api, track} from 'lwc';
 import {
   registerComponentForInit,
   initializeWithHeadless,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 
 import { keys } from 'c/quanticUtils';
@@ -67,12 +68,15 @@ export default class QuanticSearchBox extends LightningElement {
   searchBox;
   /** @type {Function} */
   unsubscribe;
+  /** @type {AnyHeadless} */
+  headless;
 
   /**
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchBox = CoveoHeadless.buildSearchBox(engine, {
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchBox = this.headless.buildSearchBox(engine, {
       options: {
         numberOfSuggestions: Number(this.numberOfSuggestions),
         highlightOptions: {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
@@ -1,4 +1,4 @@
-import {LightningElement, api,track} from 'lwc';
+import {LightningElement, api, track} from 'lwc';
 
 /**
  * @typedef Suggestion
@@ -12,6 +12,7 @@ import {LightningElement, api,track} from 'lwc';
  * @fires CustomEvent#highlightchange
  * @fires CustomEvent#suggestionselected
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-search-box-suggestions-list suggestions={suggestions} onhighlightchange={handleHighlightChange} onsuggestionselected={handleSuggestionSelection}></c-quantic-search-box-suggestions-list>
  */
@@ -29,7 +30,7 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
   @api
   selectionUp() {
     this.selectionIndex--;
-    if(this.selectionIndex < 0) {
+    if (this.selectionIndex < 0) {
       this.selectionIndex = this.suggestions.length - 1;
     }
   }
@@ -37,10 +38,10 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
   /**
    * Move highlighted selection down.
    */
-  @api 
+  @api
   selectionDown() {
     this.selectionIndex++;
-    if(this.selectionIndex >= this.suggestions.length) {
+    if (this.selectionIndex >= this.suggestions.length) {
       this.selectionIndex = 0;
     }
   }
@@ -49,9 +50,9 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
    * Return the currently selected suggestion.
    * @returns {Suggestion}
    */
-  @api 
+  @api
   getCurrentSelectedValue() {
-    if(this.selectionIndex > -1) {
+    if (this.selectionIndex > -1) {
       return this.suggestions[this.selectionIndex];
     }
     return undefined;
@@ -60,16 +61,16 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
   /**
    * Reset the current selection.
    */
-  @api 
+  @api
   resetSelection() {
     this.selectionIndex = -1;
   }
-  
+
   /** @type {number} */
   @track selectionIndex = -1;
 
   renderedCallback() {
-    if(this.selectionIndex > -1) {
+    if (this.selectionIndex > -1) {
       this.emitSuggestionHighlighted();
     }
   }
@@ -77,13 +78,13 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
   get suggestionsToRender() {
     return this.suggestions.map((s, i) => ({
       ...s,
-      isSelected: this.selectionIndex === i
+      isSelected: this.selectionIndex === i,
     }));
   }
 
   emitSuggestionHighlighted() {
     const highlightChangeEvent = new CustomEvent('highlightchange', {
-      detail: this.suggestions[this.selectionIndex]
+      detail: this.suggestions[this.selectionIndex],
     });
     this.dispatchEvent(highlightChangeEvent);
   }
@@ -93,7 +94,7 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
     const textValue = liElement.dataset.rawvalue;
 
     const suggestionSelectedEvent = new CustomEvent('suggestionselected', {
-      detail: textValue
+      detail: textValue,
     });
     this.dispatchEvent(suggestionSelectedEvent);
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -99,7 +99,8 @@ export default class QuanticSearchInterface extends LightningElement {
               this.engineOptions,
               CoveoHeadless.buildSearchEngine,
               this.engineId,
-              this
+              this,
+              CoveoHeadless
             );
             setInitializedCallback(this.initialize, this.engineId);
           }

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
@@ -2,6 +2,7 @@ import {LightningElement, track, api} from 'lwc';
 import {
   registerComponentForInit,
   initializeWithHeadless,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 
 import sortBy from '@salesforce/label/c.quantic_SortBy';
@@ -50,6 +51,8 @@ export default class QuanticSort extends LightningElement {
   unsubscribeSearchStatus;
   /** @type {Array.<SortOption>} */
   options;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     sortBy,
@@ -70,9 +73,10 @@ export default class QuanticSort extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
+    this.headless = getHeadlessBundle(this.engineId);
     this.options = this.buildOptions();
-    this.sort = CoveoHeadless.buildSort(engine);
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.sort = this.headless.buildSort(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSort = this.sort.subscribe(() => this.updateState());
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
@@ -93,16 +97,16 @@ export default class QuanticSort extends LightningElement {
     return [
       {
         label: this.labels.relevancy,
-        value: CoveoHeadless.buildCriterionExpression(this.relevancy),
+        value: this.headless.buildCriterionExpression(this.relevancy),
         criterion: this.relevancy,
       },
       {
         label: this.labels.newest,
-        value: CoveoHeadless.buildCriterionExpression(this.dateDescending),
+        value: this.headless.buildCriterionExpression(this.dateDescending),
         criterion: this.dateDescending},
       {
         label: this.labels.oldest,
-        value: CoveoHeadless.buildCriterionExpression(this.dateAscending),
+        value: this.headless.buildCriterionExpression(this.dateAscending),
         criterion: this.dateAscending,
       },
     ];
@@ -116,18 +120,18 @@ export default class QuanticSort extends LightningElement {
   }
 
   get relevancy() {
-    return CoveoHeadless.buildRelevanceSortCriterion();
+    return this.headless.buildRelevanceSortCriterion();
   }
 
   get dateDescending() {
-    return CoveoHeadless.buildDateSortCriterion(
-      CoveoHeadless.SortOrder.Descending
+    return this.headless.buildDateSortCriterion(
+      this.headless.SortOrder.Descending
     );
   }
 
   get dateAscending() {
-    return CoveoHeadless.buildDateSortCriterion(
-      CoveoHeadless.SortOrder.Ascending
+    return this.headless.buildDateSortCriterion(
+      this.headless.SortOrder.Ascending
     );
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
@@ -25,6 +25,7 @@ import oldest from '@salesforce/label/c.quantic_Oldest';
 /**
  * The `QuanticSort` component renders a dropdown that the end user can interact with to select the criterion to use when sorting query results.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-sort engine-id={engineId}></c-quantic-sort>
  */
@@ -81,7 +82,7 @@ export default class QuanticSort extends LightningElement {
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateState()
     );
-  }
+  };
 
   disconnectedCallback() {
     this.unsubscribeSort?.();
@@ -103,7 +104,8 @@ export default class QuanticSort extends LightningElement {
       {
         label: this.labels.newest,
         value: this.headless.buildCriterionExpression(this.dateDescending),
-        criterion: this.dateDescending},
+        criterion: this.dateDescending,
+      },
       {
         label: this.labels.oldest,
         value: this.headless.buildCriterionExpression(this.dateAscending),
@@ -116,7 +118,9 @@ export default class QuanticSort extends LightningElement {
    * @param {CustomEvent<{value: string}>} e
    */
   handleChange(e) {
-    this.sort.sortBy(this.options.find((option) => option.value === e.detail.value).criterion);
+    this.sort.sortBy(
+      this.options.find((option) => option.value === e.detail.value).criterion
+    );
   }
 
   get relevancy() {

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
@@ -1,7 +1,11 @@
 import {LightningElement, track, api} from 'lwc';
 import LOCALE from '@salesforce/i18n/locale';
 
-import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
+import {
+  registerComponentForInit,
+  initializeWithHeadless,
+  getHeadlessBundle,
+} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import noResults from '@salesforce/label/c.quantic_NoResults';
@@ -18,6 +22,7 @@ import showingResultsOfWithQuery_plural from '@salesforce/label/c.quantic_Showin
 /**
  * The `QuanticSummary` component displays information about the current range of results (e.g., "Results 1-10 of 123").
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-summary engine-id={engineId}></c-quantic-summary>
  */
@@ -45,8 +50,8 @@ export default class QuanticSummary extends LightningElement {
     showingResultsOf,
     showingResultsOf_plural,
     showingResultsOfWithQuery,
-    showingResultsOfWithQuery_plural
-  }
+    showingResultsOfWithQuery_plural,
+  };
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -63,12 +68,12 @@ export default class QuanticSummary extends LightningElement {
     this.headless = getHeadlessBundle(this.engineId);
     this.querySummary = this.headless.buildQuerySummary(engine);
     this.unsubscribe = this.querySummary.subscribe(() => this.updateState());
-  }
+  };
 
   disconnectedCallback() {
     this.unsubscribe?.();
   }
-  
+
   updateState() {
     this.state = this.querySummary.state;
   }
@@ -86,7 +91,9 @@ export default class QuanticSummary extends LightningElement {
   }
 
   get range() {
-    return `${Intl.NumberFormat(LOCALE).format(this.state?.firstResult)}-${Intl.NumberFormat(LOCALE).format(this.state?.lastResult)}`;
+    return `${Intl.NumberFormat(LOCALE).format(
+      this.state?.firstResult
+    )}-${Intl.NumberFormat(LOCALE).format(this.state?.lastResult)}`;
   }
 
   get total() {
@@ -95,18 +102,38 @@ export default class QuanticSummary extends LightningElement {
 
   get noResultsLabel() {
     return I18nUtils.format(
-        this.hasQuery ? this.labels.noResultsFor : this.labels.noResults,
-        I18nUtils.getTextBold(I18nUtils.escapeHTML(this.query)));
+      this.hasQuery ? this.labels.noResultsFor : this.labels.noResults,
+      I18nUtils.getTextBold(I18nUtils.escapeHTML(this.query))
+    );
   }
 
   get summaryLabel() {
     const labelName = this.hasQuery
-      ? I18nUtils.getLabelNameWithCount('showingResultsOfWithQuery', this.state?.lastResult)
-      : I18nUtils.getLabelNameWithCount('showingResultsOf', this.state?.lastResult);
+      ? I18nUtils.getLabelNameWithCount(
+          'showingResultsOfWithQuery',
+          this.state?.lastResult
+        )
+      : I18nUtils.getLabelNameWithCount(
+          'showingResultsOf',
+          this.state?.lastResult
+        );
     return I18nUtils.format(
       this.labels[labelName],
-      I18nUtils.getTextWithDecorator(this.range, '<b class="summary__range">', '</b>'),
-      I18nUtils.getTextWithDecorator(this.total, '<b class="summary__total">', '</b>'),
-      I18nUtils.getTextWithDecorator(I18nUtils.escapeHTML(this.query), '<b class="summary__query">', '</b>'));
+      I18nUtils.getTextWithDecorator(
+        this.range,
+        '<b class="summary__range">',
+        '</b>'
+      ),
+      I18nUtils.getTextWithDecorator(
+        this.total,
+        '<b class="summary__total">',
+        '</b>'
+      ),
+      I18nUtils.getTextWithDecorator(
+        I18nUtils.escapeHTML(this.query),
+        '<b class="summary__query">',
+        '</b>'
+      )
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.js
@@ -1,7 +1,7 @@
 import {LightningElement, track, api} from 'lwc';
 import LOCALE from '@salesforce/i18n/locale';
 
-import {registerComponentForInit, initializeWithHeadless} from 'c/quanticHeadlessLoader';
+import {registerComponentForInit, initializeWithHeadless, getHeadlessBundle} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import noResults from '@salesforce/label/c.quantic_NoResults';
@@ -36,6 +36,8 @@ export default class QuanticSummary extends LightningElement {
   querySummary;
   /** @type {Function} */
   unsubscribe;
+  /** @type {AnyHeadless} */
+  headless;
 
   labels = {
     noResults,
@@ -58,7 +60,8 @@ export default class QuanticSummary extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.querySummary = CoveoHeadless.buildQuerySummary(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.querySummary = this.headless.buildQuerySummary(engine);
     this.unsubscribe = this.querySummary.subscribe(() => this.updateState());
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
@@ -11,6 +11,7 @@ import {
 /**
  * The `QuanticTab` component allows the end user to view a subset of results.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-tab engine-id={engineId} label="Community" expression="@objecttype==&quot;Message&quot;" is-active></c-quantic-tab>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.js
@@ -2,6 +2,7 @@ import {LightningElement, api, track} from 'lwc';
 import {
   registerComponentForInit,
   initializeWithHeadless,
+  getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
@@ -55,6 +56,8 @@ export default class QuanticTab extends LightningElement {
   unsubscribe;
   /** @type {Function} */
   unsubscribeSearchStatus;
+  /** @type {AnyHeadless} */
+  headless;
 
   connectedCallback() {
     registerComponentForInit(this, this.engineId);
@@ -69,7 +72,8 @@ export default class QuanticTab extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.tab = CoveoHeadless.buildTab(engine, {
+    this.headless = getHeadlessBundle(this.engineId);
+    this.tab = this.headless.buildTab(engine, {
       options: {
         expression: this.expression,
         id: this.label,
@@ -78,7 +82,7 @@ export default class QuanticTab extends LightningElement {
         isActive: this.isActive,
       },
     });
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
 
     this.unsubscribe = this.tab.subscribe(() => this.updateState());
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -5,6 +5,7 @@ import more from '@salesforce/label/c.quantic_More';
 /**
  *  The `QuanticTabBar` component displays the Quantic Tabs in a responsive manner. When tabs are wider than the available space, the tabs that cannot fit in the space are moved in the "More" drop-down list.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-tab-bar>
  *   <c-quantic-tab engine-id={engineId} label="Tab 1" expression={expressionOne} is-active></c-quantic-tab>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframe/quanticTimeframe.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframe/quanticTimeframe.js
@@ -5,6 +5,7 @@ import {api, LightningElement} from 'lwc';
  *
  * A timeframe is a span of time from now to a specific time in the past, or the future.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-timeframe amount="6" unit="month"></c-quantic-timeframe>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -58,6 +58,7 @@ import apply from '@salesforce/label/c.quantic_Apply';
 /**
  * The `QuanticTimeframeFacet` component displays dates as relative ranges.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-timeframe-facet engine-id={engineId} field="Date" label="Indexed Date" is-collapsed with-date-picker>
  *   <c-quantic-timeframe period="past" unit="year" amount="10" label="Past decade"></c-quantic-timeframe>
@@ -132,7 +133,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
     'withDatePicker',
     'noFilterFacetCount',
     'injectionDepth',
-  ]
+  ];
 
   /** @type {DateFacetState} */
   @track facetState;
@@ -190,11 +191,15 @@ export default class QuanticTimeframeFacet extends LightningElement {
    * Gets whether to show the facet.
    */
   get showFacet() {
-    const facetIsActivated = this.hasActiveValues || !!this.dateFilterState.range;
+    const facetIsActivated =
+      this.hasActiveValues || !!this.dateFilterState.range;
     const canRefineWithCustomRange = this.hasResults && this.withDatePicker;
-    const canRefineWithTimeframes = this.hasResults && this.formattedValues.length > 0;
+    const canRefineWithTimeframes =
+      this.hasResults && this.formattedValues.length > 0;
 
-    return facetIsActivated || canRefineWithCustomRange || canRefineWithTimeframes;
+    return (
+      facetIsActivated || canRefineWithCustomRange || canRefineWithTimeframes
+    );
   }
 
   /**
@@ -206,15 +211,11 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   get startDateNoTime() {
-    return this.startDate
-      ? DateUtils.trimIsoTime(this.startDate)
-      : '';
+    return this.startDate ? DateUtils.trimIsoTime(this.startDate) : '';
   }
 
   get endDateNoTime() {
-    return this.endDate
-      ? DateUtils.trimIsoTime(this.endDate)
-      : '';
+    return this.endDate ? DateUtils.trimIsoTime(this.endDate) : '';
   }
 
   /**
@@ -272,7 +273,9 @@ export default class QuanticTimeframeFacet extends LightningElement {
     const values = this.facetState?.values || [];
 
     return values
-      .filter((value) => value.numberOfResults > 0 || value.state === 'selected')
+      .filter(
+        (value) => value.numberOfResults > 0 || value.state === 'selected'
+      )
       .map((value) => ({
         ...value,
         label: this.formatFacetValue(value),
@@ -331,14 +334,14 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   /**
-   * @param {Event} evt 
+   * @param {Event} evt
    */
-   preventDefault(evt) {
+  preventDefault(evt) {
     evt.preventDefault();
   }
 
   /**
-   * @param {SearchEngine} engine 
+   * @param {SearchEngine} engine
    */
   initialize = (engine) => {
     this.headless = getHeadlessBundle(this.engineId);
@@ -349,12 +352,12 @@ export default class QuanticTimeframeFacet extends LightningElement {
       label: this.label,
       facetId: this.facet.state.facetId,
       format: this.formatFacetValue,
-      element: this.template.host
+      element: this.template.host,
     });
   };
 
   /**
-   * @param {SearchEngine} engine 
+   * @param {SearchEngine} engine
    */
   initializeSearchStatusController(engine) {
     this.searchStatus = this.headless.buildSearchStatus(engine);
@@ -364,7 +367,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   /**
-   * @param {SearchEngine} engine 
+   * @param {SearchEngine} engine
    */
   initializeFacetController(engine) {
     this.facet = this.headless.buildDateFacet(engine, {
@@ -382,7 +385,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   /**
-   * @param {SearchEngine} engine 
+   * @param {SearchEngine} engine
    */
   initializeDateFilterController(engine) {
     const dateFilterId = (this.facetId || this.field) + '_input';
@@ -416,7 +419,10 @@ export default class QuanticTimeframeFacet extends LightningElement {
     this.dateFilterState = this.dateFilter.state;
 
     if (this.dateFilterState.range) {
-      this.tryUpdateFilterRange(this.dateFilterState.range.start, this.dateFilterState.range.end);
+      this.tryUpdateFilterRange(
+        this.dateFilterState.range.start,
+        this.dateFilterState.range.end
+      );
       this.enableRangeValidation(false);
       this._showValues = false;
     } else {
@@ -483,7 +489,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   };
 
   /**
-   * @param {CustomEvent<{value: string}>} evt 
+   * @param {CustomEvent<{value: string}>} evt
    */
   onSelectValue(evt) {
     const item = this.formattedValues.find(
@@ -561,8 +567,18 @@ export default class QuanticTimeframeFacet extends LightningElement {
       return;
     }
 
-    const startDate = DateUtils.fromLocalIsoDate(this.startDatepicker.value, 0, 0, 0);
-    const endDate = DateUtils.fromLocalIsoDate(this.endDatepicker.value, 23, 59, 59);
+    const startDate = DateUtils.fromLocalIsoDate(
+      this.startDatepicker.value,
+      0,
+      0,
+      0
+    );
+    const endDate = DateUtils.fromLocalIsoDate(
+      this.endDatepicker.value,
+      23,
+      59,
+      59
+    );
 
     this.updateRangeInHeadless(startDate, endDate);
   }
@@ -578,7 +594,10 @@ export default class QuanticTimeframeFacet extends LightningElement {
 
     this.startDatepicker.required = shouldValidate;
     this.endDatepicker.required = shouldValidate;
-    this.startDatepicker.max = shouldValidate && hasEndDate ? DateUtils.trimIsoTime(this.endDatepicker.value) : '';
+    this.startDatepicker.max =
+      shouldValidate && hasEndDate
+        ? DateUtils.trimIsoTime(this.endDatepicker.value)
+        : '';
   }
 
   disableRangeRequirement() {
@@ -607,7 +626,9 @@ export default class QuanticTimeframeFacet extends LightningElement {
     this.startDatepicker.reportValidity();
     this.endDatepicker.reportValidity();
 
-    return this.startDatepicker.checkValidity() && this.endDatepicker.checkValidity();
+    return (
+      this.startDatepicker.checkValidity() && this.endDatepicker.checkValidity()
+    );
   }
 
   updateRangeInHeadless(startDate, endDate) {

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -247,7 +247,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   get currentValues() {
     return this.timeframes.map((timeframe) => {
       return timeframe.period === 'past'
-        ? CoveoHeadless.buildDateRange({
+        ? getHeadlessBundle(this.engineId).buildDateRange({
             start: {
               period: timeframe.period,
               unit: timeframe.unit,
@@ -255,7 +255,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
             },
             end: {period: 'now'},
           })
-        : CoveoHeadless.buildDateRange({
+        : getHeadlessBundle(this.engineId).buildDateRange({
             start: {period: 'now'},
             end: {
               period: timeframe.period,
@@ -634,13 +634,13 @@ export default class QuanticTimeframeFacet extends LightningElement {
   updateRangeInHeadless(startDate, endDate) {
     const engine = getHeadlessBindings(this.engineId).engine;
     engine.dispatch(
-      CoveoHeadless.loadDateFacetSetActions(engine).deselectAllDateFacetValues(
-        this.facet.state.facetId
-      )
+      getHeadlessBundle(this.engineId)
+        .loadDateFacetSetActions(engine)
+        .deselectAllDateFacetValues(this.facet.state.facetId)
     );
 
     this.dateFilter.setRange(
-      CoveoHeadless.buildDateRange({
+      getHeadlessBundle(this.engineId).buildDateRange({
         start: DateUtils.toLocalSearchApiDate(startDate),
         end: DateUtils.toLocalSearchApiDate(endDate),
       })

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -1,5 +1,6 @@
 import {
   getHeadlessBindings,
+  getHeadlessBundle,
   initializeWithHeadless,
   registerComponentForInit,
   registerToStore,
@@ -156,6 +157,8 @@ export default class QuanticTimeframeFacet extends LightningElement {
   dateFilter;
   /** @type {Function} */
   unsubscribeDateFilter;
+  /** @type {AnyHeadless} */
+  headless;
 
   _isCollapsed = false;
   _showValues = true;
@@ -338,6 +341,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
    * @param {SearchEngine} engine 
    */
   initialize = (engine) => {
+    this.headless = getHeadlessBundle(this.engineId);
     this.initializeSearchStatusController(engine);
     this.initializeFacetController(engine);
     this.initializeDateFilterController(engine);
@@ -353,7 +357,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
    * @param {SearchEngine} engine 
    */
   initializeSearchStatusController(engine) {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() =>
       this.updateSearchStatusState()
     );
@@ -363,7 +367,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
    * @param {SearchEngine} engine 
    */
   initializeFacetController(engine) {
-    this.facet = CoveoHeadless.buildDateFacet(engine, {
+    this.facet = this.headless.buildDateFacet(engine, {
       options: {
         field: this.field,
         currentValues: this.currentValues,
@@ -383,7 +387,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   initializeDateFilterController(engine) {
     const dateFilterId = (this.facetId || this.field) + '_input';
 
-    this.dateFilter = CoveoHeadless.buildDateFilter(engine, {
+    this.dateFilter = this.headless.buildDateFilter(engine, {
       options: {
         field: this.field,
         facetId: dateFilterId,
@@ -448,8 +452,8 @@ export default class QuanticTimeframeFacet extends LightningElement {
    */
   formatFacetValue = (facetValue) => {
     try {
-      const startDate = CoveoHeadless.deserializeRelativeDate(facetValue.start);
-      const endDate = CoveoHeadless.deserializeRelativeDate(facetValue.end);
+      const startDate = this.headless.deserializeRelativeDate(facetValue.start);
+      const endDate = this.headless.deserializeRelativeDate(facetValue.end);
 
       const relativeDate = startDate.period === 'past' ? startDate : endDate;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2353

This PR updates the Quantic components that are reused in more than one use case to use the Headless bundle that matches the interface. In other words, a `QuanticResultList` declared inside a `QuanticSearchInterface` will use the loaded Search Headless bundle while the same `QuanticResultList` declared inside a `QuanticInsightInterface` will use the Insight Headless bundle.

In most cases, the change is simply to update the component initialization to:
1. store a reference on the headless bundle using the `getHeadlessBundle(engineId)` function
2. update direct references to Headless bundles to use the dynamic reference instead (i.e., `CoveoHeadless.buildSomething(engine)` --> `this.headless.buildSomething(engine)`)

This PR depends on the other Headless controllers PRs as the controller functions have to be exported.
We'll also need to make sure these symbols are exported:

* `buildCriterionExpression`
* `buildRelevanceSortCriterion`
* `buildDateSortCriterion`
* `deserializeRelativeDate`
* `loadNumericFacetSetActions`
* `loadRecentResultsActions`
* `SortOrder`
