### PR TITLE
feat(atomic-hosted-page): add new atomic-simple-builder component

### DIFF
--- a/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
+++ b/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
@@ -1,11 +1,26 @@
 describe('smoke test', () => {
-  it('should load', () => {
+  it('should load atomic-hosted-page component', () => {
     cy.intercept({
       method: 'POST',
       path: '**/rest/ua/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3335/').wait('@analytics');
+    cy.get('atomic-search-box')
+      .should('exist')
+      .shadow()
+      .find('input')
+      .type('test{enter}');
+  });
+
+  // TODO: unskip smoke test
+  it.skip('should load atomic-simple-builder component', () => {
+    cy.intercept({
+      method: 'POST',
+      path: '**/rest/ua/v15/analytics/*',
+    }).as('analytics');
+
+    cy.visit('http://localhost:3335/simple-builder.html').wait('@analytics');
     cy.get('atomic-search-box')
       .should('exist')
       .shadow()

--- a/packages/atomic-hosted-page/src/components.d.ts
+++ b/packages/atomic-hosted-page/src/components.d.ts
@@ -7,7 +7,10 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface AtomicHostedPage {
-        "initialize": (options: AtomicPageInitializationOptions) => Promise<void>;
+        "initialize": (options: AtomicHostedPageInitializationOptions) => Promise<void>;
+    }
+    interface AtomicSimpleBuilder {
+        "initialize": (options: AtomicSimpleBuilderInitializationOptions) => Promise<void>;
     }
 }
 declare global {
@@ -17,15 +20,25 @@ declare global {
         prototype: HTMLAtomicHostedPageElement;
         new (): HTMLAtomicHostedPageElement;
     };
+    interface HTMLAtomicSimpleBuilderElement extends Components.AtomicSimpleBuilder, HTMLStencilElement {
+    }
+    var HTMLAtomicSimpleBuilderElement: {
+        prototype: HTMLAtomicSimpleBuilderElement;
+        new (): HTMLAtomicSimpleBuilderElement;
+    };
     interface HTMLElementTagNameMap {
         "atomic-hosted-page": HTMLAtomicHostedPageElement;
+        "atomic-simple-builder": HTMLAtomicSimpleBuilderElement;
     }
 }
 declare namespace LocalJSX {
     interface AtomicHostedPage {
     }
+    interface AtomicSimpleBuilder {
+    }
     interface IntrinsicElements {
         "atomic-hosted-page": AtomicHostedPage;
+        "atomic-simple-builder": AtomicSimpleBuilder;
     }
 }
 export { LocalJSX as JSX };
@@ -33,6 +46,7 @@ declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
             "atomic-hosted-page": LocalJSX.AtomicHostedPage & JSXBase.HTMLAttributes<HTMLAtomicHostedPageElement>;
+            "atomic-simple-builder": LocalJSX.AtomicSimpleBuilder & JSXBase.HTMLAttributes<HTMLAtomicSimpleBuilderElement>;
         }
     }
 }

--- a/packages/atomic-hosted-page/src/components/atomic-hosted-page/hosted-pages.ts
+++ b/packages/atomic-hosted-page/src/components/atomic-hosted-page/hosted-pages.ts
@@ -65,3 +65,44 @@ export interface HostedPageJavascriptFile {
    */
   url?: string;
 }
+
+export function processHostedPage(
+  element: HTMLElement,
+  hostedPage: HostedPage
+) {
+  element.innerHTML = hostedPage.html;
+  hostedPage.javascript?.forEach((file) => insertJS(file));
+  hostedPage.css?.forEach((file) => insertCSS(file));
+}
+
+function insertJS(file: HostedPageJavascriptFile) {
+  const script = document.createElement('script');
+  if (file.isModule) {
+    script.type = 'module';
+  }
+
+  if (file.url) {
+    script.src = file.url;
+  }
+
+  if (file.inlineContent) {
+    script.innerHTML = file.inlineContent;
+  }
+
+  document.head.appendChild(script);
+}
+
+function insertCSS(file: HostedPageCssFile) {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+
+  if (file.url) {
+    link.href = file.url;
+  }
+
+  if (file.inlineContent) {
+    link.innerHTML = file.inlineContent;
+  }
+
+  document.head.appendChild(link);
+}

--- a/packages/atomic-hosted-page/src/components/atomic-simple-builder/atomic-simple-builder.tsx
+++ b/packages/atomic-hosted-page/src/components/atomic-simple-builder/atomic-simple-builder.tsx
@@ -57,7 +57,7 @@ export class AtomicSimpleBuilder implements ComponentInterface {
 
     try {
       const pageResponse = await fetch(
-        `${platformUrl}/rest/organizations/${options.organizationId}/searchinterfaces/${options.interfaceId}/hostedpage`,
+        `${platformUrl}/rest/organizations/${options.organizationId}/searchinterfaces/${options.interfaceId}/hostedpage/v1`,
         {
           headers: {
             Authorization: `Bearer ${options.accessToken}`,

--- a/packages/atomic-hosted-page/src/components/atomic-simple-builder/atomic-simple-builder.tsx
+++ b/packages/atomic-hosted-page/src/components/atomic-simple-builder/atomic-simple-builder.tsx
@@ -1,12 +1,12 @@
 import {Schema, StringValue} from '@coveo/bueno';
 import {Component, ComponentInterface, Method, Element} from '@stencil/core';
-import {processHostedPage} from './hosted-pages';
+import {processHostedPage} from '../atomic-hosted-page/hosted-pages';
 
-interface AtomicHostedPageInitializationOptions {
+interface AtomicSimpleBuilderInitializationOptions {
   /**
-   * The unique identifier of the hosted page.
+   * The unique identifier of the search interface.
    */
-  pageId: string;
+  interfaceId: string;
   /**
    * The unique identifier of the target Coveo Cloud organization (e.g., `mycoveocloudorganizationg8tp8wu3`)
    */
@@ -24,22 +24,22 @@ interface AtomicHostedPageInitializationOptions {
 }
 
 /**
- * A Web Component used to inject a Coveo Hosted Search Page in the DOM.
- * Pulls from the [Hosted Pages API](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20Interface%20Service#/Hosted%20Page)
+ * A Web Component used to inject a [Coveo Search Interface made with the simple builder](https://docs.coveo.com/en/m7e92019/adobe/build-the-search-solution-using-a-coveo-ui-library-directly#search-interface-builder) in the DOM.
+ * Pulls from the [Search Interfaces API](https://platform.cloud.coveo.com/docs?urls.primaryName=Search%20Interface%20Service#/)
  * @internal
  */
 @Component({
-  tag: 'atomic-hosted-page',
+  tag: 'atomic-simple-builder',
   shadow: false,
 })
-export class AtomicHostedPage implements ComponentInterface {
+export class AtomicSimpleBuilder implements ComponentInterface {
   @Element() private element!: HTMLElement;
 
-  private validateOptions(opts: AtomicHostedPageInitializationOptions) {
+  private validateOptions(opts: AtomicSimpleBuilderInitializationOptions) {
     try {
       new Schema({
         organizationId: new StringValue({required: true, emptyAllowed: false}),
-        pageId: new StringValue({required: true, emptyAllowed: false}),
+        interfaceId: new StringValue({required: true, emptyAllowed: false}),
         accessToken: new StringValue({required: true, emptyAllowed: false}),
         platformUrl: new StringValue({required: false, emptyAllowed: false}),
       }).validate(opts);
@@ -49,7 +49,7 @@ export class AtomicHostedPage implements ComponentInterface {
   }
 
   @Method() public async initialize(
-    options: AtomicHostedPageInitializationOptions
+    options: AtomicSimpleBuilderInitializationOptions
   ) {
     this.validateOptions(options);
     const platformUrl =
@@ -57,7 +57,7 @@ export class AtomicHostedPage implements ComponentInterface {
 
     try {
       const pageResponse = await fetch(
-        `${platformUrl}/rest/organizations/${options.organizationId}/hostedpages/${options.pageId}`,
+        `${platformUrl}/rest/organizations/${options.organizationId}/searchinterfaces/${options.interfaceId}/hostedpage`,
         {
           headers: {
             Authorization: `Bearer ${options.accessToken}`,

--- a/packages/atomic-hosted-page/src/pages/simple-builder.html
+++ b/packages/atomic-hosted-page/src/pages/simple-builder.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Coveo Atomic Hosted Page</title>
+
+    <script type="module" src="/build/atomic-hosted-page.esm.js"></script>
+    <script>
+      (async () => {
+        await customElements.whenDefined('atomic-simple-builder');
+
+        const builder = document.querySelector('atomic-simple-builder');
+        /*
+          TODO: switch for following values when route in prod
+          interfaceId: '0c9eaa4a-8dab-4c11-83d6-24dd1feb961e',
+          accessToken: 'xx71d82ce9-f6fe-4be0-9209-c0e43f6fae81',
+          organizationId: 'searchuisamples',
+        */
+        await builder.initialize({
+          interfaceId: '45f9a933-b329-491e-bb15-64105eeea7e7',
+          accessToken: 'xx4bf05218-829b-4839-ab16-6ef044146909',
+          organizationId: 'hostedsearchpagetest5ftf64ka',
+          platformUrl: 'https://platformdev.cloud.coveo.com',
+        });
+      })();
+    </script>
+  </head>
+  <body>
+    <atomic-simple-builder></atomic-simple-builder>
+  </body>
+</html>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2335

Goes along with https://github.com/coveo/search-interface-service/pull/786

This pulls the new route, which takes a page made with the builder and inserts it into a customer's page, just like the hosted pages.

It was either adding a different config, or having a conditional config, so I decided to simply share some code and make a new component. Its ownership will be more clear and future-proof.

Open to different names...

Proof:
![Screen Shot 2023-03-07 at 2 56 29 PM](https://user-images.githubusercontent.com/4923043/223538237-67f075e4-80a4-4acb-8c08-6b59985597c7.png)
