### PR TITLE
fix(headless): remove facetSearch analytics

### DIFF
--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
@@ -673,12 +673,6 @@ describe('Category Facet Test Suites', () => {
         );
       });
 
-      describe('verify analytics', () => {
-        before(setupSearchFor);
-
-        CommonFacetAssertions.assertLogFacetSearch(hierarchicalField);
-      });
-
       describe('when selecting a search result', () => {
         function setupSelectSearchResult() {
           setupSearchFor();

--- a/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
@@ -169,12 +169,6 @@ describe('Color Facet Test Suites', () => {
           );
         });
 
-        describe('verify analytics', () => {
-          before(setupSearchFor);
-
-          CommonFacetAssertions.assertLogFacetSearch(colorFacetField);
-        });
-
         describe('when selecting a search result', () => {
           function setupSelectSearchResult() {
             setupSearchFor();

--- a/packages/atomic/cypress/e2e/facets/facet-common-assertions.ts
+++ b/packages/atomic/cypress/e2e/facets/facet-common-assertions.ts
@@ -256,14 +256,6 @@ export function assertNoMatchesFoundContainsQuery(
   });
 }
 
-export function assertLogFacetSearch(field: string) {
-  it('should log the facet search to UA', () => {
-    cy.expectSearchEvent('facetSearch').then((analyticsBody) => {
-      expect(analyticsBody.customData).to.have.property('facetField', field);
-    });
-  });
-}
-
 export function assertDisplayShowMoreButton(
   FacetWithShowMoreLessSelector: FacetWithShowMoreLessSelector,
   display: boolean,

--- a/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
@@ -186,12 +186,6 @@ describe('Facet v1 Test Suites', () => {
           CommonFacetAssertions.assertHighlightsResults(FacetSelectors, query);
         });
 
-        describe('verify analytics', () => {
-          before(setupSearchFor);
-
-          CommonFacetAssertions.assertLogFacetSearch(field);
-        });
-
         describe('when selecting a search result', () => {
           function setupSelectSearchResult() {
             setupSearchFor();
@@ -475,12 +469,6 @@ describe('Facet v1 Test Suites', () => {
           CommonFacetAssertions.assertHighlightsResults(FacetSelectors, query);
         });
 
-        describe('verify analytics', () => {
-          before(setupSearchFor);
-
-          CommonFacetAssertions.assertLogFacetSearch(field);
-        });
-
         describe('when selecting a search result', () => {
           function setupSelectSearchResult() {
             setupSearchFor();
@@ -612,12 +600,6 @@ describe('Facet v1 Test Suites', () => {
           FacetAssertions.assertNumberOfIdleBoxValues(defaultNumberOfValues);
           FacetAssertions.assertNumberOfSelectedBoxValues(0);
           CommonFacetAssertions.assertHighlightsResults(FacetSelectors, query);
-        });
-
-        describe('verify analytics', () => {
-          before(setupSearchFor);
-
-          CommonFacetAssertions.assertLogFacetSearch(field);
         });
 
         describe('when selecting a search result', () => {

--- a/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
+++ b/packages/headless/src/features/facets/facet-search-set/generic/generic-facet-search-actions.ts
@@ -13,7 +13,6 @@ import {
   requiredNonEmptyString,
   validatePayload,
 } from '../../../../utils/validate-payload';
-import {logFacetSearch} from '../../facet-set/facet-set-analytics-actions';
 import {facetIdDefinition} from '../../generic/facet-actions-validation';
 import {buildCategoryFacetSearchRequest} from '../category/category-facet-search-request-builder';
 import {buildSpecificFacetSearchRequest} from '../specific/specific-facet-search-request-builder';
@@ -41,10 +40,7 @@ const getExecuteFacetSearchThunkPayloadCreator =
     ExecuteFacetSearchThunkArg,
     ExecuteFacetSearchThunkApiConfig
   > =>
-  async (
-    facetId: string,
-    {dispatch, getState, extra: {apiClient, validatePayload}}
-  ) => {
+  async (facetId: string, {getState, extra: {apiClient, validatePayload}}) => {
     const state = getState();
     let req: SpecificFacetSearchRequest | CategoryFacetSearchRequest;
     validatePayload(facetId, requiredNonEmptyString);
@@ -63,9 +59,6 @@ const getExecuteFacetSearchThunkPayloadCreator =
     }
 
     const response = await apiClient.facetSearch(req);
-    if (!isFieldSuggestionsRequest) {
-      dispatch(logFacetSearch(facetId));
-    }
 
     return {facetId, response};
   };

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -46,19 +46,6 @@ export const logFacetShowLess = (facetId: string): SearchAction =>
     }
   );
 
-export const logFacetSearch = (facetId: string): SearchAction =>
-  makeAnalyticsAction(
-    'analytics/facet/search',
-    AnalyticsType.Search,
-    (client, state) => {
-      validatePayload(facetId, facetIdDefinition);
-      const stateForAnalytics = getStateNeededForFacetMetadata(state);
-      const metadata = buildFacetBaseMetadata(facetId, stateForAnalytics);
-
-      return client.makeFacetSearch(metadata);
-    }
-  );
-
 export interface LogFacetUpdateSortActionCreatorPayload {
   /**
    * The facet id.

--- a/packages/headless/src/integration-tests/category-field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/category-field-suggestions.test.ts
@@ -1,4 +1,3 @@
-import {CoveoSearchPageClient} from 'coveo.analytics';
 import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
@@ -103,7 +102,6 @@ describe('category field suggestions', () => {
 
     describe('after calling #search', () => {
       beforeEach(async () => {
-        jest.spyOn(CoveoSearchPageClient.prototype, 'logFacetSearch');
         await waitForNextStateChange(categoryFieldSuggestions, {
           action: () => categoryFieldSuggestions.search(),
           expectedSubscriberCalls: 2,
@@ -128,12 +126,6 @@ describe('category field suggestions', () => {
         expect(categoryFieldSuggestions.state.values.length).toBeGreaterThan(
           numberOfValues
         );
-      });
-
-      it('does not log analytics', () => {
-        expect(
-          CoveoSearchPageClient.prototype.logFacetSearch
-        ).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -1,4 +1,3 @@
-import {CoveoSearchPageClient} from 'coveo.analytics';
 import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
@@ -121,7 +120,6 @@ describe('field suggestions', () => {
 
     describe('after calling #search', () => {
       beforeEach(async () => {
-        jest.spyOn(CoveoSearchPageClient.prototype, 'logFacetSearch');
         await waitForNextStateChange(fieldSuggestions, {
           action: () => fieldSuggestions.search(),
           expectedSubscriberCalls: 2,
@@ -146,12 +144,6 @@ describe('field suggestions', () => {
         expect(fieldSuggestions.state.values.length).toBeGreaterThan(
           numberOfValues
         );
-      });
-
-      it('does not log analytics', () => {
-        expect(
-          CoveoSearchPageClient.prototype.logFacetSearch
-        ).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-1/category-facet/category-facet.cypress.ts
@@ -284,7 +284,6 @@ describe('quantic-category-facet', () => {
 
               Actions.typeQueryInSearchInput(query);
 
-              Expect.logFacetSearch(hierarchicalField);
               Expect.displayFacet(true);
               Expect.displayNoMatchesFound(false);
               Expect.displayMoreMatchesFound(true);
@@ -306,7 +305,6 @@ describe('quantic-category-facet', () => {
               });
 
               Actions.typeQueryInSearchInput(query);
-              Expect.logFacetSearch(hierarchicalField);
 
               Actions.selectSearchResult(selectedValue);
               Expect.logCategoryFacetSelected(montrealHierarchy);
@@ -325,11 +323,9 @@ describe('quantic-category-facet', () => {
               });
 
               Actions.typeQueryInSearchInput(query);
-              Expect.logFacetSearch(hierarchicalField);
               Expect.searchResults(8);
 
               Actions.clickSearchClearButton();
-              Expect.logFacetSearch(hierarchicalField);
               Expect.numberOfValues(defaultNumberOfValues - 1);
               Expect.searchInputEmpty();
             });
@@ -346,7 +342,6 @@ describe('quantic-category-facet', () => {
 
               Actions.typeQueryInSearchInput(query);
 
-              Expect.logFacetSearch(hierarchicalField);
               Expect.displayNoMatchesFound(true);
               Expect.noMatchesFoundContainsQuery(query);
               Expect.displaySearchClearButton(true);
@@ -379,7 +374,6 @@ describe('quantic-category-facet', () => {
               setupWithCustomBasePath(basePath, useCaseEnum.search, true);
 
               Actions.typeQueryInSearchInput(query);
-              Expect.logFacetSearch(hierarchicalField);
               Expect.searchResults(2);
               Expect.searchResultsPathContains(allCategories);
             });

--- a/packages/quantic/cypress/e2e/facets-1/facet-common-expectations.ts
+++ b/packages/quantic/cypress/e2e/facets-1/facet-common-expectations.ts
@@ -271,19 +271,6 @@ export function facetWithSearchExpectations(selector: FacetWithSearchSelector) {
           `"No matches found for" label should have the query "${query}"`
         );
     },
-
-    logFacetSearch: (field: string) => {
-      cy.wait(InterceptAliases.UA.Facet.Search)
-        .then((interception) => {
-          const analyticsBody = interception.request.body;
-          expect(analyticsBody).to.have.property('actionCause', 'facetSearch');
-          expect(analyticsBody.customData).to.have.property(
-            'facetField',
-            field
-          );
-        })
-        .logDetail('should log the "facetSearch" UA event');
-    },
   };
 }
 

--- a/packages/quantic/cypress/e2e/facets-1/facet/facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-1/facet/facet.cypress.ts
@@ -263,7 +263,6 @@ describe('Facet Test Suite', () => {
               Expect.displayShowMoreButton(false);
               Expect.displaySearchClearButton(true);
               Expect.highlightsResults(query);
-              Expect.logFacetSearch(defaultField);
             });
 
             scope('when clearing the facet search results', () => {
@@ -545,7 +544,6 @@ describe('Facet Test Suite', () => {
               Expect.displayShowMoreButton(false);
               Expect.displaySearchClearButton(true);
               Expect.highlightsResults(query);
-              Expect.logFacetSearch(defaultField);
 
               scope('when clearing the facet search results', () => {
                 function clearSearchInput() {


### PR DESCRIPTION
KIT-2261

-----

Given that:
- the facetSearch call does not return a searchUUID,
- a search analytics log requires a searchUUID
- how the feature work (see jira)

I reckon that we shouldn't log analytics on facet search. This is further confirmed imo by the fact that the old JSUI doesn't log analytics on facet search either.

draft to run the tests