### PR TITLE
Pager doesn't show the correct max number of pages

### DIFF
--- a/packages/headless/src/features/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.ts
@@ -31,7 +31,6 @@ import {
   nextPage,
 } from './pagination-actions';
 import {
-  maximumNumberOfResultsFromIndex,
   minimumPage,
 } from './pagination-constants';
 import {getPaginationInitialState, PaginationState} from './pagination-state';
@@ -159,9 +158,5 @@ export function calculateMaxPage(
   totalCountFiltered: number,
   numberOfResults: number
 ) {
-  const totalCount = Math.min(
-    totalCountFiltered,
-    maximumNumberOfResultsFromIndex
-  );
-  return Math.ceil(totalCount / numberOfResults);
+  return Math.ceil(totalCountFiltered / numberOfResults);
 }


### PR DESCRIPTION
The pager is limited to showing a number of pages divisible by the number of results per page and the 5000 item limit per query. Unfortunately, 5000 is the results per query limit and an index can have many more items. 

When you limit the max count to 5000 (number of items max returned) the pager fails to calculate the correct number of pages available. For example, my index has 310,000 items and if I am displaying 50 at a time, I should have a pager that goes to 6200 pages. However, I cannot get it to render more than a number divisible by 5000 and this creates a bad UI when in combination with the facet counts. 

Expected behaviour:

The pager will render the correct total max page and clicking on the pager page will create a fetch query starting at the correct record number 

For reference of where the 5000 limit came from.
https://docs.coveo.com/en/1461/build-a-search-ui/query-parameters#RestQueryParameters-numberOfResults

Full disclosure the code in the PR renders the correct amount of pager items but breaks when clicked on.
