### PR TITLE
fix(quantic): removed unnecessary margins from result template slots

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.html
@@ -1,17 +1,17 @@
 <template>
   <div class="lgc-bg slds-border_bottom slds-p-vertical_medium">
-    <div class="slds-grid slds-wrap slds-col slds-grid_vertical-align-center slds-size_1-of-1 slds-text-align_left slds-m-bottom_x-small">
+    <div class={headerCssClass}>
       <div class="slds-col slds-m-right_small slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1">
-        <slot name="label"></slot>
+        <slot name="label" onslotchange={handleHeaderSlotChange}></slot>
       </div>
-      <div class="badge__container slds-col slds-order_1 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-vertical_xx-small slds-m-right_small">
-        <slot name="badges"></slot>
+      <div class={badgesSlotCssClass}>
+        <slot name="badges" onslotchange={handleHeaderSlotChange}></slot>
       </div>
       <div class="slds-col slds-order_3 slds-col_bump-left slds-p-right_xx-small">
-        <slot name="actions"></slot>
+        <slot name="actions" onslotchange={handleHeaderSlotChange}></slot>
       </div>
       <div class="date__container slds-truncate slds-col slds-order_4 slds-text-align_right">
-        <slot name="date"></slot>
+        <slot name="date" onslotchange={handleHeaderSlotChange}></slot>
       </div>
     </div>
     <div class="slds-grid slds-size_1-of-1 main-content__container">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.js
@@ -18,4 +18,34 @@ import {LightningElement} from 'lwc';
  *   <div slot="bottom-metadata"></div>
  * </c-quantic-result-template>
  */
-export default class QuanticResultTemplate extends LightningElement {}
+export default class QuanticResultTemplate extends LightningElement {
+  /** @type {boolean} */
+  isHeaderEmpty = true;
+  /** @type {boolean} */
+  isBadgesSlotEmpty = true;
+
+  handleHeaderSlotChange(event) {
+    const slot = event.target;
+    const slotHasContent = !!slot.assignedElements().length;
+    if (slotHasContent) {
+      this.isHeaderEmpty = false;
+      if (slot.name === 'badges') {
+        this.isBadgesSlotEmpty = false;
+      }
+    }
+  }
+
+  /** Returns the CSS class of the header of the result template */
+  get headerCssClass() {
+    return `slds-grid slds-wrap slds-col slds-grid_vertical-align-center slds-size_1-of-1 slds-text-align_left ${
+      this.isHeaderEmpty ? '' : 'slds-m-bottom_x-small'
+    }`;
+  }
+
+    /** Returns the CSS class  of the badges slot of the result template */
+    get badgesSlotCssClass() {
+      return `badge__container slds-col slds-order_1 slds-small-order_1 slds-medium-order_2 slds-large-order_2 slds-m-right_small ${
+        this.isBadgesSlotEmpty ? '' : 'slds-m-vertical_xx-small'
+      }`;
+    }
+}


### PR DESCRIPTION
### The issue
The results templates slots were taking some space even when the slots are completely empty.

### Before:
<img width="275" alt="NoBAdgeBEfore" src="https://user-images.githubusercontent.com/86681870/189167624-a3fb3109-8bcb-4189-bbac-e654b7e5934c.png">

### After:
<img width="270" alt="NoBAdgesAfter" src="https://user-images.githubusercontent.com/86681870/189168198-2dd92629-99b5-4b11-8b74-0222b77fe6bc.png">

Note: Changes in this PR do not have any impact when the slots are provided.
Quantic standard result templates still look absolutely  the same:
<img width="287" alt="NoBadgesAfter2Standard" src="https://user-images.githubusercontent.com/86681870/189168633-7d9d7f5b-246e-4869-843a-95ed72529679.png">
