### PR TITLE
feat(quantic): add focus control to modal

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -51,10 +51,10 @@ export default class QuanticResultLink extends LightningElement {
   /**
    * A function used to set focus to the link.
    * @api
-   * @type {()=>void}
+   * @type {VoidFunction}
    */
   @api setFocus() {
-    this.template.querySelector('a').focus();
+    this.anchorHTMLElement.focus();
   }
 
   /** @type {SearchEngine} */
@@ -85,4 +85,8 @@ export default class QuanticResultLink extends LightningElement {
       this.headless.buildInteractiveResult
     );
   };
+
+  get anchorHTMLElement() {
+    return this.template.querySelector('a');
+  }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -54,7 +54,11 @@ export default class QuanticResultLink extends LightningElement {
    * @type {VoidFunction}
    */
   @api setFocus() {
-    this.anchorHTMLElement.focus();
+    const focusTarget = this.template.querySelector('a');
+    if (focusTarget) {
+      // @ts-ignore
+      focusTarget.focus();
+    }
   }
 
   /** @type {SearchEngine} */
@@ -85,8 +89,4 @@ export default class QuanticResultLink extends LightningElement {
       this.headless.buildInteractiveResult
     );
   };
-
-  get anchorHTMLElement() {
-    return this.template.querySelector('a');
-  }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -1,5 +1,8 @@
 import {LightningElement, api} from 'lwc';
-import {getHeadlessBundle, getHeadlessEnginePromise} from 'c/quanticHeadlessLoader';
+import {
+  getHeadlessBundle,
+  getHeadlessEnginePromise,
+} from 'c/quanticHeadlessLoader';
 import {ResultUtils} from 'c/quanticUtils';
 
 /** @typedef {import("coveo").Result} Result */
@@ -45,17 +48,28 @@ export default class QuanticResultLink extends LightningElement {
    */
   @api useCase = 'search';
 
+  /**
+   * A function used to set focus to the link.
+   * @api
+   * @type {()=>void}
+   */
+  @api setFocus() {
+    this.template.querySelector('a').focus();
+  }
+
   /** @type {SearchEngine} */
   engine;
   /** @type {AnyHeadless} */
   headless;
 
   connectedCallback() {
-    getHeadlessEnginePromise(this.engineId).then((engine) => {
-      this.initialize(engine);
-    }).catch((error) => {
-      console.error(error.message);
-    });
+    getHeadlessEnginePromise(this.engineId)
+      .then((engine) => {
+        this.initialize(engine);
+      })
+      .catch((error) => {
+        console.error(error.message);
+      });
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -46,6 +46,6 @@
         </template>
       </div>
     </section>
-    <div class={backdropClass}></div>
+    <div class={backdropClass} onfocus={lastElementOnFocus} tabindex="0"></div>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -46,6 +46,6 @@
         </template>
       </div>
     </section>
-    <div class={backdropClass} onfocus={lastElementOnFocus} tabindex="0"></div>
+    <div class={backdropClass} onfocus={setFocusToTop} tabindex="0"></div>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -105,11 +105,9 @@ export default class QuanticResultQuickview extends LightningElement {
       // eslint-disable-next-line @lwc/lwc/no-inner-html
       this.contentContainer.innerHTML = this.state.content;
       // eslint-disable-next-line @lwc/lwc/no-async-operation
-      setTimeout(() => {
-        this.template
-          .querySelector('c-quantic-result-link')
-          .shadowRoot.firstChild.focus();
-      }, 0);
+      this.template
+        .querySelector('c-quantic-result-link')
+        .shadowRoot.firstChild.focus();
     }
     this.injectIdToSlots();
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -84,7 +84,7 @@ export default class QuanticResultQuickview extends LightningElement {
   /** @type {AnyHeadless} */
   headless;
   /** @type {boolean} */
-  previewRendered;
+  isFirstPreviewRender = true;
 
   labels = {
     close,
@@ -106,10 +106,9 @@ export default class QuanticResultQuickview extends LightningElement {
     if (this.contentContainer && this.state?.resultHasPreview) {
       // eslint-disable-next-line @lwc/lwc/no-inner-html
       this.contentContainer.innerHTML = this.state.content;
-      if (!this.previewRendered) {
-        this.previewRendered = true;
-        // @ts-ignore
-        this.headerElement?.setFocus();
+      if (this.isQuickviewOpen && this.isFirstPreviewRender) {
+        this.isFirstPreviewRender = false;
+        this.setFocusToHeader();
       }
     }
     this.injectIdToSlots();
@@ -157,7 +156,7 @@ export default class QuanticResultQuickview extends LightningElement {
 
   closeQuickview() {
     this.isQuickviewOpen = false;
-    this.previewRendered = false;
+    this.isFirstPreviewRender = true;
   }
 
   stopPropagation(evt) {
@@ -188,19 +187,6 @@ export default class QuanticResultQuickview extends LightningElement {
         slotContent.dataset.id = this.result.uniqueId;
       }
     });
-  }
-
-  lastElementOnFocus() {
-    // @ts-ignore
-    this.getCloseButton?.focus();
-  }
-
-  get headerElement() {
-    return this.template.querySelector('c-quantic-result-link');
-  }
-
-  get closeButton() {
-    return this.template.querySelector(`.slds-button.slds-button_icon`);
   }
 
   get isLoading() {
@@ -245,5 +231,25 @@ export default class QuanticResultQuickview extends LightningElement {
 
   get hasButtonLabel() {
     return !!this.previewButtonLabel;
+  }
+
+  setFocusToHeader() {
+    const focusTarget = this.template.querySelector('c-quantic-result-link');
+
+    if (focusTarget) {
+      // @ts-ignore
+      focusTarget.setFocus();
+    }
+  }
+
+  setFocusToTop() {
+    const focusTarget = this.template.querySelector(
+      `.slds-button.slds-button_icon`
+    );
+
+    if (focusTarget) {
+      // @ts-ignore
+      focusTarget.focus();
+    }
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -108,7 +108,8 @@ export default class QuanticResultQuickview extends LightningElement {
       this.contentContainer.innerHTML = this.state.content;
       if (!this.previewRendered) {
         this.previewRendered = true;
-        this.getHTMLHeader()?.focus();
+        // @ts-ignore
+        this.headerElement?.setFocus();
       }
     }
     this.injectIdToSlots();
@@ -189,17 +190,17 @@ export default class QuanticResultQuickview extends LightningElement {
     });
   }
 
-  getHTMLHeader() {
-    return this.template.querySelector('c-quantic-result-link').shadowRoot
-      .firstChild;
-  }
-
-  getCloseButton() {
-    return this.template.querySelector(`.slds-button.slds-button_icon`);
-  }
-
   lastElementOnFocus() {
-    this.getCloseButton()?.focus();
+    // @ts-ignore
+    this.getCloseButton?.focus();
+  }
+
+  get headerElement() {
+    return this.template.querySelector('c-quantic-result-link');
+  }
+
+  get closeButton() {
+    return this.template.querySelector(`.slds-button.slds-button_icon`);
   }
 
   get isLoading() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -104,6 +104,12 @@ export default class QuanticResultQuickview extends LightningElement {
     if (this.contentContainer && this.state?.resultHasPreview) {
       // eslint-disable-next-line @lwc/lwc/no-inner-html
       this.contentContainer.innerHTML = this.state.content;
+      // eslint-disable-next-line @lwc/lwc/no-async-operation
+      setTimeout(() => {
+        this.template
+          .querySelector('c-quantic-result-link')
+          .shadowRoot.firstChild.focus();
+      }, 0);
     }
     this.injectIdToSlots();
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -83,6 +83,8 @@ export default class QuanticResultQuickview extends LightningElement {
   unsubscribe;
   /** @type {AnyHeadless} */
   headless;
+  /** @type {boolean} */
+  previewRendered;
 
   labels = {
     close,
@@ -104,10 +106,10 @@ export default class QuanticResultQuickview extends LightningElement {
     if (this.contentContainer && this.state?.resultHasPreview) {
       // eslint-disable-next-line @lwc/lwc/no-inner-html
       this.contentContainer.innerHTML = this.state.content;
-      // eslint-disable-next-line @lwc/lwc/no-async-operation
-      this.template
-        .querySelector('c-quantic-result-link')
-        .shadowRoot.firstChild.focus();
+      if (!this.previewRendered) {
+        this.previewRendered = true;
+        this.getHTMLHeader()?.focus();
+      }
     }
     this.injectIdToSlots();
   }
@@ -154,6 +156,7 @@ export default class QuanticResultQuickview extends LightningElement {
 
   closeQuickview() {
     this.isQuickviewOpen = false;
+    this.previewRendered = false;
   }
 
   stopPropagation(evt) {
@@ -184,6 +187,19 @@ export default class QuanticResultQuickview extends LightningElement {
         slotContent.dataset.id = this.result.uniqueId;
       }
     });
+  }
+
+  getHTMLHeader() {
+    return this.template.querySelector('c-quantic-result-link').shadowRoot
+      .firstChild;
+  }
+
+  getCloseButton() {
+    return this.template.querySelector(`.slds-button.slds-button_icon`);
+  }
+
+  lastElementOnFocus() {
+    this.getCloseButton()?.focus();
   }
 
   get isLoading() {


### PR DESCRIPTION
[2295](https://coveord.atlassian.net/browse/SVCC-2295)
Added focus control to modal;
Preview now set focus to modal's title (element `<a>`) after modal is rendered
<img width="1204" alt="Screen Shot 2022-08-24 at 4 21 10 PM" src="https://user-images.githubusercontent.com/108746208/186516035-c4b5cca0-8033-4b89-8461-6193749600c4.png">

Preview now set focus to the first focusable element when tab is pressed on the last element.
