### PR TITLE
fix(headless): fix branch name detection in CI

### DIFF
--- a/scripts/git.mjs
+++ b/scripts/git.mjs
@@ -10,7 +10,10 @@ import {execute} from './exec.mjs';
 const releaseBranch = 'master';
 
 async function getBranchName() {
-  return await execute('git', ['branch', '--show-current']);
+  return (
+    process.env.BRANCH_NAME ||
+    (await execute('git', ['rev-parse', '--abbrev-ref', 'HEAD']))
+  );
 }
 
 export async function isOnReleaseBranch() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2156

Will merge as `fix(headless): fix branch name detection in CI`

I updated the `getBranchName` command to use an older command which gives the same output. However, in Jenkins, it returns "HEAD" instead of the branch name since Jenkins is in a detached HEAD state.

I tested the following in Jenkins to confirm that node is able to read the environment variable:
```groovy
sh 'echo "console.log(process.env.BRANCH_NAME);" | node'
```
