### PR TITLE
fix(headless): new html method added to the insight api client

### DIFF
--- a/packages/headless/src/api/service/insight/insight-api-client.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.ts
@@ -4,6 +4,8 @@ import {ClientThunkExtraArguments} from '../../../app/thunk-extra-arguments';
 import {InsightAppState} from '../../../state/insight-app-state';
 import {PlatformClient} from '../../platform-client';
 import {PreprocessRequest} from '../../preprocess-request';
+import {getHtml} from '../../search/html/html-api-client';
+import {HtmlRequest} from '../../search/html/html-request';
 import {buildAPIResponseFromErrorOrThrow} from '../../search/search-api-error-response';
 import {SearchResponseSuccess} from '../../search/search/search-response';
 import {
@@ -111,5 +113,9 @@ export class InsightAPIClient {
     return response.ok
       ? {success: body as InsightUserActionsResponse}
       : {error: body as InsightAPIErrorStatusResponse};
+  }
+
+  async html(req: HtmlRequest) {
+    return getHtml(req, {...this.options});
   }
 }


### PR DESCRIPTION
### Issue:
The` html `method was missing from the `Insight API Client` causing the following error:
`apiClient.html is not a function`

https://user-images.githubusercontent.com/86681870/187944356-e2c6718f-e874-4de7-a3cd-3b77acb61ebc.mov

### Solution:
The `html` method added to the `Insight API Client`:

https://user-images.githubusercontent.com/86681870/187944690-90d0f3ba-dcdf-49f2-b5a3-d043664a3251.mov


### Note:
The error `apiClient.html is not a function` is fixed by the change in this PR but the QuickView is still not working correctly  because of a second issue which is that we are calling the SearchAPI to get the result preview with a Platform Token and platform tokens are not supported in the SearchAPI.
The plan is to to proxy this call by the Customer Service API first, like we currently do for the search queries. This will be added in a future iteration.