### PR TITLE
fix(quantic): overflow issue fixed in the quantic smart snippet source component

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSource/quanticSmartSnippetSource.html
@@ -1,11 +1,12 @@
 <template>
   <div class="smart-snippet__source">
-    <div>
-      <a data-cy="smart-snippet__source-uri" class="slds-text-title_bold smart-snippet__source-uri" href={uri}>{uri}</a>
+    <div class="slds-truncate">
+      <a data-cy="smart-snippet__source-uri" class="slds-text-title_bold smart-snippet__source-uri" title={uri}
+        href={uri}>{uri}</a>
     </div>
     <div class="slds-var-m-top_xx-small">
-      <a data-cy="smart-snippet__source-title" class="smart-snippet__source-title slds-text-heading_small"
-        href={uri}>{title}</a>
+      <a data-cy="smart-snippet__source-title" class="smart-snippet__source-title slds-text-heading_small" href={uri}
+        title={title}>{title}</a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
[SFINT-4823](https://coveord.atlassian.net/browse/SFINT-4823)

### Before:
![image-20230222-213952](https://user-images.githubusercontent.com/86681870/221290834-e5bd7c93-50ac-467e-8461-599d93d3c784.png)


### After:
<img width="294" alt="OverflowFixed" src="https://user-images.githubusercontent.com/86681870/221290791-62f39fae-66bf-4150-85d7-ecc617da8558.png">


[SFINT-4823]: https://coveord.atlassian.net/browse/SFINT-4823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ