### PR TITLE
fix(atomic): handle active breadcrumb corner case for insight-refine-toggle disable

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.tsx
@@ -79,7 +79,9 @@ export class AtomicInsightRefineToggle {
       <atomic-icon-button
         tooltip={this.bindings.i18n.t('filters')}
         icon={FilterIcon}
-        disabled={!this.searchStatusState.hasResults}
+        disabled={
+          !this.searchStatusState.hasResults && !this.numberOfBreadcrumbs
+        }
         labelI18nKey="sort"
         clickCallback={() => {
           this.bindings.store.waitUntilAppLoaded(() => {


### PR DESCRIPTION
Small adjustment on yesterday PR: Need to handle when there is an active facet that causes no results to return.

https://coveord.atlassian.net/browse/KIT-2019