### PR TITLE
fix(quantic): Fix voiceover breadcrumb and style

### DIFF
--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-expectations.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-expectations.ts
@@ -51,13 +51,12 @@ function baseBreadcrumbManagerExpectations(
         .contains(value)
         .logDetail(`should have the value "${value}" at first value`);
     },
-    firstBreadcrumbAltTextContains: (value: string) => {
+    firstBreadcrumbAltTextEq: (value: string) => {
       selector
         .firstBreadcrumbAltText()
-        .contains(value)
-        .logDetail(
-          `should have the "${value}" as slds-assistive-text at first value`
-        );
+        .invoke('attr', 'aria-label')
+        .should('eq', value)
+        .logDetail(`should have the "${value}" as aria-label at first value`);
     },
     displayShowMore: (display: boolean) => {
       selector

--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-selectors.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager-selectors.ts
@@ -26,9 +26,7 @@ const FacetBreadcrumbSelectors: BreadcrumbSelector = {
   firstBreadcrumbValueLabel: () =>
     FacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
   firstBreadcrumbAltText: () =>
-    FacetBreadcrumbSelectors.get()
-      .find('lightning-icon > .slds-assistive-text')
-      .first(),
+    FacetBreadcrumbSelectors.get().find('button.pill__container').first(),
   showMoreButton: () =>
     FacetBreadcrumbSelectors.get().find('.breadcrumb-manager__more-button'),
 };
@@ -44,7 +42,7 @@ const NumericFacetBreadcrumbSelectors: BreadcrumbSelector = {
     NumericFacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
   firstBreadcrumbAltText: () =>
     NumericFacetBreadcrumbSelectors.get()
-      .find('lightning-icon > .slds-assistive-text')
+      .find('button.pill__container')
       .first(),
   showMoreButton: () =>
     NumericFacetBreadcrumbSelectors.get().find(
@@ -65,7 +63,7 @@ const CategoryFacetBreadcrumbSelectors: BreadcrumbSelector = {
       .first(),
   firstBreadcrumbAltText: () =>
     CategoryFacetBreadcrumbSelectors.get()
-      .find('lightning-icon > .slds-assistive-text')
+      .find('button.pill__container')
       .first(),
 };
 
@@ -77,9 +75,7 @@ const DateFacetBreadcrumbSelectors: BreadcrumbSelector = {
   firstBreadcrumbValueLabel: () =>
     DateFacetBreadcrumbSelectors.get().find('.pill__text-container').first(),
   firstBreadcrumbAltText: () =>
-    DateFacetBreadcrumbSelectors.get()
-      .find('lightning-icon > .slds-assistive-text')
-      .first(),
+    DateFacetBreadcrumbSelectors.get().find('button.pill__container').first(),
   showMoreButton: () =>
     DateFacetBreadcrumbSelectors.get().find('.breadcrumb-manager__more-button'),
 };

--- a/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager.cypress.ts
+++ b/packages/quantic/cypress/integration/breadcrumb-manager/breadcrumb-manager.cypress.ts
@@ -11,7 +11,7 @@ describe('quantic-breadcrumb-manager', () => {
   const numericField = 'ytlikecount';
   const dateField = 'date';
   const categoryField = 'geographicalhierarchy';
-  const clearActionName = 'Clear';
+  const clearActionName = 'Clear filter';
 
   interface BreadcrumbOptions {
     categoryDivider: string;
@@ -101,8 +101,8 @@ describe('quantic-breadcrumb-manager', () => {
         Expect.dateFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           timeframeLabel1
         );
-        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextContains(
-          `${dateFacetName} ${clearActionName}`
+        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextEq(
+          `${dateFacetName} ${timeframeLabel1} ${clearActionName}`
         );
 
         Actions.timeframeFacet.selectValue(timeframeLabel2);
@@ -140,8 +140,8 @@ describe('quantic-breadcrumb-manager', () => {
         Expect.categoryFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           path[0]
         );
-        Expect.categoryFacetBreadcrumb.firstBreadcrumbAltTextContains(
-          `${categoryFacetName} ${clearActionName}`
+        Expect.categoryFacetBreadcrumb.firstBreadcrumbAltTextEq(
+          `${categoryFacetName} ${path[0]} ${clearActionName}`
         );
 
         Actions.categoryFacet.selectChildValue(path[1]);
@@ -235,8 +235,8 @@ describe('quantic-breadcrumb-manager', () => {
         Expect.dateFacetBreadcrumb.firstBreadcrumbValueLabelContains(
           'Past 6 months'
         );
-        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextContains(
-          `${dateFacetName} ${clearActionName}`
+        Expect.dateFacetBreadcrumb.firstBreadcrumbAltTextEq(
+          `${dateFacetName} Past 6 months ${clearActionName}`
         );
         Expect.categoryFacetBreadcrumb.displayBreadcrumb(true);
         Expect.categoryFacetBreadcrumb.displayLabel(true);

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.css
@@ -11,6 +11,10 @@
   white-space: nowrap;
 }
 
+.breadcrumb-manager__more-button {
+  line-height: var(--lwc-lineHeightText, 1.5);
+}
+
 .breadcrumb-manager__more-button:hover {
   color: var(--color-text-action-label);
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -9,7 +9,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -26,7 +26,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>
@@ -42,7 +42,7 @@
               <span class="slds-col breadcrumb-manager__field-name">{breadcrumbValue.label}{labels.colon} </span>
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <li class="breadcrumb__container">
-                  <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumbValue.label} action-name={labels.clear}></c-quantic-pill>
+                  <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumbValue.label} action-name={labels.clearFilter}></c-quantic-pill>
                 </li>
               </ul>
             </li>
@@ -53,7 +53,7 @@
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                   <li key={breadcrumbValue.value} class="breadcrumb__container">
-                    <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clear}></c-quantic-pill>
+                    <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                   </li>
                 </template>
                 <template if:true={breadcrumb.showMoreButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -72,7 +72,7 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   labels = {
     nMore,
-    clearFilter: clearFilter,
+    clearFilter,
     clearAllFilters,
     colon
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -12,7 +12,7 @@ import {I18nUtils, RelativeDateFormatter, Store} from 'c/quanticUtils';
 
 import nMore from '@salesforce/label/c.quantic_NMore';
 import clearAllFilters from '@salesforce/label/c.quantic_ClearAllFilters';
-import clear from '@salesforce/label/c.quantic_Clear';
+import clearFilter from '@salesforce/label/c.quantic_ClearFilter';
 import colon from '@salesforce/label/c.quantic_Colon';
 
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
@@ -72,7 +72,7 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   labels = {
     nMore,
-    clear,
+    clearFilter: clearFilter,
     clearAllFilters,
     colon
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
@@ -10,7 +10,7 @@
 
 .pill__text-container {
   min-width: 0;
-  line-height: var(--lwc-varLineHeightText,1.5);
+  line-height: var(--lwc-lineHeightText, 1.5);
 }
 
 a {

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.css
@@ -10,6 +10,7 @@
 
 .pill__text-container {
   min-width: 0;
+  line-height: var(--lwc-varLineHeightText,1.5);
 }
 
 a {

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.html
@@ -1,6 +1,6 @@
 <template>
-  <button class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small slds-button slds-var-m-around_xxx-small" onclick={deselect}>
-    <span class="slds-nowrap pill__text-container slds-truncate">{label}</span>
-    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" alternative-text={alternativeText} size="xx-small"></lightning-icon>
+  <button class="pill__container slds-grid_vertical-align-center slds-p-horizontal_x-small slds-p-vertical_xx-small slds-button slds-var-m-around_xxx-small" onclick={deselect} aria-label={alternativeText}>
+    <span class="slds-nowrap pill__text-container slds-truncate" aria-hidden="true">{label}</span>
+    <lightning-icon class="slds-current-color slds-m-left_xx-small" icon-name="utility:close" size="xx-small"></lightning-icon>
   </button>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticPill/quanticPill.js
@@ -39,8 +39,8 @@ export default class QuanticPill extends LightningElement {
 
   get alternativeText() {
     let label = this.altText;
-    if(this.groupName && this.actionName) {
-      label = `${this.groupName} ${this.actionName}`.trim();
+    if(this.groupName && this.actionName && this.label) {
+      label = `${this.groupName} ${this.label} ${this.actionName}`.trim();
     }
     return label;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2354

Before:
![image](https://user-images.githubusercontent.com/2488155/180568895-3ad13f5a-a8ea-44d7-9155-cfcad4f5aff4.png)

After:
![image](https://user-images.githubusercontent.com/2488155/180568927-7c53fe38-749b-42db-9fba-6e1196454259.png)

And for the voiceover for each values in the breadcrumb:

Example with Type = Space
Before: 
🔊: "Space Type Clear, button"

After:
🔊: "Type Space Clear Filter, button"