### PR TITLE
fix(quantic): making the QuanticNoResult use the correct headless bundle

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -1,5 +1,5 @@
 import {api, LightningElement, track} from 'lwc';
-import {initializeWithHeadless, registerComponentForInit} from 'c/quanticHeadlessLoader';
+import {initializeWithHeadless, registerComponentForInit, getHeadlessBundle,} from 'c/quanticHeadlessLoader';
 import {I18nUtils} from 'c/quanticUtils';
 
 import noResultsForTitle from '@salesforce/label/c.quantic_NoResultsForTitle';
@@ -81,14 +81,17 @@ export default class QuanticNoResults extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.searchStatus = CoveoHeadless.buildSearchStatus(engine);
-    this.historyManager = CoveoHeadless.buildHistoryManager(engine);
-    this.querySummary = CoveoHeadless.buildQuerySummary(engine);
-    this.breadcrumbManager = CoveoHeadless.buildBreadcrumbManager(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.searchStatus = this.headless.buildSearchStatus(engine);
+    this.querySummary = this.headless.buildQuerySummary(engine);
+    this.breadcrumbManager = this.headless.buildBreadcrumbManager(engine);
     this.unsubscribeSearchStatus = this.searchStatus.subscribe(() => this.updateState());
-    this.unsubscribeHistoryManager = this.historyManager.subscribe(() => this.updateState());
     this.unsubscribeQuerySummary = this.querySummary.subscribe(() => this.updateState());
     this.unsubscribeBreadcrumbsManager = this.breadcrumbManager.subscribe(() => this.updateState());
+    if(!this.disableCancelLastAction){
+      this.historyManager = this.headless.buildHistoryManager(engine);
+      this.unsubscribeHistoryManager = this.historyManager.subscribe(() => this.updateState());
+    }
   }
 
   disconnectedCallback() {

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -103,7 +103,7 @@ export default class QuanticNoResults extends LightningElement {
   
   updateState() {
     this.showNoResultsPanel = this.searchStatus.state.firstSearchExecuted && !this.searchStatus.state.isLoading && !this.searchStatus.state.hasResults && !this.searchStatus.state.hasError;
-    this.showUndoButton = !this.disableCancelLastAction && this.historyManager.state.past.length;
+    this.showUndoButton = !this.disableCancelLastAction && this.historyManager?.state.past.length;
     this.query = this.querySummary.state.hasQuery ? this.querySummary.state.query : "";
     this.hasBreadcrumbs = this.breadcrumbManager.state.hasBreadcrumbs;
   }


### PR DESCRIPTION
[SFINT-4605](https://coveord.atlassian.net/browse/SFINT-4605)
Making the `QuanticNoResullt` component use the right headless bundle to make it usable in multiple use cases.

Note that the HistoryManager controller is not adapted to the insight use case yet. For this reason this component will be use in the new Coveo Quantic Insight Panel only with the property `disableCancelLastAction` set to `true`.
