### PR TITLE
feat(quantic): 

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-expectations.ts
@@ -75,6 +75,20 @@ function tabBarExpectations(selector: TabBarSelector) {
         .should(display ? 'exist' : 'not.exist')
         .logDetail(`${should(display)} display the more button icon`);
     },
+
+    displayWithLightTheme(lightThemeEnabled: boolean) {
+      selector
+        .tabBarContainer()
+        .should(
+          lightThemeEnabled ? 'not.have.class' : 'have.class',
+          'slds-theme_shade'
+        )
+        .logDetail(
+          `${should(
+            lightThemeEnabled
+          )} display the component with the light theme styles`
+        );
+    },
   };
 }
 

--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-selectors.ts
@@ -11,6 +11,7 @@ export interface TabBarSelector extends ComponentSelector {
   moreButtonIcon: () => CypressSelector;
   dropdown: () => CypressSelector;
   allDropdownOptions: () => CypressSelector;
+  tabBarContainer: () => CypressSelector;
 }
 
 export const TabBarSelectors: TabBarSelector = {
@@ -26,4 +27,5 @@ export const TabBarSelectors: TabBarSelector = {
   dropdown: () => TabBarSelectors.get().find('.slds-dropdown-trigger'),
   allDropdownOptions: () =>
     TabBarSelectors.dropdown().find('.slds-dropdown__item'),
+  tabBarContainer: () => TabBarSelectors.get().find('.tab-bar_container'),
 };

--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar.cypress.ts
@@ -10,6 +10,11 @@ import {
 } from '../../../page-objects/use-case';
 import {performSearch} from '../../../page-objects/actions/action-perform-search';
 
+interface TabBarOptions {
+  lightTheme: boolean;
+  useCase: string;
+}
+
 describe('quantic-tab-bar', () => {
   const pageUrl = 's/quantic-tab-bar';
   const extraSmallViewportWidth = 200;
@@ -21,16 +26,19 @@ describe('quantic-tab-bar', () => {
   const TAB_3 = 'Tab 3';
   const TAB_4 = 'Tab 4';
 
-  function visitPage(useCase: string, waitForSearch = true) {
+  function visitPage(
+    options: Partial<TabBarOptions> = {},
+    waitForSearch = true
+  ) {
     interceptSearch();
     cy.visit(pageUrl);
-    configure({useCase: useCase});
-    if (useCase === useCaseEnum.insight) {
+    configure(options);
+    if (options.useCase === useCaseEnum.insight) {
       InsightInterfaceExpect.isInitialized();
       performSearch();
     }
     if (waitForSearch) {
-      cy.wait(getAlias(useCase));
+      cy.wait(getAlias(options.useCase));
     }
   }
 
@@ -38,10 +46,11 @@ describe('quantic-tab-bar', () => {
     describe(param.label, () => {
       describe("when the container's width can fit all the tabs", () => {
         it('should display all the tabs without displaying the dropdown list', () => {
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when loading the page', () => {
             Expect.displayTabs(true);
+            Expect.displayWithLightTheme(false);
             Expect.displayedTabsEqual([TAB_1, TAB_2, TAB_3, TAB_4]);
             Expect.activeTabContains(TAB_1);
             Expect.displayMoreButton(false);
@@ -58,10 +67,11 @@ describe('quantic-tab-bar', () => {
       describe('when the viewport is resized to a medium width', () => {
         it('should display only the first two tabs, the other tabs should be displayed in the dropdown list', () => {
           cy.viewport(mediumViewportWidth, 900);
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when loading the page', () => {
             Expect.displayTabs(true);
+            Expect.displayWithLightTheme(false);
             Expect.displayedTabsEqual([TAB_1, TAB_2]);
             Expect.tabsInDropdownEqual([TAB_3, TAB_4]);
             Expect.activeTabContains(TAB_1);
@@ -91,10 +101,11 @@ describe('quantic-tab-bar', () => {
       describe('when the viewport is resized to a small width', () => {
         it('should display only the selected tab, the other tabs should be displayed in the dropdown list', () => {
           cy.viewport(smallViewportWidth, 900);
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when loading the page', () => {
             Expect.displayTabs(true);
+            Expect.displayWithLightTheme(false);
             Expect.displayedTabsEqual([TAB_1]);
             Expect.tabsInDropdownEqual([TAB_2, TAB_3, TAB_4]);
             Expect.activeTabContains(TAB_1);
@@ -119,10 +130,11 @@ describe('quantic-tab-bar', () => {
       describe('when the viewport is resized to an extra small width', () => {
         it('should display only the selected tab, the other tabs should be displayed in the dropdown list and the more button should be shrunk', () => {
           cy.viewport(extraSmallViewportWidth, 900);
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when loading the page', () => {
             Expect.displayTabs(true);
+            Expect.displayWithLightTheme(false);
             Expect.displayedTabsEqual([TAB_1]);
             Expect.tabsInDropdownEqual([TAB_2, TAB_3, TAB_4]);
             Expect.activeTabContains(TAB_1);
@@ -147,7 +159,7 @@ describe('quantic-tab-bar', () => {
       describe('when the dropdown loses focus', () => {
         it('should automatically close the dropdown list', () => {
           cy.viewport(mediumViewportWidth, 900);
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when opening the dropdown list', () => {
             Actions.openDropdown();
@@ -164,7 +176,7 @@ describe('quantic-tab-bar', () => {
       describe('when a tab containing the same expression as another tab is selected from the dropdown list', () => {
         it('should correctly select the tab', () => {
           cy.viewport(extraSmallViewportWidth, 900);
-          visitPage(param.useCase);
+          visitPage({useCase: param.useCase});
 
           scope('when loading the page', () => {
             Expect.displayedTabsEqual([TAB_1]);
@@ -178,6 +190,17 @@ describe('quantic-tab-bar', () => {
             Actions.selectTabFromDropdown(TAB_4);
             Expect.displayedTabsEqual([TAB_4]);
             Expect.tabsInDropdownEqual([TAB_1, TAB_2, TAB_3]);
+          });
+        });
+      });
+
+      describe('when the light theme property is set to true', () => {
+        it('should display the component with the light theme styles', () => {
+          visitPage({useCase: param.useCase, lightTheme: true});
+
+          scope('when loading the page', () => {
+            Expect.displayTabs(true);
+            Expect.displayWithLightTheme(true);
           });
         });
       });

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.html
@@ -5,7 +5,7 @@
     </c-configurator>
 
     <c-example-use-case slot="preview" use-case={config.useCase} engine-id={engineId}>
-      <c-quantic-tab-bar>
+      <c-quantic-tab-bar light-theme={config.lightTheme}>
         <c-quantic-tab label="Tab 1" engine-id={engineId} is-active></c-quantic-tab>
         <c-quantic-tab label="Tab 2" engine-id={engineId} expression="@sfkbid"></c-quantic-tab>
         <c-quantic-tab label="Tab 3" engine-id={engineId} expression="@jisourcetype"></c-quantic-tab>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.js
@@ -14,7 +14,7 @@ export default class ExampleQuanticTabBar extends LightningElement {
       attribute: 'lightTheme',
       label: 'Light Theme',
       description:
-        'Whether to apply the light theme styles on this component. .',
+        'Whether to apply the light theme styles on this component.',
       defaultValue: false,
     },
     {

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticTabBar/exampleQuanticTabBar.js
@@ -11,6 +11,13 @@ export default class ExampleQuanticTabBar extends LightningElement {
 
   options = [
     {
+      attribute: 'lightTheme',
+      label: 'Light Theme',
+      description:
+        'Whether to apply the light theme styles on this component. .',
+      defaultValue: false,
+    },
+    {
       attribute: 'useCase',
       label: 'Use Case',
       description:

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="tab-bar_container slds-theme_shade slds-size_1-of-1">
+  <div class={tabBarContainerClasses}>
     <div class="tab-bar_list-container slds-tabs_default slds-tabs_default__nav slds-is-relative">
       <slot></slot>
       <div

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -1,4 +1,4 @@
-import {LightningElement} from 'lwc';
+import {LightningElement, api} from 'lwc';
 
 import more from '@salesforce/label/c.quantic_More';
 
@@ -7,7 +7,7 @@ import more from '@salesforce/label/c.quantic_More';
  * @category Search
  * @category Insight Panel
  * @example
- * <c-quantic-tab-bar>
+ * <c-quantic-tab-bar light-theme>
  *   <c-quantic-tab engine-id={engineId} label="Tab 1" expression={expressionOne} is-active></c-quantic-tab>
  *   <c-quantic-tab engine-id={engineId} label="Tab 2" expression={expressionTwo}></c-quantic-tab>
  *   <c-quantic-tab engine-id={engineId} label="Tab 3" expression={expressionThree}></c-quantic-tab>
@@ -17,6 +17,13 @@ export default class QuanticTabBar extends LightningElement {
   labels = {
     more,
   };
+
+  /**
+   * Whether to apply the light theme styles on this component. 
+   * @api
+   * @type {boolean}
+   */
+  @api lightTheme = false;
 
   /** @type {boolean} */
   hasRendered = false;
@@ -293,6 +300,16 @@ export default class QuanticTabBar extends LightningElement {
       this.lastVisibleTab.getBoundingClientRect().right -
       this.tabBarListContainer.getBoundingClientRect().left
     );
+  }
+
+  /**
+   * Returns the CSS classes of the tab bar container.
+   * @returns {string}
+   */
+  get tabBarContainerClasses() {
+    return `tab-bar_container slds-size_1-of-1 ${
+      this.lightTheme ? '' : 'slds-theme_shade'
+    }`;
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -19,7 +19,7 @@ export default class QuanticTabBar extends LightningElement {
   };
 
   /**
-   * Whether to apply the light theme styles on this component. 
+   * Whether to apply the light theme styles on this component. This properety has an impact only in a SF console.
    * @api
    * @type {boolean}
    */


### PR DESCRIPTION
[SFINT-4687](https://coveord.atlassian.net/browse/SFINT-4687)

#### In this PR I've added a new property that will give us the possibility to have a white background in the `QuanticTabBar` component.

#### Why do we need a white background in the `QuanticTabBar` component?
Because currently in the InsightFull search, the Quantic Tab Bar component is only component with a grey background, it was pervasively discussed with our UX team that a white background would be better.

<img width="910" alt="InsightFullSearch" src="https://user-images.githubusercontent.com/86681870/201105467-fb3db0bc-10de-4a3e-9961-8b3a5fe7c0d3.png">


#### After this PR:
<img width="932" alt="InsightFulSearchAfter" src="https://user-images.githubusercontent.com/86681870/201105493-b7f8e659-4b81-44ea-b533-71c7c334bd74.png">

#### Note: This property has an impact only when the component is used in a Salesforce console. In a SF community for instance, the background of the QuanticTabBar is always white.
