### PR TITLE
docs(atomic): fixed folded result list atomic-react sample

### DIFF
--- a/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
@@ -22,8 +22,6 @@ import {
   FoldedResult,
   AtomicResultSectionChildren,
   AtomicFoldedResultList,
-  AtomicResultChildren,
-  AtomicResultChildrenTemplate,
 } from '@coveo/atomic-react';
 import {AtomicPageWrapper} from '../components/AtomicPageWrapper';
 

--- a/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
@@ -63,13 +63,11 @@ function MyTemplate(result: FoldedResult) {
         <AtomicResultText field="ec_shortdesc" />
       </AtomicResultSectionExcerpt>
       <AtomicResultSectionChildren>
-        <AtomicResultChildren>
-          <AtomicResultChildrenTemplate>
-            <template>
-              <AtomicResultLink />
-            </template>
-          </AtomicResultChildrenTemplate>
-        </AtomicResultChildren>
+        {result.children.map((child) => (
+          <p>
+            <a href={child.result.clickUri}>{child.result.title}</a>
+          </p>
+        ))}
       </AtomicResultSectionChildren>
       <AtomicResultSectionBottomMetadata>
         <AtomicResultFieldsList>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1973

Unfortunately, that fix makes it almost identical to the "custom children" page, since this is the only way to display folded children right now.