### PR TITLE
feat(atomic): add browser cond. export

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -10,6 +10,13 @@
   },
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
+  "exports": {
+    "." : {
+      "browser":"./dist/components/index.js",
+      "import":"./dist/index.js",
+      "require":"./dist/index.cjs.js"
+    }
+  },
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
This will allow users to use [conditions](https://nodejs.org/api/packages.html#resolving-user-conditions) to resolve `@coveo/atomic` differently.
We already did it for CJS/ESM with the `main` and `module` fields, but this adds another [community condition](https://nodejs.org/api/packages.html#community-conditions-definitions): browser.

`browser` will point towards the tree-shakeable version of the CLI, allowing the user to transpile/bundle/build its project using Atomic and have treeshaking, while having user-friendly import (i.e.  not `@coveo/atomic/dist/components/index.js` but `@coveo/atomic`)
