### PR TITLE
feat(atomic): add result link for quickview header

### DIFF
--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.pcss
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.pcss
@@ -1,4 +1,5 @@
 @import '../../../../global/global.pcss';
+@import '../../../../global/mixins.pcss';
 
 .atomic-quickview-modal {
   &::part(backdrop) {
@@ -24,5 +25,13 @@
 
   &::part(backdrop) {
     grid-template-rows: 1fr 100% 3fr;
+  }
+
+  &::part(header-wrapper) {
+    @apply bg-neutral-light;
+  }
+
+  a {
+    @mixin link-style;
   }
 }

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -9,7 +9,9 @@ import {
   Watch,
   Method,
   VNode,
+  Fragment,
 } from '@stencil/core';
+import CloseIcon from '../../../../images/close.svg';
 import {
   InitializableComponent,
   InitializeBindings,
@@ -90,18 +92,29 @@ export class AtomicQuickviewModal implements InitializableComponent {
         options: {result: this.result},
       });
       headerContent = (
-        <LinkWithResultAnalytics
-          href={this.result?.clickUri}
-          onSelect={() => interactiveResult.select()}
-          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
-          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
-        >
-          {this.result.title}
-        </LinkWithResultAnalytics>
+        <Fragment>
+          <LinkWithResultAnalytics
+            href={this.result?.clickUri}
+            onSelect={() => interactiveResult.select()}
+            onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
+            onCancelPendingSelect={() =>
+              interactiveResult.cancelPendingSelect()
+            }
+          >
+            {this.result.title}
+          </LinkWithResultAnalytics>
+          <atomic-icon-button
+            icon={CloseIcon}
+            clickCallback={() => this.onClose()}
+            labelI18nKey="close"
+            buttonStyle="text-transparent"
+            tooltip={this.bindings.i18n.t('close')}
+          ></atomic-icon-button>
+        </Fragment>
       );
     }
     return (
-      <div slot="header" class="w-full flex justify-between">
+      <div slot="header" class="w-full flex justify-between items-center">
         {headerContent}
       </div>
     );

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -87,7 +87,7 @@ export class AtomicQuickviewModal implements InitializableComponent {
     let headerContent: VNode | null = null;
     if (this.result) {
       const interactiveResult = buildInteractiveResult(this.bindings.engine, {
-        options: {result: this.result!},
+        options: {result: this.result},
       });
       headerContent = (
         <LinkWithResultAnalytics

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -1,4 +1,4 @@
-import {Result} from '@coveo/headless';
+import {buildInteractiveResult, Result} from '@coveo/headless';
 import {
   Component,
   Event,
@@ -8,14 +8,15 @@ import {
   State,
   Watch,
   Method,
+  VNode,
 } from '@stencil/core';
-import dayjs from 'dayjs';
 import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
 import {Button} from '../../../common/button';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
+import {LinkWithResultAnalytics} from '../../result-link/result-link';
 import {QuickviewSidebar} from '../atomic-quickview-sidebar/atomic-quickview-sidebar';
 import {QuickviewIframe} from '../quickview-iframe/quickview-iframe';
 import {buildQuickviewPreviewBar} from '../quickview-preview-bar/quickview-preview-bar';
@@ -83,11 +84,25 @@ export class AtomicQuickviewModal implements InitializableComponent {
   }
 
   private renderHeader() {
-    // TODO: Header should be slottable from result template definition
+    let headerContent: VNode | null = null;
+    if (this.result) {
+      const interactiveResult = buildInteractiveResult(this.bindings.engine, {
+        options: {result: this.result!},
+      });
+      headerContent = (
+        <LinkWithResultAnalytics
+          href={this.result?.clickUri}
+          onSelect={() => interactiveResult.select()}
+          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
+          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
+        >
+          {this.result.title}
+        </LinkWithResultAnalytics>
+      );
+    }
     return (
       <div slot="header" class="w-full flex justify-between">
-        <div>{this.result?.title}</div>
-        <div>{dayjs(this.result?.raw.date).format('D/M/YYYY')}</div>
+        {headerContent}
       </div>
     );
   }


### PR DESCRIPTION
So that's a big "scope down" of my initial idea, which was to make everything in the header configurable in result templates. 

So that someone could embed custom components in the header, for example, as we could see in the mockups.

I spent some time figuring out how to make it all work in the first place. The main problem is that we wanted to have arbitrary result templates components (ie: atomic-result-link, atomic-result-field, custom result template components, etc) working *outside* of their normal location (outside of the result list).

The modal is not located inside the result list/inside a result template, and we would need to do quite a bit of gymnastic to make it all work.

However, even with this working, I still had the problem of having unknown components included in the header and making sure things are displaying correctly. Which would require even more code, more documentation, more maintenance.

And at the end of they day, I'm uncertain of the level of usefulness of it all. So I prefer if we wait and see if there's any demand for it.

I've changed it so it's just a simple link with proper analytics tracking. I'm thinking this should be more than good enough for the time being.

https://coveord.atlassian.net/browse/KIT-2204