### PR TITLE
fix(headless): disabled analytics when doNotTrack is on

### DIFF
--- a/packages/atomic/cypress/e2e/search-interface.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-interface.cypress.ts
@@ -1,4 +1,3 @@
-import {setupIntercept} from '../fixtures/fixture-common';
 import {TestFixture} from '../fixtures/test-fixture';
 import {assertConsoleErrorMessage} from './common-assertions';
 import {addQuerySummary} from './query-summary-actions';

--- a/packages/atomic/cypress/e2e/search-interface.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-interface.cypress.ts
@@ -1,3 +1,4 @@
+import {setupIntercept} from '../fixtures/fixture-common';
 import {TestFixture} from '../fixtures/test-fixture';
 import {assertConsoleErrorMessage} from './common-assertions';
 import {addQuerySummary} from './query-summary-actions';
@@ -109,38 +110,84 @@ describe('Search Interface Component', () => {
     });
   });
 
-  describe('without an automatic search', () => {
+  describe('without waiting for the automatic search', () => {
+    let fixture: TestFixture;
     beforeEach(() => {
-      new TestFixture()
-        .with(addQuerySummary())
-        .withLanguage('fr')
-        .withoutFirstIntercept()
-        .init();
+      fixture = new TestFixture().withoutFirstIntercept();
     });
 
-    it('should set locale for search request', (done) => {
-      cy.wait(TestFixture.interceptAliases.Search).then((intercept) => {
-        expect(intercept.request.body.locale).to.be.eq('fr');
-        done();
+    describe('with the language set to french and a query summary present', () => {
+      beforeEach(() => {
+        fixture.with(addQuerySummary()).withLanguage('fr').init();
+      });
+
+      it('should set locale for search request', (done) => {
+        cy.wait(TestFixture.interceptAliases.Search).then((intercept) => {
+          expect(intercept.request.body.locale).to.be.eq('fr');
+          done();
+        });
+      });
+
+      it('should set language for analytics request', (done) => {
+        cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
+          const analyticsBody = intercept.request.body;
+          expect(analyticsBody).to.have.property('language', 'fr');
+          done();
+        });
       });
     });
 
-    it('should set language for analytics request', (done) => {
-      cy.wait(TestFixture.interceptAliases.UA).then((intercept) => {
-        const analyticsBody = intercept.request.body;
-        expect(analyticsBody).to.have.property('language', 'fr');
-        done();
+    describe('by default (with analytics)', () => {
+      beforeEach(() => {
+        fixture.init();
+      });
+
+      it('should call the analytics server', () => {
+        cy.wait(TestFixture.interceptAliases.Search);
+        cy.shouldBeCalled(TestFixture.urlParts.UASearch, 1);
+      });
+
+      it('should include analytics in the search request', () => {
+        cy.wait(TestFixture.interceptAliases.Search).should((firstSearch) =>
+          expect(firstSearch.request.body)
+            .to.have.property('analytics')
+            .to.have.property('actionCause', 'interfaceLoad')
+        );
       });
     });
-  });
 
-  describe('without analytics', () => {
-    beforeEach(() => {
-      new TestFixture().withoutAnalytics().init();
+    describe('without analytics', () => {
+      beforeEach(() => {
+        fixture.withoutAnalytics().init();
+      });
+
+      it('should not call the analytics server', () => {
+        cy.wait(TestFixture.interceptAliases.Search);
+        cy.shouldBeCalled(TestFixture.urlParts.UASearch, 0);
+      });
+
+      it('should not include analytics in the search request', () => {
+        cy.wait(TestFixture.interceptAliases.Search).should((firstSearch) =>
+          expect(firstSearch.request.body).not.to.have.property('analytics')
+        );
+      });
     });
 
-    it('should not call the analytics server', () => {
-      cy.shouldBeCalled(TestFixture.urlParts.UASearch, 0);
+    describe('with doNotTrack', () => {
+      beforeEach(() => {
+        fixture.withDoNotTrack().init();
+      });
+
+      it('should not call the analytics server', () => {
+        cy.wait(TestFixture.interceptAliases.Search);
+        cy.shouldBeCalled(TestFixture.urlParts.UASearch, 0);
+      });
+
+      it('should not include analytics in the search request', () => {
+        cy.wait(TestFixture.interceptAliases.Search).should((firstSearch) =>
+          expect(firstSearch.request.body).not.to.have.property('analytics')
+        );
+      });
     });
   });
 });

--- a/packages/atomic/cypress/e2e/search-interface.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-interface.cypress.ts
@@ -143,7 +143,7 @@ describe('Search Interface Component', () => {
 
       it('should call the analytics server', () => {
         cy.wait(TestFixture.interceptAliases.Search);
-        cy.shouldBeCalled(TestFixture.urlParts.UASearch, 1);
+        cy.wait(TestFixture.interceptAliases.UA).should('exist');
       });
 
       it('should include analytics in the search request', () => {

--- a/packages/atomic/cypress/e2e/search-interface.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-interface.cypress.ts
@@ -147,10 +147,10 @@ describe('Search Interface Component', () => {
       });
 
       it('should include analytics in the search request', () => {
-        cy.wait(TestFixture.interceptAliases.Search).should((firstSearch) =>
-          expect(firstSearch.request.body)
-            .to.have.property('analytics')
-            .to.have.property('actionCause', 'interfaceLoad')
+        cy.wait(TestFixture.interceptAliases.Search).should(
+          (firstSearch) =>
+            expect(firstSearch.request.body).to.have.property('analytics')
+          // TODO: in v2, add: .to.have.property('actionCause', 'interfaceLoad')
         );
       });
     });

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -8,6 +8,7 @@ import {
   Middleware,
   Reducer,
 } from '@reduxjs/toolkit';
+import coveoAnalytics from 'coveo.analytics';
 import {Logger} from 'pino';
 import {
   disableAnalytics,
@@ -157,6 +158,9 @@ export function buildEngine<
 
   if (analytics) {
     const {analyticsClientMiddleware, ...rest} = analytics;
+    if (analytics.enabled && coveoAnalytics.donottrack.doNotTrack()) {
+      rest.enabled = false;
+    }
     engine.dispatch(updateAnalyticsConfiguration(rest));
   }
 

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -1,6 +1,7 @@
 import {ArrayValue, BooleanValue, Value} from '@coveo/bueno';
 import {createAction} from '@reduxjs/toolkit';
 import {IRuntimeEnvironment} from 'coveo.analytics';
+import {doNotTrack} from '../../utils/utils';
 import {
   nonEmptyString,
   validatePayload,
@@ -143,8 +144,11 @@ export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;
 
 export const updateAnalyticsConfiguration = createAction(
   'configuration/updateAnalyticsConfiguration',
-  (payload: UpdateAnalyticsConfigurationActionCreatorPayload) =>
-    validatePayload(payload, {
+  (payload: UpdateAnalyticsConfigurationActionCreatorPayload) => {
+    if (payload.enabled && doNotTrack()) {
+      payload.enabled = false;
+    }
+    return validatePayload(payload, {
       enabled: new BooleanValue({default: true}),
       originContext: originSchemaOnConfigUpdate(),
       originLevel2: originSchemaOnConfigUpdate(),
@@ -155,7 +159,8 @@ export const updateAnalyticsConfiguration = createAction(
       deviceId: nonEmptyString,
       userDisplayName: nonEmptyString,
       documentLocation: nonEmptyString,
-    })
+    });
+  }
 );
 
 export const disableAnalytics = createAction('configuration/analytics/disable');

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -50,14 +50,17 @@ const doNotTrackValues = new Set(['1', 1, 'yes', true]);
  * Logic copied from coveo.analytics.
  */
 export function doNotTrack() {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false;
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const nav = <any | undefined>navigator;
+  const nav = <any>navigator;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const win = <any | undefined>window;
+  const win = <any>window;
   return [
-    nav?.globalPrivacyControl,
-    nav?.doNotTrack,
-    nav?.msDoNotTrack,
-    win?.doNotTrack,
+    nav.globalPrivacyControl,
+    nav.doNotTrack,
+    nav.msDoNotTrack,
+    win.doNotTrack,
   ].some((value) => doNotTrackValues.has(value));
 }

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -43,3 +43,20 @@ export function omit<T>(key: keyof T, obj: T) {
 export function getObjectHash<T>(obj: T) {
   return encodedBtoa(JSON.stringify(obj));
 }
+
+const doNotTrackValues = new Set(['1', 1, 'yes', true]);
+
+/**
+ * Logic copied from coveo.analytics.
+ */
+export function doNotTrack() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  return [
+    (<any>navigator).globalPrivacyControl,
+    (<any>navigator).doNotTrack,
+    (<any>navigator).msDoNotTrack,
+    (<any>window).doNotTrack,
+  ].some((value) => doNotTrackValues.has(value));
+}

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -50,13 +50,14 @@ const doNotTrackValues = new Set(['1', 1, 'yes', true]);
  * Logic copied from coveo.analytics.
  */
 export function doNotTrack() {
-  if (typeof navigator === 'undefined') {
-    return false;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nav = <any | undefined>navigator;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const win = <any | undefined>window;
   return [
-    (<any>navigator).globalPrivacyControl,
-    (<any>navigator).doNotTrack,
-    (<any>navigator).msDoNotTrack,
-    (<any>window).doNotTrack,
+    nav?.globalPrivacyControl,
+    nav?.doNotTrack,
+    nav?.msDoNotTrack,
+    win?.doNotTrack,
   ].some((value) => doNotTrackValues.has(value));
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2151

In v1, this isn't strictly needed, since `coveo.analytics` already disables analytics requests on its own, and Headless doesn't happen to include any identifiable information in the `analytics` object of search requests (it includes a clientId, but it's reset after each request).

In v2, this is now needed because search requests include the `actionCause` and `customData` of analytics events in their `analytics` object.

This PR removes the `analytics` object from search requests when doNotTrack is on, which is the same behaviour as when analytics are disabled.

An alternative could be to try to detect which client `coveo.analytics` initialized and disable analytics based on that.

I'm merging this in `v1` since this is non-breaking.