### PR TITLE
fix(atomic): focus first new value in facets when pressing show more

### DIFF
--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet-assertions.ts
@@ -181,9 +181,9 @@ export function assertDisplayAllCategoriesButton(display: boolean) {
   });
 }
 
-export function assertFocusFirstChildValue() {
-  it('should focus on the first value', () => {
-    CategoryFacetSelectors.childValue().first().should('be.focused');
+export function assertFocusChildValue(index: number) {
+  it(`should focus on the value at index ${index}`, () => {
+    CategoryFacetSelectors.childValue().eq(index).should('be.focused');
   });
 }
 

--- a/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/category-facet/category-facet.cypress.ts
@@ -369,28 +369,65 @@ describe('Category Facet Test Suites', () => {
     });
 
     describe('when selecting the "Show more" button, when there\'s no more "Show more" button', () => {
+      const numberOfValues = 3;
       function setupShowMore() {
-        setupWithDefaultSettings();
+        new TestFixture()
+          .with(
+            addCategoryFacet({
+              'number-of-values': numberOfValues,
+            })
+          )
+          .init();
         pressShowMore(CategoryFacetSelectors);
       }
 
       describe('verify rendering', () => {
         before(setupShowMore);
-        CategoryFacetAssertions.assertNumberOfChildValues(7);
+        CategoryFacetAssertions.assertNumberOfChildValues(numberOfValues * 2);
         CommonFacetAssertions.assertDisplayShowMoreButton(
           CategoryFacetSelectors,
-          false
+          true
         );
         CommonFacetAssertions.assertDisplayShowLessButton(
           CategoryFacetSelectors,
           true
         );
-        CategoryFacetAssertions.assertFocusFirstChildValue();
+        CategoryFacetAssertions.assertFocusChildValue(numberOfValues);
       });
 
       describe('verify analytics', () => {
         before(setupShowMore);
         CategoryFacetAssertions.assertLogFacetShowMore();
+      });
+
+      describe('when there\'s no more "Show more" button', () => {
+        function setupRepeatShowMore() {
+          new TestFixture()
+            .with(
+              addCategoryFacet({
+                'number-of-values': numberOfValues,
+              })
+            )
+            .init();
+          pressShowMore(CategoryFacetSelectors);
+          CategoryFacetSelectors.childValue()
+            .its('length')
+            .should('eq', numberOfValues * 2);
+          pressShowMore(CategoryFacetSelectors);
+        }
+
+        describe('verify rendering', () => {
+          before(setupRepeatShowMore);
+
+          CommonFacetAssertions.assertDisplayShowMoreButton(
+            CategoryFacetSelectors,
+            false
+          );
+          CommonFacetAssertions.assertDisplayShowLessButton(
+            CategoryFacetSelectors,
+            true
+          );
+        });
       });
 
       describe('when selecting the "Show less" button', () => {
@@ -401,9 +438,7 @@ describe('Category Facet Test Suites', () => {
 
         describe('verify rendering', () => {
           before(setupShowLess);
-          CategoryFacetAssertions.assertNumberOfChildValues(
-            defaultNumberOfValues
-          );
+          CategoryFacetAssertions.assertNumberOfChildValues(numberOfValues);
           CommonFacetAssertions.assertDisplayShowMoreButton(
             CategoryFacetSelectors,
             true
@@ -412,7 +447,6 @@ describe('Category Facet Test Suites', () => {
             CategoryFacetSelectors,
             false
           );
-          CategoryFacetAssertions.assertFocusFirstChildValue();
         });
 
         describe('verify analytics', () => {

--- a/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/color-facet/color-facet.cypress.ts
@@ -201,15 +201,21 @@ describe('Color Facet Test Suites', () => {
   });
 
   describe('when selecting the "Show more" button', () => {
-    function setupSelectShowMore() {
+    function setupSelectShowMore(sortCriteria?: string) {
       new TestFixture()
-        .with(addColorFacet({field: colorFacetField, label: colorFacetLabel}))
+        .with(
+          addColorFacet({
+            field: colorFacetField,
+            label: colorFacetLabel,
+            ...(sortCriteria && {'sort-criteria': sortCriteria}),
+          })
+        )
         .init();
       pressShowMore(ColorFacetSelectors);
     }
 
     describe('verify rendering', () => {
-      before(setupSelectShowMore);
+      before(() => setupSelectShowMore('automatic'));
       CommonFacetAssertions.assertDisplayShowMoreButton(
         ColorFacetSelectors,
         true
@@ -223,10 +229,20 @@ describe('Color Facet Test Suites', () => {
       ColorFacetAssertions.assertNumberOfIdleBoxValues(
         colorFacetDefaultNumberOfValues * 2
       );
-      CommonFacetAssertions.assertFocusFirstBoxValue(ColorFacetSelectors);
+      CommonFacetAssertions.assertFocusBoxValue(ColorFacetSelectors, 0);
     });
+
+    describe("when the sort order isn't automatic", () => {
+      before(() => setupSelectShowMore('alphanumeric'));
+
+      CommonFacetAssertions.assertFocusBoxValue(
+        ColorFacetSelectors,
+        colorFacetDefaultNumberOfValues
+      );
+    });
+
     describe('verify analytics', () => {
-      before(setupSelectShowMore);
+      before(() => setupSelectShowMore());
       FacetAssertions.assertLogFacetShowMore(colorFacetField);
     });
 
@@ -255,7 +271,6 @@ describe('Color Facet Test Suites', () => {
           ColorFacetSelectors,
           true
         );
-        CommonFacetAssertions.assertFocusFirstBoxValue(ColorFacetSelectors);
       });
     });
 

--- a/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/facet-common-assertions.ts
@@ -294,20 +294,22 @@ export function assertFocusHeader(BaseFacetSelector: BaseFacetSelector) {
   });
 }
 
-export function assertFocusFirstCheckboxValue(
-  FacetWithShowMoreLessSelector: FacetWithCheckboxSelector
+export function assertFocusCheckboxValue(
+  FacetWithShowMoreLessSelector: FacetWithCheckboxSelector,
+  index: number
 ) {
-  it('should focus on the first value', () => {
+  it(`should focus on the value at index ${index}`, () => {
     FacetWithShowMoreLessSelector.idleCheckboxValue()
-      .first()
+      .eq(index)
       .should('be.focused');
   });
 }
 
-export function assertFocusFirstBoxValue(
-  FacetWithShowMoreLessSelector: FacetWithBoxSelector
+export function assertFocusBoxValue(
+  FacetWithShowMoreLessSelector: FacetWithBoxSelector,
+  index: number
 ) {
-  it('should focus on the first value', () => {
-    FacetWithShowMoreLessSelector.idleBoxValue().first().should('be.focused');
+  it(`should focus on the value at index ${index}`, () => {
+    FacetWithShowMoreLessSelector.idleBoxValue().eq(index).should('be.focused');
   });
 }

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -647,13 +647,21 @@ describe('Facet v1 Test Suites', () => {
   });
 
   describe('when selecting the "Show more" button', () => {
-    function setupSelectShowMore() {
-      new TestFixture().with(addFacet({field, label})).init();
+    function setupSelectShowMore(sortCriteria?: string) {
+      new TestFixture()
+        .with(
+          addFacet({
+            field,
+            label,
+            ...(sortCriteria && {'sort-criteria': sortCriteria}),
+          })
+        )
+        .init();
       pressShowMore(FacetSelectors);
     }
 
     describe('verify rendering', () => {
-      before(setupSelectShowMore);
+      before(() => setupSelectShowMore('automatic'));
 
       CommonFacetAssertions.assertDisplayShowMoreButton(FacetSelectors, true);
       CommonFacetAssertions.assertDisplayShowLessButton(FacetSelectors, true);
@@ -662,11 +670,20 @@ describe('Facet v1 Test Suites', () => {
         FacetSelectors,
         defaultNumberOfValues * 2
       );
-      CommonFacetAssertions.assertFocusFirstCheckboxValue(FacetSelectors);
+      CommonFacetAssertions.assertFocusCheckboxValue(FacetSelectors, 0);
+    });
+
+    describe("when the sort order isn't automatic", () => {
+      before(() => setupSelectShowMore('alphanumeric'));
+
+      CommonFacetAssertions.assertFocusCheckboxValue(
+        FacetSelectors,
+        defaultNumberOfValues
+      );
     });
 
     describe('verify analytics', () => {
-      before(setupSelectShowMore);
+      before(() => setupSelectShowMore());
 
       FacetAssertions.assertLogFacetShowMore(field);
     });
@@ -686,7 +703,6 @@ describe('Facet v1 Test Suites', () => {
           false
         );
         CommonFacetAssertions.assertDisplayShowLessButton(FacetSelectors, true);
-        CommonFacetAssertions.assertFocusFirstCheckboxValue(FacetSelectors);
       });
     });
 

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -95,6 +95,7 @@ export class AtomicCategoryFacet
   @InitializeBindings() public bindings!: Bindings;
   public facet!: CategoryFacet;
   private dependenciesManager?: FacetConditionsManager;
+  private resultIndexToFocusOnShowMore = 0;
   public searchStatus!: SearchStatus;
   @Element() private host!: HTMLElement;
 
@@ -191,7 +192,10 @@ export class AtomicCategoryFacet
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
   @FocusTarget()
-  private showMoreLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -420,7 +424,8 @@ export class AtomicCategoryFacet
 
   private renderValue(
     facetValue: CategoryFacetValue,
-    isShowMoreLessFocusTarget: boolean
+    isShowLessFocusTarget: boolean,
+    isShowMoreFocusTarget: boolean
   ) {
     const displayValue = getFieldValueCaption(
       this.field,
@@ -439,9 +444,10 @@ export class AtomicCategoryFacet
           this.facet.toggleSelect(facetValue);
         }}
         searchQuery={this.facetState.facetSearch.query}
-        buttonRef={(element) =>
-          isShowMoreLessFocusTarget && this.showMoreLessFocus.setTarget(element)
-        }
+        buttonRef={(element) => {
+          isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+          isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+        }}
       >
         <FacetValueLabelHighlight
           displayValue={displayValue}
@@ -459,7 +465,11 @@ export class AtomicCategoryFacet
     return (
       <ul part="values" class={this.hasParents ? 'pl-9' : 'mt-3'}>
         {this.facetState.values.map((value, i) =>
-          this.renderValue(value, i === 0)
+          this.renderValue(
+            value,
+            i === 0,
+            i === this.resultIndexToFocusOnShowMore
+          )
         )}
       </ul>
     );
@@ -502,11 +512,12 @@ export class AtomicCategoryFacet
           label={this.label}
           i18n={this.bindings.i18n}
           onShowMore={() => {
-            this.showMoreLessFocus.focusAfterSearch();
+            this.resultIndexToFocusOnShowMore = this.facetState.values.length;
+            this.showMoreFocus.focusAfterSearch();
             this.facet.showMoreValues();
           }}
           onShowLess={() => {
-            this.showMoreLessFocus.focusAfterSearch();
+            this.showLessFocus.focusAfterSearch();
             this.facet.showLessValues();
           }}
           canShowLessValues={this.facetState.canShowLessValues}

--- a/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -92,6 +92,7 @@ export class AtomicColorFacet
   @InitializeBindings() public bindings!: Bindings;
   public facet!: Facet;
   private dependenciesManager?: FacetConditionsManager;
+  private resultIndexToFocusOnShowMore = 0;
   public searchStatus!: SearchStatus;
   @Element() private host!: HTMLElement;
 
@@ -179,7 +180,10 @@ export class AtomicColorFacet
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
   @FocusTarget()
-  private showMoreLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -296,7 +300,8 @@ export class AtomicColorFacet
   private renderValue(
     facetValue: FacetValue,
     onClick: () => void,
-    isShowMoreLessFocusTarget: boolean
+    isShowLessFocusTarget: boolean,
+    isShowMoreFocusTarget: boolean
   ) {
     const displayValue = getFieldValueCaption(
       this.facetId!,
@@ -316,10 +321,10 @@ export class AtomicColorFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
-            buttonRef={(element) =>
-              isShowMoreLessFocusTarget &&
-              this.showMoreLessFocus.setTarget(element)
-            }
+            buttonRef={(element) => {
+              isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+              isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+            }}
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -337,10 +342,10 @@ export class AtomicColorFacet
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
-            buttonRef={(element) =>
-              isShowMoreLessFocusTarget &&
-              this.showMoreLessFocus.setTarget(element)
-            }
+            buttonRef={(element) => {
+              isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+              isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+            }}
           >
             <div
               part={`value-${partValueWithDisplayValue} value-${partValueWithAPIValue} default-color-value`}
@@ -376,14 +381,22 @@ export class AtomicColorFacet
   private renderValues() {
     return this.renderValuesContainer(
       this.facetState.values.map((value, i) =>
-        this.renderValue(value, () => this.facet.toggleSelect(value), i === 0)
+        this.renderValue(
+          value,
+          () => this.facet.toggleSelect(value),
+          i === 0,
+          i ===
+            (this.sortCriteria === 'automatic'
+              ? 0
+              : this.resultIndexToFocusOnShowMore)
+        )
       )
     );
   }
 
   private renderSearchResults() {
     return this.renderValuesContainer(
-      this.facetState.facetSearch.values.map((value, i) =>
+      this.facetState.facetSearch.values.map((value) =>
         this.renderValue(
           {
             state: 'idle',
@@ -391,7 +404,8 @@ export class AtomicColorFacet
             value: value.rawValue,
           },
           () => this.facet.facetSearch.select(value),
-          i === 0
+          false,
+          false
         )
       ),
       this.facetState.facetSearch.query
@@ -415,11 +429,12 @@ export class AtomicColorFacet
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showMoreLessFocus.focusAfterSearch();
+          this.resultIndexToFocusOnShowMore = this.facet.state.values.length;
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showMoreLessFocus.focusAfterSearch();
+          this.showLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowLessValues={this.facetState.canShowLessValues}

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -91,6 +91,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   @InitializeBindings() public bindings!: Bindings;
   public facet!: Facet;
   private dependenciesManager?: FacetConditionsManager;
+  private resultIndexToFocusOnShowMore = 0;
   public searchStatus!: SearchStatus;
   @Element() private host!: HTMLElement;
 
@@ -201,7 +202,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   @Prop() public allowedValues?: string;
 
   @FocusTarget()
-  private showMoreLessFocus!: FocusTargetController;
+  private showLessFocus!: FocusTargetController;
+
+  @FocusTarget()
+  private showMoreFocus!: FocusTargetController;
 
   @FocusTarget()
   private headerFocus!: FocusTargetController;
@@ -326,7 +330,8 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   private renderValue(
     facetValue: FacetValue,
     onClick: () => void,
-    isShowMoreLessFocusTarget: boolean
+    isShowLessFocusTarget: boolean,
+    isShowMoreFocusTarget: boolean
   ) {
     const displayValue = getFieldValueCaption(
       this.field,
@@ -344,10 +349,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
-            buttonRef={(element) =>
-              isShowMoreLessFocusTarget &&
-              this.showMoreLessFocus.setTarget(element)
-            }
+            buttonRef={(element) => {
+              isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+              isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+            }}
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -365,10 +370,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
-            buttonRef={(element) =>
-              isShowMoreLessFocusTarget &&
-              this.showMoreLessFocus.setTarget(element)
-            }
+            buttonRef={(element) => {
+              isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+              isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+            }}
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -386,10 +391,10 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             i18n={this.bindings.i18n}
             onClick={onClick}
             searchQuery={this.facetState.facetSearch.query}
-            buttonRef={(element) =>
-              isShowMoreLessFocusTarget &&
-              this.showMoreLessFocus.setTarget(element)
-            }
+            buttonRef={(element) => {
+              isShowLessFocusTarget && this.showLessFocus.setTarget(element);
+              isShowMoreFocusTarget && this.showMoreFocus.setTarget(element);
+            }}
           >
             <FacetValueLabelHighlight
               displayValue={displayValue}
@@ -427,7 +432,11 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             this.displayValuesAs === 'link'
               ? this.facet.toggleSingleSelect(value)
               : this.facet.toggleSelect(value),
-          i === 0
+          i === 0,
+          i ===
+            (this.sortCriteria === 'automatic'
+              ? 0
+              : this.resultIndexToFocusOnShowMore)
         )
       )
     );
@@ -446,6 +455,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
             this.displayValuesAs === 'link'
               ? this.facet.facetSearch.singleSelect(value)
               : this.facet.facetSearch.select(value),
+          false,
           false
         )
       ),
@@ -470,11 +480,12 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
         label={this.label}
         i18n={this.bindings.i18n}
         onShowMore={() => {
-          this.showMoreLessFocus.focusAfterSearch();
+          this.resultIndexToFocusOnShowMore = this.facet.state.values.length;
+          this.showMoreFocus.focusAfterSearch();
           this.facet.showMoreValues();
         }}
         onShowLess={() => {
-          this.showMoreLessFocus.focusAfterSearch();
+          this.showLessFocus.focusAfterSearch();
           this.facet.showLessValues();
         }}
         canShowMoreValues={this.facetState.canShowMoreValues}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1879

In this PR, after a user presses "show more" under any facet's values, either:
* If the sort criteria is "automatic", the very first value is focused.
* If the sort criteria is anything other than "automatic", the first new value is focused.

Last time, I didn't do this because pressing "show more" would load some facet values in-between existing ones.

However, this time, I realized that setting a sort criteria ensures this never happens. I also noticed that the category facet never uses the "automatic" sort order. Woops...