### PR TITLE
docs(atomic): DOC-12292 clarify field usage in hrefTemplate

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1282,7 +1282,7 @@ export namespace Components {
     }
     interface AtomicResultLink {
         /**
-          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
+          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the result's `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
     }
@@ -3900,7 +3900,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultLink {
         /**
-          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
+          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the result's `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1282,7 +1282,7 @@ export namespace Components {
     }
     interface AtomicResultLink {
         /**
-          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
+          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
     }
@@ -3900,7 +3900,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultLink {
         /**
-          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
+          * Specifies a template literal from which to generate the `href` attribute value (see [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).  The template literal can reference any number of result properties from the parent result. It can also reference the window object.  For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields. ```html <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link> ```
          */
         "hrefTemplate"?: string;
     }

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
@@ -44,7 +44,7 @@ export class AtomicResultLink implements InitializableComponent {
    *
    * The template literal can reference any number of result properties from the parent result. It can also reference the window object.
    *
-   * For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields.
+   * For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the result's `clickUri` and `itemtitle` fields.
    * ```html
    * <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link>
    * ```

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-link/atomic-result-link.tsx
@@ -44,7 +44,7 @@ export class AtomicResultLink implements InitializableComponent {
    *
    * The template literal can reference any number of result properties from the parent result. It can also reference the window object.
    *
-   * For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`.
+   * For example, the following markup generates an `href` value such as `http://uri.com?id=itemTitle`, using the item `clickUri` and `itemtitle` fields.
    * ```html
    * <atomic-result-link href-template='${clickUri}?id=${raw.itemtitle}'></atomic-result-link>
    * ```


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-12292

A reader reported being confused about how to use fields in the atomic-result-link ref doc. He seems a bit confused, but to be fair we don't use the word "field". Adding a few extra words should do the trick.