### PR TITLE
fix(quantic): new title for the refine toggle when it's disabled

### DIFF
--- a/packages/quantic/cypress/integration/refine-toggle/refine-toggle.cypress.ts
+++ b/packages/quantic/cypress/integration/refine-toggle/refine-toggle.cypress.ts
@@ -29,6 +29,7 @@ const customRefineModalTitle = 'Custom Title';
 const customRefineToggleLabel = 'Custom Label';
 const defaultRefineToggleTitle = 'Sort & Filters';
 const customRefineToggleTitle = 'Filters';
+const disabledRefineToggleTitle = 'No filters available for this query';
 
 describe('quantic-refine-toggle', () => {
   const pageUrl = 's/quantic-refine-toggle';
@@ -110,6 +111,7 @@ describe('quantic-refine-toggle', () => {
           Expect.refineToggleContains(customRefineToggleLabel);
           Expect.displayFiltersCountBadge(false);
           Expect.refineToggleDisabled(true);
+          Expect.refineToggleTitleContains(disabledRefineToggleTitle);
         });
       });
     });
@@ -126,6 +128,7 @@ describe('quantic-refine-toggle', () => {
           Expect.refineToggleContains(customRefineToggleLabel);
           Expect.displayFiltersCountBadge(false);
           Expect.refineToggleDisabled(true);
+          Expect.refineToggleTitleContains(disabledRefineToggleTitle);
         });
       });
     });
@@ -257,6 +260,7 @@ describe('quantic-refine-toggle', () => {
           Expect.refineToggleContains(customRefineToggleLabel);
           Expect.displayFiltersCountBadge(false);
           Expect.refineToggleDisabled(true);
+          Expect.refineToggleTitleContains(disabledRefineToggleTitle);
         });
       });
     });
@@ -370,6 +374,7 @@ describe('quantic-refine-toggle', () => {
             Expect.refineToggleContains(customRefineToggleLabel);
             Expect.displayFiltersCountBadge(false);
             Expect.refineToggleDisabled(true);
+            Expect.refineToggleTitleContains(disabledRefineToggleTitle);
           });
         });
       });
@@ -388,6 +393,7 @@ describe('quantic-refine-toggle', () => {
           Expect.refineToggleContains(customRefineToggleLabel);
           Expect.displayFiltersCountBadge(false);
           Expect.refineToggleDisabled(true);
+          Expect.refineToggleTitleContains(disabledRefineToggleTitle);
         });
       });
     });

--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -868,4 +868,11 @@
       <protected>false</protected>
       <shortDescription>View results</shortDescription>
     </labels>
+    <labels>
+      <fullName>quantic_NoFiltersAvailableForThisQuery</fullName>
+      <value>No filters available for this query</value>
+      <language>en_US</language>
+      <protected>false</protected>
+      <shortDescription>No filters available for this query</shortDescription>
+    </labels>
 </CustomLabels>

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.html
@@ -1,9 +1,9 @@
 <template>
   <button class="slds-button slds-button_neutral refine-button slds-is-relative" onclick={openModal}
-    title={title} disabled={refineButtonDisabled}>
+    title={buttonTitle} disabled={refineButtonDisabled}>
     <slot name="button-content">
       {labels.sortAndFilters}
-      <lightning-icon size="x-small" icon-name="utility:filterList" alternative-text={title}
+      <lightning-icon size="x-small" icon-name="utility:filterList" alternative-text={buttonTitle}
         class="slds-current-color slds-var-p-vertical_x-small slds-button__icon_right">
       </lightning-icon>
     </slot>

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.js
@@ -8,6 +8,8 @@ import {
 import LOCALE from '@salesforce/i18n/locale';
 import sortAndFilters from '@salesforce/label/c.quantic_SortAndFilters';
 import viewResults from '@salesforce/label/c.quantic_ViewResults';
+import noFiltersAvailableForThisQuery from '@salesforce/label/c.quantic_NoFiltersAvailableForThisQuery';
+
 
 /**
  * @typedef {Object} QuanticModalElement
@@ -38,6 +40,7 @@ export default class QuanticRefineToggle extends LightningElement {
   labels = {
     sortAndFilters,
     viewResults,
+    noFiltersAvailableForThisQuery
   };
 
   /**
@@ -255,5 +258,15 @@ export default class QuanticRefineToggle extends LightningElement {
     return `${this.labels.viewResults} (${new Intl.NumberFormat(LOCALE).format(
       this.total
     )})`;
+  }
+
+  /**
+   * Returns the title of the refine toggle.
+   * @returns {string}
+   */
+  get buttonTitle() {
+    return this.refineButtonDisabled
+      ? this.labels.noFiltersAvailableForThisQuery
+      : this.title;
   }
 }

--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -460,4 +460,8 @@
       <label>Afficher {{0}} résultats par page.</label>
       <name>quantic_ShowNResultsPerPage</name>
     </customLabels>
+    <customLabels>
+      <label>Aucun filtre disponible pour cette requête</label>
+      <name>quantic_NoFiltersAvailableForThisQuery</name>
+    </customLabels>
 </Translations>


### PR DESCRIPTION
[SVCC-2437](https://coveord.atlassian.net/browse/SVCC-2437)
### Issue
Following a discussion with the UX team, we decided to update the title of the refine toggle button when this button is disabled.

### behaviour  we want for the refine toggle button:

When the facets are ON but the query returns no results:
Always keep filter button, we don’t want the layout to change all the time. Two situations here:

- The query is empty but there are filters selected: keep the filter panel accessible. So users can modify the filters as they might be the reason the query is not returning results.

- The query is empty but there are NO filters selected. Disable the button, it doesn’t help much to see an empty filter panel. Add a tooltip to explain the behaviour. example: No filters available for this query

### Demo
https://user-images.githubusercontent.com/86681870/189116268-9b04618b-b757-4e1f-8d83-a6620f79098c.mov

