### PR TITLE
fix(headless): Active tab added to the insight query request

### DIFF
--- a/packages/headless/src/api/service/insight/insight-api-client.test.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.test.ts
@@ -84,6 +84,7 @@ describe('insight api client', () => {
         description: 'some description',
       },
       q: 'some agent query',
+      cq: 'some expression',
       facets: [],
     };
 
@@ -103,6 +104,7 @@ describe('insight api client', () => {
           caseContext: queryRequest.caseContext,
           facets: queryRequest.facets,
           q: queryRequest.q,
+          cq: queryRequest.cq,
         },
       });
     });

--- a/packages/headless/src/api/service/insight/query/query-request.ts
+++ b/packages/headless/src/api/service/insight/query/query-request.ts
@@ -1,5 +1,6 @@
 import {NumberOfResultsParam} from '../../../platform-service-params';
 import {
+  ConstantQueryParam,
   FacetsParam,
   FirstResultParam,
   QueryParam,
@@ -15,7 +16,8 @@ export type InsightQueryRequest = InsightParam &
   FacetsParam &
   QueryParam &
   FirstResultParam &
-  NumberOfResultsParam;
+  NumberOfResultsParam &
+  ConstantQueryParam;
 
 interface CaseContextParam {
   caseContext?: Record<string, string>;

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -295,7 +295,6 @@ const buildInsightSearchRequest = (
   const cq = buildConstantQuery(state);
   const facets = getAllFacets(state);
   return mapSearchRequest<InsightQueryRequest>({
-    ...(cq && {cq}),
     accessToken: state.configuration.accessToken,
     organizationId: state.configuration.organizationId,
     url: state.configuration.platformUrl,
@@ -307,6 +306,7 @@ const buildInsightSearchRequest = (
       firstResult: state.pagination.firstResult,
       numberOfResults: state.pagination.numberOfResults,
     }),
+    ...(cq && {cq}),
   });
 };
 


### PR DESCRIPTION
### Problem:
The active tab information was missing in the insight query request sent to the customer service API.

### Solution: 
The active tab information is now sent in the constant query parameter of the  insight query request.