### PR TITLE
fix(headless): improve escape highlight function

### DIFF
--- a/packages/headless/src/utils/highlight.test.ts
+++ b/packages/headless/src/utils/highlight.test.ts
@@ -168,10 +168,10 @@ describe('highlight', () => {
 
   describe('escape', () => {
     it('should replace special characters', () => {
-      const str = "an'es'caped&<str&>ing`\"`";
-      expect(escape(str)).toBe(
-        'an&#x27es&#x27caped&amp&ltstr&amp&gting&#96&quot&#96'
+      expect(escape("an'es'caped&<str&>ing`\"`")).toBe(
+        'an&#x27;es&#x27;caped&amp;&lt;str&amp;&gt;ing&#x60;&quot;&#x60;'
       );
+      expect(escape("constante d'acidité")).toBe('constante d&#x27;acidité');
     });
   });
 });

--- a/packages/headless/src/utils/highlight.test.ts
+++ b/packages/headless/src/utils/highlight.test.ts
@@ -49,7 +49,7 @@ describe('highlight', () => {
       const testCases = [
         {
           input: 'malicious <script/> string',
-          output: 'mal<span>iciou</span>s &ltscript/&gt <span>str</span>ing',
+          output: 'mal<span>iciou</span>s &lt;script/&gt; <span>str</span>ing',
           highlights: [
             {offset: 3, length: 5},
             {offset: 20, length: 3},
@@ -58,7 +58,7 @@ describe('highlight', () => {
         {
           input: '<p>Chat test for SFCT 809</p>',
           output:
-            '&ltp&gt<span>Chat</span> <span>test</span> <span>for</span> <span>SFCT</span> <span>809</span>&lt/p&gt',
+            '&lt;p&gt;<span>Chat</span> <span>test</span> <span>for</span> <span>SFCT</span> <span>809</span>&lt;/p&gt;',
           highlights: [
             {length: 4, offset: 3},
             {length: 4, offset: 8},
@@ -84,7 +84,7 @@ describe('highlight', () => {
       const str = 'malicious <script/> string';
       const newHighlights: HighlightKeyword[] = [];
 
-      const expectedString = 'malicious &ltscript/&gt string';
+      const expectedString = 'malicious &lt;script/&gt; string';
 
       expect(
         highlightString({

--- a/packages/headless/src/utils/highlight.ts
+++ b/packages/headless/src/utils/highlight.ts
@@ -150,11 +150,20 @@ function suggestionWithDelimiters(
  */
 
 export function escape(str: string) {
-  return str
-    .replace(/&/g, '&amp')
-    .replace(/</g, '&lt')
-    .replace(/>/g, '&gt')
-    .replace(/"/g, '&quot')
-    .replace(/`/g, '&#96')
-    .replace(/'/g, '&#x27');
+  const mapOfCharToEscape: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '`': '&#x60;',
+  };
+
+  const source = '(?:' + Object.keys(mapOfCharToEscape).join('|') + ')';
+  const testRegexp = RegExp(source);
+  const replaceRegexp = RegExp(source, 'g');
+
+  return testRegexp.test(str)
+    ? str.replace(replaceRegexp, (substring) => mapOfCharToEscape[substring])
+    : str;
 }


### PR DESCRIPTION
The escape function, like the comment says, is inspired by underscore.

Problem was that the implementation was no where near what underscore does, and was buggy.

Re-implemented it properly.

https://coveord.atlassian.net/browse/KIT-2189

[KIT-2189]: https://coveord.atlassian.net/browse/KIT-2189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ