### PR TITLE
fix(atomic): handle invalid HTML highlights

### DIFF
--- a/packages/atomic/cypress/e2e/result-list/result-components/quickview.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/quickview.cypress.ts
@@ -141,4 +141,23 @@ describe('Quickview Component', () => {
       QuickviewModalSelectors.keywordsSidebar().should('exist');
     });
   });
+
+  describe('when used on an excel file with a query that returns invalid HTML', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(addFacet({field: 'filetype'}))
+        .with(addSearchBox())
+        .withHash('f-filetype=xls&q=1/12')
+        .with(addQuickviewInResultList())
+        .init();
+    });
+
+    it('should handle displaying keywords correctly', () => {
+      openModal();
+      QuickviewModalSelectors.keywordsSidebar()
+        .should('exist')
+        .should('contain.text', 'Navigate between 6 occurrences of 1')
+        .should('contain.text', 'Navigate between 6 occurrences of 12');
+    });
+  });
 });

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-sidebar/atomic-quickview-sidebar.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-sidebar/atomic-quickview-sidebar.tsx
@@ -137,11 +137,13 @@ const Keywords: FunctionalComponent<
                   class="w-5 h-5 flex-none mr-2"
                   style={{backgroundColor: keyword.color}}
                 ></div>
-                <div class="grow mr-2">{keyword.text}</div>
+                <div class="grow mr-2 whitespace-nowrap">{keyword.text}</div>
                 <div class="flex-none">
+                  (
                   {new Intl.NumberFormat(i18n.language, {
                     notation: 'compact',
                   }).format(keyword.occurrences)}
+                  )
                 </div>
               </div>
               <FieldsetGroup

--- a/packages/atomic/src/components/search/result-template-components/quickview-word-highlight/quickview-word-highlight.tsx
+++ b/packages/atomic/src/components/search/result-template-components/quickview-word-highlight/quickview-word-highlight.tsx
@@ -22,8 +22,8 @@ export class QuickviewWordHighlight {
       throw 'Invalid keyword identifier for quickview';
     }
 
-    this.indexIdentifier = parsed.keywordIdentifier;
     this.text = this.getText(keywordElementInIframe);
+    this.indexIdentifier = `${parsed.keywordIdentifier}-${this.text}`;
     this.color = keywordElementInIframe.style.backgroundColor;
     this.focusedColor = this.computeInvertedColor();
     this.previewBorderColor = this.computeSaturatedColor();
@@ -78,7 +78,7 @@ export class QuickviewWordHighlight {
 
   private getText(element: HTMLElement) {
     const innerTextOfHTMLElement = this.getHighlightedInnerText(element);
-    return this.resolveOriginalTerm(innerTextOfHTMLElement);
+    return this.resolveOriginalTerm(innerTextOfHTMLElement).trim();
   }
 
   private resolveOriginalTerm(highlight: string): string {


### PR DESCRIPTION
I played with different solutions here, and this is what I think is the best.

I'll try to explain what happens for some queries:

The index will understand some queries as "a phrase", or a single term. So, in this particular JIRA, the query was `1/12`. In some documents (for example excel files), the index will do some very weird stuff at the word highlighting level.

In some documents, it might even create invalid HTML, and so we would see "empty" keywords being highlighted. Since those are just illogical, I've added a `trim` to just hide them from the end users. As for fixing it at the index level, I will open a discuss about it.

Next related problem was that it then consider pretty different keywords in the document as being part of the same group. 

By that I mean that for the query `1/12` for example, it would group `1/12` , `1.12`, `1-12`, `1`, `12` etc as all the same keyword. 

From a purely keyword based search approach, this makes a ton of sense. ie: When you search and retrieve/rank documents in an index, this is a good behaviour. 

But for quickview highlighting, the result for an end user would be pretty weird.

ie: You want to highlight the number `1`, and you end up seeing `12` highlighted instead. So I've added a separator on the text of the keyword itself, as opposed to only rely on the parsed index identifier (ie: what the index consider part of the same keyword group).


https://coveord.atlassian.net/browse/KIT-2221