### PR TITLE
docs(atomic): removed header-bg in commerce-full.html

### DIFF
--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -118,11 +118,6 @@
         margin: 0;
       }
 
-      .header-bg {
-        background-color: var(--atomic-neutral-light);
-        grid-area: 1 / -1 / 1 / 1;
-      }
-
       atomic-search-layout {
         row-gap: var(--atomic-layout-spacing-y);
       }
@@ -154,7 +149,6 @@
       fields-to-include="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
     >
       <atomic-search-layout>
-        <div class="header-bg"></div>
         <atomic-layout-section section="search">
           <div id="result-display-option">
             <label for="result-display-select">Result list layout:&nbsp;</label


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1881

A lack of contrast between the search box's outline and the header-bg was reported.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/54454747/181049562-f62e38a6-315e-4cf5-9a4d-02295a0f5994.png">
