### PR TITLE
fix(atomic): fix insight panel widget mode + refactor pager

### DIFF
--- a/packages/atomic/src/components/common/pager/pager-common.tsx
+++ b/packages/atomic/src/components/common/pager/pager-common.tsx
@@ -1,58 +1,56 @@
-import {EventEmitter, h} from '@stencil/core';
+import {EventEmitter, FunctionalComponent, h} from '@stencil/core';
 import ArrowRight from '../../../images/arrow-right.svg';
 import {FocusTargetController} from '../../../utils/accessibility-utils';
 import {randomID} from '../../../utils/utils';
 import {Button} from '../button';
+import {Hidden} from '../hidden';
 import {AnyBindings} from '../interface/bindings';
 import {RadioButton} from '../radio-button';
-import {Pager, SearchStatus} from '../types';
-
-interface SearchStatusOptions {
+interface PagerProps {
   bindings: AnyBindings;
-  initializeSearchStatus(): SearchStatus;
-  initializePager(): Pager;
-  getEventEmitter(): EventEmitter | undefined;
-  getActivePage(): FocusTargetController | undefined;
+  searchStatusState: {
+    hasResults: boolean;
+    hasError: boolean;
+  };
+  pagerState: {
+    hasPreviousPage: boolean;
+    currentPages: number[];
+    hasNextPage: boolean;
+  };
+  eventEmitter: EventEmitter;
+  activePage: FocusTargetController | undefined;
+  pager: {
+    selectPage: (page: number) => void;
+    nextPage: () => void;
+    previousPage: () => void;
+    isCurrentPage: (page: number) => boolean;
+    state: {};
+  };
 }
 
-export class PagerCommon {
-  private bindings: AnyBindings;
-  private searchStatus: SearchStatus;
-  private pager: Pager;
-  private getEventEmitter: () => EventEmitter | undefined;
-  private getActivePage: () => FocusTargetController | undefined;
-  private readonly radioGroupName = randomID('atomic-insight-pager-');
+export const PagerCommon: FunctionalComponent<PagerProps> = (props) => {
+  const radioGroupName = randomID('atomic-insight-pager-');
 
-  constructor(props: SearchStatusOptions) {
-    this.bindings = props.bindings;
-    this.searchStatus = props.initializeSearchStatus();
-    this.pager = props.initializePager();
-    this.getEventEmitter = props.getEventEmitter;
-    this.getActivePage = props.getActivePage;
-  }
+  const scrollToTop = () => {
+    props.eventEmitter?.emit();
+  };
 
-  public selectPage(page: number) {
-    this.pager.selectPage(page);
-    this.getActivePage()
-      ?.focusAfterSearch()
-      .then(() => this.scrollToTop());
-  }
+  const selectPage = (page: number) => {
+    props.pager.selectPage(page);
+    props.activePage?.focusAfterSearch().then(() => scrollToTop());
+  };
 
-  private scrollToTop() {
-    this.getEventEmitter()?.emit();
-  }
-
-  private get previousButton() {
+  const renderPreviousButton = () => {
     return (
       <Button
         style="outline-primary"
-        ariaLabel={this.bindings.i18n.t('previous')}
+        ariaLabel={props.bindings.i18n.t('previous')}
         onClick={() => {
-          this.pager.previousPage();
-          this.scrollToTop();
+          props.pager.previousPage();
+          scrollToTop();
         }}
         part="previous-button"
-        disabled={!this.pager.state.hasPreviousPage}
+        disabled={!props.pagerState.hasPreviousPage}
         class="p-1 min-w-[2.5rem] min-h-[2.5rem]"
       >
         <atomic-icon
@@ -61,19 +59,19 @@ export class PagerCommon {
         ></atomic-icon>
       </Button>
     );
-  }
+  };
 
-  private get pages() {
-    const pages = this.pager.state.currentPages;
+  const renderPages = () => {
+    const pages = props.pagerState.currentPages;
     return (
       <div part="page-buttons" role="radiogroup" class="contents">
-        {pages.map((page) => this.buildPage(page))}
+        {pages.map(renderPage)}
       </div>
     );
-  }
+  };
 
-  private buildPage(page: number) {
-    const isSelected = this.pager.isCurrentPage(page);
+  const renderPage = (page: number) => {
+    const isSelected = props.pager.isCurrentPage(page);
     const parts = ['page-button'];
     if (isSelected) {
       parts.push('active-page-button');
@@ -81,54 +79,56 @@ export class PagerCommon {
     return (
       <RadioButton
         key={page}
-        groupName={this.radioGroupName}
+        groupName={radioGroupName}
         style="outline-neutral"
         checked={isSelected}
         ariaCurrent={isSelected ? 'page' : 'false'}
-        ariaLabel={this.bindings.i18n.t('page-number', {page})}
-        onChecked={() => this.selectPage(page)}
+        ariaLabel={props.bindings.i18n.t('page-number', {page})}
+        onChecked={() => selectPage(page)}
         class="btn-page focus-visible:bg-neutral-light p-1 min-w-[2.5rem] min-h-[2.5rem]"
         part={parts.join(' ')}
-        text={page.toLocaleString(this.bindings.i18n.language)}
-        ref={isSelected ? this.getActivePage()?.setTarget : undefined}
+        text={page.toLocaleString(props.bindings.i18n.language)}
+        ref={isSelected ? props.activePage?.setTarget : undefined}
       ></RadioButton>
     );
-  }
+  };
 
-  private get nextButton() {
+  const renderNextButton = () => {
     return (
       <Button
         style="outline-primary"
-        ariaLabel={this.bindings.i18n.t('next')}
+        ariaLabel={props.bindings.i18n.t('next')}
         onClick={() => {
-          this.pager.nextPage();
-          this.scrollToTop();
+          props.pager.nextPage();
+          scrollToTop();
         }}
         part="next-button"
-        disabled={!this.pager.state.hasNextPage}
+        disabled={!props.pagerState.hasNextPage}
         class="p-1 min-w-[2.5rem] min-h-[2.5rem]"
       >
         <atomic-icon icon={ArrowRight} class="w-5 align-middle"></atomic-icon>
       </Button>
     );
+  };
+
+  if (props.searchStatusState.hasError) {
+    return <Hidden />;
   }
 
-  public render() {
-    if (
-      !this.bindings.store.isAppLoaded() ||
-      !this.searchStatus.state.hasResults
-    ) {
-      return;
-    }
-
-    return (
-      <nav aria-label={this.bindings.i18n.t('pagination')}>
-        <div part="buttons" class="flex gap-2 flex-wrap">
-          {this.previousButton}
-          {this.pages}
-          {this.nextButton}
-        </div>
-      </nav>
-    );
+  if (
+    !props.bindings.store.isAppLoaded() ||
+    !props.searchStatusState.hasResults
+  ) {
+    return;
   }
-}
+
+  return (
+    <nav aria-label={props.bindings.i18n.t('pagination')}>
+      <div part="buttons" class="flex gap-2 flex-wrap">
+        {renderPreviousButton()}
+        {renderPages()}
+        {renderNextButton()}
+      </div>
+    </nav>
+  );
+};

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -51,28 +51,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
     }
     `;
 
-  const pagination = `
-    ${sectionSelector('pagination')} {
-      background: var(--atomic-neutral-light);
-      padding: 1rem 1.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: stretch;
-    }
-    ${
-      widget
-        ? `
-        ${sectionSelector('pagination')} ${pagerSelector} {
-          width: 100%;
-        }
-        ${sectionSelector('pagination')} ${pagerSelector}::part(buttons) {
-          justify-content: space-between;
-        }
-    `
-        : ''
-    }
-    `;
-  return [interfaceStyle, search, results, pagination]
+  return [interfaceStyle, search, results]
     .filter((declaration) => declaration !== '')
     .join('\n\n');
 }

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -5,7 +5,6 @@ import {
 
 const tabsSelector = 'atomic-insight-tabs';
 const refineModalSelector = 'atomic-insight-refine-modal';
-const pagerSelector = 'atomic-insight-pager';
 
 export function buildInsightLayout(element: HTMLElement, widget: boolean) {
   const id = element.id;

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.pcss
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.pcss
@@ -3,3 +3,12 @@
 [part='page-button'] {
   @apply bg-transparent;
 }
+
+:host {
+  background: var(--atomic-neutral-light);
+  height: 100%;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
@@ -16,7 +16,6 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
-import {Hidden} from '../../common/hidden';
 import {PagerCommon} from '../../common/pager/pager-common';
 import {InsightBindings} from '../atomic-insight-interface/atomic-insight-interface';
 
@@ -31,7 +30,6 @@ import {InsightBindings} from '../atomic-insight-interface/atomic-insight-interf
 export class AtomicInsightPager
   implements InitializableComponent<InsightBindings>
 {
-  private pagerCommon!: PagerCommon;
   @InitializeBindings() public bindings!: InsightBindings;
   public pager!: InsightPager;
   public searchStatus!: InsightSearchStatus;
@@ -58,24 +56,22 @@ export class AtomicInsightPager
   private activePage!: FocusTargetController;
 
   public initialize() {
-    this.pagerCommon = new PagerCommon({
-      bindings: this.bindings,
-      initializeSearchStatus: () =>
-        (this.searchStatus = buildInsightSearchStatus(this.bindings.engine)),
-      initializePager: () =>
-        (this.pager = buildInsightPager(this.bindings.engine, {
-          options: {numberOfPages: this.numberOfPages},
-        })),
-      getEventEmitter: () => this.scrollToTopEvent,
-      getActivePage: () => this.activePage,
+    this.searchStatus = buildInsightSearchStatus(this.bindings.engine);
+    this.pager = buildInsightPager(this.bindings.engine, {
+      options: {numberOfPages: this.numberOfPages},
     });
   }
 
   public render() {
-    if (!this.pagerCommon) {
-      return <Hidden></Hidden>;
-    }
-
-    return this.pagerCommon.render();
+    return (
+      <PagerCommon
+        bindings={this.bindings}
+        eventEmitter={this.scrollToTopEvent}
+        activePage={this.activePage}
+        pager={this.pager}
+        pagerState={this.pagerState}
+        searchStatusState={this.searchStatusState}
+      />
+    );
   }
 }

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
@@ -16,7 +16,6 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
-import {Hidden} from '../../common/hidden';
 import {PagerCommon} from '../../common/pager/pager-common';
 import {Bindings} from '../atomic-search-interface/atomic-search-interface';
 
@@ -36,7 +35,6 @@ import {Bindings} from '../atomic-search-interface/atomic-search-interface';
   shadow: true,
 })
 export class AtomicPager implements InitializableComponent {
-  private pagerCommon!: PagerCommon;
   @InitializeBindings() public bindings!: Bindings;
   public pager!: Pager;
   public searchStatus!: SearchStatus;
@@ -63,24 +61,22 @@ export class AtomicPager implements InitializableComponent {
   private activePage!: FocusTargetController;
 
   public initialize() {
-    this.pagerCommon = new PagerCommon({
-      bindings: this.bindings,
-      initializeSearchStatus: () =>
-        (this.searchStatus = buildSearchStatus(this.bindings.engine)),
-      initializePager: () =>
-        (this.pager = buildPager(this.bindings.engine, {
-          options: {numberOfPages: this.numberOfPages},
-        })),
-      getEventEmitter: () => this.scrollToTopEvent,
-      getActivePage: () => this.activePage,
+    this.searchStatus = buildSearchStatus(this.bindings.engine);
+    this.pager = buildPager(this.bindings.engine, {
+      options: {numberOfPages: this.numberOfPages},
     });
   }
 
   public render() {
-    if (!this.pagerCommon) {
-      return <Hidden></Hidden>;
-    }
-
-    return this.pagerCommon.render();
+    return (
+      <PagerCommon
+        activePage={this.activePage}
+        bindings={this.bindings}
+        eventEmitter={this.scrollToTopEvent}
+        pager={this.pager}
+        pagerState={this.pagerState}
+        searchStatusState={this.searchStatusState}
+      />
+    );
   }
 }

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -24,9 +24,10 @@
       main();
     </script>
     <style>
+      atomic-insight-interface:not([widget='false']),
       atomic-insight-layout:not([widget='false']) {
-        width: 400px;
-        height: 720px;
+        width: 500px;
+        height: 1000px;
         margin-left: auto;
         margin-right: auto;
         box-shadow: 0px 3px 24px 0px #0000001a;
@@ -228,12 +229,14 @@
       updateWrapper(widgetView);
 
       async function updateWrapper(widgetView) {
-        await customElements.whenDefined('atomic-insight-layout');
-        const insightInterface = document.querySelector('atomic-insight-layout');
+        const interface = 'atomic-insight-interface';
+        const layout = 'atomic-insight-layout';
+        await Promise.all([customElements.whenDefined(interface), customElements.whenDefined(layout)]);
+        const insightElements = [document.querySelector(interface), document.querySelector(layout)];
         if (widgetView) {
-          insightInterface.setAttribute('widget', true);
+          insightElements.forEach((el) => el.setAttribute('widget', true));
         } else {
-          insightInterface.setAttribute('widget', false);
+          insightElements.forEach((el) => el.setAttribute('widget', false));
         }
       }
     </script>


### PR DESCRIPTION
Original bug was a relatively small fix to the local "widget" mode, which forced the width and height of the panel to look like a small window (in `insights.html`).

While working on that I also found some rendering problems with the pagination section when there are no results or there is a query error.

I moved styling from the layouts to the atomic-insight-pager component itself, so we can better control when it is hidden or shown.

Also refactored PagerCommon from a class to a function component.


https://coveord.atlassian.net/browse/KIT-1957