### PR TITLE
feat(atomic): make atomic-popover backdrop transparent & make it clickable

### DIFF
--- a/packages/atomic/src/components/search/facets/atomic-popover/atomic-popover.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-popover/atomic-popover.tsx
@@ -179,7 +179,7 @@ export class AtomicPopover implements InitializableComponent {
     return (
       <div
         part="backdrop"
-        class="fixed left-0 top-0 right-0 bottom-0 z-[9998] bg-background opacity-50"
+        class="fixed left-0 top-0 right-0 bottom-0 z-[9998] bg-transparent cursor-pointer"
         onClick={() => this.togglePopover()}
       ></div>
     );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1974

After showing the popover to UX we came to the conclusion it was better this way.