### PR TITLE
feat(headless): insight quickview using proper endpoint

### DIFF
--- a/packages/headless/src/api/service/insight/insight-params.ts
+++ b/packages/headless/src/api/service/insight/insight-params.ts
@@ -12,8 +12,10 @@ export interface InsightIdParam {
 
 export type InsightParam = BaseParam & InsightIdParam;
 
-export const baseInsightUrl = (req: InsightParam, path: string) =>
-  `${req.url}/rest/organizations/${req.organizationId}/insight/v1/configs/${req.insightId}${path}`;
+export const baseInsightUrl = (req: InsightParam, path?: string) =>
+  `${req.url}/rest/organizations/${req.organizationId}/insight/v1/configs/${
+    req.insightId
+  }${path ?? ''}`;
 
 export const baseInsightRequest = (
   req: InsightParam,

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
@@ -1,0 +1,132 @@
+import {configuration, resultPreview} from '../../../app/reducers';
+import {updateContentURL} from '../../../features/result-preview/result-preview-actions';
+import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
+import {buildMockResult} from '../../../test';
+import {
+  buildMockInsightEngine,
+  MockInsightEngine,
+} from '../../../test/mock-engine';
+import {buildMockResultPreviewState} from '../../../test/mock-result-preview-state';
+import {
+  buildQuickview,
+  QuickviewOptions,
+  Quickview,
+} from './headless-insight-quickview';
+
+describe('Insight Quickview', () => {
+  let engine: MockInsightEngine;
+  let options: QuickviewOptions;
+  let quickview: Quickview;
+
+  function initQuickview() {
+    quickview = buildQuickview(engine, {options});
+  }
+
+  beforeEach(() => {
+    engine = buildMockInsightEngine();
+    options = {
+      result: buildMockResult(),
+      maximumPreviewSize: 0,
+    };
+
+    initQuickview();
+  });
+
+  it('initializes', () => {
+    expect(quickview).toBeTruthy();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({
+      configuration,
+      resultPreview,
+    });
+  });
+
+  it('exposes a subscribe method', () => {
+    expect(quickview.subscribe).toBeTruthy();
+  });
+
+  describe('#fetchResultContent', () => {
+    const uniqueId = '1';
+    const requestedOutputSize = 0;
+
+    beforeEach(() => {
+      options.result = buildMockResult({uniqueId});
+      initQuickview();
+
+      quickview.fetchResultContent();
+    });
+
+    it('dispatches a #updateContentURL action with the result uniqueId', () => {
+      const action = engine.findAsyncAction(updateContentURL.pending);
+
+      expect(action?.meta.arg.uniqueId).toBe(uniqueId);
+      expect(action?.meta.arg.requestedOutputSize).toBe(requestedOutputSize);
+      expect(action?.meta.arg.path).toBe('/quickview');
+    });
+
+    it('dispatches a document quickview click event', () => {
+      const result = buildMockResult();
+      const thunk = logDocumentQuickview(result);
+      const action = engine.findAsyncAction(thunk.pending);
+
+      expect(action).toBeTruthy();
+    });
+  });
+
+  it(`when configured result uniqueId matches the uniqueId in state,
+  #state.content returns the content in state`, () => {
+    const uniqueId = '1';
+    const content = '<div></div>';
+
+    engine.state.resultPreview = buildMockResultPreviewState({
+      uniqueId,
+      content,
+    });
+    options.result = buildMockResult({uniqueId});
+    initQuickview();
+
+    expect(quickview.state.content).toEqual(content);
+  });
+
+  it(`when configured result uniqueId matches the uniqueId in state,
+  #state.content returns an empty string`, () => {
+    engine.state.resultPreview = buildMockResultPreviewState({
+      uniqueId: '1',
+      content: '<div></div>',
+    });
+    options.result = buildMockResult({uniqueId: '2'});
+    initQuickview();
+
+    expect(quickview.state.content).toEqual('');
+  });
+
+  [true, false].forEach((testValue) => {
+    it(`when the result #hasHtmlVersion is ${testValue} #state.resultHasPreview should be ${testValue}`, () => {
+      options.result = buildMockResult({hasHtmlVersion: testValue});
+      initQuickview();
+
+      expect(quickview.state.resultHasPreview).toBe(testValue);
+    });
+  });
+
+  [true, false].forEach((testValue) => {
+    it(`when the resultPreview state #isLoading is ${testValue} #state.isLoading should be ${testValue}`, () => {
+      engine.state.resultPreview = buildMockResultPreviewState({
+        isLoading: testValue,
+      });
+      initQuickview();
+
+      expect(quickview.state.isLoading).toBe(testValue);
+    });
+  });
+
+  it(`when the resultPreview is initialized,
+  #options.maximumPreviewSize is 0`, () => {
+    engine.state.resultPreview = buildMockResultPreviewState();
+    initQuickview();
+
+    expect(options.maximumPreviewSize).toBe(0);
+  });
+});

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
@@ -1,4 +1,8 @@
-import {configuration, resultPreview} from '../../../app/reducers';
+import {
+  configuration,
+  insightInterface,
+  resultPreview,
+} from '../../../app/reducers';
 import {updateContentURL} from '../../../features/result-preview/result-preview-actions';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
 import {buildMockResult} from '../../../test';
@@ -40,6 +44,7 @@ describe('Insight Quickview', () => {
     expect(engine.addReducers).toHaveBeenCalledWith({
       configuration,
       resultPreview,
+      insightInterface,
     });
   });
 

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.test.ts
@@ -36,7 +36,7 @@ describe('Insight Quickview', () => {
     expect(quickview).toBeTruthy();
   });
 
-  it('it adds the correct reducers to engine', () => {
+  it('adds the correct reducers to engine', () => {
     expect(engine.addReducers).toHaveBeenCalledWith({
       configuration,
       resultPreview,

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -1,6 +1,7 @@
+import {baseInsightUrl} from '../../../api/service/insight/insight-params';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
+import {buildInsightResultPreviewRequest} from '../../../features/insight-search/insight-result-preview-request-builder';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
-import {buildResultPreviewRequest} from '../../../features/result-preview/result-preview-request-builder';
 import {
   QuickviewProps,
   QuickviewOptions,
@@ -25,12 +26,31 @@ export function buildQuickview(
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
 
+  const getState = () => engine.state;
+
+  const {platformUrl, accessToken, organizationId} = getState().configuration;
+  const {insightId} = getState().insightConfiguration;
+
   const path = '/quickview';
+  const url = baseInsightUrl(
+    {
+      url: platformUrl,
+      accessToken,
+      organizationId,
+      insightId,
+    },
+    ''
+  );
 
   return buildCoreQuickview(
     engine,
-    props,
-    buildResultPreviewRequest,
+    {
+      options: {
+        ...props.options,
+        onlyContentURL: true,
+      },
+    },
+    (state, options) => buildInsightResultPreviewRequest(state, options, url),
     path,
     fetchResultContentCallback
   );

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -1,6 +1,8 @@
-import {baseInsightUrl} from '../../../api/service/insight/insight-params';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
-import {buildInsightResultPreviewRequest} from '../../../features/insight-search/insight-result-preview-request-builder';
+import {
+  buildInsightResultPreviewRequest,
+  StateNeededByInsightHtmlEndpoint,
+} from '../../../features/insight-search/insight-result-preview-request-builder';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
 import {
   QuickviewProps,
@@ -26,18 +28,7 @@ export function buildQuickview(
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
 
-  const getState = () => engine.state;
-
-  const {platformUrl, accessToken, organizationId} = getState().configuration;
-  const {insightId} = getState().insightConfiguration;
-
   const path = '/quickview';
-  const url = baseInsightUrl({
-    url: platformUrl,
-    accessToken,
-    organizationId,
-    insightId,
-  });
   const coreProps = {
     options: {
       ...props.options,
@@ -48,7 +39,11 @@ export function buildQuickview(
   return buildCoreQuickview(
     engine,
     coreProps,
-    (state, options) => buildInsightResultPreviewRequest(state, options, url),
+    (state, options) =>
+      buildInsightResultPreviewRequest(
+        state as StateNeededByInsightHtmlEndpoint,
+        options
+      ),
     path,
     fetchResultContentCallback
   );

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -32,24 +32,22 @@ export function buildQuickview(
   const {insightId} = getState().insightConfiguration;
 
   const path = '/quickview';
-  const url = baseInsightUrl(
-    {
-      url: platformUrl,
-      accessToken,
-      organizationId,
-      insightId,
+  const url = baseInsightUrl({
+    url: platformUrl,
+    accessToken,
+    organizationId,
+    insightId,
+  });
+  const coreProps = {
+    options: {
+      ...props.options,
+      onlyContentURL: true,
     },
-    ''
-  );
+  };
 
   return buildCoreQuickview(
     engine,
-    {
-      options: {
-        ...props.options,
-        onlyContentURL: true,
-      },
-    },
+    coreProps,
     (state, options) => buildInsightResultPreviewRequest(state, options, url),
     path,
     fetchResultContentCallback

--- a/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
+++ b/packages/headless/src/controllers/insight/quickview/headless-insight-quickview.ts
@@ -1,18 +1,79 @@
+import {Result} from '../../../api/search/search/result';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
+import {
+  configuration,
+  resultPreview,
+  insightInterface,
+} from '../../../app/reducers';
 import {
   buildInsightResultPreviewRequest,
   StateNeededByInsightHtmlEndpoint,
 } from '../../../features/insight-search/insight-result-preview-request-builder';
 import {logDocumentQuickview} from '../../../features/result-preview/result-preview-analytics-actions';
-import {
-  QuickviewProps,
-  QuickviewOptions,
-  Quickview,
-  QuickviewState,
-  buildCoreQuickview,
-} from '../../core/quickview/headless-core-quickview';
+import {loadReducerError} from '../../../utils/errors';
+import {Controller} from '../../controller/headless-controller';
+import {buildCoreQuickview} from '../../core/quickview/headless-core-quickview';
 
-export type {QuickviewOptions, QuickviewState, QuickviewProps, Quickview};
+export interface QuickviewProps {
+  /**
+   * The options for the insight `Quickview` controller.
+   */
+  options: QuickviewOptions;
+}
+
+export interface QuickviewOptions {
+  /**
+   * The result to retrieve a quickview for.
+   */
+  result: Result;
+  /**
+   * The maximum preview size to retrieve, in bytes. By default, the full preview is retrieved.
+   */
+  maximumPreviewSize?: number;
+  /**
+   * Whether to only update the `contentURL` attribute when using `fetchResultContent` rather than updating `content`.
+   * Use this if you are using an iframe with `state.contentURL` as the source url.
+   * @deprecated This option is always set to `true` ad the Insight Quickview only supports `contentURL` mode.
+   */
+  onlyContentURL?: boolean;
+}
+
+export interface Quickview extends Controller {
+  /**
+   * Updates the `contentURL` state property with the correct URL.
+   */
+  fetchResultContent(): void;
+
+  /**
+   * The state for the `Quickview` controller.
+   */
+  state: QuickviewState;
+}
+
+export interface QuickviewState {
+  /**
+   * The result preview HTML content.
+   *
+   * @default ""
+   * @deprecated This value will always be empty as the InsightQuickview only supports usage of the `contentURL`.
+   */
+  content: string;
+
+  /**
+   * `true` if the configured result has a preview, and `false` otherwise.
+   */
+  resultHasPreview: boolean;
+
+  /**
+   * `true` if content is being fetched, and `false` otherwise.
+   */
+  isLoading: boolean;
+
+  /**
+   * The `src` path to use if rendering the quickview in an iframe.
+   */
+  contentURL?: string;
+}
 
 /**
  * Creates an insight `Quickview` controller instance.
@@ -24,6 +85,10 @@ export function buildQuickview(
   engine: InsightEngine,
   props: QuickviewProps
 ): Quickview {
+  if (!loadQuickviewReducers(engine)) {
+    throw loadReducerError;
+  }
+
   const fetchResultContentCallback = () => {
     engine.dispatch(logDocumentQuickview(props.options.result));
   };
@@ -47,4 +112,11 @@ export function buildQuickview(
     path,
     fetchResultContentCallback
   );
+}
+
+function loadQuickviewReducers(
+  engine: InsightEngine
+): engine is InsightEngine<StateNeededByInsightHtmlEndpoint> {
+  engine.addReducers({configuration, resultPreview, insightInterface});
+  return true;
 }

--- a/packages/headless/src/features/insight-search/insight-result-preview-request-builder.test.ts
+++ b/packages/headless/src/features/insight-search/insight-result-preview-request-builder.test.ts
@@ -1,0 +1,43 @@
+import {HtmlRequestOptions} from '../../api/search/html/html-request';
+import {getConfigurationInitialState} from '../configuration/configuration-state';
+import {getQueryInitialState} from '../query/query-state';
+import {StateNeededByHtmlEndpoint} from '../result-preview/result-preview-request-builder';
+import {getResultPreviewInitialState} from '../result-preview/result-preview-state';
+import {buildInsightResultPreviewRequest} from './insight-result-preview-request-builder';
+
+describe('ResultPreviewRequestBuilder', () => {
+  let state: StateNeededByHtmlEndpoint;
+  let options: HtmlRequestOptions;
+
+  const testUrl = 'http://test.url.com';
+
+  beforeEach(() => {
+    state = {
+      configuration: getConfigurationInitialState(),
+      resultPreview: getResultPreviewInitialState(),
+      query: getQueryInitialState(),
+    };
+    options = {
+      uniqueId: '1',
+    };
+  });
+
+  it('should build the quickview request with the given parameters', async () => {
+    options.requestedOutputSize = undefined;
+    const finalRequest = await buildInsightResultPreviewRequest(
+      state,
+      options,
+      testUrl
+    );
+    expect(finalRequest).toEqual({
+      accessToken: '',
+      enableNavigation: false,
+      organizationId: '',
+      q: '',
+      requestedOutputSize: 0,
+      uniqueId: '1',
+      url: testUrl,
+      visitorId: expect.any(String),
+    });
+  });
+});

--- a/packages/headless/src/features/insight-search/insight-result-preview-request-builder.test.ts
+++ b/packages/headless/src/features/insight-search/insight-result-preview-request-builder.test.ts
@@ -1,21 +1,31 @@
 import {HtmlRequestOptions} from '../../api/search/html/html-request';
 import {getConfigurationInitialState} from '../configuration/configuration-state';
 import {getQueryInitialState} from '../query/query-state';
-import {StateNeededByHtmlEndpoint} from '../result-preview/result-preview-request-builder';
 import {getResultPreviewInitialState} from '../result-preview/result-preview-state';
-import {buildInsightResultPreviewRequest} from './insight-result-preview-request-builder';
+import {
+  buildInsightResultPreviewRequest,
+  StateNeededByInsightHtmlEndpoint,
+} from './insight-result-preview-request-builder';
 
 describe('ResultPreviewRequestBuilder', () => {
-  let state: StateNeededByHtmlEndpoint;
+  let state: StateNeededByInsightHtmlEndpoint;
   let options: HtmlRequestOptions;
 
-  const testUrl = 'http://test.url.com';
+  const testOrgId = 'someOrgId';
+  const testConfigId = 'some-insight-id-123';
+  const expectedUrl = `https://platform.cloud.coveo.com/rest/organizations/${testOrgId}/insight/v1/configs/${testConfigId}`;
 
   beforeEach(() => {
     state = {
-      configuration: getConfigurationInitialState(),
+      configuration: {
+        ...getConfigurationInitialState(),
+        organizationId: testOrgId,
+      },
       resultPreview: getResultPreviewInitialState(),
       query: getQueryInitialState(),
+      insightConfiguration: {
+        insightId: testConfigId,
+      },
     };
     options = {
       uniqueId: '1',
@@ -24,19 +34,15 @@ describe('ResultPreviewRequestBuilder', () => {
 
   it('should build the quickview request with the given parameters', async () => {
     options.requestedOutputSize = undefined;
-    const finalRequest = await buildInsightResultPreviewRequest(
-      state,
-      options,
-      testUrl
-    );
+    const finalRequest = await buildInsightResultPreviewRequest(state, options);
     expect(finalRequest).toEqual({
       accessToken: '',
       enableNavigation: false,
-      organizationId: '',
+      organizationId: testOrgId,
       q: '',
       requestedOutputSize: 0,
       uniqueId: '1',
-      url: testUrl,
+      url: expectedUrl,
       visitorId: expect.any(String),
     });
   });

--- a/packages/headless/src/features/insight-search/insight-result-preview-request-builder.ts
+++ b/packages/headless/src/features/insight-search/insight-result-preview-request-builder.ts
@@ -1,0 +1,28 @@
+import {getVisitorID} from '../../api/analytics/search-analytics';
+import {
+  HtmlRequest,
+  HtmlRequestOptions,
+} from '../../api/search/html/html-request';
+import {StateNeededByHtmlEndpoint} from '../result-preview/result-preview-request-builder';
+
+export async function buildInsightResultPreviewRequest(
+  state: StateNeededByHtmlEndpoint,
+  options: HtmlRequestOptions,
+  url: string
+): Promise<HtmlRequest> {
+  const {accessToken, organizationId, analytics} = state.configuration;
+  const q = state.query?.q || '';
+
+  return {
+    url,
+    accessToken,
+    organizationId,
+    enableNavigation: false,
+    ...(analytics.enabled && {
+      visitorId: await getVisitorID(state.configuration.analytics),
+    }),
+    q,
+    ...options,
+    requestedOutputSize: options.requestedOutputSize || 0,
+  };
+}

--- a/packages/headless/src/features/insight-search/insight-result-preview-request-builder.ts
+++ b/packages/headless/src/features/insight-search/insight-result-preview-request-builder.ts
@@ -3,15 +3,28 @@ import {
   HtmlRequest,
   HtmlRequestOptions,
 } from '../../api/search/html/html-request';
+import {baseInsightUrl} from '../../api/service/insight/insight-params';
+import {InsightConfigurationSection} from '../../state/state-sections';
 import {StateNeededByHtmlEndpoint} from '../result-preview/result-preview-request-builder';
 
+export type StateNeededByInsightHtmlEndpoint = StateNeededByHtmlEndpoint &
+  InsightConfigurationSection;
+
 export async function buildInsightResultPreviewRequest(
-  state: StateNeededByHtmlEndpoint,
-  options: HtmlRequestOptions,
-  url: string
+  state: StateNeededByInsightHtmlEndpoint,
+  options: HtmlRequestOptions
 ): Promise<HtmlRequest> {
-  const {accessToken, organizationId, analytics} = state.configuration;
+  const {platformUrl, accessToken, organizationId, analytics} =
+    state.configuration;
+  const {insightId} = state.insightConfiguration;
+
   const q = state.query?.q || '';
+  const url = baseInsightUrl({
+    url: platformUrl,
+    accessToken,
+    organizationId,
+    insightId,
+  });
 
   return {
     url,

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -178,10 +178,10 @@ export type {
 export {buildQuerySummary} from './controllers/insight/query-summary/headless-insight-query-summary';
 
 export type {
-  Quickview,
-  QuickviewOptions,
   QuickviewProps,
+  QuickviewOptions,
   QuickviewState,
+  Quickview,
 } from './controllers/insight/quickview/headless-insight-quickview';
 export {buildQuickview} from './controllers/insight/quickview/headless-insight-quickview';
 


### PR DESCRIPTION
*WIP as the proxy endpoint is not yet in production*
Modified the insight quickview controller to use the quickview endpoint on the customer-service-api.