### PR TITLE
docs(headless): clarify RecentResultList doc

### DIFF
--- a/packages/headless/src/controllers/recent-results-list/headless-recent-results-list.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-recent-results-list.ts
@@ -60,7 +60,7 @@ const optionsSchema = new Schema<RecentResultsListOptions>({
 });
 
 /**
- * The `RecentResultsList` controller manages the user's recent results.
+ * The `RecentResultsList` controller manages a user's recently clicked results.
  */
 export interface RecentResultsList extends Controller {
   /**


### PR DESCRIPTION
Clarifies the doc for the RecentResultList controller to mention "clicked" results.

https://coveord.atlassian.net/browse/KIT-2303