### PR TITLE
docs(atomic): move mustMatch and mustNotMatch annotations

### DIFF
--- a/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.tsx
@@ -10,8 +10,8 @@ import {makeMatchConditions} from '../../../common/result-template/result-templa
 
 /**
  * The `atomic-field-condition` component takes a list of conditions that, if fulfilled, apply the template in which it's defined.
- * @MapProp name: mustMatch;attr: must-match;docs: Creates a condition which verifies that a field's value contains any of the specified values.;type: Record<string, string[]> ;default: {}
- * @MapProp name: mustNotMatch;attr: must-not-match;docs: Creates a condition which verifies that a field's value doesn't contain any of the specified values.;type: Record<string, string[]> ;default: {}
+ * @MapProp name: mustMatch;attr: must-match;docs: The field and values that define which result items the condition must be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`;type: Record<string, string[]> ;default: {}
+ * @MapProp name: mustNotMatch;attr: must-not-match;docs: The field and values that define which result items the condition must not be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage";type: Record<string, string[]> ;default: {}
  */
 @Component({
   tag: 'atomic-field-condition',
@@ -37,18 +37,8 @@ export class AtomicFieldCondition {
    */
   @Prop() conditions: ResultTemplateCondition[] = [];
 
-  /**
-   * The field and values that define which result items the condition must be applied to.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
-   */
   @MapProp({splitValues: true}) mustMatch: Record<string, string[]> = {};
 
-  /**
-   * The field and values that define which result items the condition must not be applied to.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
-   */
   @MapProp({splitValues: true}) mustNotMatch: Record<string, string[]> = {};
 
   private shouldBeRemoved = false;

--- a/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
@@ -7,7 +7,7 @@ import {ResultTemplateCommon} from '../result-template-common';
 /**
  * The `atomic-result-children-template` component determines the format of the child results, depending on the conditions that are defined for each template. A `template` element must be the child of an `atomic-result-children-template`, and an `atomic-result-children` must be the parent of each `atomic-result-children-template`.
  *
- * Note: Any `<script>` tags defined inside of a `<template>` element will not be executed when results are being rendered.*
+ * Note: Any `<script>` tags defined inside of a `<template>` element will not be executed when results are being rendered.
  * @MapProp name: mustMatch;attr: must-match;docs: The field and values that define which result items the condition must be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`;type: Record<string, string[]> ;default: {}
  * @MapProp name: mustNotMatch;attr: must-not-match;docs: The field and values that define which result items the condition must not be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage";type: Record<string, string[]> ;default: {}
  */

--- a/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
@@ -7,7 +7,9 @@ import {ResultTemplateCommon} from '../result-template-common';
 /**
  * The `atomic-result-children-template` component determines the format of the child results, depending on the conditions that are defined for each template. A `template` element must be the child of an `atomic-result-children-template`, and an `atomic-result-children` must be the parent of each `atomic-result-children-template`.
  *
- * Note: Any `<script>` tags defined inside of a `<template>` element will not be executed when results are being rendered.
+ * Note: Any `<script>` tags defined inside of a `<template>` element will not be executed when results are being rendered.*
+ * @MapProp name: mustMatch;attr: must-match;docs: The field and values that define which result items the condition must be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`;type: Record<string, string[]> ;default: {}
+ * @MapProp name: mustNotMatch;attr: must-not-match;docs: The field and values that define which result items the condition must not be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage";type: Record<string, string[]> ;default: {}
  */
 @Component({
   tag: 'atomic-result-children-template',
@@ -26,18 +28,8 @@ export class AtomicResultChildrenTemplate {
    */
   @Prop() public conditions: ResultTemplateCondition[] = [];
 
-  /**
-   * Fields and field values that results must match for the result template to apply.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
-   */
   @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
 
-  /**
-   * Fields and field values that results must not match for the result template to apply.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
-   */
   @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
     {};
 

--- a/packages/atomic/src/components/search/result-templates/atomic-result-template/atomic-result-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-template/atomic-result-template.tsx
@@ -8,6 +8,8 @@ import {makeMatchConditions} from '../../../common/result-template/result-templa
  * The `atomic-result-template` component determines the format of the query results, depending on the conditions that are defined for each template. A `template` element must be the child of an `atomic-result-template`, and either an `atomic-result-list` or `atomic-folded-result-list` must be the parent of each `atomic-result-template`.
  *
  * Note: Any `<script>` tags defined inside of a `<template>` element will not be executed when results are being rendered.
+ * @MapProp name: mustMatch;attr: must-match;docs: The field and values that define which result items the condition must be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`;type: Record<string, string[]> ;default: {}
+ * @MapProp name: mustNotMatch;attr: must-not-match;docs: The field and values that define which result items the condition must not be applied to. For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage";type: Record<string, string[]> ;default: {}
  */
 @Component({
   tag: 'atomic-result-template',
@@ -26,18 +28,8 @@ export class AtomicResultTemplate {
    */
   @Prop() public conditions: ResultTemplateCondition[] = [];
 
-  /**
-   * The field and values that define which result items the condition must be applied to.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
-   */
   @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
 
-  /**
-   * The field and values that define which result items the condition must not be applied to.
-   *
-   * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
-   */
   @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
     {};
 


### PR DESCRIPTION
Moving the annotations because MapProp annotations must be written with tags in the main component annotation.