### PR TITLE
feat(atomic, headless): clear segmented facet (hasBreadcrumb) values on new query

### DIFF
--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -337,19 +337,10 @@ describe('facet-set slice', () => {
     jest.spyOn(FacetReducers, 'handleFacetDeselectAll').mockReset();
 
     state['1'] = buildMockFacetRequest();
-    state['2'] = buildMockFacetRequest();
+    state['2'] = buildMockFacetRequest({hasBreadcrumbs: false});
     facetSetReducer(state, deselectAllBreadcrumbs());
 
     expect(FacetReducers.handleFacetDeselectAll).toHaveBeenCalledTimes(2);
-  });
-
-  it('dispatching #deselectAllBreadcrumbs does not call #handleFacetDeselectAll for a facet where hasBreadcrumbs is false', () => {
-    jest.spyOn(FacetReducers, 'handleFacetDeselectAll').mockReset();
-
-    state['1'] = buildMockFacetRequest({hasBreadcrumbs: false});
-    facetSetReducer(state, deselectAllBreadcrumbs());
-
-    expect(FacetReducers.handleFacetDeselectAll).toHaveBeenCalledTimes(0);
   });
 
   it('dispatching #updateFacetSortCriterion calls #handleFacetSortCriterionUpdate', () => {

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -121,12 +121,10 @@ export const facetSetReducer = createReducer(
         });
       })
       .addCase(deselectAllBreadcrumbs, (state) => {
-        Object.values(state)
-          .filter((req) => req.hasBreadcrumbs)
-          .forEach((req) => {
-            const request = state[req.facetId];
-            handleFacetDeselectAll(request);
-          });
+        Object.values(state).forEach((req) => {
+          const request = state[req.facetId];
+          handleFacetDeselectAll(request);
+        });
       })
       .addCase(updateFacetAutoSelection, (state, action) =>
         Object.keys(state).forEach((facetId) => {


### PR DESCRIPTION
After a discussion with UX...
If we want to provide an option we'd do it for all facets as we previously discussed

https://coveord.atlassian.net/browse/KIT-1965