### PR TITLE
feat(headless): updated insight result template detail type

### DIFF
--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -38,9 +38,12 @@ interface Badge {
   color: string;
 }
 
+export type InsightFieldType = 'string' | 'date' | 'number' | 'multi';
+
 interface Detail {
   field: string;
   label?: string;
+  fieldType?: InsightFieldType;
 }
 
 type ResultAction =


### PR DESCRIPTION
The customer-service-api now returns the field type for result template details to allow the ui to render the appropriate result-template-[text|number|date|multi-value] component.