### PR TITLE
feat(atomic): added query syntax support to search box

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -1401,13 +1401,13 @@ Example:
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['clearFilters', 'disableSearch', 'numberOfQueries', 'redirectionUrl', 'suggestionTimeout']
+  inputs: ['clearFilters', 'disableSearch', 'enableQuerySyntax', 'numberOfQueries', 'redirectionUrl', 'suggestionTimeout']
 })
 @Component({
   selector: 'atomic-search-box',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['clearFilters', 'disableSearch', 'numberOfQueries', 'redirectionUrl', 'suggestionTimeout']
+  inputs: ['clearFilters', 'disableSearch', 'enableQuerySyntax', 'numberOfQueries', 'redirectionUrl', 'suggestionTimeout']
 })
 export class AtomicSearchBox {
   protected el: HTMLElement;

--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -3,7 +3,7 @@ import {
   StorageItems,
 } from '../../../src/utils/local-storage-utils';
 import {RouteAlias} from '../../fixtures/fixture-common';
-import {TestFixture} from '../../fixtures/test-fixture';
+import {generateComponentHTML, TestFixture} from '../../fixtures/test-fixture';
 import * as CommonAssertions from '../common-assertions';
 import {selectIdleCheckboxValueAt} from '../facets/facet-common-actions';
 import * as FacetCommonAssertions from '../facets/facet-common-assertions';
@@ -11,6 +11,14 @@ import {addFacet, field} from '../facets/facet/facet-actions';
 import {FacetSelectors} from '../facets/facet/facet-selectors';
 import {addQuerySummary} from '../query-summary-actions';
 import * as QuerySummaryAssertions from '../query-summary-assertions';
+import {
+  resultTextComponent,
+  ResultTextSelectors,
+} from '../result-list/result-components/result-text-selectors';
+import {
+  addResultList,
+  buildTemplateWithoutSections,
+} from '../result-list/result-list-actions';
 import {addSearchBox} from './search-box-actions';
 import * as SearchBoxAssertions from './search-box-assertions';
 import {searchBoxComponent, SearchBoxSelectors} from './search-box-selectors';
@@ -317,5 +325,27 @@ describe('Search Box Test Suites', () => {
       FacetSelectors,
       0
     );
+  });
+
+  describe('with the query syntax enabled', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(addSearchBox({props: {'enable-query-syntax': ''}}))
+        .with(
+          addResultList(
+            buildTemplateWithoutSections(
+              generateComponentHTML(resultTextComponent, {field: 'title'})
+            )
+          )
+        )
+        .withoutFirstAutomaticSearch()
+        .init();
+    });
+
+    it('uses the query syntax', () => {
+      SearchBoxSelectors.inputBox().type('@urihash=Wl1SZoqFsR8bpsbG');
+      SearchBoxSelectors.submitButton().click();
+      ResultTextSelectors.firstInResult().should('have.text', 'bushy lichens');
+    });
   });
 });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1421,6 +1421,10 @@ export namespace Components {
          */
         "disableSearch": boolean;
         /**
+          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+         */
+        "enableQuerySyntax": boolean;
+        /**
           * The amount of queries displayed when the user interacts with the search box. By default, a mix of query suggestions and recent queries will be shown. You can configure those settings using the following components as children:  - atomic-search-box-query-suggestions  - atomic-search-box-recent-queries
          */
         "numberOfQueries": number;
@@ -3977,6 +3981,10 @@ declare namespace LocalJSX {
           * Whether to prevent the user from triggering a search from the component. Perfect for use cases where you need to disable the search conditionally, like when the input is empty.
          */
         "disableSearch"?: boolean;
+        /**
+          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+         */
+        "enableQuerySyntax"?: boolean;
         /**
           * The amount of queries displayed when the user interacts with the search box. By default, a mix of query suggestions and recent queries will be shown. You can configure those settings using the following components as children:  - atomic-search-box-query-suggestions  - atomic-search-box-recent-queries
          */

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1421,7 +1421,7 @@ export namespace Components {
          */
         "disableSearch": boolean;
         /**
-          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query. You should only enable query syntax in the search box if you have good reasons to do so, as it requires end users to be familiar with Coveo Cloud query syntax, otherwise they will likely be surprised by the search box behaviour.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same `enable-query-syntax` value.
          */
         "enableQuerySyntax": boolean;
         /**
@@ -3982,7 +3982,7 @@ declare namespace LocalJSX {
          */
         "disableSearch"?: boolean;
         /**
-          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+          * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query. You should only enable query syntax in the search box if you have good reasons to do so, as it requires end users to be familiar with Coveo Cloud query syntax, otherwise they will likely be surprised by the search box behaviour.  When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same `enable-query-syntax` value.
          */
         "enableQuerySyntax"?: boolean;
         /**

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -164,9 +164,12 @@ export class AtomicSearchBox {
   @Prop({reflect: true}) public clearFilters = true;
 
   /**
-   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query.
+   * You should only enable query syntax in the search box if you have good reasons to do so, as it
+   * requires end users to be familiar with Coveo Cloud query syntax, otherwise they will likely be surprised
+   * by the search box behaviour.
    *
-   * When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+   * When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same `enable-query-syntax` value.
    */
   @Prop({reflect: true}) public enableQuerySyntax = false;
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -26,7 +26,11 @@ import {
   BindStateToController,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
-import {SafeStorage, StorageItems} from '../../../utils/local-storage-utils';
+import {
+  SafeStorage,
+  StandaloneSearchBoxData,
+  StorageItems,
+} from '../../../utils/local-storage-utils';
 import {promiseTimeout} from '../../../utils/promise-utils';
 import {updateBreakpoints} from '../../../utils/replace-breakpoint';
 import {getUniqueItemsByProperties, once, randomID} from '../../../utils/utils';
@@ -160,6 +164,13 @@ export class AtomicSearchBox {
   @Prop({reflect: true}) public clearFilters = true;
 
   /**
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   *
+   * When the `redirection-url` property is set and redirects to a page with more `atomic-search-box` components, all `atomic-search-box` components need to have the same value for `enable-query-syntax`.
+   */
+  @Prop({reflect: true}) public enableQuerySyntax = false;
+
+  /**
    * Event that is emitted when a standalone search box redirection is triggered. By default, the search box will directly change the URL and redirect accordingly, so if you want to handle the redirection differently, use this event.
    *
    * Example:
@@ -203,6 +214,7 @@ export class AtomicSearchBox {
         },
       },
       clearFilters: this.clearFilters,
+      enableQuerySyntax: this.enableQuerySyntax,
     };
 
     this.searchBox = this.redirectionUrl
@@ -245,7 +257,11 @@ export class AtomicSearchBox {
     if (redirectTo === '') {
       return;
     }
-    const data = {value, analytics};
+    const data: StandaloneSearchBoxData = {
+      value,
+      enableQuerySyntax: this.enableQuerySyntax,
+      analytics,
+    };
     const storage = new SafeStorage();
     storage.setJSON(StorageItems.STANDALONE_SEARCH_BOX_DATA, data);
 

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -303,8 +303,8 @@ export class AtomicSearchInterface
 
     safeStorage.removeItem(StorageItems.STANDALONE_SEARCH_BOX_DATA);
     const {updateQuery} = loadQueryActions(this.engine!);
-    const {value, analytics} = standaloneSearchBoxData;
-    this.engine!.dispatch(updateQuery({q: value}));
+    const {value, enableQuerySyntax, analytics} = standaloneSearchBoxData;
+    this.engine!.dispatch(updateQuery({q: value, enableQuerySyntax}));
     this.engine.executeFirstSearchAfterStandaloneSearchBoxRedirect(analytics);
   }
 

--- a/packages/atomic/src/utils/local-storage-utils.tsx
+++ b/packages/atomic/src/utils/local-storage-utils.tsx
@@ -7,6 +7,7 @@ export enum StorageItems {
 
 export interface StandaloneSearchBoxData {
   value: string;
+  enableQuerySyntax?: boolean;
   analytics: StandaloneSearchBoxAnalytics;
 }
 

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box-options.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box-options.ts
@@ -16,7 +16,7 @@ export interface SearchBoxOptions {
   id?: string;
 
   /**
-   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query.
    *
    * @defaultValue `false`
    */

--- a/packages/headless/src/features/query/query-actions.ts
+++ b/packages/headless/src/features/query/query-actions.ts
@@ -9,7 +9,7 @@ export interface UpdateQueryActionCreatorPayload {
   q?: string;
 
   /**
-   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query.
    */
   enableQuerySyntax?: boolean;
 }

--- a/packages/headless/src/features/query/query-state.ts
+++ b/packages/headless/src/features/query/query-state.ts
@@ -4,7 +4,7 @@ export interface QueryState {
    */
   q: string;
   /**
-   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query.
    */
   enableQuerySyntax: boolean;
 }

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -34,7 +34,7 @@ export interface SearchParameters {
   df?: Record<string, DateRangeRequest[]>;
 
   /**
-   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/searching-with-coveo/search-prefixes-and-operators) in the query.
+   * Whether to interpret advanced [Coveo Cloud query syntax](https://docs.coveo.com/en/1814/) in the query.
    */
   enableQuerySyntax?: boolean;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2201

I also added support for the query syntax in the standalone search box, so that the query syntax can be used for the initial search. However, both the standalone search box and the normal search box must have the query syntax enabled for that to work.
