### PR TITLE
fix(atomic): added smart snippet inline link analytics

### DIFF
--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -204,6 +204,7 @@ export class TestFixture {
               modifier.predicate(combinedResponse) || combinedResponse;
             modifier.times--;
           });
+          return combinedResponse;
         });
       }
 

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -21,6 +21,11 @@ export type SearchResponseModifierPredicate = (
   response: SearchResponseSuccess
 ) => SearchResponseSuccess | void;
 
+interface SearchResponseModifier {
+  predicate: SearchResponseModifierPredicate;
+  times: number;
+}
+
 export type SearchInterface = HTMLElement & {
   initialize: (opts: {
     accessToken: string;
@@ -48,7 +53,7 @@ export class TestFixture {
   private fieldCaptions: {field: string; captions: Record<string, string>}[] =
     [];
   private translations: Record<string, string> = {};
-  private responseModifiers: SearchResponseModifierPredicate[] = [];
+  private responseModifiers: SearchResponseModifier[] = [];
   private returnError = false;
   private reflectStateInUrl = true;
   private redirected = false;
@@ -122,8 +127,11 @@ export class TestFixture {
     return this;
   }
 
-  public withCustomResponse(predicate: SearchResponseModifierPredicate) {
-    this.responseModifiers.push(predicate);
+  public withCustomResponse(
+    predicate: SearchResponseModifierPredicate,
+    times = 9999
+  ) {
+    this.responseModifiers.push({predicate, times});
     return this;
   }
 
@@ -186,13 +194,17 @@ export class TestFixture {
       }
 
       if (this.responseModifiers.length) {
-        interceptSearchResponse((response) =>
-          this.responseModifiers.reduce(
-            (combinedResponse, modifier) =>
-              modifier(combinedResponse) || combinedResponse,
-            response
-          )
-        );
+        interceptSearchResponse((response) => {
+          let combinedResponse = response;
+          this.responseModifiers.forEach((modifier) => {
+            if (modifier.times <= 0) {
+              return;
+            }
+            combinedResponse =
+              modifier.predicate(combinedResponse) || combinedResponse;
+            modifier.times--;
+          });
+        });
       }
 
       if (this.returnError) {

--- a/packages/atomic/cypress/integration/smart-snippet-actions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-actions.ts
@@ -23,15 +23,15 @@ export const addSmartSnippetDefaultOptions: Required<AddSmartSnippetOptions> = {
   question: 'Creating an In-Product Experience (IPX)',
   answer: `
     <ol>
-      <li>On the <b>In-Product Experiences</b> page, click Add <b>In-Product Experience</b>.</li>
+      <li>On the <a href="https://platform.cloud.coveo.com/admin/#/orgid/search/in-app-widgets/">In-Product Experiences</a> page, click Add <b>In-Product Experience</b>.</li>
       <li>In the Configuration tab, fill the Basic settings section.</li>
-      <li>(Optional) Use the Design and Content access tabs to customize your <b>IPX</b> interface.</li>
+      <li>(Optional) Use the Design and Content access tabs to <a href="https://docs.coveo.com/en/3160/#customizing-an-ipx-interface">customize your <b>IPX</b> interface</a>.</li>
       <li>Click Save.</li>
       <li>In the Loader snippet panel that appears, you may click Copy to save the loader snippet for your <b>IPX</b> to your clipboard, and then click Save.  You can Always retrieve the loader snippet later.</li>
     </ol>
 
     <p>
-      You're now ready to load your IPX interface in the desired web site or application. However, we recommend that you configure query pipelines for your IPX interface before.
+      You're now ready to <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications">embed your IPX interface</a>. However, we recommend that you <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#configuring-query-pipelines-for-an-ipx-interface-recommended">configure query pipelines for your IPX interface</a> before.
     </p>
   `,
   sourceTitle: 'Manage the Coveo In-Product Experiences (IPX)',

--- a/packages/atomic/cypress/integration/smart-snippet-assertions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-assertions.ts
@@ -1,3 +1,4 @@
+import {InlineLink} from '@coveo/headless';
 import {AnalyticsTracker} from '../utils/analyticsUtils';
 import {should} from './common-assertions';
 import {SmartSnippetSelectors} from './smart-snippet-selectors';
@@ -91,6 +92,26 @@ export function assertlogOpenSmartSnippetSource(log: boolean) {
   it(`${should(log)} log a openSmartSnippetSource click event`, () => {
     if (log) {
       cy.expectClickEvent('openSmartSnippetSource');
+    } else {
+      cy.wait(50);
+      cy.wrap(AnalyticsTracker).invoke('getLastClickEvent').should('not.exist');
+    }
+  });
+}
+
+export function assertlogOpenSmartSnippetInlineLink(
+  getLinkToLog: (() => InlineLink) | null
+) {
+  it(`${should(
+    !!getLinkToLog
+  )} log a openSmartSnippetInlineLink click event`, () => {
+    if (getLinkToLog) {
+      const {linkText, linkURL} = getLinkToLog();
+      cy.expectClickEvent('openSmartSnippetInlineLink').should((clickEvent) => {
+        expect(clickEvent).to.have.property('customData');
+        expect(clickEvent.customData).to.have.property('linkText', linkText);
+        expect(clickEvent.customData).to.have.property('linkURL', linkURL);
+      });
     } else {
       cy.wait(50);
       cy.wrap(AnalyticsTracker).invoke('getLastClickEvent').should('not.exist');

--- a/packages/atomic/cypress/integration/smart-snippet-assertions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-assertions.ts
@@ -88,7 +88,7 @@ export function assertLogDislikeSmartSnippet() {
   });
 }
 
-export function assertlogOpenSmartSnippetSource(log: boolean) {
+export function assertLogOpenSmartSnippetSource(log: boolean) {
   it(`${should(log)} log a openSmartSnippetSource click event`, () => {
     if (log) {
       cy.expectClickEvent('openSmartSnippetSource');
@@ -99,7 +99,7 @@ export function assertlogOpenSmartSnippetSource(log: boolean) {
   });
 }
 
-export function assertlogOpenSmartSnippetInlineLink(
+export function assertLogOpenSmartSnippetInlineLink(
   getLinkToLog: (() => InlineLink) | null
 ) {
   it(`${should(

--- a/packages/atomic/cypress/integration/smart-snippet-suggestions-actions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions-actions.ts
@@ -1,14 +1,12 @@
-import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
+import {
+  generateComponentHTML,
+  SearchResponseModifierPredicate,
+  TestFixture,
+} from '../fixtures/test-fixture';
 import {toArray} from '../utils/arrayUtils';
 import {addSmartSnippetDefaultOptions} from './smart-snippet-actions';
 
-export interface AddSmartSnippetSuggestionsOptions {
-  remSize?: number;
-  props?: {
-    'heading-level'?: number;
-    'snippet-style'?: string;
-  };
-  content?: HTMLElement | HTMLElement[];
+export interface GetResponseModifierWithSmartSnippetSuggestionsOptions {
   relatedQuestions?: {
     question: string;
     answer: string;
@@ -18,22 +16,30 @@ export interface AddSmartSnippetSuggestionsOptions {
   }[];
 }
 
-export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetSuggestionsOptions> =
+export interface AddSmartSnippetSuggestionsOptions
+  extends GetResponseModifierWithSmartSnippetSuggestionsOptions {
+  remSize?: number;
+  props?: {
+    'heading-level'?: number;
+    'snippet-style'?: string;
+  };
+  content?: HTMLElement | HTMLElement[];
+  timesToIntercept?: number;
+}
+
+export const getResponseModifierWithSmartSnippetSuggestionsDefaultOptions: Required<GetResponseModifierWithSmartSnippetSuggestionsOptions> =
   {
-    remSize: 12,
-    props: {},
-    content: [],
     relatedQuestions: [
       {
         question: 'Where does the name "Nurse Sharks" come from?',
         answer: `
-          <p>
-            The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the catsharks of the family Scyliorhinidae.
-          </p>
-          <p>
-            The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the Greek words <i>ginglymos</i> (γίγγλυμος) meaning "<b>hinge</b>" and <i>stoma</i> (στόμα) meaning "<b>mouth</b>". 
-          </p>
-        `,
+      <p>
+        The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the <a href="https://en.wikipedia.org/wiki/Catshark">catsharks</a> of the family Scyliorhinidae.
+      </p>
+      <p>
+        The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the <a href="https://en.wikipedia.org/wiki/Greek_language">Greek</a> words <i>ginglymos</i> (<a href="https://en.wiktionary.org/wiki/%CE%B3%CE%AF%CE%B3%CE%B3%CE%BB%CF%85%CE%BC%CE%BF%CF%82#Ancient_Greek">γίγγλυμος</a>) meaning "<b>hinge</b>" and <i>stoma</i> (<a href="https://en.wiktionary.org/wiki/%CF%83%CF%84%CF%8C%CE%BC%CE%B1#Ancient_Greek">στόμα</a>) meaning "<b>mouth</b>". 
+      </p>
+    `,
         sourceTitle: 'Nurse Sharks',
         sourceUrl: 'https://www.inaturalist.org/taxa/49968',
         id: 'nurse-sharks',
@@ -41,13 +47,13 @@ export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetS
       {
         question: 'What are sea monkeys?',
         answer: `
-          <p>
-            Breeds of Artemia are sold as novelty gifts under the marketing name Sea-Monkeys. 
-          </p>
-          <p>
-            <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. Artemia, the only genus in the family <i>Artemiidae</i>.
-          </p>
-        `,
+      <p>
+        Breeds of Artemia are sold as novelty gifts under the marketing name <a href="https://en.wikipedia.org/wiki/Sea-Monkeys">Sea-Monkeys</a>. 
+      </p>
+      <p>
+        <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. It is the only genus in the <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> <b>Artemiidae</b>.
+      </p>
+    `,
         sourceTitle: 'Brine Shrimp',
         sourceUrl: 'https://www.inaturalist.org/taxa/86651',
         id: 'brine-shrimp',
@@ -55,16 +61,61 @@ export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetS
       {
         question: 'What is a dove snail?',
         answer: `
-          <p>
-            The <b>Columbellidae</b>, the dove snails or dove shells, are a family of minute to small sea snails, marine gastropod mollusks in the order <i>Neogastropoda</i>.
-          </p>
-        `,
+      <p>
+        The <b>Columbellidae</b>, the dove snails or dove shells, are a <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> of minute to small <a href="https://en.wikipedia.org/wiki/Sea_snail">sea snails</a>, <a href="https://en.wikipedia.org/wiki/Marine_(ocean)">marine</a> <a href="https://en.wikipedia.org/wiki/Gastropod">gastropod</a> <a href="https://en.wikipedia.org/wiki/Mollusk">mollusks</a> in the order <a href="https://en.wikipedia.org/wiki/Neogastropoda">Neogastropoda</a>.
+      </p>
+    `,
         sourceTitle: 'Dove Snails',
         sourceUrl: 'https://www.inaturalist.org/taxa/50704',
         id: 'dove-snail',
       },
     ],
   };
+
+export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetSuggestionsOptions> =
+  {
+    ...getResponseModifierWithSmartSnippetSuggestionsDefaultOptions,
+    remSize: 12,
+    props: {},
+    content: [],
+    timesToIntercept: 9999,
+  };
+
+export const getResponseModifierWithSmartSnippetSuggestions: (
+  options: GetResponseModifierWithSmartSnippetSuggestionsOptions
+) => SearchResponseModifierPredicate = (options) => (response) => {
+  const relatedQuestions =
+    options.relatedQuestions ??
+    addSmartSnippetSuggestionsDefaultOptions.relatedQuestions;
+  const [firstResult] = response.results;
+  response.results = relatedQuestions.map((relatedQuestion) => ({
+    ...firstResult,
+    title: relatedQuestion.sourceTitle,
+    clickUri: relatedQuestion.sourceUrl,
+    raw: {
+      ...firstResult.raw,
+      permanentid: relatedQuestion.id,
+    },
+  }));
+  response.questionAnswer = {
+    documentId: {
+      contentIdKey: 'permanentid',
+      contentIdValue: firstResult.raw.permanentid!,
+    },
+    question: addSmartSnippetDefaultOptions.question,
+    answerSnippet: addSmartSnippetDefaultOptions.answer,
+    relatedQuestions: relatedQuestions.map((relatedQuestion, i) => ({
+      documentId: {
+        contentIdKey: 'permanentid',
+        contentIdValue: relatedQuestion.id,
+      },
+      question: relatedQuestion.question,
+      answerSnippet: relatedQuestion.answer,
+      score: (relatedQuestions.length - i) * 100,
+    })),
+    score: 1337,
+  };
+};
 
 export const addSmartSnippetSuggestions =
   (options: AddSmartSnippetSuggestionsOptions = {}) =>
@@ -78,9 +129,6 @@ export const addSmartSnippetSuggestions =
         options.content ?? addSmartSnippetSuggestionsDefaultOptions.content
       )
     );
-    const relatedQuestions =
-      options.relatedQuestions ??
-      addSmartSnippetSuggestionsDefaultOptions.relatedQuestions;
     fixture
       .withStyle(
         `html { font-size: ${
@@ -88,34 +136,8 @@ export const addSmartSnippetSuggestions =
         }px; }`
       )
       .withElement(element)
-      .withCustomResponse((response) => {
-        const [firstResult] = response.results;
-        response.results = relatedQuestions.map((relatedQuestion) => ({
-          ...firstResult,
-          title: relatedQuestion.sourceTitle,
-          clickUri: relatedQuestion.sourceUrl,
-          raw: {
-            ...firstResult.raw,
-            permanentid: relatedQuestion.id,
-          },
-        }));
-        response.questionAnswer = {
-          documentId: {
-            contentIdKey: 'permanentid',
-            contentIdValue: firstResult.raw.permanentid!,
-          },
-          question: addSmartSnippetDefaultOptions.question,
-          answerSnippet: addSmartSnippetDefaultOptions.answer,
-          relatedQuestions: relatedQuestions.map((relatedQuestion, i) => ({
-            documentId: {
-              contentIdKey: 'permanentid',
-              contentIdValue: relatedQuestion.id,
-            },
-            question: relatedQuestion.question,
-            answerSnippet: relatedQuestion.answer,
-            score: (relatedQuestions.length - i) * 100,
-          })),
-          score: 1337,
-        };
-      });
+      .withCustomResponse(
+        getResponseModifierWithSmartSnippetSuggestions(options),
+        options.timesToIntercept
+      );
   };

--- a/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
@@ -1,3 +1,4 @@
+import {InlineLink} from '@coveo/headless';
 import {AnalyticsTracker} from '../utils/analyticsUtils';
 import {should} from './common-assertions';
 import {SmartSnippetSuggestionsSelectors} from './smart-snippet-suggestions-selectors';
@@ -33,6 +34,28 @@ export function assertlogOpenSmartSnippetSuggestionsSource(log: boolean) {
   )} log a openSmartSnippetSuggestionSource click event`, () => {
     if (log) {
       cy.expectClickEvent('openSmartSnippetSuggestionSource');
+    } else {
+      cy.wait(50);
+      cy.wrap(AnalyticsTracker).invoke('getLastClickEvent').should('not.exist');
+    }
+  });
+}
+
+export function assertlogOpenSmartSnippetSuggestionsInlineLink(
+  getLinkToLog: (() => InlineLink) | null
+) {
+  it(`${should(
+    !!getLinkToLog
+  )} log a openSmartSnippetSuggestionsInlineLink click event`, () => {
+    if (getLinkToLog) {
+      const {linkText, linkURL} = getLinkToLog();
+      cy.expectClickEvent('openSmartSnippetSuggestionsInlineLink').should(
+        (clickEvent) => {
+          expect(clickEvent).to.have.property('customData');
+          expect(clickEvent.customData).to.have.property('linkText', linkText);
+          expect(clickEvent.customData).to.have.property('linkURL', linkURL);
+        }
+      );
     } else {
       cy.wait(50);
       cy.wrap(AnalyticsTracker).invoke('getLastClickEvent').should('not.exist');

--- a/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions-assertions.ts
@@ -28,7 +28,7 @@ export function assertAnswerBottomMargin(
   });
 }
 
-export function assertlogOpenSmartSnippetSuggestionsSource(log: boolean) {
+export function assertLogOpenSmartSnippetSuggestionsSource(log: boolean) {
   it(`${should(
     log
   )} log a openSmartSnippetSuggestionSource click event`, () => {
@@ -41,7 +41,7 @@ export function assertlogOpenSmartSnippetSuggestionsSource(log: boolean) {
   });
 }
 
-export function assertlogOpenSmartSnippetSuggestionsInlineLink(
+export function assertLogOpenSmartSnippetSuggestionsInlineLink(
   getLinkToLog: (() => InlineLink) | null
 ) {
   it(`${should(

--- a/packages/atomic/cypress/integration/smart-snippet-suggestions.cypress.ts
+++ b/packages/atomic/cypress/integration/smart-snippet-suggestions.cypress.ts
@@ -276,7 +276,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
       SmartSnippetSuggestionsSelectors.sourceTitle().first().rightclick();
     });
 
-    SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsSource(
+    SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsSource(
       true
     );
 
@@ -286,7 +286,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
         SmartSnippetSuggestionsSelectors.sourceUrl().first().rightclick();
       });
 
-      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsSource(
+      SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsSource(
         false
       );
     });
@@ -298,7 +298,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
         SmartSnippetSuggestionsSelectors.sourceTitle().first().rightclick();
       });
 
-      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsSource(
+      SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsSource(
         true
       );
     });
@@ -340,7 +340,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
       click(SmartSnippetSuggestionsSelectors.answer().eq(0).find('a').eq(0));
     });
 
-    SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsInlineLink(
+    SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsInlineLink(
       () => lastClickedLink
     );
 
@@ -350,7 +350,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
         click(SmartSnippetSuggestionsSelectors.answer().eq(0).find('a').eq(0));
       });
 
-      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsInlineLink(
+      SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsInlineLink(
         null
       );
     });
@@ -373,7 +373,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
         click(SmartSnippetSuggestionsSelectors.answer().eq(0).find('a').eq(0));
       });
 
-      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsInlineLink(
+      SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsInlineLink(
         () => lastClickedLink
       );
     });
@@ -384,7 +384,7 @@ describe('Smart Snippet Suggestions Test Suites', () => {
         click(SmartSnippetSuggestionsSelectors.answer().eq(0).find('a').eq(1));
       });
 
-      SmartSnippetSuggestionsAssertions.assertlogOpenSmartSnippetSuggestionsInlineLink(
+      SmartSnippetSuggestionsAssertions.assertLogOpenSmartSnippetSuggestionsInlineLink(
         () => lastClickedLink
       );
     });

--- a/packages/atomic/cypress/integration/smart-snippet.cypress.ts
+++ b/packages/atomic/cypress/integration/smart-snippet.cypress.ts
@@ -281,7 +281,7 @@ describe('Smart Snippet Test Suites', () => {
       SmartSnippetSelectors.sourceTitle().rightclick();
     });
 
-    SmartSnippetAssertions.assertlogOpenSmartSnippetSource(true);
+    SmartSnippetAssertions.assertLogOpenSmartSnippetSource(true);
 
     describe('then liking the snippet then clicking the title again', () => {
       beforeEach(() => {
@@ -290,7 +290,7 @@ describe('Smart Snippet Test Suites', () => {
         SmartSnippetSelectors.sourceTitle().rightclick();
       });
 
-      SmartSnippetAssertions.assertlogOpenSmartSnippetSource(false);
+      SmartSnippetAssertions.assertLogOpenSmartSnippetSource(false);
     });
 
     describe('then getting a new snippet and clicking on the title again', () => {
@@ -300,7 +300,7 @@ describe('Smart Snippet Test Suites', () => {
         SmartSnippetSelectors.sourceTitle().rightclick();
       });
 
-      SmartSnippetAssertions.assertlogOpenSmartSnippetSource(true);
+      SmartSnippetAssertions.assertLogOpenSmartSnippetSource(true);
     });
   });
 
@@ -328,7 +328,7 @@ describe('Smart Snippet Test Suites', () => {
       click(SmartSnippetSelectors.answer().find('a').eq(0));
     });
 
-    SmartSnippetAssertions.assertlogOpenSmartSnippetInlineLink(
+    SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
       () => lastClickedLink
     );
 
@@ -339,7 +339,7 @@ describe('Smart Snippet Test Suites', () => {
         click(SmartSnippetSelectors.answer().find('a').eq(0));
       });
 
-      SmartSnippetAssertions.assertlogOpenSmartSnippetInlineLink(null);
+      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(null);
     });
 
     describe('then getting a new snippet and clicking on the same inline link again', () => {
@@ -351,7 +351,7 @@ describe('Smart Snippet Test Suites', () => {
         click(SmartSnippetSelectors.answer().find('a').eq(0));
       });
 
-      SmartSnippetAssertions.assertlogOpenSmartSnippetInlineLink(
+      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
         () => lastClickedLink
       );
     });
@@ -362,7 +362,7 @@ describe('Smart Snippet Test Suites', () => {
         click(SmartSnippetSelectors.answer().find('a').eq(1));
       });
 
-      SmartSnippetAssertions.assertlogOpenSmartSnippetInlineLink(
+      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
         () => lastClickedLink
       );
     });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, LogLevel, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine } from "@coveo/headless";
+import { CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, InlineLink, LogLevel, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine } from "@coveo/headless";
 import { AnyBindings } from "./components/common/interface/bindings";
 import { DateFilter, DateFilterState, NumericFilter, NumericFilterState, RelativeDateUnit } from "./components/common/types";
 import { NumberInputType } from "./components/common/facets/facet-number-input/number-input-type";
@@ -3697,6 +3697,9 @@ declare namespace LocalJSX {
         "htmlContent": string;
         "innerStyle"?: string;
         "onAnswerSizeUpdated"?: (event: AtomicSmartSnippetAnswerCustomEvent<{height: number}>) => void;
+        "onBeginDelayedSelectInlineLink"?: (event: AtomicSmartSnippetAnswerCustomEvent<InlineLink>) => void;
+        "onCancelPendingSelectInlineLink"?: (event: AtomicSmartSnippetAnswerCustomEvent<InlineLink>) => void;
+        "onSelectInlineLink"?: (event: AtomicSmartSnippetAnswerCustomEvent<InlineLink>) => void;
     }
     interface AtomicSmartSnippetExpandableAnswer {
         /**
@@ -3709,8 +3712,11 @@ declare namespace LocalJSX {
           * The maximum height (in pixels) a snippet can have before the component truncates it and displays a "show more" button.
          */
         "maximumHeight"?: number;
+        "onBeginDelayedSelectInlineLink"?: (event: AtomicSmartSnippetExpandableAnswerCustomEvent<InlineLink>) => void;
+        "onCancelPendingSelectInlineLink"?: (event: AtomicSmartSnippetExpandableAnswerCustomEvent<InlineLink>) => void;
         "onCollapse"?: (event: AtomicSmartSnippetExpandableAnswerCustomEvent<any>) => void;
         "onExpand"?: (event: AtomicSmartSnippetExpandableAnswerCustomEvent<any>) => void;
+        "onSelectInlineLink"?: (event: AtomicSmartSnippetExpandableAnswerCustomEvent<InlineLink>) => void;
         /**
           * Sets the style of the snippet.  Example: ```ts expandableAnswer.snippetStyle = `   b {     color: blue;   } `; ```
          */

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-expandable-answer.tsx
@@ -1,3 +1,4 @@
+import {InlineLink} from '@coveo/headless';
 import {
   h,
   Component,
@@ -54,6 +55,12 @@ export class AtomicSmartSnippetExpandableAnswer {
 
   @Event() expand!: EventEmitter;
   @Event() collapse!: EventEmitter;
+  @Event({bubbles: false})
+  private selectInlineLink!: EventEmitter<InlineLink>;
+  @Event({bubbles: false})
+  private beginDelayedSelectInlineLink!: EventEmitter<InlineLink>;
+  @Event({bubbles: false})
+  private cancelPendingSelectInlineLink!: EventEmitter<InlineLink>;
 
   private validateProps() {
     if (this.maximumHeight < this.collapsedHeight) {
@@ -109,6 +116,13 @@ export class AtomicSmartSnippetExpandableAnswer {
           htmlContent={this.htmlContent}
           innerStyle={this.snippetStyle}
           onAnswerSizeUpdated={(e) => (this.fullHeight = e.detail.height)}
+          onSelectInlineLink={(e) => this.selectInlineLink.emit(e.detail)}
+          onBeginDelayedSelectInlineLink={(e) =>
+            this.beginDelayedSelectInlineLink.emit(e.detail)
+          }
+          onCancelPendingSelectInlineLink={(e) =>
+            this.cancelPendingSelectInlineLink.emit(e.detail)
+          }
         ></atomic-smart-snippet-answer>
       </div>
     );

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-suggestions.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-suggestions.stories.tsx
@@ -16,7 +16,7 @@ const {defaultModuleExport, exportedStory} = defaultStory(
               clickUri: 'https://www.inaturalist.org/taxa/49968',
               uniqueId: '42.29355$https://www.inaturalist.org/taxa/49968',
               excerpt: 'Nurse Sharks',
-              firstSentences: null,
+              firstSentences: '',
               summary: null,
               flags: 'HasHtmlVersion;SkipSentencesScoring',
               hasHtmlVersion: true,
@@ -42,7 +42,7 @@ const {defaultModuleExport, exportedStory} = defaultStory(
               clickUri: 'https://www.inaturalist.org/taxa/86651',
               uniqueId: '42.29355$https://www.inaturalist.org/taxa/86651',
               excerpt: 'Brine Shrimp',
-              firstSentences: null,
+              firstSentences: '',
               summary: null,
               flags: 'HasHtmlVersion;SkipSentencesScoring',
               hasHtmlVersion: true,
@@ -68,7 +68,7 @@ const {defaultModuleExport, exportedStory} = defaultStory(
               clickUri: 'https://www.inaturalist.org/taxa/50704',
               uniqueId: '42.29355$https://www.inaturalist.org/taxa/50704',
               excerpt: 'Dove Snails',
-              firstSentences: null,
+              firstSentences: '',
               summary: null,
               flags: 'HasHtmlVersion;SkipSentencesScoring',
               hasHtmlVersion: true,
@@ -101,10 +101,10 @@ const {defaultModuleExport, exportedStory} = defaultStory(
                 question: 'Where does the name "Nurse Sharks" come from?',
                 answerSnippet: `
                   <p>
-                    The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the catsharks of the family Scyliorhinidae.
+                    The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the <a href="https://en.wikipedia.org/wiki/Catshark">catsharks</a> of the family Scyliorhinidae.
                   </p>
                   <p>
-                    The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the Greek words <i>ginglymos</i> (γίγγλυμος) meaning "<b>hinge</b>" and <i>stoma</i> (στόμα) meaning "<b>mouth</b>". 
+                    The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the <a href="https://en.wikipedia.org/wiki/Greek_language">Greek</a> words <i>ginglymos</i> (<a href="https://en.wiktionary.org/wiki/%CE%B3%CE%AF%CE%B3%CE%B3%CE%BB%CF%85%CE%BC%CE%BF%CF%82#Ancient_Greek">γίγγλυμος</a>) meaning "<b>hinge</b>" and <i>stoma</i> (<a href="https://en.wiktionary.org/wiki/%CF%83%CF%84%CF%8C%CE%BC%CE%B1#Ancient_Greek">στόμα</a>) meaning "<b>mouth</b>". 
                   </p>
                 `,
                 documentId: {
@@ -117,10 +117,10 @@ const {defaultModuleExport, exportedStory} = defaultStory(
                 question: 'What are sea monkeys?',
                 answerSnippet: `
                   <p>
-                    Breeds of Artemia are sold as novelty gifts under the marketing name Sea-Monkeys. 
+                    Breeds of Artemia are sold as novelty gifts under the marketing name <a href="https://en.wikipedia.org/wiki/Sea-Monkeys">Sea-Monkeys</a>. 
                   </p>
                   <p>
-                    <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. Artemia, the only genus in the family <i>Artemiidae</i>.
+                    <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. It is the only genus in the <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> <b>Artemiidae</b>.
                   </p>
                 `,
                 documentId: {
@@ -133,7 +133,7 @@ const {defaultModuleExport, exportedStory} = defaultStory(
                 question: 'What is a dove snail?',
                 answerSnippet: `
                   <p>
-                    The <b>Columbellidae</b>, the dove snails or dove shells, are a family of minute to small sea snails, marine gastropod mollusks in the order <i>Neogastropoda</i>.
+                    The <b>Columbellidae</b>, the dove snails or dove shells, are a <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> of minute to small <a href="https://en.wikipedia.org/wiki/Sea_snail">sea snails</a>, <a href="https://en.wikipedia.org/wiki/Marine_(ocean)">marine</a> <a href="https://en.wikipedia.org/wiki/Gastropod">gastropod</a> <a href="https://en.wikipedia.org/wiki/Mollusk">mollusks</a> in the order <a href="https://en.wikipedia.org/wiki/Neogastropoda">Neogastropoda</a>.
                   </p>
                 `,
                 documentId: {

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-suggestions.tsx
@@ -166,6 +166,24 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
         exportparts="answer"
         htmlContent={relatedQuestion.answer}
         innerStyle={this.style}
+        onSelectInlineLink={(e) =>
+          this.smartSnippetQuestionsList.selectInlineLink(
+            relatedQuestion.questionAnswerId,
+            e.detail
+          )
+        }
+        onBeginDelayedSelectInlineLink={(e) =>
+          this.smartSnippetQuestionsList.beginDelayedSelectInlineLink(
+            relatedQuestion.questionAnswerId,
+            e.detail
+          )
+        }
+        onCancelPendingSelectInlineLink={(e) =>
+          this.smartSnippetQuestionsList.cancelPendingSelectInlineLink(
+            relatedQuestion.questionAnswerId,
+            e.detail
+          )
+        }
       ></atomic-smart-snippet-answer>
     );
   }

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.stories.tsx
@@ -19,15 +19,15 @@ const {defaultModuleExport, exportedStory} = defaultStory(
             question: 'Creating an In-Product Experience (IPX)',
             answerSnippet: `
               <ol>
-                <li>On the <b>In-Product Experiences</b> page, click Add <b>In-Product Experience</b>.</li>
+                <li>On the <a href="https://platform.cloud.coveo.com/admin/#/orgid/search/in-app-widgets/">In-Product Experiences</a> page, click Add <b>In-Product Experience</b>.</li>
                 <li>In the Configuration tab, fill the Basic settings section.</li>
-                <li>(Optional) Use the Design and Content access tabs to customize your <b>IPX</b> interface.</li>
+                <li>(Optional) Use the Design and Content access tabs to <a href="https://docs.coveo.com/en/3160/#customizing-an-ipx-interface">customize your <b>IPX</b> interface</a>.</li>
                 <li>Click Save.</li>
                 <li>In the Loader snippet panel that appears, you may click Copy to save the loader snippet for your <b>IPX</b> to your clipboard, and then click Save.  You can Always retrieve the loader snippet later.</li>
               </ol>
               
               <p>
-                You're now ready to load your IPX interface in the desired web site or application. However, we recommend that you configure query pipelines for your IPX interface before.
+                You're now ready to <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications">embed your IPX interface</a>. However, we recommend that you <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#configuring-query-pipelines-for-an-ipx-interface-recommended">configure query pipelines for your IPX interface</a> before.
               </p>
             `,
             relatedQuestions: [],

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -157,6 +157,13 @@ export class AtomicSmartSnippet implements InitializableComponent {
         snippetStyle={this.style}
         onExpand={() => this.smartSnippet.expand()}
         onCollapse={() => this.smartSnippet.collapse()}
+        onSelectInlineLink={(e) => this.smartSnippet.selectInlineLink(e.detail)}
+        onBeginDelayedSelectInlineLink={(e) =>
+          this.smartSnippet.beginDelayedSelectInlineLink(e.detail)
+        }
+        onCancelPendingSelectInlineLink={(e) =>
+          this.smartSnippet.cancelPendingSelectInlineLink(e.detail)
+        }
       ></atomic-smart-snippet-expandable-answer>
     );
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2014

Copies https://github.com/coveo/search-ui/pull/1901

Depends on https://github.com/coveo/ui-kit/pull/2416

Analytics logged when clicking this:
![image](https://user-images.githubusercontent.com/54454747/189692780-9046cc83-1726-47eb-9c33-a876082816ff.png)

Other changes in this PR:
* Added `times?: number` parameter to `TestFixture`'s `withCustomResponse`.
* Extracted `bindAnalyticsToLink(element: HTMLAnchorElement, options: ...)` from `LinkWithResultAnalytics`.
* Added links to example & test snippets (copied from Wikipedia).
