### PR TITLE
fix(atomic): removed timespan offset input timezone offset

### DIFF
--- a/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet-assertions.ts
+++ b/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet-assertions.ts
@@ -30,13 +30,40 @@ export function assertDisplayInputWarning(length: number, message?: string) {
   });
 }
 
-export function assertMinInputValue(value: number) {
+export function assertRangeHash(
+  startDate: `${number}-${number}-${number}`,
+  endDate: `${number}-${number}-${number}`
+) {
+  const expectedRange = `${startDate.replaceAll(
+    '-',
+    '/'
+  )}@00:00:00..${endDate.replaceAll('-', '/')}@00:00:00` as const;
+
+  function getHash(win: Window) {
+    return win.location.hash
+      .slice(1)
+      .split('&')
+      .map((value) => value.split('='))
+      .reduce(
+        (obj, [key, value]) => ({...obj, [key]: value}),
+        <Record<string, string>>{}
+      );
+  }
+
+  it(`should set the date range in the hash to ${expectedRange}`, () => {
+    cy.window().should((win) =>
+      expect(getHash(win)).to.have.property('df[date_input]', expectedRange)
+    );
+  });
+}
+
+export function assertMinInputValue(value: string) {
   it(`should display Min value of "${value}"`, () => {
     TimeframeFacetSelectors.startDate().should('have.value', value);
   });
 }
 
-export function assertMaxInputValue(value: number) {
+export function assertMaxInputValue(value: string) {
   it(`should display Max value of "${value}"`, () => {
     TimeframeFacetSelectors.endDate().should('have.value', value);
   });

--- a/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/atomic/cypress/integration/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -176,31 +176,46 @@ describe('Timeframe Facet V1 Test Suites', () => {
     });
 
     describe('with custom #withInput', () => {
-      function setupTimeFrameWithInputRange() {
-        new TestFixture()
-          .with(
-            addTimeframeFacet(
-              {
-                label: timeframeFacetLabel,
-                field: timeframeFacetField,
-                'with-date-picker': '',
-              },
-              unitFrames
-            )
+      const addTimeFrameWithInputRange = () => (fixture: TestFixture) => {
+        fixture.with(
+          addTimeframeFacet(
+            {
+              label: timeframeFacetLabel,
+              field: timeframeFacetField,
+              'with-date-picker': '',
+            },
+            unitFrames
           )
-          .init();
-      }
+        );
+      };
 
       describe('verify rendering', () => {
         before(() => {
-          setupTimeFrameWithInputRange();
+          new TestFixture().with(addTimeFrameWithInputRange()).init();
         });
         TimeframeFacetAssertions.assertDisplayRangeInput(true);
       });
 
+      describe('with a date range in the hash', () => {
+        before(() => {
+          new TestFixture()
+            .with(addTimeFrameWithInputRange())
+            .withHash(
+              `df[date_input]=${startDate.replaceAll(
+                '-',
+                '/'
+              )}@00:00:00..${endDate.replaceAll('-', '/')}@00:00:00`
+            )
+            .init();
+        });
+
+        TimeframeFacetAssertions.assertMinInputValue(startDate);
+        TimeframeFacetAssertions.assertMaxInputValue(endDate);
+      });
+
       describe('when select a valid range', () => {
         function setupInputRange() {
-          setupTimeFrameWithInputRange();
+          new TestFixture().with(addTimeFrameWithInputRange()).init();
           inputStartDate(startDate);
           inputEndDate(endDate);
           clickApplyButton();
@@ -208,6 +223,7 @@ describe('Timeframe Facet V1 Test Suites', () => {
 
         describe('verify rendering', () => {
           before(setupInputRange);
+          TimeframeFacetAssertions.assertRangeHash(startDate, endDate);
           TimeframeFacetAssertions.assertDisplayRangeInput(true);
           CommonFacetAssertions.assertDisplayValues(
             TimeframeFacetSelectors,

--- a/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
@@ -107,7 +107,9 @@ export class FacetDateInput {
           max={this.formattedDateValue(this.end)}
           value={this.formattedDateValue(this.filterState.range?.start)}
           onInput={(e) =>
-            (this.start = new Date((e.target as HTMLInputElement).value))
+            (this.start = parseDate(
+              (e.target as HTMLInputElement).value
+            ).toDate())
           }
         />
         <label
@@ -130,7 +132,9 @@ export class FacetDateInput {
           min={this.formattedDateValue(this.start)}
           value={this.formattedDateValue(this.filterState.range?.end)}
           onInput={(e) =>
-            (this.end = new Date((e.target as HTMLInputElement).value))
+            (this.end = parseDate(
+              (e.target as HTMLInputElement).value
+            ).toDate())
           }
         />
         <Button


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1989

When using the input to type a date in the timespan facet, the user's timezone was assumed, which caused the values to change when when the search is resolved.

The timezone in the facet is now assumed to be UTC.