### PR TITLE
fix(quantic): fixed tab dropdown visibility

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-expectations.ts
@@ -56,10 +56,13 @@ function tabBarExpectations(selector: TabBarSelector) {
 
     displayDropdown(display: boolean) {
       selector
-        .dropdown()
+        .dropdownTrigger()
         .should('exist')
-        .should(display ? 'have.class' : 'not.have.class', 'slds-is-open')
-        .logDetail(`${should(display)} display the dropdown list`);
+        .should(display ? 'have.class' : 'not.have.class', 'slds-is-open');
+      selector
+        .dropdown()
+        .should(display ? 'be.visible' : 'not.be.visible')
+        .logDetail(`${should(display)} display the dropdown`);
     },
 
     displayMoreButtonLabel(text: string) {

--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar-selectors.ts
@@ -9,6 +9,7 @@ export interface TabBarSelector extends ComponentSelector {
   moreButton: () => CypressSelector;
   moreButtonLabel: () => CypressSelector;
   moreButtonIcon: () => CypressSelector;
+  dropdownTrigger: () => CypressSelector;
   dropdown: () => CypressSelector;
   allDropdownOptions: () => CypressSelector;
   tabBarContainer: () => CypressSelector;
@@ -24,8 +25,9 @@ export const TabBarSelectors: TabBarSelector = {
   moreButtonLabel: () =>
     TabBarSelectors.moreButton().find('button').first().invoke('text'),
   moreButtonIcon: () => TabBarSelectors.moreButton().find('lightning-icon'),
-  dropdown: () => TabBarSelectors.get().find('.slds-dropdown-trigger'),
+  dropdownTrigger: () => TabBarSelectors.get().find('.slds-dropdown-trigger'),
+  dropdown: () => TabBarSelectors.get().find('.slds-dropdown'),
   allDropdownOptions: () =>
-    TabBarSelectors.dropdown().find('.slds-dropdown__item'),
+    TabBarSelectors.dropdownTrigger().find('.slds-dropdown__item'),
   tabBarContainer: () => TabBarSelectors.get().find('.tab-bar_container'),
 };

--- a/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticTab/quanticTab.css
@@ -2,4 +2,5 @@
     padding: 0;
     margin: 0 0px;
     padding:0 10px;
+    max-width: 150px;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.css
@@ -1,4 +1,7 @@
 .tab-bar_list-container {
   display: flex;
-  overflow: hidden;
+}
+
+.tab-bar_dropdown {
+  max-width: 150px;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
@@ -12,12 +12,12 @@
             {moreButtonLabel}
             <lightning-icon class={moreButtonIconClasses} icon-name={arrowIconName} size="xx-small" aria-hidden="true"> </lightning-icon>
           </button>
-          <div class="slds-dropdown slds-dropdown_right">
+          <div class="tab-bar_dropdown slds-dropdown slds-dropdown_right">
             <ul class="slds-dropdown__list slds-dropdown_length-with-icon-10" role="menu">
               <template for:each={tabsInDropdown} for:item="tab">
                 <li class="slds-dropdown__item" role="presentation" key={tab.id}>
                   <button
-                    class="slds-button slds-tabs_default__item"
+                    class="slds-size_1-of-1 slds-button slds-tabs_default__item"
                     role="menuitem"
                     tabindex={optionTabIndex}
                     onclick={handleDropdownTabSelect}


### PR DESCRIPTION
Overflow is now shown so we can see the dropdown.
Also added an arbitrary max width of 150px so long tab names get truncated.

<img width="445" alt="Screen Shot 2022-11-21 at 3 16 54 PM" src="https://user-images.githubusercontent.com/16785453/203151101-11656801-c7be-4f69-8629-52bd459dd603.png">
<img width="443" alt="Screen Shot 2022-11-21 at 3 17 11 PM" src="https://user-images.githubusercontent.com/16785453/203151098-a110fbc7-83bd-4015-a3d7-e48ea6046ee2.png">