### PR TITLE
feat(atomic,atomic-react): added render function to atomic-result-children

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -720,7 +720,8 @@ export declare interface AtomicResultChildren extends Components.AtomicResultChi
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['imageSize', 'inheritTemplates', 'noResultText']
+  inputs: ['imageSize', 'inheritTemplates', 'noResultText'],
+  methods: ['setRenderFunction']
 })
 @Component({
   selector: 'atomic-result-children',

--- a/packages/atomic-react/src/components/FoldedResultListWrapper.tsx
+++ b/packages/atomic-react/src/components/FoldedResultListWrapper.tsx
@@ -1,14 +1,14 @@
 import React, {useEffect, useRef} from 'react';
 import type {JSX as AtomicJSX} from '@coveo/atomic';
 import type {FoldedResult} from '@coveo/atomic/headless';
-import {AtomicFoldedResultList} from './stencil-generated';
+import {
+  AtomicFoldedResultList,
+  AtomicResultChildren,
+} from './stencil-generated';
 import {renderToString} from 'react-dom/server';
 import {createRoot} from 'react-dom/client';
 
-/**
- * The properties of the AtomicFoldedResultList component
- */
-interface WrapperProps extends AtomicJSX.AtomicFoldedResultList {
+interface TemplateProp {
   /**
    * A template function that takes a result item and outputs its target rendering as a JSX element.
    * It can be used to conditionally render different type of result templates based on the properties of each result.
@@ -17,12 +17,28 @@ interface WrapperProps extends AtomicJSX.AtomicFoldedResultList {
 }
 
 /**
+ * The properties of the AtomicFoldedResultList component
+ */
+interface FoldedResultListWrapperProps
+  extends AtomicJSX.AtomicFoldedResultList,
+    TemplateProp {}
+
+/**
+ * The properties of the AtomicResultChildren component
+ */
+interface ResultChildrenWrapperProps
+  extends AtomicJSX.AtomicFoldedResultList,
+    TemplateProp {}
+
+/**
  * This component serves as a wrapper for the core AtomicResultList.
  *
  * @param props
  * @returns
  */
-export const FoldedResultListWrapper: React.FC<WrapperProps> = (props) => {
+export const FoldedResultListWrapper: React.FC<FoldedResultListWrapperProps> = (
+  props
+) => {
   const {template, ...otherProps} = props;
   const foldedResultListRef = useRef<HTMLAtomicFoldedResultListElement>(null);
   useEffect(() => {
@@ -32,4 +48,24 @@ export const FoldedResultListWrapper: React.FC<WrapperProps> = (props) => {
     });
   }, [foldedResultListRef]);
   return <AtomicFoldedResultList ref={foldedResultListRef} {...otherProps} />;
+};
+
+/**
+ * This component serves as a wrapper for the core AtomicResultList.
+ *
+ * @param props
+ * @returns
+ */
+export const ResultChildrenWrapper: React.FC<ResultChildrenWrapperProps> = (
+  props
+) => {
+  const {template, ...otherProps} = props;
+  const resultChildrenRef = useRef<HTMLAtomicResultChildrenElement>(null);
+  useEffect(() => {
+    resultChildrenRef.current?.setRenderFunction((foldedResult, root) => {
+      createRoot(root).render(template(foldedResult as FoldedResult));
+      return renderToString(template(foldedResult as FoldedResult));
+    });
+  }, [resultChildrenRef]);
+  return <AtomicResultChildren ref={resultChildrenRef} {...otherProps} />;
 };

--- a/packages/atomic-react/src/components/index.ts
+++ b/packages/atomic-react/src/components/index.ts
@@ -6,5 +6,8 @@ export {Bindings, i18n} from '@coveo/atomic';
 // and should wrap it nicely for users of the library
 export {SearchInterfaceWrapper as AtomicSearchInterface} from './SearchInterfaceWrapper';
 export {ResultListWrapper as AtomicResultList} from './ResultListWrapper';
-export {FoldedResultListWrapper as AtomicFoldedResultList} from './FoldedResultListWrapper';
+export {
+  FoldedResultListWrapper as AtomicFoldedResultList,
+  ResultChildrenWrapper as AtomicResultChildren,
+} from './FoldedResultListWrapper';
 export {SearchBoxInstantResultsWrapper as AtomicSearchBoxInstantResults} from './SearchBoxInstantResultsWrapper';

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1008,6 +1008,11 @@ export namespace Components {
           * @defaultValue `No documents are related to this one.`
          */
         "noResultText": string;
+        /**
+          * Sets a rendering function to bypass the standard HTML template mechanism for rendering results. You can use this function while working with web frameworks that don't use plain HTML syntax, e.g., React, Angular or Vue.  Do not use this method if you integrate Atomic in a plain HTML deployment.
+          * @param render
+         */
+        "setRenderFunction": (render: ResultRenderingFunction) => Promise<void>;
     }
     interface AtomicResultChildrenTemplate {
         /**

--- a/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
@@ -63,13 +63,7 @@ function MyTemplate(result: FoldedResult) {
         <AtomicResultText field="ec_shortdesc" />
       </AtomicResultSectionExcerpt>
       <AtomicResultSectionChildren>
-        <AtomicResultChildren>
-          <AtomicResultChildrenTemplate>
-            <template>
-              <AtomicResultLink />
-            </template>
-          </AtomicResultChildrenTemplate>
-        </AtomicResultChildren>
+        <AtomicResultChildren template={() => <AtomicResultLink />} />
       </AtomicResultSectionChildren>
       <AtomicResultSectionBottomMetadata>
         <AtomicResultFieldsList>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1973

Fixes an error in the atomic-react sample.

Now works the same way as the result list and the folded result list.