### PR TITLE
fix(atomic): fix insight-refine-toggle title and tooltip 

### DIFF
--- a/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/facet/facet.cypress.ts
@@ -275,7 +275,7 @@ describe('Facet v1 Test Suites', () => {
       });
 
       describe('when searching for a value that returns a single result', () => {
-        const query = 'Gregory';
+        const query = 'BillV';
         function setupSearchForSingleValue() {
           setupSelectCheckboxValue();
           typeFacetSearchQuery(FacetSelectors, query, true);

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -1,116 +1,95 @@
-import {h, VNode} from '@stencil/core';
+import {FunctionalComponent, h} from '@stencil/core';
 import CloseIcon from 'coveo-styleguide/resources/icons/svg/close.svg';
 import {Button} from '../button';
 import {BaseFacetElement} from '../facets/facet-common';
 import {AnyBindings} from '../interface/bindings';
-import {FacetManager, QuerySummary} from '../types';
+import {FacetManager} from '../types';
 import {popoverClass} from '../../search/facets/atomic-popover/popover-type';
 
-interface RefineModalCommonRenderProps {
+interface RefineModalCommonProps {
+  host: HTMLElement;
+  bindings: AnyBindings;
+  onClose(): void;
+  title: string;
+  querySummaryState: {
+    total: number;
+  };
   isOpen: boolean;
   openButton?: HTMLElement;
 }
 
-interface RefineModalCommonOptions {
-  host: HTMLElement;
-  bindings: AnyBindings;
-  initializeQuerySummary(): QuerySummary;
-  onClose(): void;
-  title: string;
-}
-
-export class RefineModalCommon {
-  private host: HTMLElement;
-  private bindings: AnyBindings;
-  private querySummary: QuerySummary;
-  private onClose: () => void;
-  private title: string;
-
-  public exportparts =
+export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
+  props,
+  children
+) => {
+  const exportparts =
     'container,header,header-wrapper,header-ruler,body,body-wrapper,footer,footer-wrapper,footer-wrapper';
 
-  constructor(props: RefineModalCommonOptions) {
-    this.host = props.host;
-    this.bindings = props.bindings;
-    this.querySummary = props.initializeQuerySummary();
-    this.onClose = props.onClose;
-    this.title = props.title;
-  }
+  const flushFacetElements = () => {
+    props.host.querySelector('div[slot="facets"]')?.remove();
+  };
 
-  public showModal() {
-    this.host.style.display = '';
-  }
-
-  public flushFacetElements() {
-    this.host.querySelector('div[slot="facets"]')?.remove();
-  }
-
-  public renderHeader() {
+  const renderHeader = () => {
     return (
       <div slot="header" class="contents">
-        <h1 class="truncate">{this.title}</h1>
+        <h1 class="truncate">{props.title}</h1>
         <Button
           style="text-transparent"
           class="grid place-items-center"
           part="close-button"
-          onClick={this.onClose}
-          ariaLabel={this.bindings.i18n.t('close')}
+          onClick={props.onClose}
+          ariaLabel={props.bindings.i18n.t('close')}
         >
           <atomic-icon class="w-5 h-5" icon={CloseIcon}></atomic-icon>
         </Button>
       </div>
     );
-  }
+  };
 
-  public renderFooter() {
+  const renderFooter = () => {
     return (
       <div slot="footer">
         <Button
           style="primary"
           part="footer-button"
           class="w-full p-3 flex text-lg justify-center"
-          onClick={this.onClose}
+          onClick={props.onClose}
         >
           <span class="truncate mr-1">
-            {this.bindings.i18n.t('view-results')}
+            {props.bindings.i18n.t('view-results')}
           </span>
           <span>
-            {this.bindings.i18n.t('between-parentheses', {
-              text: this.querySummary.state.total.toLocaleString(
-                this.bindings.i18n.language
+            {props.bindings.i18n.t('between-parentheses', {
+              text: props.querySummaryState.total.toLocaleString(
+                props.bindings.i18n.language
               ),
             })}
           </span>
         </Button>
       </div>
     );
-  }
+  };
 
-  public render(
-    children: VNode,
-    {isOpen, openButton}: RefineModalCommonRenderProps
-  ) {
-    return (
-      <atomic-modal
-        fullscreen
-        isOpen={isOpen}
-        source={openButton}
-        container={this.host}
-        close={this.onClose}
-        onAnimationEnded={() => {
-          if (!isOpen) {
-            this.flushFacetElements();
-          }
-        }}
-        exportparts="container,header,header-wrapper,header-ruler,body,body-wrapper,footer,footer-wrapper,footer-wrapper"
-      >
-        {this.renderHeader()}
-        {children}
-        {this.renderFooter()}
-      </atomic-modal>
-    );
-  }
-}
+  return (
+    <atomic-modal
+      fullscreen
+      isOpen={props.isOpen}
+      source={props.openButton}
+      container={props.host}
+      close={props.onClose}
+      onAnimationEnded={() => {
+        if (!props.isOpen) {
+          flushFacetElements();
+        }
+      }}
+      exportparts={exportparts}
+    >
+      {renderHeader()}
+      {...children}
+      {renderFooter()}
+    </atomic-modal>
+  );
+};
 
 export function getClonedFacetElements(
   facetElements: HTMLElement[],

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -16,6 +16,7 @@ interface RefineModalCommonOptions {
   bindings: AnyBindings;
   initializeQuerySummary(): QuerySummary;
   onClose(): void;
+  title: string;
 }
 
 export class RefineModalCommon {
@@ -23,6 +24,7 @@ export class RefineModalCommon {
   private bindings: AnyBindings;
   private querySummary: QuerySummary;
   private onClose: () => void;
+  private title: string;
 
   public exportparts =
     'container,header,header-wrapper,header-ruler,body,body-wrapper,footer,footer-wrapper,footer-wrapper';
@@ -32,6 +34,7 @@ export class RefineModalCommon {
     this.bindings = props.bindings;
     this.querySummary = props.initializeQuerySummary();
     this.onClose = props.onClose;
+    this.title = props.title;
   }
 
   public showModal() {
@@ -45,7 +48,7 @@ export class RefineModalCommon {
   public renderHeader() {
     return (
       <div slot="header" class="contents">
-        <h1 class="truncate">{this.bindings.i18n.t('sort-and-filter')}</h1>
+        <h1 class="truncate">{this.title}</h1>
         <Button
           style="text-transparent"
           class="grid place-items-center"

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -141,7 +141,7 @@ export class AtomicInsightRefineModal
           isOpen={this.isOpen}
           onClose={() => (this.isOpen = false)}
           querySummaryState={this.querySummaryState}
-          title={this.bindings.i18n.t('sort')}
+          title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
         >
           {this.renderBody()}

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -11,12 +11,12 @@ import {
   InsightInterfaceDimensions,
 } from '../atomic-insight-interface/atomic-insight-interface';
 import {
-  buildInsightFacetManager,
-  buildInsightQuerySummary,
-  InsightFacetManager,
-  InsightQuerySummary,
-  InsightQuerySummaryState,
-} from '..';
+  buildFacetManager,
+  FacetManager,
+  QuerySummary,
+  QuerySummaryState,
+  buildQuerySummary,
+} from '@coveo/headless/insight';
 import {
   getClonedFacetElements,
   RefineModalCommon,
@@ -34,13 +34,12 @@ import {Hidden} from '../../common/hidden';
 export class AtomicInsightRefineModal
   implements InitializableComponent<InsightBindings>
 {
-  private refineModalCommon!: RefineModalCommon;
   @InitializeBindings() public bindings!: InsightBindings;
   @Element() public host!: HTMLElement;
 
   @BindStateToController('querySummary')
   @State()
-  public querySummaryState!: InsightQuerySummaryState;
+  public querySummaryState!: QuerySummaryState;
 
   @State()
   public error!: Error;
@@ -53,11 +52,11 @@ export class AtomicInsightRefineModal
   @Prop({reflect: true, mutable: true}) isOpen = false;
 
   private interfaceDimensions?: InsightInterfaceDimensions;
-  private facetManager!: InsightFacetManager;
+  private facetManager!: FacetManager;
   private resizeObserver?: ResizeObserver;
   private debouncedUpdateDimensions = debounce(this.updateDimensions, 500);
   private scrollCallback = () => this.debouncedUpdateDimensions();
-  public querySummary!: InsightQuerySummary;
+  public querySummary!: QuerySummary;
 
   @Watch('isOpen')
   watchEnabled(isOpen: boolean) {
@@ -107,17 +106,8 @@ export class AtomicInsightRefineModal
   }
 
   public initialize() {
-    this.refineModalCommon = new RefineModalCommon({
-      title: this.bindings.i18n.t('sort'),
-      host: this.host,
-      bindings: this.bindings,
-      initializeQuerySummary: () =>
-        (this.querySummary = buildInsightQuerySummary(this.bindings.engine)),
-      onClose: () => {
-        this.isOpen = false;
-      },
-    });
-    this.facetManager = buildInsightFacetManager(this.bindings.engine);
+    this.facetManager = buildFacetManager(this.bindings.engine);
+    this.querySummary = buildQuerySummary(this.bindings.engine);
   }
 
   private renderBody() {
@@ -133,9 +123,6 @@ export class AtomicInsightRefineModal
   }
 
   public render() {
-    if (!this.refineModalCommon) {
-      return <Hidden></Hidden>;
-    }
     return (
       <Host>
         {this.interfaceDimensions && (
@@ -148,15 +135,22 @@ export class AtomicInsightRefineModal
             }`}
           </style>
         )}
-        {this.refineModalCommon.render(this.renderBody(), {
-          isOpen: this.isOpen && !this.loadingDimensions,
-          openButton: this.openButton,
-        })}
+        <RefineModalCommon
+          bindings={this.bindings}
+          host={this.host}
+          isOpen={this.isOpen}
+          onClose={() => (this.isOpen = false)}
+          querySummaryState={this.querySummaryState}
+          title={this.bindings.i18n.t('sort')}
+          openButton={this.openButton}
+        >
+          {this.renderBody()}
+        </RefineModalCommon>
       </Host>
     );
   }
 
   public componentDidLoad() {
-    this.refineModalCommon.showModal();
+    this.host.style.display = '';
   }
 }

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -11,12 +11,12 @@ import {
   InsightInterfaceDimensions,
 } from '../atomic-insight-interface/atomic-insight-interface';
 import {
-  buildFacetManager,
-  FacetManager,
-  QuerySummary,
-  QuerySummaryState,
-  buildQuerySummary,
-} from '@coveo/headless/insight';
+  buildInsightFacetManager,
+  InsightFacetManager,
+  InsightQuerySummary,
+  InsightQuerySummaryState,
+  buildInsightQuerySummary,
+} from '..';
 import {
   getClonedFacetElements,
   RefineModalCommon,
@@ -39,7 +39,7 @@ export class AtomicInsightRefineModal
 
   @BindStateToController('querySummary')
   @State()
-  public querySummaryState!: QuerySummaryState;
+  public querySummaryState!: InsightQuerySummaryState;
 
   @State()
   public error!: Error;
@@ -52,11 +52,11 @@ export class AtomicInsightRefineModal
   @Prop({reflect: true, mutable: true}) isOpen = false;
 
   private interfaceDimensions?: InsightInterfaceDimensions;
-  private facetManager!: FacetManager;
+  private facetManager!: InsightFacetManager;
   private resizeObserver?: ResizeObserver;
   private debouncedUpdateDimensions = debounce(this.updateDimensions, 500);
   private scrollCallback = () => this.debouncedUpdateDimensions();
-  public querySummary!: QuerySummary;
+  public querySummary!: InsightQuerySummary;
 
   @Watch('isOpen')
   watchEnabled(isOpen: boolean) {
@@ -106,8 +106,8 @@ export class AtomicInsightRefineModal
   }
 
   public initialize() {
-    this.facetManager = buildFacetManager(this.bindings.engine);
-    this.querySummary = buildQuerySummary(this.bindings.engine);
+    this.facetManager = buildInsightFacetManager(this.bindings.engine);
+    this.querySummary = buildInsightQuerySummary(this.bindings.engine);
   }
 
   private renderBody() {

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -108,6 +108,7 @@ export class AtomicInsightRefineModal
 
   public initialize() {
     this.refineModalCommon = new RefineModalCommon({
+      title: this.bindings.i18n.t('sort'),
       host: this.host,
       bindings: this.bindings,
       initializeQuerySummary: () =>

--- a/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
@@ -68,8 +68,9 @@ export class AtomicInsightRefineToggle {
   public render() {
     return (
       <atomic-icon-button
+        tooltip={this.bindings.i18n.t('sort')}
         icon={FilterIcon}
-        labelI18nKey="insight-history"
+        labelI18nKey="sort"
         clickCallback={() => {
           this.bindings.store.waitUntilAppLoaded(() => {
             this.enableModal();

--- a/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
@@ -68,7 +68,7 @@ export class AtomicInsightRefineToggle {
   public render() {
     return (
       <atomic-icon-button
-        tooltip={this.bindings.i18n.t('sort')}
+        tooltip={this.bindings.i18n.t('filters')}
         icon={FilterIcon}
         labelI18nKey="sort"
         clickCallback={() => {

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -96,6 +96,7 @@ export class AtomicRefineModal implements InitializableComponent {
   public initialize() {
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
     this.refineModalCommon = new RefineModalCommon({
+      title: this.bindings.i18n.t('sort-and-filter'),
       host: this.host,
       bindings: this.bindings,
       initializeQuerySummary: () =>

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -3,7 +3,6 @@ import {
   BreadcrumbManager,
   buildBreadcrumbManager,
   BreadcrumbManagerState,
-  buildQuerySummary,
   QuerySummary,
   QuerySummaryState,
   FacetManager,
@@ -12,6 +11,7 @@ import {
   Sort,
   buildSort,
   SortState,
+  buildQuerySummary,
 } from '@coveo/headless';
 import {
   BindStateToController,
@@ -26,7 +26,6 @@ import {
   getClonedFacetElements,
   RefineModalCommon,
 } from '../../common/refine-modal/refine-modal-common';
-import {Hidden} from '../../common/hidden';
 
 /**
  * The `atomic-refine-modal` is automatically created as a child of the `atomic-search-interface` when the `atomic-refine-toggle` is initialized.
@@ -54,7 +53,6 @@ import {Hidden} from '../../common/hidden';
   shadow: true,
 })
 export class AtomicRefineModal implements InitializableComponent {
-  private refineModalCommon!: RefineModalCommon;
   private sort!: Sort;
   private breadcrumbManager!: BreadcrumbManager;
   public querySummary!: QuerySummary;
@@ -95,18 +93,9 @@ export class AtomicRefineModal implements InitializableComponent {
 
   public initialize() {
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
-    this.refineModalCommon = new RefineModalCommon({
-      title: this.bindings.i18n.t('sort-and-filter'),
-      host: this.host,
-      bindings: this.bindings,
-      initializeQuerySummary: () =>
-        (this.querySummary = buildQuerySummary(this.bindings.engine)),
-      onClose: () => {
-        this.isOpen = false;
-      },
-    });
     this.facetManager = buildFacetManager(this.bindings.engine);
     this.sort = buildSort(this.bindings.engine);
+    this.querySummary = buildQuerySummary(this.bindings.engine);
     this.watchEnabled(this.isOpen);
   }
 
@@ -192,16 +181,22 @@ export class AtomicRefineModal implements InitializableComponent {
   }
 
   public render() {
-    if (!this.refineModalCommon) {
-      return <Hidden></Hidden>;
-    }
-    return this.refineModalCommon.render(this.renderBody(), {
-      isOpen: this.isOpen,
-      openButton: this.openButton,
-    });
+    return (
+      <RefineModalCommon
+        bindings={this.bindings}
+        host={this.host}
+        isOpen={this.isOpen}
+        onClose={() => (this.isOpen = false)}
+        title={this.bindings.i18n.t('sort-and-filter')}
+        querySummaryState={this.querySummaryState}
+        openButton={this.openButton}
+      >
+        {this.renderBody()}
+      </RefineModalCommon>
+    );
   }
 
   public componentDidLoad() {
-    this.refineModalCommon.showModal();
+    this.host.style.display = '';
   }
 }


### PR DESCRIPTION
The original story was a relatively small fix: add a tooltip to insight-refine-toggle + change the title of the modal from `Sort and filter` to only `Sort`.

I however took the opportunity to also refactor the code for `RefineModalCommon`. It was kind of a weird class with a bunch of stateful option.

I've changed it to a (hopefully) simpler standard functional component.

https://coveord.atlassian.net/browse/KIT-1975