### PR TITLE
fix(atomic,headless): log proper search ID with instant results

### DIFF
--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -1,6 +1,6 @@
 import {
   buildInstantResults,
-  buildInteractiveResult,
+  buildInteractiveInstantResult,
   InstantResults,
   Result,
 } from '@coveo/headless';
@@ -129,9 +129,12 @@ export class AtomicSearchBoxInstantResults implements InitializableComponent {
             key={`instant-result-${encodeForDomAttribute(result.uniqueId)}`}
             part="outline"
             result={result}
-            interactiveResult={buildInteractiveResult(this.bindings.engine, {
-              options: {result},
-            })}
+            interactiveResult={buildInteractiveInstantResult(
+              this.bindings.engine,
+              {
+                options: {result},
+              }
+            )}
             display={this.display}
             density={this.density}
             imageSize={this.imageSize}

--- a/packages/headless/src/api/analytics/instant-result-analytics.ts
+++ b/packages/headless/src/api/analytics/instant-result-analytics.ts
@@ -1,0 +1,23 @@
+import {SearchAnalyticsProvider} from './search-analytics';
+
+export class InstantResultsAnalyticsProvider extends SearchAnalyticsProvider {
+  private get instantResultsSearchUid() {
+    const state = this.getState().instantResults;
+    if (!state) {
+      return null;
+    }
+
+    for (const id in state) {
+      for (const query in state[id].cache) {
+        if (state[id].cache[query].isActive) {
+          return state[id].cache[query].searchUid;
+        }
+      }
+    }
+
+    return null;
+  }
+  public getSearchUID(): string {
+    return this.instantResultsSearchUid || super.getSearchUID();
+  }
+}

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -163,6 +163,13 @@ export type {
 export {buildInteractiveResult} from './result-list/headless-interactive-result';
 
 export type {
+  InteractiveInstantResultOptions,
+  InteractiveInstantResultProps,
+  InteractiveInstantResult,
+} from './instant-results/headless-interactive-instant-result';
+export {buildInteractiveInstantResult} from './instant-results/headless-interactive-instant-result';
+
+export type {
   ResultsPerPageInitialState,
   ResultsPerPageProps,
   ResultsPerPageState,

--- a/packages/headless/src/controllers/instant-results/headless-interactive-instant-result.ts
+++ b/packages/headless/src/controllers/instant-results/headless-interactive-instant-result.ts
@@ -1,0 +1,56 @@
+import {SearchEngine} from '../../app/search-engine/search-engine';
+import {logInstantResultOpen} from '../../features/instant-results/instant-result-analytics-actions';
+import {pushRecentResult} from '../../features/recent-results/recent-results-actions';
+import {
+  buildInteractiveResultCore,
+  InteractiveResultCoreProps,
+} from '../core/interactive-result/headless-core-interactive-result';
+import {
+  InteractiveResult,
+  InteractiveResultOptions,
+} from '../result-list/headless-interactive-result';
+
+export interface InteractiveInstantResultOptions
+  extends InteractiveResultOptions {}
+
+export interface InteractiveInstantResultProps
+  extends InteractiveResultCoreProps {
+  /**
+   * The options for the `InteractiveInstantResult` controller.
+   * */
+  options: InteractiveInstantResultOptions;
+}
+
+/**
+ * The `InteractiveInstantResult` controller provides an interface for triggering desirable side effects, such as logging UA events to the Coveo Platform, when a user selects a query result.
+ */
+export interface InteractiveInstantResult extends InteractiveResult {}
+
+/**
+ * Creates an `InteractiveInstantResult` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `InteractiveInstantResult` properties.
+ * @returns An `InteractiveInstantResult` controller instance.
+ */
+export function buildInteractiveInstantResult(
+  engine: SearchEngine,
+  props: InteractiveInstantResultProps
+): InteractiveInstantResult {
+  let wasOpened = false;
+
+  const logAnalyticsIfNeverOpened = () => {
+    if (wasOpened) {
+      return;
+    }
+    wasOpened = true;
+    engine.dispatch(logInstantResultOpen(props.options.result));
+  };
+
+  const action = () => {
+    logAnalyticsIfNeverOpened();
+    engine.dispatch(pushRecentResult(props.options.result));
+  };
+
+  return buildInteractiveResultCore(engine, props, action);
+}

--- a/packages/headless/src/features/instant-results/instant-result-analytics-actions.ts
+++ b/packages/headless/src/features/instant-results/instant-result-analytics-actions.ts
@@ -1,0 +1,33 @@
+import {InstantResultsAnalyticsProvider} from '../../api/analytics/instant-result-analytics';
+import {Result} from '../../api/search/search/result';
+import {
+  partialDocumentInformation,
+  documentIdentifier,
+  validateResultPayload,
+  makeAnalyticsAction,
+  AnalyticsType,
+  ClickAction,
+  SearchAction,
+} from '../analytics/analytics-utils';
+
+export const logInstantResultOpen = (result: Result): ClickAction =>
+  makeAnalyticsAction(
+    'analytics/instantResult/open',
+    AnalyticsType.Click,
+    (client, state) => {
+      validateResultPayload(result);
+      return client.makeDocumentOpen(
+        partialDocumentInformation(result, state),
+        documentIdentifier(result)
+      );
+    },
+    (getState) => new InstantResultsAnalyticsProvider(getState)
+  );
+
+export const logInstantResultsSearch = (): SearchAction =>
+  makeAnalyticsAction(
+    'analytics/instantResult/searchboxAsYouType',
+    AnalyticsType.Search,
+    (client) => client.makeSearchboxAsYouType(),
+    (getState) => new InstantResultsAnalyticsProvider(getState)
+  );

--- a/packages/headless/src/features/instant-results/instant-results-actions.ts
+++ b/packages/headless/src/features/instant-results/instant-results-actions.ts
@@ -1,5 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
-import {Result} from '../../case-assist.index';
+import {Result} from '../../index';
 import {InstantResultSection} from '../../state/state-sections';
 import {
   validatePayload,

--- a/packages/headless/src/features/instant-results/instant-results-slice.ts
+++ b/packages/headless/src/features/instant-results/instant-results-slice.ts
@@ -39,18 +39,28 @@ export const instantResultsReducer = createReducer(
       });
     });
     builder.addCase(fetchInstantResults.pending, (state, action) => {
+      for (const id in state) {
+        for (const query in state[id].cache) {
+          state[id].cache[query].isActive = false;
+        }
+      }
+
       if (!getCached(state, action.meta)) {
         makeEmptyCache(state, action.meta);
-      } else {
-        const cached = getCached(state, action.meta);
-        cached!.isLoading = true;
-        cached!.error = null;
+        return;
       }
+
+      const cached = getCached(state, action.meta);
+      cached!.isLoading = true;
+      cached!.error = null;
     });
     builder.addCase(fetchInstantResults.fulfilled, (state, action) => {
-      const {results} = action.payload;
+      const {results, searchUid} = action.payload;
       const {cacheTimeout} = action.meta.arg;
       const cached = getCached(state, action.meta);
+
+      cached!.isActive = true;
+      cached!.searchUid = searchUid;
       cached!.isLoading = false;
       cached!.error = null;
       cached!.results = results;
@@ -74,6 +84,8 @@ const makeEmptyCache = (
     error: null,
     results: [],
     expiresAt: 0,
+    isActive: false,
+    searchUid: '',
   };
 };
 

--- a/packages/headless/src/features/instant-results/instant-results-state.ts
+++ b/packages/headless/src/features/instant-results/instant-results-state.ts
@@ -1,6 +1,6 @@
 import {SerializedError} from '@reduxjs/toolkit';
 import {SearchAPIErrorWithStatusCode} from '../../api/search/search-api-error-response';
-import {Result} from '../../case-assist.index';
+import {Result} from '../../index';
 
 export type InstantResultCache = {
   expiresAt: number;

--- a/packages/headless/src/features/instant-results/instant-results-state.ts
+++ b/packages/headless/src/features/instant-results/instant-results-state.ts
@@ -7,6 +7,8 @@ export type InstantResultCache = {
   isLoading: boolean;
   error: SearchAPIErrorWithStatusCode | SerializedError | null;
   results: Result[];
+  isActive: boolean;
+  searchUid: string;
 };
 
 export type InstantResultsState = Record<

--- a/packages/headless/src/features/query/query-analytics-actions.ts
+++ b/packages/headless/src/features/query/query-analytics-actions.ts
@@ -10,10 +10,3 @@ export const logSearchboxSubmit = (): SearchAction =>
     AnalyticsType.Search,
     (client) => client.makeSearchboxSubmit()
   );
-
-export const logSearchboxAsYouType = (): SearchAction =>
-  makeAnalyticsAction(
-    'analytics/searchbox/asYouType',
-    AnalyticsType.Search,
-    (client) => client.makeSearchboxAsYouType()
-  );

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -20,6 +20,7 @@ import {
   deselectAllNonBreadcrumbs,
 } from '../breadcrumb/breadcrumb-actions';
 import {updateFacetAutoSelection} from '../facets/generic/facet-actions';
+import {logInstantResultsSearch} from '../instant-results/instant-result-analytics-actions';
 import {
   FetchInstantResultsActionCreatorPayload,
   FetchInstantResultsThunkReturn,
@@ -30,7 +31,6 @@ import {
   updateQuery,
   UpdateQueryActionCreatorPayload,
 } from '../query/query-actions';
-import {logSearchboxAsYouType} from '../query/query-analytics-actions';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/search-and-folding-request';
 import {
   AsyncSearchThunkProcessor,
@@ -222,7 +222,7 @@ export const fetchInstantResults = createAsyncThunk<
     const {q, maxResultsPerQuery} = payload;
     const state = config.getState();
     const {analyticsClientMiddleware, preprocessRequest, logger} = config.extra;
-    const {action: analyticsAction} = await logSearchboxAsYouType().prepare({
+    const {action: analyticsAction} = await logInstantResultsSearch().prepare({
       getState: () => config.getState(),
       analyticsClientMiddleware,
       preprocessRequest,

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -2,7 +2,6 @@ import {createReducer, PayloadAction} from '@reduxjs/toolkit';
 import {
   executeSearch,
   fetchFacetValues,
-  fetchInstantResults,
   fetchMoreResults,
   fetchPage,
 } from './search-actions';
@@ -90,9 +89,6 @@ export const searchReducer = createReducer(
     builder.addCase(fetchFacetValues.fulfilled, (state, action) => {
       state.response.facets = action.payload.response.facets;
       state.response.searchUid = action.payload.response.searchUid;
-    });
-    builder.addCase(fetchInstantResults.fulfilled, (state, action) => {
-      state.response.searchUid = action.payload.searchUid;
     });
     builder.addCase(executeSearch.pending, handlePendingSearch);
     builder.addCase(fetchMoreResults.pending, handlePendingSearch);


### PR DESCRIPTION
Undoes some of https://github.com/coveo/ui-kit/pull/2703 for a better solution