### PR TITLE
test(headless): fix failing test for field suggestions (again)

### DIFF
--- a/packages/headless/src/integration-tests/field-suggestions.test.ts
+++ b/packages/headless/src/integration-tests/field-suggestions.test.ts
@@ -198,9 +198,9 @@ describe('field suggestions', () => {
     });
 
     it('can update captions', async () => {
-      const rawValue = 'PDF';
-      const displayValue = 'Portable Document Format';
-      const query = 'doc';
+      const rawValue = 'lithiumboard';
+      const displayValue = 'Message board';
+      const query = 'mess';
       fieldSuggestions.updateCaptions({[rawValue]: displayValue});
       await waitForNextStateChange(fieldSuggestions, {
         action: () => fieldSuggestions.updateText(query),


### PR DESCRIPTION
Same test I had fixed (too) quickly last week.

I had a discussion about it with Jeremie on Slack.
Ultimately this should be improved a the search API level. It could cause issues for clients.
You can see the linked search API ticket in JIRA.

For the time being, we can change to an entirely different facet value for the test, linked to a specific source that is frozen in the sample org (so should not get random casing change).



https://coveord.atlassian.net/browse/KIT-2355