### PR TITLE
feat(headless): made search box only update enableQuerySyntax when explicitly set

### DIFF
--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box-options.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box-options.ts
@@ -45,11 +45,10 @@ export interface SearchBoxOptions {
 
 type DefaultSearchBoxOptions = Pick<
   SearchBoxOptions,
-  'enableQuerySyntax' | 'numberOfSuggestions' | 'clearFilters'
+  'numberOfSuggestions' | 'clearFilters'
 >;
 
 export const defaultSearchBoxOptions: Required<DefaultSearchBoxOptions> = {
-  enableQuerySyntax: false,
   numberOfSuggestions: 5,
   clearFilters: true,
 };

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
@@ -173,7 +173,7 @@ export function buildCoreSearchBox(
   const getState = () => engine.state;
 
   const id = props.options?.id || randomID('search_box');
-  const options: Required<SearchBoxOptions> = {
+  const options = {
     id,
     highlightOptions: {...props.options?.highlightOptions},
     ...defaultSearchBoxOptions,

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -94,7 +94,7 @@ export function buildStandaloneSearchBox(
   const getState = () => engine.state;
 
   const id = props.options.id || randomID('standalone_search_box');
-  const options: Required<StandaloneSearchBoxOptions> = {
+  const options = {
     id,
     highlightOptions: {...props.options.highlightOptions},
     ...defaultSearchBoxOptions,

--- a/packages/headless/src/features/query/query-slice.ts
+++ b/packages/headless/src/features/query/query-slice.ts
@@ -1,4 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {mergeObjects} from '../../utils/utils';
 import {applyDidYouMeanCorrection} from '../did-you-mean/did-you-mean-actions';
 import {change} from '../history/history-actions';
 import {selectQuerySuggestion} from '../query-suggest/query-suggest-actions';
@@ -8,7 +9,9 @@ import {getQueryInitialState} from './query-state';
 
 export const queryReducer = createReducer(getQueryInitialState(), (builder) =>
   builder
-    .addCase(updateQuery, (state, action) => ({...state, ...action.payload}))
+    .addCase(updateQuery, (state, action) =>
+      mergeObjects(state, action.payload)
+    )
     .addCase(applyDidYouMeanCorrection, (state, action) => {
       state.q = action.payload;
     })

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -64,3 +64,18 @@ export function doNotTrack() {
     win.doNotTrack,
   ].some((value) => doNotTrackValues.has(value));
 }
+
+export function mergeObjects<T>(...objects: Partial<T>[]): T {
+  return objects
+    .flatMap((obj) => (obj ? Object.entries(obj) : []))
+    .reduce(
+      (mergedObject, [key, value]) =>
+        value !== undefined
+          ? {
+              ...mergedObject,
+              [key]: value,
+            }
+          : mergedObject,
+      {} as T
+    );
+}


### PR DESCRIPTION
The issue: in Atomic, it's currently impossible for a user to submit a query using the query syntax with `atomic-search-box`.

The cause of this issue is that Headless's search box controller takes `enableQuerySyntax` as an option (optional) and **always** updates `engine.state.query.enableQuerySyntax` when calling `submit`.

There's two obvious solutions to the problem:
1. We add an `enableQuerySyntax` option to the `atomic-search-box`.
2. We make Headless search boxes only update `enableQuerySyntax` when it was explicitly set as an option.

In this PR, I want with solution 2, because:
1. It's possible to globally update `enableQuerySyntax` by either dispatching `updateQuery` or through the url/searchparams managers. I don't know if we want to encourage either of those, but it seems about as intuitive to assume that it's a global property than to assume it's not, and we don't have any warning not to (that I'm aware of).
2. The alternative solution would probably require adding some more documentation, so it's quicker for me to make this change.

I didn't add tests yet in case you prefer solution 1.

https://coveord.atlassian.net/browse/KIT-2201