### PR TITLE
feat(atomic): added prop to omit the modal focus trap

### DIFF
--- a/packages/atomic/cypress/integration-insight-panel/insight-panel-selectors.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel-selectors.ts
@@ -17,6 +17,10 @@ export const InsightPanelsSelectors = {
     InsightPanelsSelectors.interface().find('atomic-insight-refine-toggle'),
   refineModal: () =>
     InsightPanelsSelectors.interface().find('atomic-insight-refine-modal'),
+  focusTrap: () =>
+    InsightPanelsSelectors.refineModal().shadow().find('atomic-focus-trap', {
+      includeShadowDom: true,
+    }),
   filtersModal: () =>
     InsightPanelsSelectors.refineModal().shadow().find('atomic-modal'),
   filters: () => InsightPanelsSelectors.refineModal().find('[slot~="facets"]'),

--- a/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
@@ -78,6 +78,7 @@ describe('Insight Panel test suites', () => {
     it('should display refine-modal', () => {
       InsightPanelsSelectors.refineToggle().click();
       InsightPanelsSelectors.refineModal().should('exist');
+      InsightPanelsSelectors.focusTrap().should('not.exist');
 
       InsightPanelsSelectors.filtersModal().should('have.attr', 'is-open');
 

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -755,6 +755,7 @@ export namespace Components {
         "container"?: HTMLElement;
         "fullscreen": boolean;
         "isOpen": boolean;
+        "noFocusTrap": boolean;
         "source"?: HTMLElement;
     }
     interface AtomicNoResults {
@@ -3380,6 +3381,7 @@ declare namespace LocalJSX {
         "container"?: HTMLElement;
         "fullscreen"?: boolean;
         "isOpen"?: boolean;
+        "noFocusTrap"?: boolean;
         "onAnimationEnded"?: (event: AtomicModalCustomEvent<never>) => void;
         "source"?: HTMLElement;
     }

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -77,9 +77,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       if (watchToggleOpenExecution !== this.currentWatchToggleOpenExecution) {
         return;
       }
-      if (!this.noFocusTrap) {
-        this.focusTrap!.active = true;
-      }
+      !this.noFocusTrap && (this.focusTrap!.active = true);
     } else {
       document.body.classList.remove(modalOpenedClass);
       if (isIOS()) {
@@ -88,9 +86,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       if (watchToggleOpenExecution !== this.currentWatchToggleOpenExecution) {
         return;
       }
-      if (!this.noFocusTrap) {
-        this.focusTrap!.active = false;
-      }
+      !this.noFocusTrap && (this.focusTrap!.active = false);
     }
   }
 
@@ -135,7 +131,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   public render() {
     this.updateBreakpoints();
 
-    const content = (
+    const Content = () => (
       <article
         part="container"
         class={`flex flex-col justify-between bg-background text-on-background ${
@@ -191,7 +187,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
           onClick={(e) => e.target === e.currentTarget && this.close()}
         >
           {this.noFocusTrap ? (
-            content
+            <Content />
           ) : (
             <atomic-focus-trap
               role="dialog"
@@ -201,7 +197,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
               container={this.container ?? this.host}
               ref={(ref) => (this.focusTrap = ref)}
             >
-              {content}
+              <Content />
             </atomic-focus-trap>
           )}
         </div>

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -53,6 +53,7 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   @Prop({mutable: true}) container?: HTMLElement;
   @Prop({reflect: true, mutable: true}) isOpen = false;
   @Prop({mutable: true}) close: () => void = () => (this.isOpen = false);
+  @Prop({reflect: true}) noFocusTrap = false;
 
   @Event() animationEnded!: EventEmitter<never>;
 
@@ -76,7 +77,9 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       if (watchToggleOpenExecution !== this.currentWatchToggleOpenExecution) {
         return;
       }
-      this.focusTrap!.active = true;
+      if (!this.noFocusTrap) {
+        this.focusTrap!.active = true;
+      }
     } else {
       document.body.classList.remove(modalOpenedClass);
       if (isIOS()) {
@@ -85,7 +88,9 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
       if (watchToggleOpenExecution !== this.currentWatchToggleOpenExecution) {
         return;
       }
-      this.focusTrap!.active = false;
+      if (!this.noFocusTrap) {
+        this.focusTrap!.active = false;
+      }
     }
   }
 
@@ -130,6 +135,54 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
   public render() {
     this.updateBreakpoints();
 
+    const content = (
+      <article
+        part="container"
+        class={`flex flex-col justify-between bg-background text-on-background ${
+          this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
+        } ${this.wasEverOpened ? '' : 'invisible'}`}
+        onAnimationEnd={() => this.animationEnded.emit()}
+        ref={(ref) => (this.animatableContainer = ref)}
+      >
+        <header part="header-wrapper" class="flex flex-col items-center">
+          <div
+            part="header"
+            class="flex justify-between text-xl w-full max-w-lg"
+            id={this.headerId}
+          >
+            <slot name="header"></slot>
+          </div>
+        </header>
+        <hr part="header-ruler" class="border-neutral"></hr>
+        <div
+          part="body-wrapper"
+          class="overflow-auto grow flex flex-col items-center w-full"
+        >
+          <div
+            part="body"
+            class="w-full max-w-lg"
+            ref={(element) =>
+              element?.addEventListener(
+                'touchmove',
+                (e) => this.isOpen && e.stopPropagation(),
+                {passive: false}
+              )
+            }
+          >
+            <slot name="body"></slot>
+          </div>
+        </div>
+        <footer
+          part="footer-wrapper"
+          class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
+        >
+          <div part="footer" class="w-full max-w-lg">
+            <slot name="footer"></slot>
+          </div>
+        </footer>
+      </article>
+    );
+
     return (
       <Host class={this.getClasses().join(' ')}>
         <div
@@ -137,60 +190,20 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
           class="fixed left-0 top-0 right-0 bottom-0 z-[9999]"
           onClick={(e) => e.target === e.currentTarget && this.close()}
         >
-          <atomic-focus-trap
-            role="dialog"
-            aria-modal={this.isOpen.toString()}
-            aria-labelledby={this.headerId}
-            source={this.source}
-            container={this.container ?? this.host}
-            ref={(ref) => (this.focusTrap = ref)}
-          >
-            <article
-              part="container"
-              class={`flex flex-col justify-between bg-background text-on-background ${
-                this.isOpen ? 'animate-scaleUpModal' : 'animate-slideDownModal'
-              } ${this.wasEverOpened ? '' : 'invisible'}`}
-              onAnimationEnd={() => this.animationEnded.emit()}
-              ref={(ref) => (this.animatableContainer = ref)}
+          {this.noFocusTrap ? (
+            content
+          ) : (
+            <atomic-focus-trap
+              role="dialog"
+              aria-modal={this.isOpen.toString()}
+              aria-labelledby={this.headerId}
+              source={this.source}
+              container={this.container ?? this.host}
+              ref={(ref) => (this.focusTrap = ref)}
             >
-              <header part="header-wrapper" class="flex flex-col items-center">
-                <div
-                  part="header"
-                  class="flex justify-between text-xl w-full max-w-lg"
-                  id={this.headerId}
-                >
-                  <slot name="header"></slot>
-                </div>
-              </header>
-              <hr part="header-ruler" class="border-neutral"></hr>
-              <div
-                part="body-wrapper"
-                class="overflow-auto grow flex flex-col items-center w-full"
-              >
-                <div
-                  part="body"
-                  class="w-full max-w-lg"
-                  ref={(element) =>
-                    element?.addEventListener(
-                      'touchmove',
-                      (e) => this.isOpen && e.stopPropagation(),
-                      {passive: false}
-                    )
-                  }
-                >
-                  <slot name="body"></slot>
-                </div>
-              </div>
-              <footer
-                part="footer-wrapper"
-                class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
-              >
-                <div part="footer" class="w-full max-w-lg">
-                  <slot name="footer"></slot>
-                </div>
-              </footer>
-            </article>
-          </atomic-focus-trap>
+              {content}
+            </atomic-focus-trap>
+          )}
         </div>
       </Host>
     );

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -19,6 +19,7 @@ interface RefineModalCommonProps {
   };
   isOpen: boolean;
   openButton?: HTMLElement;
+  noFocusTrap?: boolean;
 }
 
 export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
@@ -92,6 +93,7 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
         }
       }}
       exportparts={exportparts}
+      noFocusTrap={props.noFocusTrap}
     >
       {renderHeader()}
       {...children}

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -157,6 +157,7 @@ export class AtomicInsightRefineModal
           querySummaryState={this.querySummaryState}
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
+          noFocusTrap
         >
           {this.renderBody()}
         </RefineModalCommon>


### PR DESCRIPTION
[SVCC-2776](https://coveord.atlassian.net/browse/SVCC-2776)

The Atomic insight panel is currently exclusively used in the hosted insight panel builder and the focus trap is disabling the builder form elements from being interacted with which is pretty annoying.

This PR adds an optional prop to be able to render the atomic-modal without a focus-trap component.

A future improvement could be to still allow the modal to hide its sibling elements (under the modal) which would make lots of sense in the context of an insight panel or IPX which is only a widget on the screen.

[SVCC-2776]: https://coveord.atlassian.net/browse/SVCC-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ