### PR TITLE
feat(quantic): new QuanticColoredResultBadge component created

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -1,0 +1,180 @@
+import {createElement} from 'lwc';
+import QuanticColoredResultBadge from '../quanticColoredResultBadge';
+
+const defaultPrimaryColor = '#FFF7BA';
+const defaultSecondaryColor = '#E2B104';
+const defaultLabel = 'Case';
+
+const defaultResult = {
+  raw: {
+    fieldOne: 'valueOne',
+  },
+};
+
+const colorsToTest = [
+  {
+    primaryColor: '#DABFE9',
+    expectedSecondaryColor: 'hsl(279, 48.8%, 35.1%)',
+  },
+  {
+    primaryColor: '#EF233C',
+    expectedSecondaryColor: 'hsl(353, 86.4%, 5.7%)',
+  },
+  {
+    primaryColor: '03A06E',
+    expectedSecondaryColor: 'hsl(161, 96.3%, 80.0%)',
+  },
+  {
+    primaryColor: 'FFF',
+    expectedSecondaryColor: 'hsl(0, 0%, 52.0%)',
+  },
+];
+
+const invalidColors = [
+  {
+    primaryColor: '#ZZFFFF',
+    portion: 'red',
+  },
+  {
+    primaryColor: '#FFZZFF',
+    portion: 'green',
+  },
+  {
+    primaryColor: '#FFFFZZ',
+    portion: 'blue',
+  },
+];
+
+const invalidPropertiesError =
+  '"QuanticColoredResultBadge" requires either specified value for label or a result object with a fieldname to display correctly.';
+
+function createTestComponent(color, label = defaultLabel, result, fieldname) {
+  const element = createElement('c-colored-result-badge', {
+    is: QuanticColoredResultBadge,
+  });
+  element.label = label;
+  element.color = color;
+  element.result = result;
+  element.fieldname = fieldname;
+
+  document.body.appendChild(element);
+
+  return element;
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  // eslint-disable-next-line no-undef
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('c-quantic-colored-result-badge', () => {
+  function cleanup() {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  }
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('should display the colored badge with the correct label and color when the label property is given', async () => {
+    const label = 'Document';
+    const element = createTestComponent('#FFF7BA', label);
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe(label);
+  });
+
+  it('should display the colored badge with the correct label and color the result and fieldname properties are given', async () => {
+    const element = createTestComponent(
+      '#FFF7BA',
+      '',
+      defaultResult,
+      'fieldOne'
+    );
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe(defaultResult.raw.fieldOne);
+  });
+
+  it('should not display the colored badge when the label and the result properties are missing', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const element = createTestComponent('#FFF7BA', null, null);
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).toBeNull();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toBe(invalidPropertiesError);
+  });
+
+  it('should not display the colored badge when the result property is given but the fieldname property is missing', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const element = createTestComponent('#FFF7BA', null, defaultResult, null);
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).toBeNull();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toBe(invalidPropertiesError);
+  });
+
+  colorsToTest.forEach((color) => {
+    it(`should display the colored badge with the following colors: Primary Color: ${color.primaryColor}; Secondary Color: ${color.expectedSecondaryColor}`, async () => {
+      const element = createTestComponent(color.primaryColor);
+      await flushPromises();
+
+      const badge = element.shadowRoot.querySelector('.result-badge');
+
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).toBe(defaultLabel);
+      expect(badge.style._values['--primaryColor']).toBe(color.primaryColor);
+      expect(badge.style._values['--secondaryColor']).toBe(
+        color.expectedSecondaryColor
+      );
+    });
+  });
+
+  invalidColors.forEach((color) => {
+    it(`should display the colored badge with the correct label and the default colors when the ${color.portion} portion of the color value is invalid`, async () => {
+      const invalidColor = color.primaryColor;
+      const element = createTestComponent(invalidColor);
+      await flushPromises();
+
+      const badge = element.shadowRoot.querySelector('.result-badge');
+
+      expect(badge).not.toBeNull();
+      expect(badge.textContent).toBe(defaultLabel);
+      expect(badge.style._values['--primaryColor']).toBe(defaultPrimaryColor);
+      expect(badge.style._values['--secondaryColor']).toBe(
+        defaultSecondaryColor
+      );
+    });
+  });
+
+  it('should display the colored badge with the correct label and the default colors when the color is not given', async () => {
+    const element = createTestComponent('');
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe(defaultLabel);
+    expect(badge.style._values['--primaryColor']).toBe(defaultPrimaryColor);
+    expect(badge.style._values['--secondaryColor']).toBe(defaultSecondaryColor);
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -123,6 +123,19 @@ describe('c-quantic-colored-result-badge', () => {
     });
   });
 
+  it(`should display the colored badge with the correct label and the default colors when the given the color value is an invalid HEX color value`, async () => {
+    const invalidColor = '#AAAAAAB';
+    const element = createTestComponent(invalidColor);
+    await flushPromises();
+
+    const badge = element.shadowRoot.querySelector('.result-badge');
+
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe(defaultLabel);
+    expect(badge.style._values['--primaryColor']).toBe(defaultPrimaryColor);
+    expect(badge.style._values['--secondaryColor']).toBe(defaultSecondaryColor);
+  });
+
   it('should display the colored badge with the correct label and the default colors when the color is not given', async () => {
     const element = createTestComponent('');
     await flushPromises();

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -49,7 +49,7 @@ const invalidPropertiesError =
   '"QuanticColoredResultBadge" requires either specified value for label or a result object with a fieldname to display correctly.';
 
 function createTestComponent(color, label = defaultLabel, result, fieldname) {
-  const element = createElement('c-colored-result-badge', {
+  const element = createElement('c-quantic-colored-result-badge', {
     is: QuanticColoredResultBadge,
   });
   element.label = label;

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -92,7 +92,7 @@ describe('c-quantic-colored-result-badge', () => {
     expect(badge.textContent).toBe(label);
   });
 
-  it('should display the colored badge with the correct label and color the result and fieldname properties are given', async () => {
+  it('should display the colored badge with the correct label and color when the result and fieldname properties are given', async () => {
     const element = createTestComponent(
       '#FFF7BA',
       '',

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -5,12 +5,6 @@ const defaultPrimaryColor = '#FFF7BA';
 const defaultSecondaryColor = '#E2B104';
 const defaultLabel = 'Case';
 
-const defaultResult = {
-  raw: {
-    fieldOne: 'valueOne',
-  },
-};
-
 const colorsToTest = [
   {
     primaryColor: '#DABFE9',
@@ -45,17 +39,12 @@ const invalidColors = [
   },
 ];
 
-const invalidPropertiesError =
-  '"QuanticColoredResultBadge" requires either specified value for label or a result object with a fieldname to display correctly.';
-
-function createTestComponent(color, label = defaultLabel, result, fieldname) {
+function createTestComponent(color, label = defaultLabel) {
   const element = createElement('c-quantic-colored-result-badge', {
     is: QuanticColoredResultBadge,
   });
   element.label = label;
   element.color = color;
-  element.result = result;
-  element.fieldname = fieldname;
 
   document.body.appendChild(element);
 
@@ -92,45 +81,13 @@ describe('c-quantic-colored-result-badge', () => {
     expect(badge.textContent).toBe(label);
   });
 
-  it('should display the colored badge with the correct label and color when the result and fieldname properties are given', async () => {
-    const element = createTestComponent(
-      '#FFF7BA',
-      '',
-      defaultResult,
-      'fieldOne'
-    );
-    await flushPromises();
-
-    const badge = element.shadowRoot.querySelector('.result-badge');
-
-    expect(badge).not.toBeNull();
-    expect(badge.textContent).toBe(defaultResult.raw.fieldOne);
-  });
-
-  it('should not display the colored badge when the label and the result properties are missing', async () => {
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    const element = createTestComponent('#FFF7BA', null, null);
+  it('should not display the colored badge when the label property is missing', async () => {
+    const element = createTestComponent('#FFF7BA', null);
     await flushPromises();
 
     const badge = element.shadowRoot.querySelector('.result-badge');
 
     expect(badge).toBeNull();
-    expect(error).toHaveBeenCalledTimes(1);
-    expect(error.mock.calls[0][0]).toBe(invalidPropertiesError);
-  });
-
-  it('should not display the colored badge when the result property is given but the fieldname property is missing', async () => {
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    const element = createTestComponent('#FFF7BA', null, defaultResult, null);
-    await flushPromises();
-
-    const badge = element.shadowRoot.querySelector('.result-badge');
-
-    expect(badge).toBeNull();
-    expect(error).toHaveBeenCalledTimes(1);
-    expect(error.mock.calls[0][0]).toBe(invalidPropertiesError);
   });
 
   colorsToTest.forEach((color) => {

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/__tests__/quanticColoredResultBadge.test.js
@@ -64,8 +64,8 @@ function createTestComponent(color, label = defaultLabel, result, fieldname) {
 
 // Helper function to wait until the microtask queue is empty.
 function flushPromises() {
-  // eslint-disable-next-line no-undef
-  return new Promise((resolve) => setImmediate(resolve));
+  // eslint-disable-next-line @lwc/lwc/no-async-operation
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('c-quantic-colored-result-badge', () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/colorsUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/colorsUtils.js
@@ -1,0 +1,91 @@
+/**
+ * Indicates whether the RGB values are invalid.
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ * @returns {boolean}
+ */
+function invalidRGBValues(r, g, b) {
+  if (isNaN(r) || r < 0 || r > 255) return true;
+  if (isNaN(g) || g < 0 || g > 255) return true;
+  if (isNaN(b) || b < 0 || b > 255) return true;
+  return false;
+}
+
+/**
+ * Converts a Hex color value to RGB.
+ * @param {string} color the Hex color value.
+ * @returns {{r: number, g: number, b: number}}
+ */
+function HEXToRGB(color) {
+  let redHex, greenHex, blueHex;
+  if (color[0] === '#') {
+    color = color.slice(1);
+  }
+
+  if (color.length === 3) {
+    redHex = color[0] + color[0];
+    greenHex = color[1] + color[1];
+    blueHex = color[2] + color[2];
+  } else if (color.length === 6) {
+    redHex = color.substring(0, 2);
+    greenHex = color.substring(2, 4);
+    blueHex = color.substring(4, 6);
+  }
+
+  const r = parseInt(redHex, 16);
+  const g = parseInt(greenHex, 16);
+  const b = parseInt(blueHex, 16);
+  return {
+    r,
+    g,
+    b,
+  };
+}
+
+/**
+ * Converts an RGB color value to HSL.
+ * Adapted from https://css-tricks.com/converting-color-spaces-in-javascript/#aa-rgb-to-hsl.
+ * @returns {{h: number, s: number, l: number}}
+ */
+function RGBToHSL(r, g, b) {
+  let h, s, l;
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+
+  l = (max + min) / 2;
+
+  if (delta === 0) {
+    h = 0;
+  } else {
+    // eslint-disable-next-line default-case
+    switch (max) {
+      case r:
+        h = ((g - b) / delta) % 6;
+        break;
+      case g:
+        h = (b - r) / delta + 2;
+        break;
+      case b:
+        h = (r - g) / delta + 4;
+        break;
+    }
+  }
+
+  h = Math.round(h * 60);
+  if (h < 0) h += 360;
+
+  s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  s = +(s * 100).toFixed(1);
+  l = +(l * 100).toFixed(1);
+
+  return { h, s, l };
+}
+
+export { invalidRGBValues, RGBToHSL, HEXToRGB };

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.css
@@ -1,0 +1,8 @@
+.result-badge {
+  border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+  text-transform: uppercase;
+  font-size: 10px;
+  background-color: var(--primaryColor, #fff7ba);
+  color: var(--secondaryColor, #e2b104);
+  border: 1px solid var(--secondaryColor, #e2b104);
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
@@ -1,7 +1,7 @@
 <template>
-  <template if:true={displayedLabel}>
+  <template if:true={label}>
     <div class="slds-var-p-horizontal_medium slds-text-title_bold result-badge">
-      {displayedLabel}
+      {label}
     </div>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
@@ -1,0 +1,7 @@
+<template>
+  <template if:true={displayedLabel}>
+    <div class="slds-var-p-horizontal_medium slds-text-title_bold result-badge">
+      {displayedLabel}
+    </div>
+  </template>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -31,8 +31,10 @@ export default class QuanticColoredResultBadge extends LightningElement {
   invalidColor = false;
 
   renderedCallback() {
-    if (this.label) {
+    if (this.label && this.color) {
       this.setBadgeColors();
+    } else if (this.label) {
+      this.setBadgeDefaultColors();
     }
   }
 
@@ -52,6 +54,17 @@ export default class QuanticColoredResultBadge extends LightningElement {
       '--secondaryColor',
       this.invalidColor ? defaultSecondaryColor : secondaryColor
     );
+  }
+
+  /**
+   * Sets the primary and scondary colors of the badge to the default colors.
+   * @returns {void}
+   */
+  setBadgeDefaultColors() {
+    const styles = this.template.querySelector('.result-badge')?.style;
+
+    styles.setProperty('--primaryColor', defaultPrimaryColor);
+    styles.setProperty('--secondaryColor', defaultSecondaryColor);
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -9,7 +9,7 @@ const lightnessDegree = 48;
 
 /**
  * The `QuanticColoredResultBadge` component displays a colored badge showing a label.
- * If the `Label` property is set in this component, its value will be displayed in the badge, Otherwise the `Result` and 'Fieldname' properties are required and the value of the given field will lbe displayed.
+ * If the `Label` property is set in this component, its value will be displayed in the badge, Otherwise the `Result` and `Fieldname` properties are required and the value of the given field will lbe displayed.
  * @category Result Template
  * @example
  * <c-quantic-colored-result-badge label="Account"></c-quantic-colored-result-badge>

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -1,0 +1,82 @@
+import { LightningElement, api } from 'lwc';
+import { RGBToHSL, HEXToRGB, invalidRGBValues } from './colorsUtils';
+
+const defaultPrimaryColor = '#FFF7BA';
+const defaultSecondaryColor = '#E2B104';
+const lightnessDegree = 48;
+
+export default class QuanticColoredResultBadge extends LightningElement {
+  /** @type {string} */
+  @api label;
+  /** @type {string} */
+  @api fieldname;
+  /** @type {object}*/
+  @api result;
+  /** @type{string} */
+  @api color;
+
+  /** @type{boolean} */
+  invalidColor = false;
+
+  connectedCallback() {
+    if ((!this.result || !this.fieldname) && !this.label) {
+      console.error(
+        `"QuanticColoredResultBadge" requires either specified value for label or a result object with a fieldname to display correctly.`
+      );
+    }
+  }
+
+  renderedCallback() {
+    if (this.displayedLabel) {
+      this.setBadgeColors();
+    }
+  }
+
+  /**
+   * Sets the primary and scondary colors to be used in the colored badge.
+   * @returns {void}
+   */
+  setBadgeColors() {
+    // @ts-ignore
+    const styles = this.template.querySelector('.result-badge')?.style;
+    const secondaryColor = this.generateSecondaryColor(lightnessDegree);
+    styles.setProperty('--primaryColor', this.invalidColor ? defaultPrimaryColor : this.color);
+    styles.setProperty('--secondaryColor', this.invalidColor ? defaultSecondaryColor : secondaryColor);
+  }
+
+  /**
+   * Generates the secondary color.
+   * @param {number} lightnessAmount the amount of lightness with which to update the primary color.
+   * @returns {string}
+   */
+  generateSecondaryColor(lightnessAmount) {
+    const { r, g, b } = HEXToRGB(this.color);
+
+    if (invalidRGBValues(r, g, b)) {
+      this.invalidColor = true;
+      return defaultSecondaryColor;
+    }
+
+    const HSLColor = RGBToHSL(r, g, b);
+    const { h, s } = HSLColor;
+    let l = HSLColor.l;
+
+    if (l >= 50) {
+      l -= lightnessAmount;
+    } else {
+      l += lightnessAmount;
+    }
+    
+    return `hsl(${h}, ${s}%, ${l.toFixed(1)}%)`;
+  }
+
+  get displayedLabel() {
+    if (this.label) {
+      return this.label;
+    } else if (this.result) {
+      const value = this.result.raw?.[this.fieldname];
+      return value;
+    }
+    return null;
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -9,10 +9,9 @@ const lightnessDegree = 48;
 
 /**
  * The `QuanticColoredResultBadge` component displays a colored badge showing a label.
- * If the `Label` property is set in this component, its value will be displayed in the badge, Otherwise the `Result` and `Fieldname` properties are required and the value of the given field will lbe displayed.
  * @category Result Template
  * @example
- * <c-quantic-colored-result-badge label="Account"></c-quantic-colored-result-badge>
+ * <c-quantic-colored-result-badge label="Case"></c-quantic-colored-result-badge>
  */
 export default class QuanticColoredResultBadge extends LightningElement {
   /**
@@ -21,18 +20,6 @@ export default class QuanticColoredResultBadge extends LightningElement {
    * @type {string}
    */
   @api label;
-  /**
-   * The name of the field whose value we want to display.
-   * @api
-   * @type {string}
-   */
-  @api fieldname;
-  /**
-   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result) to use to infer label and icon.
-   * @api
-   * @type {Result}
-   */
-  @api result;
   /**
    * The primary color of the badge.
    * @api
@@ -43,16 +30,8 @@ export default class QuanticColoredResultBadge extends LightningElement {
   /** @type{boolean} */
   invalidColor = false;
 
-  connectedCallback() {
-    if ((!this.result || !this.fieldname) && !this.label) {
-      console.error(
-        `"QuanticColoredResultBadge" requires either specified value for label or a result object with a fieldname to display correctly.`
-      );
-    }
-  }
-
   renderedCallback() {
-    if (this.displayedLabel) {
+    if (this.label) {
       this.setBadgeColors();
     }
   }
@@ -99,15 +78,5 @@ export default class QuanticColoredResultBadge extends LightningElement {
     }
 
     return `hsl(${h}, ${s}%, ${l.toFixed(1)}%)`;
-  }
-
-  get displayedLabel() {
-    if (this.label) {
-      return this.label;
-    } else if (this.result) {
-      const value = this.result.raw?.[this.fieldname];
-      return value;
-    }
-    return null;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -61,6 +61,7 @@ export default class QuanticColoredResultBadge extends LightningElement {
    * @returns {void}
    */
   setBadgeDefaultColors() {
+    // @ts-ignore
     const styles = this.template.querySelector('.result-badge')?.style;
 
     styles.setProperty('--primaryColor', defaultPrimaryColor);

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js
@@ -1,18 +1,43 @@
-import { LightningElement, api } from 'lwc';
-import { RGBToHSL, HEXToRGB, invalidRGBValues } from './colorsUtils';
+import {LightningElement, api} from 'lwc';
+import {RGBToHSL, HEXToRGB, invalidRGBValues} from './colorsUtils';
 
 const defaultPrimaryColor = '#FFF7BA';
 const defaultSecondaryColor = '#E2B104';
 const lightnessDegree = 48;
 
+/** @typedef {import("coveo").Result} Result */
+
+/**
+ * The `QuanticColoredResultBadge` component displays a colored badge showing a label.
+ * If the `Label` property is set in this component, its value will be displayed in the badge, Otherwise the `Result` and 'Fieldname' properties are required and the value of the given field will lbe displayed.
+ * @category Result Template
+ * @example
+ * <c-quantic-colored-result-badge label="Account"></c-quantic-colored-result-badge>
+ */
 export default class QuanticColoredResultBadge extends LightningElement {
-  /** @type {string} */
+  /**
+   * The label to display.
+   * @api
+   * @type {string}
+   */
   @api label;
-  /** @type {string} */
+  /**
+   * The name of the field whose value we want to display.
+   * @api
+   * @type {string}
+   */
   @api fieldname;
-  /** @type {object}*/
+  /**
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result) to use to infer label and icon.
+   * @api
+   * @type {Result}
+   */
   @api result;
-  /** @type{string} */
+  /**
+   * The primary color of the badge.
+   * @api
+   * @type {string}
+   */
   @api color;
 
   /** @type{boolean} */
@@ -40,8 +65,14 @@ export default class QuanticColoredResultBadge extends LightningElement {
     // @ts-ignore
     const styles = this.template.querySelector('.result-badge')?.style;
     const secondaryColor = this.generateSecondaryColor(lightnessDegree);
-    styles.setProperty('--primaryColor', this.invalidColor ? defaultPrimaryColor : this.color);
-    styles.setProperty('--secondaryColor', this.invalidColor ? defaultSecondaryColor : secondaryColor);
+    styles.setProperty(
+      '--primaryColor',
+      this.invalidColor ? defaultPrimaryColor : this.color
+    );
+    styles.setProperty(
+      '--secondaryColor',
+      this.invalidColor ? defaultSecondaryColor : secondaryColor
+    );
   }
 
   /**
@@ -50,7 +81,7 @@ export default class QuanticColoredResultBadge extends LightningElement {
    * @returns {string}
    */
   generateSecondaryColor(lightnessAmount) {
-    const { r, g, b } = HEXToRGB(this.color);
+    const {r, g, b} = HEXToRGB(this.color);
 
     if (invalidRGBValues(r, g, b)) {
       this.invalidColor = true;
@@ -58,7 +89,7 @@ export default class QuanticColoredResultBadge extends LightningElement {
     }
 
     const HSLColor = RGBToHSL(r, g, b);
-    const { h, s } = HSLColor;
+    const {h, s} = HSLColor;
     let l = HSLColor.l;
 
     if (l >= 50) {
@@ -66,7 +97,7 @@ export default class QuanticColoredResultBadge extends LightningElement {
     } else {
       l += lightnessAmount;
     }
-    
+
     return `hsl(${h}, ${s}%, ${l.toFixed(1)}%)`;
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
## Colored Result Badge component

- This component will be used inside the result template of the Insight Panel to display the result badges.
<img width="515" alt="ResultTemplate" src="https://user-images.githubusercontent.com/86681870/184880501-107997fe-6af0-4f85-9bf8-3b31afce5b0c.png">

- In the Insight Panel configuration we receive the following information about the badge to display for each result template: 

```
badge: {
  label: "Document",
  color: "#DABFE9"
}
```
- This component will create a badge with the correct label and the correct color.
- This component contains the logic to create a secondary color from the given primary color.
- The given primary color will be used as the background color of the badge and the secondary color will be used as the text color as well as the border color.
- This component will first convert the given Hex color to RGB, then will convert the RGB color to [HSL](https://www.w3schools.com/colors/colors_hsl.asp)(Hue, Saturation, Lightness) then will update the lightness of this color to generate the secondary color.

#### Examples of the badges created with diffrent colors:
<img width="96" alt="ColoredResultBadge" src="https://user-images.githubusercontent.com/86681870/184868871-72700d2e-66ed-4eba-a034-ef90597f44b3.png">
