### PR TITLE
feat(headless):  tab query parameter added to the insight search query

### DIFF
--- a/packages/headless/src/api/service/insight/insight-api-client.test.ts
+++ b/packages/headless/src/api/service/insight/insight-api-client.test.ts
@@ -80,6 +80,7 @@ describe('insight api client', () => {
       q: 'some agent query',
       cq: 'some expression',
       facets: [],
+      tab: 'selected tab',
     };
 
     it('should call the platform endpoint with the correct arguments', async () => {
@@ -99,6 +100,7 @@ describe('insight api client', () => {
           facets: queryRequest.facets,
           q: queryRequest.q,
           cq: queryRequest.cq,
+          tab: queryRequest.tab,
         },
       });
     });

--- a/packages/headless/src/api/service/insight/query/query-request.ts
+++ b/packages/headless/src/api/service/insight/query/query-request.ts
@@ -7,6 +7,7 @@ import {
   FirstResultParam,
   QueryParam,
   SortCriteriaParam,
+  TabParam,
 } from '../../../search/search-api-params';
 import {
   baseInsightRequest,
@@ -24,7 +25,8 @@ export type InsightQueryRequest = InsightParam &
   SortCriteriaParam &
   FieldsToIncludeParam &
   EnableDidYouMeanParam &
-  ConstantQueryParam;
+  ConstantQueryParam &
+  TabParam;
 
 interface CaseContextParam {
   caseContext?: Record<string, string>;

--- a/packages/headless/src/features/insight-search/insight-search-request.ts
+++ b/packages/headless/src/features/insight-search/insight-search-request.ts
@@ -55,6 +55,7 @@ export const buildInsightSearchRequest = (
     ...(state.sortCriteria && {
       sortCriteria: state.sortCriteria,
     }),
+    tab: state.configuration.analytics.originLevel2,
   });
 };
 


### PR DESCRIPTION
[SFINT-4580](https://coveord.atlassian.net/browse/SFINT-4580)

- ### Tab query parameter added to the insight search query.

### Demo:
<img width="901" alt="TabParameter" src="https://user-images.githubusercontent.com/86681870/206460882-a6b90d2a-fe91-4d96-98b0-5451b8d375a5.png">
