### PR TITLE
feat(headless): reset preview content on new query

### DIFF
--- a/packages/headless/src/features/result-preview/result-preview-slice.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.test.ts
@@ -1,4 +1,7 @@
 import {buildMockResultPreviewRequest} from '../../test/mock-result-preview-request-builder';
+import {buildMockSearch} from '../../test/mock-search';
+import {logInterfaceLoad} from '../analytics/analytics-actions';
+import {executeSearch} from '../insight-search/insight-search-actions';
 import {fetchResultContent, updateContentURL} from './result-preview-actions';
 import {resultPreviewReducer} from './result-preview-slice';
 import {
@@ -20,6 +23,21 @@ describe('ResultPreview', () => {
       content: '',
       isLoading: false,
     });
+  });
+
+  it('re-initialize the state to initial when a query returns correctly', () => {
+    state.content = 'content';
+    state.contentURL = 'url';
+    state.isLoading = true;
+    state.uniqueId = 'uniqueId';
+    const action = executeSearch.fulfilled(
+      buildMockSearch(),
+      '',
+      logInterfaceLoad()
+    );
+    const finalState = resultPreviewReducer(state, action);
+
+    expect(finalState).toEqual(getResultPreviewInitialState());
   });
 
   it(`on #fetchResultContent.pending,

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -18,17 +18,10 @@ export const resultPreviewReducer = createReducer(
         state.isLoading = false;
       })
       .addCase(updateContentURL.fulfilled, (state, action) => {
-        const {contentURL} = action.payload;
-
-        state.contentURL = contentURL;
+        state.contentURL = action.payload.contentURL;
       })
       .addCase(executeSearch.fulfilled, (state) => {
-        const {content, isLoading, uniqueId, contentURL} =
-          getResultPreviewInitialState();
-        state.content = content;
-        state.isLoading = isLoading;
-        state.uniqueId = uniqueId;
-        state.contentURL = contentURL;
+        Object.assign(state, getResultPreviewInitialState());
       });
   }
 );

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -21,7 +21,12 @@ export const resultPreviewReducer = createReducer(
         state.contentURL = action.payload.contentURL;
       })
       .addCase(executeSearch.fulfilled, (state) => {
-        Object.assign(state, getResultPreviewInitialState());
+        const {content, isLoading, uniqueId, contentURL} =
+          getResultPreviewInitialState();
+        state.content = content;
+        state.isLoading = isLoading;
+        state.uniqueId = uniqueId;
+        state.contentURL = contentURL;
       });
   }
 );

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -1,4 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {executeSearch} from '../search/search-actions';
 import {fetchResultContent, updateContentURL} from './result-preview-actions';
 import {getResultPreviewInitialState} from './result-preview-state';
 
@@ -19,6 +20,14 @@ export const resultPreviewReducer = createReducer(
       .addCase(updateContentURL.fulfilled, (state, action) => {
         const {contentURL} = action.payload;
 
+        state.contentURL = contentURL;
+      })
+      .addCase(executeSearch.fulfilled, (state) => {
+        const {content, isLoading, uniqueId, contentURL} =
+          getResultPreviewInitialState();
+        state.content = content;
+        state.isLoading = isLoading;
+        state.uniqueId = uniqueId;
         state.contentURL = contentURL;
       });
   }


### PR DESCRIPTION
My initial thought was to add a new action to clear the preview content from the state.

This would be used by UI's when they want to "clear" the Quickview from the page, and don't need it loaded in memory anymore.

However I realized we could also just clear it automatically for our users whenever there is a new query executed, since... that's pretty much when you would want to unload any displayed Quickview from a page anyway...

Said differently, you load a quickview from a given list of result currently displayed to users.

When a new query is performed (and a new set of results is retrieved), then keeping the Quickview content in memory seems superfluous and we can just clear it automatically.

https://coveord.atlassian.net/browse/KIT-2198