### PR TITLE
feat(quantic): Recent queries accessibility fix

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.css
@@ -5,6 +5,7 @@
   flex-direction: row;
   min-width: 0;
   border-radius: .25rem;
+  line-height: var(--lwc-varLineHeightText,1.5);
 }
 
 a {

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
@@ -21,10 +21,10 @@
           <ul>
             <template for:each={queries} for:item="query" for:index="index">
               <li key={query} class="slds-grid" value={index} onclick={executeQuery}>
-                <a class="recent-query__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
-                  <lightning-icon class="recent-query__icon slds-current-color" icon-name="utility:search" alternative-text="search icon" size="xx-small"></lightning-icon>
+                <button class="slds-button recent-query__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
+                  <lightning-icon class="recent-query__icon slds-current-color" icon-name="utility:search" size="xx-small" aria-hidden="true"></lightning-icon>
                   <span class="slds-text-body_small nowrap query-text__container slds-truncate">{query}</span>
-                </a>
+                </button>
               </li>
             </template>
           </ul>


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/2488155/180846057-4fb6f3a3-4e49-4cdd-bf66-0a28b515b857.png)

After:
![image](https://user-images.githubusercontent.com/2488155/180846090-33fd086b-6c88-4682-be2d-492b87a08d46.png)

Before:
🔊Nothing, was not accessible
After:
🔊 Value of the text within the recent query