### PR TITLE
feat(headless): added platform-specific origins to requests

### DIFF
--- a/packages/headless/src/api/commerce/product-listings/product-listing-api-client.test.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-api-client.test.ts
@@ -60,6 +60,7 @@ describe('product listing api client', () => {
         contentType: 'application/json',
         url: `${request.platformUrl}/rest/organizations/${request.organizationId}/commerce/v1/products/listing`,
         accessToken: request.accessToken,
+        origin: 'commerceApiFetch',
         requestParams: {
           url: request.url,
           additionalFields: request.additionalFields,

--- a/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
+++ b/packages/headless/src/api/commerce/product-listings/product-listing-params.ts
@@ -49,7 +49,7 @@ export const baseProductListingRequest = (
   queryStringArguments: Record<string, string> = {}
 ): Pick<
   PlatformClientCallOptions,
-  'accessToken' | 'method' | 'contentType' | 'url'
+  'accessToken' | 'method' | 'contentType' | 'url' | 'origin'
 > => {
   const {platformUrl, organizationId, accessToken, version} = req;
   const baseUrl = `${platformUrl}/rest/organizations/${organizationId}/commerce/${
@@ -63,6 +63,7 @@ export const baseProductListingRequest = (
     method,
     contentType,
     url: effectiveUrl,
+    origin: 'commerceApiFetch',
   };
 };
 

--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -46,6 +46,7 @@ describe('PlatformClient call', () => {
       url: platformUrl(),
       preprocessRequest: NoopPreprocessRequest,
       logger: pino({level: 'silent'}),
+      origin: 'searchApiFetch',
       ...options,
     });
   }

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -9,6 +9,7 @@ import {Logger} from 'pino';
 import {DisconnectedError, ExpiredTokenError} from '../utils/errors';
 import {canBeFormUrlEncoded, encodeAsFormUrl} from './form-url-encoder';
 import {
+  PlatformClientOrigin,
   PlatformRequestOptions,
   PreprocessRequest,
   RequestMetadata,
@@ -19,6 +20,7 @@ function isThrottled(status: number): boolean {
 }
 
 export interface PlatformClientCallOptions {
+  origin: PlatformClientOrigin;
   url: string;
   method: HttpMethods;
   contentType: HTTPContentType;
@@ -53,7 +55,7 @@ export class PlatformClient {
       ...(preprocessRequest
         ? await preprocessRequest(
             defaultRequestOptions,
-            'searchApiFetch',
+            options.origin,
             requestMetadata
           )
         : {}),

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -48,14 +48,14 @@ export class PlatformClient {
     options: PlatformClientCallOptions
   ): Promise<Response | PlatformClientCallError> {
     const defaultRequestOptions = buildDefaultRequestOptions(options);
-    const {preprocessRequest, logger, requestMetadata} = options;
+    const {origin, preprocessRequest, logger, requestMetadata} = options;
 
     const requestInfo: PlatformRequestOptions = {
       ...defaultRequestOptions,
       ...(preprocessRequest
         ? await preprocessRequest(
             defaultRequestOptions,
-            options.origin,
+            origin,
             requestMetadata
           )
         : {}),

--- a/packages/headless/src/api/preprocess-request.ts
+++ b/packages/headless/src/api/preprocess-request.ts
@@ -5,8 +5,12 @@ export interface PlatformRequestOptions extends RequestInit {
   url: string;
 }
 
-// TODO: V2 add more types for each different client e.g. 'insightApiFetch' or 'commerceApiFetch'
-export type PlatformClientOrigin = AnalyticsClientOrigin | 'searchApiFetch';
+export type PlatformClientOrigin =
+  | AnalyticsClientOrigin
+  | 'searchApiFetch'
+  | 'insightApiFetch'
+  | 'caseAssistApiFetch'
+  | 'commerceApiFetch';
 
 export interface RequestMetadata {
   /**

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -174,6 +174,7 @@ describe('search api client', () => {
           state.configuration.search.apiBaseUrl
         }?${getOrganizationIdQueryParam(req)}`,
         logger,
+        origin: 'searchApiFetch',
         requestParams: {
           q: state.query.q,
           debug: false,
@@ -245,6 +246,7 @@ describe('search api client', () => {
           state.configuration.search.apiBaseUrl
         }/plan?${getOrganizationIdQueryParam(req)}`,
         logger,
+        origin: 'searchApiFetch',
         requestParams: {
           q: state.query.q,
           context: state.context.contextValues,
@@ -294,6 +296,7 @@ describe('search api client', () => {
           state.configuration.search.apiBaseUrl
         }/querySuggest?${getOrganizationIdQueryParam(req)}`,
         logger,
+        origin: 'searchApiFetch',
         requestParams: {
           q: state.querySet[id],
           count: state.querySuggest[id]!.count,
@@ -497,6 +500,7 @@ describe('search api client', () => {
           recommendationState.configuration.search.apiBaseUrl
         }?${getOrganizationIdQueryParam(req)}`,
         logger,
+        origin: 'searchApiFetch',
         requestParams: {
           recommendation: recommendationState.recommendation.id,
           aq: recommendationState.advancedSearchQueries.aq,
@@ -574,6 +578,7 @@ describe('search api client', () => {
           productRecommendationsState.configuration.search.apiBaseUrl
         }?${getOrganizationIdQueryParam(req)}`,
         logger,
+        origin: 'searchApiFetch',
         requestParams: {
           recommendation: productRecommendationsState.productRecommendations.id,
           context: productRecommendationsState.context.contextValues,

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -1,7 +1,11 @@
 import {history} from 'coveo.analytics';
 import {FacetOptions} from '../../features/facet-options/facet-options';
 import {AnyFacetRequest} from '../../features/facets/generic/interfaces/generic-facet-request';
-import {HTTPContentType, HttpMethods} from '../platform-client';
+import {
+  HTTPContentType,
+  HttpMethods,
+  PlatformClientCallOptions,
+} from '../platform-client';
 import {BaseParam} from '../platform-service-params';
 
 export interface QueryParam {
@@ -123,13 +127,17 @@ export const baseSearchRequest = (
   method: HttpMethods,
   contentType: HTTPContentType,
   path: string
-) => ({
+): Pick<
+  PlatformClientCallOptions,
+  'accessToken' | 'method' | 'contentType' | 'url' | 'origin'
+> => ({
   accessToken: req.accessToken,
   method,
   contentType,
   url: `${req.url}${path}?${getOrganizationIdQueryParam(req)}${
     req.authentication ? `&${getAuthenticationQueryParam(req)}` : ''
   }`,
+  origin: 'searchApiFetch',
 });
 
 export const getOrganizationIdQueryParam = (req: BaseParam) =>

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
@@ -71,6 +71,7 @@ describe('case assist api client', () => {
         contentType: 'application/json',
         url: `${request.url}/rest/organizations/${request.organizationId}/caseassists/${request.caseAssistId}/classify`,
         accessToken: request.accessToken,
+        origin: 'caseAssistApiFetch',
         requestParams: {
           visitorId: request.visitorId,
           locale: request.locale,
@@ -188,6 +189,7 @@ describe('case assist api client', () => {
         contentType: 'application/json',
         url: `${request.url}/rest/organizations/${request.organizationId}/caseassists/${request.caseAssistId}/documents/suggest`,
         accessToken: request.accessToken,
+        origin: 'caseAssistApiFetch',
         requestParams: {
           visitorId: request.visitorId,
           locale: request.locale,

--- a/packages/headless/src/api/service/case-assist/case-assist-params.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-params.test.ts
@@ -30,6 +30,7 @@ describe('case assist params', () => {
         accessToken: request.accessToken,
         method,
         contentType,
+        origin: 'caseAssistApiFetch',
         url: `${request.url}/rest/organizations/${request.organizationId}/caseassists/${request.caseAssistId}${path}`,
       });
     });

--- a/packages/headless/src/api/service/case-assist/case-assist-params.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-params.ts
@@ -1,4 +1,8 @@
-import {HTTPContentType, HttpMethods} from '../../platform-client';
+import {
+  HTTPContentType,
+  HttpMethods,
+  PlatformClientCallOptions,
+} from '../../platform-client';
 import {BaseParam} from '../../platform-service-params';
 
 export interface CaseAssistIdParam {
@@ -33,7 +37,10 @@ export const baseCaseAssistRequest = (
   contentType: HTTPContentType,
   path: string,
   queryStringArguments: Record<string, string> = {}
-) => {
+): Pick<
+  PlatformClientCallOptions,
+  'accessToken' | 'method' | 'contentType' | 'url' | 'origin'
+> => {
   validateCaseAssistRequestParams(req);
 
   const baseUrl = `${req.url}/rest/organizations/${req.organizationId}/caseassists/${req.caseAssistId}${path}`;
@@ -45,6 +52,7 @@ export const baseCaseAssistRequest = (
     method,
     contentType,
     url: effectiveUrl,
+    origin: 'caseAssistApiFetch',
   };
 };
 

--- a/packages/headless/src/api/service/insight/insight-api-client.test.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.test.ts
@@ -50,6 +50,7 @@ describe('insight api client', () => {
         method: 'GET',
         contentType: 'application/json',
         url: `${insightRequest.url}/rest/organizations/${insightRequest.organizationId}/insight/v1/configs/${insightRequest.insightId}/interface`,
+        origin: 'insightApiFetch',
       });
     });
 
@@ -100,6 +101,7 @@ describe('insight api client', () => {
         method: 'POST',
         contentType: 'application/json',
         url: `${queryRequest.url}/rest/organizations/${queryRequest.organizationId}/insight/v1/configs/${queryRequest.insightId}/search`,
+        origin: 'insightApiFetch',
         requestParams: {
           caseContext: queryRequest.caseContext,
           facets: queryRequest.facets,
@@ -154,6 +156,7 @@ describe('insight api client', () => {
         method: 'POST',
         contentType: 'application/json',
         url: `${userActionsRequest.url}/rest/organizations/${userActionsRequest.organizationId}/insight/v1/configs/${userActionsRequest.insightId}/useractions`,
+        origin: 'insightApiFetch',
         requestParams: {
           ticketCreationDate: userActionsRequest.ticketCreationDate,
           numberSessionsBefore: userActionsRequest.numberSessionsBefore,

--- a/packages/headless/src/api/service/insight/insight-params.test.ts
+++ b/packages/headless/src/api/service/insight/insight-params.test.ts
@@ -24,6 +24,7 @@ describe('insight params', () => {
         accessToken: request.accessToken,
         method,
         contentType,
+        origin: 'insightApiFetch',
         url: `${request.url}/rest/organizations/${request.organizationId}/insight/v1/configs/${request.insightId}${path}`,
       });
     });

--- a/packages/headless/src/api/service/insight/insight-params.ts
+++ b/packages/headless/src/api/service/insight/insight-params.ts
@@ -1,5 +1,9 @@
 import {pickNonBaseParams} from '../../api-client-utils';
-import {HTTPContentType, HttpMethods} from '../../platform-client';
+import {
+  HTTPContentType,
+  HttpMethods,
+  PlatformClientCallOptions,
+} from '../../platform-client';
 import {BaseParam} from '../../platform-service-params';
 
 export interface InsightIdParam {
@@ -13,7 +17,10 @@ export const baseInsightRequest = (
   method: HttpMethods,
   contentType: HTTPContentType,
   path: string
-) => {
+): Pick<
+  PlatformClientCallOptions,
+  'accessToken' | 'method' | 'contentType' | 'url' | 'origin'
+> => {
   validateInsightRequestParams(req);
 
   const baseUrl = `${req.url}/rest/organizations/${req.organizationId}/insight/v1/configs/${req.insightId}${path}`;
@@ -23,6 +30,7 @@ export const baseInsightRequest = (
     method,
     contentType,
     url: baseUrl,
+    origin: 'insightApiFetch',
   };
 };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2017

# Deprecations

## Changed

* The `clientOrigin` parameter of `preprocessRequest` for some search requests was changed.
  * Product listing requests now have the `clientOrigin` `commerceApiFetch`
  * Case assist requests now have the `clientOrigin` `caseAssistApiFetch`
  * Insight requests now have the `clientOrigin` `insightApiFetch`