### PR TITLE
fix(quantic): numeric facet displayed only when it contains facet values

### DIFF
--- a/packages/quantic/cypress/e2e/facets-1/facet-common-selectors.ts
+++ b/packages/quantic/cypress/e2e/facets-1/facet-common-selectors.ts
@@ -9,7 +9,7 @@ export interface BaseFacetSelector extends ComponentSelector {
   collapseButton: () => CypressSelector;
   expandButton: () => CypressSelector;
   placeholder: () => CypressSelector;
-  searchInput: () => CypressSelector;
+  searchInput?: () => CypressSelector;
 }
 
 export interface FacetWithValuesSelector extends ComponentSelector {

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-expectations.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-expectations.ts
@@ -22,6 +22,12 @@ const getEvenRangeValue = (value: {start?: unknown; end?: unknown}) => {
 
 const numericFacetExpectations = (selector: AllFacetSelectors) => {
   return {
+    displayNumericFacetCard: (display: boolean) => {
+      selector
+        .numericFacetCard()
+        .should(display ? 'exist' : 'not.exist')
+        .logDetail(`${should(display)} display the numeric facet card`);
+    },
     displaySearchForm: (display: boolean) => {
       selector
         .searchForm()

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-selectors.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-selectors.ts
@@ -15,6 +15,7 @@ export interface NumericFacetSelector extends ComponentSelector {
   helpMessage: () => CypressSelector;
   inputMinWarning: () => CypressSelector;
   inputMaxWarning: () => CypressSelector;
+  numericFacetCard: () => CypressSelector;
 }
 
 export type AllFacetSelectors = BaseFacetSelector &
@@ -65,4 +66,6 @@ export const NumericFacetSelectors: AllFacetSelectors = {
     NumericFacetSelectors.get().find(
       '.numeric__input-max div.slds-form-element__help'
     ),
+  numericFacetCard: () =>
+    NumericFacetSelectors.get().find('[data-cy="numeric-facet__card"]'),
 };

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet.cypress.ts
@@ -5,6 +5,7 @@ import {
   InterceptAliases,
   interceptSearch,
   mockSearchNoResults,
+  mockSearchWithoutAnyFacetValues,
 } from '../../../page-objects/search';
 import {
   useCaseParamTest,
@@ -164,6 +165,20 @@ describe('quantic-numeric-facet', () => {
                 Expect.numberOfSelectedCheckboxValues(0);
               });
             });
+        });
+
+        describe('when no numeric facet values are returned', () => {
+          it('should work as expected', () => {
+            mockSearchWithoutAnyFacetValues(param.useCase);
+            visitNumericFacetPage({
+              ...customWithInputSettings,
+              useCase: param.useCase,
+            });
+
+            scope('on initial load', () => {
+              Expect.displayNumericFacetCard(false);
+            });
+          });
         });
       });
 
@@ -360,6 +375,20 @@ describe('quantic-numeric-facet', () => {
             Expect.inputMinEmpty();
           });
         });
+
+        describe('when no numeric facet values are returned', () => {
+          it('should work as expected', () => {
+            mockSearchWithoutAnyFacetValues(param.useCase);
+            visitNumericFacetPage({
+              ...customWithInputSettings,
+              useCase: param.useCase,
+            });
+
+            scope('on initial load', () => {
+              Expect.displayNumericFacetCard(false);
+            });
+          });
+        });
       });
 
       describe('when selecting range with no search results', () => {
@@ -514,6 +543,7 @@ describe('quantic-numeric-facet', () => {
               useCase: param.useCase,
             });
 
+            Expect.displayNumericFacetCard(true);
             Expect.displayLabel(true);
             Expect.displayValues(true);
             Expect.numberOfValues(2);
@@ -528,8 +558,7 @@ describe('quantic-numeric-facet', () => {
               useCase: param.useCase,
             });
 
-            Expect.displayLabel(false);
-            Expect.displayValues(false);
+            Expect.displayNumericFacetCard(false);
           });
 
           scope(
@@ -543,9 +572,7 @@ describe('quantic-numeric-facet', () => {
                 useCase: param.useCase,
               });
 
-              Expect.displayLabel(true);
-              Expect.displaySearchForm(true);
-              Expect.displayValues(false);
+              Expect.displayNumericFacetCard(false);
             }
           );
         });

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -243,8 +243,8 @@ export function getRoute(useCase?: string) {
     : routeMatchers.search;
 }
 
-export function mockSearchWithoutAnyFacetValues() {
-  cy.intercept(routeMatchers.search, (req) => {
+export function mockSearchWithoutAnyFacetValues(useCase: string) {
+  cy.intercept(getRoute(useCase), (req) => {
     req.continue((res) => {
       res.body.facets.forEach((facet: {values: string[]}) => {
         facet.values = [];

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
@@ -3,7 +3,7 @@
     <c-quantic-placeholder variant="card" number-of-rows={numberOfValues}></c-quantic-placeholder>
   </template>
   <template if:true={shouldRenderFacet}>
-    <div class="slds-size_1-of-1">
+    <div data-cy="numeric-facet__card" class="slds-size_1-of-1">
       <c-quantic-card-container title={label} onheaderclick={toggleFacetVisibility} onheaderkeydown={toggleFacetVisibility}>
         <lightning-button-icon
           class={actionButtonCssClasses}

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js
@@ -390,7 +390,7 @@ export default class QuanticNumericFacet extends LightningElement {
 
   get shouldRenderInput() {
     return (
-      (this.withInput && this.searchStatus?.state?.hasResults) ||
+      (this.withInput && !!this.values.length) ||
       !!this.filterState?.range
     );
   }


### PR DESCRIPTION
[SFINT-4795](https://coveord.atlassian.net/browse/SFINT-4795)

### Issue: 
The numeric facet was always displayed when the property `withInput` was set to `true`  even if there is no numeric facet values in this facet:

https://user-images.githubusercontent.com/86681870/220132515-a72c681e-8155-4c22-b8d8-c142ae1caf05.mov


### Solution:
Numeric facet displayed only when it is relevant, only when it contains numeric facet values:

https://user-images.githubusercontent.com/86681870/220132799-56313131-d3b3-4916-a030-6540635ebd34.mov



[SFINT-4795]: https://coveord.atlassian.net/browse/SFINT-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ