### PR TITLE
fix(quantic): fixed facet value overflow

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -21,7 +21,7 @@
                   <c-quantic-timeframe amount="6" unit="month"></c-quantic-timeframe>
                   <c-quantic-timeframe unit="year"></c-quantic-timeframe>
                 </c-quantic-timeframe-facet>
-                <c-quantic-category-facet field="geographicalhierarchy" label="Country" engine-id={engineId}></c-quantic-category-facet>
+                <c-quantic-category-facet with-search field="geographicalhierarchy" label="Country" engine-id={engineId}></c-quantic-category-facet>
               </c-quantic-facet-manager>
             </div>
             <div class="slds-col slds-order_1 slds-large-order_2 slds-size_1-of-1 slds-large-size_6-of-12">

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.html
@@ -34,13 +34,13 @@
               <li class="facet__value-option slds-size_1-of-1 slds-p-around_x-small">
                 <div
                   role="button"
-                  class="facet__allCategories slds-grid slds-grid_vertical-align-center"
+                  class="facet__allCategories slds-grid slds-size_1-of-1 slds-grid_vertical-align-center"
                   tabindex="0"
                   onclick={reset}
                   onkeydown={onKeyDownReset}
                 >
                   <lightning-icon class="slds-m-right_xxx-small" icon-name="utility:chevronleft" size="xx-small"></lightning-icon>
-                  <span class="nowrap">{labels.allCategories}</span>
+                  <span class="slds-truncate" title={labels.allCategories}>{labels.allCategories}</span>
                 </div>
               </li>
             </template>
@@ -57,11 +57,11 @@
               <li class="facet__active-parent slds-grid slds-grid_vertical-align-center slds-p-around_x-small slds-m-left_medium">
                 <div
                   role="button"
-                  class="slds-size_1-of-1 facet__value-container"
+                  class="slds-size_1-of-1 slds-grid facet__value-container"
                   aria-pressed="true"
                   tabindex="0"
                 >
-                  <span class="nowrap parent-text__bold">{activeParent.value}</span>
+                  <span class="slds-truncate parent-text__bold" title={activeParent.value}>{activeParent.value}</span>
                   <span class="facet__number-of-results parent-text__bold slds-var-m-left_xx-small">({activeParent.numberOfResults})</span>
                 </div>
               </li>

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.css
@@ -1,5 +1,9 @@
 @import 'c/quanticFacetStyles';
 
+:host {
+  width: 100%;
+}
+
 .facet__path {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
@@ -10,10 +10,10 @@
   >
     <template if:true={nonActiveParent}>
       <div
-        class="facet__parent-value-option facet__value-option slds-grid slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small"
+        class="facet__parent-value-option facet__value-option slds-grid slds-truncate slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small"
       >
         <lightning-icon class="slds-m-right_xxx-small" icon-name="utility:chevronleft" size="xx-small"></lightning-icon>
-        <span class="nowrap">{item.value}</span>
+        <span class="slds-truncate" title={item.value}>{item.value}</span>
         <span class="facet__number-of-results slds-var-m-left_xx-small">({item.numberOfResults})</span>
       </div>
     </template>
@@ -22,13 +22,13 @@
         <div
           class="nowrap slds-grid slds-grid_vertical-align-center slds-text-color_default facet__child-value-option facet__value-option slds-size_1-of-1 slds-p-around_x-small"
         >
-          {item.value}
+          <span class="slds-truncate" title={item.value}>{item.value}</span>
           <span class="facet__number-of-results slds-var-m-left_xx-small">({item.numberOfResults})</span>
         </div>
       </template>
       <template if:true={isSearchResult}>
         <div class="facet__value-option slds-size_1-of-1 slds-p-around_x-small slds-text-color_default">
-          <div class="slds-grid slds-grid_vertical">
+          <div class="slds-grid slds-grid_vertical slds-size_1-of-1">
             <div
               class="slds-col slds-p-left_none slds-grid_vertical-align-center facet__search-results slds-m-bottom_xxx-small"
             >
@@ -39,7 +39,7 @@
               <span class="facet__number-of-results slds-var-m-left_xx-small">({item.numberOfResults})</span>
             </div>
             <div class="slds-col slds-p-left_none">
-              <span class="facet__path">{labels.inLabel} {item.localizedPath}</span>
+              <span class="facet__path slds-truncate">{labels.inLabel} {item.localizedPath}</span>
             </div>
           </div>
         </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
@@ -20,7 +20,7 @@
     <template if:false={nonActiveParent}>
       <template if:false={isSearchResult}>
         <div
-          class="nowrap slds-grid slds-grid_vertical-align-center slds-text-color_default facet__child-value-option facet__value-option slds-size_1-of-1 slds-p-around_x-small"
+          class="slds-grid slds-grid_vertical-align-center slds-text-color_default facet__child-value-option facet__value-option slds-size_1-of-1 slds-p-around_x-small"
         >
           <span class="slds-truncate" title={item.value}>{item.value}</span>
           <span class="facet__number-of-results slds-var-m-left_xx-small">({item.numberOfResults})</span>
@@ -40,7 +40,7 @@
               <span class="facet__number-of-results slds-var-m-left_xx-small">({item.numberOfResults})</span>
             </div>
             <div class="slds-col slds-p-left_none">
-              <span class="facet__path slds-truncate">{labels.inLabel} {item.localizedPath}</span>
+              <span class="facet__path slds-truncate" title={pathLabel}>{pathLabel}</span>
             </div>
           </div>
         </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
@@ -31,6 +31,7 @@
           <div class="slds-grid slds-grid_vertical slds-size_1-of-1">
             <div
               class="slds-col slds-p-left_none slds-grid_vertical-align-center facet__search-results slds-m-bottom_xxx-small"
+              title={item.value}
             >
               <lightning-formatted-rich-text
                 class="slds-truncate slds-float_left"

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.js
@@ -73,6 +73,11 @@ export default class QuanticCategoryFacetValue extends LightningElement {
     return this.item?.state === 'selected' ? 'true' : 'false';
   }
 
+  get pathLabel() {
+    // @ts-ignore
+    return `${this.labels.inLabel} ${this.item.localizedPath}`;
+  }
+
   /**
    * @param {Event} evt
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
@@ -29,7 +29,7 @@
               size="xx-small"
               aria-hidden="true"
             ></lightning-icon>
-            <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
+            <span class="pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>
         </template>
         <template if:false={isCollapsed}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -29,7 +29,7 @@
               size="xx-small"
               aria-hidden="true"
             ></lightning-icon>
-            <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
+            <span class="pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>
         </template>
         <template if:false={isCollapsed}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles.css
@@ -5,6 +5,10 @@
   border-radius: 4px;
 }
 
+fieldset {
+  min-width: 0;
+}
+
 .facet__show-less {
   font-size: 12px;
   background-color: white;

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -23,18 +23,18 @@
     </template>
     <template if:true={isChecked}>
       <span
-        class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected"
+        class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small facet__value-text facet__value_selected"
         title={formattedFacetValue}
         >{formattedFacetValue}</span
       >
-      <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected"
+      <span class="slds-var-m-top_xxx-small facet__number-of-results facet__value_selected"
         >({numberOfResults})</span
       >
     </template>
     <template if:false={isChecked}>
       <template if:true={isStandardFacet}>
         <span
-          class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle"
+          class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small facet__value-text facet__value_idle"
           title={formattedFacetValue}
         >
           <lightning-formatted-rich-text value={item.highlightedResult} disable-linkify></lightning-formatted-rich-text>
@@ -42,12 +42,12 @@
       </template>
       <template if:false={isStandardFacet}>
         <span
-          class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle"
+          class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small facet__value-text facet__value_idle"
           title={formattedFacetValue}
           >{formattedFacetValue}</span
         >
       </template>
-      <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
+      <span class="slds-var-m-top_xxx-small facet__number-of-results">({numberOfResults})</span>
     </template>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -24,6 +24,7 @@
     <template if:true={isChecked}>
       <span
         class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_selected"
+        title={formattedFacetValue}
         >{formattedFacetValue}</span
       >
       <span class="nowrap slds-var-m-top_xxx-small facet__number-of-results facet__value_selected"
@@ -34,6 +35,7 @@
       <template if:true={isStandardFacet}>
         <span
           class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle"
+          title={formattedFacetValue}
         >
           <lightning-formatted-rich-text value={item.highlightedResult} disable-linkify></lightning-formatted-rich-text>
         </span>
@@ -41,6 +43,7 @@
       <template if:false={isStandardFacet}>
         <span
           class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small nowrap facet__value-text facet__value_idle"
+          title={formattedFacetValue}
           >{formattedFacetValue}</span
         >
       </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
@@ -29,7 +29,7 @@
               size="xx-small"
               aria-hidden="true"
             ></lightning-icon>
-            <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
+            <span class="pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>
         </template>
         <template if:false={isCollapsed}>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
@@ -24,7 +24,7 @@
               <li key={query} class="slds-grid" value={index} onclick={executeQuery}>
                 <button class="slds-button recent-query__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
                   <lightning-icon class="recent-query__icon slds-current-color" icon-name="utility:search" size="xx-small" aria-hidden="true"></lightning-icon>
-                  <span class="slds-text-body_small nowrap query-text__container slds-truncate">{query}</span>
+                  <span class="slds-text-body_small query-text__container slds-truncate">{query}</span>
                 </button>
               </li>
             </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
@@ -24,7 +24,7 @@
               <li class="slds-grid" key={result.uniqueId}>
                 <div class="recent-result__container slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small">
                   <lightning-icon class="recent-result__icon slds-current-color" icon-name="utility:page" alternative-text="page icon" size="xx-small"></lightning-icon>
-                  <div class="slds-text-body_small nowrap result-link__container">
+                  <div class="slds-text-body_small result-link__container">
                     <c-quantic-recent-result-link result={result} engine-id={engineId} target={target}></c-quantic-recent-result-link>
                   </div>
                 </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.css
@@ -1,3 +1,5 @@
+@import 'c/quanticFacetStyles';
+
 .timeframe-facet__input-label {
   color: var(--lwc-colorTextIconDefault, #747474);
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -31,7 +31,7 @@
               aria-hidden="true"
               size="xx-small"
             ></lightning-icon>
-            <span class="nowrap pill__text-container slds-truncate">{clearFilterLabel}</span>
+            <span class="pill__text-container slds-truncate">{clearFilterLabel}</span>
           </button>
         </template>
 


### PR DESCRIPTION
Fixed the facet value overflow behaviour. It worked correctly before but we seem to have lost it in some more recent modifications. Pretty much every type of facet had the same issue.

Also added some title attributes so a user can hover over a facet value and see the whole string if it's truncated.
Also removed some `nowrap` classes which don't exist. `slds-nowrap` would be valid but clearly we don't need them.

## Before
<img width="568" alt="Screen Shot 2022-11-01 at 1 03 52 PM" src="https://user-images.githubusercontent.com/16785453/199329812-0928197c-7354-4a6e-a7dd-9e8e533e6a7b.png">

## Now

### Standard Facet
#### Regular value
<img width="361" alt="Screen Shot 2022-11-01 at 1 20 44 PM" src="https://user-images.githubusercontent.com/16785453/199330217-f3e2bdfb-9fe9-4ced-a9c1-bb9ee85a0001.png">

#### Search result
<img width="287" alt="Screen Shot 2022-11-01 at 4 00 33 PM" src="https://user-images.githubusercontent.com/16785453/199330550-e94bb57e-6c8f-4908-9fff-ac3b620818d4.png">

### Timeframe Facet
<img width="277" alt="Screen Shot 2022-11-01 at 4 01 03 PM" src="https://user-images.githubusercontent.com/16785453/199330697-d17960e1-d4e1-4356-994b-856f2591f499.png">

### Numeric Facet
<img width="283" alt="Screen Shot 2022-11-01 at 4 01 14 PM" src="https://user-images.githubusercontent.com/16785453/199330728-4567535d-a706-413a-bce1-2aebc2dad9b5.png">

### Category Facet
#### Regular value
<img width="284" alt="Screen Shot 2022-11-01 at 3 44 27 PM" src="https://user-images.githubusercontent.com/16785453/199330811-6d06195a-b823-4ff4-ad5a-624693c97265.png">

#### Search result
<img width="285" alt="Screen Shot 2022-11-01 at 3 59 33 PM" src="https://user-images.githubusercontent.com/16785453/199330845-c5df2057-a5d6-417b-9203-ce3952842e08.png">
