### PR TITLE
fix(quantic): JS doc comment fixed to generate the correct documentation for the QuanticNoResults component

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.js
@@ -17,6 +17,7 @@ import undoLastAction from '@salesforce/label/c.quantic_UndoLastAction';
 /**
  * The `QuanticNoResults` component displays search tips and a "Cancel last action" button when there are no results. Any additional content embedded inside the component will be displayed as well.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-no-results engine-id={engineId} disable-cancel-last-action></c-quantic-no-results>  
  */


### PR DESCRIPTION
Insight Panel category added to the JS doc of the QuanticNoResults component. this change will make this component appear under the Quantic Insight Panel components section in our documentation. 