### PR TITLE
chore(atomic): os-agnostic filecheck

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -51,7 +51,7 @@
     "build:storybook": "npm run storybook:lit-analyze && build-storybook && ncp dist/ storybook-static/",
     "storybook:lit-analyze": "lit-analyzer dist/types/components.d.ts src/components/**/*.stories.tsx",
     "doc:list-assets": "node scripts/list-assets.js",
-    "validate:definitions": "! tsc --allowSyntheticDefaultImports dist/types/index.d.ts | grep -q 'components.d.ts'"
+    "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts"
   },
   "dependencies": {
     "@coveo/bueno": "0.42.1",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1961

Previous steps (should) already have emitted the types, so we just need to check the files exists and that it's valid.
This tsc command will do it.

@lvu285, if you can confirm that it addresses your problem, it'd be nice ;) 