### PR TITLE
fix(headless): exporting the missing pieces

### DIFF
--- a/packages/headless/src/features/insight-search/insight-search-analytics-actions.test.ts
+++ b/packages/headless/src/features/insight-search/insight-search-analytics-actions.test.ts
@@ -23,7 +23,7 @@ const exampleSubject = 'example subject';
 const exampleDescription = 'example description';
 
 describe('logContextChanged', () => {
-  it('should log #logContextChanged whith the right payload', async () => {
+  it('should log #logContextChanged with the right payload', async () => {
     const exampleSubject = 'example subject';
     const exampleDescription = 'example description';
 
@@ -56,7 +56,7 @@ describe('logContextChanged', () => {
 });
 
 describe('logExpandToFullUI', () => {
-  it('should log #logExpandToFullUI whith the right payload', async () => {
+  it('should log #logExpandToFullUI with the right payload', async () => {
     const engine = buildMockInsightEngine({
       state: buildMockInsightState({
         insightCaseContext: {

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -218,6 +218,15 @@ export type {
 } from './controllers/insight/sort/headless-insight-sort';
 export {buildSort} from './controllers/insight/sort/headless-insight-sort';
 
+export type {
+  TabInitialState,
+  TabOptions,
+  TabProps,
+  TabState,
+  Tab,
+} from './controllers/insight/tab/headless-insight-tab';
+export {buildTab} from './controllers/insight/tab/headless-insight-tab';
+
 export type {InsightInterfaceState} from './features/insight-interface/insight-interface-state';
 export type {InsightInterface} from './controllers/insight-interface/insight-interface';
 export {buildInsightInterface} from './controllers/insight-interface/insight-interface';

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -25,6 +25,7 @@ export * from './features/insight-search/insight-search-actions-loader';
 export * from './features/analytics/insight-analytics-actions-loader';
 export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 export * from './features/recent-results/recent-results-actions-loader';
+export * from './features/case-context/case-context-actions-loader';
 
 // Controllers
 export type {

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -222,6 +222,9 @@ export type {InsightInterfaceState} from './features/insight-interface/insight-i
 export type {InsightInterface} from './controllers/insight-interface/insight-interface';
 export {buildInsightInterface} from './controllers/insight-interface/insight-interface';
 
+export type {ResultTemplatesManager} from './features/result-templates/result-templates-manager';
+export {buildResultTemplatesManager} from './features/result-templates/result-templates-manager';
+
 // Types & Helpers
 export {
   SortOrder,

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -26,6 +26,7 @@ export * from './features/analytics/insight-analytics-actions-loader';
 export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 export * from './features/recent-results/recent-results-actions-loader';
 export * from './features/case-context/case-context-actions-loader';
+export * from './features/insight-search/insight-search-analytics-actions-loader';
 
 // Controllers
 export type {


### PR DESCRIPTION
### Changes made in this PR:
- caseContextActionsLoader is now correctly exported.
- InsightSearchAnalyticsActionsLoader is now correctly exported.
- buildResultTemplatesManager is now correctly exported.
- buildTab is now correctly exported.
- Typos fixed.