### PR TITLE
feat(headless): add src to use quickview in iframe

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
-  "ignorePatterns": [
-    "node_modules",
-    "stencil-generated",
-    "dist"
-  ],
+  "ignorePatterns": ["node_modules", "stencil-generated", "dist"],
   "env": {
     "jest": true,
     "es6": true
@@ -32,7 +28,9 @@
         "@typescript-eslint/no-empty-interface": [
           "error",
           {"allowSingleExtends": true}
-        ]
+        ],
+        "node/no-unsupported-features/node-builtins": "off",
+        "node/no-unsupported-features/es-builtins": "error"
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,9 +28,7 @@
         "@typescript-eslint/no-empty-interface": [
           "error",
           {"allowSingleExtends": true}
-        ],
-        "node/no-unsupported-features/node-builtins": "off",
-        "node/no-unsupported-features/es-builtins": "error"
+        ]
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install all dependencies and link local packages, run:
 npm i
 ```
 
-To install a dependencies in a specific package, specify the workspace:
+To install a dependency in a specific package, specify the workspace:
 
 ```sh
 npm i lodash -w @coveo/headless-react-samples
@@ -38,7 +38,7 @@ npm run build -w @coveo/atomic
 To start a single project in development (for instance, the `quantic` package), run:
 
 ```sh
-npm start -w @coveo/quantic 
+npm start -w @coveo/quantic
 ```
 
 To start Atomic & Headless simultaneously in development (recommended), run:
@@ -55,27 +55,32 @@ The following Visual Studio Code extensions are recommended:
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 
 ## Prerelease
+
 ### To start a major prerelease (e.g., `1.2.3` → `2.0.0-pre.0`)
+
 1. Make sure that `HEAD` refers to a version bump on `master`.
 2. Create a new branch prefixed with `prerelease/` (e.g., `prerelease/headless_atomic_v2`).
 3. Run `npm run bump:version:major-prerelease -- @coveo/package1 @coveo/package2 @coveo/package3`.
 4. Push the new commit and its tags to the branch.
 
 ### Adding a new package to an already started prerelease
+
 1. Checkout the prerelease branch.
 2. Run `npm run bump:version:major-prerelease -- @coveo/package1` where `@coveo/package1` is the new package.
 3. Push the new commit and its tags to the branch.
 
 ### Updating a prerelease branch
+
 1. Wait for `master` to reference a version bump.
 2. Pull changes from `master` into the prerelease branch.
 
 ### Officially releasing (e.g., `2.0.0-pre.15` → `2.0.0`)
+
 1. Create a pull request from the prerelease branch to “master”.
-    * Associate with a Jira issue which QA will use to validate.
-    * Update the changelogs manually, adding all the changes from the last release to the new release.
-    * Update all dependents to use the prerelease version (include the `-pre.` suffix).
+   - Associate with a Jira issue which QA will use to validate.
+   - Update the changelogs manually, adding all the changes from the last release to the new release.
+   - Update all dependents to use the prerelease version (include the `-pre.` suffix).
 2. Wait for `master` to reference a version bump.
 3. Squash as a version bump.
-    * You can copy the title & description of the last version bump commit on the prerelease branch.
-    * You must add the link to the Jira issue at the beginning of the description.
+   - You can copy the title & description of the last version bump commit on the prerelease branch.
+   - You must add the link to the Jira issue at the beginning of the description.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -68,5 +68,9 @@
     "@microsoft/tsdoc": "0.14.1",
     "jest-fetch-mock": "3.0.3",
     "ts-node": "10.9.1"
+  },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.6.0"
   }
 }

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -44,6 +44,9 @@ export const buildSrcPath = (req: HtmlRequest, path: string) => {
       `${req.requestedOutputSize}`
     );
   }
+  if (req.visitorId !== undefined) {
+    url.searchParams.append('visitorId', `${req.visitorId}`);
+  }
   return url.href;
 };
 

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -33,8 +33,17 @@ export const buildSrcPath = (req: HtmlRequest, path: string) => {
   url.searchParams.append('access_token', req.accessToken);
   url.searchParams.append('organizationId', req.organizationId);
   url.searchParams.append('uniqueId', req.uniqueId);
-  if (req.q) {
+  if (req.q !== undefined) {
     url.searchParams.append('q', req.q);
+  }
+  if (req.enableNavigation !== undefined) {
+    url.searchParams.append('enableNavigation', `${req.enableNavigation}`);
+  }
+  if (req.requestedOutputSize !== undefined) {
+    url.searchParams.append(
+      'requestedOutputSize',
+      `${req.requestedOutputSize}`
+    );
   }
   return url.href;
 };

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -28,7 +28,6 @@ export interface HtmlAPIClientOptions {
 }
 
 export const buildSrcPath = (req: HtmlRequest, path: string) => {
-  // eslint-disable-next-line node/no-unsupported-features/node-builtins
   const url = new URL(`${req.url}${path}`);
   url.searchParams.append('access_token', req.accessToken);
   url.searchParams.append('organizationId', req.organizationId);

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -27,6 +27,18 @@ export interface HtmlAPIClientOptions {
   requestMetadata?: RequestMetadata;
 }
 
+export const buildSrcPath = (req: HtmlRequest, path: string) => {
+  // eslint-disable-next-line node/no-unsupported-features/node-builtins
+  const url = new URL(`${req.url}${path}`);
+  url.searchParams.append('access_token', req.accessToken);
+  url.searchParams.append('organizationId', req.organizationId);
+  url.searchParams.append('uniqueId', req.uniqueId);
+  if (req.q) {
+    url.searchParams.append('q', req.q);
+  }
+  return url.href;
+};
+
 export const getHtml = async (
   req: HtmlRequest,
   options: HtmlAPIClientOptions

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -27,7 +27,7 @@ export interface HtmlAPIClientOptions {
   requestMetadata?: RequestMetadata;
 }
 
-export const buildSrcPath = (req: HtmlRequest, path: string) => {
+export const buildContentURL = (req: HtmlRequest, path: string) => {
   const url = new URL(`${req.url}${path}`);
   url.searchParams.append('access_token', req.accessToken);
   url.searchParams.append('organizationId', req.organizationId);

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -1,5 +1,6 @@
 import {Logger} from 'pino';
 import {TextDecoder} from 'web-encoding';
+import {URLPath} from '../../../utils/url-utils';
 import {pickNonBaseParams, unwrapError} from '../../api-client-utils';
 import {PlatformClient} from '../../platform-client';
 import {PreprocessRequest, RequestMetadata} from '../../preprocess-request';
@@ -28,24 +29,21 @@ export interface HtmlAPIClientOptions {
 }
 
 export const buildContentURL = (req: HtmlRequest, path: string) => {
-  const url = new URL(`${req.url}${path}`);
-  url.searchParams.append('access_token', req.accessToken);
-  url.searchParams.append('organizationId', req.organizationId);
-  url.searchParams.append('uniqueId', req.uniqueId);
+  const url = new URLPath(`${req.url}${path}`);
+  url.addParam('access_token', req.accessToken);
+  url.addParam('organizationId', req.organizationId);
+  url.addParam('uniqueId', req.uniqueId);
   if (req.q !== undefined) {
-    url.searchParams.append('q', req.q);
+    url.addParam('q', req.q);
   }
   if (req.enableNavigation !== undefined) {
-    url.searchParams.append('enableNavigation', `${req.enableNavigation}`);
+    url.addParam('enableNavigation', `${req.enableNavigation}`);
   }
   if (req.requestedOutputSize !== undefined) {
-    url.searchParams.append(
-      'requestedOutputSize',
-      `${req.requestedOutputSize}`
-    );
+    url.addParam('requestedOutputSize', `${req.requestedOutputSize}`);
   }
   if (req.visitorId !== undefined) {
-    url.searchParams.append('visitorId', `${req.visitorId}`);
+    url.addParam('visitorId', `${req.visitorId}`);
   }
   return url.href;
 };

--- a/packages/headless/src/api/service/insight/insight-params.ts
+++ b/packages/headless/src/api/service/insight/insight-params.ts
@@ -8,6 +8,9 @@ export interface InsightIdParam {
 
 export type InsightParam = BaseParam & InsightIdParam;
 
+export const baseInsightUrl = (req: InsightParam, path: string) =>
+  `${req.url}/rest/organizations/${req.organizationId}/insight/v1/configs/${req.insightId}${path}`;
+
 export const baseInsightRequest = (
   req: InsightParam,
   method: HttpMethods,
@@ -16,7 +19,7 @@ export const baseInsightRequest = (
 ) => {
   validateInsightRequestParams(req);
 
-  const baseUrl = `${req.url}/rest/organizations/${req.organizationId}/insight/v1/configs/${req.insightId}${path}`;
+  const baseUrl = baseInsightUrl(req, path);
 
   return {
     accessToken: req.accessToken,

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.test.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.test.ts
@@ -1,7 +1,7 @@
 import {configuration, resultPreview} from '../../../app/reducers';
 import {
   fetchResultContent,
-  updateSrcPath,
+  updateContentURL,
 } from '../../../features/result-preview/result-preview-actions';
 import {
   buildMockResult,
@@ -61,16 +61,16 @@ describe('QuickviewCore', () => {
     const uniqueId = '1';
     const requestedOutputSize = 0;
 
-    describe('when #onlySrcPath is true', () => {
+    describe('when #onlyContentURL is true', () => {
       beforeEach(() => {
         defaultOptions.result = buildMockResult({uniqueId});
-        initQuickview({...defaultOptions, onlySrcPath: true});
+        initQuickview({...defaultOptions, onlyContentURL: true});
 
         quickview.fetchResultContent();
       });
 
-      it('dispatches a #updateSrcPath action with the result uniqueId', () => {
-        const action = engine.findAsyncAction(updateSrcPath.pending);
+      it('dispatches a #updateContentURL action with the result uniqueId', () => {
+        const action = engine.findAsyncAction(updateContentURL.pending);
         expect(action?.meta.arg).toEqual({
           uniqueId,
           requestedOutputSize,
@@ -80,7 +80,7 @@ describe('QuickviewCore', () => {
       });
     });
 
-    describe('when #onlySrcPath is falsy', () => {
+    describe('when #onlyContentURL is falsy', () => {
       beforeEach(() => {
         defaultOptions.result = buildMockResult({uniqueId});
         initQuickview();

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.test.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.test.ts
@@ -5,6 +5,7 @@ import {
   buildMockSearchAppEngine,
   MockSearchEngine,
 } from '../../../test';
+import {buildMockResultPreviewRequest} from '../../../test/mock-result-preview-request-builder';
 import {buildMockResultPreviewState} from '../../../test/mock-result-preview-state';
 import {
   buildCoreQuickview,
@@ -17,8 +18,15 @@ describe('QuickviewCore', () => {
   let options: QuickviewOptions;
   let quickview: Quickview;
 
+  const path = '/html';
+
   function initQuickview() {
-    quickview = buildCoreQuickview(engine, {options});
+    quickview = buildCoreQuickview(
+      engine,
+      {options},
+      buildMockResultPreviewRequest,
+      path
+    );
   }
 
   beforeEach(() => {

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
@@ -39,19 +39,20 @@ export interface QuickviewOptions {
    * The maximum preview size to retrieve, in bytes. By default, the full preview is retrieved.
    */
   maximumPreviewSize?: number;
+
+  /**
+   * Whether to only update the `srcPath` attribute when using `fetchResultContent` rather than updating `content`.
+   * Use this if you are using an iframe with `state.srcPath` as the source url.
+   */
+  onlySrcPath?: boolean;
 }
 
 export interface Quickview extends Controller {
   /**
    * Retrieves the preview content for the configured result.
+   * If `options.onlySrcPath` is `true` this will update the `srcPath` state property rather than `content`.
    */
   fetchResultContent(): void;
-
-  /*
-   * Executes the callback function intended for when quickview content is fetched.
-   * Use this when using the quickview `srcPath` in an iframe.
-   */
-  executeOnFetchCallback(): void;
 
   /**
    * The state for the `Quickview` controller.
@@ -111,28 +112,25 @@ export function buildCoreQuickview(
   const {result, maximumPreviewSize} = props.options;
   const uniqueId = result.uniqueId;
 
-  dispatch(
-    updateSrcPath({
-      uniqueId,
-      requestedOutputSize: maximumPreviewSize,
-      buildResultPreviewRequest,
-      path,
-    })
-  );
-
   return {
     ...controller,
 
     fetchResultContent() {
-      dispatch(
-        fetchResultContent({uniqueId, requestedOutputSize: maximumPreviewSize})
-      );
-      if (fetchResultContentCallback) {
-        fetchResultContentCallback();
-      }
-    },
-
-    executeOnFetchCallback() {
+      props.options.onlySrcPath
+        ? dispatch(
+            updateSrcPath({
+              uniqueId,
+              requestedOutputSize: maximumPreviewSize,
+              buildResultPreviewRequest,
+              path,
+            })
+          )
+        : dispatch(
+            fetchResultContent({
+              uniqueId,
+              requestedOutputSize: maximumPreviewSize,
+            })
+          );
       if (fetchResultContentCallback) {
         fetchResultContentCallback();
       }

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
@@ -9,7 +9,7 @@ import {configuration, resultPreview} from '../../../app/reducers';
 import {ClientThunkExtraArguments} from '../../../app/thunk-extra-arguments';
 import {
   fetchResultContent,
-  updateSrcPath,
+  updateContentURL,
 } from '../../../features/result-preview/result-preview-actions';
 import {StateNeededByHtmlEndpoint} from '../../../features/result-preview/result-preview-request-builder';
 import {
@@ -41,16 +41,16 @@ export interface QuickviewOptions {
   maximumPreviewSize?: number;
 
   /**
-   * Whether to only update the `srcPath` attribute when using `fetchResultContent` rather than updating `content`.
-   * Use this if you are using an iframe with `state.srcPath` as the source url.
+   * Whether to only update the `contentURL` attribute when using `fetchResultContent` rather than updating `content`.
+   * Use this if you are using an iframe with `state.contentURL` as the source url.
    */
-  onlySrcPath?: boolean;
+  onlyContentURL?: boolean;
 }
 
 export interface Quickview extends Controller {
   /**
    * Retrieves the preview content for the configured result.
-   * If `options.onlySrcPath` is `true` this will update the `srcPath` state property rather than `content`.
+   * If `options.onlyContentURL` is `true` this will update the `contentURL` state property rather than `content`.
    */
   fetchResultContent(): void;
 
@@ -81,7 +81,7 @@ export interface QuickviewState {
   /**
    * The `src` path to use if rendering the quickview in an iframe.
    */
-  srcPath?: string;
+  contentURL?: string;
 }
 
 /**
@@ -116,9 +116,9 @@ export function buildCoreQuickview(
     ...controller,
 
     fetchResultContent() {
-      props.options.onlySrcPath
+      props.options.onlyContentURL
         ? dispatch(
-            updateSrcPath({
+            updateContentURL({
               uniqueId,
               requestedOutputSize: maximumPreviewSize,
               buildResultPreviewRequest,
@@ -142,13 +142,13 @@ export function buildCoreQuickview(
       const preview = state.resultPreview;
       const content = uniqueId === preview.uniqueId ? preview.content : '';
       const isLoading = preview.isLoading;
-      const srcPath = preview.srcPath;
+      const contentURL = preview.contentURL;
 
       return {
         content,
         resultHasPreview,
         isLoading,
-        srcPath,
+        contentURL,
       };
     },
   };

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
@@ -62,6 +62,11 @@ export interface QuickviewState {
    * `true` if content is being fetched, and `false` otherwise.
    */
   isLoading: boolean;
+
+  /**
+   * The `src` path to use if rendering the quickview in an iframe.
+   */
+  srcPath?: string;
 }
 
 /**
@@ -75,7 +80,8 @@ export interface QuickviewState {
 export function buildCoreQuickview(
   engine: CoreEngine,
   props: QuickviewProps,
-  fetchResultContentCallback?: () => void
+  fetchResultContentCallback?: () => void,
+  htmlUrl?: string
 ): Quickview {
   if (!loadQuickviewReducers(engine)) {
     throw loadReducerError;
@@ -100,15 +106,21 @@ export function buildCoreQuickview(
     },
 
     get state() {
+      const state = getState();
+      const {accessToken, organizationId} = state.configuration;
       const resultHasPreview = result.hasHtmlVersion;
-      const preview = getState().resultPreview;
+      const preview = state.resultPreview;
       const content = uniqueId === preview.uniqueId ? preview.content : '';
       const isLoading = preview.isLoading;
+      const srcPath = htmlUrl
+        ? `${htmlUrl}?access_token=${accessToken}&organizationId=${organizationId}&uniqueId=${result.uniqueId}`
+        : undefined;
 
       return {
         content,
         resultHasPreview,
         isLoading,
+        srcPath,
       };
     },
   };

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
@@ -39,6 +39,12 @@ export interface Quickview extends Controller {
    */
   fetchResultContent(): void;
 
+  /*
+   * Executes the callback function intended for when quickview content is fetched.
+   * Use this when using the quickview `srcPath` in an iframe.
+   */
+  executeOnFetchCallback(): void;
+
   /**
    * The state for the `Quickview` controller.
    */
@@ -100,6 +106,12 @@ export function buildCoreQuickview(
       dispatch(
         fetchResultContent({uniqueId, requestedOutputSize: maximumPreviewSize})
       );
+      if (fetchResultContentCallback) {
+        fetchResultContentCallback();
+      }
+    },
+
+    executeOnFetchCallback() {
       if (fetchResultContentCallback) {
         fetchResultContentCallback();
       }

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -1,6 +1,6 @@
-import {baseInsightUrl} from '../../../api/service/insight/insight-params';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
+import {buildResultPreviewRequest} from '../../../features/result-preview/result-preview-request-builder';
 import {
   QuickviewProps,
   QuickviewOptions,
@@ -25,17 +25,13 @@ export function buildQuickview(
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
 
-  const {accessToken, organizationId, platformUrl} = engine.state.configuration;
-  const {insightId} = engine.state.insightConfiguration;
-  const htmlUrl = baseInsightUrl(
-    {
-      accessToken,
-      organizationId,
-      url: platformUrl,
-      insightId,
-    },
-    '/quickview'
-  );
+  const path = '/quickview';
 
-  return buildCoreQuickview(engine, props, fetchResultContentCallback, htmlUrl);
+  return buildCoreQuickview(
+    engine,
+    props,
+    buildResultPreviewRequest,
+    path,
+    fetchResultContentCallback
+  );
 }

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -1,3 +1,4 @@
+import {baseInsightUrl} from '../../../api/service/insight/insight-params';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
 import {
@@ -24,5 +25,17 @@ export function buildQuickview(
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
 
-  return buildCoreQuickview(engine, props, fetchResultContentCallback);
+  const {accessToken, organizationId, platformUrl} = engine.state.configuration;
+  const {insightId} = engine.state.insightConfiguration;
+  const htmlUrl = baseInsightUrl(
+    {
+      accessToken,
+      organizationId,
+      url: platformUrl,
+      insightId,
+    },
+    '/quickview'
+  );
+
+  return buildCoreQuickview(engine, props, fetchResultContentCallback, htmlUrl);
 }

--- a/packages/headless/src/controllers/quickview/case-assist-headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/case-assist-headless-quickview.ts
@@ -1,5 +1,6 @@
 import {CaseAssistEngine} from '../../app//case-assist-engine/case-assist-engine';
 import {logQuickviewDocumentSuggestionClick} from '../../features/case-assist/case-assist-analytics-actions';
+import {buildResultPreviewRequest} from '../../features/result-preview/result-preview-request-builder';
 import {
   buildCoreQuickview,
   QuickviewOptions,
@@ -32,6 +33,13 @@ export function buildCaseAssistQuickview(
       logQuickviewDocumentSuggestionClick(props.options.result.uniqueId)
     );
   };
+  const path = '/html';
 
-  return buildCoreQuickview(engine, props, fetchResultContentCallback);
+  return buildCoreQuickview(
+    engine,
+    props,
+    buildResultPreviewRequest,
+    path,
+    fetchResultContentCallback
+  );
 }

--- a/packages/headless/src/controllers/quickview/headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/headless-quickview.ts
@@ -1,5 +1,6 @@
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {logDocumentQuickview} from '../../features/result-preview/result-preview-analytics-actions';
+import {buildResultPreviewRequest} from '../../features/result-preview/result-preview-request-builder';
 import {
   buildCoreQuickview,
   QuickviewOptions,
@@ -24,8 +25,13 @@ export function buildQuickview(
   const fetchResultContentCallback = () => {
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
+  const path = '/html';
 
-  const htmlUrl = `${engine.state.configuration.search.apiBaseUrl}/html`;
-
-  return buildCoreQuickview(engine, props, fetchResultContentCallback, htmlUrl);
+  return buildCoreQuickview(
+    engine,
+    props,
+    buildResultPreviewRequest,
+    path,
+    fetchResultContentCallback
+  );
 }

--- a/packages/headless/src/controllers/quickview/headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/headless-quickview.ts
@@ -25,5 +25,7 @@ export function buildQuickview(
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
 
-  return buildCoreQuickview(engine, props, fetchResultContentCallback);
+  const htmlUrl = `${engine.state.configuration.search.apiBaseUrl}/html`;
+
+  return buildCoreQuickview(engine, props, fetchResultContentCallback, htmlUrl);
 }

--- a/packages/headless/src/features/result-preview/result-preview-actions.ts
+++ b/packages/headless/src/features/result-preview/result-preview-actions.ts
@@ -1,6 +1,6 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {
-  buildSrcPath,
+  buildContentURL,
   HtmlApiClient,
 } from '../../api/search/html/html-api-client';
 import {
@@ -21,11 +21,11 @@ interface FetchResultContentResponse {
   uniqueId: string;
 }
 
-interface UpdateSrcPathActionCreatorPayload {
+interface UpdateContentURLActionCreatorPayload {
   /**
    * The path to retrieve result quickview content.
    */
-  srcPath?: string;
+  contentURL?: string;
 }
 
 export interface AsyncThunkGlobalOptions<T>
@@ -55,7 +55,7 @@ export const fetchResultContent = createAsyncThunk<
   }
 );
 
-type UpdateSrcPathOptions = HtmlRequestOptions & {
+type UpdateContentURLOptions = HtmlRequestOptions & {
   path: string;
   buildResultPreviewRequest: (
     state: StateNeededByHtmlEndpoint,
@@ -63,15 +63,15 @@ type UpdateSrcPathOptions = HtmlRequestOptions & {
   ) => Promise<HtmlRequest>;
 };
 
-export const updateSrcPath = createAsyncThunk<
-  UpdateSrcPathActionCreatorPayload,
-  UpdateSrcPathOptions,
+export const updateContentURL = createAsyncThunk<
+  UpdateContentURLActionCreatorPayload,
+  UpdateContentURLOptions,
   AsyncThunkGlobalOptions<StateNeededByHtmlEndpoint>
 >(
-  'resultPreview/updateSrcPath',
-  async (options: UpdateSrcPathOptions, {getState}) => {
+  'resultPreview/updateContentURL',
+  async (options: UpdateContentURLOptions, {getState}) => {
     const state = getState();
-    const srcPath = buildSrcPath(
+    const contentURL = buildContentURL(
       await options.buildResultPreviewRequest(state, {
         uniqueId: options.uniqueId,
         requestedOutputSize: options.requestedOutputSize,
@@ -80,7 +80,7 @@ export const updateSrcPath = createAsyncThunk<
     );
 
     return {
-      srcPath,
+      contentURL: contentURL,
     };
   }
 );

--- a/packages/headless/src/features/result-preview/result-preview-actions.ts
+++ b/packages/headless/src/features/result-preview/result-preview-actions.ts
@@ -81,7 +81,7 @@ export const updateContentURL = createAsyncThunk<
       options.path
     );
 
-    if (contentURL.length > MAX_GET_LENGTH) {
+    if (contentURL?.length > MAX_GET_LENGTH) {
       extra.logger.error(
         `The content URL was truncated as it exceeds the maximum allowed length of ${MAX_GET_LENGTH} characters.`
       );

--- a/packages/headless/src/features/result-preview/result-preview-actions.ts
+++ b/packages/headless/src/features/result-preview/result-preview-actions.ts
@@ -63,13 +63,15 @@ type UpdateContentURLOptions = HtmlRequestOptions & {
   ) => Promise<HtmlRequest>;
 };
 
+const MAX_GET_LENGTH = 2048;
+
 export const updateContentURL = createAsyncThunk<
   UpdateContentURLActionCreatorPayload,
   UpdateContentURLOptions,
   AsyncThunkGlobalOptions<StateNeededByHtmlEndpoint>
 >(
   'resultPreview/updateContentURL',
-  async (options: UpdateContentURLOptions, {getState}) => {
+  async (options: UpdateContentURLOptions, {getState, extra}) => {
     const state = getState();
     const contentURL = buildContentURL(
       await options.buildResultPreviewRequest(state, {
@@ -78,6 +80,12 @@ export const updateContentURL = createAsyncThunk<
       }),
       options.path
     );
+
+    if (contentURL.length > MAX_GET_LENGTH) {
+      extra.logger.error(
+        `The content URL was truncated as it exceeds the maximum allowed length of ${MAX_GET_LENGTH} characters.`
+      );
+    }
 
     return {
       contentURL: contentURL,

--- a/packages/headless/src/features/result-preview/result-preview-slice.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.test.ts
@@ -1,4 +1,5 @@
-import {fetchResultContent} from './result-preview-actions';
+import {buildMockResultPreviewRequest} from '../../test/mock-result-preview-request-builder';
+import {fetchResultContent, updateContentURL} from './result-preview-actions';
 import {resultPreviewReducer} from './result-preview-slice';
 import {
   getResultPreviewInitialState,
@@ -52,5 +53,24 @@ describe('ResultPreview', () => {
 
       expect(state.isLoading).toBe(false);
     });
+  });
+
+  it('on #updateContentURL.fulfilled, it sets #contentURL', () => {
+    const testPath = '/html';
+    const testUniqueId = '1';
+    const payload = {
+      contentURL: 'https://testurl.coveo.com/html?',
+    };
+
+    state.contentURL = undefined;
+    const action = updateContentURL.fulfilled(payload, '', {
+      uniqueId: testUniqueId,
+      path: testPath,
+      buildResultPreviewRequest: buildMockResultPreviewRequest,
+    });
+
+    state = resultPreviewReducer(state, action);
+
+    expect(state.contentURL).toBe(payload.contentURL);
   });
 });

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -1,5 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
-import {fetchResultContent, updateSrcPath} from './result-preview-actions';
+import {fetchResultContent, updateContentURL} from './result-preview-actions';
 import {getResultPreviewInitialState} from './result-preview-state';
 
 export const resultPreviewReducer = createReducer(
@@ -16,9 +16,10 @@ export const resultPreviewReducer = createReducer(
         state.uniqueId = uniqueId;
         state.isLoading = false;
       })
-      .addCase(updateSrcPath.fulfilled, (state, action) => {
-        const {srcPath} = action.payload;
-        state.srcPath = srcPath;
+      .addCase(updateContentURL.fulfilled, (state, action) => {
+        const {contentURL} = action.payload;
+
+        state.contentURL = contentURL;
       });
   }
 );

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -1,5 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
-import {fetchResultContent} from './result-preview-actions';
+import {fetchResultContent, updateSrcPath} from './result-preview-actions';
 import {getResultPreviewInitialState} from './result-preview-state';
 
 export const resultPreviewReducer = createReducer(
@@ -15,6 +15,10 @@ export const resultPreviewReducer = createReducer(
         state.content = content;
         state.uniqueId = uniqueId;
         state.isLoading = false;
+      })
+      .addCase(updateSrcPath.fulfilled, (state, action) => {
+        const {srcPath} = action.payload;
+        state.srcPath = srcPath;
       });
   }
 );

--- a/packages/headless/src/features/result-preview/result-preview-state.ts
+++ b/packages/headless/src/features/result-preview/result-preview-state.ts
@@ -2,7 +2,7 @@ export interface ResultPreviewState {
   uniqueId: string;
   content: string;
   isLoading: boolean;
-  srcPath?: string;
+  contentURL?: string;
 }
 
 export function getResultPreviewInitialState(): ResultPreviewState {

--- a/packages/headless/src/features/result-preview/result-preview-state.ts
+++ b/packages/headless/src/features/result-preview/result-preview-state.ts
@@ -2,6 +2,7 @@ export interface ResultPreviewState {
   uniqueId: string;
   content: string;
   isLoading: boolean;
+  srcPath?: string;
 }
 
 export function getResultPreviewInitialState(): ResultPreviewState {

--- a/packages/headless/src/test/mock-result-preview-request-builder.ts
+++ b/packages/headless/src/test/mock-result-preview-request-builder.ts
@@ -1,0 +1,18 @@
+import {HtmlRequestOptions, HtmlRequest} from '../api/search/html/html-request';
+import {StateNeededByHtmlEndpoint} from '../features/result-preview/result-preview-request-builder';
+
+export async function buildMockResultPreviewRequest(
+  _state: StateNeededByHtmlEndpoint,
+  options: HtmlRequestOptions
+): Promise<HtmlRequest> {
+  return {
+    url: 'https://testurl.coveo.com',
+    accessToken: 'access-token-xxxxx',
+    organizationId: 'some-org-id',
+    enableNavigation: false,
+    visitorId: 'visitor-id',
+    q: 'query',
+    requestedOutputSize: options.requestedOutputSize || 0,
+    ...options,
+  };
+}

--- a/packages/headless/src/utils/url-utils.test.ts
+++ b/packages/headless/src/utils/url-utils.test.ts
@@ -1,0 +1,44 @@
+import {URLPath} from './url-utils';
+
+describe('URLPath', () => {
+  const testBasePath = 'https://www.test.com';
+  describe('without params', () => {
+    it('should return base url', () => {
+      const url = new URLPath(testBasePath);
+
+      expect(url.href).toBe(testBasePath);
+    });
+  });
+
+  describe('with params', () => {
+    const testParams = [
+      {
+        key: 'testKey',
+        value: 'test#Value',
+      },
+      {
+        key: 'testKey1',
+        value: 'test#Value1',
+      },
+    ];
+
+    it('should return full url', () => {
+      const url = new URLPath(testBasePath);
+      const param = testParams[0];
+
+      url.addParam(param.key, param.value);
+
+      expect(url.href).toBe('https://www.test.com?testKey=test%23Value');
+    });
+
+    it('should return full url with concatenated params', () => {
+      const url = new URLPath(testBasePath);
+
+      testParams.forEach((param) => url.addParam(param.key, param.value));
+
+      expect(url.href).toBe(
+        'https://www.test.com?testKey=test%23Value&testKey1=test%23Value1'
+      );
+    });
+  });
+});

--- a/packages/headless/src/utils/url-utils.ts
+++ b/packages/headless/src/utils/url-utils.ts
@@ -1,0 +1,35 @@
+export class URLPath {
+  private _basePath: string;
+  private _params: Record<string, string> = {};
+
+  constructor(basePath: string) {
+    this._basePath = basePath;
+  }
+
+  public addParam(name: string, value: string) {
+    this._params = {
+      ...this.params,
+      [name]: value,
+    };
+  }
+
+  get basePath() {
+    return this._basePath;
+  }
+
+  get params() {
+    return this._params;
+  }
+
+  get hasParams() {
+    return Object.entries(this._params).length;
+  }
+
+  get href() {
+    return this.hasParams
+      ? `${this.basePath}?${Object.entries(this.params)
+          .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+          .join('&')}`
+      : this.basePath;
+  }
+}

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -192,7 +192,7 @@ export function mockSearchWithResults() {
 }
 
 export function interceptResultHtmlContent() {
-  cy.intercept('POST', routeMatchers.html).as(
+  cy.intercept('GET', routeMatchers.html).as(
     InterceptAliases.ResultHtml.substring(1)
   );
 }

--- a/packages/quantic/force-app/main/default/cspTrustedSites/QuanticCoveoPlatform.cspTrustedSite-meta.xml
+++ b/packages/quantic/force-app/main/default/cspTrustedSites/QuanticCoveoPlatform.cspTrustedSite-meta.xml
@@ -4,5 +4,6 @@
     <endpointUrl>https://*.coveo.com</endpointUrl>
     <isActive>true</isActive>
     <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
+    <isApplicableToFrameSrc>true</isApplicableToFrameSrc>
     <context>All</context>
 </CspTrustedSite>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.css
@@ -1,5 +1,6 @@
 .quickview__content-container {
   overflow: auto;
+  border: none;
 }
 
 .quickview__result-title {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -38,13 +38,14 @@
             <lightning-spinner alternative-text="Loading" size="large"></lightning-spinner>
           </div>
         </template>
+        <iframe
+          id="quickview__content-container"
+          class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap"
+          src={srcPath}
+          height="100%"
+          onload={onIframeLoaded}
+        ></iframe>
         <template if:false={isLoading}>
-          <iframe
-            id="quickview__content-container"
-            class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap"
-            src={srcPath}
-            height="100%"
-          ></iframe>
           <footer onclick={stopPropagation} class="slds-modal__footer slds-p-top_none slds-p-bottom_none">
             <slot name="footer"></slot>
           </footer>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -41,7 +41,7 @@
         <iframe
           id="quickview__content-container"
           class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap"
-          src={srcPath}
+          src={contentURL}
           height="100%"
           onload={onIframeLoaded}
         ></iframe>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -39,7 +39,12 @@
           </div>
         </template>
         <template if:false={isLoading}>
-          <div onclick={stopPropagation} class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap" id="quickview__content-container" lwc:dom="manual"></div>
+          <iframe
+            id="quickview__content-container"
+            class="quickview__content-container slds-modal__content slds-p-around_large slds-wrap"
+            src={srcPath}
+            height="100%"
+          ></iframe>
           <footer onclick={stopPropagation} class="slds-modal__footer slds-p-top_none slds-p-bottom_none">
             <slot name="footer"></slot>
           </footer>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -139,10 +139,10 @@ export default class QuanticResultQuickview extends LightningElement {
 
   openQuickview() {
     this.isQuickviewOpen = true;
-    this.quickview.fetchResultContent();
     if (!isHeadlessBundle(this.engineId, HeadlessBundleNames.caseAssist)) {
       this.addRecentResult();
     }
+    this.quickview.executeOnFetchCallback();
     this.sendResultPreviewEvent(true);
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -1,4 +1,7 @@
-import {LightningElement, api, track} from 'lwc';
+import close from '@salesforce/label/c.quantic_Close';
+import noPreview from '@salesforce/label/c.quantic_NoPreviewAvailable';
+import openFileForPreview from '@salesforce/label/c.quantic_OpenFileForPreview';
+import openPreview from '@salesforce/label/c.quantic_OpenPreview';
 import {
   getHeadlessBundle,
   getHeadlessEnginePromise,
@@ -6,11 +9,7 @@ import {
   isHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
 import {I18nUtils, getLastFocusableElement} from 'c/quanticUtils';
-
-import close from '@salesforce/label/c.quantic_Close';
-import openPreview from '@salesforce/label/c.quantic_OpenPreview';
-import noPreview from '@salesforce/label/c.quantic_NoPreviewAvailable';
-import openFileForPreview from '@salesforce/label/c.quantic_OpenFileForPreview';
+import {LightningElement, api, track} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
 /** @typedef {import("coveo").Quickview} Quickview */
@@ -107,9 +106,8 @@ export default class QuanticResultQuickview extends LightningElement {
 
   renderedCallback() {
     if (this.contentContainer && this.state?.resultHasPreview) {
-      // eslint-disable-next-line @lwc/lwc/no-inner-html
-      this.contentContainer.innerHTML = this.state.content;
       if (this.isQuickviewOpen && this.isFirstPreviewRender) {
+        // this.quickview.fetchSrcPath();
         this.isFirstPreviewRender = false;
         this.setFocusToHeader();
       }
@@ -206,7 +204,7 @@ export default class QuanticResultQuickview extends LightningElement {
     return !!this.previewButtonIcon;
   }
 
-  /** @type {HTMLElement} */
+  /** @type {HTMLIFrameElement} */
   get contentContainer() {
     return this.template.querySelector('.quickview__content-container');
   }
@@ -241,6 +239,10 @@ export default class QuanticResultQuickview extends LightningElement {
 
   get hasButtonLabel() {
     return !!this.previewButtonLabel;
+  }
+
+  get srcPath() {
+    return this.state.srcPath;
   }
 
   setFocusToHeader() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -107,7 +107,6 @@ export default class QuanticResultQuickview extends LightningElement {
   renderedCallback() {
     if (this.contentContainer && this.state?.resultHasPreview) {
       if (this.isQuickviewOpen && this.isFirstPreviewRender) {
-        // this.quickview.fetchSrcPath();
         this.isFirstPreviewRender = false;
         this.setFocusToHeader();
       }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -86,6 +86,8 @@ export default class QuanticResultQuickview extends LightningElement {
   headless;
   /** @type {boolean} */
   isFirstPreviewRender = true;
+  /** @type {boolean} */
+  _isLoading = false;
 
   labels = {
     close,
@@ -122,6 +124,7 @@ export default class QuanticResultQuickview extends LightningElement {
     const options = {
       result: this.result,
       maximumPreviewSize: Number(this.maximumPreviewSize),
+      onlySrcPath: true,
     };
     this.quickview = this.headless.buildQuickview(engine, {options});
     this.unsubscribe = this.quickview.subscribe(() => this.updateState());
@@ -139,10 +142,11 @@ export default class QuanticResultQuickview extends LightningElement {
 
   openQuickview() {
     this.isQuickviewOpen = true;
+    this._isLoading = true;
     if (!isHeadlessBundle(this.engineId, HeadlessBundleNames.caseAssist)) {
       this.addRecentResult();
     }
-    this.quickview.executeOnFetchCallback();
+    this.quickview.fetchResultContent();
     this.sendResultPreviewEvent(true);
   }
 
@@ -192,7 +196,7 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get isLoading() {
-    return this.state?.isLoading;
+    return this._isLoading;
   }
 
   get hasNoPreview() {
@@ -241,7 +245,11 @@ export default class QuanticResultQuickview extends LightningElement {
   }
 
   get srcPath() {
-    return this.state.srcPath;
+    return this.state.srcPath?.includes(
+      encodeURIComponent(this.result.uniqueId)
+    )
+      ? this.state.srcPath
+      : undefined;
   }
 
   setFocusToHeader() {
@@ -279,6 +287,10 @@ export default class QuanticResultQuickview extends LightningElement {
         this.setFocusToHeader();
       }
     }
+  }
+
+  onIframeLoaded() {
+    this._isLoading = false;
   }
 
   get lastFocusableElementInFooterSlot() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -124,7 +124,7 @@ export default class QuanticResultQuickview extends LightningElement {
     const options = {
       result: this.result,
       maximumPreviewSize: Number(this.maximumPreviewSize),
-      onlySrcPath: true,
+      onlyContentURL: true,
     };
     this.quickview = this.headless.buildQuickview(engine, {options});
     this.unsubscribe = this.quickview.subscribe(() => this.updateState());
@@ -244,11 +244,11 @@ export default class QuanticResultQuickview extends LightningElement {
     return !!this.previewButtonLabel;
   }
 
-  get srcPath() {
-    return this.state.srcPath?.includes(
+  get contentURL() {
+    return this.state.contentURL?.includes(
       encodeURIComponent(this.result.uniqueId)
     )
-      ? this.state.srcPath
+      ? this.state.contentURL
       : undefined;
   }
 


### PR DESCRIPTION
Added `srcPath` to the quickview state to be used optionally if the implementation requires usage of the GET endpoint rather than the POST.

Quantic was also updated to leverage the change.

Misc changes:
- Fixed a typo in the readme. It formatted the whole file on save... is my linting setup wrong? I'm using `Prettier ESLint`
- Added the `engines` config to headless because, while attempting to use `URL` I got an error saying we needed to be compatible with Node v8. Looks like the root config doesn't get inherited by the packages.
- Speaking of `URL` apparently it looks like React Native has [some differences](https://www.npmjs.com/package/react-native-url-polyfill#user-content-why-do-we-need-this) with its URL implementation to I created a util to replace it for my purposes.