### PR TITLE
fix(headless): allowed empty string for query pipeline

### DIFF
--- a/packages/headless/src/app/recommendation-engine/recommendation-engine-configuration.ts
+++ b/packages/headless/src/app/recommendation-engine/recommendation-engine-configuration.ts
@@ -1,4 +1,4 @@
-import {Schema} from '@coveo/bueno';
+import {Schema, StringValue} from '@coveo/bueno';
 import {nonEmptyString} from '../../utils/validate-payload';
 import {
   EngineConfiguration,
@@ -45,7 +45,7 @@ export interface RecommendationEngineConfiguration extends EngineConfiguration {
 export const recommendationEngineConfigurationSchema =
   new Schema<RecommendationEngineConfiguration>({
     ...engineConfigurationDefinitions,
-    pipeline: nonEmptyString,
+    pipeline: new StringValue({required: false, emptyAllowed: true}),
     searchHub: nonEmptyString,
     locale: nonEmptyString,
     timezone: nonEmptyString,

--- a/packages/headless/src/app/recommendation-engine/recommendation-engine.test.ts
+++ b/packages/headless/src/app/recommendation-engine/recommendation-engine.test.ts
@@ -28,9 +28,9 @@ describe('buildRecommendationEngine', () => {
     expect(initEngine).toThrow();
   });
 
-  it('passing an invalid pipeline throws', () => {
+  it('passing an empty pipeline does not throw', () => {
     options.configuration.pipeline = '';
-    expect(initEngine).toThrow();
+    expect(initEngine).not.toThrow();
   });
 
   it('#engine.state retrieves the updated state', () => {

--- a/packages/headless/src/app/search-engine/search-engine-configuration.ts
+++ b/packages/headless/src/app/search-engine/search-engine-configuration.ts
@@ -1,4 +1,4 @@
-import {ArrayValue, RecordValue, Schema} from '@coveo/bueno';
+import {ArrayValue, RecordValue, Schema, StringValue} from '@coveo/bueno';
 import {
   PostprocessFacetSearchResponseMiddleware,
   PostprocessQuerySuggestResponseMiddleware,
@@ -81,7 +81,7 @@ export const searchEngineConfigurationSchema =
         required: false,
       },
       values: {
-        pipeline: nonEmptyString,
+        pipeline: new StringValue({required: false, emptyAllowed: true}),
         searchHub: nonEmptyString,
         locale: nonEmptyString,
         timezone: nonEmptyString,

--- a/packages/headless/src/app/search-engine/search-engine.test.ts
+++ b/packages/headless/src/app/search-engine/search-engine.test.ts
@@ -30,9 +30,9 @@ describe('searchEngine', () => {
       expect(initEngine).toThrow();
     });
 
-    it('passing an invalid pipeline throws', () => {
+    it('passing an empty pipeline does not throw', () => {
       options.configuration.search!.pipeline = '';
-      expect(initEngine).toThrow();
+      expect(initEngine).not.toThrow();
     });
 
     it('exposes an #executeFirstSearch method', () => {

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -1,4 +1,4 @@
-import {ArrayValue, BooleanValue, Value} from '@coveo/bueno';
+import {ArrayValue, BooleanValue, StringValue, Value} from '@coveo/bueno';
 import {createAction} from '@reduxjs/toolkit';
 import {IRuntimeEnvironment} from 'coveo.analytics';
 import {doNotTrack} from '../../utils/utils';
@@ -77,7 +77,7 @@ export const updateSearchConfiguration = createAction(
   (payload: UpdateSearchConfigurationActionCreatorPayload) =>
     validatePayload(payload, {
       apiBaseUrl: nonEmptyString,
-      pipeline: nonEmptyString,
+      pipeline: new StringValue({required: false, emptyAllowed: true}),
       searchHub: nonEmptyString,
       timezone: nonEmptyString,
       locale: nonEmptyString,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2225

I'm not sure of the exact reason why, but changing the page in Storybook or changing any option caused the whole search interface to crash with an error that said `search: value is an empty string.`.

My guess is that my recent changes to the `atomic-search-interface` (specifically adding `mutable: true` to `pipeline` and setting `this.pipeline = this.engine!.state.pipeline;` after initialization) caused Stencil to add `pipeline=""` to the search interface, and a piece of logic in Storybook that's responsible for cloning the interface and replacing it with the clone, caused the search interface to try to initialize the engine with an empty string as a pipeline.

When I added a check that excludes the pipeline from the engine's initial configuration when the pipeline is an empty string, the error would stop happening.

I decided to allow empty strings when configuring the pipeline, since:
* the pipeline's default value is an empty string. See: https://github.com/coveo/ui-kit/blob/51fa84ec66072d7974fec66106fa1f73aba79531/packages/headless/src/features/pipeline/pipeline-state.ts#L1
* the pipeline's `setPipeline` action allows empty strings. See: https://github.com/coveo/ui-kit/blob/51fa84ec66072d7974fec66106fa1f73aba79531/packages/headless/src/features/pipeline/pipeline-actions.ts#L5-L10
  * However, the searchHub's `setSearchHub` action also allows empty strings, despite its default parameter instead being `"default"`. See: https://github.com/coveo/ui-kit/blob/e91f6597baf1d661f761d4045fd08664ba6a3c61/packages/headless/src/features/search-hub/search-hub-actions.ts#L5-L10 and https://github.com/coveo/ui-kit/blob/e91f6597baf1d661f761d4045fd08664ba6a3c61/packages/headless/src/features/search-hub/search-hub-state.ts#L1