### PR TITLE
fix(atomic): moved insight facets outside of the refine-toggle

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/insight-layout.ts
@@ -63,13 +63,18 @@ export function buildInsightLayout(element: HTMLElement, widget: boolean) {
     }
     `;
 
+  const facets = `${sectionSelector('facets')} {
+      display: none;
+    }
+    `;
+
   const results = `
     ${sectionSelector('results')} {
       overflow: auto;
     }
     `;
 
-  return [interfaceStyle, search, results]
+  return [interfaceStyle, search, facets, results]
     .filter((declaration) => declaration !== '')
     .join('\n\n');
 }

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -40,30 +40,7 @@
       <atomic-insight-layout>
         <atomic-layout-section section="search">
           <atomic-insight-search-box></atomic-insight-search-box>
-          <atomic-insight-refine-toggle>
-            <atomic-insight-facet field="source" label="Source" display-values-as="checkbox"></atomic-insight-facet>
-            <atomic-insight-facet field="filetype" label="Filetype" display-values-as="checkbox"></atomic-insight-facet>
-            <atomic-insight-numeric-facet
-              field="ytlikecount"
-              label="Youtube Likes"
-              display-values-as="link"
-              with-input="integer"
-            >
-              <atomic-numeric-range start="0" end="1000" label="Unpopular"></atomic-numeric-range>
-              <atomic-numeric-range start="1000" end="8000" label="Well liked"></atomic-numeric-range>
-              <atomic-numeric-range start="8000" end="100000" label="Popular"></atomic-numeric-range>
-              <atomic-numeric-range start="100000" end="999999999" label="Treasured"></atomic-numeric-range>
-            </atomic-insight-numeric-facet>
-            <atomic-insight-timeframe-facet label="Listed within" with-date-picker heading-level="2">
-              <atomic-timeframe unit="hour"></atomic-timeframe>
-              <atomic-timeframe unit="day"></atomic-timeframe>
-              <atomic-timeframe unit="week"></atomic-timeframe>
-              <atomic-timeframe unit="month"></atomic-timeframe>
-              <atomic-timeframe unit="quarter"></atomic-timeframe>
-              <atomic-timeframe unit="year"></atomic-timeframe>
-              <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe>
-            </atomic-insight-timeframe-facet>
-          </atomic-insight-refine-toggle>
+          <atomic-insight-refine-toggle></atomic-insight-refine-toggle>
           <atomic-insight-edit-toggle tooltip="This is a tooltip"></atomic-insight-edit-toggle>
           <atomic-insight-history-toggle tooltip="This is a tooltip"></atomic-insight-history-toggle>
           <atomic-insight-tabs>
@@ -73,6 +50,30 @@
             <atomic-insight-tab label="Salesforce" expression="@filetype==SalesforceItem"></atomic-insight-tab>
             <atomic-insight-tab label="Txt" expression="@filetype==txt"></atomic-insight-tab>
           </atomic-insight-tabs>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-insight-facet field="source" label="Source" display-values-as="checkbox"></atomic-insight-facet>
+          <atomic-insight-facet field="filetype" label="Filetype" display-values-as="checkbox"></atomic-insight-facet>
+          <atomic-insight-numeric-facet
+            field="ytlikecount"
+            label="Youtube Likes"
+            display-values-as="link"
+            with-input="integer"
+          >
+            <atomic-numeric-range start="0" end="1000" label="Unpopular"></atomic-numeric-range>
+            <atomic-numeric-range start="1000" end="8000" label="Well liked"></atomic-numeric-range>
+            <atomic-numeric-range start="8000" end="100000" label="Popular"></atomic-numeric-range>
+            <atomic-numeric-range start="100000" end="999999999" label="Treasured"></atomic-numeric-range>
+          </atomic-insight-numeric-facet>
+          <atomic-insight-timeframe-facet label="Listed within" with-date-picker heading-level="2">
+            <atomic-timeframe unit="hour"></atomic-timeframe>
+            <atomic-timeframe unit="day"></atomic-timeframe>
+            <atomic-timeframe unit="week"></atomic-timeframe>
+            <atomic-timeframe unit="month"></atomic-timeframe>
+            <atomic-timeframe unit="quarter"></atomic-timeframe>
+            <atomic-timeframe unit="year"></atomic-timeframe>
+            <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe>
+          </atomic-insight-timeframe-facet>
         </atomic-layout-section>
         <atomic-layout-section section="status">
           <atomic-insight-query-summary></atomic-insight-query-summary>


### PR DESCRIPTION
Recent changes to the atomic-icon-button have clashed with the way the atomic-insight-refine-toggle component was designed. The latter expected the facet elements to be placed within its tags but this now causes this awful looking visual bug.

<img width="699" alt="Screen Shot 2023-02-06 at 2 22 25 PM" src="https://user-images.githubusercontent.com/16785453/217066036-58659ecf-b727-4253-9c69-5af09a5adf80.png">

This PR moves the facets outside of the refine-toggle to more closely match how the rest of atomic handles it.

<img width="699" alt="Screen Shot 2023-02-06 at 2 23 43 PM" src="https://user-images.githubusercontent.com/16785453/217066220-241f4e14-4b6a-47f8-b932-bf2eadba0689.png">