### PR TITLE
fix(atomic): insight tab section full width

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -56,6 +56,10 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
       flex-shrink: 0;
     }`
     )}
+
+    ${sectionSelector('search')} ${tabsSelector} {
+      width: 100%;
+    }
     `;
 
   const results = `


### PR DESCRIPTION
Set the tab section to full width in the insight layout.

Before
<img width="557" alt="Screen Shot 2023-01-02 at 9 47 04 AM" src="https://user-images.githubusercontent.com/16785453/210247027-7fdd225f-6d31-4068-9b51-080954d6a08c.png">


After
<img width="559" alt="Screen Shot 2023-01-02 at 9 46 50 AM" src="https://user-images.githubusercontent.com/16785453/210247036-ea96c9ff-32d1-422d-9fbe-4155fa2a5100.png">
