### PR TITLE
ci: fix invalidate-cloudfront.mjs import

### DIFF
--- a/scripts/deploy/invalidate-cloudfront.mjs
+++ b/scripts/deploy/invalidate-cloudfront.mjs
@@ -1,8 +1,8 @@
-import {CloudFront} from 'aws-sdk';
+import awsSDK from 'aws-sdk';
 import {resolve} from 'path';
 import {getPackageFromPath, workspacesRoot} from '../packages.mjs';
 
-const cloudfront = new CloudFront();
+const cloudfront = new awsSDK.CloudFront();
 
 async function getMajorVersion(dir) {
   const {version} = getPackageFromPath(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2150

Should be the last fix necessary due to converting from CJS to ESM.
