### PR TITLE
ci: fix manual version bump "npm install"

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "packages/atomic",
     "packages/quantic",
     "packages/atomic-react",
+    "packages/atomic-angular",
     "packages/atomic-angular/projects/*",
     "packages/samples/*"
   ],

--- a/scripts/prerelease.mjs
+++ b/scripts/prerelease.mjs
@@ -6,13 +6,12 @@ import {
   gitAdd,
 } from '@coveo/semantic-monorepo-tools';
 import semver from 'semver';
-import {execute} from './exec.mjs';
 import {commitVersionBump, tagPackages} from './git.mjs';
 import {
   packageDirsNpmTag,
   getPackageDefinitionFromPackageDir,
-  updatePackageVersion,
   getPackagePathFromPackageDir,
+  updatePackageVersionsAndDependents,
 } from './packages.mjs';
 
 /**
@@ -51,15 +50,12 @@ async function getNewVersion(packageDef) {
  * @param {PackageDefinition[]} packages
  */
 async function locallyBumpVersions(packages) {
+  /** @type {{ [packageDir: import('./packages.mjs').PackageDir]: string }} */
+  const newVersions = {};
   for (const packageDef of packages) {
-    const newVersion = await getNewVersion(packageDef);
-    updatePackageVersion(
-      packageDef.name,
-      newVersion,
-      packages.map(({packageDir}) => packageDir)
-    );
+    newVersions[packageDef.packageDir] = await getNewVersion(packageDef);
   }
-  await execute('npm', ['install', '--package-lock-only']);
+  await updatePackageVersionsAndDependents(newVersions);
 }
 
 export async function bumpPrereleaseVersionAndPush() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2158

# Relatively detailed story (I want you to feel my pain)
1. I tried to run `npm run bump:version:major-prerelease -- @coveo/headless @coveo/quantic @coveo/atomic @coveo/atomic-react @coveo/atomic-angular` (this is meant to bump the specified packages to `2.0.0-pre.0`). `npm install --no-package-lock` failed with the following error:
```
 npm ERR! code
  ETARGET
 npm
  ERR! 
 notarget No matching version found for @coveo/headless@2.0.0-pre.0.
npm
  
 ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! 
 notarget a package version that doesn't exist.
 
npm 
 ERR! A complete log of this run can be found in:
npm ERR!     /Users/btaillon/.npm/_logs/2022-12-05T20_34_36_681Z-debug-0.log
```
2. I tried removing `package-lock.json` and generating a new one with `npm install --no-package-lock`, which worked, but the project no longer builds due to a bunch of packages getting updated, so I gave up on that solution. 
3. I deleted `node_modules` then did `npm install`, which didn't work.
4. I looked at the `package-lock.json`, even going so far as to write a short script to filter all the irrelevant packages out of it, but nothing looked wrong.
5. I changed the dependents to instead depend on `*` and did `npm install --no-package-lock`. That worked. Then I changed the versions back to the correct `-pre.0` versions and did `npm install --no-package-lock` again, which worked again.
6. Doing `npm install` without `--no-package-lock` no longer worked, giving off this error:
	```
	npm ERR! code ERR_INVALID_ARG_TYPE
	npm ERR! The “from” argument must be of type string. Received undefined
	npm ERR! A complete log of this run can be found in:
	npm ERR!     /Users/btaillon/.npm/_logs/2022-12-05T19_25_36_008Z-debug-0.log
	```
7. I tried to delete `node_modules` before doing `npm install` without `--no-package-lock`. This fixes the issue.
8. `npm run build` no longer works because `atomic-angular` is unable to import `@coveo/atomic`.
9. I noticed that even though `packages/atomic-angular` is private, it isn't included in the npm workspaces, and therefor it uses an old version of Atomic. So I added it to the workspaces, which fixed the build.
10. I tried reverting my changes from step 5, but got the error from step 1 again.

I don't know why this last solution works, I really couldn't find anything particularly wrong in the package-lock.json, and 

# The final solution / tl;dr
* I changed the process which bumps version to do the following:
  1. Update the version of each package we want to bump in their respective `package.json`.
  2. Update all dependent packages to depend on version `"*"` instead of a specific version.
  3. Do `npm install`
  4. Update all dependent packages to depend on the new version.
  5. Delete `node_modules`
  6. Do `npm install` again.
* I added `packages/atomic-angular` to the NPM workspaces list, since it depends on one of the workspaces (atomic).
* I bumped the dependents of not only the packages we're bumping, but also private packages (such as samples), since we often use them for testing.

# Could this be cleaner?
Probably, but it doesn't seem to be worth the time if we want the prerelease ready any time soon.