### PR TITLE
fix(atomic): added warning when declaring a template with section and non-section elements

### DIFF
--- a/packages/atomic/cypress/e2e/result-list/result-list-actions.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-list-actions.ts
@@ -13,19 +13,19 @@ import {
 import {resultTemplateComponent} from './result-template-selectors';
 
 export function buildTemplateWithoutSections(
-  elements: HTMLElement | HTMLElement[],
+  nodes: Node | Node[],
   props: TagProps = {},
   templateComponent = resultTemplateComponent
 ) {
   const resultTemplate = generateComponentHTML(templateComponent, props);
   const template = generateComponentHTML('template') as HTMLTemplateElement;
   resultTemplate.appendChild(template);
-  toArray(elements).forEach((element) => template.content.appendChild(element));
+  template.content.append(...toArray(nodes));
   return resultTemplate;
 }
 
 export function buildTemplateWithSections(
-  sections: Partial<Record<ResultSection, HTMLElement | HTMLElement[]>>,
+  sections: Partial<Record<ResultSection, Node | Node[]>>,
   props: TagProps = {},
   templateComponent = resultTemplateComponent
 ) {
@@ -34,9 +34,9 @@ export function buildTemplateWithSections(
     HTMLElement | HTMLElement[]
   ][];
   const sectionsEls: HTMLElement[] = [];
-  for (const [section, elements] of sectionPairs) {
+  for (const [section, nodes] of sectionPairs) {
     const sectionEl = generateComponentHTML(resultSectionTags[section]);
-    toArray(elements).forEach((e) => sectionEl.appendChild(e));
+    sectionEl.append(...toArray(nodes));
     sectionsEls.push(sectionEl);
   }
   return buildTemplateWithoutSections(sectionsEls, props, templateComponent);

--- a/packages/atomic/cypress/e2e/result-list/result-template.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-template.cypress.ts
@@ -1,5 +1,9 @@
+import {tableElementTagName} from '../../../src/components/search/atomic-table-result/table-element-utils';
 import {generateComponentHTML, TestFixture} from '../../fixtures/test-fixture';
-import {assertContainsComponentError} from '../common-assertions';
+import {
+  assertConsoleWarning,
+  assertContainsComponentError,
+} from '../common-assertions';
 import {
   addFieldValueInResponse,
   addResultList,
@@ -9,6 +13,7 @@ import {
 import {
   resultListComponent,
   ResultListSelectors,
+  resultSectionTags,
 } from './result-list-selectors';
 import {addResultTable} from './result-table-actions';
 import {ResultTableSelectors} from './result-table-selectors';
@@ -59,6 +64,42 @@ describe('Result Template Component', () => {
     });
 
     assertContainsComponentError(ResultTemplateSelectors, true);
+  });
+
+  describe('when it has both section and non-section elements', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addResultList(
+            buildTemplateWithoutSections([
+              new Text('hello'),
+              generateComponentHTML(resultSectionTags.actions),
+            ])
+          )
+        )
+        .init();
+    });
+
+    assertConsoleWarning(true);
+  });
+
+  describe('when it has strictly section and table-element elements', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addResultList(
+            buildTemplateWithoutSections([
+              generateComponentHTML(tableElementTagName),
+              new Text('    \n    '),
+              generateComponentHTML(resultSectionTags.actions),
+            ])
+          )
+        )
+        .init();
+    });
+
+    assertContainsComponentError(ResultTemplateSelectors, false);
+    assertConsoleWarning(false);
   });
 
   describe('with a visual section', () => {

--- a/packages/atomic/src/components/common/layout/display-options.ts
+++ b/packages/atomic/src/components/common/layout/display-options.ts
@@ -1,4 +1,4 @@
-import {containsSections, resultSectionTags} from './sections';
+import {containsSections, ResultSectionTagName} from './sections';
 
 export type ResultDisplayBasicLayout = 'list' | 'grid';
 export type ResultDisplayLayout = ResultDisplayBasicLayout | 'table';
@@ -84,7 +84,7 @@ export class ResultLayout {
     return imageSize as ResultDisplayImageSize;
   }
 
-  private getSection(section: typeof resultSectionTags[number]) {
+  private getSection(section: ResultSectionTagName) {
     return Array.from(this.children).find(
       (element) => element.tagName.toLowerCase() === section
     );

--- a/packages/atomic/src/components/common/layout/sections.ts
+++ b/packages/atomic/src/components/common/layout/sections.ts
@@ -1,4 +1,6 @@
-export const resultSectionTags = [
+import {isElementNode} from '../../../utils/utils';
+
+export const resultSectionTags = new Set([
   'atomic-result-section-visual',
   'atomic-result-section-badges',
   'atomic-result-section-actions',
@@ -7,20 +9,26 @@ export const resultSectionTags = [
   'atomic-result-section-emphasized',
   'atomic-result-section-excerpt',
   'atomic-result-section-bottom-metadata',
-] as const;
+] as const);
 
-export function containsSections(content: string): boolean;
-export function containsSections(content: HTMLCollection): boolean;
+type SetValueType<T> = T extends Set<infer U> ? U : never;
 
-export function containsSections(content: string | HTMLCollection) {
+export type ResultSectionTagName = SetValueType<typeof resultSectionTags>;
+
+export function isResultSectionNode(element: Node) {
+  if (!isElementNode(element)) {
+    return false;
+  }
+  return resultSectionTags.has(
+    element.tagName.toLowerCase() as ResultSectionTagName
+  );
+}
+
+export function containsSections(content: string | NodeList | HTMLCollection) {
   if (typeof content === 'string') {
-    return resultSectionTags.some((resultSectionTag) =>
+    return Array.from(resultSectionTags.values()).some((resultSectionTag) =>
       content.includes(resultSectionTag)
     );
   }
-  return Array.from(content).some((child) =>
-    (resultSectionTags as readonly string[]).includes(
-      child.tagName.toLowerCase()
-    )
-  );
+  return Array.from(content).some((child) => isResultSectionNode(child));
 }

--- a/packages/atomic/src/components/common/result-list/table-display-results.tsx
+++ b/packages/atomic/src/components/common/result-list/table-display-results.tsx
@@ -1,4 +1,5 @@
 import {FunctionalComponent, h} from '@stencil/core';
+import {tableElementTagName} from '../../search/atomic-table-result/table-element-utils';
 import {extractUnfoldedResult} from '../interface/result';
 import {ResultListDisplayProps} from './result-list-common-interface';
 
@@ -84,7 +85,7 @@ const getFieldTableColumnsFromRenderingFunction = (
   contentOfRenderingFunction.innerHTML = contentOfRenderingFunctionAsString;
 
   return Array.from(
-    contentOfRenderingFunction.querySelectorAll('atomic-table-element')
+    contentOfRenderingFunction.querySelectorAll(tableElementTagName)
   );
 };
 
@@ -94,5 +95,5 @@ const getFieldTableColumnsFromHTMLTemplate = (
   Array.from(
     props.resultTemplateProvider
       .getTemplateContent(props.getResultListState().results[0])
-      .querySelectorAll('atomic-table-element')
+      .querySelectorAll(tableElementTagName)
   );

--- a/packages/atomic/src/components/common/result-templates/result-template-common.tsx
+++ b/packages/atomic/src/components/common/result-templates/result-template-common.tsx
@@ -4,6 +4,9 @@ import {
   ResultTemplatesHelpers,
 } from '@coveo/headless';
 import {h} from '@stencil/core';
+import {isElementNode, isVisualNode} from '../../../utils/utils';
+import {tableElementTagName} from '../../search/atomic-table-result/table-element-utils';
+import {isResultSectionNode} from '../layout/sections';
 
 export type TemplateContent = DocumentFragment;
 
@@ -12,6 +15,36 @@ interface ResultTemplateCommonProps {
   host: HTMLDivElement;
   validParents: string[];
   setError: (error: Error) => void;
+}
+
+export function getTemplateNodeType(node: Node) {
+  if (isResultSectionNode(node)) {
+    return 'section';
+  }
+  if (!isVisualNode(node)) {
+    return 'metadata';
+  }
+  if (
+    isElementNode(node) &&
+    node.tagName.toLowerCase() === tableElementTagName
+  ) {
+    return 'table-column-definition';
+  }
+  return 'other';
+}
+
+function separateSectionAndNonSectionNodes(nodes: NodeList) {
+  const sectionNodes: Node[] = [];
+  const otherNodes: Node[] = [];
+  for (const node of Array.from(nodes)) {
+    const nodeType = getTemplateNodeType(node);
+    if (nodeType === 'section') {
+      sectionNodes.push(node);
+    } else if (nodeType === 'other') {
+      otherNodes.push(node);
+    }
+  }
+  return {sectionNodes, otherNodes};
 }
 
 export class ResultTemplateCommon {
@@ -60,17 +93,28 @@ export class ResultTemplateCommon {
       return;
     }
 
-    if (!allowEmpty && !template?.innerHTML.trim()) {
+    if (!allowEmpty && !template.innerHTML.trim()) {
       setError(
-        new Error(`The "template" tag inside "${tagName}" cannot be empty`)
+        new Error(`The "template" tag inside "${tagName}" cannot be empty.`)
       );
       return;
     }
 
-    if (template?.content.querySelector('script')) {
+    if (template.content.querySelector('script')) {
       console.warn(
-        'Any "script" tags defined inside of "template" elements are not supported and will not be executed when the results are rendered',
+        'Any "script" tags defined inside of "template" elements are not supported and will not be executed when the results are rendered.',
         host
+      );
+    }
+
+    const {sectionNodes, otherNodes} = separateSectionAndNonSectionNodes(
+      template.content.childNodes
+    );
+    if (sectionNodes.length && otherNodes.length) {
+      console.warn(
+        'Result templates should only contain section elements or non-section elements. Future updates could unpredictably affect this result template.',
+        host,
+        {sectionNodes, otherNodes}
       );
     }
   }

--- a/packages/atomic/src/components/search/atomic-table-result/table-element-utils.tsx
+++ b/packages/atomic/src/components/search/atomic-table-result/table-element-utils.tsx
@@ -1,0 +1,1 @@
+export const tableElementTagName = 'atomic-table-element';

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -56,13 +56,28 @@ export function parseHTML(string: string) {
   return new window.DOMParser().parseFromString(string, 'text/html');
 }
 
+export function isElementNode(node: Node): node is Element {
+  return node.nodeType === NODE_TYPES.ELEMENT_NODE;
+}
+
+export function isTextNode(node: Node): node is Text {
+  return node.nodeType === NODE_TYPES.TEXT_NODE;
+}
+
+export function isVisualNode(node: Node) {
+  if (isElementNode(node)) {
+    return !(node instanceof HTMLStyleElement);
+  }
+  if (isTextNode(node)) {
+    return !!node.textContent?.trim();
+  }
+  return false;
+}
+
 export function containsVisualElement(node: Node) {
   for (let i = 0; i < node.childNodes.length; i++) {
     const child = node.childNodes.item(i);
-    if (
-      child.nodeType === NODE_TYPES.ELEMENT_NODE ||
-      (child.nodeType === NODE_TYPES.TEXT_NODE && child.textContent?.trim())
-    ) {
+    if (isVisualNode(child)) {
       return true;
     }
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2081

**Caveat**: the error is only logged when the template is declared using HTML. Results rendered using Javascript or using React/Angular do not log an error.

This took me much longer than expected because I came up with a way to refactor the rendering of result template, which I wanted to leverage to validate templates when rendered regardless of the framework. I stashed that solution and will re-explore it when we refactor the result list.

<details>
<summary>Details on the refactor I stashed</summary>

My refactor would've eliminated lots of repetition in `atomic-result`/`atomic-insight-result`/`atomic-recs-result` and would've completely removed the `string` type for templates. Rendering and validation of result templates would've been handled by a functional component which takes `{ content?: ParentNode } | { renderingFunction?: ResultRenderingFunction }` as a prop. However, this solution broke in React since `createRoot(...).render()` returns a different output than `renderToString`.
</details>

