### PR TITLE
fix(atomic,headless): fix atomic pager size overflow + headless page fraction

### DIFF
--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.pcss
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.pcss
@@ -1,7 +1,1 @@
 @import '../../../global/global.pcss';
-
-button,
-.btn-page {
-  @apply min-w-[2.5rem] min-h-[2.5rem];
-  @apply p-1;
-}

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.pcss
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.pcss
@@ -2,5 +2,6 @@
 
 button,
 .btn-page {
-  @apply w-10 h-10;
+  @apply min-w-[2.5rem] min-h-[2.5rem];
+  @apply p-1;
 }

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
@@ -91,6 +91,7 @@ export class AtomicPager implements InitializableComponent {
         }}
         part="previous-button"
         disabled={!this.pagerState.hasPreviousPage}
+        class="p-1 min-w-[2.5rem] min-h-[2.5rem]"
       >
         <atomic-icon
           icon={ArrowRight}
@@ -111,6 +112,7 @@ export class AtomicPager implements InitializableComponent {
         }}
         part="next-button"
         disabled={!this.pagerState.hasNextPage}
+        class="p-1 min-w-[2.5rem] min-h-[2.5rem]"
       >
         <atomic-icon icon={ArrowRight} class="w-5 align-middle"></atomic-icon>
       </Button>
@@ -141,7 +143,7 @@ export class AtomicPager implements InitializableComponent {
         ariaCurrent={isSelected ? 'page' : 'false'}
         ariaLabel={this.bindings.i18n.t('page-number', {page})}
         onChecked={() => this.selectPage(page)}
-        class="btn-page focus-visible:bg-neutral-light"
+        class="btn-page focus-visible:bg-neutral-light p-1 min-w-[2.5rem] min-h-[2.5rem]"
         part={parts.join(' ')}
         text={page.toLocaleString(this.bindings.i18n.language)}
         ref={isSelected ? this.activePage.setTarget : undefined}

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
@@ -92,7 +92,10 @@ export class AtomicPager implements InitializableComponent {
         part="previous-button"
         disabled={!this.pagerState.hasPreviousPage}
       >
-        <atomic-icon icon={ArrowRight} class="w-5 rotate-180"></atomic-icon>
+        <atomic-icon
+          icon={ArrowRight}
+          class="w-5 align-middle rotate-180"
+        ></atomic-icon>
       </Button>
     );
   }
@@ -109,7 +112,7 @@ export class AtomicPager implements InitializableComponent {
         part="next-button"
         disabled={!this.pagerState.hasNextPage}
       >
-        <atomic-icon icon={ArrowRight} class="w-5"></atomic-icon>
+        <atomic-icon icon={ArrowRight} class="w-5 align-middle"></atomic-icon>
       </Button>
     );
   }

--- a/packages/headless/src/features/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.test.ts
@@ -151,6 +151,16 @@ describe('pagination slice', () => {
     expect(determinePage(finalState)).toBe(1);
   });
 
+  it('does not return fraction of pages', () => {
+    state.numberOfResults = 3;
+
+    state.firstResult = 2;
+    expect(determinePage(state)).toBe(2);
+
+    state.firstResult = 4;
+    expect(determinePage(state)).toBe(2);
+  });
+
   it('executeSearch.fulfilled updates totalCountFiltered to the response value', () => {
     const search = buildMockSearch();
     search.response.totalCountFiltered = 100;

--- a/packages/headless/src/features/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.ts
@@ -156,7 +156,7 @@ export function calculateFirstResult(page: number, numberOfResults: number) {
 }
 
 export function calculatePage(firstResult: number, numberOfResults: number) {
-  return firstResult / numberOfResults + 1;
+  return Math.round(firstResult / numberOfResults) + 1;
 }
 
 export function calculateMaxPage(


### PR DESCRIPTION
Couple different problems fixed in this PR:

* Headless would return fraction of pages when manually changing `firstResult` in the URL
* Atomic would incorrectly display very big pager number in `atomic-pager` (would overflow)
* Fix some alignment issue with next and previous pager button

https://coveord.atlassian.net/browse/KIT-1906