### PR TITLE
SVCINT-1999 Feat: example of ipx with target selector

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -754,7 +754,6 @@ export namespace Components {
          */
         "container"?: HTMLElement;
         "fullscreen": boolean;
-        "isIPX": boolean;
         "isOpen": boolean;
         "noFocusTrap": boolean;
         "source"?: HTMLElement;
@@ -3400,7 +3399,6 @@ declare namespace LocalJSX {
          */
         "container"?: HTMLElement;
         "fullscreen"?: boolean;
-        "isIPX"?: boolean;
         "isOpen"?: boolean;
         "noFocusTrap"?: boolean;
         "onAnimationEnded"?: (event: AtomicModalCustomEvent<never>) => void;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -747,7 +747,7 @@ export namespace Components {
         /**
           * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
-        "animateOverEntirePage": boolean;
+        "boundaries": 'page' | 'element';
         "close": () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
@@ -3393,7 +3393,7 @@ declare namespace LocalJSX {
         /**
           * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
-        "animateOverEntirePage"?: boolean;
+        "boundaries"?: 'page' | 'element';
         "close"?: () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -744,12 +744,17 @@ export namespace Components {
     interface AtomicLoadMoreResults {
     }
     interface AtomicModal {
+        /**
+          * Wether to display the open and close animations over the entire page or the atomic-modal only.
+         */
+        "animateOverEntirePage": boolean;
         "close": () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
         "fullscreen": boolean;
+        "isIPX": boolean;
         "isOpen": boolean;
         "noFocusTrap": boolean;
         "source"?: HTMLElement;
@@ -3385,12 +3390,17 @@ declare namespace LocalJSX {
     interface AtomicLoadMoreResults {
     }
     interface AtomicModal {
+        /**
+          * Wether to display the open and close animations over the entire page or the atomic-modal only.
+         */
+        "animateOverEntirePage"?: boolean;
         "close"?: () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
         "fullscreen"?: boolean;
+        "isIPX"?: boolean;
         "isOpen"?: boolean;
         "noFocusTrap"?: boolean;
         "onAnimationEnded"?: (event: AtomicModalCustomEvent<never>) => void;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -679,6 +679,7 @@ export namespace Components {
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
+        "isEmbedded": boolean;
         "isOpen": boolean;
         "source"?: HTMLElement;
     }
@@ -3286,6 +3287,7 @@ declare namespace LocalJSX {
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
+        "isEmbedded"?: boolean;
         "isOpen"?: boolean;
         "onAnimationEnded"?: (event: AtomicIpxModalCustomEvent<never>) => void;
         "source"?: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -747,7 +747,7 @@ export namespace Components {
         /**
           * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
-        "boundaries": 'page' | 'element';
+        "boundary": 'page' | 'element';
         "close": () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -656,6 +656,9 @@ export namespace Components {
          */
         "withDatePicker": boolean;
     }
+    interface AtomicIpxBody {
+        "isOpen": boolean;
+    }
     interface AtomicIpxButton {
         /**
           * The close icon of the button.
@@ -668,18 +671,23 @@ export namespace Components {
         /**
           * The label that will be shown to the user.
          */
-        "label": string;
+        "label"?: string;
         /**
           * The open icon of the button.
          */
         "openIcon": string;
+    }
+    interface AtomicIpxEmbedded {
+        /**
+          * The container to hide from the tabindex and accessibility DOM when the modal is closed.
+         */
+        "container"?: HTMLElement;
     }
     interface AtomicIpxModal {
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
-        "isEmbedded": boolean;
         "isOpen": boolean;
         "source"?: HTMLElement;
     }
@@ -1774,6 +1782,14 @@ export interface AtomicInsightPagerCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomicInsightPagerElement;
 }
+export interface AtomicIpxBodyCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLAtomicIpxBodyElement;
+}
+export interface AtomicIpxEmbeddedCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLAtomicIpxEmbeddedElement;
+}
 export interface AtomicIpxModalCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomicIpxModalElement;
@@ -2055,11 +2071,23 @@ declare global {
         prototype: HTMLAtomicInsightTimeframeFacetElement;
         new (): HTMLAtomicInsightTimeframeFacetElement;
     };
+    interface HTMLAtomicIpxBodyElement extends Components.AtomicIpxBody, HTMLStencilElement {
+    }
+    var HTMLAtomicIpxBodyElement: {
+        prototype: HTMLAtomicIpxBodyElement;
+        new (): HTMLAtomicIpxBodyElement;
+    };
     interface HTMLAtomicIpxButtonElement extends Components.AtomicIpxButton, HTMLStencilElement {
     }
     var HTMLAtomicIpxButtonElement: {
         prototype: HTMLAtomicIpxButtonElement;
         new (): HTMLAtomicIpxButtonElement;
+    };
+    interface HTMLAtomicIpxEmbeddedElement extends Components.AtomicIpxEmbedded, HTMLStencilElement {
+    }
+    var HTMLAtomicIpxEmbeddedElement: {
+        prototype: HTMLAtomicIpxEmbeddedElement;
+        new (): HTMLAtomicIpxEmbeddedElement;
     };
     interface HTMLAtomicIpxModalElement extends Components.AtomicIpxModal, HTMLStencilElement {
     }
@@ -2576,7 +2604,9 @@ declare global {
         "atomic-insight-tab": HTMLAtomicInsightTabElement;
         "atomic-insight-tabs": HTMLAtomicInsightTabsElement;
         "atomic-insight-timeframe-facet": HTMLAtomicInsightTimeframeFacetElement;
+        "atomic-ipx-body": HTMLAtomicIpxBodyElement;
         "atomic-ipx-button": HTMLAtomicIpxButtonElement;
+        "atomic-ipx-embedded": HTMLAtomicIpxEmbeddedElement;
         "atomic-ipx-modal": HTMLAtomicIpxModalElement;
         "atomic-ipx-refine-modal": HTMLAtomicIpxRefineModalElement;
         "atomic-ipx-refine-toggle": HTMLAtomicIpxRefineToggleElement;
@@ -3264,6 +3294,10 @@ declare namespace LocalJSX {
          */
         "withDatePicker"?: boolean;
     }
+    interface AtomicIpxBody {
+        "isOpen"?: boolean;
+        "onAnimationEnded"?: (event: AtomicIpxBodyCustomEvent<never>) => void;
+    }
     interface AtomicIpxButton {
         /**
           * The close icon of the button.
@@ -3282,12 +3316,18 @@ declare namespace LocalJSX {
          */
         "openIcon"?: string;
     }
+    interface AtomicIpxEmbedded {
+        /**
+          * The container to hide from the tabindex and accessibility DOM when the modal is closed.
+         */
+        "container"?: HTMLElement;
+        "onAnimationEnded"?: (event: AtomicIpxEmbeddedCustomEvent<never>) => void;
+    }
     interface AtomicIpxModal {
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.
          */
         "container"?: HTMLElement;
-        "isEmbedded"?: boolean;
         "isOpen"?: boolean;
         "onAnimationEnded"?: (event: AtomicIpxModalCustomEvent<never>) => void;
         "source"?: HTMLElement;
@@ -4369,7 +4409,9 @@ declare namespace LocalJSX {
         "atomic-insight-tab": AtomicInsightTab;
         "atomic-insight-tabs": AtomicInsightTabs;
         "atomic-insight-timeframe-facet": AtomicInsightTimeframeFacet;
+        "atomic-ipx-body": AtomicIpxBody;
         "atomic-ipx-button": AtomicIpxButton;
+        "atomic-ipx-embedded": AtomicIpxEmbedded;
         "atomic-ipx-modal": AtomicIpxModal;
         "atomic-ipx-refine-modal": AtomicIpxRefineModal;
         "atomic-ipx-refine-toggle": AtomicIpxRefineToggle;
@@ -4495,7 +4537,9 @@ declare module "@stencil/core" {
             "atomic-insight-tab": LocalJSX.AtomicInsightTab & JSXBase.HTMLAttributes<HTMLAtomicInsightTabElement>;
             "atomic-insight-tabs": LocalJSX.AtomicInsightTabs & JSXBase.HTMLAttributes<HTMLAtomicInsightTabsElement>;
             "atomic-insight-timeframe-facet": LocalJSX.AtomicInsightTimeframeFacet & JSXBase.HTMLAttributes<HTMLAtomicInsightTimeframeFacetElement>;
+            "atomic-ipx-body": LocalJSX.AtomicIpxBody & JSXBase.HTMLAttributes<HTMLAtomicIpxBodyElement>;
             "atomic-ipx-button": LocalJSX.AtomicIpxButton & JSXBase.HTMLAttributes<HTMLAtomicIpxButtonElement>;
+            "atomic-ipx-embedded": LocalJSX.AtomicIpxEmbedded & JSXBase.HTMLAttributes<HTMLAtomicIpxEmbeddedElement>;
             "atomic-ipx-modal": LocalJSX.AtomicIpxModal & JSXBase.HTMLAttributes<HTMLAtomicIpxModalElement>;
             "atomic-ipx-refine-modal": LocalJSX.AtomicIpxRefineModal & JSXBase.HTMLAttributes<HTMLAtomicIpxRefineModalElement>;
             "atomic-ipx-refine-toggle": LocalJSX.AtomicIpxRefineToggle & JSXBase.HTMLAttributes<HTMLAtomicIpxRefineToggleElement>;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -745,7 +745,7 @@ export namespace Components {
     }
     interface AtomicModal {
         /**
-          * Wether to display the open and close animations over the entire page or the atomic-modal only.
+          * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
         "animateOverEntirePage": boolean;
         "close": () => void;
@@ -3391,7 +3391,7 @@ declare namespace LocalJSX {
     }
     interface AtomicModal {
         /**
-          * Wether to display the open and close animations over the entire page or the atomic-modal only.
+          * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
         "animateOverEntirePage"?: boolean;
         "close"?: () => void;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -3392,7 +3392,7 @@ declare namespace LocalJSX {
         /**
           * Whether to display the open and close animations over the entire page or the atomic-modal only.
          */
-        "boundaries"?: 'page' | 'element';
+        "boundary"?: 'page' | 'element';
         "close"?: () => void;
         /**
           * The container to hide from the tabindex and accessibility DOM when the modal is closed.

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.pcss
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.pcss
@@ -13,6 +13,10 @@ atomic-focus-trap {
   grid-area: modal;
 }
 
+.animate-scaleUpModalIPX[part='container'] {
+  @apply rounded shadow;
+}
+
 :host(.open) {
   [part='backdrop'] {
     @apply pointer-events-auto;

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -55,7 +55,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   @Prop({mutable: true}) close: () => void = () => (this.isOpen = false);
   @Prop({reflect: true}) noFocusTrap = false;
   /**
-   * Wether to display the open and close animations over the entire page or the atomic-modal only.
+   * Whether to display the open and close animations over the entire page or the atomic-modal only.
    */
   @Prop({reflect: true}) animateOverEntirePage = true;
   @Prop({reflect: true}) isIPX = false;

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -57,7 +57,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   /**
    * Whether to display the open and close animations over the entire page or the atomic-modal only.
    */
-  @Prop({reflect: true}) boundaries: 'page' | 'element' = 'page';
+  @Prop({reflect: true}) boundary: 'page' | 'element' = 'page';
 
   @Event() animationEnded!: EventEmitter<never>;
 
@@ -188,7 +188,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
         <div
           part="backdrop"
           class={`
-            ${this.boundaries === 'page' ? 'fixed' : 'absolute'}
+            ${this.boundary === 'page' ? 'fixed' : 'absolute'}
             left-0 top-0 right-0 bottom-0 z-[9999]
           `}
           onClick={(e) => e.target === e.currentTarget && this.close()}

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -58,7 +58,6 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
    * Whether to display the open and close animations over the entire page or the atomic-modal only.
    */
   @Prop({reflect: true}) boundaries: 'page' | 'element' = 'page';
-  @Prop({reflect: true}) isIPX = false;
 
   @Event() animationEnded!: EventEmitter<never>;
 
@@ -140,13 +139,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       <article
         part="container"
         class={`flex flex-col justify-between bg-background text-on-background
-          ${
-            this.isOpen
-              ? this.isIPX
-                ? 'animate-scaleUpModalIPX'
-                : 'animate-scaleUpModal'
-              : 'animate-slideDownModal'
-          }
+          ${this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'}
           ${this.wasEverOpened ? '' : 'invisible'}`}
         onAnimationEnd={() => this.animationEnded.emit()}
         ref={(ref) => (this.animatableContainer = ref)}

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -57,7 +57,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   /**
    * Whether to display the open and close animations over the entire page or the atomic-modal only.
    */
-  @Prop({reflect: true}) animateOverEntirePage = true;
+  @Prop({reflect: true}) boundaries: 'page' | 'element' = 'page';
   @Prop({reflect: true}) isIPX = false;
 
   @Event() animationEnded!: EventEmitter<never>;
@@ -195,7 +195,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
         <div
           part="backdrop"
           class={`
-            ${this.animateOverEntirePage ? 'fixed' : 'absolute'}
+            ${this.boundaries === 'page' ? 'fixed' : 'absolute'}
             left-0 top-0 right-0 bottom-0 z-[9999]
           `}
           onClick={(e) => e.target === e.currentTarget && this.close()}

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -54,6 +54,11 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   @Prop({reflect: true, mutable: true}) isOpen = false;
   @Prop({mutable: true}) close: () => void = () => (this.isOpen = false);
   @Prop({reflect: true}) noFocusTrap = false;
+  /**
+   * Wether to display the open and close animations over the entire page or the atomic-modal only.
+   */
+  @Prop({reflect: true}) animateOverEntirePage = true;
+  @Prop({reflect: true}) isIPX = false;
 
   @Event() animationEnded!: EventEmitter<never>;
 
@@ -134,9 +139,15 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
     const Content = () => (
       <article
         part="container"
-        class={`flex flex-col justify-between bg-background text-on-background ${
-          this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
-        } ${this.wasEverOpened ? '' : 'invisible'}`}
+        class={`flex flex-col justify-between bg-background text-on-background
+          ${
+            this.isOpen
+              ? this.isIPX
+                ? 'animate-scaleUpModalIPX'
+                : 'animate-scaleUpModal'
+              : 'animate-slideDownModal'
+          }
+          ${this.wasEverOpened ? '' : 'invisible'}`}
         onAnimationEnd={() => this.animationEnded.emit()}
         ref={(ref) => (this.animatableContainer = ref)}
       >
@@ -183,7 +194,10 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       <Host class={this.getClasses().join(' ')}>
         <div
           part="backdrop"
-          class="fixed left-0 top-0 right-0 bottom-0 z-[9999]"
+          class={`
+            ${this.animateOverEntirePage ? 'fixed' : 'absolute'}
+            left-0 top-0 right-0 bottom-0 z-[9999]
+          `}
           onClick={(e) => e.target === e.currentTarget && this.close()}
         >
           {this.noFocusTrap ? (

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -20,7 +20,7 @@ interface RefineModalCommonProps {
   isOpen: boolean;
   openButton?: HTMLElement;
   noFocusTrap?: boolean;
-  animateOverEntirePage?: boolean;
+  boundaries?: 'page' | 'element';
   isIPX?: boolean;
 }
 
@@ -96,7 +96,7 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
       }}
       exportparts={exportparts}
       noFocusTrap={props.noFocusTrap}
-      animateOverEntirePage={props.animateOverEntirePage}
+      boundaries={props.boundaries}
       isIPX={props.isIPX}
     >
       {renderHeader()}

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -21,7 +21,6 @@ interface RefineModalCommonProps {
   openButton?: HTMLElement;
   noFocusTrap?: boolean;
   boundaries?: 'page' | 'element';
-  isIPX?: boolean;
 }
 
 export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
@@ -97,7 +96,6 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
       exportparts={exportparts}
       noFocusTrap={props.noFocusTrap}
       boundaries={props.boundaries}
-      isIPX={props.isIPX}
     >
       {renderHeader()}
       {...children}

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -20,6 +20,8 @@ interface RefineModalCommonProps {
   isOpen: boolean;
   openButton?: HTMLElement;
   noFocusTrap?: boolean;
+  animateOverEntirePage?: boolean;
+  isIPX?: boolean;
 }
 
 export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
@@ -94,6 +96,8 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
       }}
       exportparts={exportparts}
       noFocusTrap={props.noFocusTrap}
+      animateOverEntirePage={props.animateOverEntirePage}
+      isIPX={props.isIPX}
     >
       {renderHeader()}
       {...children}

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -20,7 +20,7 @@ interface RefineModalCommonProps {
   isOpen: boolean;
   openButton?: HTMLElement;
   noFocusTrap?: boolean;
-  boundaries?: 'page' | 'element';
+  boundary?: 'page' | 'element';
 }
 
 export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
@@ -95,7 +95,7 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
       }}
       exportparts={exportparts}
       noFocusTrap={props.noFocusTrap}
-      boundaries={props.boundaries}
+      boundary={props.boundary}
     >
       {renderHeader()}
       {...children}

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
@@ -1,0 +1,30 @@
+@import '../../../global/global.pcss';
+
+:host {
+  &::part(container) {
+    @apply rounded;
+    @apply overflow-hidden flex flex-col justify-between bg-background box-border;
+    grid-area: modal;
+    width: var(--atomic-ipx-width, 31.25rem);
+    height: var(--atomic-ipx-height, 43.75rem);
+    box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
+  }
+
+  &::part(header-wrapper) {
+    @apply px-6 pt-4 w-full grid bg-neutral-light;
+    padding: 1.5rem 1.5rem 0 1.5rem;
+  }
+
+  &::part(header) {
+    @apply font-bold;
+  }
+
+  &::part(body-wrapper) {
+    padding: 1rem 1.5rem 1rem 1.5rem;
+  }
+
+  &::part(footer-wrapper) {
+    @apply bg-neutral-light items-stretch;
+    padding: 1rem 1.75rem;
+  }
+}

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
@@ -1,12 +1,15 @@
 @import '../../../global/global.pcss';
 
 :host {
+  position: relative;
+  overflow: hidden;
+  height: inherit;
+
   &::part(container) {
     @apply rounded;
     @apply overflow-hidden flex flex-col justify-between bg-background box-border;
     grid-area: modal;
-    width: var(--atomic-ipx-width, 31.25rem);
-    height: var(--atomic-ipx-height, 43.75rem);
+    height: inherit;
     box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
   }
 

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -1,0 +1,77 @@
+import {
+  Component,
+  h,
+  State,
+  Element,
+  Event,
+  EventEmitter,
+  Prop,
+} from '@stencil/core';
+import {
+  InitializableComponent,
+  InitializeBindings,
+} from '../../../utils/initialization-utils';
+import {updateBreakpoints} from '../../../utils/replace-breakpoint';
+import {once, randomID} from '../../../utils/utils';
+import {AnyBindings} from '../../common/interface/bindings';
+
+/**
+ * @internal
+ */
+@Component({
+  tag: 'atomic-ipx-body',
+  styleUrl: 'atomic-ipx-body.pcss',
+  shadow: true,
+})
+export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
+  @InitializeBindings() public bindings!: AnyBindings;
+  @Element() public host!: HTMLElement;
+
+  @State() public error!: Error;
+
+  @Event() animationEnded!: EventEmitter<never>;
+
+  @Prop() isOpen = true;
+
+  public componentDidLoad() {
+    const id = this.host.id || randomID('atomic-ipx-body-');
+    this.host.id = id;
+  }
+
+  private updateBreakpoints = once(() => updateBreakpoints(this.host));
+
+  public render() {
+    this.updateBreakpoints();
+
+    return (
+      <article
+        part="container"
+        class={`${this.isOpen ? 'visible' : 'invisible'}`}
+        onAnimationEnd={() => this.animationEnded.emit()}
+      >
+        <header part="header-wrapper" class="flex flex-col items-center">
+          <div part="header">
+            <slot name="header"></slot>
+          </div>
+        </header>
+        <hr part="header-ruler" class="border-neutral"></hr>
+        <div
+          part="body-wrapper"
+          class="overflow-auto grow flex flex-col w-full"
+        >
+          <div part="body" class="w-full max-w-lg">
+            <slot name="body"></slot>
+          </div>
+        </div>
+        <footer
+          part="footer-wrapper"
+          class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
+        >
+          <div part="footer" class="max-w-lg">
+            <slot name="footer"></slot>
+          </div>
+        </footer>
+      </article>
+    );
+  }
+}

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
@@ -17,7 +17,7 @@ export class AtomicIPXButton {
   /**
    * The label that will be shown to the user.
    */
-  @Prop({reflect: true}) public label = 'Workplace Search';
+  @Prop({reflect: true}) public label?: string;
 
   /**
    * The close icon of the button.

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.pcss
@@ -1,8 +1,12 @@
 @import '../../../global/global.pcss';
 
 :host {
+  box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
+  height: inherit;
+
   &::part(backdrop) {
     @apply pointer-events-auto;
+    height: inherit;
     inset: auto 3rem 4.25rem auto;
   }
 }

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.pcss
@@ -1,18 +1,8 @@
 @import '../../../global/global.pcss';
 
-atomic-focus-trap {
-  @apply contents;
-}
-
-:host(.open) {
+:host {
   &::part(backdrop) {
     @apply pointer-events-auto;
     inset: auto 3rem 4.25rem auto;
-  }
-}
-
-:host {
-  &::part(backdrop) {
-    @apply pointer-events-none;
   }
 }

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
@@ -52,7 +52,6 @@ export class AtomicIPXEmbedded implements InitializableComponent<AnyBindings> {
         <div part="backdrop">
           <atomic-ipx-body>
             <slot name="header" slot="header" />
-            <slot name="facets" slot="facets" />
             <slot name="body" slot="body" />
             <slot name="footer" slot="footer" />
           </atomic-ipx-body>

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
@@ -1,0 +1,63 @@
+import {
+  Component,
+  h,
+  State,
+  Prop,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+} from '@stencil/core';
+import {
+  InitializableComponent,
+  InitializeBindings,
+} from '../../../utils/initialization-utils';
+import {updateBreakpoints} from '../../../utils/replace-breakpoint';
+import {once, randomID} from '../../../utils/utils';
+import {AnyBindings} from '../../common/interface/bindings';
+
+/**
+ * @internal
+ */
+@Component({
+  tag: 'atomic-ipx-embedded',
+  styleUrl: 'atomic-ipx-embedded.pcss',
+  shadow: true,
+})
+export class AtomicIPXEmbedded implements InitializableComponent<AnyBindings> {
+  @InitializeBindings() public bindings!: AnyBindings;
+  @Element() public host!: HTMLElement;
+
+  @State() public error!: Error;
+
+  /**
+   * The container to hide from the tabindex and accessibility DOM when the modal is closed.
+   */
+  @Prop({mutable: true}) container?: HTMLElement;
+
+  @Event() animationEnded!: EventEmitter<never>;
+
+  public componentDidLoad() {
+    const id = this.host.id || randomID('atomic-ipx-embedded-');
+    this.host.id = id;
+  }
+
+  private updateBreakpoints = once(() => updateBreakpoints(this.host));
+
+  public render() {
+    this.updateBreakpoints();
+
+    return (
+      <Host>
+        <div part="backdrop">
+          <atomic-ipx-body>
+            <slot name="header" slot="header" />
+            <slot name="facets" slot="facets" />
+            <slot name="body" slot="body" />
+            <slot name="footer" slot="footer" />
+          </atomic-ipx-body>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.pcss
@@ -2,17 +2,31 @@
 
 atomic-focus-trap {
   @apply contents;
+  height: inherit;
+}
+
+:host {
+  width: var(--atomic-ipx-width, 31.25rem);
+  height: var(--atomic-ipx-height, 43.75rem);
+  box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
+  inset: auto 3rem 4.25rem auto;
+  position: fixed;
 }
 
 :host(.open) {
+  display: block;
+
   &::part(backdrop) {
     @apply pointer-events-auto;
-    inset: auto 3rem 4.25rem auto;
+    height: inherit;
   }
 }
 
 :host {
+  display: none;
+
   &::part(backdrop) {
     @apply pointer-events-none;
+    height: inherit;
   }
 }

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -92,10 +92,7 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
     return (
       <Host class={this.getClasses().join(' ')}>
-        <div
-          part="backdrop"
-          class="fixed left-0 top-0 right-0 bottom-0 z-[9999]"
-        >
+        <div part="backdrop">
           <atomic-focus-trap
             role="dialog"
             aria-modal={this.isOpen.toString()}

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -34,7 +34,6 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
   @Prop({mutable: true}) source?: HTMLElement;
 
-  @Prop() isEmbedded = false;
   /**
    * The container to hide from the tabindex and accessibility DOM when the modal is closed.
    */
@@ -48,9 +47,6 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
   @Watch('isOpen')
   async watchToggleOpen(isOpen: boolean) {
-    if (this.isEmbedded) {
-      return;
-    }
     const watchToggleOpenExecution = ++this.currentWatchToggleOpenExecution;
     const modalOpenedClass = 'atomic-ipx-modal-opened';
 
@@ -83,10 +79,6 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     this.isOpen && e.preventDefault();
   }
 
-  public componentWillLoad(): void {
-    this.isOpen = this.isOpen || this.isEmbedded;
-  }
-
   public componentDidLoad() {
     const id = this.host.id || randomID('atomic-ipx-modal-');
     this.host.id = id;
@@ -102,11 +94,7 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
       <Host class={this.getClasses().join(' ')}>
         <div
           part="backdrop"
-          class={
-            this.isEmbedded
-              ? ''
-              : 'fixed left-0 top-0 right-0 bottom-0 z-[9999]'
-          }
+          class="fixed left-0 top-0 right-0 bottom-0 z-[9999]"
         >
           <atomic-focus-trap
             role="dialog"
@@ -115,44 +103,11 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
             container={this.container ?? this.host}
             ref={(ref) => (this.focusTrap = ref)}
           >
-            <article
-              part="container"
-              class={`${this.isOpen ? 'visible' : 'invisible'}`}
-              onAnimationEnd={() => this.animationEnded.emit()}
-            >
-              <header part="header-wrapper" class="flex flex-col items-center">
-                <div part="header">
-                  <slot name="header"></slot>
-                </div>
-              </header>
-              <hr part="header-ruler" class="border-neutral"></hr>
-              <div
-                part="body-wrapper"
-                class="overflow-auto grow flex flex-col w-full"
-              >
-                <div
-                  part="body"
-                  class="w-full max-w-lg"
-                  ref={(element) =>
-                    element?.addEventListener(
-                      'touchmove',
-                      (e) => this.isOpen && e.stopPropagation(),
-                      {passive: false}
-                    )
-                  }
-                >
-                  <slot name="body"></slot>
-                </div>
-              </div>
-              <footer
-                part="footer-wrapper"
-                class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
-              >
-                <div part="footer" class="max-w-lg">
-                  <slot name="footer"></slot>
-                </div>
-              </footer>
-            </article>
+            <atomic-ipx-body isOpen={this.isOpen}>
+              <slot name="header" slot="header" />
+              <slot name="body" slot="body" />
+              <slot name="footer" slot="footer" />
+            </atomic-ipx-body>
           </atomic-focus-trap>
         </div>
       </Host>

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.pcss
@@ -1,1 +1,5 @@
 @import '../../common/refine-modal/refine-modal-common.pcss';
+
+:host::part(container) {
+  @apply rounded;
+}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -124,7 +124,6 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
           boundaries="element"
-          isIPX={true}
           noFocusTrap
         >
           {this.renderBody()}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -123,7 +123,7 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           querySummaryState={this.querySummaryState}
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
-          boundaries="element"
+          boundary="element"
           noFocusTrap
         >
           {this.renderBody()}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -171,6 +171,7 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           openButton={this.openButton}
           boundaries="element"
           isIPX={true}
+          noFocusTrap
         >
           {this.renderBody()}
         </RefineModalCommon>

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -170,7 +170,7 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           querySummaryState={this.querySummaryState}
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
-          animateOverEntirePage={false}
+          boundaries="element"
           isIPX={true}
         >
           {this.renderBody()}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -7,7 +7,6 @@ import {
   QuerySummaryState,
 } from '@coveo/headless';
 import {Component, h, State, Prop, Element, Watch, Host} from '@stencil/core';
-import {rectEquals} from '../../../utils/dom-utils';
 import {
   BindStateToController,
   InitializableComponent,
@@ -74,44 +73,7 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           )
         );
       }
-      this.onAnimationFrame();
     }
-  }
-
-  private getAtomicModalDimensions(): DOMRect | undefined {
-    const parentIPX =
-      this.bindings.interfaceElement.querySelector('atomic-ipx-modal') ??
-      this.bindings.interfaceElement.querySelector('atomic-ipx-embedded');
-    return parentIPX!.shadowRoot
-      ?.querySelector('atomic-ipx-body')!
-      .shadowRoot?.querySelector('article[part="container"]')!
-      .getBoundingClientRect();
-  }
-
-  private onAnimationFrame() {
-    if (!this.isOpen) {
-      return;
-    }
-    const atomicModalDimensions = this.getAtomicModalDimensions();
-    if (
-      !!atomicModalDimensions &&
-      this.dimensionChanged(atomicModalDimensions)
-    ) {
-      this.updateDimensions(atomicModalDimensions);
-    }
-    window.requestAnimationFrame(() => this.onAnimationFrame());
-  }
-
-  private dimensionChanged(atomicModalDimensions: DOMRect) {
-    if (!this.interfaceDimensions) {
-      return true;
-    }
-
-    return !rectEquals(this.interfaceDimensions, atomicModalDimensions);
-  }
-
-  public updateDimensions(atomicModalDimensions: DOMRect) {
-    this.interfaceDimensions = atomicModalDimensions;
   }
 
   public initialize() {
@@ -153,14 +115,6 @@ export class AtomicIPXRefineModal implements InitializableComponent {
   public render() {
     return (
       <Host>
-        {this.interfaceDimensions && (
-          <style>
-            {`atomic-modal::part(backdrop) {
-            width: ${this.interfaceDimensions.width}px;
-            height: ${this.interfaceDimensions.height}px;
-            }`}
-          </style>
-        )}
         <RefineModalCommon
           bindings={this.bindings}
           host={this.host}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -158,7 +158,6 @@ export class AtomicIPXRefineModal implements InitializableComponent {
             {`atomic-modal::part(backdrop) {
             width: ${this.interfaceDimensions.width}px;
             height: ${this.interfaceDimensions.height}px;
-            ${this.isOpen ? '' : 'display: none;'}
             }`}
           </style>
         )}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -78,32 +78,40 @@ export class AtomicIPXRefineModal implements InitializableComponent {
     }
   }
 
+  private getAtomicModalDimensions(): DOMRect | undefined {
+    const parentIPX =
+      this.bindings.interfaceElement.querySelector('atomic-ipx-modal') ??
+      this.bindings.interfaceElement.querySelector('atomic-ipx-embedded');
+    return parentIPX!.shadowRoot
+      ?.querySelector('atomic-ipx-body')!
+      .shadowRoot?.querySelector('article[part="container"]')!
+      .getBoundingClientRect();
+  }
+
   private onAnimationFrame() {
     if (!this.isOpen) {
       return;
     }
-    if (this.dimensionChanged()) {
-      this.updateDimensions();
+    const atomicModalDimensions = this.getAtomicModalDimensions();
+    if (
+      !!atomicModalDimensions &&
+      this.dimensionChanged(atomicModalDimensions)
+    ) {
+      this.updateDimensions(atomicModalDimensions);
     }
     window.requestAnimationFrame(() => this.onAnimationFrame());
   }
 
-  private dimensionChanged() {
+  private dimensionChanged(atomicModalDimensions: DOMRect) {
     if (!this.interfaceDimensions) {
       return true;
     }
 
-    return !rectEquals(
-      this.interfaceDimensions,
-      this.bindings.interfaceElement.getBoundingClientRect()
-    );
+    return !rectEquals(this.interfaceDimensions, atomicModalDimensions);
   }
 
-  public updateDimensions() {
-    this.interfaceDimensions = this.bindings.interfaceElement
-      .querySelector('atomic-ipx-modal')!
-      .shadowRoot?.querySelector('article[part="container"]')!
-      .getBoundingClientRect();
+  public updateDimensions(atomicModalDimensions: DOMRect) {
+    this.interfaceDimensions = atomicModalDimensions;
   }
 
   public initialize() {
@@ -148,10 +156,9 @@ export class AtomicIPXRefineModal implements InitializableComponent {
         {this.interfaceDimensions && (
           <style>
             {`atomic-modal::part(backdrop) {
-            top: ${this.interfaceDimensions.top}px;
-            left: ${this.interfaceDimensions.left}px;
             width: ${this.interfaceDimensions.width}px;
             height: ${this.interfaceDimensions.height}px;
+            ${this.isOpen ? '' : 'display: none;'}
             }`}
           </style>
         )}
@@ -163,6 +170,8 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           querySummaryState={this.querySummaryState}
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
+          animateOverEntirePage={false}
+          isIPX={true}
         >
           {this.renderBody()}
         </RefineModalCommon>

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
@@ -239,7 +239,7 @@ export class AtomicRecsList implements InitializableComponent<RecsBindings> {
 
     if (recListWithRecommendation.length > 1) {
       this.bindings.engine.logger.warn(
-        `There are multiple atomic-recs-list in this page with the same recommendation propery "${this.recommendation}". Make sure to set a different recommendation property for each.`
+        `There are multiple atomic-recs-list in this page with the same recommendation property "${this.recommendation}". Make sure to set a different recommendation property for each.`
       );
     }
   }

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.pcss
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.pcss
@@ -1,0 +1,9 @@
+@import '../../../global/global.pcss';
+
+:host {
+  height: inherit;
+  width: inherit;
+  & > slot {
+    height: inherit;
+  }
+}

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -53,6 +53,7 @@ export type Bindings = CommonBindings<
  */
 @Component({
   tag: 'atomic-search-interface',
+  styleUrl: 'atomic-search-interface.pcss',
   shadow: true,
   assetsDirs: ['lang'],
 })

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -408,7 +408,7 @@
           </a>
         </div>
       </atomic-ipx-modal>
-      <atomic-ipx-button is-modal-open="true" label="Workplace Search"></atomic-ipx-button>
+      <atomic-ipx-button is-modal-open="true" label="Help"></atomic-ipx-button>
     </atomic-search-interface>
     <div id="host-div">
       <atomic-search-interface fields-to-include='["snrating","sncost"]'>

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -152,6 +152,14 @@
       body:not(.atomic-ipx-modal-opened) > atomic-search-interface > atomic-ipx-modal {
         display: none;
       }
+
+      #host-div {
+        height: 900px;
+        position: relative;
+        width: 500px;
+        top: 10px;
+        left: 5px;
+      }
     </style>
   </head>
 
@@ -178,7 +186,7 @@
             </atomic-ipx-tabs>
           </atomic-layout-section>
         </div>
-        <atomic-layout-section section="facets" slot="facets">
+        <atomic-layout-section section="facets">
           <atomic-facet field="source" label="Source" display-values-as="checkbox"></atomic-facet>
           <atomic-facet field="filetype" label="Filetype" display-values-as="checkbox"></atomic-facet>
           <atomic-numeric-facet

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -27,7 +27,7 @@
         //searchInterface.executeFirstSearch();
 
         await customElements.whenDefined('atomic-recs-interface');
-        const recsInterface = document.querySelector('atomic-recs-interface');
+        const recsInterface = searchInterface.querySelector('atomic-recs-interface');
         await recsInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
@@ -44,7 +44,9 @@
         embeddedSearchInterfaceChildren.forEach((element) => {
           hostDiv.querySelector('atomic-ipx-embedded').appendChild(element);
         });
-        await initializeSearchInterface(hostDiv.querySelector('atomic-search-interface'));
+        const searchInterface = hostDiv.querySelector('atomic-search-interface');
+        searchInterface.querySelector('atomic-recs-list').setAttribute('recommendation', 'frequentViewed');
+        await initializeSearchInterface(searchInterface);
       };
 
       (async () => {
@@ -137,12 +139,21 @@
       atomic-search-interface:not(.atomic-search-interface-search-executed)
         > atomic-ipx-modal
         > div[slot='body']
+        > atomic-layout-section,
+      atomic-search-interface:not(.atomic-search-interface-search-executed)
+        > atomic-ipx-embedded
+        > div[slot='body']
         > atomic-layout-section {
         display: none;
       }
 
       atomic-search-interface.atomic-search-interface-search-executed
         > atomic-ipx-modal
+        > div[slot='body']
+        > atomic-recs-interface
+        > atomic-recs-list,
+      atomic-search-interface.atomic-search-interface-search-executed
+        > atomic-ipx-embedded
         > div[slot='body']
         > atomic-recs-interface
         > atomic-recs-list {

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -39,20 +39,24 @@
         });
       };
 
+      const setupEmbeddedInterface = async (embeddedSearchInterface) => {
+        const hostDiv = document.querySelector('div#host-div');
+        hostDiv.style.display = 'none';
+        hostDiv.appendChild(ipxInSelector);
+        embeddedSearchInterface.querySelector('atomic-ipx-modal').setAttribute('is-embedded', 'true');
+        embeddedSearchInterface.removeChild(ipxInSelector.querySelector('atomic-ipx-button'));
+        await initializeSearchInterface(ipxInSelector);
+      };
+
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
         const searchInterface = document.querySelector('atomic-search-interface');
 
-        const ipxInSelector = searchInterface.cloneNode(true);
+        const embeddedSearchInterface = searchInterface.cloneNode(true);
 
         await initializeSearchInterface(searchInterface);
 
-        const hostDiv = document.querySelector('div#host-div');
-        hostDiv.style.display = 'none';
-        hostDiv.appendChild(ipxInSelector);
-        ipxInSelector.querySelector('atomic-ipx-modal').setAttribute('is-embedded', 'true');
-        ipxInSelector.removeChild(ipxInSelector.querySelector('atomic-ipx-button'));
-        await initializeSearchInterface(ipxInSelector);
+        await setupEmbeddedInterface(embeddedSearchInterface);
 
         const displaySelect = document.getElementById('ipx-display-select');
         displaySelect.addEventListener('change', ({target: {value}}) => {

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -9,9 +9,17 @@
     <script nomodule src="/build/atomic.js"></script>
     <link rel="stylesheet" href="/themes/coveo.css" />
     <script>
-      (async () => {
-        await customElements.whenDefined('atomic-search-interface');
-        const searchInterface = document.querySelector('atomic-search-interface');
+      const ipxSelectorToButtonMode = (searchInterface, hostDiv) => {
+        searchInterface.style.display = 'inline';
+        hostDiv.style.display = 'none';
+      };
+
+      const ipxButtonToSelectorMode = (searchInterface, hostDiv) => {
+        searchInterface.style.display = 'none';
+        hostDiv.style.display = 'inline';
+      };
+
+      const initializeSearchInterface = async (searchInterface) => {
         await searchInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
@@ -28,6 +36,35 @@
 
         searchInterface.i18n.addResourceBundle('en', 'caption-filetype', {
           '.html': 'html',
+        });
+      };
+
+      (async () => {
+        await customElements.whenDefined('atomic-search-interface');
+        const searchInterface = document.querySelector('atomic-search-interface');
+
+        const ipxInSelector = searchInterface.cloneNode(true);
+
+        await initializeSearchInterface(searchInterface);
+
+        const hostDiv = document.querySelector('div#host-div');
+        hostDiv.style.display = 'none';
+        hostDiv.appendChild(ipxInSelector);
+        ipxInSelector.querySelector('atomic-ipx-modal').setAttribute('is-embedded', 'true');
+        ipxInSelector.removeChild(ipxInSelector.querySelector('atomic-ipx-button'));
+        await initializeSearchInterface(ipxInSelector);
+
+        const displaySelect = document.getElementById('ipx-display-select');
+        displaySelect.addEventListener('change', ({target: {value}}) => {
+          switch (value) {
+            case 'button':
+              ipxSelectorToButtonMode(searchInterface, hostDiv);
+              break;
+            case 'target-selector':
+              ipxButtonToSelectorMode(searchInterface, hostDiv);
+            default:
+              break;
+          }
         });
       })();
     </script>
@@ -114,6 +151,13 @@
   </head>
 
   <body>
+    <div id="ipx-display-option">
+      <label for="ipx-display-select">IPX display type:&nbsp;</label>
+      <select id="ipx-display-select">
+        <option value="button" selected>Button</option>
+        <option value="target-selector">Target Selector</option>
+      </select>
+    </div>
     <atomic-search-interface fields-to-include='["snrating","sncost"]'>
       <atomic-ipx-modal is-open="true">
         <div slot="header">
@@ -342,6 +386,7 @@
       </atomic-ipx-modal>
       <atomic-ipx-button is-modal-open="true"></atomic-ipx-button>
     </atomic-search-interface>
+    <div id="host-div"></div>
     <script src="../header.js" type="text/javascript"></script>
   </body>
 </html>

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -39,24 +39,25 @@
         });
       };
 
-      const setupEmbeddedInterface = async (embeddedSearchInterface) => {
-        const hostDiv = document.querySelector('div#host-div');
+      const setupEmbeddedInterface = async (embeddedSearchInterfaceChildren, hostDiv) => {
         hostDiv.style.display = 'none';
-        hostDiv.appendChild(ipxInSelector);
-        embeddedSearchInterface.querySelector('atomic-ipx-modal').setAttribute('is-embedded', 'true');
-        embeddedSearchInterface.removeChild(ipxInSelector.querySelector('atomic-ipx-button'));
-        await initializeSearchInterface(ipxInSelector);
+        embeddedSearchInterfaceChildren.forEach((element) => {
+          hostDiv.querySelector('atomic-ipx-embedded').appendChild(element);
+        });
+        await initializeSearchInterface(hostDiv.querySelector('atomic-search-interface'));
       };
 
       (async () => {
         await customElements.whenDefined('atomic-search-interface');
         const searchInterface = document.querySelector('atomic-search-interface');
+        const ipxModal = document.querySelector('atomic-ipx-modal');
+        const hostDiv = document.querySelector('div#host-div');
 
-        const embeddedSearchInterface = searchInterface.cloneNode(true);
+        const embeddedSearchInterfaceChildren = Array.from(ipxModal.cloneNode(true).childNodes);
 
         await initializeSearchInterface(searchInterface);
 
-        await setupEmbeddedInterface(embeddedSearchInterface);
+        await setupEmbeddedInterface(embeddedSearchInterfaceChildren, hostDiv);
 
         const displaySelect = document.getElementById('ipx-display-select');
         displaySelect.addEventListener('change', ({target: {value}}) => {
@@ -177,7 +178,7 @@
             </atomic-ipx-tabs>
           </atomic-layout-section>
         </div>
-        <atomic-layout-section section="facets">
+        <atomic-layout-section section="facets" slot="facets">
           <atomic-facet field="source" label="Source" display-values-as="checkbox"></atomic-facet>
           <atomic-facet field="filetype" label="Filetype" display-values-as="checkbox"></atomic-facet>
           <atomic-numeric-facet
@@ -388,9 +389,13 @@
           </a>
         </div>
       </atomic-ipx-modal>
-      <atomic-ipx-button is-modal-open="true"></atomic-ipx-button>
+      <atomic-ipx-button is-modal-open="true" label="Workplace Search"></atomic-ipx-button>
     </atomic-search-interface>
-    <div id="host-div"></div>
+    <div id="host-div">
+      <atomic-search-interface fields-to-include='["snrating","sncost"]'>
+        <atomic-ipx-embedded></atomic-ipx-embedded>
+      </atomic-search-interface>
+    </div>
     <script src="../header.js" type="text/javascript"></script>
   </body>
 </html>

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -63,8 +63,6 @@ module.exports = {
       animation: {
         scaleUpModal:
           'scaleUp .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) forwards',
-        scaleUpModalIPX:
-          'scaleUpIPX .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) backwards',
         slideDownModal: 'slideDown .5s linear forwards',
       },
       transitionProperty: {
@@ -72,11 +70,7 @@ module.exports = {
       },
       keyframes: {
         scaleUp: {
-          '0%': {transform: 'scale(0.7) translateY(1000px)', opacity: '0.7'},
-          '100%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
-        },
-        scaleUpIPX: {
-          '0%': {transform: 'scale(1) translateY(500px)', opacity: '0.7'},
+          '0%': {transform: 'scale(0.7) translateY(150vh)', opacity: '0.7'},
           '100%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
         },
         slideDown: {

--- a/packages/atomic/tailwind.config.js
+++ b/packages/atomic/tailwind.config.js
@@ -63,6 +63,8 @@ module.exports = {
       animation: {
         scaleUpModal:
           'scaleUp .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) forwards',
+        scaleUpModalIPX:
+          'scaleUpIPX .5s cubic-bezier(0.165, 0.840, 0.440, 1.000) backwards',
         slideDownModal: 'slideDown .5s linear forwards',
       },
       transitionProperty: {
@@ -71,6 +73,10 @@ module.exports = {
       keyframes: {
         scaleUp: {
           '0%': {transform: 'scale(0.7) translateY(1000px)', opacity: '0.7'},
+          '100%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
+        },
+        scaleUpIPX: {
+          '0%': {transform: 'scale(1) translateY(500px)', opacity: '0.7'},
           '100%': {transform: 'scale(1) translateY(0px)', opacity: '1'},
         },
         slideDown: {


### PR DESCRIPTION
[SVCINT-1999](https://coveord.atlassian.net/browse/SVCINT-1999)

- Split the ipx components into 3: `atomic-ipx-modal`, `atomic-ipx-embedded` and `atomic-ipx-body`
- Create a new `scaleUpModalIPX` animation with a lower `translateY` value to avoid bugs
- Update a whole bunch of components to make sure `height` and `width` is inherited throughout the search interface into the `part=container` elements
- Update the `ipx.html` file to be able to toggle between the button and embedded ipx
- Probably other changes I forgot about

[SVCINT-1999]: https://coveord.atlassian.net/browse/SVCINT-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://user-images.githubusercontent.com/71142397/214706917-836e8a5c-ddad-40a0-8636-c6401d253fab.mov