### PR TITLE
ci: publish prerelease versions

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -190,7 +190,8 @@
     "no_endpoint": true
   },
   "package_rollout": {
-    "only_consider_changesets_after": "b244fe702d8e96d016a52715e92c8131acfde3ba"
+    "only_consider_changesets_after": "b244fe702d8e96d016a52715e92c8131acfde3ba",
+    "disabled": $[STOP_AT_DEV]
   },
   "deployment_config_version": 7
 }

--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 'prerelease/**'
 jobs:
   build:
     name: 'Build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,17 @@
+def parseSemanticVersion(String version) {
+  def semanticVersionRegex = /^(((([0-9]+)\.[0-9]+)\.[0-9]+)(?:\-.+)?)$/
+  def (_, prerelease, patch, minor, major) = (version =~ semanticVersionRegex)[0]
+  return [major, minor, patch, prerelease]
+}
+
 node('heavy && linux && docker') {
   checkout scm
   def tag = sh(script: "git tag --contains", returnStdout: true).trim()
   def isBump = !!tag
-  def isMaster = env.BRANCH_NAME == 'master'
+  def isOnReleaseBranch = env.BRANCH_NAME == 'master'
+  def isOnPrereleaseBranch = env.BRANCH_NAME.startsWith('prerelease/')
 
-  if (!isMaster) {
+  if (!isOnReleaseBranch && !isOnPrereleaseBranch) {
     return
   }
 
@@ -32,12 +39,14 @@ node('heavy && linux && docker') {
       sh 'git clean -f'
     }
 
-    withDockerContainer(image: 'node:16', args: '-u=root -e HOME=/tmp -e NPM_CONFIG_PREFIX=/tmp/.npm') {
-      stage('Npm publish') {
-        withCredentials([
-        string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {
-          sh "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc"
-          sh 'npm run npm:publish:alpha || true'
+    if (isOnReleaseBranch) {
+      withDockerContainer(image: 'node:16', args: '-u=root -e HOME=/tmp -e NPM_CONFIG_PREFIX=/tmp/.npm') {
+        stage('Npm publish') {
+          withCredentials([
+          string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {
+            sh "echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc"
+            sh 'npm run npm:publish:alpha || true'
+          }
         }
       }
     }
@@ -48,23 +57,22 @@ node('heavy && linux && docker') {
         headless = readJSON file: 'packages/headless/package.json'
         atomic = readJSON file: 'packages/atomic/package.json'
         atomicReact = readJSON file: 'packages/atomic-react/package.json'
-        semanticVersionRegex = /^([^\.]*)\.[^\.]*/
 
-        (headlessMinor, headlessMajor) = (headless.version =~ semanticVersionRegex)[0]
-        (atomicMinor, atomicMajor) = (atomic.version =~ semanticVersionRegex)[0]
-        (atomicReactMinor, atomicReactMajor) = (atomicReact.version =~ semanticVersionRegex)[0]
-
+        (headlessMajor, headlessMinor, headlessPatch) = parseSemanticVersion(headless.version)
+        (atomicMajor, atomicMinor, atomicPatch) = parseSemanticVersion(atomic.version)
+        (atomicReactMajor, atomicReactMinor, atomicReactPatch) = parseSemanticVersion(atomicReact)
         
         sh "deployment-package package create --with-deploy \
         --resolve HEADLESS_MAJOR_VERSION=${headlessMajor} \
         --resolve HEADLESS_MINOR_VERSION=${headlessMinor} \
-        --resolve HEADLESS_PATCH_VERSION=${headless.version} \
+        --resolve HEADLESS_PATCH_VERSION=${headlessPatch} \
         --resolve ATOMIC_MAJOR_VERSION=${atomicMajor} \
         --resolve ATOMIC_MINOR_VERSION=${atomicMinor} \
-        --resolve ATOMIC_PATCH_VERSION=${atomic.version} \
+        --resolve ATOMIC_PATCH_VERSION=${atomicPatch} \
         --resolve ATOMIC_REACT_MAJOR_VERSION=${atomicReactMajor} \
         --resolve ATOMIC_REACT_MINOR_VERSION=${atomicReactMinor} \
-        --resolve ATOMIC_REACT_PATCH_VERSION=${atomicReact.version} \
+        --resolve ATOMIC_REACT_PATCH_VERSION=${atomicReactPatch} \
+        --resolve STOP_AT_DEV=${!isOnReleaseBranch}
         || true"
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ node('heavy && linux && docker') {
         --resolve ATOMIC_REACT_MAJOR_VERSION=${atomicReactMajor} \
         --resolve ATOMIC_REACT_MINOR_VERSION=${atomicReactMinor} \
         --resolve ATOMIC_REACT_PATCH_VERSION=${atomicReactPatch} \
-        --resolve STOP_AT_DEV=${!isOnReleaseBranch}
+        --resolve STOP_AT_DEV=${!isOnReleaseBranch} \
         || true"
       }
     }

--- a/scripts/git.js
+++ b/scripts/git.js
@@ -1,0 +1,25 @@
+const {promisify} = require('util');
+const exec = promisify(require('child_process').exec);
+
+const releaseBranch = 'master';
+
+async function getBranchName() {
+  const {stdout} = await exec('git branch --show-current');
+  return stdout;
+}
+
+async function isOnReleaseBranch() {
+  return (await getBranchName()) === releaseBranch;
+}
+
+async function getHowManyCommitsBehind() {
+  const {stdout} = await exec('git rev-list --count HEAD..@{u}');
+  return parseInt(stdout);
+}
+
+async function getHeadCommitTag() {
+  const {stdout} = await exec('git tag --points-at HEAD');
+  return stdout;
+}
+
+module.exports = {isOnReleaseBranch, getHowManyCommitsBehind, getHeadCommitTag};

--- a/scripts/packages.js
+++ b/scripts/packages.js
@@ -5,13 +5,9 @@ const packageDirsNpmTag = [
   'headless',
   'atomic-react',
   'atomic-angular/projects/atomic-angular',
-  'quantic'
+  'quantic',
 ];
 
-const packageDirsSnyk = [
-  'headless',
-  'atomic',
-];
+const packageDirsSnyk = ['headless', 'atomic'];
 
-exports.packageDirsNpmTag = packageDirsNpmTag;
-exports.packageDirsSnyk = packageDirsSnyk;
+module.exports = {packageDirsNpmTag, packageDirsSnyk};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2114

In theory, this PR should cause the following to happen:
* Any commit on a branch titled `prerelease/**` should execute the same CI as the `master` branch
  * Commit bumps on this branch will instead bump packages with Lerna's default `-pre.#` suffix (see [conventional-prerelease](https://github.com/lerna/lerna/tree/main/commands/version#--conventional-prerelease)).
  * Jenkins will skip updating the `alpha` NPM tag for any commit that isn't on the `master` branch.
  * The deployment pipeline will disable `package_rollout` for any commit that isn't on the `master` branch, which will prevent it from ever reaching `stg` and `prd` (which are responsible for publishing to the staging CDN, publishing to the prod CDN, updating the NPM `beta` tag and updating the NPM `latest` tag).