### PR TITLE
feat(atomic): add ipx layout

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -670,6 +670,8 @@ export namespace Components {
          */
         "withDatePicker": boolean;
     }
+    interface AtomicIpxLayout {
+    }
     interface AtomicLayoutSection {
         /**
           * For column sections, the maximum horizontal space it should take. E.g. '300px'
@@ -1998,6 +2000,12 @@ declare global {
         prototype: HTMLAtomicInsightTimeframeFacetElement;
         new (): HTMLAtomicInsightTimeframeFacetElement;
     };
+    interface HTMLAtomicIpxLayoutElement extends Components.AtomicIpxLayout, HTMLStencilElement {
+    }
+    var HTMLAtomicIpxLayoutElement: {
+        prototype: HTMLAtomicIpxLayoutElement;
+        new (): HTMLAtomicIpxLayoutElement;
+    };
     interface HTMLAtomicLayoutSectionElement extends Components.AtomicLayoutSection, HTMLStencilElement {
     }
     var HTMLAtomicLayoutSectionElement: {
@@ -2472,6 +2480,7 @@ declare global {
         "atomic-insight-tab": HTMLAtomicInsightTabElement;
         "atomic-insight-tabs": HTMLAtomicInsightTabsElement;
         "atomic-insight-timeframe-facet": HTMLAtomicInsightTimeframeFacetElement;
+        "atomic-ipx-layout": HTMLAtomicIpxLayoutElement;
         "atomic-layout-section": HTMLAtomicLayoutSectionElement;
         "atomic-load-more-children-results": HTMLAtomicLoadMoreChildrenResultsElement;
         "atomic-load-more-results": HTMLAtomicLoadMoreResultsElement;
@@ -3164,6 +3173,8 @@ declare namespace LocalJSX {
           * Whether this facet should contain an datepicker allowing users to set custom ranges.
          */
         "withDatePicker"?: boolean;
+    }
+    interface AtomicIpxLayout {
     }
     interface AtomicLayoutSection {
         /**
@@ -4203,6 +4214,7 @@ declare namespace LocalJSX {
         "atomic-insight-tab": AtomicInsightTab;
         "atomic-insight-tabs": AtomicInsightTabs;
         "atomic-insight-timeframe-facet": AtomicInsightTimeframeFacet;
+        "atomic-ipx-layout": AtomicIpxLayout;
         "atomic-layout-section": AtomicLayoutSection;
         "atomic-load-more-children-results": AtomicLoadMoreChildrenResults;
         "atomic-load-more-results": AtomicLoadMoreResults;
@@ -4322,6 +4334,7 @@ declare module "@stencil/core" {
             "atomic-insight-tab": LocalJSX.AtomicInsightTab & JSXBase.HTMLAttributes<HTMLAtomicInsightTabElement>;
             "atomic-insight-tabs": LocalJSX.AtomicInsightTabs & JSXBase.HTMLAttributes<HTMLAtomicInsightTabsElement>;
             "atomic-insight-timeframe-facet": LocalJSX.AtomicInsightTimeframeFacet & JSXBase.HTMLAttributes<HTMLAtomicInsightTimeframeFacetElement>;
+            "atomic-ipx-layout": LocalJSX.AtomicIpxLayout & JSXBase.HTMLAttributes<HTMLAtomicIpxLayoutElement>;
             "atomic-layout-section": LocalJSX.AtomicLayoutSection & JSXBase.HTMLAttributes<HTMLAtomicLayoutSectionElement>;
             "atomic-load-more-children-results": LocalJSX.AtomicLoadMoreChildrenResults & JSXBase.HTMLAttributes<HTMLAtomicLoadMoreChildrenResultsElement>;
             "atomic-load-more-results": LocalJSX.AtomicLoadMoreResults & JSXBase.HTMLAttributes<HTMLAtomicLoadMoreResultsElement>;

--- a/packages/atomic/src/components/search/atomic-ipx-layout/atomic-ipx-layout.tsx
+++ b/packages/atomic/src/components/search/atomic-ipx-layout/atomic-ipx-layout.tsx
@@ -1,0 +1,23 @@
+import {Component, Element} from '@stencil/core';
+import {randomID} from '../../../utils/utils';
+import {buildIPXLayout} from './ipx-layout';
+
+/**
+ * @internal
+ */
+@Component({
+  tag: 'atomic-ipx-layout',
+  shadow: false,
+})
+export class AtomicIPXLayout {
+  @Element() private host!: HTMLElement;
+
+  public componentDidLoad() {
+    const id = this.host.id || randomID('atomic-ipx-layout-');
+    this.host.id = id;
+
+    const styleTag = document.createElement('style');
+    styleTag.innerHTML = buildIPXLayout(this.host);
+    this.host.appendChild(styleTag);
+  }
+}

--- a/packages/atomic/src/components/search/atomic-ipx-layout/ipx-layout.ts
+++ b/packages/atomic/src/components/search/atomic-ipx-layout/ipx-layout.ts
@@ -1,0 +1,61 @@
+import {sectionSelector} from '../../common/atomic-layout-section/sections';
+
+const pagerSelector = 'atomic-pager';
+
+export function buildIPXLayout(element: HTMLElement) {
+  const id = element.id;
+  const layoutSelector = `atomic-ipx-layout#${id}`;
+
+  const interfaceStyle = `
+  ${layoutSelector} {
+    display: grid;
+    grid-template-rows: auto auto auto 8fr 1fr;
+    max-height: 100%;
+    box-sizing: border-box;
+    width: 500px;
+    height: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+    box-shadow: 0px 3px 24px 0px #0000001a;
+  }`;
+
+  const search = `${sectionSelector('search')} {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-gap: 0.5rem;
+      background: var(--atomic-neutral-light);
+      padding: 1.5rem;
+      box-sizing: border-box;
+     }
+    }
+    ${sectionSelector('search')} {
+      grid-column: 1 / 5;
+    }
+    `;
+
+  const status = `${sectionSelector('status')} {
+    padding: 1rem;
+  }`;
+
+  const results = `
+    ${sectionSelector('results')} {
+      overflow: auto;
+    }
+    `;
+
+  const pagination = `
+    ${sectionSelector('pagination')} ${pagerSelector} {
+      background: var(--atomic-neutral-light);
+      height: 100%;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `;
+
+  return [interfaceStyle, search, status, results, pagination]
+    .filter((declaration) => declaration !== '')
+    .join('\n\n');
+}

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Coveo Atomic: IPX example</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script>
+      (async () => {
+        await customElements.whenDefined('atomic-search-interface');
+        const searchInterface = document.querySelector('atomic-search-interface');
+        await searchInterface.initialize({
+          accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+          organizationId: 'searchuisamples',
+        });
+        searchInterface.executeFirstSearch();
+        searchInterface.i18n.addResourceBundle('en', 'caption-filetype', {
+          '.html': 'html',
+        });
+      })();
+    </script>
+  </head>
+
+  <body>
+    <atomic-search-interface fields-to-include="snrating,sncost">
+      <atomic-ipx-layout>
+        <div class="header-bg"></div>
+        <atomic-layout-section section="search">
+          <atomic-search-box></atomic-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="status">
+          <atomic-breadbox></atomic-breadbox>
+          <atomic-query-summary></atomic-query-summary>
+          <atomic-did-you-mean></atomic-did-you-mean>
+          <atomic-notifications></atomic-notifications>
+        </atomic-layout-section>
+        <atomic-layout-section section="results">
+          <atomic-smart-snippet></atomic-smart-snippet>
+          <atomic-smart-snippet-suggestions></atomic-smart-snippet-suggestions>
+          <atomic-result-list>
+            <atomic-result-template>
+              <template>
+                <style>
+                  .field {
+                    display: inline-flex;
+                    align-items: center;
+                  }
+
+                  .field-label {
+                    font-weight: bold;
+                    margin-right: 0.25rem;
+                  }
+
+                  .thumbnail {
+                    display: none;
+                    width: 100%;
+                    height: 100%;
+                  }
+
+                  .icon {
+                    display: none;
+                  }
+
+                  .result-root.image-small .thumbnail,
+                  .result-root.image-large .thumbnail {
+                    display: inline-block;
+                  }
+
+                  .result-root.image-icon .icon {
+                    display: inline-block;
+                  }
+
+                  .result-root.image-small atomic-result-section-visual,
+                  .result-root.image-large atomic-result-section-visual {
+                    border-radius: var(--atomic-border-radius-xl);
+                  }
+                </style>
+                <atomic-result-section-badges>
+                  <atomic-field-condition must-match-sourcetype="Salesforce">
+                    <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
+                  </atomic-field-condition>
+                  <atomic-result-badge
+                    icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
+                  >
+                    <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
+                  </atomic-result-badge>
+                  <atomic-field-condition must-match-is-recommendation="true">
+                    <atomic-result-badge label="Recommended"></atomic-result-badge>
+                  </atomic-field-condition>
+                  <atomic-field-condition must-match-is-top-result="true">
+                    <atomic-result-badge label="Top Result"></atomic-result-badge>
+                  </atomic-field-condition>
+                </atomic-result-section-badges>
+                <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
+                <atomic-result-section-title-metadata>
+                  <atomic-field-condition class="field" if-defined="snrating">
+                    <atomic-result-rating field="snrating"></atomic-result-rating>
+                  </atomic-field-condition>
+                  <atomic-field-condition class="field" if-not-defined="snrating">
+                    <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
+                  </atomic-field-condition>
+                </atomic-result-section-title-metadata>
+                <atomic-result-section-excerpt
+                  ><atomic-result-text field="excerpt"></atomic-result-text
+                ></atomic-result-section-excerpt>
+                <atomic-result-section-bottom-metadata>
+                  <atomic-result-fields-list>
+                    <atomic-field-condition class="field" if-defined="author">
+                      <span class="field-label"><atomic-text value="author"></atomic-text>:</span>
+                      <atomic-result-text field="author"></atomic-result-text>
+                    </atomic-field-condition>
+
+                    <atomic-field-condition class="field" if-defined="source">
+                      <span class="field-label"><atomic-text value="source"></atomic-text>:</span>
+                      <atomic-result-text field="source"></atomic-result-text>
+                    </atomic-field-condition>
+
+                    <atomic-field-condition class="field" if-defined="language">
+                      <span class="field-label"><atomic-text value="language"></atomic-text>:</span>
+                      <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
+                    </atomic-field-condition>
+
+                    <atomic-field-condition class="field" if-defined="filetype">
+                      <span class="field-label"><atomic-text value="fileType"></atomic-text>:</span>
+                      <atomic-result-text field="filetype"></atomic-result-text>
+                    </atomic-field-condition>
+
+                    <atomic-field-condition class="field" if-defined="sncost">
+                      <span class="field-label">Cost:</span>
+                      <atomic-result-number field="sncost">
+                        <atomic-format-currency currency="CAD"></atomic-format-currency>
+                      </atomic-result-number>
+                    </atomic-field-condition>
+
+                    <span class="field">
+                      <span class="field-label">Date:</span>
+                      <atomic-result-date format="ddd MMM D YYYY"></atomic-result-date>
+                    </span>
+                  </atomic-result-fields-list>
+                </atomic-result-section-bottom-metadata>
+              </template>
+            </atomic-result-template>
+          </atomic-result-list>
+          <atomic-query-error></atomic-query-error>
+          <atomic-no-results></atomic-no-results>
+        </atomic-layout-section>
+        <atomic-layout-section section="pagination">
+          <atomic-pager></atomic-pager>
+        </atomic-layout-section>
+      </atomic-ipx-layout>
+    </atomic-search-interface>
+    <script src="../header.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/header.js
+++ b/packages/atomic/src/pages/header.js
@@ -18,6 +18,7 @@ const links = [
     href: '/accessibility/commerce-full.html',
     label: 'Accessible Commerce Full',
   },
+  {href: '/examples/ipx.html', label: 'IPX'},
 ];
 
 const header = document.createElement('header');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCINT-1915

Adds a new atomic-layout-component. The ipx is very basic for now, but more components will be added later. 

<img width="2904" alt="image" src="https://user-images.githubusercontent.com/64476861/199964527-194387f5-8c37-402b-ab7d-3e1020f8eddf.png">
