### PR TITLE
feat(quantic): added aria-pressed for pager

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
@@ -1,8 +1,3 @@
 <template>
-  <template if:true={selected}>
-    <button class="slds-button slds-button_brand slds-m-left_xx-small" aria-pressed="true" key={pageNumber} onclick={select}>{number}</button>
-  </template>
-  <template if:false={selected}>
-    <button class="slds-button slds-button_outline-brand slds-m-left_xx-small" aria-pressed="false" key={pageNumber} onclick={select}>{number}</button>
-  </template>
+  <button class={buttonClasses} aria-pressed={isPressed} key={pageNumber} onclick={select}>{number}</button>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
@@ -1,11 +1,8 @@
 <template>
-  <lightning-button
-    key={pageNumber}
-    variant={variant}
-    label={number}
-    title={number}
-    class="slds-m-left_xx-small"
-    value={number}
-    onclick={select}
-  ></lightning-button>
+  <template if:true={selected}>
+    <button class="slds-button slds-button_brand slds-m-left_xx-small" aria-pressed="true" key={pageNumber} onclick={select}>{number}</button>
+  </template>
+  <template if:false={selected}>
+    <button class="slds-button slds-button_outline-brand slds-m-left_xx-small" aria-pressed="false" key={pageNumber} onclick={select}>{number}</button>
+  </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
@@ -25,6 +25,14 @@ export default class QuanticNumberButton extends LightningElement {
     return `${this.selected}`;
   }
 
+  get buttonClasses() {
+    const classes = ['slds-button', 'slds-m-left__xx-small'];
+    classes.push(
+      this.selected ? 'slds-button_brand' : 'slds-button_outline-brand'
+    );
+    return classes.join(' ');
+  }
+
   select() {
     this.dispatchEvent(new CustomEvent('select', {detail: this.number}));
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
@@ -21,8 +21,8 @@ export default class QuanticNumberButton extends LightningElement {
    */
   @api selected;
 
-  get variant() {
-    return this.selected ? 'brand' : 'brand-outline';
+  get isPressed() {
+    return `${this.selected}`;
   }
 
   select() {


### PR DESCRIPTION
[2306](https://coveord.atlassian.net/browse/SVCC-2306)

Facet Values’ aria-pressed is implemented along with `SVCC-2272`

Both QuanticPager and QuanticResultsPerPage render quanticNumberButton, so changes are applied to quanticNumberButton. `<lightning-button>` is replaced by `<button>`, since it does not support "aria-pressed".