### PR TITLE
feat(headless): added insight query suggest support

### DIFF
--- a/packages/headless/src/api/service/insight/insight-api-client.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.ts
@@ -4,6 +4,7 @@ import {ClientThunkExtraArguments} from '../../../app/thunk-extra-arguments';
 import {InsightAppState} from '../../../state/insight-app-state';
 import {PlatformClient} from '../../platform-client';
 import {PreprocessRequest} from '../../preprocess-request';
+import {QuerySuggestSuccessResponse} from '../../search/query-suggest/query-suggest-response';
 import {buildAPIResponseFromErrorOrThrow} from '../../search/search-api-error-response';
 import {SearchResponseSuccess} from '../../search/search/search-response';
 import {
@@ -11,8 +12,10 @@ import {
   GetInsightInterfaceConfigRequest,
 } from './get-interface/get-interface-config-request';
 import {GetInsightInterfaceConfigResponse} from './get-interface/get-interface-config-response';
+import {InsightQuerySuggestRequest} from './query-suggest/query-suggest-request';
 import {
   buildInsightQueryRequest,
+  buildInsightQuerySuggestRequest,
   InsightQueryRequest,
 } from './query/query-request';
 import {
@@ -92,6 +95,25 @@ export class InsightAPIClient {
     const body = await response.json();
     return response.ok
       ? {success: body as SearchResponseSuccess}
+      : {error: body as InsightAPIErrorStatusResponse};
+  }
+
+  async querySuggest(
+    req: InsightQuerySuggestRequest
+  ): Promise<InsightAPIResponse<QuerySuggestSuccessResponse>> {
+    const response = await PlatformClient.call({
+      ...buildInsightQuerySuggestRequest(req),
+      ...this.options,
+    });
+
+    if (response instanceof Error) {
+      return buildAPIResponseFromErrorOrThrow(response);
+    }
+
+    const body = await response.json();
+
+    return body.completions
+      ? {success: body}
       : {error: body as InsightAPIErrorStatusResponse};
   }
 

--- a/packages/headless/src/api/service/insight/query-suggest/query-suggest-request.ts
+++ b/packages/headless/src/api/service/insight/query-suggest/query-suggest-request.ts
@@ -1,0 +1,25 @@
+import {
+  ContextParam,
+  LocaleParam,
+  VisitorIDParam,
+} from '../../../platform-service-params';
+import {
+  ActionsHistoryParam,
+  AnalyticsParam,
+  AuthenticationParam,
+  QueryParam,
+  TimezoneParam,
+} from '../../../search/search-api-params';
+import {InsightParam} from '../insight-params';
+
+export type InsightQuerySuggestRequest = InsightParam &
+  QueryParam &
+  ContextParam &
+  LocaleParam &
+  TimezoneParam &
+  ActionsHistoryParam &
+  VisitorIDParam &
+  AuthenticationParam &
+  AnalyticsParam & {
+    count: number;
+  };

--- a/packages/headless/src/api/service/insight/query/query-request.ts
+++ b/packages/headless/src/api/service/insight/query/query-request.ts
@@ -13,6 +13,7 @@ import {
   InsightParam,
   pickNonInsightParams,
 } from '../insight-params';
+import {InsightQuerySuggestRequest} from '../query-suggest/query-suggest-request';
 
 export type InsightQueryRequest = InsightParam &
   CaseContextParam &
@@ -32,6 +33,15 @@ interface CaseContextParam {
 export const buildInsightQueryRequest = (req: InsightQueryRequest) => {
   return {
     ...baseInsightRequest(req, 'POST', 'application/json', '/search'),
+    requestParams: pickNonInsightParams(req),
+  };
+};
+
+export const buildInsightQuerySuggestRequest = (
+  req: InsightQuerySuggestRequest
+) => {
+  return {
+    ...baseInsightRequest(req, 'POST', 'application/json', '/querysuggest'),
     requestParams: pickNonInsightParams(req),
   };
 };

--- a/packages/headless/src/features/insight-search/insight-query-set-actions-loader.ts
+++ b/packages/headless/src/features/insight-search/insight-query-set-actions-loader.ts
@@ -1,0 +1,56 @@
+import {PayloadAction} from '@reduxjs/toolkit';
+import {querySet} from '../../app/reducers';
+import {InsightEngine} from '../../app/insight-engine/insight-engine';
+import {
+  registerQuerySetQuery,
+  RegisterQuerySetQueryActionCreatorPayload,
+  updateQuerySetQuery,
+  UpdateQuerySetQueryActionCreatorPayload,
+} from '../query-set/query-set-actions';
+
+export type {
+  RegisterQuerySetQueryActionCreatorPayload,
+  UpdateQuerySetQueryActionCreatorPayload,
+};
+
+/**
+ * The query set action creators.
+ */
+export interface QuerySetActionCreators {
+  /**
+   * Registers a query in the query set.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  registerQuerySetQuery(
+    payload: RegisterQuerySetQueryActionCreatorPayload
+  ): PayloadAction<RegisterQuerySetQueryActionCreatorPayload>;
+
+  /**
+   * Updates a query in the query set.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  updateQuerySetQuery(
+    payload: UpdateQuerySetQueryActionCreatorPayload
+  ): PayloadAction<UpdateQuerySetQueryActionCreatorPayload>;
+}
+
+/**
+ * Loads the `querySet` reducer and returns possible action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadQuerySetActions(
+  engine: InsightEngine
+): QuerySetActionCreators {
+  engine.addReducers({querySet});
+
+  return {
+    registerQuerySetQuery,
+    updateQuerySetQuery,
+  };
+}

--- a/packages/headless/src/features/insight-search/insight-query-suggest-request.ts
+++ b/packages/headless/src/features/insight-search/insight-query-suggest-request.ts
@@ -1,0 +1,38 @@
+import {historyStore, getVisitorID} from '../../api/analytics/search-analytics';
+import {InsightQuerySuggestRequest} from '../../api/service/insight/query-suggest/query-suggest-request';
+import {InsightAppState} from '../../state/insight-app-state';
+import {
+  ConfigurationSection,
+  InsightConfigurationSection,
+} from '../../state/state-sections';
+import {fromAnalyticsStateToAnalyticsParams} from '../configuration/analytics-params';
+
+type StateNeededByQuerySuggest = ConfigurationSection &
+  InsightConfigurationSection &
+  Partial<InsightAppState>;
+
+export const buildInsightQuerySuggestRequest = async (
+  id: string,
+  s: StateNeededByQuerySuggest
+): Promise<InsightQuerySuggestRequest> => {
+  return {
+    accessToken: s.configuration.accessToken,
+    organizationId: s.configuration.organizationId,
+    url: s.configuration.platformUrl,
+    count: s.querySuggest![id]!.count,
+    insightId: s.insightConfiguration.insightId,
+    q: s.query?.q,
+    timezone: s.configuration.search.timezone,
+    actionsHistory: s.configuration.analytics.enabled
+      ? historyStore.getHistory()
+      : [],
+    ...(s.insightCaseContext?.caseContext && {
+      context: s.insightCaseContext.caseContext,
+    }),
+    ...(s.configuration.analytics.enabled && {
+      visitorId: await getVisitorID(s.configuration.analytics),
+      ...(s.configuration.analytics.enabled &&
+        (await fromAnalyticsStateToAnalyticsParams(s.configuration.analytics))),
+    }),
+  };
+};

--- a/packages/headless/src/features/insight-search/insight-query-suggest-request.ts
+++ b/packages/headless/src/features/insight-search/insight-query-suggest-request.ts
@@ -21,7 +21,7 @@ export const buildInsightQuerySuggestRequest = async (
     url: s.configuration.platformUrl,
     count: s.querySuggest![id]!.count,
     insightId: s.insightConfiguration.insightId,
-    q: s.query?.q,
+    q: s.querySet?.[id],
     timezone: s.configuration.search.timezone,
     actionsHistory: s.configuration.analytics.enabled
       ? historyStore.getHistory()

--- a/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
@@ -18,6 +18,8 @@ import {
   StateNeededByQuerySuggest,
 } from './insight-search-actions';
 
+export type {FetchQuerySuggestionsActionCreatorPayload};
+
 export interface InsightSearchActionCreators {
   /**
    * Creates an action that executes a search query.

--- a/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
@@ -3,13 +3,19 @@ import {AsyncThunkInsightOptions} from '../../api/service/insight/insight-api-cl
 import {search} from '../../app/reducers';
 import {InsightEngine} from '../../insight.index';
 import {InsightAction} from '../analytics/analytics-utils';
+import {
+  FetchQuerySuggestionsActionCreatorPayload,
+  FetchQuerySuggestionsThunkReturn,
+} from '../query-suggest/query-suggest-actions';
 import {ExecuteSearchThunkReturn} from '../search/search-actions';
 import {
   executeSearch,
   fetchFacetValues,
   fetchMoreResults,
   fetchPage,
+  fetchQuerySuggestions,
   StateNeededByExecuteSearch,
+  StateNeededByQuerySuggest,
 } from './insight-search-actions';
 
 export interface InsightSearchActionCreators {
@@ -73,6 +79,20 @@ export interface InsightSearchActionCreators {
     InsightAction,
     AsyncThunkInsightOptions<StateNeededByExecuteSearch>
   >;
+
+  /**
+   * Fetches a list of query suggestions for a specific query suggest entity according to the current headless state.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  fetchQuerySuggestions(
+    payload: FetchQuerySuggestionsActionCreatorPayload
+  ): AsyncThunkAction<
+    FetchQuerySuggestionsThunkReturn,
+    FetchQuerySuggestionsActionCreatorPayload,
+    AsyncThunkInsightOptions<StateNeededByQuerySuggest>
+  >;
 }
 
 /**
@@ -91,5 +111,6 @@ export function loadInsightSearchActions(
     fetchFacetValues,
     fetchMoreResults,
     fetchPage,
+    fetchQuerySuggestions,
   };
 }

--- a/packages/headless/src/features/insight-search/insight-search-request.ts
+++ b/packages/headless/src/features/insight-search/insight-search-request.ts
@@ -12,6 +12,7 @@ import {MappedSearchRequest, mapSearchRequest} from '../search/search-mappings';
 type StateNeededBySearchRequest = ConfigurationSection &
   InsightConfigurationSection &
   Partial<InsightAppState>;
+
 export const buildInsightSearchRequest = (
   state: StateNeededBySearchRequest
 ): MappedSearchRequest<InsightQueryRequest> => {

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -22,6 +22,7 @@ export type {LogLevel} from './app/logger';
 // Action loaders
 export * from './features/insight-interface/insight-interface-actions-loader';
 export * from './features/insight-search/insight-search-actions-loader';
+export * from './features/insight-search/insight-query-set-actions-loader';
 export * from './features/analytics/insight-analytics-actions-loader';
 export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';


### PR DESCRIPTION
Added support for query suggestions in the `insight` use case. The client targets the querySuggest proxy on the customer-service-api.
Prior to this change the query suggestion fetch was no-op.