### PR TITLE
fix(atomic): made search box suggestions usable on iOS VoiceOver

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -238,6 +238,8 @@ export namespace Components {
          */
         "ifNotDefined"?: string;
     }
+    interface AtomicFocusDetector {
+    }
     interface AtomicFocusTrap {
         "active": boolean;
         /**
@@ -1575,6 +1577,12 @@ declare global {
         prototype: HTMLAtomicFieldConditionElement;
         new (): HTMLAtomicFieldConditionElement;
     };
+    interface HTMLAtomicFocusDetectorElement extends Components.AtomicFocusDetector, HTMLStencilElement {
+    }
+    var HTMLAtomicFocusDetectorElement: {
+        prototype: HTMLAtomicFocusDetectorElement;
+        new (): HTMLAtomicFocusDetectorElement;
+    };
     interface HTMLAtomicFocusTrapElement extends Components.AtomicFocusTrap, HTMLStencilElement {
     }
     var HTMLAtomicFocusTrapElement: {
@@ -2128,6 +2136,7 @@ declare global {
         "atomic-facet-manager": HTMLAtomicFacetManagerElement;
         "atomic-facet-number-input": HTMLAtomicFacetNumberInputElement;
         "atomic-field-condition": HTMLAtomicFieldConditionElement;
+        "atomic-focus-detector": HTMLAtomicFocusDetectorElement;
         "atomic-focus-trap": HTMLAtomicFocusTrapElement;
         "atomic-folded-result-list": HTMLAtomicFoldedResultListElement;
         "atomic-format-currency": HTMLAtomicFormatCurrencyElement;
@@ -2433,6 +2442,10 @@ declare namespace LocalJSX {
           * Verifies whether the specified fields are not defined.
          */
         "ifNotDefined"?: string;
+    }
+    interface AtomicFocusDetector {
+        "onFocusEnter"?: (event: CustomEvent<any>) => void;
+        "onFocusExit"?: (event: CustomEvent<any>) => void;
     }
     interface AtomicFocusTrap {
         "active"?: boolean;
@@ -3664,6 +3677,7 @@ declare namespace LocalJSX {
         "atomic-facet-manager": AtomicFacetManager;
         "atomic-facet-number-input": AtomicFacetNumberInput;
         "atomic-field-condition": AtomicFieldCondition;
+        "atomic-focus-detector": AtomicFocusDetector;
         "atomic-focus-trap": AtomicFocusTrap;
         "atomic-folded-result-list": AtomicFoldedResultList;
         "atomic-format-currency": AtomicFormatCurrency;
@@ -3772,6 +3786,7 @@ declare module "@stencil/core" {
             "atomic-facet-manager": LocalJSX.AtomicFacetManager & JSXBase.HTMLAttributes<HTMLAtomicFacetManagerElement>;
             "atomic-facet-number-input": LocalJSX.AtomicFacetNumberInput & JSXBase.HTMLAttributes<HTMLAtomicFacetNumberInputElement>;
             "atomic-field-condition": LocalJSX.AtomicFieldCondition & JSXBase.HTMLAttributes<HTMLAtomicFieldConditionElement>;
+            "atomic-focus-detector": LocalJSX.AtomicFocusDetector & JSXBase.HTMLAttributes<HTMLAtomicFocusDetectorElement>;
             "atomic-focus-trap": LocalJSX.AtomicFocusTrap & JSXBase.HTMLAttributes<HTMLAtomicFocusTrapElement>;
             "atomic-folded-result-list": LocalJSX.AtomicFoldedResultList & JSXBase.HTMLAttributes<HTMLAtomicFoldedResultListElement>;
             "atomic-format-currency": LocalJSX.AtomicFormatCurrency & JSXBase.HTMLAttributes<HTMLAtomicFormatCurrencyElement>;

--- a/packages/atomic/src/components/common/atomic-focus-detector.tsx
+++ b/packages/atomic/src/components/common/atomic-focus-detector.tsx
@@ -1,0 +1,56 @@
+import {
+  h,
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Listen,
+  Host,
+} from '@stencil/core';
+import {getFocusedElement, isAncestorOf} from '../../utils/utils';
+
+/**
+ * @internal
+ */
+@Component({
+  tag: 'atomic-focus-detector',
+  shadow: false,
+})
+export class AtomicFocusDetector {
+  @Element() private host!: HTMLElement;
+
+  @Event() focusEnter!: EventEmitter;
+  @Event() focusExit!: EventEmitter;
+
+  private focusWasContained = this.containsFocus;
+
+  private get containsFocus() {
+    const focusedElement = getFocusedElement();
+
+    return !!focusedElement && isAncestorOf(this.host, focusedElement);
+  }
+
+  @Listen('focusin', {target: 'document'})
+  onFocusIn() {
+    this.onFocusChanged();
+  }
+
+  @Listen('focusout', {target: 'document'})
+  onFocusOut() {
+    this.onFocusChanged();
+  }
+
+  private onFocusChanged() {
+    const containsFocus = this.containsFocus;
+    if (containsFocus === this.focusWasContained) {
+      return;
+    }
+
+    this.focusWasContained = containsFocus;
+    containsFocus ? this.focusEnter.emit() : this.focusExit.emit();
+  }
+
+  render() {
+    return <Host style={{display: 'contents'}}></Host>;
+  }
+}

--- a/packages/atomic/src/components/common/atomic-focus-trap.tsx
+++ b/packages/atomic/src/components/common/atomic-focus-trap.tsx
@@ -1,34 +1,11 @@
 import {Component, Element, Listen, Prop, Watch} from '@stencil/core';
 import {getFirstFocusableDescendant} from '../../utils/accessibility-utils';
-import {defer, getFocusedElement} from '../../utils/utils';
-
-function getParent(element: Element | ShadowRoot) {
-  if (element.parentNode) {
-    return element.parentNode as Element | ShadowRoot;
-  }
-  if (element instanceof ShadowRoot) {
-    return element.host;
-  }
-  return null;
-}
-
-function contains(
-  ancestor: Element | ShadowRoot,
-  element: Element | ShadowRoot
-): boolean {
-  if (element === ancestor) {
-    return true;
-  }
-  if (
-    element instanceof HTMLElement &&
-    element.assignedSlot &&
-    contains(ancestor, element.assignedSlot)
-  ) {
-    return true;
-  }
-  const parent = getParent(element);
-  return parent === null ? false : contains(ancestor, parent);
-}
+import {
+  isAncestorOf,
+  defer,
+  getFocusedElement,
+  getParent,
+} from '../../utils/utils';
 
 /**
  * @internal
@@ -74,7 +51,10 @@ export class AtomicFocusTrap {
       if (sibling === element) {
         return;
       }
-      if (sibling.assignedSlot && contains(this.host, sibling.assignedSlot)) {
+      if (
+        sibling.assignedSlot &&
+        isAncestorOf(this.host, sibling.assignedSlot)
+      ) {
         return;
       }
       this.hide(sibling);
@@ -130,7 +110,7 @@ export class AtomicFocusTrap {
 
     const focusedElement = getFocusedElement();
 
-    if (focusedElement && contains(this.host, focusedElement)) {
+    if (focusedElement && isAncestorOf(this.host, focusedElement)) {
       return;
     }
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -560,6 +560,9 @@ export class AtomicSearchBox {
           this.focusPanel(this.leftPanelRef);
         }
         break;
+      case 'Tab':
+        this.clearSuggestions();
+        break;
     }
   }
 
@@ -737,28 +740,29 @@ export class AtomicSearchBox {
     this.updateBreakpoints();
     return [
       <SearchBoxWrapper disabled={this.disableSearch}>
-        <SearchInput
-          inputRef={this.inputRef}
-          loading={this.searchBoxState.isLoading}
-          ref={(el) => (this.inputRef = el as HTMLInputElement)}
-          bindings={this.bindings}
-          value={this.searchBoxState.value}
-          ariaLabel={this.getSearchInputLabel()}
-          onFocus={() => this.onFocus()}
-          onInput={(e) => this.onInput((e.target as HTMLInputElement).value)}
-          onBlur={() => this.clearSuggestions()}
-          onKeyDown={(e) => this.onKeyDown(e)}
-          onClear={() => this.searchBox.clear()}
-          aria-controls={this.popupId}
-          role="combobox"
-          aria-activedescendant={this.activeDescendant}
-        />
-        {this.renderSuggestions()}
-        <SubmitButton
-          bindings={this.bindings}
-          disabled={this.disableSearch}
-          onClick={() => this.searchBox.submit()}
-        />
+        <atomic-focus-detector onFocusExit={() => this.clearSuggestions()}>
+          <SearchInput
+            inputRef={this.inputRef}
+            loading={this.searchBoxState.isLoading}
+            ref={(el) => (this.inputRef = el as HTMLInputElement)}
+            bindings={this.bindings}
+            value={this.searchBoxState.value}
+            ariaLabel={this.getSearchInputLabel()}
+            onFocus={() => this.onFocus()}
+            onInput={(e) => this.onInput((e.target as HTMLInputElement).value)}
+            onKeyDown={(e) => this.onKeyDown(e)}
+            onClear={() => this.searchBox.clear()}
+            aria-controls={this.popupId}
+            role="combobox"
+            aria-activedescendant={this.activeDescendant}
+          />
+          {this.renderSuggestions()}
+          <SubmitButton
+            bindings={this.bindings}
+            disabled={this.disableSearch}
+            onClick={() => this.searchBox.submit()}
+          />
+        </atomic-focus-detector>
       </SearchBoxWrapper>,
       !this.suggestions.length && (
         <slot>

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -191,3 +191,31 @@ export function getUniqueItemsByProperties<Item extends object>(
       )
   );
 }
+
+export function getParent(element: Element | ShadowRoot) {
+  if (element.parentNode) {
+    return element.parentNode as Element | ShadowRoot;
+  }
+  if (element instanceof ShadowRoot) {
+    return element.host;
+  }
+  return null;
+}
+
+export function isAncestorOf(
+  ancestor: Element | ShadowRoot,
+  element: Element | ShadowRoot
+): boolean {
+  if (element === ancestor) {
+    return true;
+  }
+  if (
+    element instanceof HTMLElement &&
+    element.assignedSlot &&
+    isAncestorOf(ancestor, element.assignedSlot)
+  ) {
+    return true;
+  }
+  const parent = getParent(element);
+  return parent === null ? false : isAncestorOf(ancestor, parent);
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1941

iOS VoiceOver was calling the input's `onBlur`, which cleared suggestions.

Instead of detecting `blur` on the search input, I'm detecting when the entire search box component is blurred, and closing suggestions when `tab` is pressed to maintain the normal behaviour on desktop.