### PR TITLE
docs(headless): removed generic type of FacetProps

### DIFF
--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
@@ -54,11 +54,11 @@ import {
 
 export type {FacetOptions, FacetSearchOptions, FacetValueState};
 
-export interface FacetProps<Options = FacetOptions> {
+export interface CoreFacetProps {
   /**
-   * The options for the `Facet` controller.
+   * The options for the core `Facet` controller.
    * */
-  options: Options;
+  options: FacetOptions;
 }
 
 export interface Facet extends CoreFacet {
@@ -288,7 +288,7 @@ export interface FacetValue {
  * */
 export function buildCoreFacet(
   engine: CoreEngine,
-  props: FacetProps,
+  props: CoreFacetProps,
   optionsSchema = facetOptionsSchema
 ): CoreFacet {
   if (!loadFacetReducers(engine)) {

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -33,7 +33,6 @@ import {buildFacetSearch} from '../../core/facets/facet-search/specific/headless
 import {
   buildCoreFacet,
   Facet,
-  FacetProps,
   FacetSearch,
   FacetSearchState,
   FacetState,
@@ -52,7 +51,6 @@ export type {
   FacetOptions,
   FacetSearchOptions,
   FacetValueState,
-  FacetProps,
   Facet,
   FacetState,
   FacetSearch,
@@ -63,6 +61,13 @@ export type {
   CoreFacetState,
 };
 
+export interface FacetProps {
+  /**
+   * The options for the `Facet` controller.
+   * */
+  options: FacetOptions;
+}
+
 /**
  * Creates a `Facet` controller instance.
  *
@@ -70,10 +75,7 @@ export type {
  * @param props - The configurable `Facet` properties.
  * @returns A `Facet` controller instance.
  * */
-export function buildFacet(
-  engine: SearchEngine,
-  props: FacetProps<FacetOptions>
-): Facet {
+export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
   if (!loadFacetReducers(engine)) {
     throw loadReducerError;
   }

--- a/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet-options.ts
+++ b/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet-options.ts
@@ -14,7 +14,7 @@ import {
   FacetSearchOptions,
 } from '../../../core/facets/facet/headless-core-facet-options';
 
-export type {FacetSearchOptions};
+export type {FacetSearchOptions, CoreFacetOptions};
 
 export interface FacetOptions extends CoreFacetOptions {
   /**

--- a/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet.ts
+++ b/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet.ts
@@ -30,7 +30,6 @@ import {
   CoreFacet,
   CoreFacetState,
   Facet,
-  FacetProps,
   FacetSearch,
   FacetSearchState,
   FacetState,
@@ -41,13 +40,13 @@ import {
   FacetOptions,
   FacetSearchOptions,
   facetOptionsSchema,
+  CoreFacetOptions,
 } from './headless-insight-facet-options';
 
 export type {
   FacetOptions,
   FacetSearchOptions,
   FacetValueState,
-  FacetProps,
   Facet,
   FacetState,
   FacetSearch,
@@ -56,7 +55,15 @@ export type {
   FacetValue,
   CoreFacet,
   CoreFacetState,
+  CoreFacetOptions,
 };
+
+export interface FacetProps {
+  /**
+   * The options for the `Facet` controller.
+   * */
+  options: FacetOptions;
+}
 
 /**
  * Creates an insight `Facet` controller instance.
@@ -65,10 +72,7 @@ export type {
  * @param props - The configurable `Facet` properties.
  * @returns A `Facet` controller instance.
  */
-export function buildFacet(
-  engine: InsightEngine,
-  props: FacetProps<FacetOptions>
-): Facet {
+export function buildFacet(engine: InsightEngine, props: FacetProps): Facet {
   if (!loadFacetReducers(engine)) {
     throw loadReducerError;
   }

--- a/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
+++ b/packages/headless/src/controllers/product-listing/facet/headless-product-listing-facet.ts
@@ -25,7 +25,6 @@ import {
   buildCoreFacet,
   Facet,
   FacetOptions,
-  FacetProps,
   FacetSearch,
   FacetSearchOptions,
   FacetSearchState,
@@ -40,7 +39,6 @@ export type {
   FacetOptions,
   FacetSearchOptions,
   FacetValueState,
-  FacetProps,
   Facet,
   FacetState,
   FacetSearch,
@@ -50,6 +48,13 @@ export type {
   CoreFacet,
   CoreFacetState,
 };
+
+export interface FacetProps {
+  /**
+   * The options for the `Facet` controller.
+   * */
+  options: FacetOptions;
+}
 
 /**
  * Creates a `Facet` controller instance for the product listing.

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -113,6 +113,7 @@ export type {
   SpecificFacetSearchResult,
   CoreFacet,
   CoreFacetState,
+  CoreFacetOptions,
 } from './controllers/insight/facets/facet/headless-insight-facet';
 export {buildFacet} from './controllers/insight/facets/facet/headless-insight-facet';
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2174

The doc parser was unable to extract the doc of FacetOptions since it was passed as a generic type to FacetProps.

I tried to refactor all "Option" interfaces from `core` files, prefixing them with "Core" (e.g., "FacetSearchOptions" -> "CoreFacetSearchOptions"), but this ended up being too big of a change and causing a lot of issues, so I dropped it.

Diff of the `parsed_doc.json` file with the changes in this PR: https://gist.github.com/btaillon/8a88b39f8869b88d1f302a37077f6535/revisions