### PR TITLE
feat(headless): refactored field suggestion options

### DIFF
--- a/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.test.ts
@@ -38,8 +38,10 @@ describe('categoryFieldSuggestions', () => {
 
   beforeEach(() => {
     options = {
-      facetId,
-      field: 'geography',
+      facet: {
+        facetId,
+        field: 'geography',
+      },
     };
 
     state = createMockState();

--- a/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.ts
@@ -1,4 +1,4 @@
-import {CoreEngine} from '../../..';
+import {CoreEngine} from '../../../app/engine';
 import {
   categoryFacetSet,
   configuration,
@@ -9,7 +9,6 @@ import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {SearchThunkExtraArguments} from '../../../app/search-thunk-extra-arguments';
 import {registerCategoryFacet} from '../../../features/facets/category-facet-set/category-facet-set-actions';
 import {defaultCategoryFacetOptions} from '../../../features/facets/category-facet-set/category-facet-set-slice';
-import {CategoryFacetSortCriterion} from '../../../features/facets/category-facet-set/interfaces/request';
 import {
   CategoryFacetSearchSection,
   CategoryFacetSection,
@@ -17,12 +16,12 @@ import {
   SearchSection,
 } from '../../../state/state-sections';
 import {loadReducerError} from '../../../utils/errors';
-import {omit} from '../../../utils/utils';
 import {
   buildController,
   Subscribable,
 } from '../../controller/headless-controller';
 import {determineFacetId} from '../../core/facets/_common/facet-id-determinor';
+import {CategoryFacetOptions} from '../../facets/category-facet/headless-category-facet';
 import {buildCategoryFacetSearch} from '../../facets/category-facet/headless-category-facet-search';
 
 export interface CategoryFieldSuggestionsValue {
@@ -119,89 +118,11 @@ export interface CategoryFieldSuggestions extends Subscribable {
   state: CategoryFieldSuggestionsState;
 }
 
-// TODO: In v2, move these options into `FieldSuggestionsOptions` and remove `facetSearch`.
-export interface CategoryFieldSuggestionsFacetSearchOptions {
-  /**
-   * A dictionary that maps field values to field suggestion display names.
-   */
-  captions?: Record<string, string>;
-
-  /**
-   * The maximum number of suggestions to request.
-   *
-   * @defaultValue `10`
-   */
-  numberOfValues?: number;
-
-  /**
-   * The query with which to request field suggestions.
-   */
-  query?: string;
-}
-
 export interface CategoryFieldSuggestionsOptions {
   /**
-   * The field for which you wish to get field suggestions.
+   * The options used to register the category facet used by the field suggestions controller.
    */
-  field: string;
-
-  /**
-   * The base path shared by all values for the field suggestions.
-   *
-   * @defaultValue `[]`
-   */
-  basePath?: string[];
-
-  /**
-   * The character that specifies the hierarchical dependency.
-   *
-   * @defaultValue `;`
-   */
-  delimitingCharacter?: string;
-
-  /**
-   * A unique identifier for the controller. By default, a random unique identifier is generated.
-   *
-   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`. However, you must make sure to build the field suggestion controller after the facet controller.
-   */
-  facetId?: string;
-
-  /**
-   * The options related to search.
-   */
-  facetSearch?: CategoryFieldSuggestionsFacetSearchOptions;
-
-  /**
-   * Whether to filter the results using `basePath`.
-   *
-   * @defaultValue `true`
-   */
-  filterByBasePath?: boolean;
-
-  /**
-   * Whether to exclude the parents of folded results when estimating the result count for each field suggestion.
-   *
-   * @defaultValue `true`
-   */
-  filterFacetCount?: boolean;
-
-  /**
-   * @deprecated This option has no effect.
-   */
-  injectionDepth?: number;
-
-  /**
-   * This option has no effect.
-   */
-  numberOfValues?: number;
-
-  /**
-   * The criterion to use to sort returned field suggestions.
-   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/#RestFacetRequest-sortCriteria).
-   *
-   * @defaultValue `automatic`
-   */
-  sortCriteria?: CategoryFacetSortCriterion;
+  facet: CategoryFacetOptions;
 }
 
 export interface CategoryFieldSuggestionsProps {
@@ -213,6 +134,10 @@ export interface CategoryFieldSuggestionsProps {
 
 /**
  * Creates a `CategoryFieldSuggestions` controller instance.
+ *
+ * This controller initializes a category facet, but exposes state and methods that are relevant for suggesting fields values based on a query.
+ * It's important not to initialize a category facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken.
+ *
  * @param engine The headless engine.
  * @param props The configurable `CategoryFieldSuggestions` controller properties.
  * @returns A `CategoryFieldSuggestions` controller instance.
@@ -224,18 +149,19 @@ export function buildCategoryFieldSuggestions(
   if (!loadCategoryFieldSuggestionsReducers(engine)) {
     throw loadReducerError;
   }
-  const facetId = determineFacetId(engine, props.options);
+  const {facetSearch: facetSearchOptions, ...facetOptions} =
+    props.options.facet;
+  const facetId = determineFacetId(engine, facetOptions);
   engine.dispatch(
     registerCategoryFacet({
       ...defaultCategoryFacetOptions,
-      ...omit('facetSearch', props.options),
-      field: props.options.field,
+      ...facetOptions,
       facetId,
     })
   );
 
   const facetSearch = buildCategoryFacetSearch(engine, {
-    options: {...props.options.facetSearch, facetId},
+    options: {...facetSearchOptions, facetId},
     isForFieldSuggestions: true,
   });
   const controller = buildController(engine);

--- a/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/category-facet/headless-category-field-suggestions.ts
@@ -120,7 +120,7 @@ export interface CategoryFieldSuggestions extends Subscribable {
 
 export interface CategoryFieldSuggestionsOptions {
   /**
-   * The options used to register the category facet used by the field suggestions controller.
+   * The options used to register the category facet used under the hood by the field suggestions controller.
    */
   facet: CategoryFacetOptions;
 }
@@ -135,8 +135,8 @@ export interface CategoryFieldSuggestionsProps {
 /**
  * Creates a `CategoryFieldSuggestions` controller instance.
  *
- * This controller initializes a category facet, but exposes state and methods that are relevant for suggesting fields values based on a query.
- * It's important not to initialize a category facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken.
+ * This controller initializes a category facet under the hood, but exposes state and methods that are relevant for suggesting field values based on a query.
+ * It's important not to initialize a category facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken into account.
  *
  * @param engine The headless engine.
  * @param props The configurable `CategoryFieldSuggestions` controller properties.

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.test.ts
@@ -42,8 +42,10 @@ describe('fieldSuggestions', () => {
 
   beforeEach(() => {
     options = {
-      facetId,
-      field: 'author',
+      facet: {
+        facetId,
+        field: 'author',
+      },
     };
 
     state = createMockState();

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -11,7 +11,6 @@ import {updateFacetOptions} from '../../../features/facet-options/facet-options-
 import {registerFacet} from '../../../features/facets/facet-set/facet-set-actions';
 import {logFacetSelect} from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {defaultFacetOptions} from '../../../features/facets/facet-set/facet-set-slice';
-import {FacetSortCriterion} from '../../../features/facets/facet-set/interfaces/request';
 import {executeSearch} from '../../../features/search/search-actions';
 import {
   FacetSection,
@@ -20,13 +19,13 @@ import {
   SearchSection,
 } from '../../../state/state-sections';
 import {loadReducerError} from '../../../utils/errors';
-import {omit} from '../../../utils/utils';
 import {
   buildController,
   Subscribable,
 } from '../../controller/headless-controller';
 import {determineFacetId} from '../../core/facets/_common/facet-id-determinor';
 import {buildFacetSearch} from '../../core/facets/facet-search/specific/headless-facet-search';
+import {FacetOptions} from '../../facets/facet/headless-facet-options';
 
 export interface FieldSuggestionsValue {
   /**
@@ -124,83 +123,11 @@ export interface FieldSuggestions extends Subscribable {
   state: FieldSuggestionsState;
 }
 
-// TODO: In v2, move these options into `FieldSuggestionsOptions` and remove `facetSearch`.
-export interface FieldSuggestionsFacetSearchOptions {
-  /**
-   * A dictionary that maps field values to field suggestion display names.
-   */
-  captions?: Record<string, string>;
-
-  /**
-   * The maximum number of suggestions to request.
-   *
-   * @defaultValue `10`
-   */
-  numberOfValues?: number;
-
-  /**
-   * The query with which to request field suggestions.
-   */
-  query?: string;
-}
-
 export interface FieldSuggestionsOptions {
   /**
-   * The field for which you wish to get field suggestions.
+   * The options used to register the facet used by the field suggestions controller.
    */
-  field: string;
-
-  /**
-   * @deprecated This option has no effect.
-   */
-  delimitingCharacter?: string;
-
-  /**
-   * A unique identifier for the controller. By default, a random unique identifier is generated.
-   *
-   * If a facet shares the same id, then its values are going to be selectable with `select` and `singleSelect`.
-   */
-  facetId?: string;
-
-  /**
-   * The options related to search.
-   */
-  facetSearch?: FieldSuggestionsFacetSearchOptions;
-
-  /**
-   * Whether to exclude the parents of folded results when estimating the result count for each field suggestion.
-   *
-   * @defaultValue `true`
-   */
-  filterFacetCount?: boolean;
-
-  /**
-   * @deprecated This option has no effect.
-   */
-  injectionDepth?: number;
-
-  /**
-   * This option has no effect.
-   */
-  numberOfValues?: number;
-
-  /**
-   * The criterion to use to sort returned field suggestions.
-   * Learn more about `sortCriteria` values and the default behavior of specific facets in the [Search API documentation](https://docs.coveo.com/en/1461/#RestFacetRequest-sortCriteria).
-   *
-   * @defaultValue `automatic`
-   */
-  sortCriteria?: FacetSortCriterion;
-
-  /**
-   * @deprecated This option has no effect.
-   */
-  allowedValues?: string[];
-
-  /**
-   * @deprecated This option has no effect.
-   */
-  hasBreadcrumbs?: boolean;
+  facet: FacetOptions;
 }
 
 export interface FieldSuggestionsProps {
@@ -212,6 +139,10 @@ export interface FieldSuggestionsProps {
 
 /**
  * Creates a `FieldSuggestions` controller instance.
+ *
+ * This controller initializes a facet, but exposes state and methods that are relevant for suggesting fields values based on a query.
+ * It's important not to initialize a facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken.
+ *
  * @param engine The headless engine.
  * @param props The configurable `FieldSuggestions` controller properties.
  * @returns A `FieldSuggestions` controller instance.
@@ -223,18 +154,28 @@ export function buildFieldSuggestions(
   if (!loadFieldSuggestionsReducers(engine)) {
     throw loadReducerError;
   }
-  const facetId = determineFacetId(engine, props.options);
+  const {
+    facetSearch: facetSearchOptions,
+    allowedValues,
+    ...facetOptions
+  } = props.options.facet;
+  const facetId = determineFacetId(engine, facetOptions);
   engine.dispatch(
     registerFacet({
       ...defaultFacetOptions,
-      ...omit('facetSearch', props.options),
-      field: props.options.field,
+      ...facetOptions,
       facetId,
+      ...(allowedValues && {
+        allowedValues: {
+          type: 'simple',
+          values: allowedValues,
+        },
+      }),
     })
   );
 
   const facetSearch = buildFacetSearch(engine, {
-    options: {...props.options.facetSearch, facetId},
+    options: {...facetSearchOptions, facetId},
     select: (value) => {
       engine.dispatch(updateFacetOptions({freezeFacetOrder: true}));
       engine.dispatch(

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -140,8 +140,8 @@ export interface FieldSuggestionsProps {
 /**
  * Creates a `FieldSuggestions` controller instance.
  *
- * This controller initializes a facet, but exposes state and methods that are relevant for suggesting fields values based on a query.
- * It's important not to initialize a facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken.
+ * This controller initializes a facet under the hood, but exposes state and methods that are relevant for suggesting field values based on a query.
+ * It's important not to initialize a facet with the same `facetId` but different options, because only the options of the controller which is built first will be taken into account.
  *
  * @param engine The headless engine.
  * @param props The configurable `FieldSuggestions` controller properties.

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -377,7 +377,6 @@ export type {
   FieldSuggestionsValue,
   FieldSuggestionsState,
   FieldSuggestions,
-  FieldSuggestionsFacetSearchOptions,
   FieldSuggestionsOptions,
   FieldSuggestionsProps,
 } from './field-suggestions/facet/headless-field-suggestions';
@@ -387,7 +386,6 @@ export type {
   CategoryFieldSuggestionsValue,
   CategoryFieldSuggestionsState,
   CategoryFieldSuggestions,
-  CategoryFieldSuggestionsFacetSearchOptions,
   CategoryFieldSuggestionsOptions,
   CategoryFieldSuggestionsProps,
 } from './field-suggestions/category-facet/headless-category-field-suggestions';

--- a/packages/headless/src/integration-tests/category-field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/category-field-suggestions.test.ts
@@ -44,8 +44,10 @@ describe('category field suggestions', () => {
         action: () =>
           (categoryFieldSuggestions = buildCategoryFieldSuggestions(engine, {
             options: {
-              field,
-              facetId: categoryFacet.state.facetId,
+              facet: {
+                field,
+                facetId: categoryFacet.state.facetId,
+              },
             },
           })),
         expectedSubscriberCalls: 2,
@@ -84,7 +86,7 @@ describe('category field suggestions', () => {
       await waitForNextStateChange(engine, {
         action: () =>
           (categoryFieldSuggestions = buildCategoryFieldSuggestions(engine, {
-            options: {field},
+            options: {facet: {field}},
           })),
         expectedSubscriberCalls: 3,
       });
@@ -229,7 +231,7 @@ describe('category field suggestions', () => {
     await waitForNextStateChange(engine, {
       action: () =>
         (categoryFieldSuggestions = buildCategoryFieldSuggestions(engine, {
-          options: {field, basePath},
+          options: {facet: {field, basePath}},
         })),
       expectedSubscriberCalls: 3,
     });

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -43,7 +43,7 @@ describe('field suggestions', () => {
       await waitForNextStateChange(engine, {
         action: () =>
           (fieldSuggestions = buildFieldSuggestions(engine, {
-            options: {field, facetId: facet.state.facetId},
+            options: {facet: {field, facetId: facet.state.facetId}},
           })),
         expectedSubscriberCalls: 2,
       });
@@ -104,7 +104,7 @@ describe('field suggestions', () => {
       await waitForNextStateChange(engine, {
         action: () =>
           (fieldSuggestions = buildFieldSuggestions(engine, {
-            options: {field},
+            options: {facet: {field}},
           })),
         expectedSubscriberCalls: 3,
       });

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "dev": "react-scripts start",
-    "build": "echo 'no'",
+    "build": "tsc --noEmit && tsc --module commonjs --noEmit",
     "build:server": "tsc --project ./tsconfig.server.json",
     "test": "react-scripts test --env=./jest.setup.js",
     "eject": "react-scripts eject",

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "dev": "react-scripts start",
-    "build": "tsc --noEmit && tsc --module commonjs --noEmit",
+    "build": "echo 'no'",
     "build:server": "tsc --project ./tsconfig.server.json",
     "test": "react-scripts test --env=./jest.setup.js",
     "eject": "react-scripts eject",

--- a/packages/samples/headless-react/src/components/field-suggestions/category-field/category-suggestions.class.tsx
+++ b/packages/samples/headless-react/src/components/field-suggestions/category-field/category-suggestions.class.tsx
@@ -8,8 +8,11 @@ import {
 import {Component, ContextType} from 'react';
 import {AppContext} from '../../../context/engine';
 
+type CategoryFieldSuggestionsFacetOptions =
+  CategoryFieldSuggestionsOptions['facet'];
+
 interface CategoryFieldSuggestionsProps
-  extends CategoryFieldSuggestionsOptions {
+  extends CategoryFieldSuggestionsFacetOptions {
   facetId: string;
 }
 
@@ -25,7 +28,7 @@ export class CategoryFieldSuggestions extends Component<
 
   componentDidMount() {
     this.controller = buildCategoryFieldSuggestions(this.context.engine!, {
-      options: this.props,
+      options: {facet: this.props},
     });
     this.updateState();
 

--- a/packages/samples/headless-react/src/components/field-suggestions/specific-field/field-suggestions.class.tsx
+++ b/packages/samples/headless-react/src/components/field-suggestions/specific-field/field-suggestions.class.tsx
@@ -8,7 +8,9 @@ import {
 import {Component, ContextType} from 'react';
 import {AppContext} from '../../../context/engine';
 
-interface FieldSuggestionsProps extends FieldSuggestionsOptions {
+type FieldSuggestionsFacetOptions = FieldSuggestionsOptions['facet'];
+
+interface FieldSuggestionsProps extends FieldSuggestionsFacetOptions {
   facetId: string;
 }
 
@@ -24,7 +26,7 @@ export class FieldSuggestions extends Component<
 
   componentDidMount() {
     this.controller = buildFieldSuggestions(this.context.engine!, {
-      options: this.props,
+      options: {facet: this.props},
     });
     this.updateState();
 

--- a/packages/samples/headless-react/src/pages/SearchPage.tsx
+++ b/packages/samples/headless-react/src/pages/SearchPage.tsx
@@ -368,13 +368,15 @@ export class SearchPage extends Component {
     );
 
     this.fieldSuggestionsAuthor = buildFieldSuggestions(this.engine, {
-      options: {field: 'author', facetId: 'author-2'},
+      options: {facet: {field: 'author', facetId: 'author-2'}},
     });
 
     this.categoryFieldSuggestions = buildCategoryFieldSuggestions(this.engine, {
       options: {
-        field: 'geographicalhierarchy',
-        facetId: 'geographicalhierarchy-3',
+        facet: {
+          field: 'geographicalhierarchy',
+          facetId: 'geographicalhierarchy-3',
+        },
       },
     });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2101

The purpose of this Jira was to remove deprecated options, however, I noticed there was also issues with the documentation for field suggestions; field suggestions are tightly tied with facets, and their options are used to register a facet, which is important to know for users if they want to understand the behaviour of field suggestions (especially when field suggestions and a facet share the same facet id).

In this PR, I tested one possible solution to this problem in my opinion:
1. Adding documentation to field suggestions themselves that clarify that they actually initialize a facet.
2. Moving all field suggestions options under "facet" sub-options, since they are all used to register a facet. I think this really clarifies the purpose of all options nested under it and emphasizes the fact that field suggestions rely on facets. If we have to add options to field suggestions, this will also clarify that which options aren't used to register a facet.

Other alternatives would be:
* Alternative A: Not changing the options hierarchy at all, and only doing documentation.
* Alternative B: Moving `field` (and maybe `facetSearch`) out of the `facet` sub-options to make the hierarchy less deep and the options prettier. This would however force us to re-declare all facet options in a new interface that is specific to field suggestions, just like it was prior to this change, since we (presumably) can't use `Omit` with the doc parser.

# Deprecations
## Changed
* Removed the `FieldSuggestionsFacetSearchOptions` interface.
  * `FacetSearchOptions` is used instead.
* Removed the `CategoryFieldSuggestionsFacetSearchOptions` interface.
  * `CategoryFacetSearchOptions` is used instead.
* Refactored `FieldSuggestionsOptions`, nesting all its options under `facet: FacetOptions`.
  * `buildFieldSuggestions(engine, { options: { field: 'filetype' } });` would become `buildFieldSuggestions(engine, { options: { facet: { field: 'filetype' } } });`
* Refactored `CategoryFieldSuggestionsOptions`, nesting all its options under `facet: FacetOptions`.
  * `buildCategoryFieldSuggestions(engine, { options: { field: 'category' } });` would become `buildCategoryFieldSuggestions(engine, { options: { facet: { field: 'category' } } });`
* Removed the `delimitingCharacter` option from `FieldSuggestions`
  * It didn't do anything.
* Removed the `delimitingCharacter` option from `CategoryFieldSuggestions`
  * It didn't do anything.