### PR TITLE
fix(atomic): use closest for internal initialization utils

### DIFF
--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -23,6 +23,7 @@ export const initializeEventName = 'atomic/initializeComponent';
 const initializableElements = [
   'atomic-recs-interface',
   'atomic-search-interface',
+  'atomic-relevance-inspector',
   'atomic-insight-interface',
   'atomic-external',
 ];

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -144,29 +144,34 @@ export function InitializeBindings<SpecificBindings extends AnyBindings>({
       const element = getElement(this);
       element.setAttribute(renderedAttribute, 'false');
       element.setAttribute(loadedAttribute, 'false');
-      buildCustomEvent(initializeEventName, (bindings: SpecificBindings) => {
-        this.bindings = bindings;
+      const event = buildCustomEvent(
+        initializeEventName,
+        (bindings: SpecificBindings) => {
+          this.bindings = bindings;
 
-        const updateLanguage = () => forceUpdateComponent(this);
-        this.bindings.i18n.on('languageChanged', updateLanguage);
-        unsubscribeLanguage = () =>
-          this.bindings.i18n.off('languageChanged', updateLanguage);
+          const updateLanguage = () => forceUpdateComponent(this);
+          this.bindings.i18n.on('languageChanged', updateLanguage);
+          unsubscribeLanguage = () =>
+            this.bindings.i18n.off('languageChanged', updateLanguage);
 
-        try {
-          // When no controller is initialized, updating a property with a State() decorator, there will be no re-render.
-          // In this case, we have to manually trigger it.
-          if (this.initialize) {
-            this.initialize();
-            if (forceUpdate) {
+          try {
+            // When no controller is initialized, updating a property with a State() decorator, there will be no re-render.
+            // In this case, we have to manually trigger it.
+            if (this.initialize) {
+              this.initialize();
+              if (forceUpdate) {
+                forceUpdateComponent(this);
+              }
+            } else {
               forceUpdateComponent(this);
             }
-          } else {
-            forceUpdateComponent(this);
+          } catch (e) {
+            this.error = e as Error;
           }
-        } catch (e) {
-          this.error = e as Error;
         }
-      });
+      );
+
+      element.dispatchEvent(event);
 
       if (!closest(element, initializableElements.join(', '))) {
         this.error = new MissingInterfaceParentError(

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -21,6 +21,7 @@ export type InitializeEventHandler = (bindings: AnyBindings) => void;
 export type InitializeEvent = CustomEvent<InitializeEventHandler>;
 export const initializeEventName = 'atomic/initializeComponent';
 const initializableElements = [
+  'atomic-recs-interface',
   'atomic-search-interface',
   'atomic-insight-interface',
   'atomic-external',

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -144,35 +144,31 @@ export function InitializeBindings<SpecificBindings extends AnyBindings>({
       const element = getElement(this);
       element.setAttribute(renderedAttribute, 'false');
       element.setAttribute(loadedAttribute, 'false');
-      const event = buildCustomEvent(
-        initializeEventName,
-        (bindings: SpecificBindings) => {
-          this.bindings = bindings;
+      buildCustomEvent(initializeEventName, (bindings: SpecificBindings) => {
+        this.bindings = bindings;
 
-          const updateLanguage = () => forceUpdateComponent(this);
-          this.bindings.i18n.on('languageChanged', updateLanguage);
-          unsubscribeLanguage = () =>
-            this.bindings.i18n.off('languageChanged', updateLanguage);
+        const updateLanguage = () => forceUpdateComponent(this);
+        this.bindings.i18n.on('languageChanged', updateLanguage);
+        unsubscribeLanguage = () =>
+          this.bindings.i18n.off('languageChanged', updateLanguage);
 
-          try {
-            // When no controller is initialized, updating a property with a State() decorator, there will be no re-render.
-            // In this case, we have to manually trigger it.
-            if (this.initialize) {
-              this.initialize();
-              if (forceUpdate) {
-                forceUpdateComponent(this);
-              }
-            } else {
+        try {
+          // When no controller is initialized, updating a property with a State() decorator, there will be no re-render.
+          // In this case, we have to manually trigger it.
+          if (this.initialize) {
+            this.initialize();
+            if (forceUpdate) {
               forceUpdateComponent(this);
             }
-          } catch (e) {
-            this.error = e as Error;
+          } else {
+            forceUpdateComponent(this);
           }
+        } catch (e) {
+          this.error = e as Error;
         }
-      );
+      });
 
-      const canceled = element.dispatchEvent(event);
-      if (canceled) {
+      if (!closest(element, initializableElements.join(', '))) {
         this.error = new MissingInterfaceParentError(
           element.nodeName.toLowerCase()
         );

--- a/packages/samples/stencil/cypress/integration/stencil/smoke-test.cypress.ts
+++ b/packages/samples/stencil/cypress/integration/stencil/smoke-test.cypress.ts
@@ -13,6 +13,14 @@ describe('smoke test', () => {
     cy.visit('http://localhost:3666/search').wait('@analytics');
   }
 
+  function setupHSP() {
+    cy.intercept({
+      method: 'POST',
+      path: '**/rest/ua/v15/analytics/*',
+    }).as('analytics');
+    cy.visit('http://localhost:3666/hsp.html').wait('@analytics');
+  }
+
   function assertions() {
     it('should load', () => {
       cy.get('atomic-search-box')
@@ -90,5 +98,15 @@ describe('smoke test', () => {
     });
 
     assertions();
+  });
+
+  describe('testing the /hsp sample', () => {
+    before(() => {
+      setupHSP();
+    });
+
+    it('should not log an error to the console', () => {
+      cy.get('@consoleError').should('not.be.called');
+    });
   });
 });

--- a/packages/samples/stencil/src/components.d.ts
+++ b/packages/samples/stencil/src/components.d.ts
@@ -10,6 +10,8 @@ import { Router } from "stencil-router-v2";
 export namespace Components {
     interface AppRoot {
     }
+    interface ResultsManager {
+    }
     interface SampleComponent {
     }
     interface SampleResultComponent {
@@ -27,6 +29,12 @@ declare global {
     var HTMLAppRootElement: {
         prototype: HTMLAppRootElement;
         new (): HTMLAppRootElement;
+    };
+    interface HTMLResultsManagerElement extends Components.ResultsManager, HTMLStencilElement {
+    }
+    var HTMLResultsManagerElement: {
+        prototype: HTMLResultsManagerElement;
+        new (): HTMLResultsManagerElement;
     };
     interface HTMLSampleComponentElement extends Components.SampleComponent, HTMLStencilElement {
     }
@@ -54,6 +62,7 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "app-root": HTMLAppRootElement;
+        "results-manager": HTMLResultsManagerElement;
         "sample-component": HTMLSampleComponentElement;
         "sample-result-component": HTMLSampleResultComponentElement;
         "search-page": HTMLSearchPageElement;
@@ -62,6 +71,8 @@ declare global {
 }
 declare namespace LocalJSX {
     interface AppRoot {
+    }
+    interface ResultsManager {
     }
     interface SampleComponent {
     }
@@ -75,6 +86,7 @@ declare namespace LocalJSX {
     }
     interface IntrinsicElements {
         "app-root": AppRoot;
+        "results-manager": ResultsManager;
         "sample-component": SampleComponent;
         "sample-result-component": SampleResultComponent;
         "search-page": SearchPage;
@@ -86,6 +98,7 @@ declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
             "app-root": LocalJSX.AppRoot & JSXBase.HTMLAttributes<HTMLAppRootElement>;
+            "results-manager": LocalJSX.ResultsManager & JSXBase.HTMLAttributes<HTMLResultsManagerElement>;
             "sample-component": LocalJSX.SampleComponent & JSXBase.HTMLAttributes<HTMLSampleComponentElement>;
             "sample-result-component": LocalJSX.SampleResultComponent & JSXBase.HTMLAttributes<HTMLSampleResultComponentElement>;
             "search-page": LocalJSX.SearchPage & JSXBase.HTMLAttributes<HTMLSearchPageElement>;

--- a/packages/samples/stencil/src/components/results-manager/results-manager.tsx
+++ b/packages/samples/stencil/src/components/results-manager/results-manager.tsx
@@ -1,0 +1,11 @@
+import {Component, h} from '@stencil/core';
+
+@Component({
+  tag: 'results-manager',
+  shadow: false,
+})
+export class ResultsManager {
+  public render() {
+    return <atomic-result-list></atomic-result-list>;
+  }
+}

--- a/packages/samples/stencil/src/pages/hsp.html
+++ b/packages/samples/stencil/src/pages/hsp.html
@@ -1,0 +1,68 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic in Stencil</title>
+    <link rel="stylesheet" href="/build/atomic/themes/coveo.css" />
+    <script type="module" src="/build/app.esm.js"></script>
+
+    <script>
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = 'https://static.cloud.coveo.com/atomic/v2/atomic.esm.js'; // fix: src="/build/atomic/atomic.esm.js"
+      document.head.appendChild(script);
+    </script>
+
+    <script>
+      (async () => {
+        await customElements.whenDefined('atomic-search-interface');
+        const searchInterface = document.querySelector('atomic-search-interface');
+
+        // Initialization
+        await searchInterface.initialize({
+          accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+          organizationId: 'searchuisamples',
+        });
+
+        // Trigger a first search
+        searchInterface.executeFirstSearch();
+      })();
+    </script>
+  </head>
+  <body>
+    <atomic-search-interface>
+      <atomic-search-layout>
+        <atomic-layout-section section="search">
+          <atomic-search-box></atomic-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facet-manager>
+            <atomic-facet field="filetype" label="Filetype"></atomic-facet>
+            <atomic-facet field="source" label="Source"></atomic-facet>
+          </atomic-facet-manager>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-layout-section section="status">
+            <atomic-breadbox></atomic-breadbox>
+            <atomic-query-summary></atomic-query-summary>
+            <atomic-refine-toggle></atomic-refine-toggle>
+            <atomic-sort-dropdown>
+              <atomic-sort-expression label="relevance" expression="relevancy"></atomic-sort-expression>
+              <atomic-sort-expression label="most-recent" expression="date descending"></atomic-sort-expression>
+            </atomic-sort-dropdown>
+            <atomic-did-you-mean></atomic-did-you-mean>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <results-manager></results-manager>
+            <atomic-query-error></atomic-query-error>
+            <atomic-no-results></atomic-no-results>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-load-more-results></atomic-load-more-results>
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-search-layout>
+    </atomic-search-interface>
+  </body>
+</html>

--- a/packages/samples/stencil/src/pages/hsp.html
+++ b/packages/samples/stencil/src/pages/hsp.html
@@ -10,7 +10,7 @@
     <script>
       const script = document.createElement('script');
       script.type = 'module';
-      script.src = 'https://static.cloud.coveo.com/atomic/v2/atomic.esm.js'; // fix: src="/build/atomic/atomic.esm.js"
+      script.src = '/build/atomic/atomic.esm.js';
       document.head.appendChild(script);
     </script>
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2313

Some context, we used the [custom event return value](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent#return_value) as a basis for when a component has been initialized properly or not (the event’s payload is an “initialize” callback. The return value is basically:

- false if event is cancelable, and at least one of the event handlers which received event called [Event.preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). We call prevent default from atomic-search-interface, for example/
- Otherwise true.

This is synchronous, if dealing with a simple DOM, like our basic search interfaces, this will always work. When we started to expose these custom events for our custom elements, we started to have issues with Stencil. When those events where dispatched from inside another Stencil component, they would reach the “atomic-search-interface” but with some delay, causing the dispatchEvent return value to be true. A typical race condition problem. We could argue that Stencil’s rendering inner workings is at fault, or that the method we used to make sure the component is initialized properly was not the best solution (flaky). https://github.com/coveo/ui-kit/pull/2242or we could have some sort of asynchronous polling method to check if init is called. 

TLDR: there is a false negative init error when using imbricated Stencil components.