### PR TITLE
fix(quantic): linkify property disabled in Quantic Summary and Quantic No Results

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
@@ -6,7 +6,7 @@
             </div>
             <div class="slds-col slds-size_12-of-12">
                 <div class="slds-text-heading_small slds-text-align_center slds-var-m-around_small">
-                    <lightning-formatted-rich-text value={noResultsTitleLabel}></lightning-formatted-rich-text>
+                    <lightning-formatted-rich-text value={noResultsTitleLabel} disable-linkify></lightning-formatted-rich-text>
                 </div>
                 <p class="slds-text-body_small slds-text-align_center">
                     <template if:true={hasBreadcrumbs}>

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.html
@@ -1,7 +1,7 @@
 <template>
   <template if:true={hasResults}>
     <p class="slds-text-color_weak">
-      <lightning-formatted-rich-text value={summaryLabel}></lightning-formatted-rich-text>
+      <lightning-formatted-rich-text value={summaryLabel} disable-linkify></lightning-formatted-rich-text>
     </p>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.html
@@ -13,7 +13,7 @@
             <lightning-icon class={moreButtonIconClasses} icon-name={arrowIconName} size="xx-small" aria-hidden="true"> </lightning-icon>
           </button>
           <div class="tab-bar_dropdown slds-dropdown slds-dropdown_right">
-            <ul class="slds-dropdown__list slds-dropdown_length-with-icon-10" role="menu">
+            <ul class="slds-dropdown__list" role="menu">
               <template for:each={tabsInDropdown} for:item="tab">
                 <li class="slds-dropdown__item" role="presentation" key={tab.id}>
                   <button


### PR DESCRIPTION
## Issue 1: [SVCC-2784](https://coveord.atlassian.net/browse/SVCC-2784)

`disable-linkify` property added to the Lightning Formatted Rich Text component used in the Quantic Summary and the Quantic No Results:

#### Before:
<img width="300" alt="Error1 2" src="https://user-images.githubusercontent.com/86681870/214634200-d53a95d2-92fa-453d-919c-a88ba105afa4.png">
<img width="300" alt="Error1 1" src="https://user-images.githubusercontent.com/86681870/214634205-d544bfb0-cb7e-407b-b773-86a1805b3d2b.png">

#### After:
<img width="300" alt="SOL1 1" src="https://user-images.githubusercontent.com/86681870/214634808-7d7f581e-382d-4450-8648-8020d5fa3f16.png">
<img width="300" alt="Sol1 2" src="https://user-images.githubusercontent.com/86681870/214634809-982845f7-d9f6-44b6-9df1-89816b515465.png">

## Issue 2: [SFINT-4781](https://coveord.atlassian.net/browse/SFINT-4781)

Removed unnecessary scroll bar from the Quantic Tab Bar component:

#### Before:
<img width="300" alt="2 1" src="https://user-images.githubusercontent.com/86681870/214635525-aa6e3e53-371c-4d4a-8975-20b507587c85.png">

#### After:

https://user-images.githubusercontent.com/86681870/214635566-49d5170e-dd11-46f0-b530-a5f36e6b24bc.mov



 

[SVCC-2784]: https://coveord.atlassian.net/browse/SVCC-2784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFINT-4781]: https://coveord.atlassian.net/browse/SFINT-4781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ