### PR TITLE
feat(headless): Case Id and Case Number added to the case context state

### DIFF
--- a/packages/headless/src/features/case-context/case-context-actions-loader.ts
+++ b/packages/headless/src/features/case-context/case-context-actions-loader.ts
@@ -1,7 +1,7 @@
 import {PayloadAction} from '@reduxjs/toolkit';
 import {CoreEngine} from '../..';
 import {insightCaseContext} from '../../app/reducers';
-import {setCaseContext} from './case-context-actions';
+import {setCaseContext, setCaseId, setCaseNumber} from './case-context-actions';
 
 /**
  * The case context action creators.
@@ -16,6 +16,22 @@ export interface CaseContextActionCreators {
   setCaseContext(
     payload: Record<string, string>
   ): PayloadAction<Record<string, string>>;
+
+  /**
+   * Sets the case id.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  setCaseId(payload: string): PayloadAction<string>;
+
+  /**
+   * Sets the case number.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  setCaseNumber(payload: string): PayloadAction<string>;
 }
 
 /**
@@ -31,5 +47,7 @@ export function loadCaseContextActions(
 
   return {
     setCaseContext,
+    setCaseId,
+    setCaseNumber,
   };
 }

--- a/packages/headless/src/features/case-context/case-context-actions.ts
+++ b/packages/headless/src/features/case-context/case-context-actions.ts
@@ -29,3 +29,37 @@ export const setCaseContext = createAction(
     return {payload};
   }
 );
+
+/**
+ * Set case id action
+ */
+export const setCaseId = createAction(
+  'insight/caseId/set',
+  (payload: string) => {
+    const valueSchema = requiredEmptyAllowedString;
+    const valuesError = validatePayload(payload, valueSchema).error;
+
+    if (valuesError) {
+      return {payload, error: valuesError};
+    }
+
+    return {payload};
+  }
+);
+
+/**
+ * Set case number action
+ */
+export const setCaseNumber = createAction(
+  'insight/caseNumber/set',
+  (payload: string) => {
+    const valueSchema = requiredEmptyAllowedString;
+    const valuesError = validatePayload(payload, valueSchema).error;
+
+    if (valuesError) {
+      return {payload, error: valuesError};
+    }
+
+    return {payload};
+  }
+);

--- a/packages/headless/src/features/case-context/case-context-slice.spec.ts
+++ b/packages/headless/src/features/case-context/case-context-slice.spec.ts
@@ -1,31 +1,63 @@
-import {setCaseContext} from './case-context-actions';
+import {setCaseContext, setCaseId, setCaseNumber} from './case-context-actions';
 import {caseContextReducer} from './case-context-slice';
 
 describe('case context slice', () => {
   it('initializes state correctly', () => {
     const finalState = caseContextReducer(undefined, {type: ''});
-    expect(finalState).toEqual({caseContext: {}});
+    expect(finalState).toEqual({caseContext: {}, caseId: '', caseNumber: ''});
   });
 
-  it('stores the object in state', () => {
-    const payload = {price: 'cad'};
-    const action = setCaseContext(payload);
+  describe('caseContext', () => {
+    it('stores the object in state', () => {
+      const payload = {price: 'cad'};
+      const action = setCaseContext(payload);
 
-    const {caseContext} = caseContextReducer(undefined, action);
-    expect(caseContext).toEqual(payload);
+      const {caseContext} = caseContextReducer(undefined, action);
+      expect(caseContext).toEqual(payload);
+    });
+
+    it('when the payload is not an object, the action contains an error', () => {
+      const payload = setCaseContext(
+        undefined as unknown as Record<string, string>
+      );
+      expect('error' in payload).toBe(true);
+    });
+
+    it('when a value is not a string, the action contains an error', () => {
+      const payload = setCaseContext({
+        a: true,
+      } as unknown as Record<string, string>);
+      expect('error' in payload).toBe(true);
+    });
   });
 
-  it('when the payload is not an object, the action contains an error', () => {
-    const payload = setCaseContext(
-      undefined as unknown as Record<string, string>
-    );
-    expect('error' in payload).toBe(true);
+  describe('caseId', () => {
+    it('stores the case id in state', () => {
+      const payload = 'example case id';
+      const action = setCaseId(payload);
+
+      const {caseId} = caseContextReducer(undefined, action);
+      expect(caseId).toEqual(payload);
+    });
+
+    it('when the payload is not a string, the action contains an error', () => {
+      const payload = setCaseId(undefined as unknown as string);
+      expect('error' in payload).toBe(true);
+    });
   });
 
-  it('when a value is not a string, the action contains an error', () => {
-    const payload = setCaseContext({
-      a: true,
-    } as unknown as Record<string, string>);
-    expect('error' in payload).toBe(true);
+  describe('caseNumber', () => {
+    it('stores the case number in state', () => {
+      const payload = 'example case number';
+      const action = setCaseNumber(payload);
+
+      const {caseNumber} = caseContextReducer(undefined, action);
+      expect(caseNumber).toEqual(payload);
+    });
+
+    it('when the payload is not a string, the action contains an error', () => {
+      const payload = setCaseNumber(undefined as unknown as string);
+      expect('error' in payload).toBe(true);
+    });
   });
 });

--- a/packages/headless/src/features/case-context/case-context-slice.ts
+++ b/packages/headless/src/features/case-context/case-context-slice.ts
@@ -1,12 +1,19 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {getCaseContextInitialState} from './case-context-state';
-import {setCaseContext} from './case-context-actions';
+import {setCaseContext, setCaseId, setCaseNumber} from './case-context-actions';
 
 export const caseContextReducer = createReducer(
   getCaseContextInitialState(),
   (builder) => {
-    builder.addCase(setCaseContext, (state, action) => {
-      state.caseContext = action.payload;
-    });
+    builder
+      .addCase(setCaseContext, (state, action) => {
+        state.caseContext = action.payload;
+      })
+      .addCase(setCaseId, (state, action) => {
+        state.caseId = action.payload;
+      })
+      .addCase(setCaseNumber, (state, action) => {
+        state.caseNumber = action.payload;
+      });
   }
 );

--- a/packages/headless/src/features/case-context/case-context-state.ts
+++ b/packages/headless/src/features/case-context/case-context-state.ts
@@ -3,6 +3,14 @@ export interface CaseContextState {
    * The case context
    */
   caseContext: Record<string, string>;
+  /**
+   * The case id
+   */
+  caseId: string;
+  /**
+   * The case number
+   */
+  caseNumber: string;
 }
 
 /**
@@ -11,4 +19,6 @@ export interface CaseContextState {
  */
 export const getCaseContextInitialState = (): CaseContextState => ({
   caseContext: {},
+  caseId: '',
+  caseNumber: '',
 });

--- a/packages/headless/src/features/insight-search/insight-search-analytics-actions.test.ts
+++ b/packages/headless/src/features/insight-search/insight-search-analytics-actions.test.ts
@@ -5,6 +5,7 @@ import {
   logExpandToFullUI,
 } from './insight-search-analytics-actions';
 import * as CoveoAnalytics from 'coveo.analytics';
+import {getCaseContextInitialState} from '../case-context/case-context-state';
 
 const mockLogContextChanged = jest.fn();
 const mockLogExpandtoFullUI = jest.fn();
@@ -30,6 +31,7 @@ describe('logContextChanged', () => {
     const engine = buildMockInsightEngine({
       state: buildMockInsightState({
         insightCaseContext: {
+          ...getCaseContextInitialState(),
           caseContext: {
             Case_Subject: exampleSubject,
             Case_Description: exampleDescription,
@@ -60,6 +62,7 @@ describe('logExpandToFullUI', () => {
     const engine = buildMockInsightEngine({
       state: buildMockInsightState({
         insightCaseContext: {
+          ...getCaseContextInitialState(),
           caseContext: {
             Case_Subject: exampleSubject,
             Case_Description: exampleDescription,


### PR DESCRIPTION
`Case Id` and `Case Number` need to be sent in each insight analytics events, example:

<img width="471" alt="AfterCustom" src="https://user-images.githubusercontent.com/86681870/190634526-62b3abe7-2079-440a-a0ad-cd5a5ac842f6.png">

Thus the need to add this piece of information to the case context  state and allow the user to set it with the new actions: `setCaseId` and `setCaseNumber`.

In a future PR coming soon, I'll add case number and case id to the payload sent in all the insight analytics events.

