### PR TITLE
chore(atomic): removed deprecations

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -782,13 +782,13 @@ export declare interface AtomicResult extends Components.AtomicResult {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['classes', 'content', 'density', 'display', 'engine', 'imageSize', 'result', 'stopPropagation']
+  inputs: ['classes', 'content', 'density', 'display', 'imageSize', 'result', 'stopPropagation']
 })
 @Component({
   selector: 'atomic-result',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['classes', 'content', 'density', 'display', 'engine', 'imageSize', 'result', 'stopPropagation']
+  inputs: ['classes', 'content', 'density', 'display', 'imageSize', 'result', 'stopPropagation']
 })
 export class AtomicResult {
   protected el: HTMLElement;

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -968,13 +968,13 @@ export declare interface AtomicResultLink extends Components.AtomicResultLink {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['hrefTemplate', 'target']
+  inputs: ['hrefTemplate']
 })
 @Component({
   selector: 'atomic-result-link',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['hrefTemplate', 'target']
+  inputs: ['hrefTemplate']
 })
 export class AtomicResultLink {
   protected el: HTMLElement;

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -216,14 +216,14 @@ export declare interface AtomicFoldedResultList extends Components.AtomicFoldedR
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['childField', 'collectionField', 'density', 'fieldsToInclude', 'imageSize', 'parentField'],
+  inputs: ['childField', 'collectionField', 'density', 'imageSize', 'parentField'],
   methods: ['setRenderFunction']
 })
 @Component({
   selector: 'atomic-folded-result-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['childField', 'collectionField', 'density', 'fieldsToInclude', 'imageSize', 'parentField']
+  inputs: ['childField', 'collectionField', 'density', 'imageSize', 'parentField']
 })
 export class AtomicFoldedResultList {
   protected el: HTMLElement;
@@ -989,14 +989,14 @@ export declare interface AtomicResultList extends Components.AtomicResultList {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['density', 'display', 'fieldsToInclude', 'imageSize'],
+  inputs: ['density', 'display', 'imageSize'],
   methods: ['setRenderFunction']
 })
 @Component({
   selector: 'atomic-result-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['density', 'display', 'fieldsToInclude', 'imageSize']
+  inputs: ['density', 'display', 'imageSize']
 })
 export class AtomicResultList {
   protected el: HTMLElement;

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -572,14 +572,12 @@ export class AtomicQueryError {
 export declare interface AtomicQuerySummary extends Components.AtomicQuerySummary {}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
-  inputs: ['enableDuration']
+  defineCustomElementFn: undefined
 })
 @Component({
   selector: 'atomic-query-summary',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: '<ng-content></ng-content>',
-  inputs: ['enableDuration']
+  template: '<ng-content></ng-content>'
 })
 export class AtomicQuerySummary {
   protected el: HTMLElement;

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -784,13 +784,13 @@ export declare interface AtomicResult extends Components.AtomicResult {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['classes', 'content', 'density', 'display', 'engine', 'image', 'imageSize', 'result', 'stopPropagation']
+  inputs: ['classes', 'content', 'density', 'display', 'engine', 'imageSize', 'result', 'stopPropagation']
 })
 @Component({
   selector: 'atomic-result',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['classes', 'content', 'density', 'display', 'engine', 'image', 'imageSize', 'result', 'stopPropagation']
+  inputs: ['classes', 'content', 'density', 'display', 'engine', 'imageSize', 'result', 'stopPropagation']
 })
 export class AtomicResult {
   protected el: HTMLElement;
@@ -991,14 +991,14 @@ export declare interface AtomicResultList extends Components.AtomicResultList {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['density', 'display', 'fieldsToInclude', 'image', 'imageSize'],
+  inputs: ['density', 'display', 'fieldsToInclude', 'imageSize'],
   methods: ['setRenderFunction']
 })
 @Component({
   selector: 'atomic-result-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['density', 'display', 'fieldsToInclude', 'image', 'imageSize']
+  inputs: ['density', 'display', 'fieldsToInclude', 'imageSize']
 })
 export class AtomicResultList {
   protected el: HTMLElement;

--- a/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/SearchInterfaceWrapper.tsx
@@ -18,13 +18,6 @@ interface WrapperProps extends Omit<JSX.AtomicSearchInterface, 'i18n'> {
    */
   onReady?: (executeFirstSearch: ExecuteSearch) => Promise<void>;
   /**
-   * @deprecated
-   *
-   * Read more about theming and visual customization here : https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/
-   *
-   */
-  theme?: string | 'none';
-  /**
    * An optional callback that lets you control the interface localization.
    *
    * The function receives the search interface 18n instance, which you can then modify (see [Localization](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/)).
@@ -33,13 +26,10 @@ interface WrapperProps extends Omit<JSX.AtomicSearchInterface, 'i18n'> {
   localization?: (i18n: i18n) => void;
 }
 
-const DefaultProps: Required<
-  Pick<WrapperProps, 'onReady' | 'theme' | 'localization'>
-> = {
+const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'localization'>> = {
   onReady: (executeFirstSearch) => {
     return executeFirstSearch();
   },
-  theme: 'coveo',
   localization: () => {},
 };
 

--- a/packages/atomic-react/src/components/recommendation/RecsInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/recommendation/RecsInterfaceWrapper.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useRef} from 'react';
 import type {JSX, i18n} from '@coveo/atomic';
 import {
   getSampleRecommendationEngineConfiguration,
-  buildRecommendationEngine
+  buildRecommendationEngine,
 } from '@coveo/atomic/headless/recommendation';
 import {AtomicRecsInterface} from '../stencil-generated/index';
 
@@ -18,13 +18,6 @@ interface WrapperProps extends Omit<JSX.AtomicRecsInterface, 'i18n'> {
    */
   onReady?: (getRecommendations: GetRecommendations) => Promise<void>;
   /**
-   * @deprecated
-   *
-   * Read more about theming and visual customization here : https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/
-   *
-   */
-  theme?: string | 'none';
-  /**
    * An optional callback that lets you control the interface localization.
    *
    * The function receives the search interface 18n instance, which you can then modify (see [Localization](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/)).
@@ -33,13 +26,10 @@ interface WrapperProps extends Omit<JSX.AtomicRecsInterface, 'i18n'> {
   localization?: (i18n: i18n) => void;
 }
 
-const DefaultProps: Required<
-  Pick<WrapperProps, 'onReady' | 'theme' | 'localization'>
-> = {
+const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'localization'>> = {
   onReady: (getRecommendations) => {
     return getRecommendations();
   },
-  theme: 'coveo',
   localization: () => {},
 };
 
@@ -64,7 +54,8 @@ export const RecsInterfaceWrapper = (
   useEffect(() => {
     const recsInterfaceAtomic = recsInterfaceRef.current!;
     if (!initialization) {
-      initialization = recsInterfaceAtomic.initializeWithRecommendationEngine(engine);
+      initialization =
+        recsInterfaceAtomic.initializeWithRecommendationEngine(engine);
       initialization.then(() => {
         localization(recsInterfaceAtomic.i18n);
         onReady(

--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
@@ -495,7 +495,7 @@ describe('Category Facet Test Suites', () => {
       new TestFixture()
         .with(
           addCategoryFacet(
-            {'base-path': togoHierarchy.slice(0, 2).join(',')},
+            {'base-path': JSON.stringify(togoHierarchy.slice(0, 2))},
             true
           )
         )
@@ -506,34 +506,6 @@ describe('Category Facet Test Suites', () => {
     CategoryFacetAssertions.assertFirstChildContains(togoHierarchy[2]);
     CategoryFacetAssertions.assertDisplayAllCategoriesButton(false);
     CategoryFacetAssertions.assertNumberOfParentValues(0);
-  });
-
-  describe('with #basePath using a JSON string representation', () => {
-    let test: TestFixture;
-    before(() => {
-      test = new TestFixture().with(
-        addCategoryFacet(
-          {
-            'base-path': '["some value with a, comma","another value"]',
-          },
-          true
-        )
-      );
-    });
-
-    it('should send the proper base path split on the delitiming character', () => {
-      cy.intercept({
-        method: 'POST',
-        url: '**/rest/search/v2?*',
-      }).as('searchRequest');
-
-      test.init();
-      cy.wait('@searchRequest').then(({request}) => {
-        const basePathRequested = request.body.facets[0].basePath;
-        cy.wrap(basePathRequested[0]).should('eq', 'some value with a, comma');
-        cy.wrap(basePathRequested[1]).should('eq', 'another value');
-      });
-    });
   });
 
   describe('with #basePath using incorrect JSON array', () => {
@@ -549,7 +521,7 @@ describe('Category Facet Test Suites', () => {
         )
         .init();
     });
-    CommonAssertions.assertConsoleWarningMessage(
+    CommonAssertions.assertConsoleErrorMessage(
       'Error while parsing attribute base-path'
     );
   });
@@ -560,7 +532,7 @@ describe('Category Facet Test Suites', () => {
         .with(
           addCategoryFacet(
             {
-              'base-path': togoHierarchy.slice(0, 2).join(','),
+              'base-path': JSON.stringify(togoHierarchy.slice(0, 2)),
               'filter-by-base-path': 'false',
             },
             true

--- a/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
@@ -1075,36 +1075,20 @@ describe('Facet v1 Test Suites', () => {
   describe('with allowed-values', () => {
     beforeEach(() => {
       new TestFixture()
-        .with(addFacet({field: 'objecttype', 'allowed-values': 'FAQ,File'}))
-        .init();
-    });
-
-    it('returns only allowed values', () => {
-      FacetSelectors.values()
-        .should('contain.text', 'FAQ')
-        .should('contain.text', 'File')
-        .should('not.contain.text', 'Message');
-    });
-
-    CommonAssertions.assertConsoleWarningMessage(
-      'This will be enforced in the next major versio'
-    );
-  });
-
-  describe('with allowed-values as JSON string array', () => {
-    beforeEach(() => {
-      new TestFixture()
         .with(
-          addFacet({field: 'objecttype', 'allowed-values': '["FAQ","File"]'})
+          addFacet({
+            field: 'objecttype',
+            'allowed-values': JSON.stringify(['FAQ', 'File']),
+          })
         )
         .init();
     });
+
     it('returns only allowed values', () => {
       FacetSelectors.values()
         .should('contain.text', 'FAQ')
         .should('contain.text', 'File')
         .should('not.contain.text', 'Message');
     });
-    CommonAssertions.assertConsoleWarning(false);
   });
 });

--- a/packages/atomic/cypress/e2e/query-summary.cypress.ts
+++ b/packages/atomic/cypress/e2e/query-summary.cypress.ts
@@ -91,6 +91,7 @@ describe('Query Summary Test Suites', () => {
       .with(addSearchBox())
       .withHash('q=test')
       .init();
+    QuerySummarySelectors.query().should('be.visible');
     QuerySummarySelectors.duration().should('not.be.visible');
   });
 

--- a/packages/atomic/cypress/e2e/query-summary.cypress.ts
+++ b/packages/atomic/cypress/e2e/query-summary.cypress.ts
@@ -1,6 +1,9 @@
 import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
 import {addQuerySummary} from './query-summary-actions';
-import {QuerySummarySelectors} from './query-summary-selectors';
+import {
+  querySummaryComponent,
+  QuerySummarySelectors,
+} from './query-summary-selectors';
 import * as CommonAssertions from './common-assertions';
 import {addSearchBox} from './search-box/search-box-actions';
 import * as QuerySummaryAssertions from './query-summary-assertions';
@@ -82,13 +85,28 @@ describe('Query Summary Test Suites', () => {
     });
   });
 
-  // TODO: remove v2, deprecated prop
-  it('when "enableDuration" is false, should not show duration', () => {
+  it('by default, should not show duration', () => {
     new TestFixture()
       .with(addQuerySummary())
       .with(addSearchBox())
       .withHash('q=test')
       .init();
     QuerySummarySelectors.duration().should('not.be.visible');
+  });
+
+  it('when the part is shown, should show duration', () => {
+    new TestFixture()
+      .with(addQuerySummary())
+      .with(addSearchBox())
+      .withStyle(
+        `
+          ${querySummaryComponent}::part(duration) {
+            display: inline-block;
+          }
+        `
+      )
+      .withHash('q=test')
+      .init();
+    QuerySummarySelectors.duration().should('be.visible');
   });
 });

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-link.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-link.cypress.ts
@@ -45,16 +45,12 @@ describe('Result Link Component', () => {
     const title = 'Abc result';
     const author = 'Albert';
 
-    function setupResultLink({
-      target,
-      hrefTemplate,
-      slots,
-    }: ResultLinkOptions = {}) {
+    function setupResultLink({hrefTemplate, slots}: ResultLinkOptions = {}) {
       new TestFixture()
         .with(
           addResultLinkInResultList(
             pickBy(
-              {target: target, 'href-template': hrefTemplate},
+              {'href-template': hrefTemplate},
               (property) => property !== undefined
             ) as TagProps,
             slots
@@ -69,13 +65,6 @@ describe('Result Link Component', () => {
         )
         .init();
     }
-
-    it('the "target" prop should set the target on the "a" tag', () => {
-      setupResultLink({target: '_parent'});
-      ResultLinkSelectors.firstInResult()
-        .find('a')
-        .should('have.attr', 'target', '_parent');
-    });
 
     it('the "href" attribute of the "a" tag should be the result\'s clickUri', () => {
       setupResultLink();

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
@@ -122,8 +122,7 @@ describe('Result Printable Uri Component', () => {
 
       ResultPrintableUriSelectors.links()
         .should('exist')
-        .should('have.attr', 'href', 'https://coveo.com')
-        .should('have.attr', 'target', '_self');
+        .should('have.attr', 'href', 'https://coveo.com');
     });
   });
 

--- a/packages/atomic/cypress/e2e/result-list/result-list.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-list.cypress.ts
@@ -211,32 +211,3 @@ configs.forEach(({componentSelectors, componentTag, addResultFn, title}) => {
     });
   });
 });
-
-describe('deprecated image prop on result-list', () => {
-  it('should use image prop if defined', () => {
-    new TestFixture()
-      .with(addResultList(undefined, {image: 'large'}))
-      .withoutFirstAutomaticSearch()
-      .init();
-
-    ResultListSelectors.shadow().find('.image-large').should('exist');
-  });
-
-  it('should use image-size prop if defined', () => {
-    new TestFixture()
-      .with(addResultList(undefined, {'image-size': 'small'}))
-      .withoutFirstAutomaticSearch()
-      .init();
-
-    ResultListSelectors.shadow().find('.image-small').should('exist');
-  });
-  it('should prioritize image-size over image prop if both are defined', () => {
-    new TestFixture()
-      .with(addResultList(undefined, {'image-size': 'small', image: 'large'}))
-      .withoutFirstAutomaticSearch()
-      .init();
-
-    ResultListSelectors.shadow().find('.image-small').should('exist');
-    ResultListSelectors.shadow().find('.image-large').should('not.exist');
-  });
-});

--- a/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results.cypress.ts
@@ -295,7 +295,7 @@ describe('Instant Results Test Suites', () => {
     });
 
     describe('when clicking a result', () => {
-      before(() => {
+      beforeEach(() => {
         setupWithSuggestionsAndRecentQueries();
         SearchBoxSelectors.inputBox().type('{downarrow}', {
           delay: 200,

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -801,11 +801,6 @@ export namespace Components {
     interface AtomicQueryError {
     }
     interface AtomicQuerySummary {
-        /**
-          * Whether to display the duration of the last query execution.
-          * @deprecated Use the `duration` part.
-         */
-        "enableDuration": boolean;
     }
     interface AtomicRatingFacet {
         /**
@@ -3290,11 +3285,6 @@ declare namespace LocalJSX {
     interface AtomicQueryError {
     }
     interface AtomicQuerySummary {
-        /**
-          * Whether to display the duration of the last query execution.
-          * @deprecated Use the `duration` part.
-         */
-        "enableDuration"?: boolean;
     }
     interface AtomicRatingFacet {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -833,7 +833,7 @@ export namespace Components {
          */
         "headingLevel": number;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon": string;
         /**
@@ -883,7 +883,7 @@ export namespace Components {
          */
         "headingLevel": number;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon": string;
         /**
@@ -1295,7 +1295,7 @@ export namespace Components {
          */
         "field": string;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon": string;
         /**
@@ -3322,7 +3322,7 @@ declare namespace LocalJSX {
          */
         "headingLevel"?: number;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon"?: string;
         /**
@@ -3372,7 +3372,7 @@ declare namespace LocalJSX {
          */
         "headingLevel"?: number;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon"?: string;
         /**
@@ -3746,7 +3746,7 @@ declare namespace LocalJSX {
          */
         "field": string;
         /**
-          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-facet-icon-active-color` - `--atomic-rating-facet-icon-inactive-color`
+          * The SVG icon to use to display the rating.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.  When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`. This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):  - `--atomic-rating-icon-active-color` - `--atomic-rating-icon-inactive-color`
          */
         "icon"?: string;
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1194,11 +1194,6 @@ export namespace Components {
           * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
-        /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
-          * @deprecated Use the "attributes" slot instead to pass down attributes to the link.
-         */
-        "target": string;
     }
     interface AtomicResultList {
         /**
@@ -3625,11 +3620,6 @@ declare namespace LocalJSX {
           * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
-        /**
-          * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).  The following keywords have special meanings:  * _self: the current browsing context. (Default) * _blank: usually a new tab, but users can configure their browsers to open a new window instead. * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`. * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
-          * @deprecated Use the "attributes" slot instead to pass down attributes to the link.
-         */
-        "target"?: string;
     }
     interface AtomicResultList {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -550,9 +550,9 @@ export namespace Components {
          */
         "imageSize": ResultDisplayImageSize;
         /**
-          * The InteractiveResult item. TODO: v2 make required
+          * The InteractiveResult item.
          */
-        "interactiveResult"?: InsightInteractiveResult;
+        "interactiveResult": InsightInteractiveResult;
         "loadingFlag"?: string;
         /**
           * The result item.
@@ -1096,9 +1096,9 @@ export namespace Components {
          */
         "imageSize": ResultDisplayImageSize;
         /**
-          * The InteractiveResult item. TODO: v2 make required
+          * The InteractiveResult item.
          */
-        "interactiveResult"?: InteractiveResult;
+        "interactiveResult": InteractiveResult;
         "loadingFlag"?: string;
         /**
           * Internal function used by atomic-recs-list in advanced setups, which lets you bypass the standard HTML template system. Particularly useful for Atomic React
@@ -3016,9 +3016,9 @@ declare namespace LocalJSX {
          */
         "imageSize"?: ResultDisplayImageSize;
         /**
-          * The InteractiveResult item. TODO: v2 make required
+          * The InteractiveResult item.
          */
-        "interactiveResult"?: InsightInteractiveResult;
+        "interactiveResult": InsightInteractiveResult;
         "loadingFlag"?: string;
         /**
           * The result item.
@@ -3526,9 +3526,9 @@ declare namespace LocalJSX {
          */
         "imageSize"?: ResultDisplayImageSize;
         /**
-          * The InteractiveResult item. TODO: v2 make required
+          * The InteractiveResult item.
          */
-        "interactiveResult"?: InteractiveResult;
+        "interactiveResult": InteractiveResult;
         "loadingFlag"?: string;
         /**
           * Internal function used by atomic-recs-list in advanced setups, which lets you bypass the standard HTML template system. Particularly useful for Atomic React

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -38,7 +38,7 @@ export namespace Components {
     }
     interface AtomicCategoryFacet {
         /**
-          * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```  Specifying the property as a comma separated string is deprecated.
+          * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```
          */
         "basePath"?: string[];
         /**
@@ -158,7 +158,7 @@ export namespace Components {
     }
     interface AtomicFacet {
         /**
-          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  Specifying the property as a comma separated string is deprecated.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
         "allowedValues"?: string[];
         /**
@@ -418,9 +418,9 @@ export namespace Components {
          */
         "executeFirstSearch": () => Promise<void>;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-insight-interface fields-to-include='["fieldA", "fieldB"]'></atomic-insight-interface> ```
          */
-        "fieldsToInclude": string;
+        "fieldsToInclude": string[];
         /**
           * The service insight interface i18next instance.
          */
@@ -906,9 +906,9 @@ export namespace Components {
          */
         "engine"?: RecommendationEngine;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-recs-interface fields-to-include='["fieldA", "fieldB"]'></atomic-recs-interface> ```
          */
-        "fieldsToInclude": string;
+        "fieldsToInclude": string[];
         /**
           * Fetches new recommendations.
          */
@@ -1440,9 +1440,9 @@ export namespace Components {
          */
         "executeFirstSearch": () => Promise<void>;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-search-interface fields-to-include='["fieldA", "fieldB"]'></atomic-search-interface> ```
          */
-        "fieldsToInclude": string;
+        "fieldsToInclude": string[];
         /**
           * The search interface i18next instance.
          */
@@ -2520,7 +2520,7 @@ declare namespace LocalJSX {
     }
     interface AtomicCategoryFacet {
         /**
-          * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```  Specifying the property as a comma separated string is deprecated.
+          * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```
          */
         "basePath"?: string[];
         /**
@@ -2640,7 +2640,7 @@ declare namespace LocalJSX {
     }
     interface AtomicFacet {
         /**
-          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  Specifying the property as a comma separated string is deprecated.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
         "allowedValues"?: string[];
         /**
@@ -2896,9 +2896,9 @@ declare namespace LocalJSX {
          */
         "engine"?: InsightEngine;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-insight-interface fields-to-include='["fieldA", "fieldB"]'></atomic-insight-interface> ```
          */
-        "fieldsToInclude"?: string;
+        "fieldsToInclude"?: string[];
         /**
           * The service insight interface i18next instance.
          */
@@ -3370,9 +3370,9 @@ declare namespace LocalJSX {
          */
         "engine"?: RecommendationEngine;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-recs-interface fields-to-include='["fieldA", "fieldB"]'></atomic-recs-interface> ```
          */
-        "fieldsToInclude"?: string;
+        "fieldsToInclude"?: string[];
         /**
           * The recommendation interface i18next instance.
          */
@@ -3857,9 +3857,9 @@ declare namespace LocalJSX {
          */
         "engine"?: SearchEngine;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
+          * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-search-interface fields-to-include='["fieldA", "fieldB"]'></atomic-search-interface> ```
          */
-        "fieldsToInclude"?: string;
+        "fieldsToInclude"?: string[];
         /**
           * The search interface i18next instance.
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -276,11 +276,6 @@ export namespace Components {
          */
         "density": ResultDisplayDensity;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
-          * @deprecated add it to atomic-search-interface instead
-         */
-        "fieldsToInclude": string;
-        /**
           * The expected size of the image displayed in the results.
          */
         "imageSize": ResultDisplayImageSize;
@@ -1214,11 +1209,6 @@ export namespace Components {
           * The desired layout to use when displaying results. Layouts affect how many results to display per row and how visually distinct they are from each other.
          */
         "display": ResultDisplayLayout;
-        /**
-          * A list of non-default fields to include in the query results, separated by commas.
-          * @deprecated add it to atomic-search-interface instead
-         */
-        "fieldsToInclude": string;
         /**
           * The expected size of the image displayed in the results.
          */
@@ -2772,11 +2762,6 @@ declare namespace LocalJSX {
          */
         "density"?: ResultDisplayDensity;
         /**
-          * A list of non-default fields to include in the query results, separated by commas.
-          * @deprecated add it to atomic-search-interface instead
-         */
-        "fieldsToInclude"?: string;
-        /**
           * The expected size of the image displayed in the results.
          */
         "imageSize"?: ResultDisplayImageSize;
@@ -3655,11 +3640,6 @@ declare namespace LocalJSX {
           * The desired layout to use when displaying results. Layouts affect how many results to display per row and how visually distinct they are from each other.
          */
         "display"?: ResultDisplayLayout;
-        /**
-          * A list of non-default fields to include in the query results, separated by commas.
-          * @deprecated add it to atomic-search-interface instead
-         */
-        "fieldsToInclude"?: string;
         /**
           * The expected size of the image displayed in the results.
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1112,13 +1112,9 @@ export namespace Components {
          */
         "engine"?: SearchEngine;
         /**
-          * @deprecated use `imageSize` instead.
-         */
-        "image": ResultDisplayImageSize;
-        /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */
-        "imageSize"?: ResultDisplayImageSize;
+        "imageSize": ResultDisplayImageSize;
         /**
           * The InteractiveResult item. TODO: v2 make required
          */
@@ -1238,10 +1234,6 @@ export namespace Components {
           * @deprecated add it to atomic-search-interface instead
          */
         "fieldsToInclude": string;
-        /**
-          * @deprecated use `imageSize` instead.
-         */
-        "image": ResultDisplayImageSize;
         /**
           * The expected size of the image displayed in the results.
          */
@@ -3580,10 +3572,6 @@ declare namespace LocalJSX {
          */
         "engine"?: SearchEngine;
         /**
-          * @deprecated use `imageSize` instead.
-         */
-        "image"?: ResultDisplayImageSize;
-        /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */
         "imageSize"?: ResultDisplayImageSize;
@@ -3702,10 +3690,6 @@ declare namespace LocalJSX {
           * @deprecated add it to atomic-search-interface instead
          */
         "fieldsToInclude"?: string;
-        /**
-          * @deprecated use `imageSize` instead.
-         */
-        "image"?: ResultDisplayImageSize;
         /**
           * The expected size of the image displayed in the results.
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -40,7 +40,7 @@ export namespace Components {
         /**
           * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```  Specifying the property as a comma separated string is deprecated.
          */
-        "basePath"?: string | string[];
+        "basePath"?: string[];
         /**
           * The character that separates values of a multi-value field.
          */
@@ -160,7 +160,7 @@ export namespace Components {
         /**
           * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  Specifying the property as a comma separated string is deprecated.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
-        "allowedValues"?: string | string[];
+        "allowedValues"?: string[];
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */
@@ -2532,7 +2532,7 @@ declare namespace LocalJSX {
         /**
           * The base path shared by all values for the facet.  Specify the property as an array using a JSON string representation: ```html  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet> ```  Specifying the property as a comma separated string is deprecated.
          */
-        "basePath"?: string | string[];
+        "basePath"?: string[];
         /**
           * The character that separates values of a multi-value field.
          */
@@ -2652,7 +2652,7 @@ declare namespace LocalJSX {
         /**
           * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  Specifying the property as a comma separated string is deprecated.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
-        "allowedValues"?: string | string[];
+        "allowedValues"?: string[];
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -551,11 +551,6 @@ export namespace Components {
          */
         "density": ResultDisplayDensity;
         /**
-          * The headless search engine.
-          * @deprecated This property is currently un-used
-         */
-        "engine"?: InsightEngine;
-        /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */
         "imageSize": ResultDisplayImageSize;
@@ -1101,11 +1096,6 @@ export namespace Components {
           * How results should be displayed.
          */
         "display": ResultDisplayLayout;
-        /**
-          * The headless search engine.
-          * @deprecated This property is currently un-used
-         */
-        "engine"?: SearchEngine;
         /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */
@@ -3042,11 +3032,6 @@ declare namespace LocalJSX {
          */
         "density"?: ResultDisplayDensity;
         /**
-          * The headless search engine.
-          * @deprecated This property is currently un-used
-         */
-        "engine"?: InsightEngine;
-        /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */
         "imageSize"?: ResultDisplayImageSize;
@@ -3556,11 +3541,6 @@ declare namespace LocalJSX {
           * How results should be displayed.
          */
         "display"?: ResultDisplayLayout;
-        /**
-          * The headless search engine.
-          * @deprecated This property is currently un-used
-         */
-        "engine"?: SearchEngine;
         /**
           * The size of the visual section in result list items.  This is overwritten by the image size defined in the result content, if it exists.
          */

--- a/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
+++ b/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
@@ -4,7 +4,7 @@ import {AnyBindings} from '../interface/bindings';
 
 interface QuerySummaryCommonProps {
   bindings: AnyBindings;
-  enableDuration: boolean;
+  withDuration: boolean;
   querySummaryState: {
     hasDuration: boolean;
     durationInSeconds: number;
@@ -88,23 +88,19 @@ export const QuerySummaryCommon: FunctionalComponent<
             params={paramsWithHighlights}
             count={params.count}
           />
-          <span
-            part="duration"
-            class={
-              props.enableDuration && props.querySummaryState.hasDuration
-                ? ''
-                : 'hidden'
-            }
-          >
-            <LocalizedString
-              key="in-seconds"
-              bindings={props.bindings}
-              params={{
-                count:
-                  props.querySummaryState.durationInSeconds.toLocaleString(),
-              }}
-            />
-          </span>
+          {props.withDuration && props.querySummaryState.hasDuration && (
+            <span part="duration">
+              &nbsp;
+              <LocalizedString
+                key="in-seconds"
+                bindings={props.bindings}
+                params={{
+                  count:
+                    props.querySummaryState.durationInSeconds.toLocaleString(),
+                }}
+              />
+            </span>
+          )}
         </Fragment>
       )}
     </div>

--- a/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
+++ b/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
@@ -4,7 +4,6 @@ import {AnyBindings} from '../interface/bindings';
 
 interface QuerySummaryCommonProps {
   bindings: AnyBindings;
-  withDuration: boolean;
   querySummaryState: {
     hasDuration: boolean;
     durationInSeconds: number;
@@ -88,7 +87,7 @@ export const QuerySummaryCommon: FunctionalComponent<
             params={paramsWithHighlights}
             count={params.count}
           />
-          {props.withDuration && props.querySummaryState.hasDuration && (
+          {props.querySummaryState.hasDuration && (
             <span class="hidden" part="duration">
               &nbsp;
               <LocalizedString

--- a/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
+++ b/packages/atomic/src/components/common/query-summary/query-summary-common.tsx
@@ -89,7 +89,7 @@ export const QuerySummaryCommon: FunctionalComponent<
             count={params.count}
           />
           {props.withDuration && props.querySummaryState.hasDuration && (
-            <span part="duration">
+            <span class="hidden" part="duration">
               &nbsp;
               <LocalizedString
                 key="in-seconds"

--- a/packages/atomic/src/components/common/result-list/grid-display-results.tsx
+++ b/packages/atomic/src/components/common/result-list/grid-display-results.tsx
@@ -21,7 +21,6 @@ export const GridDisplayResults: FunctionalComponent<ResultListDisplayProps> = (
           onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
           onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
           href={unfoldedResult.clickUri}
-          target="_self"
           title={unfoldedResult.title}
           tabIndex={-1}
           ariaHidden={true}

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
@@ -25,6 +25,7 @@ import {
   buildInsightResultsPerPage,
 } from '..';
 import {loadFieldActions} from '@coveo/headless/insight';
+import {ArrayProp} from '../../../utils/props-utils';
 
 const FirstInsightRequestExecutedFlag = 'firstInsightRequestExecuted';
 export type InsightInitializationOptions = InsightEngineConfiguration;
@@ -87,9 +88,16 @@ export class AtomicInsightInterface
    */
   @Prop({reflect: true}) public iconAssetsPath = './assets';
   /**
-   * A list of non-default fields to include in the query results, separated by commas.
+   * A list of non-default fields to include in the query results.
+   *
+   * Specify the property as an array using a JSON string representation:
+   * ```html
+   * <atomic-insight-interface fields-to-include='["fieldA", "fieldB"]'></atomic-insight-interface>
+   * ```
    */
-  @Prop({reflect: true}) public fieldsToInclude = '';
+  @ArrayProp()
+  @Prop({mutable: true})
+  public fieldsToInclude: string[] = [];
   /**
    * The number of results per page. By default, this is set to `5`.
    */
@@ -121,10 +129,10 @@ export class AtomicInsightInterface
   }
 
   public registerFieldsToInclude() {
-    if (this.fieldsToInclude) {
+    if (this.fieldsToInclude.length) {
       this.engine!.dispatch(
         loadFieldActions(this.engine!).registerFieldsToInclude(
-          this.fieldsToInclude.split(',').map((field) => field.trim())
+          this.fieldsToInclude
         )
       );
     }

--- a/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.tsx
@@ -46,7 +46,7 @@ export class AtomicQuerySummary
           <QuerySummaryCommon
             setAriaLive={(msg) => (this.ariaMessage = msg)}
             bindings={this.bindings}
-            enableDuration={false}
+            withDuration={false}
             querySummaryState={this.querySummaryState}
           />
         </div>

--- a/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.tsx
@@ -46,7 +46,6 @@ export class AtomicQuerySummary
           <QuerySummaryCommon
             setAriaLive={(msg) => (this.ariaMessage = msg)}
             bindings={this.bindings}
-            withDuration={false}
             querySummaryState={this.querySummaryState}
           />
         </div>

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
@@ -11,7 +11,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
 } from '../../common/layout/display-options';
-import {InsightResult, InsightEngine, InsightInteractiveResult} from '..';
+import {InsightResult, InsightInteractiveResult} from '..';
 import {resultComponentClass} from '../../common/result-list/result-list-common';
 
 /**

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
@@ -38,10 +38,9 @@ export class AtomicInsightResult {
 
   /**
    * The InteractiveResult item.
-   * TODO: v2 make required
    * @internal
    */
-  @Prop() interactiveResult?: InsightInteractiveResult;
+  @Prop() interactiveResult!: InsightInteractiveResult;
 
   /**
    * Global Atomic state.

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
@@ -123,8 +123,8 @@ export class AtomicInsightResult {
 
   public render() {
     return (
-      // deepcode ignore ReactSetInnerHtml: This is not React code
       <Host class={resultComponentClass}>
+        {/* deepcode ignore ReactSetInnerHtml: This is not React code */}
         <div
           class={`result-root ${this.layout
             .getClasses()

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.tsx
@@ -37,12 +37,6 @@ export class AtomicInsightResult {
   @Prop() result!: InsightResult;
 
   /**
-   * The headless search engine.
-   * @deprecated This property is currently un-used
-   */
-  @Prop() engine?: InsightEngine;
-
-  /**
    * The InteractiveResult item.
    * TODO: v2 make required
    * @internal

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.tsx
@@ -20,6 +20,7 @@ import {
 import i18next, {i18n} from 'i18next';
 import {RecsLogLevel} from '..';
 import {InitializeEvent} from '../../../utils/initialization-utils';
+import {ArrayProp} from '../../../utils/props-utils';
 import {CommonBindings} from '../../common/interface/bindings';
 import {
   BaseAtomicInterface,
@@ -98,9 +99,16 @@ export class AtomicRecsInterface
   @Prop({reflect: true}) public language = 'en';
 
   /**
-   * A list of non-default fields to include in the query results, separated by commas.
+   * A list of non-default fields to include in the query results.
+   *
+   * Specify the property as an array using a JSON string representation:
+   * ```html
+   * <atomic-recs-interface fields-to-include='["fieldA", "fieldB"]'></atomic-recs-interface>
+   * ```
    */
-  @Prop({reflect: true}) public fieldsToInclude = '';
+  @ArrayProp()
+  @Prop({mutable: true})
+  public fieldsToInclude: string[] = [];
 
   /**
    * The language assets path. By default, this will be a relative URL pointing to `./lang`.
@@ -215,10 +223,7 @@ export class AtomicRecsInterface
 
   public registerFieldsToInclude() {
     const fields = EcommerceDefaultFieldsToInclude.concat(
-      this.fieldsToInclude
-        .split(',')
-        .map((field) => field.trim())
-        .filter((field) => !!field)
+      this.fieldsToInclude.filter((field) => !!field)
     );
     this.engine!.dispatch(
       loadFieldActions(this.engine!).registerFieldsToInclude(fields)

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.pcss
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.pcss
@@ -2,8 +2,4 @@
 
 :host {
   overflow: hidden;
-
-  &::part(duration) {
-    display: none;
-  }
 }

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.pcss
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.pcss
@@ -2,4 +2,8 @@
 
 :host {
   overflow: hidden;
+
+  &::part(duration) {
+    display: none;
+  }
 }

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
@@ -1,4 +1,4 @@
-import {Component, h, Prop, State} from '@stencil/core';
+import {Component, h, State} from '@stencil/core';
 import {
   QuerySummary,
   QuerySummaryState,
@@ -37,12 +37,6 @@ export class AtomicQuerySummary implements InitializableComponent {
   private querySummaryState!: QuerySummaryState;
   @State() public error!: Error;
 
-  /**
-   * Whether to display the duration of the last query execution.
-   * @deprecated Use the `duration` part.
-   */
-  @Prop({reflect: true}) enableDuration = false;
-
   @AriaLiveRegion('query-summary')
   protected ariaMessage!: string;
 
@@ -54,7 +48,7 @@ export class AtomicQuerySummary implements InitializableComponent {
     return (
       <QuerySummaryCommon
         bindings={this.bindings}
-        enableDuration={this.enableDuration}
+        withDuration={true}
         querySummaryState={this.querySummaryState}
         setAriaLive={(msg) => (this.ariaMessage = msg)}
       />

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
@@ -48,7 +48,6 @@ export class AtomicQuerySummary implements InitializableComponent {
     return (
       <QuerySummaryCommon
         bindings={this.bindings}
-        withDuration={true}
         querySummaryState={this.querySummaryState}
         setAriaLive={(msg) => (this.ariaMessage = msg)}
       />

--- a/packages/atomic/src/components/search/atomic-rating/atomic-rating.pcss
+++ b/packages/atomic/src/components/search/atomic-rating/atomic-rating.pcss
@@ -2,8 +2,7 @@
  * @prop --atomic-rating-icon-active-color: Color of the icon when active.
  */
 .icon-active {
-  /* TODO: Remove "facet" variable in v2. */
-  color: var(--atomic-rating-icon-active-color, var(--atomic-rating-facet-icon-active-color, #f6ce3c));
+  color: var(--atomic-rating-icon-active-color, #f6ce3c);
 }
 
 /**
@@ -11,10 +10,7 @@
  */
 .icon-inactive {
   /* TODO: Remove "facet" variable in v2. */
-  color: var(
-    --atomic-rating-icon-inactive-color,
-    var(--atomic-rating-facet-icon-inactive-color, var(--atomic-neutral))
-  );
+  color: var(--atomic-rating-icon-inactive-color, var(--atomic-neutral));
 }
 
 /**

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -53,8 +53,8 @@ import {
  * @part section-title - The title for each section.
  * @part select-wrapper - The wrapper around the select element, used to position the icon.
  * @part select - The `<select>` element of the drop-down list.
+ * @part select-icon-wrapper - The wrapper around the sort icon that's used to align it.
  * @part select-icon - The select dropdown's sort icon.
- * @part select-icon-size - The element around the sort icon that can be used to resize it.
  * @part filter-section - The section containing facets and the "filters" title.
  * @part filter-clear-all - The button that resets all actively selected facet values.
  * @part footer-wrapper - The wrapper with a shadow or background color around the footer.
@@ -156,11 +156,11 @@ export class AtomicRefineModal implements InitializableComponent {
             {this.options.map((option) => this.buildOption(option))}
           </select>
           <div
-            part="select-icon"
+            part="select-icon-wrapper"
             class="absolute pointer-events-none top-0 bottom-0 right-0 flex justify-center items-center pr-6"
           >
             <atomic-icon
-              part="select-icon-size" // TODO: in v2, rename to "select-icon", and rename parent.
+              part="select-icon"
               icon={SortIcon}
               class="w-6 h-6"
             ></atomic-icon>

--- a/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
@@ -44,10 +44,9 @@ export class AtomicResult {
 
   /**
    * The InteractiveResult item.
-   * TODO: v2 make required
    * @internal
    */
-  @Prop() interactiveResult?: InteractiveResult;
+  @Prop() interactiveResult!: InteractiveResult;
 
   /**
    * Global Atomic state.

--- a/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
@@ -86,12 +86,7 @@ export class AtomicResult {
    *
    * This is overwritten by the image size defined in the result content, if it exists.
    */
-  @Prop() imageSize?: ResultDisplayImageSize;
-
-  /**
-   * @deprecated use `imageSize` instead.
-   */
-  @Prop() image: ResultDisplayImageSize = 'icon';
+  @Prop() imageSize: ResultDisplayImageSize = 'icon';
 
   /**
    * The classes to add to the result element.
@@ -150,7 +145,7 @@ export class AtomicResult {
       this.content!.children,
       this.display,
       this.density,
-      this.imageSize ?? this.image
+      this.imageSize
     );
   }
 

--- a/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
@@ -1,10 +1,5 @@
 import {Component, h, Prop, Element, Listen, Host} from '@stencil/core';
-import {
-  FoldedResult,
-  InteractiveResult,
-  Result,
-  SearchEngine,
-} from '@coveo/headless';
+import {FoldedResult, InteractiveResult, Result} from '@coveo/headless';
 import {applyFocusVisiblePolyfill} from '../../../utils/initialization-utils';
 import {
   DisplayConfig,

--- a/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
+++ b/packages/atomic/src/components/search/atomic-result/atomic-result.tsx
@@ -55,12 +55,6 @@ export class AtomicResult {
   @Prop() interactiveResult?: InteractiveResult;
 
   /**
-   * The headless search engine.
-   * @deprecated This property is currently un-used
-   */
-  @Prop() engine?: SearchEngine;
-
-  /**
    * Global Atomic state.
    * @internal
    */

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -37,6 +37,7 @@ import {
   CommonAtomicInterfaceHelper,
 } from '../../common/interface/interface-common';
 import {CommonBindings} from '../../common/interface/bindings';
+import {ArrayProp} from '../../../utils/props-utils';
 
 const FirstSearchExecutedFlag = 'firstSearchExecuted';
 export type InitializationOptions = SearchEngineConfiguration;
@@ -70,9 +71,16 @@ export class AtomicSearchInterface
   @State() public error?: Error;
 
   /**
-   * A list of non-default fields to include in the query results, separated by commas.
+   * A list of non-default fields to include in the query results.
+   *
+   * Specify the property as an array using a JSON string representation:
+   * ```html
+   * <atomic-search-interface fields-to-include='["fieldA", "fieldB"]'></atomic-search-interface>
+   * ```
    */
-  @Prop({reflect: true}) public fieldsToInclude = '';
+  @ArrayProp()
+  @Prop({mutable: true})
+  public fieldsToInclude: string[] = [];
 
   /**
    * The search interface [query pipeline](https://docs.coveo.com/en/180/).
@@ -291,18 +299,8 @@ export class AtomicSearchInterface
   }
 
   private initFieldsToInclude() {
-    const fields = [...EcommerceDefaultFieldsToInclude];
-    if (this.fieldsToInclude) {
-      fields.push(
-        ...this.fieldsToInclude.split(',').map((field) => field.trim())
-      );
-    }
+    const fields = EcommerceDefaultFieldsToInclude.concat(this.fieldsToInclude);
     this.store.addFieldsToInclude(fields);
-
-    // TODO: delete v2 when fields-to-include prop on result list removed
-    this.store.onChange('fieldsToInclude', () =>
-      this.registerFieldsToInclude()
-    );
   }
 
   public registerFieldsToInclude() {

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-source.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-source.tsx
@@ -51,7 +51,6 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
         <LinkWithResultAnalytics
           title={this.source.clickUri}
           href={this.source.clickUri}
-          target="_self"
           className="block"
           part="source-url"
           onSelect={() => this.selectSource.emit()}
@@ -63,7 +62,6 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
         <LinkWithResultAnalytics
           title={this.source.title}
           href={this.source.clickUri}
-          target="_self"
           className="block"
           part="source-title"
           onSelect={() => this.selectSource.emit()}

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -155,8 +155,6 @@ export class AtomicCategoryFacet
    * ```html
    *  <atomic-category-facet base-path='["first value", "second value"]' ></atomic-category-facet>
    * ```
-   *
-   * Specifying the property as a comma separated string is deprecated.
    */
   @ArrayProp()
   @Prop({reflect: true, mutable: true})

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -51,7 +51,6 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 import {BaseFacet} from '../../../common/facets/facet-common';
 import {FacetInfo} from '../../../common/facets/facet-common-store';
 import {initializePopover} from '../atomic-popover/popover-type';
-import {isArray} from '@coveo/bueno';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -159,9 +158,9 @@ export class AtomicCategoryFacet
    *
    * Specifying the property as a comma separated string is deprecated.
    */
-  @ArrayProp({deprecationWarning: true})
+  @ArrayProp()
   @Prop({reflect: true, mutable: true})
-  public basePath?: string | string[];
+  public basePath?: string[];
   /**
    * Whether to use basePath as a filter for the results.
    */
@@ -233,7 +232,7 @@ export class AtomicCategoryFacet
       numberOfValues: this.numberOfValues,
       sortCriteria: this.sortCriteria,
       facetSearch: {numberOfValues: this.numberOfValues},
-      basePath: this.processBasePath(),
+      basePath: this.basePath,
       delimitingCharacter: this.delimitingCharacter,
       filterByBasePath: this.filterByBasePath,
       injectionDepth: this.injectionDepth,
@@ -275,22 +274,6 @@ export class AtomicCategoryFacet
     }
 
     return true;
-  }
-
-  private processBasePath() {
-    // @deprecated
-    // TODO, V2:
-    // basePath should only support JSON string representation.
-    // deprecate comma delimited string
-    if (isArray(this.basePath)) {
-      return this.basePath;
-    }
-
-    if (this.basePath) {
-      return this.basePath.split(',').map((value) => value.trim());
-    }
-
-    return undefined;
   }
 
   private get hasParents() {

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -163,8 +163,6 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   /**
    * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.
    *
-   * Specifying the property as a comma separated string is deprecated.
-   *
    * If you specify a list of values for this option, the facet uses only these values (if they are available in
    * the current result set).
    *

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -27,7 +27,6 @@ import {
   FacetCommon,
   parseDependsOn,
 } from '../../../common/facets/facet-common';
-import {isArray} from '@coveo/bueno';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -183,9 +182,9 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    *
    * Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
    */
-  @ArrayProp({deprecationWarning: true})
+  @ArrayProp()
   @Prop({mutable: true})
-  public allowedValues?: string | string[];
+  public allowedValues?: string[];
 
   @FocusTarget()
   private showLessFocus!: FocusTargetController;
@@ -205,7 +204,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
       facetSearch: {numberOfValues: this.numberOfValues},
       filterFacetCount: this.filterFacetCount,
       injectionDepth: this.injectionDepth,
-      allowedValues: this.processAllowedValues(),
+      allowedValues: this.allowedValues,
     };
 
     this.facet = buildFacet(this.bindings.engine, {options});
@@ -270,19 +269,5 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
       showMoreFocus: this.showMoreFocus,
       onToggleCollapse: () => (this.isCollapsed = !this.isCollapsed),
     });
-  }
-
-  private processAllowedValues() {
-    // @deprecated
-    // TODO, V2:
-    // basePath should only support JSON string representation.
-    // deprecate comma delimited string
-    if (isArray(this.allowedValues)) {
-      return this.allowedValues;
-    }
-    if (this.allowedValues) {
-      return this.allowedValues?.trim().split(',');
-    }
-    return undefined;
   }
 }

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -128,8 +128,8 @@ export class AtomicRatingFacet
    * When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`.
    * This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):
    *
-   * - `--atomic-rating-facet-icon-active-color`
-   * - `--atomic-rating-facet-icon-inactive-color`
+   * - `--atomic-rating-icon-active-color`
+   * - `--atomic-rating-icon-inactive-color`
 
    */
   @Prop({reflect: true}) public icon = Star;

--- a/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -119,8 +119,8 @@ export class AtomicRatingRangeFacet
    * When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`.
    * This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):
    *
-   * - `--atomic-rating-facet-icon-active-color`
-   * - `--atomic-rating-facet-icon-inactive-color`
+   * - `--atomic-rating-icon-active-color`
+   * - `--atomic-rating-icon-inactive-color`
    */
   @Prop({reflect: true}) public icon = Star;
   /**

--- a/packages/atomic/src/components/search/result-link/result-link.tsx
+++ b/packages/atomic/src/components/search/result-link/result-link.tsx
@@ -10,7 +10,6 @@ export interface ResultLinkEventProps {
 
 export interface ResultLinkProps extends ResultLinkEventProps {
   href: string;
-  target?: string;
   className?: string;
   part?: string;
   title?: string;
@@ -55,7 +54,6 @@ export const bindAnalyticsToLink = (
 export const LinkWithResultAnalytics: FunctionalComponent<ResultLinkProps> = (
   {
     href,
-    target,
     className,
     part,
     title,
@@ -76,7 +74,6 @@ export const LinkWithResultAnalytics: FunctionalComponent<ResultLinkProps> = (
       part={part}
       href={filterProtocol(href)}
       title={title}
-      target={target}
       ref={(el) => {
         if (ref) {
           ref(el);

--- a/packages/atomic/src/components/search/result-link/result-link.tsx
+++ b/packages/atomic/src/components/search/result-link/result-link.tsx
@@ -10,7 +10,7 @@ export interface ResultLinkEventProps {
 
 export interface ResultLinkProps extends ResultLinkEventProps {
   href: string;
-  target: string;
+  target?: string;
   className?: string;
   part?: string;
   title?: string;

--- a/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
@@ -75,11 +75,6 @@ export class AtomicFoldedResultList implements InitializableComponent {
   @FocusTarget() nextNewResultTarget!: FocusTargetController;
 
   /**
-   * A list of non-default fields to include in the query results, separated by commas.
-   * @deprecated add it to atomic-search-interface instead
-   */
-  @Prop({reflect: true}) public fieldsToInclude = '';
-  /**
    * The spacing of various elements in the result list, including the gap between results, the gap between parts of a result, and the font sizes of different parts in a result.
    */
   @Prop({reflect: true}) density: ResultDisplayDensity = 'normal';
@@ -134,11 +129,6 @@ export class AtomicFoldedResultList implements InitializableComponent {
 
   public initialize() {
     try {
-      this.bindings.store.addFieldsToInclude(
-        this.fieldsToInclude
-          ? this.fieldsToInclude.split(',').map((field) => field.trim())
-          : []
-      );
       this.foldedResultList = this.initFolding();
       this.resultsPerPage = buildResultsPerPage(this.bindings.engine);
     } catch (e) {

--- a/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
@@ -173,9 +173,7 @@ export class AtomicFoldedResultList implements InitializableComponent {
       loadingFlag: this.loadingFlag,
       getResultListState: () => this.foldedResultListState,
       getResultRenderingFunction: () => this.resultRenderingFunction,
-      renderResult: (props) => (
-        <atomic-result {...props} engine={this.bindings.engine}></atomic-result>
-      ),
+      renderResult: (props) => <atomic-result {...props}></atomic-result>,
       getInteractiveResult: (result: Result) =>
         buildInteractiveResult(this.bindings.engine, {
           options: {result},

--- a/packages/atomic/src/components/search/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -148,7 +148,6 @@ export class AtomicResultChildren implements InitializableComponent {
         interactiveResult={buildInteractiveResult(this.bindings.engine, {
           options: {result: extractUnfoldedResult(child)},
         })}
-        engine={this.bindings.engine}
         store={this.bindings.store}
         density={this.displayConfig.density}
         imageSize={this.imageSize || this.displayConfig.imageSize}

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -91,10 +91,6 @@ export class AtomicResultList implements InitializableComponent {
    */
   @Prop({reflect: true, mutable: true})
   public imageSize: ResultDisplayImageSize = 'icon';
-  /**
-   * @deprecated use `imageSize` instead.
-   */
-  @Prop({reflect: true}) public image: ResultDisplayImageSize = 'icon';
 
   /**
    * Sets a rendering function to bypass the standard HTML template mechanism for rendering results.
@@ -108,20 +104,6 @@ export class AtomicResultList implements InitializableComponent {
     resultRenderingFunction: ResultRenderingFunction
   ) {
     this.resultRenderingFunction = resultRenderingFunction;
-  }
-
-  public connectedCallback() {
-    this.settleImageSize();
-  }
-
-  // TODO: remove v2 when `image` prop is removed;
-  private settleImageSize() {
-    if (this.host.hasAttribute('image-size')) {
-      return;
-    }
-    if (this.host.hasAttribute('image')) {
-      this.imageSize = this.image;
-    }
   }
 
   public initialize() {

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -74,11 +74,6 @@ export class AtomicResultList implements InitializableComponent {
   @FocusTarget() nextNewResultTarget!: FocusTargetController;
 
   /**
-   * A list of non-default fields to include in the query results, separated by commas.
-   * @deprecated add it to atomic-search-interface instead
-   */
-  @Prop({reflect: true}) public fieldsToInclude = '';
-  /**
    * The desired layout to use when displaying results. Layouts affect how many results to display per row and how visually distinct they are from each other.
    */
   @Prop({reflect: true}) public display: ResultDisplayLayout = 'list';
@@ -112,11 +107,6 @@ export class AtomicResultList implements InitializableComponent {
         'Folded results will not render any children for the "atomic-result-list". Please use "atomic-folded-result-list" instead.'
       );
     }
-    this.bindings.store.addFieldsToInclude(
-      this.fieldsToInclude
-        ? this.fieldsToInclude.split(',').map((field) => field.trim())
-        : []
-    );
     this.resultList = buildResultList(this.bindings.engine);
     this.resultsPerPage = buildResultsPerPage(this.bindings.engine);
     const resultTemplateProvider = new ResultTemplateProvider({

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
@@ -39,20 +39,6 @@ export class AtomicResultLink implements InitializableComponent {
   @Element() private host!: HTMLElement;
 
   /**
-   * Where to open the linked URL, as the name for a browsing context (a tab, window, or iframe).
-   *
-   * The following keywords have special meanings:
-   *
-   * * _self: the current browsing context. (Default)
-   * * _blank: usually a new tab, but users can configure their browsers to open a new window instead.
-   * * _parent: the parent of the current browsing context. If there's no parent, this behaves as `_self`.
-   * * _top: the topmost browsing context (the "highest" context that’s an ancestor of the current one). If there are no ancestors, this behaves as `_self`.
-   *
-   * @deprecated Use the "attributes" slot instead to pass down attributes to the link.
-   */
-  @Prop({reflect: true}) target = '_self';
-
-  /**
    * Specifies a template literal from which to generate the `href` attribute value (see
    * [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).
    *
@@ -98,7 +84,6 @@ export class AtomicResultLink implements InitializableComponent {
     return (
       <LinkWithResultAnalytics
         href={href}
-        target={this.target}
         onSelect={() => this.interactiveResult.select()}
         onBeginDelayedSelect={() => this.interactiveResult.beginDelayedSelect()}
         onCancelPendingSelect={() =>

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-printable-uri/atomic-result-printable-uri.tsx
@@ -142,7 +142,6 @@ export class AtomicResultPrintableUri {
       <LinkWithResultAnalytics
         href={uri}
         title={typeof content === 'string' ? content : undefined}
-        target={this.target}
         onSelect={() => this.interactiveResult.select()}
         onBeginDelayedSelect={() => this.interactiveResult.beginDelayedSelect()}
         onCancelPendingSelect={() =>

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-rating/atomic-result-rating.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-rating/atomic-result-rating.tsx
@@ -41,8 +41,8 @@ export class AtomicResultRating {
    * When using a custom icon, at least part of your icon should have the color set to `fill="currentColor"`.
    * This part of the SVG will take on the colors set in the following [variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties):
    *
-   * - `--atomic-rating-facet-icon-active-color`
-   * - `--atomic-rating-facet-icon-inactive-color`
+   * - `--atomic-rating-icon-active-color`
+   * - `--atomic-rating-icon-inactive-color`
    */
   @Prop({reflect: true}) public icon = Star;
 

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -131,7 +131,6 @@ export class AtomicSearchBoxInstantResults implements InitializableComponent {
             interactiveResult={buildInteractiveResult(this.bindings.engine, {
               options: {result},
             })}
-            engine={this.bindings.engine}
             display={this.display}
             density={this.density}
             imageSize={this.imageSize}

--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -175,7 +175,7 @@
     <atomic-search-interface
       pipeline="Search"
       search-hub="MainSearch"
-      fields-to-include="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      fields-to-include='["ec_price", "ec_rating", "ec_images", "ec_brand", "cat_platform", "cat_condition", "cat_categories", "cat_review_count", "cat_color"]'
     >
       <atomic-search-layout>
         <atomic-layout-section section="search">

--- a/packages/atomic/src/pages/examples/fashion.html
+++ b/packages/atomic/src/pages/examples/fashion.html
@@ -85,7 +85,7 @@
   </head>
 
   <body>
-    <atomic-search-interface pipeline="Search" search-hub="MainSearch" fields-to-include="cat_rating_count">
+    <atomic-search-interface pipeline="Search" search-hub="MainSearch" fields-to-include='["cat_rating_count"]'>
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
@@ -213,7 +213,7 @@
             <atomic-no-results></atomic-no-results>
           </atomic-layout-section>
 
-          <atomic-recs-interface fields-to-include="cat_rating_count">
+          <atomic-recs-interface fields-to-include='["cat_rating_count"]'>
             <atomic-recs-list class="tiles" label="Top clothing for you" display="grid" number-of-recommendations="3">
               <atomic-recs-result-template>
                 <template>

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -42,7 +42,7 @@
   </head>
 
   <body>
-    <atomic-search-interface fields-to-include="snrating,sncost">
+    <atomic-search-interface fields-to-include='["snrating", "sncost"]'>
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">

--- a/packages/atomic/src/pages/examples/recommendations.html
+++ b/packages/atomic/src/pages/examples/recommendations.html
@@ -86,7 +86,7 @@
   <body>
     <div class="layout">
       <!-- Tiles -->
-      <atomic-recs-interface class="tiles" fields-to-include="cat_rating_count">
+      <atomic-recs-interface class="tiles" fields-to-include='["cat_rating_count"]'>
         <atomic-recs-list label="Top clothing for you" display="grid" number-of-recommendations="10">
           <atomic-recs-result-template>
             <template>
@@ -130,7 +130,7 @@
         </atomic-recs-list>
       </atomic-recs-interface>
       <!-- Rows -->
-      <atomic-recs-interface class="rows" fields-to-include="cat_rating_count">
+      <atomic-recs-interface class="rows" fields-to-include='["cat_rating_count"]'>
         <atomic-recs-list label="Frequently viewed" recommendation="frequentViewed" number-of-recommendations="6">
           <atomic-recs-result-template>
             <template>
@@ -174,7 +174,7 @@
         </atomic-recs-list>
       </atomic-recs-interface>
       <!-- Carousel -->
-      <atomic-recs-interface class="carousel" fields-to-include="cat_rating_count">
+      <atomic-recs-interface class="carousel" fields-to-include='["cat_rating_count"]'>
         <atomic-recs-list
           display="grid"
           label="Carousel"

--- a/packages/atomic/src/pages/examples/suggestions.html
+++ b/packages/atomic/src/pages/examples/suggestions.html
@@ -78,7 +78,10 @@
     </script>
   </head>
   <body>
-    <atomic-search-interface search-hub="MainSearch" fields-to-include="ec_images,ec_rating,ec_price,cat_rating_count">
+    <atomic-search-interface
+      search-hub="MainSearch"
+      fields-to-include='["ec_images", "ec_rating", "ec_price", "cat_rating_count"]'
+    >
       <atomic-search-layout mobile-breakpoint="700px">
         <atomic-layout-section section="facets">
           <atomic-facet-manager>

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -132,7 +132,7 @@
   </head>
 
   <body>
-    <atomic-search-interface fields-to-include="snrating,sncost">
+    <atomic-search-interface fields-to-include='["snrating", "sncost"]'>
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">

--- a/packages/atomic/src/pages/visualTests.html
+++ b/packages/atomic/src/pages/visualTests.html
@@ -132,7 +132,7 @@
   </head>
 
   <body>
-    <atomic-search-interface fields-to-include="snrating,sncost">
+    <atomic-search-interface fields-to-include='["snrating", "sncost"]'>
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -37,18 +37,11 @@ export function ArrayProp() {
     const {componentWillLoad} = component;
     const attributeWithBackets = camelToKebab(variableName);
 
-    if (!componentWillLoad) {
-      console.error(
-        'The "componentWillLoad" lifecycle method has to be defined for the ArrayProp decorator to work.'
-      );
-      return;
-    }
-
     component.componentWillLoad = function () {
       const attr =
         getElement(this).attributes.getNamedItem(attributeWithBackets);
       if (!attr) {
-        componentWillLoad.call(this);
+        componentWillLoad?.call(this);
         return;
       }
 
@@ -69,7 +62,7 @@ export function ArrayProp() {
         );
       }
 
-      componentWillLoad.call(this);
+      componentWillLoad?.call(this);
     };
   };
 }

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -7,12 +7,6 @@ interface MapPropOptions {
   splitValues?: boolean;
 }
 
-interface ArrayPropOptions {
-  // @deprecated
-  // TODO v2: remove deprecation warning and change to a strict error only
-  deprecationWarning: boolean;
-}
-
 export function MapProp(opts?: MapPropOptions) {
   return (component: ComponentInterface, variableName: string) => {
     const {componentWillLoad} = component;
@@ -38,15 +32,7 @@ export function MapProp(opts?: MapPropOptions) {
   };
 }
 
-export function ArrayProp(opts: ArrayPropOptions) {
-  const logWithDeprecation = (msg: string, ...other: unknown[]) =>
-    opts.deprecationWarning
-      ? console.warn(
-          `${msg} This will be enforced in the next major version`,
-          other
-        )
-      : console.error(msg, other);
-
+export function ArrayProp() {
   return (component: ComponentInterface, variableName: string) => {
     const {componentWillLoad} = component;
     const attributeWithBackets = camelToKebab(variableName);
@@ -71,13 +57,13 @@ export function ArrayProp(opts: ArrayPropOptions) {
         if (isArray(valueAsArray)) {
           this[variableName] = valueAsArray;
         } else {
-          logWithDeprecation(
+          console.error(
             `Property ${attributeWithBackets} should be an array`,
             getElement(this)
           );
         }
       } catch (e) {
-        logWithDeprecation(
+        console.error(
           `Error while parsing attribute ${attributeWithBackets} as array`,
           e
         );

--- a/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
+++ b/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
@@ -84,7 +84,7 @@
   <atomic-breadbox></atomic-breadbox>
 
   <div class="topbar">
-    <atomic-query-summary enableDuration="false"></atomic-query-summary>
+    <atomic-query-summary></atomic-query-summary>
     <atomic-refine-toggle></atomic-refine-toggle>
     <atomic-sort-dropdown>
       <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>

--- a/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
+++ b/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
@@ -2,7 +2,17 @@
   #searchInterface
   searchHub="MainSearch"
   pipeline="Search"
-  fields-to-include="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+  [fieldsToInclude]="[
+    'ec_price',
+    'ec_rating',
+    'ec_images',
+    'ec_brand',
+    'cat_platform',
+    'cat_condition',
+    'cat_categories',
+    'cat_review_count',
+    'cat_color'
+  ]"
 >
   <div class="search">
     <atomic-search-box>

--- a/packages/samples/atomic-next/pages/search-page.tsx
+++ b/packages/samples/atomic-next/pages/search-page.tsx
@@ -59,6 +59,7 @@ const SearchPage: NextPage = () => {
       pipeline="Search"
       searchHub="MainSearch"
       theme="none"
+      fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
     >
       <AtomicSearchLayout>
         <AtomicLayoutSection section="search">
@@ -136,7 +137,6 @@ const SearchPage: NextPage = () => {
           </AtomicLayoutSection>
           <AtomicLayoutSection section="results">
             <AtomicResultList
-              fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
               display="list"
               imageSize="large"
               template={MyTemplate}

--- a/packages/samples/atomic-next/pages/search-page.tsx
+++ b/packages/samples/atomic-next/pages/search-page.tsx
@@ -119,7 +119,7 @@ const SearchPage: NextPage = () => {
         <AtomicLayoutSection section="main">
           <AtomicLayoutSection section="status">
             <AtomicBreadbox />
-            <AtomicQuerySummary enableDuration={false} />
+            <AtomicQuerySummary />
             <AtomicRefineToggle />
             <AtomicSortDropdown>
               <AtomicSortExpression label="relevance" expression="relevancy" />

--- a/packages/samples/atomic-next/pages/search-page.tsx
+++ b/packages/samples/atomic-next/pages/search-page.tsx
@@ -59,10 +59,6 @@ const SearchPage: NextPage = () => {
       pipeline="Search"
       searchHub="MainSearch"
       fieldsToInclude={[
-        'ec_price',
-        'ec_rating',
-        'ec_images',
-        'ec_brand',
         'cat_platform',
         'cat_condition',
         'cat_categories',

--- a/packages/samples/atomic-next/pages/search-page.tsx
+++ b/packages/samples/atomic-next/pages/search-page.tsx
@@ -58,7 +58,6 @@ const SearchPage: NextPage = () => {
       engine={engine}
       pipeline="Search"
       searchHub="MainSearch"
-      theme="none"
       fieldsToInclude={[
         'ec_price',
         'ec_rating',

--- a/packages/samples/atomic-next/pages/search-page.tsx
+++ b/packages/samples/atomic-next/pages/search-page.tsx
@@ -59,7 +59,17 @@ const SearchPage: NextPage = () => {
       pipeline="Search"
       searchHub="MainSearch"
       theme="none"
-      fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      fieldsToInclude={[
+        'ec_price',
+        'ec_rating',
+        'ec_images',
+        'ec_brand',
+        'cat_platform',
+        'cat_condition',
+        'cat_categories',
+        'cat_review_count',
+        'cat_color',
+      ]}
     >
       <AtomicSearchLayout>
         <AtomicLayoutSection section="search">

--- a/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
+++ b/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
@@ -143,7 +143,7 @@ export const AtomicPageWrapper: FunctionComponent<Props> = ({
         <AtomicLayoutSection section="main">
           <AtomicLayoutSection section="status">
             <AtomicBreadbox />
-            <AtomicQuerySummary enableDuration={false} />
+            <AtomicQuerySummary />
             <AtomicRefineToggle />
             <AtomicSortDropdown>
               <AtomicSortExpression label="relevance" expression="relevancy" />

--- a/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
+++ b/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
@@ -67,7 +67,17 @@ export const AtomicPageWrapper: FunctionComponent<Props> = ({
       engine={engine}
       pipeline="Search"
       searchHub="MainSearch"
-      fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      fieldsToInclude={[
+        'ec_price',
+        'ec_rating',
+        'ec_images',
+        'ec_brand',
+        'cat_platform',
+        'cat_condition',
+        'cat_categories',
+        'cat_review_count',
+        'cat_color',
+      ]}
       localization={(i18n) => {
         i18n.addResourceBundle('en', 'translation', {
           'no-ratings-available': 'No ratings available',

--- a/packages/samples/atomic-react/src/pages/RecsPage.tsx
+++ b/packages/samples/atomic-react/src/pages/RecsPage.tsx
@@ -38,7 +38,17 @@ export const RecsPage: FunctionComponent = () => {
       engine={engine}
       pipeline="Search"
       searchHub="MainSearch"
-      fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
+      fieldsToInclude={[
+        'ec_price',
+        'ec_rating',
+        'ec_images',
+        'ec_brand',
+        'cat_platform',
+        'cat_condition',
+        'cat_categories',
+        'cat_review_count',
+        'cat_color',
+      ]}
       localization={(i18n) => {
         i18n.addResourceBundle('en', 'translation', {
           'no-ratings-available': 'No ratings available',

--- a/packages/samples/atomic-react/src/pages/TableResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/TableResultListPage.tsx
@@ -25,7 +25,6 @@ export const TableResultListPage: FunctionComponent = () => {
       organizationId="electronicscoveodemocomo0n2fu8v"
     >
       <AtomicResultList
-        fieldsToInclude="ec_price,ec_rating,ec_images,ec_brand,cat_platform,cat_condition,cat_categories,cat_review_count,cat_color"
         display="table"
         imageSize="large"
         template={MyTemplate}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2049

# Deprecations (extracted from the Confluence post)
## Renamed
* Renamed `atomic-result-list` and `atomic-result`'s `image` attribute to `image-size`.
* Renamed CSS variables:
  * `--atomic-rating-facet-icon-active-color` to `--atomic-rating-icon-active-color`
  * `--atomic-rating-facet-icon-inactive-color` to `--atomic-rating-icon-inactive-color`
* Renamed `atomic-refine-modal`'s `select-icon` part to `select-icon-wrapper`
* Renamed `atomic-refine-modal`'s `select-icon-size` part to `select-icon`

## Changed
* Removed `atomic-query-summary`'s `enable-duration` attribute.
  * The duration part can be used to style or hide the duration instead.
* Removed `atomic-result`'s engine attribute.
  * This attribute is unused.
* Some attributes were changed to instead take JSON or a JSX string array as a parameter.
  * The following attributes were affected:
    * `atomic-facet`'s `allowed-values`
    * `atomic-category-facet`'s `base-path`
    * `atomic-search-interface`'s `fields-to-include`
    * `atomic-insight-interface`'s `fields-to-include`
    * `atomic-recs-interface`'s `fields-to-include`
  * For instance:
    ```html
    <atomic-facet allowed-values="in progress,completed" />
    ```
    would become
    ```html
    <atomic-facet allowed-values='["in progress", "completed"]' />
    ```
  * With JSX, an array of strings can now be passed directly like so:
    ```jsx
    <AtomicFacet allowed-values={["in progress", "completed"]} />
    ```
  * This change makes it unambiguous what separator is used to divide parts of the path, and allows commas to be escaped.
* Moved `atomic-result-list` and `atomic-folded-result-list`'s `fields-to-include` attribute to `atomic-search-interface`.
* Removed `atomic-result-link`'s `target` attribute.
  * Instead, you can use the attributes slot like so:
    ```html
    <atomic-result-link>
      <a slot="attributes" target="_blank" download></a>
    </atomic-result-link>
    ```
* In atomic-react, removed `AtomicSearchInterface`'s theme attribute.
* Changed `atomic-insight-result`'s `interactive-result` attribute to be required.

### Insight panel
* Removed `atomic-insight-result`'s `engine` attribute.
  * This attribute is unused.
* Changed `atomic-insight-result`'s `interactive-result` attribute to be required.

### Recommendations
* In atomic-react, removed `AtomicSearchInterface`'s `theme` attribute.