### PR TITLE
fix: fixed v2 dependency linking

### DIFF
--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -19,11 +19,11 @@
     "@angular/platform-browser": "13.3.0",
     "@angular/platform-browser-dynamic": "13.3.0",
     "@angular/router": "13.3.0",
-    "@coveo/atomic": "2.0.0-pre.7",
+    "@coveo/atomic": "^2.0.0",
     "rxjs": "7.5.6"
   },
   "peerDependencies": {
-    "@coveo/headless": "2.0.0-pre.7"
+    "@coveo/headless": "^2.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "13.3.5",
@@ -40,6 +40,6 @@
     "ncp": "2.0.0",
     "ng-packagr": "13.3.1",
     "typescript": "4.6.4",
-    "@coveo/headless": "2.0.0-pre.7"
+    "@coveo/headless": "^2.0.0"
   }
 }

--- a/packages/atomic-angular/projects/atomic-angular/CHANGELOG.md
+++ b/packages/atomic-angular/projects/atomic-angular/CHANGELOG.md
@@ -5,12 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic-angular@1.34.1...@coveo/atomic-angular@2.0.0) (2022-12-14)
 
-### Features
-
-- release v2 ([#2611](https://github.com/coveo/ui-kit/issues/2611)) ([386b7d3](https://github.com/coveo/ui-kit/commit/386b7d3b623871861766c792662a25faf17a15c7))
-
-# [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic-angular@1.34.1...@coveo/atomic-angular@2.0.0) (2022-12-14)
-
 ### Bug Fixes
 
 - **headless:** made result template manager throw errors instead of logging errors ([#2518](https://github.com/coveo/ui-kit/issues/2518)) ([5d54709](https://github.com/coveo/ui-kit/commit/5d547095c68615120a4b087b3c993c111b3d6169))

--- a/packages/atomic-angular/projects/atomic-angular/package.json
+++ b/packages/atomic-angular/projects/atomic-angular/package.json
@@ -5,7 +5,7 @@
   "peerDependencies": {
     "@angular/common": "^13.1.0",
     "@angular/core": "^13.1.0",
-    "@coveo/headless": "2.0.0-pre.7"
+    "@coveo/headless": "^2.0.0"
   },
   "dependencies": {
     "@coveo/atomic": "2.0.0",

--- a/packages/atomic-react/CHANGELOG.md
+++ b/packages/atomic-react/CHANGELOG.md
@@ -5,12 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic-react@1.27.21...@coveo/atomic-react@2.0.0) (2022-12-14)
 
-### Features
-
-- release v2 ([#2611](https://github.com/coveo/ui-kit/issues/2611)) ([386b7d3](https://github.com/coveo/ui-kit/commit/386b7d3b623871861766c792662a25faf17a15c7))
-
-# [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic-react@1.27.21...@coveo/atomic-react@2.0.0) (2022-12-14)
-
 ### Bug Fixes
 
 - **headless:** made result template manager throw errors instead of logging errors ([#2518](https://github.com/coveo/ui-kit/issues/2518)) ([5d54709](https://github.com/coveo/ui-kit/commit/5d547095c68615120a4b087b3c993c111b3d6169))

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -45,7 +45,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/headless": "^2.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   }

--- a/packages/atomic/CHANGELOG.md
+++ b/packages/atomic/CHANGELOG.md
@@ -5,12 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic@1.126.1...@coveo/atomic@2.0.0) (2022-12-14)
 
-### Features
-
-- release v2 ([#2611](https://github.com/coveo/ui-kit/issues/2611)) ([386b7d3](https://github.com/coveo/ui-kit/commit/386b7d3b623871861766c792662a25faf17a15c7))
-
-# [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/atomic@1.126.1...@coveo/atomic@2.0.0) (2022-12-14)
-
 ### Bug Fixes
 
 - **headless:** made result template manager throw errors instead of logging errors ([#2518](https://github.com/coveo/ui-kit/issues/2518)) ([5d54709](https://github.com/coveo/ui-kit/commit/5d547095c68615120a4b087b3c993c111b3d6169))

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -116,7 +116,7 @@
     "tailwindcss": "3.0.23"
   },
   "peerDependencies": {
-    "@coveo/headless": "2.0.0-pre.7"
+    "@coveo/headless": "^2.0.0"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/headless/CHANGELOG.md
+++ b/packages/headless/CHANGELOG.md
@@ -5,12 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/headless@1.114.0...@coveo/headless@2.0.0) (2022-12-14)
 
-### Features
-
-- release v2 ([#2611](https://github.com/coveo/ui-kit/issues/2611)) ([386b7d3](https://github.com/coveo/ui-kit/commit/386b7d3b623871861766c792662a25faf17a15c7))
-
-# [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/headless@1.114.0...@coveo/headless@2.0.0) (2022-12-14)
-
 ### Bug Fixes
 
 - **headless:** made result template manager throw errors instead of logging errors ([#2518](https://github.com/coveo/ui-kit/issues/2518)) ([5d54709](https://github.com/coveo/ui-kit/commit/5d547095c68615120a4b087b3c993c111b3d6169))

--- a/packages/quantic/CHANGELOG.md
+++ b/packages/quantic/CHANGELOG.md
@@ -5,12 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/quantic@1.55.0...@coveo/quantic@2.0.0) (2022-12-14)
 
-### Features
-
-- release v2 ([#2611](https://github.com/coveo/ui-kit/issues/2611)) ([386b7d3](https://github.com/coveo/ui-kit/commit/386b7d3b623871861766c792662a25faf17a15c7))
-
-# [2.0.0](https://github.com/coveo/ui-kit/compare/@coveo/quantic@1.55.0...@coveo/quantic@2.0.0) (2022-12-14)
-
 ### Bug Fixes
 
 - **headless:** made result template manager throw errors instead of logging errors ([#2518](https://github.com/coveo/ui-kit/issues/2518)) ([5d54709](https://github.com/coveo/ui-kit/commit/5d547095c68615120a4b087b3c993c111b3d6169))

--- a/packages/samples/angular/package.json
+++ b/packages/samples/angular/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "13.3.0",
     "@angular/platform-browser-dynamic": "13.3.0",
     "@angular/router": "13.3.0",
-    "@coveo/atomic-angular": "2.0.0-pre.7",
+    "@coveo/atomic-angular": "2.0.0",
     "rxjs": "7.5.6",
     "tslib": "2.4.0",
     "zone.js": "0.11.8"

--- a/packages/samples/atomic-next/package.json
+++ b/packages/samples/atomic-next/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@coveo/atomic": "2.0.0-pre.7",
-    "@coveo/atomic-react": "2.0.0-pre.7",
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/atomic": "2.0.0",
+    "@coveo/atomic-react": "2.0.0",
+    "@coveo/headless": "2.0.0",
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/samples/atomic-react/package.json
+++ b/packages/samples/atomic-react/package.json
@@ -4,9 +4,9 @@
   "description": "Samples with atomic-react",
   "private": true,
   "dependencies": {
-    "@coveo/atomic": "2.0.0-pre.7",
-    "@coveo/atomic-react": "2.0.0-pre.7",
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/atomic": "2.0.0",
+    "@coveo/atomic-react": "2.0.0",
+    "@coveo/headless": "2.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/samples/headless-react/package.json
+++ b/packages/samples/headless-react/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@coveo/auth": "^1.9.1",
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/headless": "2.0.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.3.0",
     "@testing-library/user-event": "14.4.3",

--- a/packages/samples/stencil/package.json
+++ b/packages/samples/stencil/package.json
@@ -8,8 +8,8 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@coveo/atomic": "2.0.0-pre.7",
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/atomic": "2.0.0",
+    "@coveo/headless": "2.0.0",
     "@stencil/core": "2.17.3",
     "stencil-router-v2": "0.6.0"
   },

--- a/packages/samples/vuejs/package.json
+++ b/packages/samples/vuejs/package.json
@@ -9,8 +9,8 @@
     "copy:assets": "ncp ../../atomic/dist/atomic/assets public/assets && ncp ../../atomic/dist/atomic/lang public/lang"
   },
   "dependencies": {
-    "@coveo/atomic": "2.0.0-pre.7",
-    "@coveo/headless": "2.0.0-pre.7",
+    "@coveo/atomic": "2.0.0",
+    "@coveo/headless": "2.0.0",
     "core-js": "3.24.1",
     "vue": "3.2.37"
   },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2165

* Some dependencies weren't automatically bumped, so I made them use a caret version selector
* I manually removed the duplicate v2 changelog entries
* It looks like the package-lock was broken, I fixed it by running `lerna bootstrap` then `npm install`.