### PR TITLE
fix(atomic): improved atomic-aria-live for simultaneous messages

### DIFF
--- a/packages/atomic/cypress/integration/aria-live-selectors.ts
+++ b/packages/atomic/cypress/integration/aria-live-selectors.ts
@@ -1,5 +1,9 @@
 export const ariaLiveComponent = 'atomic-aria-live';
 
 export const AriaLiveSelectors = {
-  element: () => cy.get('atomic-search-interface').find(ariaLiveComponent),
+  region: (region: string) =>
+    cy
+      .get('atomic-search-interface')
+      .find(ariaLiveComponent)
+      .find(`[aria-live][id$="-${region}"]`),
 };

--- a/packages/atomic/cypress/integration/common-assertions.ts
+++ b/packages/atomic/cypress/integration/common-assertions.ts
@@ -89,8 +89,11 @@ export function assertRemovesComponent(
   });
 }
 
-export function assertAriaLiveMessage(message: string) {
+export function assertAriaLiveMessage(
+  selector: () => Cypress.Chainable<JQuery<HTMLElement>>,
+  message: string
+) {
   it(`screen readers should read out "${message}".`, () => {
-    AriaLiveSelectors.element().should('contain.text', message);
+    selector().should('contain.text', message);
   });
 }

--- a/packages/atomic/cypress/integration/no-results-selectors.ts
+++ b/packages/atomic/cypress/integration/no-results-selectors.ts
@@ -1,0 +1,7 @@
+import {AriaLiveSelectors} from './aria-live-selectors';
+
+export const noResultsComponent = 'atomic-no-results';
+export const NoResultsSelectors = {
+  shadow: () => cy.get(noResultsComponent).shadow(),
+  ariaLive: () => AriaLiveSelectors.region('no-results'),
+};

--- a/packages/atomic/cypress/integration/no-results.cypress.ts
+++ b/packages/atomic/cypress/integration/no-results.cypress.ts
@@ -3,16 +3,16 @@ import {getAnalyticsAt} from '../utils/network';
 import {SearchBoxSelectors} from './search-box/search-box-selectors';
 import * as CommonAssertions from './common-assertions';
 import {addSearchBox} from './search-box/search-box-actions';
+import {noResultsComponent, NoResultsSelectors} from './no-results-selectors';
 
 describe('No Results Test Suites', () => {
-  const tag = 'atomic-no-results';
   const wait = 1000;
   let env: TestFixture;
 
   beforeEach(() => {
     env = new TestFixture()
       .with(addSearchBox())
-      .withElement(generateComponentHTML(tag));
+      .withElement(generateComponentHTML(noResultsComponent));
   });
 
   describe('when there are results', () => {
@@ -21,7 +21,7 @@ describe('No Results Test Suites', () => {
     });
 
     it('should not be visible', () => {
-      cy.get(tag).should('not.be.visible');
+      cy.get(noResultsComponent).should('not.be.visible');
     });
   });
 
@@ -30,14 +30,17 @@ describe('No Results Test Suites', () => {
       env.withHash('q=gahaiusdhgaiuewjfsf').init();
     });
 
-    CommonAssertions.assertAriaLiveMessage("couldn't find anything");
+    CommonAssertions.assertAriaLiveMessage(
+      NoResultsSelectors.ariaLive,
+      "couldn't find anything"
+    );
 
     it('should be visible', () => {
-      cy.get(tag).should('be.visible');
+      cy.get(noResultsComponent).should('be.visible');
     });
 
     it('text content should match', () => {
-      cy.get(tag)
+      cy.get(noResultsComponent)
         .shadow()
         .find('[part="no-results"] [part="highlight"]')
         .should('contain.text', 'gahaiusdhgaiuewjfsf');
@@ -46,7 +49,7 @@ describe('No Results Test Suites', () => {
 
   it('cancel button should not be visible when there is no history', () => {
     env.withHash('q=gahaiusdhgaiuewjfsf').init();
-    cy.get(tag).shadow().get('button').should('not.exist');
+    cy.get(noResultsComponent).shadow().get('button').should('not.exist');
   });
 
   function submitNoResultsSearch() {
@@ -58,21 +61,21 @@ describe('No Results Test Suites', () => {
   it('cancel button should be visible when there is history', () => {
     env.init();
     submitNoResultsSearch();
-    cy.get(tag).shadow().find('button').should('be.visible');
+    cy.get(noResultsComponent).shadow().find('button').should('be.visible');
   });
 
   it('clicking on cancel should go back in history and hide the atomic-no-results component', () => {
     env.init();
     submitNoResultsSearch();
-    cy.get(tag).shadow().find('button').click();
+    cy.get(noResultsComponent).shadow().find('button').click();
     cy.wait(wait);
-    cy.get(tag).should('not.be.visible');
+    cy.get(noResultsComponent).should('not.be.visible');
   });
 
   it('clicking on cancel should log proper analytics', async () => {
     env.init();
     submitNoResultsSearch();
-    cy.get(tag).shadow().find('button').click();
+    cy.get(noResultsComponent).shadow().find('button').click();
     const analyticsBody = (await getAnalyticsAt('@coveoAnalytics', 1)).request
       .body;
     expect(analyticsBody).to.have.property('actionCause', 'noResultsBack');

--- a/packages/atomic/cypress/integration/query-error-selectors.ts
+++ b/packages/atomic/cypress/integration/query-error-selectors.ts
@@ -1,3 +1,5 @@
+import {AriaLiveSelectors} from './aria-live-selectors';
+
 export const queryErrorComponent = 'atomic-query-error';
 export const QueryErrorSelectors = {
   shadow: () => cy.get(queryErrorComponent).shadow(),
@@ -9,4 +11,5 @@ export const QueryErrorSelectors = {
   errorTitle: () => QueryErrorSelectors.shadow().find('[part="title"]'),
   errorDescription: () =>
     QueryErrorSelectors.shadow().find('[part="description"]'),
+  ariaLive: () => AriaLiveSelectors.region('query-error'),
 };

--- a/packages/atomic/cypress/integration/query-error.cypress.ts
+++ b/packages/atomic/cypress/integration/query-error.cypress.ts
@@ -9,7 +9,10 @@ describe('Query Error Test Suites', () => {
       new TestFixture().with(addQueryError()).withError().init();
     });
 
-    CommonAssertions.assertAriaLiveMessage('wrong');
+    CommonAssertions.assertAriaLiveMessage(
+      QueryErrorSelectors.ariaLive,
+      'wrong'
+    );
 
     it('should display an error title', () => {
       QueryErrorSelectors.errorTitle()

--- a/packages/atomic/cypress/integration/query-summary-selectors.ts
+++ b/packages/atomic/cypress/integration/query-summary-selectors.ts
@@ -1,3 +1,5 @@
+import {AriaLiveSelectors} from './aria-live-selectors';
+
 export const querySummaryComponent = 'atomic-query-summary';
 export const QuerySummarySelectors = {
   shadow: () => cy.get(querySummaryComponent).shadow(),
@@ -6,4 +8,5 @@ export const QuerySummarySelectors = {
     QuerySummarySelectors.shadow().find('[part="placeholder"]'),
   container: () => QuerySummarySelectors.shadow().find('[part="container"]'),
   duration: () => QuerySummarySelectors.shadow().find('[part="duration"]'),
+  ariaLive: () => AriaLiveSelectors.region('query-summary'),
 };

--- a/packages/atomic/cypress/integration/query-summary.cypress.ts
+++ b/packages/atomic/cypress/integration/query-summary.cypress.ts
@@ -50,7 +50,10 @@ describe('Query Summary Test Suites', () => {
         .init();
     });
 
-    CommonAssertions.assertAriaLiveMessage('27');
+    CommonAssertions.assertAriaLiveMessage(
+      QuerySummarySelectors.ariaLive,
+      '27'
+    );
   });
 
   describe('should match text content', () => {

--- a/packages/atomic/cypress/integration/search-box/instant-results/search-box-instant-results.cypress.ts
+++ b/packages/atomic/cypress/integration/search-box/instant-results/search-box-instant-results.cypress.ts
@@ -76,6 +76,7 @@ describe('Instant Results Test Suites', () => {
       );
       InstantResultsAssertions.assertHasResultCount(numOfInstantResults);
       CommonAssertions.assertAriaLiveMessage(
+        SearchBoxSelectors.searchBoxAriaLive,
         maxRecentQueriesWithoutQuery.toString()
       );
       InstantResultsAssertions.assertResultIsSelected(0);

--- a/packages/atomic/cypress/integration/search-box/search-box-selectors.ts
+++ b/packages/atomic/cypress/integration/search-box/search-box-selectors.ts
@@ -1,3 +1,5 @@
+import {AriaLiveSelectors} from '../aria-live-selectors';
+
 export const searchBoxComponent = 'atomic-search-box';
 
 export const SearchBoxSelectors = {
@@ -6,6 +8,8 @@ export const SearchBoxSelectors = {
   submitButton: () =>
     SearchBoxSelectors.shadow().find('[part="submit-button"]'),
   querySuggestions: () => SearchBoxSelectors.shadow().find('[data-query]'),
+  searchBoxAriaLive: () => AriaLiveSelectors.region('search-box'),
+  suggestionsAriaLive: () => AriaLiveSelectors.region('search-suggestions'),
 };
 
 export const ButtonText = {

--- a/packages/atomic/cypress/integration/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/integration/search-box/search-box.cypress.ts
@@ -80,7 +80,10 @@ describe('Search Box Test Suites', () => {
       });
 
       SearchBoxAssertions.assertHasSuggestionsCount(expectedSum);
-      CommonAssertions.assertAriaLiveMessage(expectedSum.toString());
+      CommonAssertions.assertAriaLiveMessage(
+        SearchBoxSelectors.searchBoxAriaLive,
+        expectedSum.toString()
+      );
     });
 
     describe('with input', () => {
@@ -97,7 +100,10 @@ describe('Search Box Test Suites', () => {
         });
 
         SearchBoxAssertions.assertHasSuggestionsCount(expectedSum);
-        CommonAssertions.assertAriaLiveMessage(expectedSum.toString());
+        CommonAssertions.assertAriaLiveMessage(
+          SearchBoxSelectors.searchBoxAriaLive,
+          expectedSum.toString()
+        );
       });
 
       describe('after selecting a suggestion with the mouse', () => {
@@ -146,7 +152,10 @@ describe('Search Box Test Suites', () => {
       SearchBoxSelectors.inputBox().click();
     });
 
-    CommonAssertions.assertAriaLiveMessage(' no ');
+    CommonAssertions.assertAriaLiveMessage(
+      SearchBoxSelectors.searchBoxAriaLive,
+      ' no '
+    );
   });
 
   describe('with a basic search box', () => {

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -26,6 +26,7 @@ import { InitializationOptions } from "./components/search/atomic-search-interfa
 import { StandaloneSearchBoxData } from "./utils/local-storage-utils";
 export namespace Components {
     interface AtomicAriaLive {
+        "registerRegion": (region: string, assertive: boolean) => Promise<void>;
         "updateMessage": (region: string, message: string, assertive: boolean) => Promise<void>;
     }
     interface AtomicBreadbox {

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -143,6 +143,7 @@ export class AtomicSearchInterface
   @Prop({reflect: true}) public iconAssetsPath = './assets';
 
   public constructor() {
+    this.initAriaLive();
     this.commonInterfaceHelper = new CommonAtomicInterfaceHelper(
       this,
       'CoveoAtomic'
@@ -381,6 +382,13 @@ export class AtomicSearchInterface
   }
 
   private initAriaLive() {
+    if (
+      Array.from(this.host.children).some(
+        (element) => element.tagName === 'ATOMIC-ARIA-LIVE'
+      )
+    ) {
+      return;
+    }
     this.host.prepend(document.createElement('atomic-aria-live'));
   }
 
@@ -427,7 +435,6 @@ export class AtomicSearchInterface
     await this.commonInterfaceHelper.onInitialization(initEngine);
     this.initSearchStatus();
     this.initUrlManager();
-    this.initAriaLive();
     this.initialized = true;
   }
 }

--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -142,7 +142,6 @@
   </head>
 
   <body>
-    <atomic-aria-live></atomic-aria-live>
     <atomic-search-interface
       pipeline="Search"
       search-hub="MainSearch"

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -42,7 +42,6 @@
   </head>
 
   <body>
-    <atomic-aria-live></atomic-aria-live>
     <atomic-search-interface fields-to-include="snrating,sncost">
       <atomic-search-layout>
         <div class="header-bg"></div>

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -132,7 +132,6 @@
   </head>
 
   <body>
-    <atomic-aria-live></atomic-aria-live>
     <atomic-search-interface fields-to-include="snrating,sncost">
       <atomic-search-layout>
         <div class="header-bg"></div>

--- a/packages/atomic/src/pages/visualTests.html
+++ b/packages/atomic/src/pages/visualTests.html
@@ -132,7 +132,6 @@
   </head>
 
   <body>
-    <atomic-aria-live></atomic-aria-live>
     <atomic-search-interface fields-to-include="snrating,sncost">
       <atomic-search-layout>
         <div class="header-bg"></div>

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -11,22 +11,34 @@ export interface FindAriaLiveEventArgs {
 }
 
 export function AriaLiveRegion(regionName: string, assertive = false) {
-  function dispatchMessage(message: string) {
+  function getAriaLiveElement() {
     const event = buildCustomEvent<FindAriaLiveEventArgs>(
       findAriaLiveEventName,
       {}
     );
     document.dispatchEvent(event);
     const {element} = event.detail;
-    if (element) {
-      element.updateMessage(regionName, message, assertive);
-    }
+    return element;
+  }
+
+  function dispatchMessage(message: string) {
+    getAriaLiveElement()?.updateMessage(regionName, message, assertive);
+  }
+
+  function registerRegion() {
+    getAriaLiveElement()?.registerRegion(regionName, assertive);
   }
 
   return (component: InitializableComponent, setterName: string) => {
+    const {componentWillRender} = component;
     Object.defineProperty(component, setterName, {
       set: (message: string) => dispatchMessage(message),
     });
+
+    component.componentWillRender = function () {
+      componentWillRender && componentWillRender.call(this);
+      registerRegion();
+    };
   };
 }
 

--- a/packages/atomic/src/utils/debounce-utils.spec.ts
+++ b/packages/atomic/src/utils/debounce-utils.spec.ts
@@ -1,0 +1,112 @@
+import {buildDebouncedQueue, DebouncedQueue} from './debounce-utils';
+
+describe('buildDebouncedQueue', () => {
+  let queue: DebouncedQueue;
+  const delay = 5;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    queue = buildDebouncedQueue({delay});
+  });
+
+  afterEach(() => {
+    queue.clear();
+  });
+
+  it('executes the first action synchronously', () => {
+    const action = jest.fn();
+    queue.enqueue(action);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't execute actions more than once", () => {
+    const action = jest.fn();
+    queue.enqueue(action);
+    jest.runAllTimers();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces actions by the given delay', () => {
+    const action = jest.fn();
+    queue.enqueue(() => {});
+    queue.enqueue(action);
+    jest.advanceTimersByTime(delay - 1);
+    expect(action).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces actions executed after the last action within the delay', () => {
+    queue.enqueue(() => {}); // Finishes at 0
+    queue.enqueue(() => {}); // Finishes at `delay`
+    jest.advanceTimersByTime(delay * 2 - 1);
+    const action = jest.fn();
+    queue.enqueue(action);
+    expect(action).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't debounce actions executed after the last action past the delay", () => {
+    queue.enqueue(() => {}); // Finishes at 0
+    queue.enqueue(() => {}); // Finishes at `delay`
+    jest.advanceTimersByTime(delay * 2);
+    const action = jest.fn();
+    queue.enqueue(action);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('overwrites past actions with the same id', () => {
+    const completedActions: string[] = [];
+    function enqueue(id: string) {
+      queue.enqueue(() => completedActions.push(id), id);
+    }
+
+    queue.enqueue(() => {});
+    enqueue('A');
+    enqueue('B');
+    enqueue('C');
+    enqueue('B');
+    enqueue('A');
+    jest.runAllTimers();
+    expect(completedActions).toEqual(['C', 'B', 'A']);
+  });
+
+  it('can remove an action', () => {
+    const completedActions: string[] = [];
+    function enqueue(id: string) {
+      queue.enqueue(() => completedActions.push(id), id);
+    }
+
+    queue.enqueue(() => {});
+    enqueue('A');
+    enqueue('B');
+    enqueue('C');
+    queue.cancelActionIfQueued('B');
+    queue.cancelActionIfQueued('D');
+    jest.runAllTimers();
+    expect(completedActions).toEqual(['A', 'C']);
+  });
+
+  it('can clear the queue', () => {
+    const actionA = jest.fn();
+    const actionB = jest.fn();
+    queue.enqueue(() => {});
+    queue.enqueue(actionA);
+    queue.enqueue(actionB);
+    queue.clear();
+    jest.runAllTimers();
+    expect(actionA).not.toHaveBeenCalled();
+    expect(actionB).not.toHaveBeenCalled();
+  });
+
+  it('still debounces actions enqueued within the delay after clearing', () => {
+    queue.enqueue(() => {});
+    queue.clear();
+    jest.advanceTimersByTime(delay - 1);
+    const action = jest.fn();
+    queue.enqueue(action);
+    expect(action).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/atomic/src/utils/debounce-utils.tsx
+++ b/packages/atomic/src/utils/debounce-utils.tsx
@@ -1,0 +1,52 @@
+export interface DebouncedQueueOptions {
+  delay: number;
+}
+
+export interface DebouncedQueue {
+  enqueue(execute: () => void, uniqueId?: string): void;
+  clear(): void;
+  cancelActionIfQueued(id: string): void;
+}
+
+interface QueuedAction {
+  id?: string;
+  execute: () => void;
+}
+
+export function buildDebouncedQueue(
+  options: DebouncedQueueOptions
+): DebouncedQueue {
+  let actions: QueuedAction[] = [];
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  function dequeueAction() {
+    const action = actions.shift();
+    if (action) {
+      action.execute();
+    } else {
+      clearInterval(intervalId!);
+      intervalId = null;
+    }
+  }
+
+  function cancelActionIfQueued(id: string) {
+    actions = actions.filter((action) => action.id !== id);
+  }
+
+  return {
+    enqueue(execute: () => void, uniqueId?: string) {
+      if (uniqueId) {
+        cancelActionIfQueued(uniqueId);
+      }
+      actions.push({id: uniqueId, execute});
+      if (intervalId === null) {
+        dequeueAction();
+        intervalId = setInterval(dequeueAction, options.delay);
+      }
+    },
+    clear() {
+      actions = [];
+    },
+    cancelActionIfQueued,
+  };
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1927

With the upcoming `atomic-notification` component, I noticed that screen readers weren't reading all aria-live updates, so I did a bit of investigation.

I made [a test page in codesandbox](https://zpwdgl.csb.app/) with React to test how different screen readers interpret changes to aria-live elements. Here are the results of my tests:
<table>
<tr>
  <th></th>
  <th>JAWS</th>
  <th>NVDA</th>
  <th>macOS VoiceOver</th>
  <th>iOS VoiceOver</th>
  <th>TalkBack</th>
<tr>
  <th>1 aria-live and no delay
  <td>Says the last message.
  <td>Says the last message.
  <td>Says the last message.
  <td>Says the last message.
  <td>Says the last message.
<tr>
  <th>1 aria-live and a delay
  <td>Flaky, needs a delay of at-least 5ms.
  <td>Flaky, needs a delay of at-least 15ms.
  <td>Interrupts previous message.
  <td>Flaky, needs a delay of at-least 30ms.
  <td>Flaky, needs a delay of at-least 25ms.
<tr>
  <th>2 aria-live and no delay
  <td>Read in varying DOM order (randomized per refresh).
  <td>Read in varying DOM order (randomized per refresh).
  <td>Read in varying DOM order (randomized per refresh).
  <td>Read in DOM order.
  <td>Read in change order.
<tr>
  <th>2 aria-live and a delay
  <td>Read in change order (even at 0ms).
  <td>Read in varying DOM order (randomized per refresh). Read in change order when delay >= 15ms.
  <td>Read in varying DOM order (randomized per refresh). Read in change order when delay >= 150ms.
  <td>Read in change order (even at 0ms).
  <td>Read in change order.
</table>

Based on those results, I decided to do the following:
* Instead of setting aria-live directly on the `atomic-aria-live` element, I divided it into separate elements per "region". It's ok for screen readers not to read the previous state of a region, we only care about the current state, just like we generally do for a visual component.
* I introduced a utility to debounce aria message updates. It ensures that we don't update the aria message too fast. It doesn't allow regions to queue up multiple messages, it instead removes the previous message from the same region.
* I improved `atomic-aria-live` by allowing regions to "register" themselves so that an `atomic-aria-live` component doesn't need to be included outside of the `atomic-search-interface` anymore.
