### PR TITLE
fix(headless): add warning around partial state for search parameter manager

### DIFF
--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -1,3 +1,4 @@
+import {SearchAppState} from '../..';
 import {restoreSearchParameters} from '../../features/search-parameters/search-parameter-actions';
 import {initialSearchParameterSelector} from '../../features/search-parameters/search-parameter-selectors';
 import {executeSearch} from '../../features/search/search-actions';
@@ -23,6 +24,17 @@ import {
   SearchParameterManager,
   SearchParameterManagerProps,
 } from './headless-search-parameter-manager';
+
+jest.mock('pino', () => ({
+  ...jest.requireActual('pino'),
+  __esModule: true,
+  default: () => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  }),
+}));
 
 describe('search parameter manager', () => {
   let engine: MockSearchEngine;
@@ -275,6 +287,135 @@ describe('search parameter manager', () => {
       manager.synchronize({f: {author: [value2, value1]}});
 
       expect(engine.findAsyncAction(executeSearch.pending)).toBeFalsy();
+    });
+  });
+
+  describe('with missing state parameters', () => {
+    function deletePartOfState(stateKey: keyof SearchAppState) {
+      delete (engine.state as Partial<SearchAppState>)[stateKey];
+    }
+
+    it('warn when #advancedSearchQueries is missing', () => {
+      deletePartOfState('advancedSearchQueries');
+
+      manager.synchronize({cq: 'foo'});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('advancedSearchQueries')
+      );
+    });
+
+    it('warn when #query is missing', () => {
+      deletePartOfState('query');
+
+      manager.synchronize({q: 'foo'});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('query')
+      );
+    });
+
+    it('warn when #tabSet is missing', () => {
+      deletePartOfState('tabSet');
+
+      manager.synchronize({tab: 'foo'});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('tabSet')
+      );
+    });
+
+    it('warn when #tabSet is missing', () => {
+      deletePartOfState('sortCriteria');
+
+      manager.synchronize({sortCriteria: 'foo'});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('sortCriteria')
+      );
+    });
+
+    it('warn when #facetSet is missing', () => {
+      deletePartOfState('facetSet');
+
+      manager.synchronize({f: {foo: ['bar']}});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('facetSet')
+      );
+    });
+
+    it('warn when #categoryFacetSet is missing', () => {
+      deletePartOfState('categoryFacetSet');
+
+      manager.synchronize({cf: {foo: ['bar']}});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('categoryFacetSet')
+      );
+    });
+
+    it('warn when #numericFacetSet is missing', () => {
+      deletePartOfState('numericFacetSet');
+
+      manager.synchronize({
+        nf: {foo: [{start: 1, end: 2, endInclusive: false, state: 'selected'}]},
+      });
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('numericFacetSet')
+      );
+    });
+
+    it('warn when #categoryFacetSet is missing', () => {
+      deletePartOfState('categoryFacetSet');
+
+      manager.synchronize({
+        cf: {foo: ['bar']},
+      });
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('categoryFacetSet')
+      );
+    });
+
+    it('warn when #categoryFacetSet is missing', () => {
+      deletePartOfState('dateFacetSet');
+
+      manager.synchronize({
+        df: {
+          foo: [
+            {
+              start: '2000/01/01',
+              end: '2000/01/02',
+              endInclusive: false,
+              state: 'selected',
+            },
+          ],
+        },
+      });
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('dateFacetSet')
+      );
+    });
+
+    it('warn when #pagination is missing', () => {
+      deletePartOfState('pagination');
+
+      manager.synchronize({firstResult: 1234});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('pagination')
+      );
+    });
+
+    it('warn when #debug is missing', () => {
+      deletePartOfState('debug');
+
+      manager.synchronize({debug: true});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('debug')
+      );
+    });
+
+    it('warn when #staticFilterSet is missing', () => {
+      deletePartOfState('staticFilterSet');
+
+      manager.synchronize({sf: {foo: ['bar']}});
+      expect(engine.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('staticFilterSet')
+      );
     });
   });
 });

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -1,3 +1,4 @@
+import {Logger} from 'pino';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {getDebugInitialState} from '../../features/debug/debug-state';
 import {getPaginationInitialState} from '../../features/pagination/pagination-state';
@@ -17,6 +18,7 @@ import {
   SearchParameterManagerProps,
   SearchParameterManagerState,
   validateParams,
+  warnAndHintOnPartialState,
 } from '../core/search-parameter-manager/headless-core-search-parameter-manager';
 
 export type {
@@ -69,21 +71,30 @@ export function buildSearchParameterManager(
 }
 
 function getActiveSearchParameters(engine: SearchEngine): SearchParameters {
-  const state = engine.state;
+  const {state, logger} = engine;
   return {
     ...getCoreActiveSearchParameters(engine),
-    ...getEnableQuerySyntax(state),
-    ...getAq(state),
-    ...getCq(state),
-    ...getFirstResult(state),
-    ...getNumberOfResults(state),
-    ...getDebug(state),
-    ...getStaticFilters(state),
+    ...getEnableQuerySyntax(state, logger),
+    ...getAq(state, logger),
+    ...getCq(state, logger),
+    ...getFirstResult(state, logger),
+    ...getNumberOfResults(state, logger),
+    ...getDebug(state, logger),
+    ...getStaticFilters(state, logger),
   };
 }
 
-function getEnableQuerySyntax(state: Partial<SearchParametersState>) {
+function getEnableQuerySyntax(
+  state: Partial<SearchParametersState>,
+  logger: Logger
+) {
   if (state.query === undefined) {
+    warnAndHintOnPartialState(
+      'query',
+      'enableQuerySyntax',
+      'loadQueryActions',
+      logger
+    );
     return {};
   }
 
@@ -94,8 +105,14 @@ function getEnableQuerySyntax(state: Partial<SearchParametersState>) {
   return shouldInclude ? {enableQuerySyntax} : {};
 }
 
-function getAq(state: Partial<SearchParametersState>) {
+function getAq(state: Partial<SearchParametersState>, logger: Logger) {
   if (state.advancedSearchQueries === undefined) {
+    warnAndHintOnPartialState(
+      'advancedSearchQueries',
+      'aq',
+      'loadAdvancedSearchQueryActions',
+      logger
+    );
     return {};
   }
 
@@ -104,8 +121,14 @@ function getAq(state: Partial<SearchParametersState>) {
   return shouldInclude ? {aq} : {};
 }
 
-function getCq(state: Partial<SearchParametersState>) {
+function getCq(state: Partial<SearchParametersState>, logger: Logger) {
   if (state.advancedSearchQueries === undefined) {
+    warnAndHintOnPartialState(
+      'advancedSearchQueries',
+      'cq',
+      'loadAdvancedSearchQueryActions',
+      logger
+    );
     return {};
   }
 
@@ -114,8 +137,14 @@ function getCq(state: Partial<SearchParametersState>) {
   return shouldInclude ? {cq} : {};
 }
 
-function getFirstResult(state: Partial<SearchParametersState>) {
+function getFirstResult(state: Partial<SearchParametersState>, logger: Logger) {
   if (state.pagination === undefined) {
+    warnAndHintOnPartialState(
+      'pagination',
+      'firstResult',
+      'loadPaginationActions',
+      logger
+    );
     return {};
   }
 
@@ -124,8 +153,17 @@ function getFirstResult(state: Partial<SearchParametersState>) {
   return shouldInclude ? {firstResult} : {};
 }
 
-function getNumberOfResults(state: Partial<SearchParametersState>) {
+function getNumberOfResults(
+  state: Partial<SearchParametersState>,
+  logger: Logger
+) {
   if (state.pagination === undefined) {
+    warnAndHintOnPartialState(
+      'pagination',
+      'numberOfResults',
+      'loadPaginationActions',
+      logger
+    );
     return {};
   }
 
@@ -134,8 +172,17 @@ function getNumberOfResults(state: Partial<SearchParametersState>) {
   return shouldInclude ? {numberOfResults} : {};
 }
 
-function getStaticFilters(state: Partial<SearchParametersState>) {
+function getStaticFilters(
+  state: Partial<SearchParametersState>,
+  logger: Logger
+) {
   if (state.staticFilterSet === undefined) {
+    warnAndHintOnPartialState(
+      'staticFilterSet',
+      'staticFilter',
+      'loadStaticFilterSetActions',
+      logger
+    );
     return {};
   }
 
@@ -153,8 +200,9 @@ function getSelectedStaticFilterCaptions(values: StaticFilterValue[]) {
   return values.filter((v) => v.state === 'selected').map((v) => v.caption);
 }
 
-function getDebug(state: Partial<SearchParametersState>) {
+function getDebug(state: Partial<SearchParametersState>, logger: Logger) {
   if (state.debug === undefined) {
+    warnAndHintOnPartialState('debug', 'debug', 'loadDebugActions', logger);
     return {};
   }
 

--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -198,7 +198,7 @@ describe('field suggestions', () => {
     });
 
     it('can update captions', async () => {
-      const rawValue = 'pdf';
+      const rawValue = 'PDF';
       const displayValue = 'Portable Document Format';
       const query = 'doc';
       fieldSuggestions.updateCaptions({[rawValue]: displayValue});


### PR DESCRIPTION
Context:

Search parameter manager is a module that helps synchronize an object (typically parsed from an URL) representing what should be applied to headless as an initial state.

The code in that module cannot assume the feature(s) that are available on the engine when it tries to synchronize the parameters. 

It's typically the job of the various controller, and more precisely the `loadXYZActions` function we expose) to modify the engine and add the proper reducer at runtime.

The parameter manager also cannot load every reducer pre-emptively, since it would defeat the whole system we have in place to help tree shake Headless to it's minimum payload size.

This PR adds a warning that tries to be a helpful as possible to developers, telling them that a part of the search parameters can't be synchronized and which `load` function to use to modify the engine. 

https://coveord.atlassian.net/browse/KIT-2253