### PR TITLE
feat(headless): updated insight interface with facet type

### DIFF
--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-request.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-request.ts
@@ -7,7 +7,12 @@ export const buildGetInsightInterfaceConfigRequest = (
   req: GetInsightInterfaceConfigRequest
 ) => {
   return {
-    ...baseInsightRequest(req, 'GET', 'application/json', '/interface'),
+    ...baseInsightRequest(
+      req,
+      'GET',
+      'application/json',
+      '/interface?detailed=true'
+    ),
     requestParams: {},
   };
 };

--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -50,7 +50,7 @@ type ResultAction =
   | 'sendAsEmail'
   | 'sendToFeed';
 
-type InsightFacetType = 'standard' | 'numeric' | 'timeframe';
+export type InsightFacetType = 'standard' | 'numeric' | 'timeframe';
 
 interface InsightOption {
   enabled: boolean;

--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -50,6 +50,8 @@ type ResultAction =
   | 'sendAsEmail'
   | 'sendToFeed';
 
+type FacetType = 'standard' | 'numeric' | 'timeframe';
+
 interface InsightOption {
   enabled: boolean;
 }
@@ -69,6 +71,7 @@ interface Facet {
   field: string;
   label?: string;
   displayValueAs?: string;
+  facetTypes?: FacetType;
 }
 
 interface Tab {

--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -50,7 +50,7 @@ type ResultAction =
   | 'sendAsEmail'
   | 'sendToFeed';
 
-type FacetType = 'standard' | 'numeric' | 'timeframe';
+type InsightFacetType = 'standard' | 'numeric' | 'timeframe';
 
 interface InsightOption {
   enabled: boolean;
@@ -71,7 +71,7 @@ interface Facet {
   field: string;
   label?: string;
   displayValueAs?: string;
-  facetTypes?: FacetType;
+  facetTypes?: InsightFacetType;
 }
 
 interface Tab {

--- a/packages/headless/src/api/service/insight/insight-api-client.test.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.test.ts
@@ -49,7 +49,7 @@ describe('insight api client', () => {
         accessToken: insightRequest.accessToken,
         method: 'GET',
         contentType: 'application/json',
-        url: `${insightRequest.url}/rest/organizations/${insightRequest.organizationId}/insight/v1/configs/${insightRequest.insightId}/interface`,
+        url: `${insightRequest.url}/rest/organizations/${insightRequest.organizationId}/insight/v1/configs/${insightRequest.insightId}/interface?detailed=true`,
       });
     });
 


### PR DESCRIPTION
The insight interface fetch call will now return facet type info if the `detailed=true` query param is set. We want this info returned so the insight panel can render the right type of facet.