### PR TITLE
fix(atomic): fixed insight search section grid behaviour

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -43,6 +43,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       padding-left: 1.5rem;
       padding-right: 1.5rem;
       box-sizing: border-box;
+      overflow-x: hidden;
       ${!hasTabs ? 'padding-bottom: 1.5rem;' : ''}
     }
 
@@ -55,10 +56,6 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       flex-shrink: 0;
     }`
     )}
-
-    ${sectionSelector('search')} ${tabsSelector} {
-      width: 100%
-    }
     `;
 
   const results = `

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -30,8 +30,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
   const search = `${sectionSelector('search')} {
       width: 100%;
       display: grid;
-      grid-template-columns: 1fr auto;
-      grid-template-rows: max-content;
+      grid-template-columns: 1fr repeat(4, auto);
       grid-gap: 0.5rem;
       background: var(--atomic-neutral-light);
       padding-top: 1.5rem;

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -5,6 +5,11 @@ import {
 
 const tabsSelector = 'atomic-insight-tabs';
 const refineModalSelector = 'atomic-insight-refine-modal';
+const toggleSelectors = [
+  'atomic-insight-refine-toggle',
+  'atomic-insight-edit-toggle',
+  'atomic-insight-history-toggle',
+];
 
 export function buildInsightLayout(element: HTMLElement, widget: boolean) {
   const id = element.id;
@@ -12,6 +17,14 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
 
   const hasTabs = Boolean(
     findSection(element, 'search')?.querySelector(tabsSelector)
+  );
+
+  const numToggles = toggleSelectors.reduce(
+    (numToggles, selector) =>
+      findSection(element, 'search')?.querySelector(selector)
+        ? numToggles + 1
+        : numToggles,
+    0
   );
 
   const interfaceStyle = widget
@@ -30,7 +43,9 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
   const search = `${sectionSelector('search')} {
       width: 100%;
       display: grid;
-      grid-template-columns: 1fr repeat(4, auto);
+      grid-template-columns: ${
+        numToggles ? `1fr repeat(${numToggles}, auto)` : '1fr'
+      };
       grid-gap: 0.5rem;
       background: var(--atomic-neutral-light);
       padding-top: 1.5rem;
@@ -40,7 +55,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       ${!hasTabs ? 'padding-bottom: 1.5rem;' : ''}
     }
     ${sectionSelector('search')} ${tabsSelector} {
-      grid-column: 1 / 5;
+      grid-column: ${numToggles ? `1 / ${numToggles + 2}` : 1};
     }
     `;
 

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -31,6 +31,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       width: 100%;
       display: grid;
       grid-template-columns: 1fr auto;
+      grid-template-rows: max-content;
       grid-gap: 0.5rem;
       background: var(--atomic-neutral-light);
       padding-top: 1.5rem;

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -43,7 +43,7 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       padding-left: 1.5rem;
       padding-right: 1.5rem;
       box-sizing: border-box;
-      overflow-x: hidden;
+      overflow-x: auto;
       ${!hasTabs ? 'padding-bottom: 1.5rem;' : ''}
     }
 

--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -5,6 +5,7 @@ import {
 
 const tabsSelector = 'atomic-insight-tabs';
 const refineModalSelector = 'atomic-insight-refine-modal';
+const searchBoxSelector = 'atomic-insight-search-box';
 const toggleSelectors = [
   'atomic-insight-refine-toggle',
   'atomic-insight-edit-toggle',
@@ -17,14 +18,6 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
 
   const hasTabs = Boolean(
     findSection(element, 'search')?.querySelector(tabsSelector)
-  );
-
-  const numToggles = toggleSelectors.reduce(
-    (numToggles, selector) =>
-      findSection(element, 'search')?.querySelector(selector)
-        ? numToggles + 1
-        : numToggles,
-    0
   );
 
   const interfaceStyle = widget
@@ -42,10 +35,8 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
 
   const search = `${sectionSelector('search')} {
       width: 100%;
-      display: grid;
-      grid-template-columns: ${
-        numToggles ? `1fr repeat(${numToggles}, auto)` : '1fr'
-      };
+      display: flex;
+      flex-wrap: wrap;
       grid-gap: 0.5rem;
       background: var(--atomic-neutral-light);
       padding-top: 1.5rem;
@@ -54,8 +45,19 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       box-sizing: border-box;
       ${!hasTabs ? 'padding-bottom: 1.5rem;' : ''}
     }
+
+    ${sectionSelector('search')} ${searchBoxSelector} {
+      flex-grow: 1;
+    }
+
+    ${toggleSelectors.map(
+      (toggleSelector) => `${sectionSelector('search')} ${toggleSelector} {
+      flex-shrink: 0;
+    }`
+    )}
+
     ${sectionSelector('search')} ${tabsSelector} {
-      grid-column: ${numToggles ? `1 / ${numToggles + 2}` : 1};
+      width: 100%
     }
     `;
 


### PR DESCRIPTION
The grid behaviour was yielding some weird looks with certain combinations of tabs, toggles, searchbox.
- The toggles would wrap to the next row when no tabs were present to take an entire row.
- The number of columns would not adjust to the number of elements present and empty rows still take up space so the right spacing wouldn't be correct.

FYI I can't say i'm a `display: grid` expert so let me know if you see a better way that doesn't involve as much javascript

Before
<img width="620" alt="Screen Shot 2022-12-04 at 6 19 23 PM" src="https://user-images.githubusercontent.com/16785453/205711232-ff0a4f35-a3ae-4635-ab93-0b9f48b74739.png">
<img width="642" alt="Screen Shot 2022-12-05 at 1 15 53 PM" src="https://user-images.githubusercontent.com/16785453/205711888-85aaf649-dd96-4362-9209-c0284cac8509.png">

After
<img width="642" alt="Screen Shot 2022-12-05 at 12 13 35 PM" src="https://user-images.githubusercontent.com/16785453/205712317-3548a9a4-e745-4f4b-bebd-5310d5f9b0c8.png">
<img width="642" alt="Screen Shot 2022-12-05 at 12 15 02 PM" src="https://user-images.githubusercontent.com/16785453/205711991-6966b257-69c0-4972-abbf-9da943dc607d.png">
<img width="642" alt="Screen Shot 2022-12-05 at 12 14 49 PM" src="https://user-images.githubusercontent.com/16785453/205711998-dcb6a5ca-9b15-4b09-a451-74936aca7d74.png">
<img width="642" alt="Screen Shot 2022-12-05 at 12 13 24 PM" src="https://user-images.githubusercontent.com/16785453/205711993-f69fa9f8-c31b-461d-9ba6-731961d8664f.png">
<img width="642" alt="Screen Shot 2022-12-05 at 12 14 38 PM" src="https://user-images.githubusercontent.com/16785453/205711997-c7d82f84-9a2d-4f4e-8fee-85c9cdd101c0.png">
