### PR TITLE
feat(quantic): added focus indicator for facet addMore addLess buttons.

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
@@ -17,7 +17,7 @@
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
           <button
-            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small"
+            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small"
             onclick={clearSelections}
           >
             <lightning-icon

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -17,7 +17,7 @@
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
           <button
-            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small"
+            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small"
             onclick={clearSelections}
           >
             <lightning-icon

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
@@ -1,6 +1,5 @@
 .facet__show-less {
   font-size: 12px;
-  outline: 0;
   background-color: white;
   color: #8e959d;
   border: none;
@@ -9,7 +8,6 @@
 
 .facet__show-more {
   font-size: 12px;
-  outline: 0;
   background-color: white;
   color: var(--lwc-brandTextLink, dodgerblue);
   border: none;

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
@@ -38,9 +38,3 @@
 .facet__clear-filter {
   line-height: inherit;
 }
-
-.facet__clear-filter:focus {
-  outline: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
@@ -17,7 +17,7 @@
         </lightning-button-icon>
         <template if:true={hasActiveValues}>
           <button
-            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-var-p-top_x-small slds-var-p-horizontal_x-small"
+            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-var-p-horizontal_x-small"
             onclick={clearSelections}
           >
             <lightning-icon

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
@@ -4,7 +4,7 @@
       <div class="slds-combobox_container">
         <div
           class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click"
-          aria-expanded="true"
+          aria-expanded="false"
           aria-haspopup="listbox"
           role="combobox"
         >

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -19,7 +19,7 @@
 
         <template if:true={hasActiveValues}>
           <button
-            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-top_x-small slds-p-horizontal_x-small"
+            class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small"
             onclick={clearSelections}
           >
             <lightning-icon


### PR DESCRIPTION
[SVCC-2302](https://coveord.atlassian.net/browse/SVCC-2302)
Removed `outline : 0` in order to display borders when `focus-visible` is active
After the changes:
<img width="271" alt="Screen Shot 2022-08-16 at 2 03 16 PM" src="https://user-images.githubusercontent.com/108746208/185228511-18a596ae-1d27-409a-8962-98245712d956.png">


[SVCC-2381](https://coveord.atlassian.net/browse/SVCC-2381)
Removed `outline : 0` in order to display borders when `focus-visible` is active
<img width="313" alt="Screen Shot 2022-08-17 at 3 41 56 PM" src="https://user-images.githubusercontent.com/108746208/185228526-bbdc6930-5acd-4dd5-913c-c57fc4d7510c.png">





[SVCC-2309](https://coveord.atlassian.net/browse/SVCC-2309)