### PR TITLE
fix(atomic): ensured aria labels contain innerText

### DIFF
--- a/packages/atomic/cypress/integration/common-assertions.ts
+++ b/packages/atomic/cypress/integration/common-assertions.ts
@@ -1,3 +1,4 @@
+import {getFocusableDescendants} from '../../src/utils/accessibility-utils';
 import {TestFixture} from '../fixtures/test-fixture';
 import {AriaLiveSelectors} from './aria-live-selectors';
 import {ComponentErrorSelectors} from './component-error-selectors';
@@ -28,6 +29,29 @@ export function assertAccessibility(
         cy.checkA11y(el, {rules});
       });
     }
+  });
+
+  it('every interactive element with innerText and an aria label passes WCAG success criterion 2.5.3', () => {
+    function splitIntoWords(text: string) {
+      return text.split(' ').filter((word) => !word.match(/[^a-z]/i));
+    }
+
+    cy.window()
+      .then((win) =>
+        Array.from(getFocusableDescendants(win.document.body)).filter(
+          (element) => element.hasAttribute('aria-label') && element.innerText
+        )
+      )
+      .should((elements) =>
+        Array.from(elements).forEach((element) =>
+          expect(
+            splitIntoWords(element.getAttribute('aria-label')!)
+          ).to.include.all.members(
+            splitIntoWords(element.innerText),
+            'The aria-label should include the innerText. https://www.w3.org/WAI/WCAG22/Techniques/failures/F96.html'
+          )
+        )
+      );
   });
 }
 

--- a/packages/atomic/cypress/integration/common-assertions.ts
+++ b/packages/atomic/cypress/integration/common-assertions.ts
@@ -33,7 +33,7 @@ export function assertAccessibility(
 
   it('every interactive element with innerText and an aria label passes WCAG success criterion 2.5.3', () => {
     function splitIntoWords(text: string) {
-      return text.split(' ').filter((word) => !word.match(/[^a-z]/i));
+      return text.split(/\b/g).filter((word) => !word.match(/[^a-z]/i));
     }
 
     cy.window()

--- a/packages/atomic/cypress/integration/smart-snippet.cypress.ts
+++ b/packages/atomic/cypress/integration/smart-snippet.cypress.ts
@@ -1,5 +1,8 @@
 import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
-import {SmartSnippetSelectors} from './smart-snippet-selectors';
+import {
+  smartSnippetComponent,
+  SmartSnippetSelectors,
+} from './smart-snippet-selectors';
 import * as CommonAssertions from './common-assertions';
 import * as SmartSnippetAssertions from './smart-snippet-assertions';
 import {AnalyticsTracker} from '../utils/analyticsUtils';
@@ -151,6 +154,7 @@ describe('Smart Snippet Test Suites', () => {
     SmartSnippetAssertions.assertShowMore(true);
     SmartSnippetAssertions.assertShowLess(false);
     SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
+    CommonAssertions.assertAccessibility(smartSnippetComponent);
 
     describe('then pressing show more', () => {
       before(() => {
@@ -169,6 +173,7 @@ describe('Smart Snippet Test Suites', () => {
         SmartSnippetAssertions.assertShowMore(true);
         SmartSnippetAssertions.assertShowLess(false);
         SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
+        CommonAssertions.assertAccessibility(smartSnippetComponent);
       });
     });
   });

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-feedback-banner.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-feedback-banner.tsx
@@ -41,7 +41,7 @@ export const SmartSnippetFeedbackBanner: FunctionalComponent<
       >
         <atomic-icon
           icon={Checkmark}
-          aria-hidden={true}
+          aria-hidden="true"
           class="w-3.5"
         ></atomic-icon>
         <RadioButton
@@ -61,7 +61,7 @@ export const SmartSnippetFeedbackBanner: FunctionalComponent<
       >
         <atomic-icon
           icon={Cross}
-          aria-hidden={true}
+          aria-hidden="true"
           class="w-3.5"
         ></atomic-icon>
         <RadioButton
@@ -115,7 +115,6 @@ export const SmartSnippetFeedbackBanner: FunctionalComponent<
         part="feedback-inquiry-and-buttons"
         role="radiogroup"
         aria-labelledby={inquiryId}
-        aria-controls={thankYouId}
         class="inline-flex flex-wrap gap-4"
       >
         <Inquiry></Inquiry>

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -118,7 +118,7 @@
   },
   "show-less": {
     "en": "Show less",
-    "fr": "Voir moin",
+    "fr": "Voir moins",
     "cs": "Zobrazit méně",
     "da": "Vis mindre",
     "de": "Weniger anzeigen",

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -91,7 +91,7 @@
   },
   "show-more": {
     "en": "Show more",
-    "fr": "Voir plus de résultats",
+    "fr": "Voir plus",
     "cs": "Zobrazit více",
     "da": "Vis mere",
     "de": "Mehr anzeigen",
@@ -118,7 +118,7 @@
   },
   "show-less": {
     "en": "Show less",
-    "fr": "Voir moins de résultats",
+    "fr": "Voir moin",
     "cs": "Zobrazit méně",
     "da": "Vis mindre",
     "de": "Weniger anzeigen",
@@ -143,6 +143,14 @@
     "zh-CN": "显示较少的值",
     "zh-TW": "顯示較少的值"
   },
+  "show-less-facet-values": {
+    "en": "Show less values for the {{label}} facet",
+    "fr": "Voir moins de valeurs pour la facette {{label}}"
+  },
+  "show-more-facet-values": {
+    "en": "Show more values for the {{label}} facet",
+    "fr": "Voir plus de valeurs pour la facette {{label}}"
+  },
   "facet-values": {
     "en": "Values for the {{label}} facet",
     "fr": "Valeurs pour la facette {{label}}"
@@ -150,14 +158,6 @@
   "facet-search-results": {
     "en": "Values found for {{query}} in the {{label}} facet",
     "fr": "Valeurs trouvées pour {{query}} dans la facette {{label}}"
-  },
-  "show-less-facet-values": {
-    "en": "Show fewer values for the {{label}} facet",
-    "fr": "Afficher moins de valeurs pour la facette {{label}}"
-  },
-  "show-more-facet-values": {
-    "en": "Show more values for the {{label}} facet",
-    "fr": "Afficher plus de valeurs pour la facette {{label}}"
   },
   "pagination": {
     "en": "Pagination",
@@ -1266,8 +1266,8 @@
     "fr": "seulement {{count}} étoiles sur {{count}}"
   },
   "stars-range": {
-    "en": "{{value}} to {{count}} stars",
-    "fr": "{{value}} à {{count}} étoiles"
+    "en": "{{value}} out of {{count}} stars & up",
+    "fr": "{{value}} à {{count}} étoiles & plus"
   },
   "with-colon": {
     "en": "{{text}}:",

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -133,11 +133,11 @@ function isFocusable(element: Element) {
   }
 }
 
-export function getFirstFocusableDescendant(
+export function* getFocusableDescendants(
   element: Element
-): HTMLElement | null {
+): Generator<HTMLElement> {
   if (isFocusable(element)) {
-    return element as HTMLElement;
+    yield element as HTMLElement;
   }
   let children = Array.from(element.children);
   if (element instanceof HTMLSlotElement) {
@@ -146,10 +146,12 @@ export function getFirstFocusableDescendant(
     children.push(...Array.from(element.shadowRoot.children));
   }
   for (const child of children) {
-    const focusableDescendant = getFirstFocusableDescendant(child);
-    if (focusableDescendant) {
-      return focusableDescendant;
-    }
+    yield* getFocusableDescendants(child);
   }
-  return null;
+}
+
+export function getFirstFocusableDescendant(
+  element: Element
+): HTMLElement | null {
+  return getFocusableDescendants(element).next().value ?? null;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1882

I added e2e tests to verify this along with every accessibility test.

I also added e2e accessibility tests to `atomic-smart-snippet` and fixed its minor accessibility issues.