### PR TITLE
feat(quantic): Exposed the headless recommendations scripts in coveoHeadless static resources

### DIFF
--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -23,6 +23,10 @@ const main = async () => {
     {recursive: true}
   );
   await mkdir(
+    './force-app/main/default/staticresources/coveoheadless/browser/recommendation',
+    {recursive: true}
+  );
+  await mkdir(
     './force-app/main/default/staticresources/coveoheadless/definitions/',
     {recursive: true}
   );
@@ -46,6 +50,10 @@ const main = async () => {
   await copy(
     '../../node_modules/@coveo/headless/dist/browser/insight/headless.js',
     './force-app/main/default/staticresources/coveoheadless/browser/insight/headless.js'
+  );
+  await copy(
+    '../../node_modules/@coveo/headless/dist/browser/recommendation/headless.js',
+    './force-app/main/default/staticresources/coveoheadless/browser/recommendation/headless.js'
   );
   await copy(
     '../../node_modules/@coveo/headless/dist/definitions',

--- a/packages/quantic/coveo.d.ts
+++ b/packages/quantic/coveo.d.ts
@@ -1,5 +1,9 @@
 /* eslint-disable node/no-unpublished-import */
-import {InsightEngine, SearchEngine} from '@coveo/headless';
+import {
+  InsightEngine,
+  SearchEngine,
+  RecommendationEngine,
+} from '@coveo/headless';
 import {LightningElement} from 'lwc';
 import * as BuenoTypes from './force-app/main/default/staticresources/coveobueno/definitions/index';
 import {CoreEngine} from './force-app/main/default/staticresources/coveoheadless/definitions/app/engine';
@@ -7,17 +11,20 @@ import {ExternalEngineOptions} from './force-app/main/default/staticresources/co
 import * as HeadlessCaseAssistTypes from './force-app/main/default/staticresources/coveoheadless/definitions/case-assist.index';
 import * as HeadlessTypes from './force-app/main/default/staticresources/coveoheadless/definitions/index';
 import * as HeadlessInsightTypes from './force-app/main/default/staticresources/coveoheadless/definitions/insight.index';
+import * as HeadlessRecommendationTypes from './force-app/main/default/staticresources/coveoheadless/definitions/recommendation.index';
 
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/index';
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/case-assist.index';
 export * from './force-app/main/default/staticresources/coveoheadless/definitions/insight.index';
+export * from './force-app/main/default/staticresources/coveoheadless/definitions/recommendation.index';
 export * from './force-app/main/default/staticresources/coveobueno/definitions/index';
 
 interface Bindings {
   engine?:
     | HeadlessTypes<CoreEngine>
     | HeadlessCaseAssistTypes<CoreEngine>
-    | HeadlessInsightTypes<CoreEngine>;
+    | HeadlessInsightTypes<CoreEngine>
+    | HeadlessRecommendationTypes<CoreEngine>;
   store?: Record<String, unknown>;
 }
 
@@ -26,12 +33,14 @@ declare global {
   const CoveoHeadless: typeof HeadlessTypes;
   const CoveoHeadlessCaseAssist: typeof HeadlessCaseAssistTypes;
   const CoveoHeadlessInsight: typeof HeadlessInsightTypes;
+  const CoveoHeadlessRecommendation: typeof HeadlessRecommendationTypes;
   type AnyHeadless =
     | CoveoHeadless
     | CoveoHeadlessCaseAssist
-    | CoveoHeadlessInsight;
+    | CoveoHeadlessInsight
+    | CoveoHeadlessRecommendation;
 
-  type AnyEngine = SearchEngine | InsightEngine;
+  type AnyEngine = SearchEngine | InsightEngine | RecommendationEngine;
 
   interface Window {
     coveoHeadless: {

--- a/packages/quantic/force-app/main/default/.eslintrc.json
+++ b/packages/quantic/force-app/main/default/.eslintrc.json
@@ -6,6 +6,7 @@
     "CoveoHeadless": "readonly",
     "CoveoHeadlessCaseAssist": "readonly",
     "CoveoHeadlessInsight": "readonly",
+    "CoveoHeadlessRecommendation": "readonly",
     "Bueno": "readonly"
   },
   "overrides": [

--- a/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticHeadlessLoader/quanticHeadlessLoader.js
@@ -13,6 +13,7 @@ const HeadlessBundleNames = {
   search: 'search',
   caseAssist: 'case-assist',
   insight: 'insight',
+  recommendation: 'recommendation',
 };
 
 const headlessBundles = {
@@ -27,6 +28,10 @@ const headlessBundles = {
   [HeadlessBundleNames.insight]: {
     libPath: '/browser/insight/headless.js',
     bundle: () => CoveoHeadlessInsight,
+  },
+  [HeadlessBundleNames.recommendation]: {
+    libPath: '/browser/recommendation/headless.js',
+    bundle: () => CoveoHeadlessRecommendation,
   },
 };
 


### PR DESCRIPTION
[SFINT-4832](https://coveord.atlassian.net/browse/SFINT-4832)

Following this [discussion](https://discuss.coveo.com/t/include-recommendations-into-quantic-resources/9196), exposed the headless recommendation engine to coveoheadless static resources in quantic.



[SFINT-4832]: https://coveord.atlassian.net/browse/SFINT-4832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ