### PR TITLE
fix(quantic): display of QuerySummary adjusted in the example search page

### DIFF
--- a/packages/quantic/cypress/page-objects/example-search.ts
+++ b/packages/quantic/cypress/page-objects/example-search.ts
@@ -8,7 +8,7 @@ export const selectors = {
   pager: 'c-quantic-pager',
   regularFacet: 'c-quantic-facet[data-cy="type"]',
   facetsContainer: '.facets_container',
-  refineToggle: '.refine-toggle_container',
+  refineToggle: 'c-quantic-refine-toggle',
 };
 
 export const setupAliases = () =>

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.css
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.css
@@ -20,9 +20,3 @@
   border-radius: .25rem;
   background-clip: padding-box;
 }
-
-.refine-toggle_container {
-  display: flex;
-  width: 100%;
-  justify-content: flex-end;
-}

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/exampleSearch.html
@@ -33,12 +33,14 @@
                 <c-quantic-tab label="Files" expression="@boxdocumenttype==File OR @spcontenttype==Document" engine-id={engineId}></c-quantic-tab>
               </c-quantic-tab-bar>
               <div class="slds-grid slds-var-m-top_small">
-                <c-quantic-summary class="slds-var-m-vertical_x-small slds-medium-size_7-of-12" engine-id={engineId}>
+                <c-quantic-summary class="slds-var-m-vertical_x-small slds-small-size_8-of-12 slds-large-size_7-of-12" engine-id={engineId}>
                 </c-quantic-summary>
-                <c-quantic-sort class="slds-var-m-vertical_xxx-small slds-medium-size_5-of-12 slds-col_bump-left slds-show_large" engine-id={engineId}>
+                <c-quantic-sort class="slds-var-m-vertical_xxx-small slds-large-size_5-of-12 slds-show_large" engine-id={engineId}>
                 </c-quantic-sort>
-                <div class="refine-toggle_container slds-hide_large">
-                  <c-quantic-refine-toggle engine-id={engineId} full-screen></c-quantic-refine-toggle>
+                <div class="slds-small-size_4-of-12 slds-clearfix slds-hide_large">
+                    <div class="slds-float_right">
+                      <c-quantic-refine-toggle engine-id={engineId} full-screen></c-quantic-refine-toggle>
+                    </div>
                 </div>
               </div>
               <c-quantic-query-error engine-id={engineId}></c-quantic-query-error>

--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.js
@@ -32,7 +32,7 @@ export default class QuanticNumberButton extends LightningElement {
   }
 
   get buttonClasses() {
-    const classes = ['slds-button', 'slds-m-left__xx-small'];
+    const classes = ['slds-button', 'slds-m-left_xx-small'];
     classes.push(
       this.selected ? 'slds-button_brand' : 'slds-button_outline-brand'
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.js
@@ -19,6 +19,7 @@ import { errorMap, genericError } from './errorLabels.js';
  * When the error is known, it displays a link to relevant documentation for debugging purposes.
  * When the error is unknown, it displays a small text area with the JSON content of the error.
  * @category Search
+ * @category Insight Panel
  * @example
  * <c-quantic-query-error engine-id={engineId}></c-quantic-query-error>
  */


### PR DESCRIPTION
[SFINT-4565](https://coveord.atlassian.net/browse/SFINT-4565)

 -  display of QuerySummary adjusted in the example search page.

### Before the fix:

![image-20220630-182746](https://user-images.githubusercontent.com/86681870/199804357-48142021-c54d-4562-a0d6-d30e38f10631.png)


### After the fix:
<img width="469" alt="ExampleSearch" src="https://user-images.githubusercontent.com/86681870/199770076-3c739bca-42c1-4cf3-9d33-ca54fe512f0b.png">

Additionally I fixed a margin issue in the QuanticNumberButton:
#### Before: 
<img width="450" alt="Before" src="https://user-images.githubusercontent.com/86681870/199804951-ed4a503c-4813-43f8-b37b-723fe611a718.png">

#### After: 
<img width="450" alt="MarginFixed" src="https://user-images.githubusercontent.com/86681870/199804739-185b0cba-1806-4750-8202-521526511177.png">


PS: The same exact fix will be applied to the insightFullSearch in SFIINT