### PR TITLE
fix(atomic): fixed atomic-insight-refine-modal open animation

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
@@ -33,13 +33,6 @@ export type InsightBindings = CommonBindings<
   HTMLAtomicInsightInterfaceElement
 >;
 
-export type InsightInterfaceDimensions = {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-};
-
 /**
  * @internal
  */
@@ -102,22 +95,6 @@ export class AtomicInsightInterface
   @Prop({reflect: true}) resultsPerPage = 5;
 
   @Element() public host!: HTMLAtomicInsightInterfaceElement;
-
-  @Listen('atomic/insight/getDimensions')
-  public getDimensions(
-    event: CustomEvent<(dimensions: InsightInterfaceDimensions) => void>
-  ) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const rect = this.host.getBoundingClientRect();
-    event.detail({
-      top: rect.top,
-      left: rect.left,
-      height: rect.height,
-      width: rect.width,
-    });
-  }
 
   private store = createAtomicInsightStore();
   private commonInterfaceHelper: CommonAtomicInterfaceHelper<InsightEngine>;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2009

Prior to this PR, the animation was fullscreen when the modal was opened for the first time. This was because the modal was initially rendered without knowing the dimensions of the insight interface.

Another change I made in this PR was to remove a redundant event that was used to find out the size of the insight interface. It's not necessary since we already have the bindings.