### PR TITLE
fix(atomic): improved aria label for breadcrumbs

### DIFF
--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.tsx
@@ -174,6 +174,7 @@ export class AtomicBreadbox implements InitializableComponent {
     const value = Array.isArray(breadcrumb.formattedValue)
       ? this.limitPath(breadcrumb.formattedValue)
       : breadcrumb.formattedValue;
+    const title = `${breadcrumb.label}: ${fullValue}`;
 
     return (
       <li class="breadcrumb" key={value}>
@@ -181,7 +182,10 @@ export class AtomicBreadbox implements InitializableComponent {
           part="breadcrumb-button"
           style="outline-bg-neutral"
           class="py-2 px-3 flex items-center btn-pill group"
-          title={`${breadcrumb.label}: ${fullValue}`}
+          title={title}
+          ariaLabel={this.bindings.i18n.t('remove-filter-on', {
+            value: title,
+          })}
           onClick={() => {
             if (this.numberOfBreadcrumbs > 1) {
               this.breadcrumbRemovedFocus.focusAfterSearch();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1874

Without this, screen readers only describe breadcrumbs as "Button, FacetName Colon FacetValue".