### PR TITLE
fix(headless): The state of the category facet's searchbox added to the state returned by the InsightCategoryFacet controller

### DIFF
--- a/packages/headless/src/controllers/insight/facets/category-facet/headless-insight-category-facet.ts
+++ b/packages/headless/src/controllers/insight/facets/category-facet/headless-insight-category-facet.ts
@@ -2,6 +2,7 @@ import {
   buildCoreCategoryFacet,
   CategoryFacetProps,
   CategoryFacetSearch,
+  CategoryFacetSearchState,
   CategoryFacetValue,
   CoreCategoryFacet,
   CoreCategoryFacetState,
@@ -35,7 +36,10 @@ export interface InsightCategoryFacet extends CoreCategoryFacet {
   state: InsightCategoryFacetState;
 }
 
-export interface InsightCategoryFacetState extends CoreCategoryFacetState {}
+export interface InsightCategoryFacetState extends CoreCategoryFacetState {
+  /** The state of the facet's searchbox. */
+  facetSearch: CategoryFacetSearchState;
+}
 
 /**
  * Creates a `InsightCategoryFacet` controller instance.
@@ -115,6 +119,13 @@ export function buildInsightCategoryFacet(
     showLessValues() {
       coreController.showLessValues();
       dispatch(fetchFacetValues(logFacetShowLess(getFacetId())));
+    },
+
+    get state() {
+      return {
+        ...coreController.state,
+        facetSearch: facetSearch.state,
+      };
     },
   };
 }


### PR DESCRIPTION
### Problem:
- The state returned by the InsightCategoryFacet Controller was missing the state of the category facet's searchbox.

### Solution:
- The piece of state  representing the state of the category facet's searchbox is now added.



### Question:
Before adding the state getter to the HeadlessInsightCategoryFacet controller, a weird behaviour was occurring:

The QuanticCategoryFacet component subscribes to changes occurring on the state of the category facet, when a change occurs a method named `updateState` is called.
The problem is that there is some changes in the state that doesn't trigger the call of `updateState`. For example after executing a query, the QuanticCategoryFacet component didn't get notified about the change in the state which was attributing new values to this facet.

Adding the following to the returned values of the HeadlessInsightCategoryFacet controller magically solved the issue 🧐:
```
    get state() {
      return {
        ...coreController.state,
        facetSearch: facetSearch.state,
      };
    },
```

Please reach out to me if you have any idea about the reasons behind this behaviour, I can reproduce the issue and give more details, Thank you! 



