### PR TITLE
fix(atomic): more improvements for quickview accessibility

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -868,6 +868,7 @@ export namespace Components {
     interface AtomicQuickviewModal {
         "content"?: string;
         "current"?: number;
+        "onModalClose"?: () => void;
         "reset": () => Promise<void>;
         "result"?: Result;
         "sandbox"?: string;
@@ -3518,6 +3519,7 @@ declare namespace LocalJSX {
         "current"?: number;
         "onAtomic/quickview/next"?: (event: AtomicQuickviewModalCustomEvent<any>) => void;
         "onAtomic/quickview/previous"?: (event: AtomicQuickviewModalCustomEvent<any>) => void;
+        "onModalClose"?: () => void;
         "result"?: Result;
         "sandbox"?: string;
         "total"?: number;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -868,7 +868,7 @@ export namespace Components {
     interface AtomicQuickviewModal {
         "content"?: string;
         "current"?: number;
-        "onModalClose"?: () => void;
+        "modalCloseCallback"?: () => void;
         "reset": () => Promise<void>;
         "result"?: Result;
         "sandbox"?: string;
@@ -3517,9 +3517,9 @@ declare namespace LocalJSX {
     interface AtomicQuickviewModal {
         "content"?: string;
         "current"?: number;
+        "modalCloseCallback"?: () => void;
         "onAtomic/quickview/next"?: (event: AtomicQuickviewModalCustomEvent<any>) => void;
         "onAtomic/quickview/previous"?: (event: AtomicQuickviewModalCustomEvent<any>) => void;
-        "onModalClose"?: () => void;
         "result"?: Result;
         "sandbox"?: string;
         "total"?: number;

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -73,6 +73,7 @@ export class AtomicQuickviewModal implements InitializableComponent {
   @Prop() current?: number;
   @Prop() total?: number;
   @Prop() sandbox?: string;
+  @Prop() onModalClose?: () => void;
 
   @Method()
   public async reset() {
@@ -192,6 +193,7 @@ export class AtomicQuickviewModal implements InitializableComponent {
   private onClose() {
     this.content = undefined;
     this.result = undefined;
+    this.onModalClose && this.onModalClose();
   }
 
   private get isOpen() {

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -73,7 +73,7 @@ export class AtomicQuickviewModal implements InitializableComponent {
   @Prop() current?: number;
   @Prop() total?: number;
   @Prop() sandbox?: string;
-  @Prop() onModalClose?: () => void;
+  @Prop() modalCloseCallback?: () => void;
 
   @Method()
   public async reset() {
@@ -193,7 +193,7 @@ export class AtomicQuickviewModal implements InitializableComponent {
   private onClose() {
     this.content = undefined;
     this.result = undefined;
-    this.onModalClose && this.onModalClose();
+    this.modalCloseCallback && this.modalCloseCallback();
   }
 
   private get isOpen() {

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-sidebar/atomic-quickview-sidebar.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-sidebar/atomic-quickview-sidebar.tsx
@@ -39,9 +39,11 @@ export const QuickviewSidebar: FunctionalComponent<QuickviewSidebarProps> = (
   return (
     <div class="p-4 border-r border-neutral h-full">
       {minimized && minimizeButton}
-      <div class="flex items-center">
-        <HighlightKeywordsCheckbox {...props} />
-        {!minimized && minimizeButton}
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <HighlightKeywordsCheckbox {...props} />
+        </div>
+        {!minimized && <div>{minimizeButton}</div>}
       </div>
 
       {!minimized && <Keywords {...props} words={words} />}
@@ -179,6 +181,7 @@ const Keywords: FunctionalComponent<
                   ? 'pointer-events-none opacity-50'
                   : ''
               }`}
+              tabIndex={highlightKeywords.highlightNone ? '-1' : '0'}
               ariaPressed={(!wordIsEnabled).toString()}
               style="text-transparent"
               icon={wordIsEnabled ? Remove : Add}

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -38,7 +38,7 @@ import {ResultContext} from '../result-template-decorators';
 export class AtomicQuickview implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
   @ResultContext() private result!: Result;
-  @FocusTarget() buttonFocusTarget?: FocusTargetController;
+  @FocusTarget() buttonFocusTarget!: FocusTargetController;
 
   @State() public error!: Error;
 
@@ -115,7 +115,7 @@ export class AtomicQuickview implements InitializableComponent {
       this.quickviewModalRef.total = this.quickviewState.totalResults;
       this.quickviewModalRef.current = this.quickviewState.currentResult;
       this.quickviewModalRef.onModalClose = () =>
-        this.buttonFocusTarget?.focus();
+        this.buttonFocusTarget.focus();
 
       this.quickviewAriaMessage = this.quickviewState.isLoading
         ? this.bindings.i18n.t('quickview-loading')
@@ -141,7 +141,7 @@ export class AtomicQuickview implements InitializableComponent {
           style="outline-primary"
           class="p-2"
           onClick={() => this.onClick()}
-          ref={this.buttonFocusTarget?.setTarget}
+          ref={this.buttonFocusTarget.setTarget}
         >
           <atomic-icon class="w-5" icon={QuickviewIcon}></atomic-icon>
         </Button>

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -7,7 +7,11 @@ import {
 } from '@coveo/headless';
 import {Component, h, Listen, Prop, State} from '@stencil/core';
 import QuickviewIcon from '../../../../images/quickview.svg';
-import {AriaLiveRegion} from '../../../../utils/accessibility-utils';
+import {
+  AriaLiveRegion,
+  FocusTarget,
+  FocusTargetController,
+} from '../../../../utils/accessibility-utils';
 import {
   BindStateToController,
   InitializableComponent,
@@ -34,6 +38,7 @@ import {ResultContext} from '../result-template-decorators';
 export class AtomicQuickview implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;
   @ResultContext() private result!: Result;
+  @FocusTarget() buttonFocusTarget?: FocusTargetController;
 
   @State() public error!: Error;
 
@@ -109,6 +114,9 @@ export class AtomicQuickview implements InitializableComponent {
       this.quickviewModalRef.result = this.result;
       this.quickviewModalRef.total = this.quickviewState.totalResults;
       this.quickviewModalRef.current = this.quickviewState.currentResult;
+      this.quickviewModalRef.onModalClose = () =>
+        this.buttonFocusTarget?.focus();
+
       this.quickviewAriaMessage = this.quickviewState.isLoading
         ? this.bindings.i18n.t('quickview-loading')
         : this.bindings.i18n.t('quickview-loaded', {
@@ -133,6 +141,7 @@ export class AtomicQuickview implements InitializableComponent {
           style="outline-primary"
           class="p-2"
           onClick={() => this.onClick()}
+          ref={this.buttonFocusTarget?.setTarget}
         >
           <atomic-icon class="w-5" icon={QuickviewIcon}></atomic-icon>
         </Button>

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -114,7 +114,7 @@ export class AtomicQuickview implements InitializableComponent {
       this.quickviewModalRef.result = this.result;
       this.quickviewModalRef.total = this.quickviewState.totalResults;
       this.quickviewModalRef.current = this.quickviewState.currentResult;
-      this.quickviewModalRef.onModalClose = () =>
+      this.quickviewModalRef.modalCloseCallback = () =>
         this.buttonFocusTarget.focus();
 
       this.quickviewAriaMessage = this.quickviewState.isLoading

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -103,6 +103,7 @@ export function FocusTarget() {
           }
         },
         focus: async () => {
+          // The focus seems to be flaky without deferring, especially on iOS.
           await defer();
           element?.focus();
           onFocusCallback?.();

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -49,6 +49,7 @@ export interface FocusTargetController {
   setTarget(element: HTMLElement | undefined): void;
   focusAfterSearch(): Promise<void>;
   focusOnNextTarget(): Promise<void>;
+  focus(): Promise<void>;
   disableForCurrentSearch(): void;
 }
 
@@ -98,12 +99,13 @@ export function FocusTarget() {
           element = el;
           if (focusOnNextTarget) {
             focusOnNextTarget = false;
-            // The focus seems to be flaky without deferring, especially on iOS.
-            defer().then(() => {
-              el.focus();
-              onFocusCallback?.();
-            });
+            focusTargetController.focus();
           }
+        },
+        focus: async () => {
+          await defer();
+          element?.focus();
+          onFocusCallback?.();
         },
         focusAfterSearch: () => {
           lastSearchId = this.bindings.store.getUniqueIDFromEngine(

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -168,7 +168,7 @@ export function getFocusedElement(
 }
 
 export async function defer() {
-  return new Promise<void>((resolve) => setTimeout(resolve));
+  return new Promise<void>((resolve) => setTimeout(resolve, 10));
 }
 
 // https://terodox.tech/how-to-tell-if-an-element-is-in-the-dom-including-the-shadow-dom/


### PR DESCRIPTION
* Add support to re-focus the quickview button on the result list when the modal is closed.
* Disable tabbing through the "remove specific keywords highlighting" button when the whole "highlight keywords" feature is disabled.
* Tweak some button alignment, as reported by Lucille in KIT-2259

https://coveord.atlassian.net/browse/KIT-2259