### PR TITLE
fix(quantic):  pre install script adapted to work on windows

### DIFF
--- a/packages/quantic/scripts/npm/utils.js
+++ b/packages/quantic/scripts/npm/utils.js
@@ -12,7 +12,7 @@ function quanticIsDependency() {
 }
 
 function getProjectPath() {
-  return __dirname.split('/node_modules')[0];
+  return __dirname.split('node_modules')[0];
 }
 
 module.exports = {


### PR DESCRIPTION
[SFINT-4802](https://coveord.atlassian.net/browse/SFINT-4802)

The[ following line ](https://github.com/coveo/ui-kit/blob/6ef4ce24adbbf2c7bc1397905a8ff076049cfd20/packages/quantic/scripts/npm/utils.js#L15)was making the Quantic pre install script fail when trying to install Quantic on windows:

```
return __dirname.split('/node_modules')[0];
```
Just because on windows the backward slash `\` is used in the paths instead of the forward slash `/`.

[SFINT-4802]: https://coveord.atlassian.net/browse/SFINT-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ