### PR TITLE
docs(atomic): add storybook for quickview

### DIFF
--- a/packages/atomic/.storybook/default-result-component-story.tsx
+++ b/packages/atomic/.storybook/default-result-component-story.tsx
@@ -1,15 +1,14 @@
 import {h} from '@stencil/core';
-import {Args} from '@storybook/api';
 import {DocsPage} from '@storybook/addon-docs';
-
+import {Args} from '@storybook/api';
+import {html, TemplateResult} from 'lit-html';
+import {initializeInterfaceDebounced} from './default-init';
 import sharedDefaultStory, {
   DefaultStoryAdvancedConfig,
   renderAdditionalMarkup,
   renderArgsToHTMLString,
   renderShadowPartsToStyleString,
 } from './default-story-shared';
-import {initializeInterfaceDebounced} from './default-init';
-import {html, TemplateResult} from 'lit-html';
 import {
   resultComponentArgTypes,
   resultSections,
@@ -187,9 +186,11 @@ const buildConfigPreprocessRequest = (
   advancedConfig: DefaultStoryAdvancedConfig
 ) => {
   const preprocessRequestForOneResult = (r) => {
-    const bodyParsed = JSON.parse(r.body as string);
-    bodyParsed.numberOfResults = 1;
-    r.body = JSON.stringify(bodyParsed);
+    if (r.headers['Content-Type'] === 'application/json') {
+      const bodyParsed = JSON.parse(r.body as string);
+      bodyParsed.numberOfResults = 1;
+      r.body = JSON.stringify(bodyParsed);
+    }
     return r;
   };
 

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.stories.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.stories.tsx
@@ -1,0 +1,37 @@
+import defaultResultComponentStory from '../../../../../.storybook/default-result-component-story';
+
+const {defaultModuleExport, exportedStory} = defaultResultComponentStory(
+  'Atomic/ResultList/Quickview',
+  'atomic-quickview',
+  {},
+  {
+    engineConfig: {
+      preprocessRequest: (request) => {
+        const fakeQuery = 'coveo intranet';
+        if (
+          request.headers &&
+          request.headers['Content-Type'] === 'application/json'
+        ) {
+          const parsed = JSON.parse(request.body as string);
+          parsed.aq = '@filetype=pdf';
+          parsed.q = fakeQuery;
+          request.body = JSON.stringify(parsed);
+        }
+        if (
+          request.headers &&
+          request.headers['Content-Type'] ===
+            'application/x-www-form-urlencoded'
+        ) {
+          request.body = request.body.replace(
+            'q=&',
+            `q=${encodeURIComponent(fakeQuery)}&`
+          );
+        }
+        return request;
+      },
+    },
+  }
+);
+
+export default defaultModuleExport;
+export const DefaultQuickview = exportedStory;

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -17,7 +17,11 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 import {ResultContext} from '../result-template-decorators';
 
 /**
- * TODO
+ * The `atomic-quickview` component renders a button which the end user can click to open a modal box containing a preview
+ * about a result.
+ *
+ * The `atomic-quickview` is not meant to replace the `atomic-result-link` to access an item in a result template; it has certain limitations (e.g., custom styles and embedded
+ * images/links may not work as expected in an `atomic-quickview`).
  *
  * @internal
  */

--- a/packages/headless/src/controllers/quickview/case-assist-headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/case-assist-headless-quickview.ts
@@ -57,11 +57,6 @@ export function buildCaseAssistQuickview(
   const {dispatch} = engine;
   const getState = () => engine.state;
   const getDocuments = () => getState().documentSuggestion.documents;
-  dispatch(
-    preparePreviewPagination({
-      results: getDocuments(),
-    })
-  );
 
   const fetchResultContentCallback = () => {
     engine.dispatch(
@@ -76,6 +71,12 @@ export function buildCaseAssistQuickview(
     buildResultPreviewRequest,
     path,
     fetchResultContentCallback
+  );
+
+  dispatch(
+    preparePreviewPagination({
+      results: getDocuments(),
+    })
   );
 
   return {

--- a/packages/headless/src/controllers/quickview/headless-quickview.ts
+++ b/packages/headless/src/controllers/quickview/headless-quickview.ts
@@ -23,9 +23,6 @@ export type {
   CoreQuickview,
 };
 
-/**
- * asdf
- */
 export interface QuickviewState extends CoreQuickviewState {
   /**
    * The number of available results for the current result set.
@@ -66,7 +63,6 @@ export function buildQuickview(
   const {dispatch} = engine;
   const getState = () => engine.state;
   const getResults = () => getState().search.results;
-  dispatch(preparePreviewPagination({results: getResults()}));
 
   const fetchResultContentCallback = () => {
     engine.dispatch(logDocumentQuickview(props.options.result));
@@ -80,6 +76,8 @@ export function buildQuickview(
     path,
     fetchResultContentCallback
   );
+
+  dispatch(preparePreviewPagination({results: getResults()}));
 
   return {
     ...core,


### PR DESCRIPTION
Had to fix some stuff for storybook related to "preprocess" request.

Quickviews are using `application/x-www-form-urlencoded` , which you can't JSON.parse, JSON.stringify.


Adding @jpmarceau for some doc review as well.

https://coveord.atlassian.net/browse/KIT-2224