### PR TITLE
fix(atomic): modify result-localized-text key property

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -926,13 +926,13 @@ export declare interface AtomicResultLocalizedText extends Components.AtomicResu
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['fieldCount', 'i18nKey']
+  inputs: ['fieldCount', 'localeKey']
 })
 @Component({
   selector: 'atomic-result-localized-text',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['fieldCount', 'i18nKey']
+  inputs: ['fieldCount', 'localeKey']
 })
 export class AtomicResultLocalizedText {
   protected el: HTMLElement;

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -926,13 +926,13 @@ export declare interface AtomicResultLocalizedText extends Components.AtomicResu
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['fieldCount', 'key']
+  inputs: ['fieldCount', 'i18nKey']
 })
 @Component({
   selector: 'atomic-result-localized-text',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['fieldCount', 'key']
+  inputs: ['fieldCount', 'i18nKey']
 })
 export class AtomicResultLocalizedText {
   protected el: HTMLElement;

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-localized-test.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-localized-test.cypress.ts
@@ -39,7 +39,7 @@ describe('Result Localized Text Component', () => {
       new TestFixture()
         .with(
           addResultLocalizedTextInResultList({
-            'i18n-key': 'this_does_not_exist',
+            'locale-key': 'this_does_not_exist',
           })
         )
         .init();
@@ -67,7 +67,7 @@ describe('Result Localized Text Component', () => {
         })
         .with(
           addResultLocalizedTextInResultList({
-            'i18n-key': 'foo',
+            'locale-key': 'foo',
             'field-somefield': 'replace_me',
             ...props,
           })

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-localized-test.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-localized-test.cypress.ts
@@ -37,7 +37,11 @@ describe('Result Localized Text Component', () => {
   describe('when the i18n resource does not exist', () => {
     beforeEach(() => {
       new TestFixture()
-        .with(addResultLocalizedTextInResultList({key: 'this_does_not_exist'}))
+        .with(
+          addResultLocalizedTextInResultList({
+            'i18n-key': 'this_does_not_exist',
+          })
+        )
         .init();
     });
 
@@ -63,7 +67,7 @@ describe('Result Localized Text Component', () => {
         })
         .with(
           addResultLocalizedTextInResultList({
-            key: 'foo',
+            'i18n-key': 'foo',
             'field-somefield': 'replace_me',
             ...props,
           })

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1236,7 +1236,7 @@ export namespace Components {
         /**
           * The i18n translation key.
          */
-        "i18nKey": string;
+        "localeKey": string;
     }
     interface AtomicResultMultiValueText {
         /**
@@ -3679,7 +3679,7 @@ declare namespace LocalJSX {
         /**
           * The i18n translation key.
          */
-        "i18nKey": string;
+        "localeKey": string;
     }
     interface AtomicResultMultiValueText {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1236,7 +1236,7 @@ export namespace Components {
         /**
           * The i18n translation key.
          */
-        "key": string;
+        "i18nKey": string;
     }
     interface AtomicResultMultiValueText {
         /**
@@ -3679,7 +3679,7 @@ declare namespace LocalJSX {
         /**
           * The i18n translation key.
          */
-        "key": string;
+        "i18nKey": string;
     }
     interface AtomicResultMultiValueText {
         /**

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
@@ -21,7 +21,7 @@ import {ResultContext} from '../result-template-decorators';
  *
  * The component could be configured in such a way to replace `{{name}}` with the `author` field value from the result item:
  * ```
- * <atomic-result-localized-text key="classic_book_advert" field-author="name"></atomic-result-localized-text>
+ * <atomic-result-localized-text i18n-key="classic_book_advert" field-author="name"></atomic-result-localized-text>
  * ```
  *
  * @MapProp name: field;attr: field;docs: The field from which to extract the target string and the variable used to map it to the target i18n parameter. For example, the following configuration extracts the value of `author` from a result, and assign it to the i18n parameter `name`: `field-author="name"`;type: Record<string, string> ;default: {}
@@ -37,7 +37,7 @@ export class AtomicResultLocalizedText implements InitializableComponent {
   /**
    * The i18n translation key.
    */
-  @Prop() key!: string;
+  @Prop() i18nKey!: string;
   /**
    * The field value to dynamically evaluate.
    */
@@ -48,7 +48,7 @@ export class AtomicResultLocalizedText implements InitializableComponent {
   @Prop() fieldCount?: string;
 
   render() {
-    return this.bindings.i18n.t(this.key, {
+    return this.bindings.i18n.t(this.i18nKey, {
       ...this.parseFieldValues(),
       ...this.parseFieldCount(),
     });

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
@@ -21,7 +21,7 @@ import {ResultContext} from '../result-template-decorators';
  *
  * The component could be configured in such a way to replace `{{name}}` with the `author` field value from the result item:
  * ```
- * <atomic-result-localized-text i18n-key="classic_book_advert" field-author="name"></atomic-result-localized-text>
+ * <atomic-result-localized-text locale-key="classic_book_advert" field-author="name"></atomic-result-localized-text>
  * ```
  *
  * @MapProp name: field;attr: field;docs: The field from which to extract the target string and the variable used to map it to the target i18n parameter. For example, the following configuration extracts the value of `author` from a result, and assign it to the i18n parameter `name`: `field-author="name"`;type: Record<string, string> ;default: {}
@@ -37,7 +37,7 @@ export class AtomicResultLocalizedText implements InitializableComponent {
   /**
    * The i18n translation key.
    */
-  @Prop() i18nKey!: string;
+  @Prop() localeKey!: string;
   /**
    * The field value to dynamically evaluate.
    */
@@ -48,7 +48,7 @@ export class AtomicResultLocalizedText implements InitializableComponent {
   @Prop() fieldCount?: string;
 
   render() {
-    return this.bindings.i18n.t(this.i18nKey, {
+    return this.bindings.i18n.t(this.localeKey, {
       ...this.parseFieldValues(),
       ...this.parseFieldCount(),
     });


### PR DESCRIPTION
`key` is a reserved keyword. Stencil recommends not using that.

https://coveord.atlassian.net/browse/KIT-2086