### PR TITLE
fix(atomic): fix components definition file

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "clean": "rimraf -rf dist/* headless/*",
-    "build": "npm run build:locales && npm run build:stencil && npm run doc:list-assets && npm run build:storybook",
+    "build": "npm run build:locales && npm run build:stencil && npm run doc:list-assets && npm run build:storybook && npm run validate:definitions",
     "build:locales": "node ./scripts/create-generated-folder.js && node ./scripts/split-locales.js && node ./scripts/copy-dayjs-locales.js",
     "build:stencil": "npm run copy:headless && node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build",
     "copy:headless": "node scripts/copy-headless.js",
@@ -50,7 +50,8 @@
     "storybook": "npm run storybook:lit-analyze && start-storybook -s ./dist -p 6006",
     "build:storybook": "npm run storybook:lit-analyze && build-storybook && ncp dist/ storybook-static/",
     "storybook:lit-analyze": "lit-analyzer dist/types/components.d.ts src/components/**/*.stories.tsx",
-    "doc:list-assets": "node scripts/list-assets.js"
+    "doc:list-assets": "node scripts/list-assets.js",
+    "validate:definitions": "! tsc --allowSyntheticDefaultImports dist/types/index.d.ts | grep -q 'components.d.ts'"
   },
   "dependencies": {
     "@coveo/bueno": "0.42.1",

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -16,6 +16,7 @@ import { FacetDisplayValues } from "./components/common/facets/facet-common";
 import { i18n } from "i18next";
 import { InsightInitializationOptions } from "./components/insight/atomic-insight-interface/atomic-insight-interface";
 import { NumericFacetDisplayValues } from "./components/common/facets/numeric-facet-common";
+import { AtomicInsightStore } from "./components/insight/atomic-insight-interface/store";
 import { Section } from "./components/search/atomic-layout-section/sections";
 import { RecommendationEngine } from "@coveo/headless/recommendation";
 import { AtomicStore } from "./components/search/atomic-search-interface/store";
@@ -539,7 +540,7 @@ export namespace Components {
         /**
           * Global state for Atomic.
          */
-        "store"?: ReturnType<typeof createAtomicInsightStore>;
+        "store"?: AtomicInsightStore;
     }
     interface AtomicInsightResultList {
         /**
@@ -2619,7 +2620,7 @@ declare namespace LocalJSX {
         /**
           * Global state for Atomic.
          */
-        "store"?: ReturnType<typeof createAtomicInsightStore>;
+        "store"?: AtomicInsightStore;
     }
     interface AtomicInsightResultList {
         /**

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
@@ -1,6 +1,6 @@
 import {Component, h, Prop, Element, Listen} from '@stencil/core';
 import {applyFocusVisiblePolyfill} from '../../../utils/initialization-utils';
-import {createAtomicInsightStore} from '../atomic-insight-interface/store';
+import {AtomicInsightStore} from '../atomic-insight-interface/store';
 import {
   DisplayConfig,
   ResultContextEvent,
@@ -43,7 +43,7 @@ export class AtomicInsightResult {
    * Global state for Atomic.
    * @internal
    */
-  @Prop() store?: ReturnType<typeof createAtomicInsightStore>;
+  @Prop() store?: AtomicInsightStore;
 
   /**
    * The result content to display.


### PR DESCRIPTION
Generated definition file was referencing an internal type, thus resulting in an invalid `d.ts` file.

Since its also pretty easy to get such errors (and we've had the same kind of problem in the past), I've added a small task to try and validate the components definition file.

https://coveord.atlassian.net/browse/KIT-1926