### PR TITLE
feat(atomic): set default insight panel results per page

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -453,6 +453,10 @@ export namespace Components {
           * The severity level of the messages to log in the console.
          */
         "logLevel"?: InsightLogLevel;
+        /**
+          * The number of results per page. By default, this is set to `5`.
+         */
+        "resultsPerPage": number;
     }
     interface AtomicInsightLayout {
         /**
@@ -2703,6 +2707,10 @@ declare namespace LocalJSX {
           * The severity level of the messages to log in the console.
          */
         "logLevel"?: InsightLogLevel;
+        /**
+          * The number of results per page. By default, this is set to `5`.
+         */
+        "resultsPerPage"?: number;
     }
     interface AtomicInsightLayout {
         /**

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
@@ -139,7 +139,7 @@ export class AtomicInsightInterface
       return;
     }
     buildInsightResultsPerPage(this.bindings.engine, {
-      initialState: {numberOfResults: 5},
+      initialState: {numberOfResults: this.resultsPerPage},
     });
   }
 

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
@@ -22,6 +22,7 @@ import {
   InsightEngine,
   InsightEngineConfiguration,
   buildInsightEngine,
+  buildInsightResultsPerPage,
 } from '..';
 
 const FirstInsightRequestExecutedFlag = 'firstInsightRequestExecuted';
@@ -95,6 +96,10 @@ export class AtomicInsightInterface
    * A list of non-default fields to include in the query results, separated by commas.
    */
   @Prop({reflect: true}) public fieldsToInclude = '';
+  /**
+   * The number of results per page. By default, this is set to `5`.
+   */
+  @Prop({reflect: true}) resultsPerPage = 5;
 
   @Element() public host!: HTMLAtomicInsightInterfaceElement;
 
@@ -127,6 +132,15 @@ export class AtomicInsightInterface
   public connectedCallback() {
     this.store.setLoadingFlag(FirstInsightRequestExecutedFlag);
     this.updateFieldsToInclude();
+  }
+
+  private initResultsPerPage() {
+    if (!this.commonInterfaceHelper.engineIsCreated(this.engine)) {
+      return;
+    }
+    buildInsightResultsPerPage(this.bindings.engine, {
+      initialState: {numberOfResults: 5},
+    });
   }
 
   private updateFieldsToInclude() {
@@ -225,6 +239,7 @@ export class AtomicInsightInterface
   private async internalInitialization(initEngine: () => void) {
     await this.commonInterfaceHelper.onInitialization(initEngine);
     this.store.unsetLoadingFlag(FirstInsightRequestExecutedFlag);
+    this.initResultsPerPage();
     this.initialized = true;
   }
 }

--- a/packages/atomic/src/components/insight/index.ts
+++ b/packages/atomic/src/components/insight/index.ts
@@ -71,4 +71,5 @@ export {
   Pager as InsightPager,
   PagerState as InsightPagerState,
   buildPager as buildInsightPager,
+  buildResultsPerPage as buildInsightResultsPerPage,
 } from '@coveo/headless/insight';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2012

Added a prop and set the default to 5 in the `atomic-insight-interface`.