### PR TITLE
fix(quantic): hover state removed from result only when the modal quickview is closed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
@@ -42,15 +42,21 @@ export default class QuanticResult extends LightningElement {
 
   /** @type {boolean} */
   isHovered = false;
+  /** @type {boolean} */
+  quickviewIsOpen = false;
 
   connectedCallback() {
     this.template.addEventListener('haspreview', this.onHasPreview);
     this.template.host.addEventListener('mouseenter', this.setHoverState);
     this.template.host.addEventListener('mouseleave', this.removeHoverState);
+    this.template.addEventListener('quantic__resultpreviewtoggle', this.handlePreviewToggle);
   }
 
   disconnectedCallback() {
     this.template.removeEventListener('haspreview', this.onHasPreview);
+    this.template.host.removeEventListener('mouseenter', this.setHoverState);
+    this.template.host.removeEventListener('mouseleave', this.removeHoverState);
+    this.template.removeEventListener('quantic__resultpreviewtoggle', this.handlePreviewToggle);
   }
 
   get videoThumbnail() {
@@ -94,6 +100,13 @@ export default class QuanticResult extends LightningElement {
   };
 
   removeHoverState = () => {
-    this.isHovered = false;
+    if (!this.quickviewIsOpen) {
+      this.isHovered = false;
+    }
+  };
+
+  handlePreviewToggle = (event) => {
+    this.quickviewIsOpen = event.detail.isOpen;
+    this.removeHoverState();
   };
 }


### PR DESCRIPTION
[SFINT-4766](https://coveord.atlassian.net/browse/SFINT-4766)
### The issue:
The Quickview  modal is closing it self whenever the mouse cursor leaves the page:

https://user-images.githubusercontent.com/86681870/211880769-2778f4f2-044a-4767-bdb1-f6ef623d6196.mov

This is occurring because when the mouse leaves the page the Quantic Result component is no longer hovered, which means the result actions are removed from the page including the Quickview result action, that's why the quickview modal is closing it self strangely.

### The solution:
When the Quick view modal is open, the Quantic Result component is now considered still in the hovered state even when the mouse leaves the page:

https://user-images.githubusercontent.com/86681870/211881689-218540d7-0ff1-4c77-95c8-0c562e37c706.mov



[SFINT-4760]: https://coveord.atlassian.net/browse/SFINT-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SFINT-4766]: https://coveord.atlassian.net/browse/SFINT-4766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ