### PR TITLE
feat(atomic,headless): add support for custom sort for facets

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -153,13 +153,13 @@ export declare interface AtomicFacet extends Components.AtomicFacet {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['allowedValues', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['allowedValues', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicFacet {
   protected el: HTMLElement;

--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -1083,4 +1083,18 @@ describe('Facet v1 Test Suites', () => {
         .should('not.contain.text', 'Message');
     });
   });
+
+  describe('with custom-sort', () => {
+    it('returns values sorted', () => {
+      new TestFixture()
+        .with(
+          addFacet({field: 'objecttype', 'custom-sort': 'People,File,Contact'})
+        )
+        .init();
+
+      FacetSelectors.valueLabel().eq(0).should('have.text', 'People');
+      FacetSelectors.valueLabel().eq(1).should('have.text', 'File');
+      FacetSelectors.valueLabel().eq(2).should('have.text', 'Contact');
+    });
+  });
 });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -156,6 +156,10 @@ export namespace Components {
          */
         "allowedValues"?: string;
         /**
+          * Specifies a custom order by which to sort the facet values.  Example: ```html <!-- Sort @ticketstatus facet values in a logical order for support tickets --> <atomic-facet field="@ticketstatus" custom-sort="New,Opened,Feedback,Resolved"></atomic-facet> ```
+         */
+        "customSort"?: string;
+        /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */
         "dependsOn": Record<string, string>;
@@ -2336,6 +2340,10 @@ declare namespace LocalJSX {
           * Specifies an explicit list of `allowedValues` in the Search API request, separated by commas.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values="Contact,Account,File"></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
         "allowedValues"?: string;
+        /**
+          * Specifies a custom order by which to sort the facet values.  Example: ```html <!-- Sort @ticketstatus facet values in a logical order for support tickets --> <atomic-facet field="@ticketstatus" custom-sort="New,Opened,Feedback,Resolved"></atomic-facet> ```
+         */
+        "customSort"?: string;
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -113,6 +113,16 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    */
   @Prop({reflect: true}) public sortCriteria: FacetSortCriterion = 'automatic';
   /**
+   * Specifies a custom order by which to sort the facet values.
+   *
+   * Example:
+   * ```html
+   * <!-- Sort @ticketstatus facet values in a logical order for support tickets -->
+   * <atomic-facet field="@ticketstatus" custom-sort="New,Opened,Feedback,Resolved"></atomic-facet>
+   * ```
+   */
+  @Prop({reflect: true}) public customSort?: string;
+  /**
    * Whether to display the facet values as checkboxes (multiple selection), links (single selection) or boxes (multiple selection).
    * Possible values are 'checkbox', 'link', and 'box'.
    */
@@ -137,8 +147,6 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    * Default: `1000`
    */
   @Prop() public injectionDepth = 1000;
-  // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
-
   /**
    * The required facets and values for this facet to be displayed.
    * Examples:
@@ -202,6 +210,13 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
       injectionDepth: this.injectionDepth,
       allowedValues: this.allowedValues?.trim().split(','),
     };
+
+    if (this.customSort) {
+      options.sortCriteria = {
+        type: 'custom',
+        customSort: this.customSort.split(','),
+      };
+    }
 
     this.facet = buildFacet(this.bindings.engine, {options});
     this.facetId = this.facet.state.facetId;

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
@@ -253,6 +253,18 @@ describe('facet', () => {
       expect(engine.actions).toContainEqual(action);
     });
 
+    it('dispatches a #updateFacetSortCriterion action with the passed explicit value', () => {
+      const criterion = {type: 'custom' as const, customSort: ['foo', 'bar']};
+      facet.sortBy(criterion);
+
+      const action = updateFacetSortCriterion({
+        facetId,
+        criterion,
+      });
+
+      expect(engine.actions).toContainEqual(action);
+    });
+
     it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
       facet.sortBy('score');
 
@@ -273,6 +285,50 @@ describe('facet', () => {
     setFacetRequest({sortCriteria: 'alphanumeric'});
 
     expect(facet.isSortedBy('score')).toBe(false);
+  });
+
+  it('when the passed explicit criterion matches the active sort explicit criterion, #isSortedBy returns true', () => {
+    const criterion = {type: 'custom' as const, customSort: ['foo', 'bar']};
+    setFacetRequest({sortCriteria: criterion});
+
+    expect(facet.isSortedBy(criterion)).toBe(true);
+  });
+
+  it('when the passed explicit criterion does not match the active sort explicit criterion, #isSortedBy returns false', () => {
+    const currentCriterion = {
+      type: 'custom' as const,
+      customSort: ['foo', 'bar'],
+    };
+    const targetCriterion = {
+      type: 'custom' as const,
+      customSort: ['foo', 'bazz'],
+    };
+    setFacetRequest({sortCriteria: currentCriterion});
+
+    expect(facet.isSortedBy(targetCriterion)).toBe(false);
+  });
+
+  it('when the passed string criterion does not match the active sort explicit criterion, #isSortedBy returns false', () => {
+    const currentCriterion = {
+      type: 'custom' as const,
+      customSort: ['foo', 'bar'],
+    };
+    const targetCriterion = 'occurrences';
+    setFacetRequest({sortCriteria: currentCriterion});
+
+    expect(facet.isSortedBy(targetCriterion)).toBe(false);
+  });
+
+  it('when the passed explicit criterion does not match the active sort string criterion, #isSortedBy returns false', () => {
+    const currentCriterion = 'occurrences';
+    const targetCriterion = {
+      type: 'custom' as const,
+      customSort: ['foo', 'bar'],
+    };
+
+    setFacetRequest({sortCriteria: currentCriterion});
+
+    expect(facet.isSortedBy(targetCriterion)).toBe(false);
   });
 
   describe('#showMoreValues', () => {

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -1,8 +1,5 @@
-import {Schema, StringValue} from '@coveo/bueno';
-import {
-  facetSortCriteria,
-  FacetSortCriterion,
-} from '../../../features/facets/facet-set/interfaces/request';
+import {Schema} from '@coveo/bueno';
+import {FaceSortCriterionStringOrExplicit} from '../../../features/facets/facet-set/interfaces/request';
 import {
   facetId,
   field,
@@ -69,7 +66,7 @@ export interface FacetOptions {
    *
    * @defaultValue `automatic`
    */
-  sortCriteria?: FacetSortCriterion;
+  sortCriteria?: FaceSortCriterionStringOrExplicit;
 
   /**
    * Specifies an explicit list of `allowedValues` in the Search API request.
@@ -109,14 +106,15 @@ export interface FacetSearchOptions {
   query?: string;
 }
 
-export const facetOptionsSchema = new Schema<Required<FacetOptions>>({
+export const facetOptionsSchema = new Schema<
+  Required<Omit<FacetOptions, 'sortCriteria'>>
+>({
   facetId,
   field,
   delimitingCharacter,
   filterFacetCount,
   injectionDepth,
   numberOfValues,
-  sortCriteria: new StringValue({constrainTo: facetSortCriteria}),
   facetSearch,
   allowedValues,
   hasBreadcrumbs,

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -10,11 +10,7 @@ import {
   logFacetSelect,
 } from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {FacetSortCriterion} from '../../../features/facets/facet-set/interfaces/request';
-import {
-  FacetOptions,
-  FacetSearchOptions,
-  facetOptionsSchema,
-} from './headless-facet-options';
+import {FacetOptions, FacetSearchOptions} from './headless-facet-options';
 import {FacetValueState} from '../../../features/facets/facet-api/value';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {
@@ -79,22 +75,18 @@ export function buildFacet(
   }
 
   const {dispatch} = engine;
-  const coreController = buildCoreFacet(
-    engine,
-    {
-      ...props,
-      options: {
-        ...props.options,
-        ...(props.options.allowedValues && {
-          allowedValues: {
-            type: 'simple',
-            values: props.options.allowedValues,
-          },
-        }),
-      },
+  const coreController = buildCoreFacet(engine, {
+    ...props,
+    options: {
+      ...props.options,
+      ...(props.options.allowedValues && {
+        allowedValues: {
+          type: 'simple',
+          values: props.options.allowedValues,
+        },
+      }),
     },
-    facetOptionsSchema
-  );
+  });
   const getFacetId = () => coreController.state.facetId;
 
   const createFacetSearch = () => {

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -1,5 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
-import {FacetSortCriterion} from './interfaces/request';
+import {FaceSortCriterionStringOrExplicit} from './interfaces/request';
 import {validatePayload} from '../../../utils/validate-payload';
 import {
   StringValue,
@@ -62,7 +62,7 @@ export interface RegisterFacetActionCreatorPayload {
    *
    * @defaultValue `automatic`
    */
-  sortCriteria?: FacetSortCriterion;
+  sortCriteria?: FaceSortCriterionStringOrExplicit;
 
   /**
    * Specifies an explicit list of `allowedValues` in the Search API request.
@@ -88,7 +88,7 @@ const facetRegistrationOptionsDefinition = {
   filterFacetCount: new BooleanValue({required: false}),
   injectionDepth: new NumberValue({required: false, min: 0}),
   numberOfValues: new NumberValue({required: false, min: 1}),
-  sortCriteria: new Value<FacetSortCriterion>({required: false}),
+  sortCriteria: new Value<FaceSortCriterionStringOrExplicit>({required: false}),
   allowedValues: allowedValues,
 };
 
@@ -133,7 +133,7 @@ export interface UpdateFacetSortCriterionActionCreatorPayload {
   /**
    * The criterion by which to sort the facet.
    */
-  criterion: FacetSortCriterion;
+  criterion: FaceSortCriterionStringOrExplicit;
 }
 
 export const updateFacetSortCriterion = createAction(
@@ -141,7 +141,7 @@ export const updateFacetSortCriterion = createAction(
   (payload: UpdateFacetSortCriterionActionCreatorPayload) =>
     validatePayload(payload, {
       facetId: facetIdDefinition,
-      criterion: new Value<FacetSortCriterion>({required: true}),
+      criterion: new Value<FaceSortCriterionStringOrExplicit>({required: true}),
     })
 );
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -365,6 +365,24 @@ describe('facet-set slice', () => {
     );
   });
 
+  it('dispatching #updateFacetSortCriterion with an explicit object update the state', () => {
+    const customSort = {customSort: ['foo', 'bar'], type: 'custom' as const};
+
+    buildRegistrationOptions({facetId: '1', field: 'author'});
+    const registedFacetState = facetSetReducer(
+      state,
+      registerFacet(buildRegistrationOptions({facetId: '1', field: 'author'}))
+    );
+    expect(registedFacetState['1'].sortCriteria).toBe('automatic');
+
+    const action = updateFacetSortCriterion({
+      facetId: '1',
+      criterion: customSort,
+    });
+    const newState = facetSetReducer(registedFacetState, action);
+    expect(newState['1'].sortCriteria).toMatchObject(customSort);
+  });
+
   it('dispatching #updateFacetNumberOfValues calls #handleFacetUpdateNumberOfValues', () => {
     jest.spyOn(FacetReducers, 'handleFacetUpdateNumberOfValues');
     facetSetReducer(

--- a/packages/headless/src/features/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/request.ts
@@ -4,7 +4,6 @@ import {
   Freezable,
   Delimitable,
   Type,
-  SortCriteria,
   BaseFacetValueRequest,
   Expandable,
   AllowedValues,
@@ -23,9 +22,20 @@ export type FacetSortCriterion =
   | 'occurrences'
   | 'automatic';
 
+export type BasicFacetSortCriterionOrCustom = FacetSortCriterion | 'custom';
+
 export interface FacetValueRequest extends BaseFacetValueRequest {
   value: string;
 }
+
+export type FacetSortCriterionExplicit = {
+  type: BasicFacetSortCriterionOrCustom;
+  customSort: string[];
+};
+
+export type FaceSortCriterionStringOrExplicit =
+  | FacetSortCriterion
+  | FacetSortCriterionExplicit;
 
 export interface FacetRequest
   extends BaseFacetRequest,
@@ -34,10 +44,8 @@ export interface FacetRequest
     Freezable,
     Delimitable,
     Type<'specific'>,
-    AllowedValues,
-    SortCriteria<FacetSortCriterion> {
-  /** @defaultValue `automatic` */
-  sortCriteria: FacetSortCriterion;
+    AllowedValues {
+  sortCriteria: FaceSortCriterionStringOrExplicit;
   hasBreadcrumbs?: boolean;
 }
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -97,6 +97,7 @@ export type {DateFacetValue} from './features/facets/range-facets/date-facet-set
 export type {
   FacetValueRequest,
   FacetSortCriterion,
+  FaceSortCriterionStringOrExplicit,
 } from './features/facets/facet-set/interfaces/request';
 export type {NumericRangeRequest} from './features/facets/range-facets/numeric-facet-set/interfaces/request';
 export type {NumericFacetValue} from './features/facets/range-facets/numeric-facet-set/interfaces/response';


### PR DESCRIPTION
There's some bug in the API still regarding the feature.

It does not properly handle case sensitivity for facet values, so in some cases the values are not ordered as they should be.

Ticket in search API: https://coveord.atlassian.net/browse/SEARCHAPI-7272


https://coveord.atlassian.net/browse/KIT-753