### PR TITLE
fix(atomic): ignore empty query when detecting duplicates in search box suggestions

### DIFF
--- a/packages/atomic/cypress/e2e/search-box/search-box-selectors.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box-selectors.ts
@@ -3,6 +3,7 @@ import {AriaLiveSelectors} from '../aria-live-selectors';
 export const searchBoxComponent = 'atomic-search-box';
 
 export const SearchBoxSelectors = {
+  host: () => cy.get(searchBoxComponent),
   shadow: () => cy.get(searchBoxComponent).shadow(),
   inputBox: () => SearchBoxSelectors.shadow().find('[part="input"]'),
   submitButton: () =>

--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -1,9 +1,7 @@
-import {VNode} from '@stencil/core';
 import {
   dispatchSearchBoxSuggestionsEvent,
   SearchBoxSuggestionElement,
 } from '../../../src/components/search/search-box-suggestions/suggestions-common';
-import {buildCustomEvent} from '../../../src/utils/event-utils';
 import {
   SafeStorage,
   StorageItems,

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -517,15 +517,19 @@ export class AtomicSearchBox {
 
   private getAndFilterLeftSuggestionElements() {
     const suggestionElements = this.getSuggestionElements(this.leftSuggestions);
-    // We want to remove duplicates elements for the same `query` property, but only when it's not empty.
-    // Since the custom search box suggestion system does not enforce the query property (it's optional),
-    // it's a system that custom search box suggestions component will use to provide a "title" or separator section.
-    // We don't want to detect multiple separator section with no query as duplicate
-    return suggestionElements.filter(
-      (suggestionElement, i, self) =>
-        isNullOrUndefined(suggestionElement.query) ||
-        i === self.findIndex((other) => other.query === suggestionElement.query)
-    );
+    const filterOnDuplicate = new Set();
+
+    return suggestionElements.filter((suggestionElement) => {
+      if (isNullOrUndefined(suggestionElement.query)) {
+        return true;
+      }
+      if (filterOnDuplicate.has(suggestionElement.query)) {
+        return false;
+      } else {
+        filterOnDuplicate.add(suggestionElement.query);
+        return true;
+      }
+    });
   }
 
   private onKeyDown(e: KeyboardEvent) {

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -517,9 +517,10 @@ export class AtomicSearchBox {
 
   private getAndFilterLeftSuggestionElements() {
     const suggestionElements = this.getSuggestionElements(this.leftSuggestions);
-    // We want to remove duplicates elements for the same `query` property, but only when it's not null.
-    // Since the custom search box suggestion system does not enforce a query property (it's optional),
-    // it's a system that people will use to provide a "title" section for multiple suggestions provider.
+    // We want to remove duplicates elements for the same `query` property, but only when it's not empty.
+    // Since the custom search box suggestion system does not enforce the query property (it's optional),
+    // it's a system that custom search box suggestions component will use to provide a "title" or separator section.
+    // We don't want to detect multiple separator section with no query as duplicate
     return suggestionElements.filter(
       (suggestionElement, i, self) =>
         isNullOrUndefined(suggestionElement.query) ||

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -1,3 +1,4 @@
+import {isNullOrUndefined} from '@coveo/bueno';
 import {
   SearchBox,
   SearchBoxState,
@@ -33,7 +34,7 @@ import {
 } from '../../../utils/local-storage-utils';
 import {promiseTimeout} from '../../../utils/promise-utils';
 import {updateBreakpoints} from '../../../utils/replace-breakpoint';
-import {getUniqueItemsByProperties, once, randomID} from '../../../utils/utils';
+import {once, randomID} from '../../../utils/utils';
 import {SearchBoxCommon} from '../../common/search-box/search-box-common';
 import {SearchBoxWrapper} from '../../common/search-box/search-box-wrapper';
 import {SearchInput} from '../../common/search-box/search-input';
@@ -516,7 +517,14 @@ export class AtomicSearchBox {
 
   private getAndFilterLeftSuggestionElements() {
     const suggestionElements = this.getSuggestionElements(this.leftSuggestions);
-    return getUniqueItemsByProperties(suggestionElements, ['query']);
+    // We want to remove duplicates elements for the same `query` property, but only when it's not null.
+    // Since the custom search box suggestion system does not enforce a query property (it's optional),
+    // it's a system that people will use to provide a "title" section for multiple suggestions provider.
+    return suggestionElements.filter(
+      (suggestionElement, i, self) =>
+        isNullOrUndefined(suggestionElement.query) ||
+        i === self.findIndex((other) => other.query === suggestionElement.query)
+    );
   }
 
   private onKeyDown(e: KeyboardEvent) {

--- a/packages/atomic/src/utils/utils.spec.ts
+++ b/packages/atomic/src/utils/utils.spec.ts
@@ -4,7 +4,6 @@ import {
   randomID,
   kebabToCamel,
   parseAssetURL,
-  getUniqueItemsByProperties,
   aggregate,
 } from './utils';
 
@@ -82,49 +81,6 @@ describe('parseAssetURL', () => {
   it('works with Atomic assets (with .svg)', () => {
     expect(parseAssetURL('assets://attachment.svg')).toBe(
       '/assets/attachment.svg'
-    );
-  });
-});
-
-describe('getUniqueItemsByProperties', () => {
-  it('works as expected', () => {
-    const testCases = [
-      {
-        in: [
-          {foo: 'bar', bazz: 'buzz'},
-          {foo: 'bar', bazz: 'something else'},
-        ],
-        props: ['foo'],
-        expected: [{foo: 'bar', bazz: 'buzz'}],
-      },
-      {
-        in: [
-          {foo: 'bar', bazz: 'buzz'},
-          {foo: 'bar', bazz: 'something else'},
-        ],
-        props: ['bazz'],
-        expected: [
-          {foo: 'bar', bazz: 'buzz'},
-          {foo: 'bar', bazz: 'something else'},
-        ],
-      },
-      {
-        in: [
-          {foo: 'bar', bazz: 'buzz'},
-          {foo: 'bar', bazz: 'something else'},
-        ],
-        props: ['bar', 'bazz'],
-        expected: [
-          {foo: 'bar', bazz: 'buzz'},
-          {foo: 'bar', bazz: 'something else'},
-        ],
-      },
-    ];
-
-    testCases.forEach((testCase) =>
-      expect(
-        getUniqueItemsByProperties(testCase.in, testCase.props as never)
-      ).toEqual(testCase.expected)
     );
   });
 });

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -194,19 +194,6 @@ export function isPropValuesEqual<ObjectWithProperties extends object>(
   return propNames.every((propName) => subject[propName] === target[propName]);
 }
 
-export function getUniqueItemsByProperties<Item extends object>(
-  items: Item[],
-  propNames: (keyof Item)[]
-) {
-  return items.filter(
-    (item, index, self) =>
-      index ===
-      self.findIndex((foundItem) =>
-        isPropValuesEqual(foundItem, item, propNames)
-      )
-  );
-}
-
 export function getParent(element: Element | ShadowRoot) {
   if (element.parentNode) {
     return element.parentNode as Element | ShadowRoot;


### PR DESCRIPTION
You can check the JIRA for a link to the discuss that sparked this change.

https://coveord.atlassian.net/browse/KIT-2275