### PR TITLE
fix(headless): modify delimiting character for facet in url manager

### DIFF
--- a/packages/atomic/cypress/e2e/breadbox.cypress.ts
+++ b/packages/atomic/cypress/e2e/breadbox.cypress.ts
@@ -188,7 +188,7 @@ describe('Breadbox Test Suites', () => {
       new TestFixture()
         .with(addBreadbox())
         .with(addFacet({field, label}))
-        .withHash(`f[${field}]=${activeValues.join(',')}`)
+        .withHash(`f-${field}=${activeValues.join(',')}`)
         .init();
       BreadboxSelectors.breadcrumbButton().then((buttons) =>
         cy.wrap(buttons.filter(':visible').length).as('numberOfVisibleButtons')

--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet-assertions.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet-assertions.ts
@@ -38,7 +38,7 @@ export function assertNumberOfParentValues(value: number) {
 export function assertPathInUrl(path: string[]) {
   const categoryFacetListInUrl = path.join(',');
   it(`should display the selected path "${categoryFacetListInUrl}" in the url`, () => {
-    const urlHash = `#cf[${hierarchicalField}]=${encodeURI(
+    const urlHash = `#cf-${hierarchicalField}=${encodeURI(
       categoryFacetListInUrl
     )}`;
     cy.url().should('include', urlHash);

--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
@@ -480,7 +480,7 @@ describe('Category Facet Test Suites', () => {
     before(() => {
       new TestFixture()
         .with(addCategoryFacet({}, true))
-        .withHash('cf[geographicalhierarchy]=Africa,Togo')
+        .withHash('cf-geographicalhierarchy=Africa,Togo')
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
@@ -441,7 +441,7 @@ describe('Color Facet Test Suites', () => {
     before(() => {
       new TestFixture()
         .with(addColorFacet({field: colorFacetField, label: colorFacetLabel}))
-        .withHash(`f[${colorFacetField}]=YouTubeVideo`)
+        .withHash(`f-${colorFacetField}=YouTubeVideo`)
         .init();
     });
 
@@ -497,7 +497,7 @@ describe('Color Facet Test Suites', () => {
         new TestFixture()
           .with(addColorFacet({field: colorFacetField, label: colorFacetLabel}))
           .withStyle(colorFacetStyle)
-          .withHash(`f[${colorFacetField}]=YouTubeVideo`)
+          .withHash(`f-${colorFacetField}=YouTubeVideo`)
           .init();
       }
       before(generateCustomCSS);

--- a/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
@@ -83,10 +83,10 @@ describe('Facet DependsOn Test Suites', () => {
     ) => {
       const values: string[] = [];
       if (selectLevel0) {
-        values.push(`f[${level0FacetId}]=${level0FacetExpectedValue}`);
+        values.push(`f-${level0FacetId}=${level0FacetExpectedValue}`);
       }
       if (selectLevel1) {
-        values.push(`f[${level1FacetIdA}]=${level1FacetAPossibleValue}`);
+        values.push(`f-${level1FacetIdA}=${level1FacetAPossibleValue}`);
       }
       return values.join('&');
     };

--- a/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
@@ -900,7 +900,7 @@ describe('Facet v1 Test Suites', () => {
     before(() => {
       new TestFixture()
         .with(addFacet({field, label}))
-        .withHash(`f[${field}]=Cervantes`)
+        .withHash(`f-${field}=Cervantes`)
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet-assertions.ts
+++ b/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet-assertions.ts
@@ -102,7 +102,7 @@ export function assertValueSortedByDescending() {
 
 export function assertURLHash(field: string, value: string) {
   it('should display range value on UrlHash', () => {
-    const urlHash = `#nf[${field.toLowerCase()}]=${encodeURI(value)}`;
+    const urlHash = `#nf-${field.toLowerCase()}=${encodeURI(value)}`;
     cy.url().should('include', urlHash);
   });
 }

--- a/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet.cypress.ts
@@ -561,7 +561,7 @@ describe('Numeric Facet V1 Test Suites', () => {
       });
 
       describe('verify visibility of range input', () => {
-        const activeInput = `nf[${numericFacetField}_input]=0..1000`;
+        const activeInput = `nf-${numericFacetField}_input=0..1000`;
 
         const visibilitySetup = () =>
           new TestFixture().with(
@@ -629,7 +629,7 @@ describe('Numeric Facet V1 Test Suites', () => {
               'with-input': 'integer',
             })
           )
-          .withHash(`nf[${numericFacetField}_input]=${min}..${max}`)
+          .withHash(`nf-${numericFacetField}_input=${min}..${max}`)
           .init();
       }
 
@@ -767,7 +767,7 @@ describe('Numeric Facet V1 Test Suites', () => {
         .with(
           addNumericFacet({field: numericFacetField, label: numericFacetLabel})
         )
-        .withHash(`nf[${numericFacetField}]=0..100000`)
+        .withHash(`nf-${numericFacetField}=0..100000`)
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet.cypress.ts
@@ -366,7 +366,7 @@ describe('Rating Facet Test Suites', () => {
             'display-values-as': 'link',
           })
         )
-        .withHash(`nf[${ratingFacetField}]=4..5`)
+        .withHash(`nf-${ratingFacetField}=4..5`)
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet.cypress.ts
@@ -311,7 +311,7 @@ describe('Rating Range Test Suites', () => {
             label: ratingRangeFacetLabel,
           })
         )
-        .withHash(`nf[${ratingRangeFacetField}]=4..5`)
+        .withHash(`nf-${ratingRangeFacetField}=4..5`)
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
@@ -134,7 +134,7 @@ describe('Segmented Facet Test Suites', () => {
     before(() => {
       new TestFixture()
         .with(addSegmentedFacet({field, label}))
-        .withHash(`f[${field}]=Cervantes`)
+        .withHash(`f-${field}=Cervantes`)
         .init();
     });
 

--- a/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet-assertions.ts
+++ b/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet-assertions.ts
@@ -52,7 +52,7 @@ export function assertRangeHash(
 
   it(`should set the date range in the hash to ${expectedRange}`, () => {
     cy.window().should((win) =>
-      expect(getHash(win)).to.have.property('df[date_input]', expectedRange)
+      expect(getHash(win)).to.have.property('df-date_input', expectedRange)
     );
   });
 }

--- a/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -201,7 +201,7 @@ describe('Timeframe Facet V1 Test Suites', () => {
           new TestFixture()
             .with(addTimeFrameWithInputRange())
             .withHash(
-              `df[date_input]=${startDate.replaceAll(
+              `df-date_input=${startDate.replaceAll(
                 '-',
                 '/'
               )}@00:00:00..${endDate.replaceAll('-', '/')}@00:00:00`
@@ -496,7 +496,7 @@ describe('Timeframe Facet V1 Test Suites', () => {
             unitFrames
           )
         )
-        .withHash(`df[${timeframeFacetField}]=past-1-month..now`)
+        .withHash(`df-${timeframeFacetField}=past-1-month..now`)
         .init();
     });
 

--- a/packages/headless/src/controllers/url-manager/headless-url-manager.test.ts
+++ b/packages/headless/src/controllers/url-manager/headless-url-manager.test.ts
@@ -56,7 +56,7 @@ describe('url manager', () => {
   });
 
   it('initial #restoreSearchParameters should parse the "active" fragment', () => {
-    initUrlManager('q=windmill&f[author]=Cervantes');
+    initUrlManager('q=windmill&f-author=Cervantes');
     testLatestRestoreSearchParameters({
       q: 'windmill',
       f: {author: ['Cervantes']},

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.test.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.test.ts
@@ -48,16 +48,14 @@ describe('buildSearchParameterSerializer', () => {
     it('serializes the #f parameter correctly', () => {
       const f = {author: ['a', 'b'], filetype: ['c', 'd']};
       const result = serialize({f});
-      expect(result).toEqual('f[author]=a,b&f[filetype]=c,d');
+      expect(result).toEqual('f-author=a,b&f-filetype=c,d');
     });
 
     it('serializes special characters in the #f parameter correctly', () => {
       someSpecialCharactersThatNeedsEncoding.forEach((specialChar) => {
         const f = {author: ['a', specialChar]};
         const result = serialize({f});
-        expect(result).toEqual(
-          `f[author]=a,${encodeURIComponent(specialChar)}`
-        );
+        expect(result).toEqual(`f-author=a,${encodeURIComponent(specialChar)}`);
       });
     });
 
@@ -77,7 +75,7 @@ describe('buildSearchParameterSerializer', () => {
       };
 
       const result = serialize({nf});
-      expect(result).toEqual('nf[size]=0..10,10..20&nf[amount]=100..200');
+      expect(result).toEqual('nf-size=0..10,10..20&nf-amount=100..200');
     });
 
     describe('when the #nf parameter contains facetIds with invalid values', () => {
@@ -116,7 +114,7 @@ describe('buildSearchParameterSerializer', () => {
       const range2 = `${date2}..${date3}`;
 
       expect(result).toEqual(
-        `df[date]=${range1},${range2}&df[created]=${range1}`
+        `df-date=${range1},${range2}&df-created=${range1}`
       );
     });
 
@@ -191,7 +189,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes two static filters correctly', () => {
-      const result = deserialize('sf[author]=a,b&sf[filetype]=c,d');
+      const result = deserialize('sf-author=a,b&sf-filetype=c,d');
       expect(result).toEqual({
         sf: {
           author: ['a', 'b'],
@@ -201,7 +199,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes two facets correctly', () => {
-      const result = deserialize('f[author]=a,b&f[filetype]=c,d');
+      const result = deserialize('f-author=a,b&f-filetype=c,d');
       expect(result).toEqual({
         f: {
           author: ['a', 'b'],
@@ -213,7 +211,7 @@ describe('buildSearchParameterSerializer', () => {
     it('deserializes two facets correctly with special characters', () => {
       someSpecialCharactersThatNeedsEncoding.forEach((char) => {
         const result = deserialize(
-          `f[author]=${encodeURIComponent(char)},b&f[filetype]=c,d`
+          `f-author=${encodeURIComponent(char)},b&f-filetype=c,d`
         );
         expect(result).toEqual({
           f: {
@@ -225,7 +223,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes two category facets correctly', () => {
-      const result = deserialize('cf[author]=a,b&cf[filetype]=c,d');
+      const result = deserialize('cf-author=a,b&cf-filetype=c,d');
       expect(result).toEqual({
         cf: {
           author: ['a', 'b'],
@@ -237,7 +235,7 @@ describe('buildSearchParameterSerializer', () => {
     it('deserializes two category facets correctly with special characters', () => {
       someSpecialCharactersThatNeedsEncoding.forEach((char) => {
         const result = deserialize(
-          `cf[author]=${encodeURIComponent(char)},b&cf[filetype]=c,d`
+          `cf-author=${encodeURIComponent(char)},b&cf-filetype=c,d`
         );
         expect(result).toEqual({
           cf: {
@@ -249,7 +247,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes a numeric facet with multiple selections', () => {
-      const result = deserialize('nf[size]=0..10,10..20');
+      const result = deserialize('nf-size=0..10,10..20');
       expect(result).toEqual({
         nf: {
           size: [
@@ -261,7 +259,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes multiple numeric facets with selected values', () => {
-      const result = deserialize('nf[size]=0..10&nf[amount]=100..200');
+      const result = deserialize('nf-size=0..10&nf-amount=100..200');
       expect(result).toEqual({
         nf: {
           size: [buildNumericRange({start: 0, end: 10, state: 'selected'})],
@@ -273,7 +271,7 @@ describe('buildSearchParameterSerializer', () => {
     });
 
     it('deserializes a numeric facet with a float range', () => {
-      const result = deserialize('nf[size]=7.5..8.5,8.5..9.5');
+      const result = deserialize('nf-size=7.5..8.5,8.5..9.5');
       expect(result).toEqual({
         nf: {
           size: [
@@ -286,7 +284,7 @@ describe('buildSearchParameterSerializer', () => {
 
     it(`when a numeric facet range contains a non-numeric value,
     the deserializer sets the values for the facetId to an empty array`, () => {
-      const result = deserialize('nf[size]=0..a');
+      const result = deserialize('nf-size=0..a');
       expect(result).toEqual({
         nf: {size: []},
       });
@@ -294,7 +292,7 @@ describe('buildSearchParameterSerializer', () => {
 
     it(`when a numeric facet range contains one number,
     the deserializer sets the values for the facetId to an empty array`, () => {
-      const result = deserialize('nf[size]=0');
+      const result = deserialize('nf-size=0');
       expect(result).toEqual({
         nf: {size: []},
       });
@@ -312,7 +310,7 @@ describe('buildSearchParameterSerializer', () => {
       const rangeA = `${date1}..${date2}`;
       const rangeB = `${date2}..${date3}`;
 
-      const result = deserialize(`df[date]=${rangeA},${rangeB}`);
+      const result = deserialize(`df-date=${rangeA},${rangeB}`);
 
       expect(result).toEqual({
         df: {
@@ -337,7 +335,7 @@ describe('buildSearchParameterSerializer', () => {
       const date2 = '2011/01/01@05:00:00';
       const range = `${date1}..${date2}`;
 
-      const result = deserialize(`df[date]=${range}&df[created]=${range}`);
+      const result = deserialize(`df-date=${range}&df-created=${range}`);
       const expected = buildDateRange({
         start: date1,
         end: date2,
@@ -354,7 +352,7 @@ describe('buildSearchParameterSerializer', () => {
 
     it(`when a date facet range contains a invalid format,
     the deserializer sets the values for the facetId to an empty array`, () => {
-      const result = deserialize('df[date]=2010/01/01@05:00:00..a');
+      const result = deserialize('df-date=2010/01/01@05:00:00..a');
       expect(result).toEqual({
         df: {date: []},
       });
@@ -362,7 +360,7 @@ describe('buildSearchParameterSerializer', () => {
 
     it(`when a numeric facet range contains one number,
     the deserializer sets the values for the facetId to an empty array`, () => {
-      const result = deserialize('df[date]=2010/01/01@05:00:00');
+      const result = deserialize('df-date=2010/01/01@05:00:00');
       expect(result).toEqual({
         df: {date: []},
       });

--- a/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-serializer.ts
@@ -92,7 +92,7 @@ function serializeFacets(key: string, facets: Record<string, string[]>) {
   return Object.entries(facets)
     .map(
       ([facetId, values]) =>
-        `${key}[${facetId}]${equal}${values
+        `${key}-${facetId}${equal}${values
           .map((value) => encodeURIComponent(value))
           .join(',')}`
     )
@@ -108,7 +108,7 @@ function serializeRangeFacets(
       const value = ranges
         .map(({start, end}) => `${start}${rangeDelimiter}${end}`)
         .join(',');
-      return `${key}[${facetId}]${equal}${value}`;
+      return `${key}-${facetId}${equal}${value}`;
     })
     .join(delimiter);
 }
@@ -142,7 +142,7 @@ function splitOnFirstEqual(str: string) {
 
 function preprocessObjectPairs(pair: string[]) {
   const [key, val] = pair;
-  const objectKey = /^(f|cf|nf|df|sf)\[(.+)\]$/;
+  const objectKey = /^(f|cf|nf|df|sf)-(.+)$/;
   const result = objectKey.exec(key);
 
   if (!result) {

--- a/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet-expectations.ts
+++ b/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet-expectations.ts
@@ -60,7 +60,7 @@ const categoryFacetExpectations = (selector: AllFacetSelectors) => {
     },
     urlHashContains: (path: string[]) => {
       const categoryFacetListInUrl = path.join(',');
-      const urlHash = `#cf[${hierarchicalField}]=${encodeURI(
+      const urlHash = `#cf-${hierarchicalField}=${encodeURI(
         categoryFacetListInUrl
       )}`;
       cy.url()

--- a/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet.cypress.ts
@@ -262,7 +262,7 @@ describe('quantic-category-facet', () => {
                   label: defaultLabel,
                   numberOfValues: defaultNumberOfValues,
                 },
-                `cf[geographicalhierarchy]=${path}`
+                `cf-geographicalhierarchy=${path}`
               );
 
               Expect.logFacetLoad();

--- a/packages/quantic/cypress/e2e/facets-1/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-1/facet/facet.cypress.ts
@@ -849,7 +849,7 @@ describe('Facet Test Suite', () => {
               {
                 field: defaultField,
               },
-              `f[objecttype]=${selectedValue}`
+              `f-objecttype=${selectedValue}`
             );
           }
 

--- a/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager.cypress.ts
@@ -214,7 +214,7 @@ describe('quantic-breadcrumb-manager', () => {
           it('should work as expected', () => {
             scope('with one filter', () => {
               const path = 'Africa,Togo';
-              const url = `cf[${categoryField}]=${path}`;
+              const url = `cf-${categoryField}=${path}`;
 
               loadFromUrlHash(url);
               Expect.displayBreadcrumbManager(true);
@@ -235,7 +235,7 @@ describe('quantic-breadcrumb-manager', () => {
               const path = 'North America,Canada';
               const timeframeRange = 'past-6-month..now';
               const fileType = 'txt';
-              const url = `cf[${categoryField}]=${path}&f[${facetField}]=${fileType}&df[${dateField}]=${timeframeRange}`;
+              const url = `cf-${categoryField}=${path}&f-${facetField}=${fileType}&df-${dateField}=${timeframeRange}`;
 
               loadFromUrlHash(url);
               Expect.facetBreadcrumb.displayBreadcrumb(true);

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-expectations.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-expectations.ts
@@ -90,7 +90,7 @@ const numericFacetExpectations = (selector: AllFacetSelectors) => {
     },
     urlHashContains: (value: string, fromInput = false) => {
       const input = fromInput ? '_input' : '';
-      const urlHash = `#nf[${field.toLowerCase()}${input}]=${encodeURI(value)}`;
+      const urlHash = `#nf-${field.toLowerCase()}${input}=${encodeURI(value)}`;
       cy.url()
         .should('include', urlHash)
         .logDetail(`the URL hash should contain the range "${value}"`);

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet.cypress.ts
@@ -310,7 +310,7 @@ describe('quantic-numeric-facet', () => {
                   field: defaultField,
                   useCase: param.useCase,
                 },
-                `nf[${field}]=${min}..${max}`
+                `nf-${field}=${min}..${max}`
               );
               Expect.numberOfSelectedCheckboxValues(1);
               Expect.numberOfIdleCheckboxValues(defaultNumberOfValues - 1);
@@ -321,7 +321,7 @@ describe('quantic-numeric-facet', () => {
             scope('with input', () => {
               loadFromUrlHash(
                 {...customWithInputSettings, useCase: param.useCase},
-                `nf[${field}_input]=${min}..${max}`
+                `nf-${field}_input=${min}..${max}`
               );
 
               Expect.displayFacet(true);

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-expectations.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-expectations.ts
@@ -76,7 +76,7 @@ function baseTimeframeFacetExpectations(selector: BaseFacetSelector) {
         .logDetail(`The clear filter button ${should(display)} be displayed.`),
 
     urlHashContains: (field: string, range: string) => {
-      const expectedHash = `#df[${field}]=${range}`;
+      const expectedHash = `#df-${field}=${range}`;
       cy.url()
         .should('include', expectedHash)
         .logDetail(`The URL hash should contain "${expectedHash}"`);

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
@@ -398,7 +398,7 @@ describe('quantic-timeframe-facet', () => {
                 {
                   field: 'Date',
                 },
-                'df[Date]=past-1-year..now'
+                'df-Date=past-1-year..now'
               );
 
               Expect.displayLabel(true);
@@ -417,7 +417,7 @@ describe('quantic-timeframe-facet', () => {
                   field: 'Date',
                   withDatePicker: true,
                 },
-                'df[Date_input]=' + validRange.filter
+                'df-Date_input=' + validRange.filter
               );
 
               Expect.displayLabel(true);
@@ -535,7 +535,7 @@ describe('quantic-timeframe-facet', () => {
               {
                 withDatePicker: true,
               },
-              `df[Date_input]=${validRange.filter}`
+              `df-Date_input=${validRange.filter}`
             );
 
             Expect.displayPlaceholder(false);
@@ -547,7 +547,7 @@ describe('quantic-timeframe-facet', () => {
           });
 
           it('should display facet if timeframe is specified', () => {
-            loadFromUrlHashWithNoResults({}, 'df[Date]=past-1-year..now');
+            loadFromUrlHashWithNoResults({}, 'df-Date=past-1-year..now');
 
             Expect.displayPlaceholder(false);
             Expect.displayLabel(true);


### PR DESCRIPTION
As discussed in Slack.

New format for facets in `search-parameter-manager` will be `f-facetid=facetvalue1,facetvalue2` as opposed to `f[facetid]=facetvalue1,facetvalue2` before.

https://coveord.atlassian.net/browse/KIT-2119

# Deprecations
## Headless
* The [UrlManager](https://docs.coveo.com/en/headless/latest/reference/search/controllers/url-manager/) now serializes facets with a dash instead of brackets.
  * For instance, `f[my-facet]=valueA,valueB` would become `f-my-facet=valueA,valueB`
  * This is because brackets are [reserved characters in RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), which get serialized by certain applications resulting in broken search page URLs.

## Atomic
* The hash in the URL representing the state of the search page now serializes facets with a dash instead of brackets.
  * For instance, `f[my-facet]=valueA,valueB` would become `f-my-facet=valueA,valueB`
  * This is because brackets are [reserved characters in RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), which get serialized by certain applications resulting in broken search page URLs.