### PR TITLE
chore(snyk): update Snyk report after v bump

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,7 +4,12 @@ on:
     branches:
       - master
   pull_request:
-
+  workflow_run:
+    workflows:
+      - Master Robot
+      - Manual package creation
+    types:
+      - completed
 jobs:
   snyk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes
Our Snyk gate run by comparing the report stored in GH Security Advisory for the head and base refs. Because we skip all CI for the commit created for the release, we have no report for a bit.
This fix that by running the workflow for Snyk on the master branch right after we completed the workflow for the release

## Testing
Yolo should work ™️ (it's a CI thing, hard to test 😅)


-----

KIT-1897