### PR TITLE
fix: prevent focus trapping when outside of the focus scope

### DIFF
--- a/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
@@ -76,7 +76,7 @@ describe('Insight Panel test suites', () => {
     it('should display refine-modal', () => {
       InsightPanelsSelectors.refineToggle().click();
       InsightPanelsSelectors.refineModal().should('exist');
-      InsightPanelsSelectors.focusTrap().should('not.exist');
+      InsightPanelsSelectors.focusTrap().should('exist');
 
       InsightPanelsSelectors.filtersModal().should('have.attr', 'is-open');
 

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -253,6 +253,10 @@ export namespace Components {
          */
         "container"?: HTMLElement;
         /**
+          * The ancestor of the focus trap and of all the elements that should be hidden when inside the focus trap.
+         */
+        "scope": HTMLElement;
+        /**
           * Whether the element should be hidden from screen readers & not interactive with the tab, when not active.
          */
         "shouldHideSelf": boolean;
@@ -689,7 +693,6 @@ export namespace Components {
          */
         "container"?: HTMLElement;
         "isOpen": boolean;
-        "noFocusTrap": boolean;
         "source"?: HTMLElement;
     }
     interface AtomicIpxRefineModal {
@@ -756,7 +759,7 @@ export namespace Components {
         "container"?: HTMLElement;
         "fullscreen": boolean;
         "isOpen": boolean;
-        "noFocusTrap": boolean;
+        "scope"?: HTMLElement;
         "source"?: HTMLElement;
     }
     interface AtomicNoResults {
@@ -2921,6 +2924,10 @@ declare namespace LocalJSX {
          */
         "container"?: HTMLElement;
         /**
+          * The ancestor of the focus trap and of all the elements that should be hidden when inside the focus trap.
+         */
+        "scope"?: HTMLElement;
+        /**
           * Whether the element should be hidden from screen readers & not interactive with the tab, when not active.
          */
         "shouldHideSelf"?: boolean;
@@ -3335,7 +3342,6 @@ declare namespace LocalJSX {
          */
         "container"?: HTMLElement;
         "isOpen"?: boolean;
-        "noFocusTrap"?: boolean;
         "onAnimationEnded"?: (event: AtomicIpxModalCustomEvent<never>) => void;
         "source"?: HTMLElement;
     }
@@ -3403,8 +3409,8 @@ declare namespace LocalJSX {
         "container"?: HTMLElement;
         "fullscreen"?: boolean;
         "isOpen"?: boolean;
-        "noFocusTrap"?: boolean;
         "onAnimationEnded"?: (event: AtomicModalCustomEvent<never>) => void;
+        "scope"?: HTMLElement;
         "source"?: HTMLElement;
     }
     interface AtomicNoResults {

--- a/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
+++ b/packages/atomic/src/components/common/refine-modal/refine-modal-common.tsx
@@ -19,8 +19,8 @@ interface RefineModalCommonProps {
   };
   isOpen: boolean;
   openButton?: HTMLElement;
-  noFocusTrap?: boolean;
   boundary?: 'page' | 'element';
+  scope?: HTMLElement;
 }
 
 export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
@@ -94,8 +94,8 @@ export const RefineModalCommon: FunctionalComponent<RefineModalCommonProps> = (
         }
       }}
       exportparts={exportparts}
-      noFocusTrap={props.noFocusTrap}
       boundary={props.boundary}
+      scope={props.scope}
     >
       {renderHeader()}
       {...children}

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -157,7 +157,7 @@ export class AtomicInsightRefineModal
           querySummaryState={this.querySummaryState}
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
-          noFocusTrap
+          scope={this.bindings.interfaceElement}
         >
           {this.renderBody()}
         </RefineModalCommon>

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -39,7 +39,6 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
    */
   @Prop({mutable: true}) container?: HTMLElement;
   @Prop({reflect: true, mutable: true}) isOpen = false;
-  @Prop({reflect: true}) noFocusTrap = false;
 
   @Event() animationEnded!: EventEmitter<never>;
 
@@ -54,13 +53,13 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     if (isOpen) {
       document.body.classList.add(modalOpenedClass);
       if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
-        !this.noFocusTrap && (this.focusTrap!.active = true);
+        this.focusTrap!.active = true;
       }
       return;
     }
     document.body.classList.remove(modalOpenedClass);
     if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
-      !this.noFocusTrap && (this.focusTrap!.active = false);
+      this.focusTrap!.active = false;
     }
   }
 
@@ -102,19 +101,16 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     return (
       <Host class={this.getClasses().join(' ')}>
         <div part="backdrop">
-          {this.noFocusTrap ? (
+          <atomic-focus-trap
+            role="dialog"
+            aria-modal={this.isOpen.toString()}
+            source={this.source}
+            container={this.container ?? this.host}
+            ref={(ref) => (this.focusTrap = ref)}
+            scope={this.bindings.interfaceElement}
+          >
             <Body />
-          ) : (
-            <atomic-focus-trap
-              role="dialog"
-              aria-modal={this.isOpen.toString()}
-              source={this.source}
-              container={this.container ?? this.host}
-              ref={(ref) => (this.focusTrap = ref)}
-            >
-              <Body />
-            </atomic-focus-trap>
-          )}
+          </atomic-focus-trap>
         </div>
       </Host>
     );

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -124,7 +124,7 @@ export class AtomicIPXRefineModal implements InitializableComponent {
           title={this.bindings.i18n.t('filters')}
           openButton={this.openButton}
           boundary="element"
-          noFocusTrap
+          scope={this.bindings.interfaceElement}
         >
           {this.renderBody()}
         </RefineModalCommon>

--- a/packages/atomic/src/utils/accessibility-utils.tsx
+++ b/packages/atomic/src/utils/accessibility-utils.tsx
@@ -177,3 +177,9 @@ export function getFirstFocusableDescendant(
 ): HTMLElement | null {
   return getFocusableDescendants(element).next().value ?? null;
 }
+
+export function getLastFocusableDescendant(
+  element: Element
+): HTMLElement | null {
+  return [...getFocusableDescendants(element)]?.pop() ?? null;
+}


### PR DESCRIPTION
Adds back the focus trap component in all modals with a scope prop. Essentially, the focus trap will now prevent the focus to go to any component that are inside the host (child of the `atomic-focus-trap` component) but let the focus go to anything that is outside the scope (in most cases the scope will be the `atomic-search-interface` component). 

Tested with IPX and Insight Panels:

Insight Panel:


https://user-images.githubusercontent.com/64476861/221665309-c879b3d6-6a63-417b-9384-001c1730e005.mov


IPX:

https://user-images.githubusercontent.com/64476861/221665165-4ee8373b-9b69-43d0-9c7d-c0cfed5bfaa8.mov


