### PR TITLE
fix(atomic): removed wrong section class from results

### DIFF
--- a/packages/atomic/cypress/integration/result-list/result-template-assertions.ts
+++ b/packages/atomic/cypress/integration/result-list/result-template-assertions.ts
@@ -15,8 +15,16 @@ export function assertRendersTemplate(shouldBeRendered: boolean) {
 }
 
 export function assertResultImageSize(size: ResultDisplayImageSize) {
+  function getImageClasses(element?: HTMLElement) {
+    return Array.from(element?.classList ?? []).filter((className) =>
+      className.startsWith('image-')
+    );
+  }
+
   it(`enforces the "${size}" image size on the result`, () => {
-    ResultListSelectors.firstResultRoot().should('have.class', `image-${size}`);
+    ResultListSelectors.firstResultRoot().should(([el]) =>
+      expect(getImageClasses(el)).to.deep.eq([`image-${size}`])
+    );
   });
 }
 

--- a/packages/atomic/src/components/search/result-lists/result-list-common.tsx
+++ b/packages/atomic/src/components/search/result-lists/result-list-common.tsx
@@ -225,22 +225,27 @@ export class ResultListCommon {
     return window.innerHeight + window.scrollY >= childEl?.offsetHeight;
   }
 
-  private getClasses(
-    display: ResultDisplayLayout = 'list',
-    density: ResultDisplayDensity,
-    imageSize: ResultDisplayImageSize,
+  private getLoadingClasses(
     firstSearchExecuted: boolean,
     isLoading: boolean,
     displayPlaceholders: boolean
-  ): string {
-    const classes = getResultDisplayClasses(display, density, imageSize);
+  ) {
+    const classes = [];
     if (firstSearchExecuted && isLoading) {
       classes.push('loading');
     }
     if (displayPlaceholders) {
       classes.push('placeholder');
     }
-    return classes.join(' ');
+    return classes;
+  }
+
+  private getListClasses(
+    display: ResultDisplayLayout,
+    density: ResultDisplayDensity,
+    imageSize: ResultDisplayImageSize
+  ) {
+    return getResultDisplayClasses(display, density, imageSize);
   }
 
   public renderList({
@@ -270,19 +275,28 @@ export class ResultListCommon {
 
     const displayPlaceholders = !this.bindings.store.isAppLoaded();
 
-    const classes = this.getClasses(
-      display,
-      density,
-      imageSize!,
+    const loadingClasses = this.getLoadingClasses(
       resultListState.firstSearchExecuted,
       resultListState.isLoading,
       displayPlaceholders
     );
+
+    const listClasses = [
+      ...loadingClasses,
+      ...this.getListClasses(display ?? 'list', density, imageSize ?? 'icon'),
+    ];
+
     return (
       <Host>
         {templateHasError && <slot></slot>}
-        <div class={`list-wrapper ${classes}`} ref={setListWrapperRef}>
-          <ResultDisplayWrapper classes={classes} display={display}>
+        <div
+          class={`list-wrapper ${listClasses.join(' ')}`}
+          ref={setListWrapperRef}
+        >
+          <ResultDisplayWrapper
+            classes={listClasses.join(' ')}
+            display={display}
+          >
             {displayPlaceholders && (
               <ResultsPlaceholder
                 display={display}
@@ -293,7 +307,7 @@ export class ResultListCommon {
             )}
             {resultListState.firstSearchExecuted && (
               <Results
-                classes={classes}
+                classes={loadingClasses.join(' ')}
                 bindings={this.bindings}
                 host={host}
                 display={display}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2005

If the result list had `image-size="icon"` and the visual section had `image-size="small"`, results would have both the `image-icon` and `image-small` class.

What we actually want is for the list to have the class that matches its own config, and individual results to have classes that match theirs.

The result list may be due for a small refactor 🤔 
