### PR TITLE
doc(atomic): fields to include update

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1222,7 +1222,7 @@ export namespace Components {
     }
     interface AtomicResultDate {
         /**
-          * The result field which the component should use. This will look for the field in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look for the field in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
         /**
@@ -1250,7 +1250,7 @@ export namespace Components {
     }
     interface AtomicResultImage {
         /**
-          * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
     }
@@ -1377,7 +1377,7 @@ export namespace Components {
          */
         "default"?: string;
         /**
-          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
         /**
@@ -1387,7 +1387,7 @@ export namespace Components {
     }
     interface AtomicResultTimespan {
         /**
-          * The target result field. The component first looks for the field in the Result object, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The target result field. The component first looks for the field in the Result object, and then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
         /**
@@ -3787,7 +3787,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultDate {
         /**
-          * The result field which the component should use. This will look for the field in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look for the field in the Result object first, and then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field"?: string;
         /**
@@ -3815,7 +3815,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultImage {
         /**
-          * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
     }
@@ -3933,7 +3933,7 @@ declare namespace LocalJSX {
          */
         "default"?: string;
         /**
-          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the ResultList component.
+          * The result field which the component should use. This will look in the Result object first, and then in the Result.raw object for the fields. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
         /**
@@ -3943,7 +3943,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultTimespan {
         /**
-          * The target result field. The component first looks for the field in the Result object, and then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+          * The target result field. The component first looks for the field in the Result object, and then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
          */
         "field": string;
         /**

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-date/atomic-result-date.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-date/atomic-result-date.tsx
@@ -34,7 +34,7 @@ export class AtomicResultDate implements InitializableComponent {
   /**
    * The result field which the component should use.
    * This will look for the field in the Result object first, and then in the Result.raw object.
-   * It is important to include the necessary field in the ResultList component.
+   * It is important to include the necessary field in the `atomic-search-interface` component.
    */
   @Prop({reflect: true}) field = 'date';
   /**

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-image/atomic-result-image.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-image/atomic-result-image.tsx
@@ -22,7 +22,7 @@ export class AtomicResultImage implements InitializableComponent {
   @Element() private host!: HTMLElement;
 
   /**
-   * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the ResultList component.
+   * The result field which the component should use. This will look for the field in the Result object first, then in the Result.raw object. It is important to include the necessary field in the `atomic-search-interface` component.
    */
   @Prop({reflect: true}) field!: string;
 

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-text/atomic-result-text.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-text/atomic-result-text.tsx
@@ -28,7 +28,7 @@ export class AtomicResultText implements InitializableComponent {
   /**
    * The result field which the component should use.
    * This will look in the Result object first, and then in the Result.raw object for the fields.
-   * It is important to include the necessary field in the ResultList component.
+   * It is important to include the necessary field in the `atomic-search-interface` component.
    */
   @Prop({reflect: true}) public field!: string;
   /**

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-timespan/atomic-result-timespan.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-timespan/atomic-result-timespan.tsx
@@ -27,7 +27,7 @@ export class AtomicResultTimespan {
   /**
    * The target result field.
    * The component first looks for the field in the Result object, and then in the Result.raw object.
-   * It is important to include the necessary field in the ResultList component.
+   * It is important to include the necessary field in the `atomic-search-interface` component.
    */
   @Prop({reflect: true}) field!: string;
   /**


### PR DESCRIPTION
I missed some annotations that told readers to set the fields-to-include in the result list. It should now be in the search-interface.