### PR TITLE
fix(atomic): display no results full query

### DIFF
--- a/packages/atomic/src/components/common/no-results/no-results-common.tsx
+++ b/packages/atomic/src/components/common/no-results/no-results-common.tsx
@@ -22,7 +22,10 @@ const BetweenQuotes: FunctionalComponent<{
   bindings: AnyBindings;
 }> = (props) => {
   return (
-    <span class="font-bold" part="highlight">
+    <span
+      class="font-bold truncate inline-block align-bottom max-w-full whitespace-normal"
+      part="highlight"
+    >
       <LocalizedString
         key="between-quotations"
         params={{text: props.content}}
@@ -58,7 +61,7 @@ const NoResults: FunctionalComponent<{
   );
   return (
     <div
-      class="my-2 text-2xl font-medium truncate overflow-hidden max-w-full"
+      class="my-2 text-2xl font-medium max-w-full text-center"
       part="no-results"
     >
       {content}
@@ -68,7 +71,7 @@ const NoResults: FunctionalComponent<{
 
 const SearchTips: FunctionalComponent<{bindings: AnyBindings}> = (props) => {
   return (
-    <div class="my-2 text-lg text-neutral-dark" part="search-tips">
+    <div class="my-2 text-lg text-neutral-dark text-center" part="search-tips">
       {props.bindings.i18n.t('search-tips')}
     </div>
   );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1992

Now will wrap on multiple lines, but long 1 word queries will still be truncated
![Screen Shot 2022-09-09 at 4 33 03 PM](https://user-images.githubusercontent.com/4923043/189438604-98d07114-1341-40ad-9660-9c82ee020388.png)
![Screen Shot 2022-09-09 at 4 27 00 PM](https://user-images.githubusercontent.com/4923043/189438606-63442617-0f98-4507-9cf9-d86a5c994ef2.png)
