### PR TITLE
fix(headless): fixed issues when publishing package and updating tags

### DIFF
--- a/JenkinsfileStagingRelease
+++ b/JenkinsfileStagingRelease
@@ -15,7 +15,10 @@ node('linux && docker') {
   ])
 
   dockerUtils.withDocker(image: 'node:16', args: '-e HOME=/tmp -e NPM_CONFIG_PREFIX=/tmp/.npm') {
-    
+    stage('Setup') {
+      sh 'npm ci'
+    }
+
     stage('Npm publish') {
       withCredentials([
       string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')]) {

--- a/scripts/deploy/publish.mjs
+++ b/scripts/deploy/publish.mjs
@@ -1,27 +1,30 @@
-import {resolve} from 'node:path';
 import {execute} from '../exec.mjs';
 import {isOnReleaseBranch} from '../git.mjs';
-import {getPackageDefinitionFromPath} from '../packages.mjs';
+import {getPackageManifestFromPackagePath} from '../packages.mjs';
 import {isPrereleaseVersion} from '../prerelease.mjs';
 
 const [tag] = process.argv.slice(2);
 
-const pathToPackageJSON = resolve(process.cwd(), './package.json');
-const pkg = getPackageDefinitionFromPath(pathToPackageJSON);
+const pkg = getPackageManifestFromPackagePath(process.cwd());
 const packageRef = `${pkg.name}@${pkg.version}`;
 
 async function isAlreadyPublished() {
   try {
-    const isPublished = !!execute('npm', ['view', packageRef]);
+    const isPublished = !!(await execute('npm', ['view', packageRef]));
     return isPublished;
   } catch (e) {
-    const isFirstPublish = e.includes('code E404');
+    const isFirstPublish = e.error && e.error.includes('code E404');
     return !isFirstPublish;
   }
 }
 
 async function shouldPublish() {
-  if (isAlreadyPublished()) {
+  if (await isAlreadyPublished()) {
+    console.info(
+      `Skipped publishing ${packageRef} (${
+        tag || 'latest'
+      }) since it's already published.`
+    );
     return false;
   }
   if (await isOnReleaseBranch()) {
@@ -29,7 +32,15 @@ async function shouldPublish() {
   }
   // On a prerelease branch, we may not want to prerelease some packages.
   // We only want to prerelease packages that were already bumped to a prerelease version.
-  return isPrereleaseVersion(pkg.version);
+  if (!isPrereleaseVersion(pkg.version)) {
+    console.info(
+      `Skipped publishing ${packageRef} (${
+        tag || 'latest'
+      }) since the branch isn't a release branch and the package isn't a prerelease package.`
+    );
+    return false;
+  }
+  return true;
 }
 
 async function publish() {
@@ -43,12 +54,6 @@ async function publish() {
 async function main() {
   if (await shouldPublish()) {
     await publish();
-  } else {
-    console.info(
-      `Skipped publishing ${packageRef} (${
-        tag || 'latest'
-      }) since it's already published.`
-    );
   }
 }
 

--- a/scripts/exec.mjs
+++ b/scripts/exec.mjs
@@ -44,12 +44,10 @@ export function execute(command, args = []) {
     proc.on('exit', (code) =>
       code === 0
         ? resolve(trimNewline(dataBuffer.toString('utf8')))
-        : reject(
-            JSON.stringify({
-              code,
-              error: trimNewline(errorBuffer.toString('utf8')),
-            })
-          )
+        : reject({
+            code,
+            error: trimNewline(errorBuffer.toString('utf8')),
+          })
     );
   });
 }

--- a/scripts/packages.mjs
+++ b/scripts/packages.mjs
@@ -44,7 +44,7 @@ export function getPackagePathFromPackageDir(packageDir) {
  * @param {string} fullPath
  * @returns {import('@lerna/package').RawManifest}
  */
-function getPackageManifestFromPackagePath(fullPath) {
+export function getPackageManifestFromPackagePath(fullPath) {
   return JSON.parse(readFileSync(resolve(fullPath, 'package.json')).toString());
 }
 

--- a/scripts/prerelease.mjs
+++ b/scripts/prerelease.mjs
@@ -5,7 +5,6 @@ import {
   gitPushTags,
   gitAdd,
 } from '@coveo/semantic-monorepo-tools';
-import {resolve} from 'node:path';
 import semver from 'semver';
 import {execute} from './exec.mjs';
 import {commitVersionBump, tagPackages} from './git.mjs';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2155

Will merge with the following name to force a version bump (although it will generate a changelog entry):
> fix(headless): fixed issues when publishing package and updating tags

This time, I tested `publish.mjs` locally, which I should've done the first time.