### PR TITLE
fix(headless): made field suggestions not inherit the search context 

### DIFF
--- a/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
+++ b/packages/headless/src/api/search/facet-search/base/base-facet-search-request.ts
@@ -19,7 +19,7 @@ export interface BaseFacetSearchRequest
     VisitorIDParam,
     AuthenticationParam {
   field: string;
-  searchContext: SearchRequest;
+  searchContext?: SearchRequest;
   filterFacetCount: boolean;
 }
 

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -148,7 +148,7 @@ describe('search api client', () => {
           };
         },
       });
-      const req = await buildSpecificFacetSearchRequest('test', state);
+      const req = await buildSpecificFacetSearchRequest('test', state, false);
       const res = await searchAPIClient.facetSearch(req);
       expect(res.moreValuesAvailable).toEqual(true);
     });
@@ -341,7 +341,7 @@ describe('search api client', () => {
         state.facetSearchSet[id] = facetSearchState;
         state.facetSet[id] = facetState;
 
-        const req = await buildSpecificFacetSearchRequest(id, state);
+        const req = await buildSpecificFacetSearchRequest(id, state, false);
         searchAPIClient.facetSearch(req);
 
         const request = (PlatformClient.call as jest.Mock).mock.calls[0][0];
@@ -369,7 +369,7 @@ describe('search api client', () => {
         state.facetSet[id] = facetState;
         state.configuration.search.authenticationProviders = ['foo'];
 
-        const req = await buildSpecificFacetSearchRequest(id, state);
+        const req = await buildSpecificFacetSearchRequest(id, state, false);
         searchAPIClient.facetSearch(req);
 
         const request = (PlatformClient.call as jest.Mock).mock.calls[0][0];
@@ -390,7 +390,7 @@ describe('search api client', () => {
 
         state.facetSearchSet[id] = facetSearchState;
         state.facetSet[id] = facetState;
-        const req = await buildSpecificFacetSearchRequest(id, state);
+        const req = await buildSpecificFacetSearchRequest(id, state, false);
 
         searchAPIClient.facetSearch(req);
 

--- a/packages/headless/src/controllers/core/facets/facet-search/category/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/category/headless-category-facet-search.ts
@@ -34,7 +34,7 @@ export function buildCoreCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
-    includeSearchContext: true,
+    isForFieldSuggestions: false,
   });
 
   return {

--- a/packages/headless/src/controllers/core/facets/facet-search/category/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/category/headless-category-facet-search.ts
@@ -34,6 +34,7 @@ export function buildCoreCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
+    includeSearchContext: true,
   });
 
   return {

--- a/packages/headless/src/controllers/core/facets/facet-search/facet-search.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/facet-search.test.ts
@@ -42,6 +42,7 @@ describe('FacetSearch', () => {
     props = {
       options: {facetId},
       getFacetSearch,
+      isForFieldSuggestions: false,
     };
 
     engine = buildMockSearchAppEngine();

--- a/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
@@ -5,6 +5,7 @@ import {FacetSearchOptions} from '../../../../features/facets/facet-search-set/f
 import {
   clearFacetSearch,
   executeFacetSearch,
+  executeFacetSearchWithoutSearchContext,
 } from '../../../../features/facets/facet-search-set/generic/generic-facet-search-actions';
 import {
   CategoryFacetSearchSection,
@@ -20,6 +21,7 @@ type FacetSearchState = SpecificFacetSearchState | CategoryFacetSearchState;
 export interface GenericFacetSearchProps<T extends FacetSearchState> {
   options: FacetSearchOptions;
   getFacetSearch: () => T;
+  includeSearchContext: boolean;
 }
 
 export type GenericFacetSearch = ReturnType<typeof buildGenericFacetSearch>;
@@ -58,12 +60,20 @@ export function buildGenericFacetSearch<T extends FacetSearchState>(
           numberOfValues: options.numberOfValues + initialNumberOfValues,
         })
       );
-      dispatch(executeFacetSearch(facetId));
+      dispatch(
+        props.includeSearchContext
+          ? executeFacetSearch(facetId)
+          : executeFacetSearchWithoutSearchContext(facetId)
+      );
     },
 
     /** Executes a facet search to update the values.*/
     search() {
-      dispatch(executeFacetSearch(facetId));
+      dispatch(
+        props.includeSearchContext
+          ? executeFacetSearch(facetId)
+          : executeFacetSearchWithoutSearchContext(facetId)
+      );
     },
 
     /** Resets the query and empties the values. */

--- a/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
@@ -5,7 +5,7 @@ import {FacetSearchOptions} from '../../../../features/facets/facet-search-set/f
 import {
   clearFacetSearch,
   executeFacetSearch,
-  executeFacetSearchWithoutSearchContext,
+  executeFieldSuggest,
 } from '../../../../features/facets/facet-search-set/generic/generic-facet-search-actions';
 import {
   CategoryFacetSearchSection,
@@ -21,7 +21,7 @@ type FacetSearchState = SpecificFacetSearchState | CategoryFacetSearchState;
 export interface GenericFacetSearchProps<T extends FacetSearchState> {
   options: FacetSearchOptions;
   getFacetSearch: () => T;
-  includeSearchContext: boolean;
+  isForFieldSuggestions: boolean;
 }
 
 export type GenericFacetSearch = ReturnType<typeof buildGenericFacetSearch>;
@@ -61,18 +61,18 @@ export function buildGenericFacetSearch<T extends FacetSearchState>(
         })
       );
       dispatch(
-        props.includeSearchContext
-          ? executeFacetSearch(facetId)
-          : executeFacetSearchWithoutSearchContext(facetId)
+        props.isForFieldSuggestions
+          ? executeFieldSuggest(facetId)
+          : executeFacetSearch(facetId)
       );
     },
 
     /** Executes a facet search to update the values.*/
     search() {
       dispatch(
-        props.includeSearchContext
-          ? executeFacetSearch(facetId)
-          : executeFacetSearchWithoutSearchContext(facetId)
+        props.isForFieldSuggestions
+          ? executeFieldSuggest(facetId)
+          : executeFacetSearch(facetId)
       );
     },
 

--- a/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.test.ts
@@ -35,7 +35,7 @@ describe('FacetSearch', () => {
     props = {
       options: {facetId},
       select: jest.fn(),
-      includeSearchContext: true,
+      isForFieldSuggestions: false,
     };
 
     initEngine();

--- a/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.test.ts
@@ -35,6 +35,7 @@ describe('FacetSearch', () => {
     props = {
       options: {facetId},
       select: jest.fn(),
+      includeSearchContext: true,
     };
 
     initEngine();

--- a/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
@@ -15,7 +15,7 @@ import {CoreEngine} from '../../../../../app/engine';
 export interface FacetSearchProps {
   options: FacetSearchOptions;
   select: (value: SpecificFacetSearchResult) => void;
-  includeSearchContext: boolean;
+  isForFieldSuggestions: boolean;
 }
 
 export type FacetSearch = ReturnType<typeof buildFacetSearch>;
@@ -25,7 +25,7 @@ export function buildFacetSearch(
   props: FacetSearchProps
 ) {
   const {dispatch} = engine;
-  const {options, select, includeSearchContext} = props;
+  const {options, select, isForFieldSuggestions} = props;
   const {facetId} = options;
   const getFacetSearch = () => engine.state.facetSearchSet[facetId];
 
@@ -34,7 +34,7 @@ export function buildFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
-    includeSearchContext,
+    isForFieldSuggestions,
   });
 
   return {

--- a/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
@@ -15,6 +15,7 @@ import {CoreEngine} from '../../../../../app/engine';
 export interface FacetSearchProps {
   options: FacetSearchOptions;
   select: (value: SpecificFacetSearchResult) => void;
+  includeSearchContext: boolean;
 }
 
 export type FacetSearch = ReturnType<typeof buildFacetSearch>;
@@ -24,7 +25,7 @@ export function buildFacetSearch(
   props: FacetSearchProps
 ) {
   const {dispatch} = engine;
-  const {options, select} = props;
+  const {options, select, includeSearchContext} = props;
   const {facetId} = options;
   const getFacetSearch = () => engine.state.facetSearchSet[facetId];
 
@@ -33,6 +34,7 @@ export function buildFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
+    includeSearchContext,
   });
 
   return {

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
@@ -39,6 +39,7 @@ export function buildCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
+    includeSearchContext: true,
   });
 
   return {

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
@@ -39,7 +39,7 @@ export function buildCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
-    includeSearchContext: true,
+    isForFieldSuggestions: false,
   });
 
   return {

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -110,6 +110,7 @@ export function buildFacet(
           )
         );
       },
+      includeSearchContext: false,
     });
   };
 

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -110,7 +110,7 @@ export function buildFacet(
           )
         );
       },
-      includeSearchContext: false,
+      isForFieldSuggestions: false,
     });
   };
 

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.test.ts
@@ -14,9 +14,12 @@ import {
 } from './headless-field-suggestions';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
 import {executeFacetSearch} from '../../../features/facets/facet-search-set/generic/generic-facet-search-actions';
+import {registerFacet} from '../../../features/facets/facet-set/facet-set-actions';
+import {defaultFacetOptions} from '../../../features/facets/facet-set/facet-set-slice';
 
 describe('fieldSuggestions', () => {
-  const facetId = 'id';
+  const field = 'author';
+  const facetId = 'test';
   let state: SearchAppState;
   let engine: MockSearchEngine;
   let fieldSuggestions: FieldSuggestions;
@@ -28,7 +31,10 @@ describe('fieldSuggestions', () => {
   }
 
   function setFacetRequest(config: Partial<FacetRequest> = {}) {
-    state.facetSet[facetId] = buildMockFacetRequest({facetId, ...config});
+    state.facetSet[facetId] = buildMockFacetRequest({
+      facetId,
+      ...config,
+    });
     state.facetSearchSet[facetId] = buildMockFacetSearch({
       initialNumberOfValues: 5,
     });
@@ -44,6 +50,21 @@ describe('fieldSuggestions', () => {
     setFacetRequest();
 
     initFacet();
+  });
+
+  it('should dispatch an #registerFacet action when initialized', () => {
+    expect(engine.actions).toEqual(
+      expect.arrayContaining([
+        <ReturnType<typeof registerFacet>>{
+          type: registerFacet.type,
+          payload: {
+            ...defaultFacetOptions,
+            facetId,
+            field,
+          },
+        },
+      ])
+    );
   });
 
   it('should dispatch an #updateFacetSearch and #executeFacetSearch action on #updateText', () => {

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -29,9 +29,19 @@ import {registerFacet} from '../../../features/facets/facet-set/facet-set-action
 import {FacetSortCriterion} from '../../../features/facets/facet-set/interfaces/request';
 
 export interface FieldSuggestionsValue {
-  count: number;
+  /**
+   * The custom field suggestion display name, as specified in the `captions` argument.
+   */
   displayValue: string;
+  /**
+   * The original field value, as retrieved from the field in the index.
+   */
   rawValue: string;
+  /**
+   * An estimate number of result items matching both the current query and
+   * the filter expression that would get generated if the field suggestion were selected.
+   */
+  count: number;
 }
 
 export interface FieldSuggestionsState {

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -92,14 +92,18 @@ export interface FieldSuggestions extends Subscribable {
   search(): void;
 
   /**
-   * If a facet exists with the configured `facetId`, selects a facet value.
+   * Filters the search using the specified value.
+   *
+   * If a facet exists with the configured `facetId`, selects the corresponding facet value.
    *
    * @param value - The field suggestion for which to select the matching facet value.
    */
   select(value: FieldSuggestionsValue): void;
 
   /**
-   * If a facet exists with the configured `facetId`, selects a facet value while deselecting other facet values.
+   * Filters the search using the specified value, deselecting others.
+   *
+   * If a facet exists with the configured `facetId`, selects the corresponding facet value while deselecting other facet values.
    *
    * @param value - The field suggestion for which to select the matching facet value.
    */
@@ -154,7 +158,7 @@ export interface FieldSuggestionsOptions {
   /**
    * A unique identifier for the controller. By default, a random unique identifier is generated.
    *
-   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`. However, you must make sure to build the field suggestion controller after the facet controller.
+   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`.
    */
   facetId?: string;
 

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -61,7 +61,7 @@ export interface FieldSuggestionsState {
   moreValuesAvailable: boolean;
 
   /**
-   * The field suggestions query.
+   * The query used to request field suggestions.
    */
   query: string;
 }
@@ -75,7 +75,7 @@ export interface FieldSuggestionsState {
  */
 export interface FieldSuggestions extends Subscribable {
   /**
-   * Performs a field suggestions search with a query.
+   * Requests field suggestions based on a query.
    *
    * @param text - The query to search.
    */
@@ -87,7 +87,7 @@ export interface FieldSuggestions extends Subscribable {
   showMoreResults(): void;
 
   /**
-   * Performs a field suggestions search with the current query.
+   * Requests field suggestions based on a query.
    */
   search(): void;
 

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -1,8 +1,60 @@
 import {SearchEngine} from '../../../app/search-engine/search-engine';
-import {FacetSearch} from '../../core/facets/facet-search/specific/headless-facet-search';
-import {buildFacet} from '../../facets/facet/headless-facet';
-import {FacetOptions} from '../../facets/facet/headless-facet-options';
-import {Subscribable} from '../../controller/headless-controller';
+import {buildFacetSearch} from '../../core/facets/facet-search/specific/headless-facet-search';
+import {
+  buildController,
+  Subscribable,
+} from '../../controller/headless-controller';
+import {loadReducerError} from '../../../utils/errors';
+import {CoreEngine} from '../../../app/engine';
+import {
+  facetSet,
+  configuration,
+  facetSearchSet,
+  search,
+} from '../../../app/reducers';
+import {SearchThunkExtraArguments} from '../../../app/search-thunk-extra-arguments';
+import {
+  FacetSection,
+  ConfigurationSection,
+  FacetSearchSection,
+  SearchSection,
+} from '../../../state/state-sections';
+import {determineFacetId} from '../../core/facets/_common/facet-id-determinor';
+import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
+import {executeSearch} from '../../../features/search/search-actions';
+import {logFacetSelect} from '../../../features/facets/facet-set/facet-set-analytics-actions';
+import {defaultFacetOptions} from '../../../features/facets/facet-set/facet-set-slice';
+import {omit} from '../../../utils/utils';
+import {registerFacet} from '../../../features/facets/facet-set/facet-set-actions';
+import {FacetSortCriterion} from '../../../features/facets/facet-set/interfaces/request';
+
+export interface FieldSuggestionsValue {
+  count: number;
+  displayValue: string;
+  rawValue: string;
+}
+
+export interface FieldSuggestionsState {
+  /**
+   * The field suggestions.
+   */
+  values: FieldSuggestionsValue[];
+
+  /**
+   * `true` if the field suggestions search is in progress and `false` otherwise.
+   */
+  isLoading: boolean;
+
+  /**
+   * Whether more field suggestions are available.
+   */
+  moreValuesAvailable: boolean;
+
+  /**
+   * The field suggestions query.
+   */
+  query: string;
+}
 
 /**
  * The `FieldSuggestions` controller provides query suggestions based on a particular facet field.
@@ -11,14 +63,136 @@ import {Subscribable} from '../../controller/headless-controller';
  *
  * This controller is a wrapper around the basic facet controller search functionality, and thus exposes similar options and properties.
  */
-export interface FieldSuggestions extends FacetSearch, Subscribable {}
+export interface FieldSuggestions extends Subscribable {
+  /**
+   * Performs a field suggestions search with a query.
+   *
+   * @param text - The query to search.
+   */
+  updateText(text: string): void;
 
-export interface FieldSuggestionsOptions extends FacetOptions {}
+  /**
+   * Shows more field suggestions for the current query.
+   */
+  showMoreResults(): void;
+
+  /**
+   * Performs a field suggestions search with the current query.
+   */
+  search(): void;
+
+  /**
+   * If a facet exists with the configured `facetId`, selects a facet value.
+   *
+   * @param value - The field suggestion for which to select the matching facet value.
+   */
+  select(value: FieldSuggestionsValue): void;
+
+  /**
+   * If a facet exists with the configured `facetId`, selects a facet value while deselecting other facet values.
+   *
+   * @param value - The field suggestion for which to select the matching facet value.
+   */
+  singleSelect(value: FieldSuggestionsValue): void;
+
+  /**
+   * Resets the query and empties the suggestions.
+   */
+  clear(): void;
+
+  /**
+   * Updates the field suggestions captions.
+   *
+   * @param captions - A dictionary that maps field values to field suggestion display names.
+   */
+  updateCaptions(captions: Record<string, string>): void;
+
+  state: FieldSuggestionsState;
+}
+
+// TODO: In v2, move these options into `FieldSuggestionsOptions` and remove `facetSearch`.
+export interface FieldSuggestionsFacetSearchOptions {
+  /**
+   * A dictionary that maps field values to field suggestion display names.
+   */
+  captions?: Record<string, string>;
+
+  /**
+   * The maximum number of suggestions to fetch.
+   *
+   * @defaultValue `10`
+   */
+  numberOfValues?: number;
+
+  /**
+   * The query to search the field suggestions with.
+   */
+  query?: string;
+}
+
+export interface FieldSuggestionsOptions {
+  /**
+   * The field for which you wish to get field suggestions.
+   */
+  field: string;
+
+  /**
+   * @deprecated This option has no effect.
+   */
+  delimitingCharacter?: string;
+
+  /**
+   * A unique identifier for the controller. By default, a random unique identifier is generated.
+   *
+   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`. However, you must make sure to build the field suggestions controller after the facet's controller.
+   */
+  facetId?: string;
+
+  /**
+   * The options related to search.
+   */
+  facetSearch?: FieldSuggestionsFacetSearchOptions;
+
+  /**
+   * Whether to exclude the parents of folded results when estimating the result count for each field suggestion.
+   *
+   * @defaultValue `true`
+   */
+  filterFacetCount?: boolean;
+
+  /**
+   * @deprecated This option has no effect.
+   */
+  injectionDepth?: number;
+
+  /**
+   * This option has no effect.
+   */
+  numberOfValues?: number;
+
+  /**
+   * The criterion to use for sorting returned field suggestions.
+   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestFacetRequest-sortCriteria).
+   *
+   * @defaultValue `automatic`
+   */
+  sortCriteria?: FacetSortCriterion;
+
+  /**
+   * @deprecated This option has no effect.
+   */
+  allowedValues?: string[];
+
+  /**
+   * @deprecated This option has no effect.
+   */
+  hasBreadcrumbs?: boolean;
+}
 
 export interface FieldSuggestionsProps {
   /**
    * The options for the `FieldSuggestions` controller.
-   * */
+   */
   options: FieldSuggestionsOptions;
 }
 
@@ -32,17 +206,48 @@ export function buildFieldSuggestions(
   engine: SearchEngine,
   props: FieldSuggestionsProps
 ): FieldSuggestions {
-  const facetController = buildFacet(engine, props);
-  const {facetSearch, subscribe} = facetController;
+  if (!loadFieldSuggestionsReducers(engine)) {
+    throw loadReducerError;
+  }
+  const facetId = determineFacetId(engine, props.options);
+  engine.dispatch(
+    registerFacet({
+      ...defaultFacetOptions,
+      ...omit('facetSearch', props.options),
+      field: props.options.field,
+      facetId,
+    })
+  );
+
+  const facetSearch = buildFacetSearch(engine, {
+    options: {...props.options.facetSearch, facetId},
+    select: (value) => {
+      engine.dispatch(updateFacetOptions({freezeFacetOrder: true}));
+      engine.dispatch(
+        executeSearch(logFacetSelect({facetId, facetValue: value.rawValue}))
+      );
+    },
+  });
+  const controller = buildController(engine);
   return {
-    subscribe,
+    ...controller,
     ...facetSearch,
     updateText: function (text: string) {
       facetSearch.updateText(text);
       facetSearch.search();
     },
     get state() {
-      return facetController.state.facetSearch;
+      return facetSearch.state;
     },
   };
+}
+
+function loadFieldSuggestionsReducers(
+  engine: CoreEngine
+): engine is CoreEngine<
+  FacetSection & ConfigurationSection & FacetSearchSection & SearchSection,
+  SearchThunkExtraArguments
+> {
+  engine.addReducers({facetSet, configuration, facetSearchSet, search});
+  return true;
 }

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -227,6 +227,7 @@ export function buildFieldSuggestions(
         executeSearch(logFacetSelect({facetId, facetValue: value.rawValue}))
       );
     },
+    includeSearchContext: false,
   });
   const controller = buildController(engine);
   return {

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -181,7 +181,7 @@ export interface FieldSuggestionsOptions {
   numberOfValues?: number;
 
   /**
-   * The criterion to use for sorting returned field suggestions.
+   * The criterion to use to sort returned field suggestions.
    * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/#RestFacetRequest-sortCriteria).
    *
    * @defaultValue `automatic`

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -30,7 +30,7 @@ import {FacetSortCriterion} from '../../../features/facets/facet-set/interfaces/
 
 export interface FieldSuggestionsValue {
   /**
-   * The custom field suggestion display name, as specified in the `captions` argument.
+   * The custom field suggestion display name, as specified in the `captions` argument of the `FieldSuggestion` controller.
    */
   displayValue: string;
   /**
@@ -38,8 +38,8 @@ export interface FieldSuggestionsValue {
    */
   rawValue: string;
   /**
-   * An estimate number of result items matching both the current query and
-   * the filter expression that would get generated if the field suggestion were selected.
+   * An estimated number of result items matching both the current query and
+   * the filter expression that would get generated if this field suggestion was selected.
    */
   count: number;
 }
@@ -51,7 +51,7 @@ export interface FieldSuggestionsState {
   values: FieldSuggestionsValue[];
 
   /**
-   * `true` if the field suggestions search is in progress and `false` otherwise.
+   * Whether the request for field suggestions is in progress.
    */
   isLoading: boolean;
 
@@ -111,7 +111,7 @@ export interface FieldSuggestions extends Subscribable {
   clear(): void;
 
   /**
-   * Updates the field suggestions captions.
+   * Updates the captions of field suggestions.
    *
    * @param captions - A dictionary that maps field values to field suggestion display names.
    */
@@ -128,14 +128,14 @@ export interface FieldSuggestionsFacetSearchOptions {
   captions?: Record<string, string>;
 
   /**
-   * The maximum number of suggestions to fetch.
+   * The maximum number of suggestions to request.
    *
    * @defaultValue `10`
    */
   numberOfValues?: number;
 
   /**
-   * The query to search the field suggestions with.
+   * The query with which to request field suggestions.
    */
   query?: string;
 }
@@ -154,7 +154,7 @@ export interface FieldSuggestionsOptions {
   /**
    * A unique identifier for the controller. By default, a random unique identifier is generated.
    *
-   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`. However, you must make sure to build the field suggestions controller after the facet's controller.
+   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`. However, you must make sure to build the field suggestion controller after the facet controller.
    */
   facetId?: string;
 
@@ -182,7 +182,7 @@ export interface FieldSuggestionsOptions {
 
   /**
    * The criterion to use for sorting returned field suggestions.
-   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestFacetRequest-sortCriteria).
+   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/#RestFacetRequest-sortCriteria).
    *
    * @defaultValue `automatic`
    */

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -237,7 +237,7 @@ export function buildFieldSuggestions(
         executeSearch(logFacetSelect({facetId, facetValue: value.rawValue}))
       );
     },
-    includeSearchContext: false,
+    isForFieldSuggestions: true,
   });
   const controller = buildController(engine);
   return {

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -380,6 +380,8 @@ export type {
 export {buildCoreFacetConditionsManager as buildFacetConditionsManager} from './core/facets/facet-conditions-manager/headless-facet-conditions-manager';
 
 export type {
+  FieldSuggestionsValue,
+  FieldSuggestionsState,
   FieldSuggestions,
   FieldSuggestionsOptions,
   FieldSuggestionsProps,

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -383,6 +383,7 @@ export type {
   FieldSuggestionsValue,
   FieldSuggestionsState,
   FieldSuggestions,
+  FieldSuggestionsFacetSearchOptions,
   FieldSuggestionsOptions,
   FieldSuggestionsProps,
 } from './field-suggestions/facet/headless-field-suggestions';

--- a/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet-search.ts
+++ b/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet-search.ts
@@ -40,6 +40,7 @@ export function buildCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
+    includeSearchContext: true,
   });
 
   return {

--- a/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet-search.ts
+++ b/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet-search.ts
@@ -40,7 +40,7 @@ export function buildCategoryFacetSearch(
   const genericFacetSearch = buildGenericFacetSearch(engine, {
     options,
     getFacetSearch,
-    includeSearchContext: true,
+    isForFieldSuggestions: false,
   });
 
   return {

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
@@ -81,6 +81,7 @@ export function buildFacet(
           logFacetSelect({facetId: getFacetId(), facetValue: value.rawValue})
         );
       },
+      includeSearchContext: true,
     });
   };
 

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
@@ -81,7 +81,7 @@ export function buildFacet(
           logFacetSelect({facetId: getFacetId(), facetValue: value.rawValue})
         );
       },
-      includeSearchContext: true,
+      isForFieldSuggestions: false,
     });
   };
 

--- a/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
@@ -35,7 +35,7 @@ type ExecuteFacetSearchThunkApiConfig = AsyncThunkOptions<
 
 const getExecuteFacetSearchThunkPayloadCreator =
   (
-    includeSearchContext: boolean
+    isFieldSuggestionsRequest: boolean
   ): AsyncThunkPayloadCreator<
     ExecuteFacetSearchThunkReturn,
     ExecuteFacetSearchThunkArg,
@@ -52,7 +52,7 @@ const getExecuteFacetSearchThunkPayloadCreator =
       req = await buildSpecificFacetSearchRequest(
         facetId,
         state,
-        includeSearchContext
+        isFieldSuggestionsRequest
       );
     } else {
       req = await buildCategoryFacetSearchRequest(
@@ -62,7 +62,9 @@ const getExecuteFacetSearchThunkPayloadCreator =
     }
 
     const response = await apiClient.facetSearch(req);
-    dispatch(logFacetSearch(facetId));
+    if (!isFieldSuggestionsRequest) {
+      dispatch(logFacetSearch(facetId));
+    }
 
     return {facetId, response};
   };
@@ -74,16 +76,16 @@ export const executeFacetSearch = createAsyncThunk<
     StateNeededForFacetSearch,
     ClientThunkExtraArguments<FacetSearchAPIClient>
   >
->('facetSearch/executeSearch', getExecuteFacetSearchThunkPayloadCreator(true));
+>('facetSearch/executeSearch', getExecuteFacetSearchThunkPayloadCreator(false));
 
-export const executeFacetSearchWithoutSearchContext = createAsyncThunk<
+export const executeFieldSuggest = createAsyncThunk<
   {facetId: string; response: FacetSearchResponse},
   string,
   AsyncThunkOptions<
     StateNeededForFacetSearch,
     ClientThunkExtraArguments<FacetSearchAPIClient>
   >
->('facetSearch/executeSearch', getExecuteFacetSearchThunkPayloadCreator(false));
+>('facetSearch/executeSearch', getExecuteFacetSearchThunkPayloadCreator(true)); // We use the same action type because this action is meant to be handled by reducers the same way.
 
 export const clearFacetSearch = createAction(
   'facetSearch/clearResults',

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.test.ts
@@ -17,7 +17,7 @@ describe('#buildSpecificFacetSearchRequest', () => {
   }
 
   function buildParams() {
-    return buildSpecificFacetSearchRequest(id, state);
+    return buildSpecificFacetSearchRequest(id, state, false);
   }
 
   beforeEach(() => setupState());

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
@@ -4,11 +4,11 @@ import {StateNeededForSpecificFacetSearch} from '../generic/generic-facet-search
 
 export const buildSpecificFacetSearchRequest = async (
   id: string,
-  state: StateNeededForSpecificFacetSearch
+  state: StateNeededForSpecificFacetSearch,
+  includeSearchContext: boolean
 ): Promise<SpecificFacetSearchRequest> => {
   const {captions, query, numberOfValues} = state.facetSearchSet[id].options;
   const {field, currentValues, filterFacetCount} = state.facetSet[id];
-  const searchContext = (await buildSearchRequest(state)).request;
   const ignoreValues = currentValues
     .filter((v) => v.state !== 'idle')
     .map((facetValue) => facetValue.value);
@@ -27,8 +27,10 @@ export const buildSpecificFacetSearchRequest = async (
     query: newQuery,
     field,
     ignoreValues,
-    searchContext,
     filterFacetCount,
     type: 'specific',
+    ...(includeSearchContext
+      ? {searchContext: (await buildSearchRequest(state)).request}
+      : {}),
   };
 };

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-request-builder.ts
@@ -5,7 +5,7 @@ import {StateNeededForSpecificFacetSearch} from '../generic/generic-facet-search
 export const buildSpecificFacetSearchRequest = async (
   id: string,
   state: StateNeededForSpecificFacetSearch,
-  includeSearchContext: boolean
+  isFieldSuggestionsRequest: boolean
 ): Promise<SpecificFacetSearchRequest> => {
   const {captions, query, numberOfValues} = state.facetSearchSet[id].options;
   const {field, currentValues, filterFacetCount} = state.facetSet[id];
@@ -29,8 +29,8 @@ export const buildSpecificFacetSearchRequest = async (
     ignoreValues,
     filterFacetCount,
     type: 'specific',
-    ...(includeSearchContext
-      ? {searchContext: (await buildSearchRequest(state)).request}
-      : {}),
+    ...(isFieldSuggestionsRequest
+      ? {}
+      : {searchContext: (await buildSearchRequest(state)).request}),
   };
 };

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -1,3 +1,4 @@
+import {CoveoSearchPageClient} from 'coveo.analytics';
 import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
@@ -148,10 +149,15 @@ describe('field suggestions', () => {
 
     describe('after calling #search', () => {
       beforeEach(async () => {
+        jest.spyOn(CoveoSearchPageClient.prototype, 'logFacetSearch');
         await waitForNextStateChange(fieldSuggestions, {
           action: () => fieldSuggestions.search(),
           expectedSubscriberCalls: 2,
         });
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
       });
 
       it('has more values', () => {
@@ -168,6 +174,12 @@ describe('field suggestions', () => {
         expect(fieldSuggestions.state.values.length).toBeGreaterThan(
           numberOfValues
         );
+      });
+
+      it('does not log analytics', () => {
+        expect(
+          CoveoSearchPageClient.prototype.logFacetSearch
+        ).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -120,6 +120,7 @@ describe('field suggestions', () => {
       });
     });
   });
+
   describe('initialized without a facet', () => {
     let fieldSuggestions: FieldSuggestions;
     beforeEach(() => {

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -1,0 +1,215 @@
+import {
+  buildSearchEngine,
+  getSampleSearchEngineConfiguration,
+  SearchEngine,
+  buildFieldSuggestions,
+  FieldSuggestions,
+  Controller,
+  buildFacet,
+  Facet,
+  FieldSuggestionsValue,
+} from '..';
+
+function waitForNextStateChange<T extends Controller>(
+  controller: T,
+  options: {action?: () => void; expectedSubscriberCalls?: number} = {}
+) {
+  return new Promise<void>((resolve) => {
+    let wasInitialListenerCalled = false;
+    let subscriberCalls = 0;
+    let unsubscribe = () => {};
+    unsubscribe = controller.subscribe(() => {
+      if (!wasInitialListenerCalled) {
+        wasInitialListenerCalled = true;
+        return;
+      }
+      if (++subscriberCalls < (options?.expectedSubscriberCalls ?? 1)) {
+        return;
+      }
+      unsubscribe();
+      resolve();
+    });
+    options.action?.();
+  });
+}
+
+describe('field suggestions', () => {
+  let engine: SearchEngine;
+  const field = 'filetype';
+  beforeEach(() => {
+    engine = buildSearchEngine({
+      configuration: {
+        ...getSampleSearchEngineConfiguration(),
+        analytics: {enabled: false},
+      },
+      loggerOptions: {level: 'silent'},
+    });
+  });
+
+  describe('with a matching facet', () => {
+    let facet: Facet;
+    let fieldSuggestions: FieldSuggestions;
+
+    function getSelectedValues() {
+      return facet.state.values
+        .filter((value) => value.state === 'selected')
+        .map(({value}) => value);
+    }
+
+    beforeEach(() => {
+      facet = buildFacet(engine, {options: {field}});
+      fieldSuggestions = buildFieldSuggestions(engine, {
+        options: {field, facetId: facet.state.facetId},
+      });
+    });
+
+    describe('after calling #search', () => {
+      beforeEach(async () => {
+        await waitForNextStateChange(fieldSuggestions, {
+          action: () => fieldSuggestions.search(),
+          expectedSubscriberCalls: 2,
+        });
+      });
+
+      it('can single select facet values', async () => {
+        const firstToggledValue = fieldSuggestions.state.values[0];
+        const secondToggledValue = fieldSuggestions.state.values[1];
+        await waitForNextStateChange(facet, {
+          action: () => fieldSuggestions.singleSelect(firstToggledValue),
+          expectedSubscriberCalls: 2,
+        });
+        expect(getSelectedValues()).toEqual([firstToggledValue.displayValue]);
+        await waitForNextStateChange(facet, {
+          action: () => fieldSuggestions.singleSelect(secondToggledValue),
+          expectedSubscriberCalls: 2,
+        });
+        expect(getSelectedValues()).toEqual([secondToggledValue.displayValue]);
+      });
+
+      describe('after selecting multiple facet values', () => {
+        let valuesToSelect: FieldSuggestionsValue[];
+        beforeEach(async () => {
+          const numberOfValuesToSelect = 2;
+          valuesToSelect = fieldSuggestions.state.values.slice(
+            0,
+            numberOfValuesToSelect
+          );
+          for (const value of valuesToSelect) {
+            await waitForNextStateChange(facet, {
+              action: () => fieldSuggestions.select(value),
+              expectedSubscriberCalls: 2,
+            });
+          }
+        });
+
+        it('can select multiple facet value', async () => {
+          const expectedValues = valuesToSelect.map(
+            ({displayValue}) => displayValue
+          );
+          expect(getSelectedValues()).toEqual(expectedValues);
+        });
+
+        it('after calling #search again, ignores the current search context', async () => {
+          const initialSuggestions = fieldSuggestions.state.values;
+          await waitForNextStateChange(fieldSuggestions, {
+            action: () => fieldSuggestions.search(),
+            expectedSubscriberCalls: 2,
+          });
+          expect(fieldSuggestions.state.values).toEqual(initialSuggestions);
+        });
+      });
+    });
+  });
+  describe('initialized without a facet', () => {
+    let fieldSuggestions: FieldSuggestions;
+    beforeEach(() => {
+      fieldSuggestions = buildFieldSuggestions(engine, {options: {field}});
+    });
+
+    it('has the correct initial state', () => {
+      expect(fieldSuggestions.state).toEqual({
+        isLoading: false,
+        values: [],
+        query: '',
+        moreValuesAvailable: false,
+      });
+    });
+
+    describe('after calling #search', () => {
+      beforeEach(async () => {
+        await waitForNextStateChange(fieldSuggestions, {
+          action: () => fieldSuggestions.search(),
+          expectedSubscriberCalls: 2,
+        });
+      });
+
+      it('has more values', () => {
+        expect(fieldSuggestions.state.values.length).toBeGreaterThan(0);
+      });
+
+      it('can fetch more values', async () => {
+        expect(fieldSuggestions.state.moreValuesAvailable).toBeTruthy();
+        const numberOfValues = fieldSuggestions.state.values.length;
+        await waitForNextStateChange(fieldSuggestions, {
+          action: () => fieldSuggestions.showMoreResults(),
+          expectedSubscriberCalls: 2,
+        });
+        expect(fieldSuggestions.state.values.length).toBeGreaterThan(
+          numberOfValues
+        );
+      });
+    });
+
+    it('set isLoading when calling #search', async () => {
+      await waitForNextStateChange(fieldSuggestions, {
+        action: () => fieldSuggestions.search(),
+      });
+      expect(fieldSuggestions.state.isLoading).toBeTruthy();
+      await waitForNextStateChange(fieldSuggestions);
+      expect(fieldSuggestions.state.isLoading).toBeFalsy();
+    });
+
+    it('can search with a query', async () => {
+      const query = 'doc';
+      await waitForNextStateChange(fieldSuggestions, {
+        action: () => fieldSuggestions.updateText(query),
+        expectedSubscriberCalls: 3,
+      });
+      expect(fieldSuggestions.state.query).toEqual(query);
+      expect(fieldSuggestions.state.values.length).toBeGreaterThan(0);
+      const valuesThatDontContainQuery = fieldSuggestions.state.values.filter(
+        (value) => !value.displayValue.includes(query)
+      );
+      expect(valuesThatDontContainQuery.length).toEqual(0);
+    });
+
+    it('can update captions', async () => {
+      const rawValue = 'pdf';
+      const displayValue = 'Portable Document Format';
+      const query = 'doc';
+      fieldSuggestions.updateCaptions({[rawValue]: displayValue});
+      await waitForNextStateChange(fieldSuggestions, {
+        action: () => fieldSuggestions.updateText(query),
+        expectedSubscriberCalls: 3,
+      });
+      expect(
+        fieldSuggestions.state.values.find(
+          (value) => value.rawValue === rawValue
+        )?.displayValue
+      ).toEqual(displayValue);
+    });
+
+    it('can clear the search', async () => {
+      const query = 'doc';
+      await waitForNextStateChange(fieldSuggestions, {
+        action: () => fieldSuggestions.updateText(query),
+        expectedSubscriberCalls: 3,
+      });
+      await waitForNextStateChange(fieldSuggestions, {
+        action: () => fieldSuggestions.clear(),
+      });
+      expect(fieldSuggestions.state.query).toEqual('');
+      expect(fieldSuggestions.state.values.length).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2073

In this PR, I made the following changes:
* Extracted facet and facet search interfaces into field suggestions interfaces
* Replaced `buildFacet` in field suggestions with `buildFacetSearch` (so that non-public options can be passed to it)
* Added "includeSearchContext` option to facet search
* Added executeFacetSearchWithoutSearchContext` action

I chose to continue using the generic facet search to avoid the changes being breaking, and because I thought it would save me some time making this change. Unfortunately, this had many drawbacks, and I'm not sure if I like this approach anymore. I will leave comments in this PR for discussion.