### PR TITLE
fix(headless): removed flag and renamed attribute

### DIFF
--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-request.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-request.ts
@@ -7,12 +7,7 @@ export const buildGetInsightInterfaceConfigRequest = (
   req: GetInsightInterfaceConfigRequest
 ) => {
   return {
-    ...baseInsightRequest(
-      req,
-      'GET',
-      'application/json',
-      '/interface?detailed=true'
-    ),
+    ...baseInsightRequest(req, 'GET', 'application/json', '/interface'),
     requestParams: {},
   };
 };

--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -71,7 +71,7 @@ interface Facet {
   field: string;
   label?: string;
   displayValueAs?: string;
-  facetTypes?: InsightFacetType;
+  facetType?: InsightFacetType;
 }
 
 interface Tab {


### PR DESCRIPTION
The flag was not necessary as it is only useful on the search-interface-service, not the customer-service-api which the client targets. and the customer-service-api sets it automatically.
Also I messed up the name of the interface attribute.

Really sloppy work on my end