### PR TITLE
fix(atomic,headless): fixed setRange on Firefox and Safari

### DIFF
--- a/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
@@ -1,9 +1,9 @@
 import {Component, h, State, Prop, Event, EventEmitter} from '@stencil/core';
 import {buildDateRange} from '@coveo/headless';
-import dayjs from 'dayjs';
 import {Button} from '../../button';
 import {AnyBindings} from '../../interface/bindings';
 import {DateFilter, DateFilterState} from '../../types';
+import {parseDate} from '../../../../utils/date-utils';
 
 /**
  * Internal component made to be integrated in a TimeframeFacet.
@@ -31,10 +31,10 @@ export class FacetDateInput {
 
   public connectedCallback() {
     this.start = this.filterState.range
-      ? dayjs(this.filterState.range.start).toDate()
+      ? parseDate(this.filterState.range.start).toDate()
       : undefined;
     this.end = this.filterState.range
-      ? dayjs(this.filterState.range.end).toDate()
+      ? parseDate(this.filterState.range.end).toDate()
       : undefined;
   }
 
@@ -56,7 +56,7 @@ export class FacetDateInput {
     if (!date) {
       return '';
     }
-    return dayjs(date).format('YYYY-MM-DD');
+    return parseDate(date).format('YYYY-MM-DD');
   }
 
   render() {

--- a/packages/atomic/src/components/common/facets/timeframe-facet-common.tsx
+++ b/packages/atomic/src/components/common/facets/timeframe-facet-common.tsx
@@ -1,5 +1,4 @@
 import {h, VNode} from '@stencil/core';
-import dayjs from 'dayjs';
 import {FocusTargetController} from '../../../utils/accessibility-utils';
 import {getFieldValueCaption} from '../../../utils/field-utils';
 import {Hidden} from '../hidden';
@@ -29,6 +28,7 @@ import {
 import {FacetInfo} from './facet-common-store';
 import {initializePopover} from '../../search/facets/atomic-popover/popover-type';
 import {randomID} from '../../../utils/utils';
+import {parseDate} from '../../../utils/date-utils';
 
 export interface Timeframe {
   period: RelativeDatePeriod;
@@ -259,8 +259,8 @@ export class TimeframeFacetCommon {
       );
     } catch (error) {
       return this.props.bindings.i18n.t('to', {
-        start: dayjs(facetValue.start).format('YYYY-MM-DD'),
-        end: dayjs(facetValue.end).format('YYYY-MM-DD'),
+        start: parseDate(facetValue.start).format('YYYY-MM-DD'),
+        end: parseDate(facetValue.end).format('YYYY-MM-DD'),
       });
     }
   }

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-date/atomic-result-date.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-date/atomic-result-date.tsx
@@ -1,12 +1,12 @@
 import {Component, Prop, Element, State} from '@stencil/core';
 import {Result, ResultTemplatesHelpers} from '@coveo/headless';
-import dayjs from 'dayjs';
 import {ResultContext} from '../result-template-decorators';
 import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
+import {parseDate} from '../../../../utils/date-utils';
 
 /**
  * The `atomic-result-date` component renders the value of a date result field.
@@ -49,7 +49,7 @@ export class AtomicResultDate implements InitializableComponent {
       return;
     }
 
-    const parsedValue = dayjs(value as never);
+    const parsedValue = parseDate(value as never);
     if (!parsedValue.isValid()) {
       this.error = new Error(
         `Field "${this.field}" does not contain a valid date.`

--- a/packages/atomic/src/utils/date-utils.ts
+++ b/packages/atomic/src/utils/date-utils.ts
@@ -1,0 +1,13 @@
+import {API_DATE_FORMAT} from '@coveo/headless';
+import dayjs, {ConfigType} from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
+
+export function parseDate(date: ConfigType, format?: string) {
+  const parsedDate = dayjs(date, format);
+  if (!parsedDate.isValid() && !format) {
+    return dayjs(date, API_DATE_FORMAT);
+  }
+  return parsedDate;
+}

--- a/packages/headless/src/api/search/date/date-format.test.ts
+++ b/packages/headless/src/api/search/date/date-format.test.ts
@@ -1,8 +1,8 @@
-import dayjs from 'dayjs';
 import {
   isSearchApiDate,
   formatDateForSearchApi,
   validateAbsoluteDate,
+  parseDate,
 } from './date-format';
 
 describe('#isSearchApiDate', () => {
@@ -18,8 +18,8 @@ describe('#isSearchApiDate', () => {
 describe('#formatDateForSearchApi', () => {
   it('returns the correct format', () => {
     const date = 818035920000;
-    expect(formatDateForSearchApi(dayjs(date))).toBe(
-      dayjs(date).format('YYYY/MM/DD@HH:mm:ss')
+    expect(formatDateForSearchApi(parseDate(date))).toBe(
+      parseDate(date).format('YYYY/MM/DD@HH:mm:ss')
     );
   });
 });

--- a/packages/headless/src/api/search/date/date-format.ts
+++ b/packages/headless/src/api/search/date/date-format.ts
@@ -1,22 +1,33 @@
-import dayjs from 'dayjs';
+import dayjs, {ConfigType} from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 dayjs.extend(customParseFormat);
 
+/**
+ * The date format supported by the Search API.
+ */
 export const API_DATE_FORMAT = 'YYYY/MM/DD@HH:mm:ss';
 const API_DATE_MINIMUM = '1401-01-01';
 
 export type AbsoluteDate = string | number | Date;
+
+export function parseDate(date: ConfigType, format?: string) {
+  const parsedDate = dayjs(date, format);
+  if (!parsedDate.isValid() && !format) {
+    return dayjs(date, API_DATE_FORMAT);
+  }
+  return parsedDate;
+}
 
 export function formatDateForSearchApi(date: dayjs.Dayjs) {
   return date.format(API_DATE_FORMAT);
 }
 
 export function isSearchApiDate(date: string) {
-  return formatDateForSearchApi(dayjs(date)) === date;
+  return formatDateForSearchApi(parseDate(date)) === date;
 }
 
 export function validateAbsoluteDate(date: AbsoluteDate, dateFormat?: string) {
-  const dayJSDate = dayjs(date, dateFormat);
+  const dayJSDate = parseDate(date, dateFormat);
 
   if (!dayJSDate.isValid()) {
     const provideFormat =

--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.test.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.test.ts
@@ -1,5 +1,7 @@
-import dayjs from 'dayjs';
-import {formatDateForSearchApi} from '../../../../../api/search/date/date-format';
+import {
+  formatDateForSearchApi,
+  parseDate,
+} from '../../../../../api/search/date/date-format';
 import {
   RelativeDate,
   serializeRelativeDate,
@@ -19,8 +21,8 @@ describe('date range', () => {
       });
 
       const expectedValues: DateRangeRequest = {
-        start: formatDateForSearchApi(dayjs(start)),
-        end: formatDateForSearchApi(dayjs(end)),
+        start: formatDateForSearchApi(parseDate(start)),
+        end: formatDateForSearchApi(parseDate(end)),
         endInclusive: false,
         state: 'idle',
       };

--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/date-range.ts
@@ -1,11 +1,10 @@
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
 import {DateRangeRequest} from '../../../../../features/facets/range-facets/date-facet-set/interfaces/request';
 import {FacetValueState} from '../../../../../features/facets/facet-api/value';
 import {
   formatDateForSearchApi,
   AbsoluteDate,
   validateAbsoluteDate,
+  parseDate,
 } from '../../../../../api/search/date/date-format';
 import {
   serializeRelativeDate,
@@ -15,8 +14,6 @@ import {
   validateRelativeDate,
 } from '../../../../../api/search/date/relative-date';
 import {isUndefined} from '@coveo/bueno';
-
-dayjs.extend(customParseFormat);
 
 export type DateRangeInput = AbsoluteDate | RelativeDate;
 
@@ -97,5 +94,5 @@ function buildDate(rawDate: DateRangeInput, options: DateRangeOptions) {
   }
 
   validateAbsoluteDate(rawDate, dateFormat);
-  return formatDateForSearchApi(dayjs(rawDate, dateFormat));
+  return formatDateForSearchApi(parseDate(rawDate, dateFormat));
 }

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import {createAction} from '@reduxjs/toolkit';
 import {DateFacetValue} from './interfaces/response';
 import {
@@ -28,6 +27,7 @@ import {
   isRelativeDateFormat,
 } from '../../../../api/search/date/relative-date';
 import {buildDateRange} from '../../../../controllers/core/facets/range-facet/date-facet/date-range';
+import {parseDate} from '../../../../api/search/date/date-format';
 
 export interface RegisterDateFacetActionCreatorPayload {
   /**
@@ -137,7 +137,9 @@ export function validateManualDateRanges(
 
   options.currentValues.forEach((value) => {
     const {start, end} = buildDateRange(value);
-    if (dayjs(getAbsoluteDate(start)).isAfter(dayjs(getAbsoluteDate(end)))) {
+    if (
+      parseDate(getAbsoluteDate(start)).isAfter(parseDate(getAbsoluteDate(end)))
+    ) {
       throw new Error(
         `The start value is greater than the end value for the date range ${value.start} to ${value.end}`
       );

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -58,6 +58,7 @@ export * from './features/index';
 export * from './features/analytics/index';
 
 // Types & Helpers
+export {API_DATE_FORMAT} from './api/search/date/date-format';
 export {TestUtils, HighlightUtils};
 export type {Result} from './api/search/search/result';
 export type {FieldDescription} from './api/search/fields/fields-response';

--- a/packages/samples/headless-react/src/components/date-facet/date-utils.ts
+++ b/packages/samples/headless-react/src/components/date-facet/date-utils.ts
@@ -1,4 +1,4 @@
-import {buildDateRange} from '@coveo/headless';
+import {API_DATE_FORMAT, buildDateRange} from '@coveo/headless';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 
@@ -35,6 +35,6 @@ export const dateRanges = [
   }),
 ];
 
-export function parseDate(date: string) {
-  return dayjs(date, 'YYYY/MM/DD@HH:mm:ss');
+export function parseDate(date: string | Date) {
+  return dayjs(date, API_DATE_FORMAT);
 }

--- a/packages/samples/headless-react/src/components/date-filter/date-filter.class.tsx
+++ b/packages/samples/headless-react/src/components/date-filter/date-filter.class.tsx
@@ -8,7 +8,7 @@ import {
   Unsubscribe,
 } from '@coveo/headless';
 import {AppContext} from '../../context/engine';
-import dayjs from 'dayjs';
+import {parseDate} from '../date-facet/date-utils';
 
 interface DateFilterProps extends DateFilterOptions {
   facetId: string;
@@ -47,7 +47,7 @@ export class DateFilter extends Component<DateFilterProps, DateFilterState> {
     if (!date) {
       return '';
     }
-    return dayjs(date).format('YYYY-MM-DD');
+    return parseDate(date).format('YYYY-MM-DD');
   }
 
   private apply() {

--- a/packages/samples/headless-react/src/components/date-filter/date-filter.fn.tsx
+++ b/packages/samples/headless-react/src/components/date-filter/date-filter.fn.tsx
@@ -3,7 +3,7 @@ import {
   buildDateRange,
   DateFilter as HeadlessDateFilter,
 } from '@coveo/headless';
-import dayjs from 'dayjs';
+import {parseDate} from '../date-facet/date-utils';
 
 interface DateFilterProps {
   controller: HeadlessDateFilter;
@@ -13,7 +13,7 @@ function formattedDateValue(date?: string | Date) {
   if (!date) {
     return '';
   }
-  return dayjs(date).format('YYYY-MM-DD');
+  return parseDate(date).format('YYYY-MM-DD');
 }
 
 export const DateFilter: FunctionComponent<DateFilterProps> = (props) => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1970

On Chrome, the Search API date format can be parsed implicitly, but on Firefox and Safari, dayjs won't parse the Search API date format. You can try [this demo](https://yi39he.csb.app/?date=2022%2F08%2F08%4019%3A00%3A00&withcustomparseformat=true) on different browsers to reproduce the issue.

This caused setRange to do nothing but clear the facet on Firefox and Safari. I tried to explicitly set the format for setRange, but this caused other errors to appear in the UI (such as in the breadcrumbs). Instead, I decided to try to make the behaviour as consistent between Chrome and other browsers as possible by adding the search API format as a fallback, by adding a `parseDate` util instead of calling dayjs directly. An alternative could be to make a custom plugin to extend dayjs directly, but I personally prefer not to call dayjs directly in the first place.

I also exported the Search API date format as a constant from Headless.
