### PR TITLE
added accessibility functionality to quanticFacetValue Implementation B

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -31,23 +31,6 @@
             </template>
 
             <template if:false={isFacetSearchActive}>
-              <fieldset> 
-                <legend class="slds-assistive-text">{field}</legend> 
-                <ul>          
-                  <template for:each={values} for:item="v">
-                    <li class="slds-grid" key={v.value} >
-                      <c-quantic-facet-value 
-                        onselectvalue={onSelectValue} 
-                        item={v} 
-                        is-checked={v.checked}
-                        data-cy={v.value}
-                        display-as-link={isDisplayAsLink}>
-                      </c-quantic-facet-value>
-                    </li>
-                  </template>
-                </ul>          
-              </fieldset>
-              <span>I am divider</span>
               <div aria-label={field}  role="group">                  
                 <template for:each={values} for:item="v">
                     <c-quantic-facet-value 

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -31,16 +31,23 @@
             </template>
 
             <template if:false={isFacetSearchActive}>
-              <template for:each={values} for:item="v">
-                <c-quantic-facet-value 
-                  onselectvalue={onSelectValue} 
-                  key={v.value} 
-                  item={v} 
-                  is-checked={v.checked}
-                  data-cy={v.value}
-                  display-as-link={isDisplayAsLink}>
-                </c-quantic-facet-value>
-              </template>
+              <fieldset> 
+                <legend class="slds-assistive-text">Test</legend> 
+                <ul>          
+                  <template for:each={values} for:item="v">
+                    <li class="slds-grid" key={v.value} >
+                      <c-quantic-facet-value 
+                        onselectvalue={onSelectValue} 
+                        item={v} 
+                        is-checked={v.checked}
+                        data-cy={v.value}
+                        display-as-link={isDisplayAsLink}>
+                      </c-quantic-facet-value>
+                    </li>
+                  </template>
+                </ul>          
+              </fieldset>
+ 
               <div class="facet__show slds-m-top_x-small slds-p-horizontal_x-small">
                 <template if:true={canShowLess}>
                   <button variant="base" label={labels.showLess}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -32,7 +32,7 @@
 
             <template if:false={isFacetSearchActive}>
               <fieldset> 
-                <legend class="slds-assistive-text">Test</legend> 
+                <legend class="slds-assistive-text">{field}</legend> 
                 <ul>          
                   <template for:each={values} for:item="v">
                     <li class="slds-grid" key={v.value} >
@@ -47,6 +47,22 @@
                   </template>
                 </ul>          
               </fieldset>
+              <span>I am divider</span>
+              <div aria-label="Gender"  role="group">                  
+                <template for:each={values} for:item="v">
+                    <c-quantic-facet-value 
+                      display-new
+                      key={v.value}
+                      onselectvalue={onSelectValue} 
+                      item={v} 
+                      is-checked={v.checked}
+                      data-cy={v.value}
+                      display-as-link={isDisplayAsLink}>
+                    </c-quantic-facet-value>
+                </template>
+              </div>
+
+              
  
               <div class="facet__show slds-m-top_x-small slds-p-horizontal_x-small">
                 <template if:true={canShowLess}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -48,7 +48,7 @@
                 </ul>          
               </fieldset>
               <span>I am divider</span>
-              <div aria-label="Gender"  role="group">                  
+              <div aria-label={field}  role="group">                  
                 <template for:each={values} for:item="v">
                     <c-quantic-facet-value 
                       display-new

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
@@ -17,11 +17,3 @@ li {
 .facet__value-checkbox {
   min-width: unset;
 }
-
-.accessibility-only{
-  position: absolute;
-  display: block;
-  height: 0px;
-  overflow: hidden;
-  margin: 0px;
-}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
@@ -17,3 +17,56 @@ li {
 .facet__value-checkbox {
   min-width: unset;
 }
+
+.facet__value_new-checkbox{
+  width: 20px;
+  height: 20px;
+  vertical-align: top;
+  border: solid 1px #cccccc;
+  border-radius: 4px;
+  margin-right: 6px;
+  display: inline-block;
+  position: relative;
+
+}
+
+
+
+.facet__value_checkbox-checked{
+  color: #fff;
+  position: absolute;
+  top: 3px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+}
+.facet__value_checkbox-checked::before{
+  width: 6px;
+  border-top-left-radius: 1px;
+  border-bottom-left-radius: 1px;
+  top: 5px;
+  left: 1px;
+  transform: rotate(49deg);
+
+  content: '';
+  height: 2px;
+  background-color: #0070d2;
+  display: block;
+  position: absolute;
+  transform-origin: left center;
+
+}
+.facet__value_checkbox-checked::after{
+  content: '';
+  height: 2px;
+  background-color: #0070d2;
+  display: block;
+  position: absolute;
+  width: 13px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
+  top: 10px;
+  left: 4px;
+  transform: rotate(-49deg);
+  transform-origin: left center;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.css
@@ -17,3 +17,11 @@ li {
 .facet__value-checkbox {
   min-width: unset;
 }
+
+.accessibility-only{
+  position: absolute;
+  display: block;
+  height: 0px;
+  overflow: hidden;
+  margin: 0px;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -1,49 +1,16 @@
 <template>
-  <template if:false={displayNew}> 
-    <div role={divRole} aria-checked={isChecked} onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
-      <template if:false={displayAsLink}>
-        <lightning-input 
-          tabindex="-1"
-          type="checkbox"
-          class="facet__value-checkbox"
-          variant="label-hidden"
-          label="Facet value option"
-          name="facet value checkbox"
-          onchange={onSelect}
-          checked={isChecked}
-        ></lightning-input>
-      </template>
-      <template if:true={isChecked}>
-        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
-        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected">({numberOfResults})</span>
-      </template>
-      <template if:false={isChecked}>
-              <template if:true={isStandardFacet}>
-                <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
-                  <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
-                </span>
-              </template>
-              <template if:false={isStandardFacet}>
-                <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" >{formattedFacetValue}</span>
-              </template>
-              <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
-      </template>
-    </div>
-  </template>
+  <div aria-label={ariaLabelVoiceOver} onclick={onSelect} role={divRole} aria-checked={isChecked} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
+    <template if:false={displayAsLink}>
+      <div class="facet__value_new-checkbox">
+        <template if:true={isChecked}><div class="facet__value_checkbox-checked"></div></template>
+      </div>
+    </template>
 
-  <template if:true={displayNew}> 
-    <div aria-label={ariaLabelVoiceOver} onclick={onSelect} role={divRole} aria-checked={isChecked} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
-      <template if:false={displayAsLink}>
-        <div class="facet__value_new-checkbox">
-          <template if:true={isChecked}><div class="facet__value_checkbox-checked"></div></template>
-        </div>
-      </template>
-
-      <template if:true={isChecked}>
+    <template if:true={isChecked}>
         <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected" aria-label={formattedFacetValue}>{formattedFacetValue}</span>
         <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected" aria-label={numberOfResults}>({numberOfResults})</span>
-      </template>
-      <template if:false={isChecked}>
+    </template>
+    <template if:false={isChecked}>
         <template if:true={isStandardFacet}>
           <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
             <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
@@ -53,8 +20,6 @@
           <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" aria-label={formattedFacetValue}>{formattedFacetValue}</span>
         </template>
         <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results"  aria-label={numberOfResults}>({numberOfResults})</span>
-      </template>
-    </div>
-  </template>
-
+    </template>
+  </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -1,9 +1,5 @@
 <template>
-  <fieldset  tabindex="0" onkeydown={onKeyDown}>
-    <legend class="accessibility-only">Value: {formattedFacetValue}, number of {numberOfResults}</legend>
-    <ul >  
-      <li class="slds-grid">
-        <div onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" >
+        <div role={divRole} onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
           <template if:false={displayAsLink}>
             <lightning-input 
               tabindex="-1"
@@ -32,7 +28,4 @@
             <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
           </template>
         </div>
-      </li>
-    </ul>
-  </fieldset>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -1,31 +1,60 @@
 <template>
-        <div role={divRole} onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
-          <template if:false={displayAsLink}>
-            <lightning-input 
-              tabindex="-1"
-              type="checkbox"
-              class="facet__value-checkbox"
-              variant="label-hidden"
-              label="Facet value option"
-              name="facet value checkbox"
-              onchange={onSelect}
-              checked={isChecked}
-            ></lightning-input>
-          </template>
-          <template if:true={isChecked}>
-            <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
-            <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected">({numberOfResults})</span>
-          </template>
-          <template if:false={isChecked}>
-            <template if:true={isStandardFacet}>
-              <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
-                <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
-              </span>
-            </template>
-            <template if:false={isStandardFacet}>
-              <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" >{formattedFacetValue}</span>
-            </template>
-            <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
-          </template>
+  <template if:false={displayNew}> 
+    <div role={divRole} aria-checked={isChecked} onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
+      <template if:false={displayAsLink}>
+        <lightning-input 
+          tabindex="-1"
+          type="checkbox"
+          class="facet__value-checkbox"
+          variant="label-hidden"
+          label="Facet value option"
+          name="facet value checkbox"
+          onchange={onSelect}
+          checked={isChecked}
+        ></lightning-input>
+      </template>
+      <template if:true={isChecked}>
+        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
+        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected">({numberOfResults})</span>
+      </template>
+      <template if:false={isChecked}>
+              <template if:true={isStandardFacet}>
+                <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
+                  <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
+                </span>
+              </template>
+              <template if:false={isStandardFacet}>
+                <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" >{formattedFacetValue}</span>
+              </template>
+              <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
+      </template>
+    </div>
+  </template>
+
+  <template if:true={displayNew}> 
+    <div aria-label={ariaLabelVoiceOver} onclick={onSelect} role={divRole} aria-checked={isChecked} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" tabindex="0" onkeydown={onKeyDown}>
+      <template if:false={displayAsLink}>
+        <div class="facet__value_new-checkbox">
+          <template if:true={isChecked}><div class="facet__value_checkbox-checked"></div></template>
         </div>
+      </template>
+
+      <template if:true={isChecked}>
+        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected" aria-label={formattedFacetValue}>{formattedFacetValue}</span>
+        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected" aria-label={numberOfResults}>({numberOfResults})</span>
+      </template>
+      <template if:false={isChecked}>
+        <template if:true={isStandardFacet}>
+          <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
+            <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
+          </span>
+        </template>
+        <template if:false={isStandardFacet}>
+          <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" aria-label={formattedFacetValue}>{formattedFacetValue}</span>
+        </template>
+        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results"  aria-label={numberOfResults}>({numberOfResults})</span>
+      </template>
+    </div>
+  </template>
+
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -1,32 +1,38 @@
 <template>
-  <li class="slds-grid">
-    <div onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
-      <template if:false={displayAsLink}>
-        <lightning-input 
-          type="checkbox"
-          class="facet__value-checkbox"
-          variant="label-hidden"
-          label="Facet value option"
-          name="facet value checkbox"
-          onchange={onSelect}
-          checked={isChecked}
-        ></lightning-input>
-      </template>
-      <template if:true={isChecked}>
-        <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
-        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected">({numberOfResults})</span>
-      </template>
-      <template if:false={isChecked}>
-        <template if:true={isStandardFacet}>
-          <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
-            <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
-          </span>
-        </template>
-        <template if:false={isStandardFacet}>
-          <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">{formattedFacetValue}</span>
-        </template>
-        <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
-      </template>
-    </div>
-  </li>
+  <fieldset  tabindex="0" onkeydown={onKeyDown}>
+    <legend class="accessibility-only">Value: {formattedFacetValue}, number of {numberOfResults}</legend>
+    <ul >  
+      <li class="slds-grid">
+        <div onclick={onSelect} class="facet__value-container facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small" >
+          <template if:false={displayAsLink}>
+            <lightning-input 
+              tabindex="-1"
+              type="checkbox"
+              class="facet__value-checkbox"
+              variant="label-hidden"
+              label="Facet value option"
+              name="facet value checkbox"
+              onchange={onSelect}
+              checked={isChecked}
+            ></lightning-input>
+          </template>
+          <template if:true={isChecked}>
+            <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected">{formattedFacetValue}</span>
+            <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected">({numberOfResults})</span>
+          </template>
+          <template if:false={isChecked}>
+            <template if:true={isStandardFacet}>
+              <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle">
+                <lightning-formatted-rich-text value={item.highlightedResult}></lightning-formatted-rich-text>
+              </span>
+            </template>
+            <template if:false={isStandardFacet}>
+              <span class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle" >{formattedFacetValue}</span>
+            </template>
+            <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
+          </template>
+        </div>
+      </li>
+    </ul>
+  </fieldset>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -43,6 +43,8 @@ export default class QuanticFacetValue extends LightningElement {
    */
   @api formattingFunction;
 
+  @api displayNew = false
+
   get isStandardFacet() {
     return !this.formattingFunction;
   }
@@ -60,6 +62,9 @@ export default class QuanticFacetValue extends LightningElement {
 
   get divRole (){
     return this.displayAsLink ? "button":"checkbox"
+  }
+  get ariaLabelVoiceOver(){
+    return `Filter, ${this.formattedFacetValue}, ${this.numberOfResults}`
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -58,6 +58,10 @@ export default class QuanticFacetValue extends LightningElement {
     return new Intl.NumberFormat(LOCALE).format(this.item.numberOfResults);
   }
 
+  get divRole (){
+    return this.displayAsLink ? "button":"checkbox"
+  }
+
   /**
    * @param {InputEvent} evt
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -70,4 +70,21 @@ export default class QuanticFacetValue extends LightningElement {
       }
     }));
   }
+    /**
+   * @param {KeyboardEvent} evt
+   */
+  onKeyDown(evt) {
+       
+    if(evt.code==="Enter" || evt.code==="Space"){
+      evt.preventDefault()
+      this.dispatchEvent(new CustomEvent(
+        'selectvalue', {
+        detail: {
+          value: this.formattedFacetValue
+        }
+      }));
+    }
+
+
+  }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.js
@@ -79,11 +79,10 @@ export default class QuanticFacetValue extends LightningElement {
       }
     }));
   }
-    /**
+  /**
    * @param {KeyboardEvent} evt
    */
-  onKeyDown(evt) {
-       
+  onKeyDown(evt) {   
     if(evt.code==="Enter" || evt.code==="Space"){
       evt.preventDefault()
       this.dispatchEvent(new CustomEvent(
@@ -93,7 +92,5 @@ export default class QuanticFacetValue extends LightningElement {
         }
       }));
     }
-
-
   }
 }


### PR DESCRIPTION
[SVCC-2272](https://coveord.atlassian.net/browse/SVCC-2272)
[SVCC-2273](https://coveord.atlassian.net/browse/SVCC-2273)
[SVCC-2274](https://coveord.atlassian.net/browse/SVCC-2274)

Implementation A:
https://github.com/coveo/ui-kit/pull/2237

<img width="313" alt="Screen Shot 2022-07-25 at 5 10 32 PM" src="https://user-images.githubusercontent.com/108746208/180874925-b2606073-1aac-4798-be8b-87e5e30d1a8a.png">

Implementation B
Edited tabindex to change the accessibility of certain elements.
Function onKeyDown added to track keyboard input
Removed <lightning-input(used as checkbox) and added dom element DIV to serve as checkbox(icon);
aria-label added to provide msg for screen readers

!!Further changes to NumericFacetValue might be needed!!