### PR TITLE
fix(headless): fixed didYoumean auto correction originalQuery

### DIFF
--- a/packages/atomic/cypress/integration/did-you-mean-assertions.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-assertions.ts
@@ -57,3 +57,43 @@ export function assertLogQueryTriggerUndo(undoneQuery: string) {
     );
   });
 }
+
+export function assertHasAutoCorrectOriginalQuery(originalQuery: string) {
+  it(`should display the original query ("${originalQuery}")`, () => {
+    DidYouMeanSelectors.noResultsOriginalQuery().should(($el) =>
+      expect($el.text()).to.equal(originalQuery)
+    );
+  });
+}
+
+export function assertHasAutoCorrectNewQuery(newQuery: string) {
+  it(`should display the correction of an automatically corrected query ("${newQuery}")`, () => {
+    DidYouMeanSelectors.autoCorrectedNewQuery().should(($el) =>
+      expect($el.text()).to.equal(newQuery)
+    );
+  });
+}
+
+export function assertHasManualCorrectNewQuery(newQuery: string) {
+  it(`should display a manual correction button with the new query ("${newQuery}")`, () => {
+    DidYouMeanSelectors.correctionButton().should(($el) =>
+      expect($el.text()).to.equal(newQuery)
+    );
+  });
+}
+
+export function assertHasTriggerOriginalQuery(originalQuery: string) {
+  it(`should display an undo button with the original query ("${originalQuery}")`, () => {
+    DidYouMeanSelectors.undoButton().should(($el) =>
+      expect($el.text()).to.equal(originalQuery)
+    );
+  });
+}
+
+export function assertHasTriggerNewQuery(newQuery: string) {
+  it(`should display the correction of a query trigger ("${newQuery}")`, () => {
+    DidYouMeanSelectors.showingResultsForNewQuery().should(($el) =>
+      expect($el.text()).to.equal(newQuery)
+    );
+  });
+}

--- a/packages/atomic/cypress/integration/did-you-mean-selectors.ts
+++ b/packages/atomic/cypress/integration/did-you-mean-selectors.ts
@@ -2,10 +2,16 @@ export const didYouMeanComponent = 'atomic-did-you-mean';
 export const DidYouMeanSelectors = {
   shadow: () => cy.get(didYouMeanComponent).shadow(),
   noResults: () => DidYouMeanSelectors.shadow().find('[part="no-results"]'),
+  noResultsOriginalQuery: () =>
+    DidYouMeanSelectors.noResults().find('[part~="highlight"]'),
   autoCorrected: () =>
     DidYouMeanSelectors.shadow().find('[part="auto-corrected"]'),
+  autoCorrectedNewQuery: () =>
+    DidYouMeanSelectors.autoCorrected().find('[part~="highlight"]'),
   showingResultsFor: () =>
     DidYouMeanSelectors.shadow().find('[part="showing-results-for"]'),
+  showingResultsForNewQuery: () =>
+    DidYouMeanSelectors.showingResultsFor().find('[part="highlight"]'),
   searchInsteadFor: () =>
     DidYouMeanSelectors.shadow().find('[part="search-instead-for"]'),
   didYouMean: () => DidYouMeanSelectors.shadow().find('[part="did-you-mean"]'),

--- a/packages/atomic/cypress/integration/did-you-mean.cypress.ts
+++ b/packages/atomic/cypress/integration/did-you-mean.cypress.ts
@@ -33,6 +33,8 @@ describe('Did You Mean Test Suites', () => {
     });
 
     QuerySummaryAssertions.assertHasQuery(newQuery);
+    DidYouMeanAssertions.assertHasAutoCorrectOriginalQuery(originalQuery);
+    DidYouMeanAssertions.assertHasAutoCorrectNewQuery(newQuery);
     DidYouMeanAssertions.assertDisplayAutoCorrected(true);
     DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
     DidYouMeanAssertions.assertDisplayQueryTriggered(false);
@@ -47,6 +49,7 @@ describe('Did You Mean Test Suites', () => {
     });
 
     QuerySummaryAssertions.assertHasQuery(originalQuery);
+    DidYouMeanAssertions.assertHasManualCorrectNewQuery(newQuery);
     DidYouMeanAssertions.assertDisplayAutoCorrected(false);
     DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(true);
     DidYouMeanAssertions.assertDisplayQueryTriggered(false);
@@ -83,7 +86,8 @@ describe('Did You Mean Test Suites', () => {
     });
 
     QuerySummaryAssertions.assertHasQuery(newQuery);
-    DidYouMeanAssertions.assertDisplayAutoCorrected(false);
+    DidYouMeanAssertions.assertHasTriggerOriginalQuery(originalQuery);
+    DidYouMeanAssertions.assertHasTriggerNewQuery(newQuery);
     DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
     DidYouMeanAssertions.assertDisplayQueryTriggered(true);
     DidYouMeanAssertions.assertDisplayUndoButton(true);
@@ -93,7 +97,7 @@ describe('Did You Mean Test Suites', () => {
         DidYouMeanSelectors.undoButton().click();
       });
 
-      QuerySummaryAssertions.assertHasQuery(originalQuery);
+      QuerySummaryAssertions.assertHasQuery(newQuery);
       DidYouMeanAssertions.assertDisplayAutoCorrected(false);
       DidYouMeanAssertions.assertDisplayDidYouMeanWithButton(false);
       DidYouMeanAssertions.assertDisplayQueryTriggered(false);

--- a/packages/headless/src/features/search/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/search/search-actions-thunk-processor.ts
@@ -110,6 +110,8 @@ export interface AsyncThunkConfig {
 type QueryCorrectionCallback = (modification: string) => void;
 
 export class AsyncSearchThunkProcessor<RejectionType> {
+  private readonly originalQuery: string;
+
   constructor(
     private config: AsyncThunkConfig,
     private onUpdateQueryForCorrection: QueryCorrectionCallback = (
@@ -117,7 +119,9 @@ export class AsyncSearchThunkProcessor<RejectionType> {
     ) => {
       this.dispatch(updateQuery({q: modification}));
     }
-  ) {}
+  ) {
+    this.originalQuery = this.getOriginalQuery();
+  }
 
   public async fetchFromAPI(
     {mappings, request}: MappedSearchRequest,
@@ -202,7 +206,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
         queryCorrections: successResponse.queryCorrections,
       },
       automaticallyCorrected: true,
-      originalQuery: this.getOriginalQuery(),
+      originalQuery: this.originalQuery,
       analyticsAction: logDidYouMeanAutomatic(),
     };
   }
@@ -249,7 +253,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
         ...retried.response.success,
       },
       automaticallyCorrected: false,
-      originalQuery: this.getOriginalQuery(),
+      originalQuery: this.originalQuery,
       analyticsAction: logTriggerQuery(),
     };
   }
@@ -262,7 +266,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
       ...fetched,
       response: this.getSuccessResponse(fetched)!,
       automaticallyCorrected: false,
-      originalQuery: this.getOriginalQuery(),
+      originalQuery: this.originalQuery,
       analyticsAction: this.analyticsAction!,
     };
   }
@@ -290,7 +294,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
     this.dispatch(
       applyQueryTriggerModification({
         newQuery: modified,
-        originalQuery: this.getOriginalQuery(),
+        originalQuery: this.originalQuery,
       })
     );
     this.onUpdateQueryForCorrection(modified);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2042

The new query was present instead of the original query.