### PR TITLE
fix(quantic): issue fixed when QuanticTabBar doesn't contain any tab

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -364,6 +364,9 @@ export default class QuanticTabBar extends LightningElement {
    * @returns {number}
    */
   getAbsoluteWidth(element) {
+    if (!element) {
+      return 0;
+    }
     const paddings = this.getElementPadding(element);
     const padding = paddings.left + paddings.right;
 


### PR DESCRIPTION
[SVCC-2436](https://coveord.atlassian.net/browse/SVCC-2436)

### The issue:
An error is thrown when trying to call the `getAbsoluteWidth` method with null as the parameter,  this situation happens when there is no Tab passed to the QuanticTabBar: 
 
![image-20220907-150608](https://user-images.githubusercontent.com/86681870/188971013-1866df52-4e1b-4cfd-80f2-f88c766b89c4.png)
