### PR TITLE
feat(atomic): added query trigger to `atomic-did-you-mean` component

### DIFF
--- a/packages/atomic/cypress/integration/did-you-mean-actions.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-actions.ts
@@ -1,0 +1,33 @@
+import {
+  addTag,
+  interceptSearchResponse,
+  TagProps,
+  TestFixture,
+} from '../fixtures/test-fixture';
+import {didYouMeanComponent} from './did-you-mean-selectors';
+
+export const addDidYouMean =
+  (props: TagProps = {}) =>
+  (env: TestFixture) => {
+    addTag(env, didYouMeanComponent, props);
+  };
+
+export const addDidYouMeanCorrectionToNextQuery = (
+  correction: string,
+  automatic: boolean
+) =>
+  interceptSearchResponse((response) => {
+    response.queryCorrections = [
+      {correctedQuery: correction, wordCorrections: []},
+    ];
+    if (automatic) {
+      response.results = [];
+    }
+    return response;
+  }, 1);
+
+export const addQueryTriggerCorrectionToNextQuery = (correction: string) =>
+  interceptSearchResponse((response) => {
+    response.triggers = [{type: 'query', content: correction}];
+    return response;
+  }, 1);

--- a/packages/atomic/cypress/integration/did-you-mean-assertions.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-assertions.ts
@@ -23,8 +23,13 @@ export function assertDisplayQueryTriggered(display: boolean) {
   });
 }
 
-export function assertDisplayCorrectionButton(display: boolean) {
-  it(`${should(display)} display a manual correction button`, () => {
+export function assertDisplayDidYouMeanWithButton(display: boolean) {
+  it(`${should(
+    display
+  )} display "did you mean" text with a manual correction button`, () => {
+    DidYouMeanSelectors.didYouMean().should(
+      display ? 'be.visible' : 'not.exist'
+    );
     DidYouMeanSelectors.correctionButton().should(
       display ? 'be.visible' : 'not.exist'
     );

--- a/packages/atomic/cypress/integration/did-you-mean-assertions.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-assertions.ts
@@ -1,0 +1,54 @@
+import {should} from './common-assertions';
+import {DidYouMeanSelectors} from './did-you-mean-selectors';
+
+export function assertDisplayAutoCorrected(display: boolean) {
+  it(`${should(display)} display auto corrected text`, () => {
+    DidYouMeanSelectors.noResults().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+    DidYouMeanSelectors.autoCorrected().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayQueryTriggered(display: boolean) {
+  it(`${should(display)} display query triggered text`, () => {
+    DidYouMeanSelectors.showingResultsFor().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+    DidYouMeanSelectors.searchInsteadFor().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayCorrectionButton(display: boolean) {
+  it(`${should(display)} display a manual correction button`, () => {
+    DidYouMeanSelectors.correctionButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertDisplayUndoButton(display: boolean) {
+  it(`${should(display)} display a undo button`, () => {
+    DidYouMeanSelectors.undoButton().should(
+      display ? 'be.visible' : 'not.exist'
+    );
+  });
+}
+
+export function assertLogDidYouMeanClick() {
+  it('should log didyoumeanClick to UA', () => {
+    cy.expectSearchEvent('didyoumeanClick');
+  });
+}
+
+export function assertLogQueryTriggerUndo(undoneQuery: string) {
+  it('should log the undoQuery to UA', () => {
+    cy.expectSearchEvent('undoQuery').then((payload) =>
+      expect(payload.customData).to.have.property('undoneQuery', undoneQuery)
+    );
+  });
+}

--- a/packages/atomic/cypress/integration/did-you-mean-selectors.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-selectors.ts
@@ -1,0 +1,14 @@
+export const didYouMeanComponent = 'atomic-did-you-mean';
+export const DidYouMeanSelectors = {
+  shadow: () => cy.get(didYouMeanComponent).shadow(),
+  noResults: () => DidYouMeanSelectors.shadow().find('[part="no-results"]'),
+  autoCorrected: () =>
+    DidYouMeanSelectors.shadow().find('[part="auto-corrected"]'),
+  showingResultsFor: () =>
+    DidYouMeanSelectors.shadow().find('[part="showing-results-for"]'),
+  searchInsteadFor: () =>
+    DidYouMeanSelectors.shadow().find('[part="search-instead-for"]'),
+  correctionButton: () =>
+    DidYouMeanSelectors.shadow().find('[part="correction-btn"]'),
+  undoButton: () => DidYouMeanSelectors.shadow().find('[part="undo-btn"]'),
+};

--- a/packages/atomic/cypress/integration/did-you-mean-selectors.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-selectors.ts
@@ -8,6 +8,7 @@ export const DidYouMeanSelectors = {
     DidYouMeanSelectors.shadow().find('[part="showing-results-for"]'),
   searchInsteadFor: () =>
     DidYouMeanSelectors.shadow().find('[part="search-instead-for"]'),
+  didYouMean: () => DidYouMeanSelectors.shadow().find('[part="did-you-mean"]'),
   correctionButton: () =>
     DidYouMeanSelectors.shadow().find('[part="correction-btn"]'),
   undoButton: () => DidYouMeanSelectors.shadow().find('[part="undo-btn"]'),

--- a/packages/atomic/cypress/integration/did-you-mean.cypress.ts
+++ b/packages/atomic/cypress/integration/did-you-mean.cypress.ts
@@ -1,0 +1,114 @@
+import {TestFixture} from '../fixtures/test-fixture';
+import {
+  addDidYouMean,
+  addDidYouMeanCorrectionToNextQuery,
+  addQueryTriggerCorrectionToNextQuery,
+} from './did-you-mean-actions';
+import {DidYouMeanSelectors} from './did-you-mean-selectors';
+import * as DidYouMeanAssertions from './did-you-mean-assertions';
+import {addQuerySummary} from './query-summary-actions';
+import * as QuerySummaryAssertions from './query-summary-assertions';
+import {addSearchBox} from './search-box/search-box-actions';
+import {SearchBoxSelectors} from './search-box/search-box-selectors';
+
+describe('Did You Mean Test Suites', () => {
+  const originalQuery = 'test';
+  const newQuery = 'shrimp';
+
+  function commonSetup(env: TestFixture) {
+    env.with(addSearchBox()).with(addQuerySummary()).with(addDidYouMean());
+  }
+
+  function search() {
+    SearchBoxSelectors.inputBox().type(`${originalQuery}{enter}`, {
+      force: true,
+    });
+  }
+
+  describe('with an automatic query correction', () => {
+    before(() => {
+      new TestFixture().with(commonSetup).init();
+      addDidYouMeanCorrectionToNextQuery(newQuery, true);
+      search();
+    });
+
+    QuerySummaryAssertions.assertHasQuery(newQuery);
+    DidYouMeanAssertions.assertDisplayAutoCorrected(true);
+    DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+    DidYouMeanAssertions.assertDisplayQueryTriggered(false);
+    DidYouMeanAssertions.assertDisplayUndoButton(false);
+  });
+
+  describe('with a manual query correction', () => {
+    before(() => {
+      new TestFixture().with(commonSetup).init();
+      addDidYouMeanCorrectionToNextQuery(newQuery, false);
+      search();
+    });
+
+    QuerySummaryAssertions.assertHasQuery(originalQuery);
+    DidYouMeanAssertions.assertDisplayAutoCorrected(false);
+    DidYouMeanAssertions.assertDisplayCorrectionButton(true);
+    DidYouMeanAssertions.assertDisplayQueryTriggered(false);
+    DidYouMeanAssertions.assertDisplayUndoButton(false);
+
+    describe('after pressing on the correction button', () => {
+      before(() => {
+        DidYouMeanSelectors.correctionButton().click();
+      });
+      QuerySummaryAssertions.assertHasQuery(newQuery);
+      DidYouMeanAssertions.assertDisplayAutoCorrected(false);
+      DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+      DidYouMeanAssertions.assertDisplayQueryTriggered(false);
+      DidYouMeanAssertions.assertDisplayUndoButton(false);
+    });
+  });
+
+  describe('after correcting a query', () => {
+    beforeEach(() => {
+      new TestFixture().with(commonSetup).init();
+      addDidYouMeanCorrectionToNextQuery(newQuery, false);
+      search();
+      DidYouMeanSelectors.correctionButton().click();
+    });
+
+    DidYouMeanAssertions.assertLogDidYouMeanClick();
+  });
+
+  describe('with a query trigger', () => {
+    before(() => {
+      new TestFixture().with(commonSetup).init();
+      addQueryTriggerCorrectionToNextQuery(newQuery);
+      search();
+    });
+
+    QuerySummaryAssertions.assertHasQuery(newQuery);
+    DidYouMeanAssertions.assertDisplayAutoCorrected(false);
+    DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+    DidYouMeanAssertions.assertDisplayQueryTriggered(true);
+    DidYouMeanAssertions.assertDisplayUndoButton(true);
+
+    describe('after pressing on the undo button', () => {
+      before(() => {
+        DidYouMeanSelectors.undoButton().click();
+      });
+
+      QuerySummaryAssertions.assertHasQuery(originalQuery);
+      DidYouMeanAssertions.assertDisplayAutoCorrected(false);
+      DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+      DidYouMeanAssertions.assertDisplayQueryTriggered(false);
+      DidYouMeanAssertions.assertDisplayUndoButton(false);
+    });
+  });
+
+  describe('after undoing a query', () => {
+    beforeEach(() => {
+      new TestFixture().with(commonSetup).init();
+      addQueryTriggerCorrectionToNextQuery(newQuery);
+      search();
+      DidYouMeanSelectors.undoButton().click();
+    });
+
+    DidYouMeanAssertions.assertLogQueryTriggerUndo(newQuery);
+  });
+});

--- a/packages/atomic/cypress/integration/did-you-mean.cypress.ts
+++ b/packages/atomic/cypress/integration/did-you-mean.cypress.ts
@@ -34,7 +34,7 @@ describe('Did You Mean Test Suites', () => {
 
     QuerySummaryAssertions.assertHasQuery(newQuery);
     DidYouMeanAssertions.assertDisplayAutoCorrected(true);
-    DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+    DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
     DidYouMeanAssertions.assertDisplayQueryTriggered(false);
     DidYouMeanAssertions.assertDisplayUndoButton(false);
   });
@@ -48,7 +48,7 @@ describe('Did You Mean Test Suites', () => {
 
     QuerySummaryAssertions.assertHasQuery(originalQuery);
     DidYouMeanAssertions.assertDisplayAutoCorrected(false);
-    DidYouMeanAssertions.assertDisplayCorrectionButton(true);
+    DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(true);
     DidYouMeanAssertions.assertDisplayQueryTriggered(false);
     DidYouMeanAssertions.assertDisplayUndoButton(false);
 
@@ -58,7 +58,7 @@ describe('Did You Mean Test Suites', () => {
       });
       QuerySummaryAssertions.assertHasQuery(newQuery);
       DidYouMeanAssertions.assertDisplayAutoCorrected(false);
-      DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+      DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
       DidYouMeanAssertions.assertDisplayQueryTriggered(false);
       DidYouMeanAssertions.assertDisplayUndoButton(false);
     });
@@ -84,7 +84,7 @@ describe('Did You Mean Test Suites', () => {
 
     QuerySummaryAssertions.assertHasQuery(newQuery);
     DidYouMeanAssertions.assertDisplayAutoCorrected(false);
-    DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+    DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
     DidYouMeanAssertions.assertDisplayQueryTriggered(true);
     DidYouMeanAssertions.assertDisplayUndoButton(true);
 
@@ -95,7 +95,7 @@ describe('Did You Mean Test Suites', () => {
 
       QuerySummaryAssertions.assertHasQuery(originalQuery);
       DidYouMeanAssertions.assertDisplayAutoCorrected(false);
-      DidYouMeanAssertions.assertDisplayCorrectionButton(false);
+      DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
       DidYouMeanAssertions.assertDisplayQueryTriggered(false);
       DidYouMeanAssertions.assertDisplayUndoButton(false);
     });

--- a/packages/atomic/cypress/integration/query-summary-assertions.ts
+++ b/packages/atomic/cypress/integration/query-summary-assertions.ts
@@ -17,3 +17,11 @@ export function assertHasPlaceholder() {
     QuerySummarySelectors.placeholder().should('be.visible');
   });
 }
+
+export function assertHasQuery(text: string) {
+  it(`the query should be "${text}"`, () => {
+    QuerySummarySelectors.query().should(($el) =>
+      expect($el.text()).to.equal(text)
+    );
+  });
+}

--- a/packages/atomic/cypress/integration/query-summary-selectors.ts
+++ b/packages/atomic/cypress/integration/query-summary-selectors.ts
@@ -8,5 +8,6 @@ export const QuerySummarySelectors = {
     QuerySummarySelectors.shadow().find('[part="placeholder"]'),
   container: () => QuerySummarySelectors.shadow().find('[part="container"]'),
   duration: () => QuerySummarySelectors.shadow().find('[part="duration"]'),
+  query: () => QuerySummarySelectors.shadow().find('[part~="query"]'),
   ariaLive: () => AriaLiveSelectors.region('query-summary'),
 };

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -23,6 +23,7 @@ import {LocalizedString} from '../../../utils/jsx-utils';
  * @part auto-corrected - The text displayed for the automatically corrected query.
  * @part showing-results-for - The first paragraph of the text displayed when a query trigger changes a query.
  * @part search-instead-for - The second paragraph of the text displayed when a query trigger changes a query.
+ * @part did-you-mean - The text displayed around the button to manually correct a query.
  * @part correction-btn - The button used to manually correct a query.
  * @part undo-btn - The button used to undo a query changed by a query trigger.
  * @part highlight - The query highlights.
@@ -51,11 +52,7 @@ export class AtomicDidYouMean implements InitializableComponent {
   }
 
   private withQuery(
-    key:
-      | 'no-results-for'
-      | 'query-auto-corrected-to'
-      | 'did-you-mean'
-      | 'showing-results-for',
+    key: 'no-results-for' | 'query-auto-corrected-to' | 'showing-results-for',
     query: string
   ) {
     return (
@@ -124,16 +121,23 @@ export class AtomicDidYouMean implements InitializableComponent {
 
   private renderDidYouMeanCorrection() {
     return (
-      <button
-        class="link py-1"
-        part="correction-btn"
-        onClick={() => this.didYouMean.applyCorrection()}
-      >
-        {this.withQuery(
-          'did-you-mean',
-          this.didYouMeanState!.queryCorrection.correctedQuery
-        )}
-      </button>
+      <p class="text-on-background" part="did-you-mean">
+        <LocalizedString
+          bindings={this.bindings}
+          key="did-you-mean"
+          params={{
+            query: (
+              <button
+                class="link py-1"
+                part="correction-btn"
+                onClick={() => this.didYouMean.applyCorrection()}
+              >
+                {this.didYouMeanState!.queryCorrection.correctedQuery}
+              </button>
+            ),
+          }}
+        />
+      </p>
     );
   }
 

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -612,6 +612,14 @@
     "zh-CN": "没有找到与 {{query}} 相关的结果",
     "zh-TW": "沒有找到與 {{query}} 相關的結果"
   },
+  "showing-results-for": {
+    "en": "Showing results for {{query}}",
+    "fr": "Résultats affichés pour {{query}}"
+  },
+  "search-instead-for": {
+    "en": "Search instead for {{query}}",
+    "fr": "Rechercher à la place {{query}}"
+  },
   "search-tips": {
     "en": "You may want to try using different keywords, deselecting filters, or checking for spelling mistakes.",
     "fr": "Essayez différents mots-clés, déselectionnez des filtres ou vérifiez l'orthographe de vos mots-clés."

--- a/packages/atomic/src/utils/jsx-utils.tsx
+++ b/packages/atomic/src/utils/jsx-utils.tsx
@@ -1,0 +1,44 @@
+import {Fragment, FunctionalComponent, h, VNode} from '@stencil/core';
+import {AnyBindings} from '../components/common/interface/bindings';
+
+export interface LocalizedStringProps {
+  bindings: AnyBindings;
+  key: string;
+  params: Record<string, VNode | string>;
+}
+
+export const LocalizedString: FunctionalComponent<LocalizedStringProps> = ({
+  bindings,
+  key,
+  params,
+}) => {
+  const delimitingCharacter = '\u001d'; // Unicode group separator
+  const placeholderPrefixCharacter = '\u001a'; // Unicode substitute character
+  const getPlaceholderForParamKey = (paramKey: string) =>
+    `${delimitingCharacter}${placeholderPrefixCharacter}${paramKey}${delimitingCharacter}`;
+  const getParamFromPlaceholder = (placeholder: string) =>
+    params[placeholder.slice(1)];
+
+  const placeholdersMap = Object.fromEntries(
+    Object.keys(params).map((paramKey) => [
+      paramKey,
+      getPlaceholderForParamKey(paramKey),
+    ])
+  );
+  const localizedStringWithPlaceholders = bindings.i18n.t(key, {
+    interpolation: {escapeValue: false},
+    ...placeholdersMap,
+  });
+
+  return (
+    <Fragment>
+      {localizedStringWithPlaceholders
+        .split(delimitingCharacter)
+        .map((text) =>
+          text.startsWith(placeholderPrefixCharacter)
+            ? getParamFromPlaceholder(text)
+            : text
+        )}
+    </Fragment>
+  );
+};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1932

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/54454747/184655909-5bc7c5dd-cf82-4027-b1e5-e5afbd3f7d0b.png">

Hovered:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/54454747/184655959-e898672f-02a0-4f30-bda6-f33c97afe812.png">

I also changed the manual did you mean appearance (based on Johnny's feedback).
<table>
  <tr>
    <th>Before
    <th>After
  <tr>
    <td>

![image](https://user-images.githubusercontent.com/54454747/184663447-a5ccadd9-7dd1-428b-afec-60bf076043ef.png)
    <td>

![image](https://user-images.githubusercontent.com/54454747/184663472-b814a8ac-57d5-40a1-aae3-ef135e80f9bb.png)

