### PR TITLE
fix(atomic): improved search box accessibility for macOS VoiceOver

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -23,7 +23,7 @@ import { InitializationOptions } from "./components/search/atomic-search-interfa
 import { StandaloneSearchBoxData } from "./utils/local-storage-utils";
 export namespace Components {
     interface AtomicAriaLive {
-        "updateMessage": (region: string, message: string) => Promise<void>;
+        "updateMessage": (region: string, message: string, assertive: boolean) => Promise<void>;
     }
     interface AtomicBreadbox {
     }

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -37,6 +37,8 @@ import {
   SimpleSearchSuggestion,
 } from './search-suggestion';
 
+import {isMacOS} from '../../../utils/device-utils';
+
 /**
  * The `atomic-search-box` component creates a search box with built-in support for suggestions.
  *
@@ -341,6 +343,9 @@ export class AtomicSearchBox {
     this.updateActiveDescendant(value.id);
     this.scrollActiveDescendantIntoView();
     this.updateQueryFromSuggestion();
+    if (isMacOS()) {
+      this.ariaMessage = value.ariaLabel!;
+    }
   }
 
   private focusPanel(panel: HTMLElement | undefined) {
@@ -705,7 +710,11 @@ export class AtomicSearchBox {
           ref={(el) => (this.inputRef = el as HTMLInputElement)}
           bindings={this.bindings}
           value={this.searchBoxState.value}
-          ariaLabel={this.bindings.i18n.t('search-box-with-suggestions')}
+          ariaLabel={this.bindings.i18n.t(
+            isMacOS()
+              ? 'search-box-with-suggestions-macos'
+              : 'search-box-with-suggestions'
+          )}
           onFocus={() => this.onFocus()}
           onInput={(e) => this.onInput((e.target as HTMLInputElement).value)}
           onBlur={() => this.clearSuggestions()}

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -343,9 +343,7 @@ export class AtomicSearchBox {
     this.updateActiveDescendant(value.id);
     this.scrollActiveDescendantIntoView();
     this.updateQueryFromSuggestion();
-    if (isMacOS()) {
-      this.ariaMessage = value.ariaLabel!;
-    }
+    this.updateAriaLiveActiveDescendant(value);
   }
 
   private focusPanel(panel: HTMLElement | undefined) {
@@ -356,11 +354,11 @@ export class AtomicSearchBox {
       const panelHasActiveDescendant =
         this.previousActiveDescendantElement &&
         panel.contains(this.previousActiveDescendantElement);
-      this.updateDescendants(
-        panelHasActiveDescendant
-          ? this.previousActiveDescendantElement!.id
-          : panel.firstElementChild.id
-      );
+      const newValue = panelHasActiveDescendant
+        ? this.previousActiveDescendantElement!
+        : (panel.firstElementChild as HTMLElement);
+      this.updateDescendants(newValue.id);
+      this.updateAriaLiveActiveDescendant(newValue);
     }
   }
 
@@ -484,6 +482,12 @@ export class AtomicSearchBox {
     if (suggestedQuery && this.searchBoxState.value !== suggestedQuery) {
       this.updateQuery(suggestedQuery);
       this.updateSuggestedQuery(suggestedQuery);
+    }
+  }
+
+  private updateAriaLiveActiveDescendant(value: HTMLElement) {
+    if (isMacOS()) {
+      this.ariaMessage = value.ariaLabel!;
     }
   }
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -129,7 +129,10 @@ export class AtomicSearchBox {
   @Prop({reflect: true}) public clearFilters = true;
 
   @AriaLiveRegion('search-box')
-  protected ariaMessage!: string;
+  protected searchBoxAriaMessage!: string;
+
+  @AriaLiveRegion('search-suggestions', true)
+  protected suggestionsAriaMessage!: string;
 
   public initialize() {
     this.id = randomID('atomic-search-box-');
@@ -364,7 +367,7 @@ export class AtomicSearchBox {
 
   private updateAriaMessage() {
     const elsLength = this.allSuggestionElements.filter(elementHasQuery).length;
-    this.ariaMessage = elsLength
+    this.searchBoxAriaMessage = elsLength
       ? this.bindings.i18n.t('query-suggestions-available', {
           count: elsLength,
         })
@@ -487,7 +490,7 @@ export class AtomicSearchBox {
 
   private updateAriaLiveActiveDescendant(value: HTMLElement) {
     if (isMacOS()) {
-      this.ariaMessage = value.ariaLabel!;
+      this.suggestionsAriaMessage = value.ariaLabel!;
     }
   }
 
@@ -547,7 +550,7 @@ export class AtomicSearchBox {
   private clearSuggestionElements() {
     this.leftSuggestionElements = [];
     this.rightSuggestionElements = [];
-    this.ariaMessage = '';
+    this.searchBoxAriaMessage = '';
   }
 
   private onSuggestionClick(item: SearchBoxSuggestionElement, e: Event) {

--- a/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
@@ -71,6 +71,7 @@ function getAriaLabelForRenderedSuggestion({
   index,
   lastIndex,
   isDoubleList,
+  isButton,
 }: {
   bindings: AnyBindings;
   renderedSuggestion: HTMLElement;
@@ -79,15 +80,17 @@ function getAriaLabelForRenderedSuggestion({
   index: number;
   lastIndex: number;
   isDoubleList: boolean;
+  isButton: boolean;
 }) {
   const contentLabel =
     suggestion.ariaLabel ??
     suggestion.query ??
     renderedSuggestion.innerText ??
     bindings.i18n.t('no-title');
-  const labelWithType = isMacOS()
-    ? bindings.i18n.t('search-suggestion-button', {label: contentLabel})
-    : contentLabel;
+  const labelWithType =
+    isMacOS() && isButton
+      ? bindings.i18n.t('search-suggestion-button', {label: contentLabel})
+      : contentLabel;
   const position = index + 1;
   const count = lastIndex + 1;
 
@@ -115,16 +118,19 @@ function getContentForSuggestion(suggestion: SearchBoxSuggestionElement) {
   );
 }
 
-function getCommonSearchSuggestionAttributes({
-  bindings,
-  id,
-  suggestion,
-  isSelected,
-  side,
-  index,
-  lastIndex,
-  isDoubleList,
-}: SearchSuggestionProps): JSXBase.HTMLAttributes<HTMLElement> {
+function getCommonSearchSuggestionAttributes(
+  {
+    bindings,
+    id,
+    suggestion,
+    isSelected,
+    side,
+    index,
+    lastIndex,
+    isDoubleList,
+  }: SearchSuggestionProps,
+  isButton: boolean
+): JSXBase.HTMLAttributes<HTMLElement> {
   return {
     id: id,
     key: suggestion.key,
@@ -148,6 +154,7 @@ function getCommonSearchSuggestionAttributes({
           index,
           lastIndex,
           isDoubleList,
+          isButton,
         })
       );
     },
@@ -158,7 +165,7 @@ export const SimpleSearchSuggestion: FunctionalComponent<
   SearchSuggestionProps
 > = (props) => {
   return (
-    <span {...getCommonSearchSuggestionAttributes(props)}>
+    <span {...getCommonSearchSuggestionAttributes(props, false)}>
       {getContentForSuggestion(props.suggestion)}
     </span>
   );
@@ -169,7 +176,7 @@ export const ButtonSearchSuggestion: FunctionalComponent<
 > = (props) => {
   return (
     <button
-      {...getCommonSearchSuggestionAttributes(props)}
+      {...getCommonSearchSuggestionAttributes(props, true)}
       onMouseDown={(e) => e.preventDefault()}
       onClick={(e: Event) => props.onClick?.(e)}
       onMouseOver={(e: Event) => props.onMouseOver?.(e)}

--- a/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
@@ -1,5 +1,6 @@
 import {h, FunctionalComponent, VNode, Fragment} from '@stencil/core';
 import {JSXBase} from '@stencil/core/internal';
+import {isMacOS} from '../../../utils/device-utils';
 import {AnyBindings} from '../../common/interface/bindings';
 import {SearchBoxSuggestionElement} from '../search-box-suggestions/suggestions-common';
 
@@ -84,19 +85,22 @@ function getAriaLabelForRenderedSuggestion({
     suggestion.query ??
     renderedSuggestion.innerText ??
     bindings.i18n.t('no-title');
+  const labelWithType = isMacOS()
+    ? bindings.i18n.t('search-suggestion-button', {label: contentLabel})
+    : contentLabel;
   const position = index + 1;
   const count = lastIndex + 1;
 
   if (!isDoubleList) {
     return bindings.i18n.t('search-suggestion-single-list', {
-      label: contentLabel,
+      label: labelWithType,
       position,
       count,
     });
   }
 
   return bindings.i18n.t('search-suggestion-double-list', {
-    label: contentLabel,
+    label: labelWithType,
     position,
     count,
     side: bindings.i18n.t(side === 'left' ? 'left' : 'right'),

--- a/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/search-suggestion.tsx
@@ -89,7 +89,10 @@ function getAriaLabelForRenderedSuggestion({
     bindings.i18n.t('no-title');
   const labelWithType =
     isMacOS() && isButton
-      ? bindings.i18n.t('search-suggestion-button', {label: contentLabel})
+      ? bindings.i18n.t('search-suggestion-button', {
+          label: contentLabel,
+          interpolation: {escapeValue: false},
+        })
       : contentLabel;
   const position = index + 1;
   const count = lastIndex + 1;
@@ -99,6 +102,7 @@ function getAriaLabelForRenderedSuggestion({
       label: labelWithType,
       position,
       count,
+      interpolation: {escapeValue: false},
     });
   }
 
@@ -107,6 +111,7 @@ function getAriaLabelForRenderedSuggestion({
     position,
     count,
     side: bindings.i18n.t(side === 'left' ? 'left' : 'right'),
+    interpolation: {escapeValue: false},
   });
 }
 

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-aria-live.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-aria-live.tsx
@@ -16,6 +16,7 @@ import {
 export class AtomicAriaLive {
   @Element() private host!: HTMLAtomicAriaLiveElement;
   @State() private message = '';
+  @State() private assertive = false;
 
   private lastUpdatedRegion?: string;
   private disconnectFindAriaLiveEvent?: () => void;
@@ -41,7 +42,11 @@ export class AtomicAriaLive {
    * @internal
    */
   @Method()
-  public async updateMessage(region: string, message: string) {
+  public async updateMessage(
+    region: string,
+    message: string,
+    assertive: boolean
+  ) {
     const wouldOverwriteAnotherRegion = region !== this.lastUpdatedRegion;
     if (wouldOverwriteAnotherRegion) {
       this.lastUpdatedRegion = region;
@@ -50,6 +55,7 @@ export class AtomicAriaLive {
       }
     }
     this.message = message;
+    this.assertive = assertive;
   }
 
   public connectedCallback() {
@@ -68,7 +74,7 @@ export class AtomicAriaLive {
     return (
       <Host
         style={{position: 'absolute', right: '10000px'}}
-        aria-live="polite"
+        aria-live={this.assertive ? 'assertive' : 'polite'}
         role="status"
       >
         {this.message}

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -69,6 +69,10 @@
     "en": "Search field with suggestions. To begin navigating suggestions, while focused, press Down Arrow. To send, press Enter.",
     "fr": "Champ de recherche avec des suggestions. Pour commencer à naviguer à travers les suggestions, avec cible de saisie, appuyez sur Flèche Basse. Pour envoyer, appuyez sur Entrée."
   },
+  "search-box-with-suggestions-macos": {
+    "en": "Search field with suggestions. Suggestions may be available under this field. Press enter to send.",
+    "fr": "Champ de recherche avec suggestions. Des suggestions pourraient être disponibles sous ce champ. Appuyez sur Entrée pour envoyer."
+  },
   "search-suggestions-single-list": {
     "en": "Search suggestions. To navigate between suggestions, press Up Arrow or Down Arrow. To select a suggestion, press Enter.",
     "fr": "Liste de suggestions de recherche. Pour naviguer entre les suggestions, appuyez sur Flèche Haute ou Flèche Basse. Pour sélectionner une suggestion, appuyez sur Entrée."

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -70,8 +70,8 @@
     "fr": "Champ de recherche avec des suggestions. Pour commencer à naviguer à travers les suggestions, avec cible de saisie, appuyez sur Flèche Basse. Pour envoyer, appuyez sur Entrée."
   },
   "search-box-with-suggestions-macos": {
-    "en": "Search field with suggestions. Suggestions may be available under this field. Press enter to send.",
-    "fr": "Champ de recherche avec suggestions. Des suggestions pourraient être disponibles sous ce champ. Appuyez sur Entrée pour envoyer."
+    "en": "Search field with suggestions. Suggestions may be available under this field. To send, press Enter.",
+    "fr": "Champ de recherche avec suggestions. Des suggestions pourraient être disponibles sous ce champ. Pour envoyer, appuyez sur Entrée."
   },
   "search-suggestions-single-list": {
     "en": "Search suggestions. To navigate between suggestions, press Up Arrow or Down Arrow. To select a suggestion, press Enter.",

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -89,6 +89,10 @@
     "en": "{{label}}. {{position}} of {{count}}. In {{side}} list.",
     "fr": "{{label}}. {{position}} sur {{count}}. Dans la liste {{side}}."
   },
+  "search-suggestion-button": {
+    "en": "{{label}}. Button.",
+    "fr": "{{label}}. Bouton."
+  },
   "query-suggestion-label": {
     "en": "“{{query}}”",
     "fr": "«\u00A0{{text}}\u00A0»"

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -90,8 +90,8 @@
     "fr": "{{label}}. {{position}} sur {{count}}. Dans la liste {{side}}."
   },
   "search-suggestion-button": {
-    "en": "{{label}}. Button.",
-    "fr": "{{label}}. Bouton."
+    "en": "{{label}}. Button",
+    "fr": "{{label}}. Bouton"
   },
   "query-suggestion-label": {
     "en": "“{{query}}”",

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -10,7 +10,7 @@ export interface FindAriaLiveEventArgs {
   element?: HTMLAtomicAriaLiveElement;
 }
 
-export function AriaLiveRegion(regionName: string) {
+export function AriaLiveRegion(regionName: string, assertive = false) {
   function dispatchMessage(message: string) {
     const event = buildCustomEvent<FindAriaLiveEventArgs>(
       findAriaLiveEventName,
@@ -19,7 +19,7 @@ export function AriaLiveRegion(regionName: string) {
     document.dispatchEvent(event);
     const {element} = event.detail;
     if (element) {
-      element.updateMessage(regionName, message);
+      element.updateMessage(regionName, message, assertive);
     }
   }
 

--- a/packages/atomic/src/utils/device-utils.ts
+++ b/packages/atomic/src/utils/device-utils.ts
@@ -13,3 +13,8 @@ export function isIOS() {
 
   return isIOS || (isAppleDevice && (isTouchScreen || iosQuirkPresent()));
 }
+
+export function isMacOS() {
+  // Source: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform#examples
+  return navigator.platform.startsWith('Mac');
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1908

Follow-up to https://github.com/coveo/ui-kit/pull/2286

In this PR, I changed the instructions for screen readers so they reflect the correct controls for macOS.

Also, I updated an [assertive aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live#values) whenever a suggestion is selected, since VoiceOver on macOS doesn't notify of those by default.