### PR TITLE
test(atomic): change insight e2e accessibility test to only test search box

### DIFF
--- a/packages/atomic/cypress/integration-insights-panel/insights-panel.cypress.ts
+++ b/packages/atomic/cypress/integration-insights-panel/insights-panel.cypress.ts
@@ -160,7 +160,7 @@ describe('Insights panel test suites', () => {
         .should('have.text', 'PDF');
     });
 
-    CommonAssertions.assertAccessibility();
+    CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
   });
 
   describe('when there is something written in the search box', () => {
@@ -184,6 +184,6 @@ describe('Insights panel test suites', () => {
         .should('contain.text', 'for test');
     });
 
-    CommonAssertions.assertAccessibility();
+    CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
   });
 });

--- a/packages/atomic/cypress/integration/common-assertions.ts
+++ b/packages/atomic/cypress/integration/common-assertions.ts
@@ -12,8 +12,8 @@ export function should(should: boolean) {
   return should ? 'should' : 'should not';
 }
 
-export function assertAccessibility(
-  component?: string | (() => Cypress.Chainable<JQuery<HTMLElement>>)
+export function assertAccessibility<T extends HTMLElement>(
+  component?: string | (() => Cypress.Chainable<JQuery<T>>)
 ) {
   const rulesToIgnore = ['landmark-one-main', 'page-has-heading-one', 'region'];
   const rules = rulesToIgnore.reduce(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2013

I want to test accessibility for the insight search box, since it's the only one which uses the `SearchInput` functional component without a popup, which has different accessibility properties.