### PR TITLE
feat(quantic):  QuanticSmartSnippetSource created

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/__tests__/quanticSmartSnippetSource.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/__tests__/quanticSmartSnippetSource.test.js
@@ -1,0 +1,108 @@
+// @ts-ignore
+import {createElement} from 'lwc';
+import QuanticSmartSnippetSource from '../quanticSmartSnippetSource';
+
+const functionsMocks = {
+  exampleSelect: jest.fn(() => {}),
+  exampleBeginDelayedSelect: jest.fn(() => {}),
+  exampleCancelPendingSelect: jest.fn(() => {}),
+};
+
+const selectors = {
+  sourceUri: '.smart-snippet__source-uri',
+  sourceTitle: '.smart-snippet__source-title',
+};
+
+const exampleUri = 'https://www.example.com/';
+const exampleTitle = 'example label';
+const exampleActions = {
+  select: functionsMocks.exampleSelect,
+  beginDelayedSelect: functionsMocks.exampleBeginDelayedSelect,
+  cancelPendingSelect: functionsMocks.exampleCancelPendingSelect,
+};
+
+const defaultOptions = {
+  uri: exampleUri,
+  title: exampleTitle,
+  actions: exampleActions,
+};
+
+function createTestComponent(options = defaultOptions) {
+  const element = createElement('c-quantic-smart-snippet-source', {
+    is: QuanticSmartSnippetSource,
+  });
+
+  for (const [key, value] of Object.entries(options)) {
+    element[key] = value;
+  }
+
+  document.body.appendChild(element);
+  return element;
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  // eslint-disable-next-line @lwc/lwc/no-async-operation
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const bindingsMap = {
+  contextmenu: functionsMocks.exampleSelect,
+  click: functionsMocks.exampleSelect,
+  mouseup: functionsMocks.exampleSelect,
+  mousedown: functionsMocks.exampleSelect,
+  touchstart: functionsMocks.exampleBeginDelayedSelect,
+  touchend: functionsMocks.exampleCancelPendingSelect,
+};
+
+describe('c-quantic-smart-snippet-source', () => {
+  function cleanup() {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should properly display the source uri', async () => {
+    const element = createTestComponent();
+    await flushPromises();
+
+    const sourceUri = element.shadowRoot.querySelector(selectors.sourceUri);
+
+    expect(sourceUri).not.toBeNull();
+    expect(sourceUri.textContent).toBe(exampleUri);
+    expect(sourceUri.href).toBe(exampleUri);
+  });
+
+  it('should properly display the source title', async () => {
+    const element = createTestComponent();
+    await flushPromises();
+
+    const sourceTitle = element.shadowRoot.querySelector(selectors.sourceTitle);
+
+    expect(sourceTitle).not.toBeNull();
+    expect(sourceTitle.textContent).toBe(exampleTitle);
+    expect(sourceTitle.href).toBe(exampleUri);
+  });
+
+  ['sourceUri', 'sourceTitle'].forEach((key) => {
+    describe(`the analytics bindings of the ${key}`, () => {
+      for (const [eventName, action] of Object.entries(bindingsMap)) {
+        it(`should execute the proper action when the ${eventName} is triggered`, async () => {
+          const element = createTestComponent({...defaultOptions, uri: '#'});
+          await flushPromises();
+
+          const sourceUri = element.shadowRoot.querySelector(selectors[key]);
+          sourceUri.dispatchEvent(new CustomEvent(eventName));
+
+          expect(action).toHaveBeenCalledTimes(1);
+        });
+      }
+    });
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.css
@@ -1,0 +1,8 @@
+.smart-snippet__source-uri {
+  color: #1a1b1e;
+  font-weight: 400;
+}
+
+.smart-snippet__source-title {
+  line-height: 28px;
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.css
@@ -2,7 +2,3 @@
   color: #1a1b1e;
   font-weight: 400;
 }
-
-.smart-snippet__source-title {
-  line-height: 28px;
-}

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
@@ -1,10 +1,11 @@
 <template>
   <div class="smart-snippet__source">
     <div>
-      <a class="slds-text-title_bold smart-snippet__source-uri" href={uri}>{uri}</a>
+      <a data-cy="smart-snippet__source-uri" class="slds-text-title_bold smart-snippet__source-uri" href={uri}>{uri}</a>
     </div>
-    <div>
-      <a class="smart-snippet__source-title slds-text-heading_small" href={uri}>{title}</a>
+    <div class="slds-var-m-top_xx-small">
+      <a data-cy="smart-snippet__source-title" class="smart-snippet__source-title slds-text-heading_small"
+        href={uri}>{title}</a>
     </div>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
@@ -1,0 +1,10 @@
+<template>
+  <div class="smart-snippet__source">
+    <div>
+      <a class="slds-text-title_bold smart-snippet__source-uri" href={uri}>{uri}</a>
+    </div>
+    <div>
+      <a class="smart-snippet__source-title slds-text-heading_small" href={uri}>{title}</a>
+    </div>
+  </div>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js
@@ -1,0 +1,54 @@
+import {LinkUtils} from 'c/quanticUtils';
+import {LightningElement, api} from 'lwc';
+
+/**
+ * The `QuanticSmartSnippetSource` component displays the uri and the title of the smart snippet source.
+ * @category Search
+ * @example
+ *  <c-quantic-smart-snippet-source uri={uri} title={title} actions={actions}></c-quantic-smart-snippet-source>
+ * @internal
+ */
+export default class QuanticSmartSnippetSource extends LightningElement {
+  /**
+   * The click uri of the smart snippet source.
+   * @api
+   * @type {string}
+   */
+  @api uri;
+  /**
+   * The title of the smart snippet source.
+   * @api
+   * @type {string}
+   */
+  @api title;
+  /**
+   * The actions that need to be bound to the links of the smart snippet source.
+   * @api
+   * @type {{select: function, beginDelayedSelect: function, cancelPendingSelect: function  }}
+   */
+  @api actions;
+
+  /** @type {boolean} */
+  isInitialRender = true;
+
+  renderedCallback() {
+    if (this.isInitialRender) {
+      this.isInitialRender = false;
+      this.bindAnalyticsToSmartSnippetSource();
+    }
+  }
+
+  bindAnalyticsToSmartSnippetSource() {
+    /** @type {HTMLAnchorElement} */
+    const snippetSourceUrlElement = this.template.querySelector(
+      '.smart-snippet__source-uri'
+    );
+    /** @type {HTMLAnchorElement} */
+    const snippetSourceTitleElement = this.template.querySelector(
+      '.smart-snippet__source-title'
+    );
+
+    LinkUtils.bindAnalyticsToLink(snippetSourceUrlElement, this.actions);
+    LinkUtils.bindAnalyticsToLink(snippetSourceTitleElement, this.actions);
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js
@@ -30,12 +30,21 @@ export default class QuanticSmartSnippetSource extends LightningElement {
 
   /** @type {boolean} */
   isInitialRender = true;
+  /** @type {function} */
+  removeUriBindings;
+  /** @type {function} */
+  removeTitleBindings;
 
   renderedCallback() {
     if (this.isInitialRender) {
       this.isInitialRender = false;
       this.bindAnalyticsToSmartSnippetSource();
     }
+  }
+
+  disconnectedCallback() {
+    this.removeTitleBindings?.();
+    this.removeUriBindings?.();
   }
 
   bindAnalyticsToSmartSnippetSource() {
@@ -48,7 +57,13 @@ export default class QuanticSmartSnippetSource extends LightningElement {
       '.smart-snippet__source-title'
     );
 
-    LinkUtils.bindAnalyticsToLink(snippetSourceUrlElement, this.actions);
-    LinkUtils.bindAnalyticsToLink(snippetSourceTitleElement, this.actions);
+    this.removeUriBindings = LinkUtils.bindAnalyticsToLink(
+      snippetSourceUrlElement,
+      this.actions
+    );
+    this.removeTitleBindings = LinkUtils.bindAnalyticsToLink(
+      snippetSourceTitleElement,
+      this.actions
+    );
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js-meta.xml
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -185,9 +185,9 @@ export class I18nUtils {
     if (typeof stringToFormat !== 'string')
       throw new Error("'stringToFormat' must be a String");
     return stringToFormat.replace(/{{(\d+)}}/gm, (match, index) =>
-      formattingArguments[index] === undefined
+      (formattingArguments[index] === undefined
         ? ''
-        : `${formattingArguments[index]}`
+        : `${formattingArguments[index]}`)
     );
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -131,6 +131,34 @@ export class ResultUtils {
   }
 }
 
+export class LinkUtils {
+  /**
+   * Binds the logging of a link
+   * @returns An unbind function for the events
+   * @param {HTMLAnchorElement} link the link element
+   * @param {{select:function, beginDelayedSelect: function, cancelPendingSelect: function  }} actions
+   */
+  static bindAnalyticsToLink(link, actions) {
+    const eventsMap = {
+      contextmenu: () => actions.select(),
+      click: () => actions.select(),
+      mouseup: () => actions.select(),
+      mousedown: () => actions.select(),
+      touchstart: () => actions.beginDelayedSelect(),
+      touchend: () => actions.cancelPendingSelect(),
+    };
+    Object.keys(eventsMap).forEach((key) =>
+      link.addEventListener(key, eventsMap[key])
+    );
+
+    return () => {
+      Object.keys(eventsMap).forEach((key) =>
+        link.removeEventListener(key, eventsMap[key])
+      );
+    };
+  }
+}
+
 export class I18nUtils {
   static getTextWithDecorator(text, startTag, endTag) {
     return `${startTag}${text}${endTag}`;
@@ -157,9 +185,9 @@ export class I18nUtils {
     if (typeof stringToFormat !== 'string')
       throw new Error("'stringToFormat' must be a String");
     return stringToFormat.replace(/{{(\d+)}}/gm, (match, index) =>
-      (formattingArguments[index] === undefined
+      formattingArguments[index] === undefined
         ? ''
-        : `${formattingArguments[index]}`)
+        : `${formattingArguments[index]}`
     );
   }
 


### PR DESCRIPTION
[SFINT-4796](https://coveord.atlassian.net/browse/SFINT-4796
)
- The Quantic Smart Snippet Source component created.
- The Quantic Smart Snippet Source displays the clickUri and the title of the smart snippet source.
- The Quantic Smart Snippet Source binds the correct actions to the events triggered  on the links within  this component in order to log analytics.

#### Design doc:
[Design-doc__Quantic-Smart-Snippet-components](https://docs.google.com/document/d/1kJswWu6qHp5ExMHQagkrCWphrjRmys8a5tQ0oAnQkJU/edit)

#### Demo:

https://user-images.githubusercontent.com/86681870/216156849-86e1fca3-2f2c-408b-bb5e-2c9d4d0dd5f8.mov



[SFINT-4796]: https://coveord.atlassian.net/browse/SFINT-4796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ