### PR TITLE
feat(quantic): added quantic-result-text component

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,6 +23,7 @@ runs:
           packages/atomic-angular/projects/atomic-angular/dist
           packages/samples/headless-react
           packages/quantic/force-app/main/default/staticresources/coveoheadless
+          packages/quantic/force-app/main/default/staticresources/coveobueno
           !node_modules
           !**/node_modules
         key: ${{ github.sha }}

--- a/packages/quantic/.gitignore
+++ b/packages/quantic/.gitignore
@@ -36,6 +36,7 @@ scratch-def.ci.json
 
 # Static resources copied from node_modules
 force-app/main/default/staticresources/coveoheadless
+force-app/main/default/staticresources/coveobueno
 
 # Test Coverage & Report
 coverage

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -26,6 +26,15 @@ const main = async () => {
     './force-app/main/default/staticresources/coveoheadless/definitions/',
     {recursive: true}
   );
+  await mkdir('./force-app/main/default/staticresources/coveobueno/browser', {
+    recursive: true,
+  });
+  await mkdir(
+    './force-app/main/default/staticresources/coveobueno/definitions',
+    {
+      recursive: true,
+    }
+  );
   await copy(
     '../../node_modules/@coveo/headless/dist/browser/headless.js',
     './force-app/main/default/staticresources/coveoheadless/browser/headless.js'
@@ -41,6 +50,14 @@ const main = async () => {
   await copy(
     '../../node_modules/@coveo/headless/dist/definitions',
     './force-app/main/default/staticresources/coveoheadless/definitions'
+  );
+  await copy(
+    '../../node_modules/@coveo/bueno/dist/browser/bueno.js',
+    './force-app/main/default/staticresources/coveobueno/browser/bueno.js'
+  );
+  await copy(
+    '../../node_modules/@coveo/bueno/dist/definitions',
+    './force-app/main/default/staticresources/coveobueno/definitions'
   );
 
   console.info('Headless copied.');

--- a/packages/quantic/coveo.d.ts
+++ b/packages/quantic/coveo.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable node/no-unpublished-import */
 import {InsightEngine, SearchEngine} from '@coveo/headless';
 import {LightningElement} from 'lwc';
+import * as BuenoTypes from './force-app/main/default/staticresources/coveobueno/definitions/index';
 import {CoreEngine} from './force-app/main/default/staticresources/coveoheadless/definitions/app/engine';
 import {ExternalEngineOptions} from './force-app/main/default/staticresources/coveoheadless/definitions/app/engine-configuration';
 import * as HeadlessCaseAssistTypes from './force-app/main/default/staticresources/coveoheadless/definitions/case-assist.index';
@@ -10,6 +11,7 @@ import * as HeadlessInsightTypes from './force-app/main/default/staticresources/
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/index';
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/case-assist.index';
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/insight.index';
+export * from './force-app/main/default/staticresources/coveobueno/definitions/index';
 
 interface Bindings {
   engine?:
@@ -20,6 +22,7 @@ interface Bindings {
 }
 
 declare global {
+  const Bueno: typeof BuenoTypes;
   const CoveoHeadless: typeof HeadlessTypes;
   const CoveoHeadlessCaseAssist: typeof HeadlessCaseAssistTypes;
   const CoveoHeadlessInsight: typeof HeadlessInsightTypes;

--- a/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab-bar/tab-bar.cypress.ts
@@ -175,8 +175,8 @@ describe('quantic-tab-bar', () => {
 
       describe('when a tab containing the same expression as another tab is selected from the dropdown list', () => {
         it('should correctly select the tab', () => {
-          cy.viewport(extraSmallViewportWidth, 900);
           visitPage({useCase: param.useCase});
+          cy.viewport(extraSmallViewportWidth, 900);
 
           scope('when loading the page', () => {
             Expect.displayedTabsEqual([TAB_1]);

--- a/packages/quantic/force-app/examples/main/lwc/.eslintrc.json
+++ b/packages/quantic/force-app/examples/main/lwc/.eslintrc.json
@@ -1,8 +1,8 @@
 {
-    "extends": ["@salesforce/eslint-config-lwc/recommended"],
-    "root": true,
-    "globals": {
-      "CoveoHeadless": "readonly",
-      "CoveoHeadlessCaseAssist": "readonly"
-    }
+  "extends": ["@salesforce/eslint-config-lwc/recommended"],
+  "root": true,
+  "globals": {
+    "CoveoHeadless": "readonly",
+    "CoveoHeadlessCaseAssist": "readonly"
   }
+}

--- a/packages/quantic/force-app/main/default/.eslintrc.json
+++ b/packages/quantic/force-app/main/default/.eslintrc.json
@@ -5,6 +5,7 @@
   "globals": {
     "CoveoHeadless": "readonly",
     "CoveoHeadlessCaseAssist": "readonly",
-    "CoveoHeadlessInsight": "readonly"
+    "CoveoHeadlessInsight": "readonly",
+    "Bueno": "readonly"
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.js
@@ -1,7 +1,6 @@
-import {LightningElement, api} from "lwc";
-
-import recommended from '@salesforce/label/c.quantic_Recommended';
 import featured from '@salesforce/label/c.quantic_Featured';
+import recommended from '@salesforce/label/c.quantic_Recommended';
+import {LightningElement, api} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
 
@@ -35,19 +34,24 @@ export default class QuanticResultBadge extends LightningElement {
       label: featured,
       icon: 'utility:pinned',
       condition: (result) => result.isTopResult,
-    }
+    },
   };
 
+  /** @type {string} */
   error;
 
   connectedCallback() {
     let hasError = false;
     if (!this.variant) {
-      console.error(`The ${this.template.host.localName} requires the variant attribute to be set.`);
+      console.error(
+        `The ${this.template.host.localName} requires the variant attribute to be set.`
+      );
       hasError = true;
-    } 
+    }
     if (!this.result) {
-      console.error(`The ${this.template.host.localName} requires the result attribute to be set.`);
+      console.error(
+        `The ${this.template.host.localName} requires the result attribute to be set.`
+      );
       hasError = true;
     }
     if (hasError) {
@@ -56,13 +60,15 @@ export default class QuanticResultBadge extends LightningElement {
   }
 
   renderedCallback() {
-    this.setBadgeClass()
+    this.setBadgeClass();
   }
 
   setBadgeClass() {
-    this.template.querySelector('.result-badge')?.classList.add(this.badgeClass);
+    this.template
+      .querySelector('.result-badge')
+      ?.classList.add(this.badgeClass);
   }
-  
+
   get label() {
     return this.variants[this.variant].label;
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.js
@@ -1,14 +1,12 @@
-import {LightningElement, api} from "lwc";
-
 import documentation from '@salesforce/label/c.quantic_Documentation';
 import message from '@salesforce/label/c.quantic_Message';
 import video from '@salesforce/label/c.quantic_Video';
-
-import {objectTypeIcons} from './icons/objectTypeIcons';
+import {LightningElement, api} from 'lwc';
 import {fileTypeIcons} from './icons/fileTypeIcons';
+import {objectTypeIcons} from './icons/objectTypeIcons';
 
-const KNOWLEDGE='Knowledge';
-const CHATTER='Chatter';
+const KNOWLEDGE = 'Knowledge';
+const CHATTER = 'Chatter';
 
 /** @typedef {import("coveo").Result} Result */
 
@@ -44,7 +42,7 @@ export default class QuanticResultLabel extends LightningElement {
    * @type {'xx-small' | 'x-small' | 'small' | 'medium' | 'large'}
    * @defaultValue `'small'`
    */
-  @api size  ='small';
+  @api size = 'small';
   /**
    * Whether to only display the icon without the label.
    * @api
@@ -59,24 +57,29 @@ export default class QuanticResultLabel extends LightningElement {
     video,
     chatter: CHATTER,
     knowledge: KNOWLEDGE,
-  }
+  };
 
+  /** @type {string} */
   error;
 
   connectedCallback() {
     if (!this.result && (!this.label || !this.icon)) {
-      console.error(`The ${this.template.host.localName} requires either specified value for label and icon or a result object to display correctly.`);
+      console.error(
+        `The ${this.template.host.localName} requires either specified value for label and icon or a result object to display correctly.`
+      );
       this.error = `${this.template.host.localName} Error`;
     }
   }
 
-  renderedCallback() { 
+  renderedCallback() {
     this.setLabelSize();
   }
 
   setLabelSize() {
-    // @ts-ignore
-    this.template.querySelector('.result-label__label')?.style.setProperty('font-size', this.size);
+    this.template
+      .querySelector('.result-label__label')
+      // @ts-ignore
+      ?.style.setProperty('font-size', this.size);
   }
 
   get iconToDisplay() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
@@ -75,6 +75,7 @@ describe('c-quantic-result-text', () => {
       const errorMessage = element.shadowRoot.querySelector(errorSelector);
 
       expect(errorMessage).not.toBeNull();
+      expect(console.error).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -89,6 +90,7 @@ describe('c-quantic-result-text', () => {
       const errorMessage = element.shadowRoot.querySelector(errorSelector);
 
       expect(errorMessage).not.toBeNull();
+      expect(console.error).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
@@ -1,0 +1,106 @@
+// @ts-ignore
+import {createElement} from 'lwc';
+import QuanticResultText from '../quanticResultText';
+
+const exampleField = 'exampleField';
+const exampleFieldValue = 'example value';
+const exampleLabel = 'example label';
+const exampleResult = {
+  raw: {
+    [exampleField]: exampleFieldValue,
+  },
+};
+const exampleFormattingFunction = (value) => `formatted ${value}`;
+
+const labelSelector = '.result-text__label';
+const valueSelector = '.result-text__value';
+const errorSelector = '.error-message';
+
+const defaultOptions = {
+  result: exampleResult,
+  field: exampleField,
+};
+
+function createTestComponent(options = defaultOptions) {
+  const element = createElement('c-quantic-result-text', {
+    is: QuanticResultText,
+  });
+
+  for (const [key, value] of Object.entries(options)) {
+    element[key] = value;
+  }
+
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('c-quantic-result-text', () => {
+  function cleanup() {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('when no result is given', () => {
+    it('should show an error', () => {
+      // @ts-ignore
+      const element = createTestComponent({field: exampleField});
+      const errorMessage = element.shadowRoot.querySelector(errorSelector);
+
+      expect(errorMessage).not.toBeNull();
+    });
+  });
+
+  describe('when no field is given', () => {
+    it('should show an error', () => {
+      // @ts-ignore
+      const element = createTestComponent({result: exampleResult});
+      const errorMessage = element.shadowRoot.querySelector(errorSelector);
+
+      expect(errorMessage).not.toBeNull();
+    });
+  });
+
+  describe('when required props are given', () => {
+    it('should render the result field value', () => {
+      const element = createTestComponent();
+      const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
+
+      expect(fieldValueElement.textContent).toBe(exampleFieldValue);
+    });
+  });
+
+  describe('when a label is given', () => {
+    it('should render the field value with a label', () => {
+      const element = createTestComponent({
+        ...defaultOptions,
+        label: exampleLabel,
+      });
+      const labelElement = element.shadowRoot.querySelector(labelSelector);
+      const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
+
+      expect(labelElement.textContent).toBe(`${exampleLabel}:`);
+      expect(fieldValueElement.textContent).toBe(exampleFieldValue);
+    });
+  });
+
+  describe('when a formatting function is given', () => {
+    it('should render the formatted field value', () => {
+      const element = createTestComponent({
+        ...defaultOptions,
+        formattingFunction: exampleFormattingFunction,
+      });
+      const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
+
+      expect(fieldValueElement.textContent).toBe(
+        exampleFormattingFunction(exampleFieldValue)
+      );
+    });
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/__tests__/quanticResultText.test.js
@@ -95,8 +95,10 @@ describe('c-quantic-result-text', () => {
   });
 
   describe('when required props are given', () => {
-    it('should render the result field value', () => {
+    it('should render the result field value', async () => {
       const element = createTestComponent();
+      await flushPromises();
+
       const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
 
       expect(fieldValueElement.textContent).toBe(exampleFieldValue);
@@ -104,11 +106,13 @@ describe('c-quantic-result-text', () => {
   });
 
   describe('when a label is given', () => {
-    it('should render the field value with a label', () => {
+    it('should render the field value with a label', async () => {
       const element = createTestComponent({
         ...defaultOptions,
         label: exampleLabel,
       });
+      await flushPromises();
+
       const labelElement = element.shadowRoot.querySelector(labelSelector);
       const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
 
@@ -118,11 +122,13 @@ describe('c-quantic-result-text', () => {
   });
 
   describe('when a formatting function is given', () => {
-    it('should render the formatted field value', () => {
+    it('should render the formatted field value', async () => {
       const element = createTestComponent({
         ...defaultOptions,
         formattingFunction: exampleFormattingFunction,
       });
+      await flushPromises();
+
       const fieldValueElement = element.shadowRoot.querySelector(valueSelector);
 
       expect(fieldValueElement.textContent).toBe(

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.css
@@ -1,0 +1,3 @@
+.result-text__label {
+    font-weight: var(--lwc-fontWeightBold);
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.css
@@ -1,3 +1,3 @@
 .result-text__label {
-    font-weight: var(--lwc-fontWeightBold);
+    font-weight: var(--lwc-fontWeightBold, 700);
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
@@ -1,0 +1,13 @@
+<template>
+    <div class="result-text slds-grid slds-grid_vertical-align-center">
+      <template if:true={error}>
+        <div class="error-message slds-text-color_destructive">{error}</div>
+      </template>
+      <template if:false={error}>
+        <template if:true={label}>
+          <span class="result-text__label slds-m-right_x-small">{label}:</span>
+        </template>
+        <span class="result-text__value">{valueToDisplay}</span>
+      </template>
+    </div>
+  </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
@@ -5,7 +5,7 @@
       </template>
       <template if:false={error}>
         <template if:true={label}>
-          <span class="result-text__label slds-m-right_x-small">{label}:</span>
+          <span class="result-text__label slds-m-right_xx-small">{label}:</span>
         </template>
         <span class="result-text__value">{valueToDisplay}</span>
       </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
@@ -1,5 +1,5 @@
 <template>
-    <div class="result-text slds-grid slds-grid_vertical-align-center">
+    <div class="slds-grid slds-grid_vertical-align-center">
       <template if:true={error}>
         <div class="error-message slds-text-color_destructive">{error}</div>
       </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
@@ -3,7 +3,7 @@
       <template if:true={error}>
         <div class="error-message slds-text-color_destructive">{error}</div>
       </template>
-      <template if:false={error}>
+      <template if:true={isValid}>
         <template if:true={label}>
           <span class="result-text__label slds-m-right_xx-small">{label}:</span>
         </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -61,7 +61,7 @@ export default class QuanticResultText extends LightningElement {
    */
   get fieldValue() {
     // @ts-ignore
-    return this.result?.raw[this.field];
+    return this.field ? this.result?.raw[this.field] : undefined;
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -40,6 +40,7 @@ export default class QuanticResultText extends LightningElement {
 
   /** @type {string} */
   error;
+  validated = false;
 
   connectedCallback() {
     getBueno(this).then(() => {
@@ -53,7 +54,16 @@ export default class QuanticResultText extends LightningElement {
         console.error(`The "${this.label}" label is not a valid string.`);
         this.error = `${this.template.host.localName} Error`;
       }
+      this.validated = true;
     });
+  }
+
+  /**
+   * Whether the field value can be displayed.
+   * @returns {boolean}
+   */
+  get isValid() {
+    return this.validated && !this.error;
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -19,7 +19,7 @@ export default class QuanticResultText extends LightningElement {
    * (Optional) The label to display.
    * @api
    * @type {string}
-   * @defaultValue `none`
+   * @defaultValue `undefined`
    */
   @api label;
   /**
@@ -29,10 +29,11 @@ export default class QuanticResultText extends LightningElement {
    */
   @api field;
   /**
-   * A function used to format the displayed value.
+   * The function used to format the displayed value.
    * @api
-   * @type {(result?: string) => string}
-   * @defaultValue `undefined`
+   * @type {Function}
+   * @param {string} value
+   * @returns {string}
    */
   @api formattingFunction;
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -38,6 +38,7 @@ export default class QuanticResultText extends LightningElement {
    */
   @api formattingFunction;
 
+  /** @type {string} */
   error;
 
   connectedCallback() {
@@ -65,7 +66,7 @@ export default class QuanticResultText extends LightningElement {
   }
 
   /**
-   * Whether the given result has a value for the given field
+   * Whether the given result has a value for the given field.
    * @returns {boolean}
    */
   get hasFieldValue() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -1,0 +1,77 @@
+import {LightningElement, api} from 'lwc';
+
+/** @typedef {import("coveo").Result} Result */
+
+/**
+ * The `QuanticResultText` component displays a given result field value.
+ * @category Result Template
+ * @example
+ * <c-quantic-result-text result={result} label="Source" field="source"></c-quantic-result-text>
+ */
+export default class QuanticResultText extends LightningElement {
+  /**
+   * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result) to use.
+   * @api
+   * @type {Result}
+   */
+  @api result;
+  /**
+   * (Optional) The label to display.
+   * @api
+   * @type {string}
+   * @defaultValue `none`
+   */
+  @api label;
+  /**
+   * The field whose values you want to display.
+   * @api
+   * @type {string}
+   */
+  @api field;
+  /**
+   * A function used to format the displayed value.
+   * @api
+   * @type {(result?: string) => string}
+   * @defaultValue `undefined`
+   */
+  @api formattingFunction;
+
+  error;
+
+  connectedCallback() {
+    if (!this.result || !this.field) {
+      console.error(
+        `The ${this.template.host.localName} requires a result and a field to be specified.`
+      );
+      this.error = `${this.template.host.localName} Error`;
+    }
+  }
+
+  /**
+   * The value of the given result field.
+   * @returns {string | undefined}
+   */
+  get fieldValue() {
+    // @ts-ignore
+    return this.result.raw[this.field];
+  }
+
+  /**
+   * Whether the given result has a value for the given field
+   * @returns {boolean}
+   */
+  get hasFieldValue() {
+    return !!this.fieldValue.length;
+  }
+
+  /**
+   * The value to display.
+   * @returns {string | undefined}
+   */
+  get valueToDisplay() {
+    if (this.formattingFunction) {
+      return this.formattingFunction(this.fieldValue);
+    }
+    return this.fieldValue;
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -61,7 +61,7 @@ export default class QuanticResultText extends LightningElement {
    */
   get fieldValue() {
     // @ts-ignore
-    return this.result.raw[this.field];
+    return this.result?.raw[this.field];
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -1,3 +1,4 @@
+import {getBueno} from 'c/quanticHeadlessLoader';
 import {LightningElement, api} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
@@ -40,12 +41,18 @@ export default class QuanticResultText extends LightningElement {
   error;
 
   connectedCallback() {
-    if (!this.result || !this.field) {
-      console.error(
-        `The ${this.template.host.localName} requires a result and a field to be specified.`
-      );
-      this.error = `${this.template.host.localName} Error`;
-    }
+    getBueno(this).then(() => {
+      if (!this.result || !Bueno.isString(this.field)) {
+        console.error(
+          `The ${this.template.host.localName} requires a result and a field to be specified.`
+        );
+        this.error = `${this.template.host.localName} Error`;
+      }
+      if (this.label && !Bueno.isString(this.label)) {
+        console.error(`The "${this.label}" label is not a valid string.`);
+        this.error = `${this.template.host.localName} Error`;
+      }
+    });
   }
 
   /**
@@ -62,7 +69,7 @@ export default class QuanticResultText extends LightningElement {
    * @returns {boolean}
    */
   get hasFieldValue() {
-    return !!this.fieldValue.length;
+    return !!this.fieldValue;
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/main/default/staticresources/coveobueno.resource-meta.xml
+++ b/packages/quantic/force-app/main/default/staticresources/coveobueno.resource-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contentType>application/zip</contentType>
+    <description>Coveo Bueno</description>
+    <cacheControl>Public</cacheControl>
+</StaticResource>

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@coveo/headless": "2.0.1",
-    "fs-extra": "10.1.0"
+    "@coveo/bueno": "0.42.3"
   },
   "engines": {
     "node": ">=14.0.0"
@@ -56,6 +56,7 @@
     "cypress": "10.8.0",
     "cypress-plugin-tab": "1.0.5",
     "dotenv": "10.0.0",
+    "fs-extra": "10.1.0",
     "jest-junit": "12.3.0",
     "jsdoc": "3.6.11",
     "jsdoc-tsimport-plugin": "1.0.5",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -37,7 +37,7 @@
     "postinstall": "node scripts/npm/setup-quantic.js"
   },
   "dependencies": {
-    "@coveo/headless": "1.113.0",
+    "@coveo/headless": "2.0.0",
     "@coveo/bueno": "0.43.0"
   },
   "engines": {

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -37,8 +37,8 @@
     "postinstall": "node scripts/npm/setup-quantic.js"
   },
   "dependencies": {
-    "@coveo/headless": "2.0.1",
-    "@coveo/bueno": "0.42.3"
+    "@coveo/headless": "1.113.0",
+    "@coveo/bueno": "0.43.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -37,7 +37,7 @@
     "postinstall": "node scripts/npm/setup-quantic.js"
   },
   "dependencies": {
-    "@coveo/headless": "2.0.0",
+    "@coveo/headless": "2.0.1",
     "@coveo/bueno": "0.43.0"
   },
   "engines": {

--- a/packages/quantic/typings/lwc/coveoheadless.resource.d.ts
+++ b/packages/quantic/typings/lwc/coveoheadless.resource.d.ts
@@ -1,4 +1,9 @@
-declare module "@salesforce/resourceUrl/coveoheadless" {
-    var coveoheadless: string;
-    export default coveoheadless;
+declare module '@salesforce/resourceUrl/coveoheadless' {
+  var coveoheadless: string;
+  export default coveoheadless;
+}
+
+declare module '@salesforce/resourceUrl/coveobueno' {
+  var coveobueno: string;
+  export default coveobueno;
 }


### PR DESCRIPTION
Added component for displaying a field value in a result template.

<img width="668" alt="Screen Shot 2022-12-09 at 5 30 16 PM" src="https://user-images.githubusercontent.com/16785453/206806139-805acdf8-893f-48ef-a6fb-2aa550eeaa53.png">

We're planning on adding components for numeric, date and multivalue fields too so ideally those could wrap this component and leverage the `formattingFunction` prop.

Also added our [Bueno](https://github.com/coveo/ui-kit/tree/master/packages/bueno) validation library as a dependency. It's the recommended way to validate inputs and especially relevant in a javascript environment like LWC. Given I wanted to have some validation on the component I added bueno which we can use going forward.