### PR TITLE
fix(quantic): Display the click URI in the QuanticResultLink when the title is not present

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.html
@@ -1,3 +1,3 @@
 <template>
-  <a href={result.clickUri} target={target}>{result.title}</a>
+  <a href={result.clickUri} target={target}>{displayedTitle}</a>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -89,4 +89,11 @@ export default class QuanticResultLink extends LightningElement {
       this.headless.buildInteractiveResult
     );
   };
+
+  /**
+   * Returns the title to display.
+   */
+  get displayedTitle() {
+    return this.result.title || this.result.clickUri;
+  }
 }


### PR DESCRIPTION
[SVCC-2438](https://coveord.atlassian.net/browse/SVCC-2438)

When the title is not present, the QuanticResultLink is now displaying the click URI instead of displaying nothing.

#### Before:
<img width="206" alt="WithoutTitle" src="https://user-images.githubusercontent.com/86681870/189192120-e5191209-8051-4b27-8a76-3d5c2619be3f.png">

#### After: 
<img width="206" alt="WithTitle" src="https://user-images.githubusercontent.com/86681870/189192150-593f08cb-a760-4c03-ae57-db451ac5bda3.png">
