### PR TITLE
fix(quantic): padding of the QuanticSort component fixed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.css
@@ -7,6 +7,5 @@
 .sort__header {
     color: var(--lwc-colorTextActionLabel, darkslategray);
     padding-top: 6px;
-    padding-right: 4px;
     white-space: nowrap;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.html
@@ -1,7 +1,7 @@
 <template>
   <template if:true={hasResults}>
     <div class="sort__container">
-      <lightning-layout-item class="sort__header" padding="horizontal-small">
+      <lightning-layout-item class="sort__header slds-var-p-right_small">
         <lightning-formatted-text value={labels.sortBy}></lightning-formatted-text>
       </lightning-layout-item>
       <lightning-layout-item>


### PR DESCRIPTION
[SFINT-4537](https://coveord.atlassian.net/browse/SFINT-4537)

- #### padding of the QuanticSort component fixed

#### Before:
![image-20220525-203544](https://user-images.githubusercontent.com/86681870/200028176-7f88d372-daad-4053-9821-17278d2e3ca8.png)


#### After:
<img width="420" alt="sort" src="https://user-images.githubusercontent.com/86681870/200028067-b57782e9-9e7c-4afc-b230-7e8540398bc0.png">
<img width="420" alt="Sort2" src="https://user-images.githubusercontent.com/86681870/200028072-ec7baa85-8fd4-4409-980b-ce158d084c92.png">
