### PR TITLE
[DO NOT REVIEW] COMSDZ-4: Test GraphQl client for Product listing

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -44,6 +44,7 @@
     "pino-pretty": "^6.0.0"
   },
   "dependencies": {
+    "@apollo/client": "^3.6.9",
     "@coveo/bueno": "0.42.1",
     "@reduxjs/toolkit": "1.8.1",
     "@types/pino": "6.3.11",

--- a/packages/headless/src/api/commerce/product-listings/product-listing-api-client.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-api-client.ts
@@ -15,6 +15,28 @@ import {
   ProductListingRequest,
   ProductListingSuccessResponse,
 } from './product-listing-request';
+// eslint-disable-next-line node/no-extraneous-import
+import {ApolloClient, InMemoryCache, gql} from '@Apollo/client';
+
+const QUERY = gql`
+  {
+    placementContent(
+      mode: PREVIEW
+      previewOptions: {campaignId: "foo"}
+      placementId: "foo"
+      attributes: {visitor: {id: ""}}
+    ) {
+      content
+      visitorId
+      callbackData
+    }
+  }
+`;
+
+const apolloClient = new ApolloClient({
+  cache: new InMemoryCache(),
+  uri: 'https://api.qubit.com/placements/query',
+});
 
 export interface AsyncThunkProductListingOptions<
   T extends Partial<ProductListingAppState>
@@ -94,6 +116,15 @@ export class ProductListingAPIClient implements FacetSearchAPIClient {
     return response.ok
       ? {success: body as ProductListingSuccessResponse}
       : {error: body as ProductListingAPIErrorStatusResponse};
+  }
+
+  async getGraphQlProducts() {
+    const response = await apolloClient.query({
+      query: QUERY,
+    });
+
+    const body = await response.data;
+    return body;
   }
 
   async facetSearch(req: FacetSearchRequest): Promise<FacetSearchResponse> {

--- a/packages/headless/src/features/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/product-listing/product-listing-actions.ts
@@ -92,12 +92,9 @@ export const fetchProductListing = createAsyncThunk<
   AsyncThunkProductListingOptions<StateNeededByFetchProductListing>
 >(
   'productlisting/fetch',
-  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
-    const state = getState();
+  async (_action, {dispatch, rejectWithValue, extra}) => {
     const {apiClient} = extra;
-    const fetched = await apiClient.getProducts(
-      await buildProductListingRequest(state)
-    );
+    const fetched = await apiClient.getGraphQlProducts();
 
     if (isErrorResponse(fetched)) {
       dispatch(logQueryError(fetched.error));


### PR DESCRIPTION
[Jira Ticket](https://coveord.atlassian.net/browse/COMSDZ-4)

So this is what it could look like if we'd use GraphQL instead of REST in Headless.

This exemple doesn't use the commerce-service's context so there is a lot of stuff left out.

Also I didn't remove the REST part I just added the GraphQL part and changed the action.

Instead it's using a query to the content-api that returns a _valid error_.
You can try it [here](https://api.qubit.com/placements/)

```
{
    placementContent(
      mode: PREVIEW
      previewOptions: {campaignId: "foo"}
      placementId: "foo"
      attributes: {visitor: {id: ""}}
    ) {
      content
      visitorId
      callbackData
    }
  }
```
you should get: 

```
{
  "errors": [
    {
      "message": "look up property: sql: no rows in result set",
      "path": [
        "placementContent"
      ]
    }
  ],
  "data": {
    "placementContent": null
  }
}
```
I tested it locally on the [SAQdemo](https://github.com/coveo/saqdemo)

![image](https://user-images.githubusercontent.com/94566483/185645677-2d782900-1302-4a08-917c-3b012851aa94.png)
