### PR TITLE
fix(atomic): prevented left suggestions from expanding beyond layout variable

### DIFF
--- a/packages/atomic/src/components/search/atomic-layout/atomic-search-layout.pcss
+++ b/packages/atomic/src/components/search/atomic-layout/atomic-search-layout.pcss
@@ -52,6 +52,10 @@ atomic-search-layout {
       &::part(suggestions-left) {
         flex-basis: var(--atomic-layout-search-box-left-suggestions-width, 30%);
       }
+
+      &::part(suggestions-right) {
+        flex-basis: calc(100% - var(--atomic-layout-search-box-left-suggestions-width, 30%));
+      }
     }
   }
 


### PR DESCRIPTION
The `flex-basis` of the left suggestions panel was `--atomic-layout-search-box-left-suggestions-width`, but the left & right suggestions panels both had `flex-grow: 1`, which caused them to both grow to take the extra space.

In this PR, I made the right suggestions panel have a flex-basis equal to `100% - var(--atomic-layout-search-box-left-suggestions-width)`, so that the left suggestions respect the intended size.

This also means that the left suggestions, with the search layout, are going to have a default size of 30%. Prior to this PR, since they split 20% of the remaining space with the right suggestions, the left suggestions occupied 40%. Without the search layout, the behavior is unaffected, each side takes 50%.

https://coveord.atlassian.net/browse/KIT-2147