### PR TITLE
fix(headless): fixed tab set restore on history change

### DIFF
--- a/packages/headless/src/features/tab-set/tab-set-slice.test.ts
+++ b/packages/headless/src/features/tab-set/tab-set-slice.test.ts
@@ -1,4 +1,6 @@
 import {buildMockTabSlice} from '../../test/mock-tab-state';
+import {change} from '../history/history-actions';
+import {getHistoryInitialState} from '../history/history-state';
 import {restoreSearchParameters} from '../search-parameters/search-parameter-actions';
 import {registerTab, updateActiveTab} from './tab-set-actions';
 import {tabSetReducer} from './tab-set-slice';
@@ -7,6 +9,29 @@ describe('tab set slice', () => {
   it('initializes state correctly', () => {
     const finalState = tabSetReducer(undefined, {type: ''});
     expect(finalState).toEqual({});
+  });
+
+  it('it restores the tabSet on history change', () => {
+    const tabA = buildMockTabSlice({id: 'a'});
+    const tabB = buildMockTabSlice({id: 'b'});
+
+    const payload = {
+      ...getHistoryInitialState(),
+      tabSet: {a: {...tabA, isActive: false}, b: {...tabB, isActive: true}},
+    };
+
+    const finalState = tabSetReducer(
+      {
+        a: {...tabA, isActive: true},
+        b: {...tabB, isActive: false},
+      },
+      change.fulfilled(payload, '')
+    );
+
+    expect(finalState).toEqual({
+      a: {...tabA, isActive: false},
+      b: {...tabB, isActive: true},
+    });
   });
 
   describe('#registerTab', () => {

--- a/packages/headless/src/features/tab-set/tab-set-slice.ts
+++ b/packages/headless/src/features/tab-set/tab-set-slice.ts
@@ -1,4 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {change} from '../history/history-actions';
 import {restoreSearchParameters} from '../search-parameters/search-parameter-actions';
 import {registerTab, updateActiveTab} from './tab-set-actions';
 import {getTabSetInitialState, TabSetState} from './tab-set-state';
@@ -24,6 +25,9 @@ export const tabSetReducer = createReducer(
       .addCase(restoreSearchParameters, (state, action) => {
         const id = action.payload.tab || '';
         activateTabIfIdExists(state, id);
+      })
+      .addCase(change.fulfilled, (state, action) => {
+        return action.payload?.tabSet ?? state;
       });
   }
 );


### PR DESCRIPTION
[SVCC-425](https://coveord.atlassian.net/browse/SVCC-425)

### The issue: 
The tab set state was not restored properly on history change:

https://user-images.githubusercontent.com/86681870/221574786-1e62aae0-d0e3-4870-8907-f5afc9f62fc8.mov

### The solution:
Added a new case in the tab set reducer to properly handle the history change:

https://user-images.githubusercontent.com/86681870/221575240-1a85da46-bce1-44ea-8922-77dd5bfab0f3.mov




[SVCC-425]: https://coveord.atlassian.net/browse/SVCC-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ