### PR TITLE
fix(quantic): destroy Engine performed when the QuanticInsightInterface is disconnected

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -4,6 +4,7 @@ import {
   loadDependencies,
   setEngineOptions,
   HeadlessBundleNames,
+  destroyEngine
 } from 'c/quanticHeadlessLoader';
 
 // @ts-ignore
@@ -33,6 +34,10 @@ export default class QuanticInsightInterface extends LightningElement {
 
   /** @type {InsightEngineOptions} */
   engineOptions;
+
+  disconnectedCallback(){
+    destroyEngine(this.engineId);
+  }
 
   connectedCallback() {
     loadDependencies(this, HeadlessBundleNames.insight).then(() => {


### PR DESCRIPTION
### The issue:
In the Builder of the Salesforce Service Console, updating the Configuration ID is not reflected right away on the InsightRenderer component. The  Configuration ID is only reflected after leaving the Builder and coming back to the Service Console.

https://user-images.githubusercontent.com/86681870/186428634-1daec529-b25d-425c-a4fe-6d71b1ad92c0.mov

### The Solution:
Destroying the Headless engine in the disconnected callback of the InsightRendrer component.
 I agree that this solution sounds a bit extreme but I figured out that we gonna need to do it anyway to solve this issue and other issues like this one: [SFINT-4591](https://coveord.atlassian.net/browse/SFINT-4591), which basically is that when closing and re-opening a case record, the `interface load` analytics event  is not sent again, the reason is also that the headless engine stayed alive, so when opening the case record again the engine will not execute again the first search and will not send the `interface load` event again. 

https://user-images.githubusercontent.com/86681870/186422295-879ead4d-0841-41d9-b9f1-2ae99fdc0976.mov

