### PR TITLE
fix(atomic): prevent scrolling behind refine modal on iOS

### DIFF
--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -9,6 +9,7 @@ import {
   Event,
   EventEmitter,
   Host,
+  Listen,
 } from '@stencil/core';
 import {isIOS} from '../../../utils/device-utils';
 import {listenOnce} from '../../../utils/event-utils';
@@ -109,6 +110,11 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
     return classes;
   }
 
+  @Listen('touchmove', {passive: false})
+  onWindowTouchMove(e: Event) {
+    this.isOpen && e.preventDefault();
+  }
+
   public componentDidLoad() {
     this.watchToggleOpen(this.isOpen);
   }
@@ -155,7 +161,18 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
                 part="body-wrapper"
                 class="overflow-auto grow flex flex-col items-center w-full"
               >
-                <div part="body" class="w-full max-w-lg">
+                <div
+                  part="body"
+                  class="w-full max-w-lg"
+                  ref={(element) =>
+                    element &&
+                    element.addEventListener(
+                      'touchmove',
+                      (e) => this.isOpen && e.stopPropagation(),
+                      {passive: false}
+                    )
+                  }
+                >
                   <slot name="body"></slot>
                 </div>
               </div>

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -165,8 +165,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
                   part="body"
                   class="w-full max-w-lg"
                   ref={(element) =>
-                    element &&
-                    element.addEventListener(
+                    element?.addEventListener(
                       'touchmove',
                       (e) => this.isOpen && e.stopPropagation(),
                       {passive: false}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1943

The strategy I went for is to add an event listener which completely disables scrolling and then prevent propagation where we do want scrolling to work.

This should affect all modals, including the feedback modal for smart snippet.

I tested to make sure this doesn't break scrolling on other browsers either. I tested the following:
* iOS Safari
* Android Chrome
* Android Firefox