### PR TITLE
ci(atomic-angular): fix NPM tag bump (#2740

### DIFF
--- a/packages/atomic-angular/modify-package-json.js
+++ b/packages/atomic-angular/modify-package-json.js
@@ -11,9 +11,5 @@ packageJSON.scripts['publish:npm:release'] =
   'node ../../../../../scripts/deploy/publish.mjs release';
 packageJSON.scripts['publish:npm:prerelease'] =
   'node ../../../../../scripts/deploy/publish.mjs prerelease';
-packageJSON.scripts['promote:npm:beta'] =
-  'node ../../../../../scripts/deploy/update-npm-tag.mjs beta';
-packageJSON.scripts['promote:npm:latest'] =
-  'node ../../../../../scripts/deploy/update-npm-tag.mjs latest';
 
 writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -9,8 +9,6 @@
     "build:assets": "ncp ../atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp ../atomic/dist/atomic/lang projects/atomic-angular/dist/lang",
     "publish:npm:release": "npm --prefix projects/atomic-angular/dist run publish:npm:release",
     "publish:npm:prerelease": "npm --prefix projects/atomic-angular/dist run publish:npm:prerelease",
-    "promote:npm:beta": "npm --prefix projects/atomic-angular/dist run promote:npm:beta",
-    "promote:npm:latest": "npm --prefix projects/atomic-angular/dist run promote:npm:latest",
     "build:npm-package": "node modify-package-json.js"
   },
   "private": true,

--- a/packages/atomic-angular/projects/atomic-angular/project.json
+++ b/packages/atomic-angular/projects/atomic-angular/project.json
@@ -1,4 +1,26 @@
 {
   "name": "atomic-angular",
-  "implicitDependencies": ["atomic-angular-builder"]
+  "implicitDependencies": ["atomic-angular-builder"],
+  "targets": {
+    "promote:npm:beta": {
+      "dependsOn": [],
+      "inputs": [],
+      "outputs": [],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node ../../../../../scripts/deploy/update-npm-tag.mjs beta",
+        "cwd": "packages/atomic-angular/projects/atomic-angular"
+      }
+    },
+    "promote:npm:latest": {
+      "dependsOn": [],
+      "inputs": [],
+      "outputs": [],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node ../../../../../scripts/deploy/update-npm-tag.mjs latest",
+        "cwd": "packages/atomic-angular/projects/atomic-angular"
+      }
+    }
+  }
 }

--- a/packages/atomic-angular/projects/atomic-angular/project.json
+++ b/packages/atomic-angular/projects/atomic-angular/project.json
@@ -8,7 +8,7 @@
       "outputs": [],
       "executor": "nx:run-commands",
       "options": {
-        "command": "node ../../../../../scripts/deploy/update-npm-tag.mjs beta",
+        "command": "node ../../../../scripts/deploy/update-npm-tag.mjs beta",
         "cwd": "packages/atomic-angular/projects/atomic-angular"
       }
     },
@@ -18,7 +18,7 @@
       "outputs": [],
       "executor": "nx:run-commands",
       "options": {
-        "command": "node ../../../../../scripts/deploy/update-npm-tag.mjs latest",
+        "command": "node ../../../../scripts/deploy/update-npm-tag.mjs latest",
         "cwd": "packages/atomic-angular/projects/atomic-angular"
       }
     }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2311

The `atomic-angular/dist` directory only exists when the application is built, which is required for publishing but not for updating the tag.