### PR TITLE
feat(quantic): Remove usage of header elements

### DIFF
--- a/packages/quantic/cypress/integration/facets/category-facet/category-facet-selectors.ts
+++ b/packages/quantic/cypress/integration/facets/category-facet/category-facet-selectors.ts
@@ -26,7 +26,7 @@ export type AllFacetSelectors = BaseFacetSelector &
 export const CategoryFacetSelectors: AllFacetSelectors = {
   get: () => cy.get(categoryFacetComponent),
 
-  label: () => CategoryFacetSelectors.get().find('header h2 > span'),
+  label: () => CategoryFacetSelectors.get().find('header .card__header > span'),
   values: () =>
     CategoryFacetSelectors.get().find('c-quantic-category-facet-value'),
   placeholder: () =>

--- a/packages/quantic/cypress/integration/facets/facet/facet-selectors.ts
+++ b/packages/quantic/cypress/integration/facets/facet/facet-selectors.ts
@@ -15,7 +15,7 @@ export type AllFacetSelectors = BaseFacetSelector &
 export const FacetSelectors: AllFacetSelectors = {
   get: () => cy.get(facetComponent),
 
-  label: () => FacetSelectors.get().find('header h2 > span'),
+  label: () => FacetSelectors.get().find('header .card__header > span'),
   values: () => FacetSelectors.get().find('c-quantic-facet-value'),
   clearFilterButton: () => FacetSelectors.get().find('.facet__clear-filter'),
   valueLabel: () => FacetSelectors.get().find('.facet__value-text span'),

--- a/packages/quantic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
+++ b/packages/quantic/cypress/integration/facets/numeric-facet/numeric-facet-selectors.ts
@@ -22,7 +22,7 @@ export type AllFacetSelectors = BaseFacetSelector &
 export const NumericFacetSelectors: AllFacetSelectors = {
   get: () => cy.get(numericFacetComponent),
 
-  label: () => NumericFacetSelectors.get().find('header h2 > span'),
+  label: () => NumericFacetSelectors.get().find('header .card__header > span'),
   values: () => NumericFacetSelectors.get().find('c-quantic-facet-value'),
   inputMin: () => NumericFacetSelectors.get().find('.numeric__input-min input'),
   inputMax: () => NumericFacetSelectors.get().find('.numeric__input-max input'),

--- a/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet-selectors.ts
+++ b/packages/quantic/cypress/integration/facets/timeframe-facet/timeframe-facet-selectors.ts
@@ -21,7 +21,8 @@ export interface WithDateRangeSelector extends ComponentSelector {
 export const TimeframeFacetSelectors: TimeframeFacetSelector = {
   get: () => cy.get(timeframeFacetComponent),
 
-  label: () => TimeframeFacetSelectors.get().find('header h2 > span'),
+  label: () =>
+    TimeframeFacetSelectors.get().find('header .card__header > span'),
   values: () => TimeframeFacetSelectors.get().find('c-quantic-facet-value'),
   clearFilterButton: () =>
     TimeframeFacetSelectors.get().find('.facet__clear-filter'),

--- a/packages/quantic/cypress/integration/recent-results-list/recent-results-list-selectors.ts
+++ b/packages/quantic/cypress/integration/recent-results-list/recent-results-list-selectors.ts
@@ -17,7 +17,8 @@ export const RecentResultsListSelectors: RecentResultsListSelector = {
 
   placeholder: () =>
     RecentResultsListSelectors.get().find('.placeholder__card-container'),
-  label: () => RecentResultsListSelectors.get().find('header h2 > span'),
+  label: () =>
+    RecentResultsListSelectors.get().find('header .card__header > span'),
   results: () =>
     RecentResultsListSelectors.get().find('.recent-result__container'),
   resultLinks: () =>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
@@ -18,12 +18,12 @@
     <p slot="date" class="slds-size_xx-small">
       <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
     </p>
-    <h3 slot="title" class="slds-truncate">
+    <div slot="title" class="slds-truncate">
       <span style="color: #157E19">{result.raw.sfstatus} |</span>
       <span class="slds-m-left_xx-small">
         <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
       </span>
-    </h3>
+    </div>
     <div slot="excerpt">
       {result.Excerpt}
     </div>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
@@ -13,9 +13,9 @@
     <p slot="date" class="slds-size_xx-small">
       <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
     </p>
-    <h3 slot="title" class="slds-truncate">
+    <div slot="title" class="slds-truncate">
       <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
-    </h3>
+    </div>
     <p slot="metadata" class="slds-text-body_small slds-m-bottom_xx-small" style="color:#3E3E3C">From: {result.raw.sfcreatedbyname}</p>
     <div slot="excerpt">
       {result.Excerpt}

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
@@ -13,9 +13,9 @@
     <p slot="date" class="slds-size_xx-small">
       <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
     </p>
-    <h3 slot="title" class="slds-truncate">
+    <div slot="title" class="slds-truncate">
       <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
-    </h3>
+    </div>
     <div slot="visual" class="slds-size_1-of-1 slds-medium-size_1-of-4 slds-large-size_1-of-4 slds-p-right_x-small slds-m-top_xx-small slds-m-bottom_x-small">
       <img loading="lazy" style="border-radius: 4px; border: none;" src={videoThumbnail}></img>
     </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticCardContainer/quanticCardContainer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCardContainer/quanticCardContainer.html
@@ -3,9 +3,9 @@
     <article class="card">
       <header class="slds-grid slds-p-horizontal_x-small slds-has-flexi-truncate">
         <div class="slds-media__body">
-          <h2 class="slds-grid">
+          <div class="slds-grid card__header">
             <span class="slds-text-heading_small slds-truncate">{title}</span>
-          </h2>
+          </div>
         </div>
         <div class="slds-no-flex">
           <slot name="actions"></slot>

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
@@ -5,9 +5,9 @@
                 <c-quantic-svg name="noResults"></c-quantic-svg>
             </div>
             <div class="slds-col slds-size_12-of-12">
-                <h3 class="slds-text-heading_small slds-text-align_center slds-var-m-around_small">
+                <div class="slds-text-heading_small slds-text-align_center slds-var-m-around_small">
                     <lightning-formatted-rich-text value={noResultsTitleLabel}></lightning-formatted-rich-text>
-                </h3>
+                </div>
                 <p class="slds-text-body_small slds-text-align_center">
                     <template if:true={hasBreadcrumbs}>
                         <lightning-formatted-rich-text value={labels.noResultsWithFilters}></lightning-formatted-rich-text>

--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.html
@@ -2,7 +2,7 @@
     <template if:true={hasError}>
         <div class="slds-grid slds-grid_align-center slds-gutters slds-grid_vertical">
             <div class="slds-col">
-                <h3 class="slds-text-heading_medium slds-text-color_error slds-text-align_center slds-text-title_bold slds-var-m-around_small">{errorTitle}</h3>
+                <div class="slds-text-heading_medium slds-text-color_error slds-text-align_center slds-text-title_bold slds-var-m-around_small">{errorTitle}</div>
                 <p class="slds-text-align_center">{description}</p>
             </div>
             <template if:true={link}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
@@ -13,9 +13,9 @@
     <p slot="date" class="slds-size_xx-small">
       <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
     </p>
-    <h3 slot="title" class="slds-truncate">
+    <div slot="title" class="slds-truncate">
       <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
-    </h3>
+    </div>
     <div slot="excerpt">
       {result.Excerpt}
     </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -19,7 +19,7 @@
           <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" onclick={closeQuickview}>
             <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close" alternative-text={labels.close}></lightning-icon>
           </button>
-          <h3 id="quickview-modal-heading" class="slds-modal__title slds-truncate slds-grid slds-grid_vertical-align-center">
+          <div id="quickview-modal-heading" class="slds-modal__title slds-truncate slds-grid slds-grid_vertical-align-center">
             <div class="slds-grid slds-truncate slds-grid_vertical-align-center slds-text-align_left">
               <div class="slds-m-right_small">
                 <c-quantic-result-label result={result} icon-only></c-quantic-result-label>
@@ -31,7 +31,7 @@
             <div class="slds-text-align_right quickview__result-date slds-col_bump-left">
               <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
             </div>
-          </h3>
+          </div>
         </header>
         <template if:true={isLoading}>
           <div onclick={stopPropagation} class="quickview__spinner-container slds-modal__content slds-p-around_large slds-is-relative">


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-2286

Using headers is probably a bad idea for two reasons.
1. right now, for a screen reader that reads the ui, it normally ties `<h3>` elements with the previous `<h2>` element. The problem is that in quantic, facet titles are using `<h2>` and the quantic result link of the templates are using `<h3>`. So semantically it looks like the last facet title, is the title of all the result links.
2. It is very possible that customers already use a hierarchy of headers in their page, we can't assume we are the only ones using `<h2>` and `<h3>`.

Before:
![image](https://user-images.githubusercontent.com/2488155/181364383-136c0ebb-52fb-4531-b2f8-7cd786654387.png)


After:
![image](https://user-images.githubusercontent.com/2488155/181363718-2d83f841-fd0c-4cd5-9115-8136ddc17441.png)

* So I removed all the h2, h3 and replaced by div, and the styling has not changed. 
* I also fixed the cypress selectors.
