### PR TITLE
feat(quantic): QuanticQueryError updated to support the insight use case

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
@@ -43,6 +43,8 @@ export default class QuanticQueryError extends LightningElement {
   unsubscribe;
   /** @type {import('c/quanticUtils').AriaLiveUtils} */
   errorAriaMessage;
+  /** @type {AnyHeadless} */
+  headless;
 
   showMoreInfo = false;
 

--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
@@ -1,5 +1,5 @@
 import { LightningElement, api, track } from 'lwc';
-import { registerComponentForInit, initializeWithHeadless } from 'c/quanticHeadlessLoader';
+import { registerComponentForInit, initializeWithHeadless, getHeadlessBundle } from 'c/quanticHeadlessLoader';
 import { AriaLiveRegion, I18nUtils } from 'c/quanticUtils';
 
 import coveoOnlineHelpLink from '@salesforce/label/c.quantic_CoveoOnlineHelpLink';
@@ -67,7 +67,8 @@ export default class QuanticQueryError extends LightningElement {
    * @param {SearchEngine} engine
    */
   initialize = (engine) => {
-    this.queryError = CoveoHeadless.buildQueryError(engine);
+    this.headless = getHeadlessBundle(this.engineId);
+    this.queryError = this.headless.buildQueryError(engine);
     this.errorAriaMessage = AriaLiveRegion('queryerror', this);
     this.unsubscribe = this.queryError.subscribe(() => this.updateState());
   }


### PR DESCRIPTION
[SFINT-4674](https://coveord.atlassian.net/browse/SFINT-4674)

### In this PR: 
- `QunticQueryError` component updated to be able to work correctly with both the Headless search bundle and the Headless insight bundle.