### PR TITLE
fix: update css to not hide error in ipx

### DIFF
--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -136,36 +136,16 @@
         inset: unset;
       }
 
-      atomic-search-interface:not(.atomic-search-interface-search-executed)
+      :is(atomic-search-interface:not(.atomic-search-interface-search-executed), atomic-search-interface:not(.atomic-search-interface-search-executed))
         > atomic-ipx-modal
         > div[slot='body']
         > atomic-layout-section
-        > atomic-result-list,
-      atomic-search-interface:not(.atomic-search-interface-search-executed)
-        > atomic-ipx-modal
-        > div[slot='body']
-        > atomic-layout-section
-        > atomic-query-summary,
-      atomic-search-interface:not(.atomic-search-interface-search-executed)
-        > atomic-ipx-embedded
-        > div[slot='body']
-        > atomic-layout-section
-        > atomic-result-list,
-      atomic-search-interface:not(.atomic-search-interface-search-executed)
-        > atomic-ipx-embedded
-        > div[slot='body']
-        > atomic-layout-section
-        > atomic-query-summary {
+        > :is(atomic-result-list, atomic-query-summary) {
         display: none;
       }
 
       atomic-search-interface.atomic-search-interface-search-executed
-        > atomic-ipx-modal
-        > div[slot='body']
-        > atomic-recs-interface
-        > atomic-recs-list,
-      atomic-search-interface.atomic-search-interface-search-executed
-        > atomic-ipx-embedded
+        > :is(atomic-ipx-modal, atomic-ipx-embedded)
         > div[slot='body']
         > atomic-recs-interface
         > atomic-recs-list {

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -137,7 +137,7 @@
       }
 
       :is(atomic-search-interface:not(.atomic-search-interface-search-executed), atomic-search-interface:not(.atomic-search-interface-search-executed))
-        > atomic-ipx-modal
+        > :is(atomic-ipx-modal, atomic-ipx-embedded)
         > div[slot='body']
         > atomic-layout-section
         > :is(atomic-result-list, atomic-query-summary) {

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -139,11 +139,23 @@
       atomic-search-interface:not(.atomic-search-interface-search-executed)
         > atomic-ipx-modal
         > div[slot='body']
-        > atomic-layout-section,
+        > atomic-layout-section
+        > atomic-result-list,
+      atomic-search-interface:not(.atomic-search-interface-search-executed)
+        > atomic-ipx-modal
+        > div[slot='body']
+        > atomic-layout-section
+        > atomic-query-summary,
       atomic-search-interface:not(.atomic-search-interface-search-executed)
         > atomic-ipx-embedded
         > div[slot='body']
-        > atomic-layout-section {
+        > atomic-layout-section
+        > atomic-result-list,
+      atomic-search-interface:not(.atomic-search-interface-search-executed)
+        > atomic-ipx-embedded
+        > div[slot='body']
+        > atomic-layout-section
+        > atomic-query-summary {
         display: none;
       }
 

--- a/packages/atomic/src/utils/initialization-utils.spec.ts
+++ b/packages/atomic/src/utils/initialization-utils.spec.ts
@@ -144,7 +144,7 @@ describe('BindStateToController decorator', () => {
     component.initialize!();
 
     expect(console.error).toHaveBeenCalledWith(
-      'ControllerState: The "initialize" method has to be defined and instanciate a controller for the property controller',
+      'ControllerState: The "initialize" method has to be defined and instantiate a controller for the property controller',
       component
     );
   });

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -262,7 +262,7 @@ export function BindStateToController(
 
       if (!initialize) {
         return console.error(
-          `ControllerState: The "initialize" method has to be defined and instanciate a controller for the property ${controllerProperty}`,
+          `ControllerState: The "initialize" method has to be defined and instantiate a controller for the property ${controllerProperty}`,
           component
         );
       }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCINT-2157

Little issue with some css blocking the display of the query error component, updated the rules to unhide it !

Before with errors:
https://user-images.githubusercontent.com/71142397/225121137-b84883b6-b60a-46dc-b78e-f4b6c57db34b.mov

After without errors:
https://user-images.githubusercontent.com/71142397/225121425-e498b8dc-023d-4073-a776-632034e9225a.mov

After with errors:
https://user-images.githubusercontent.com/71142397/225121491-c5213d7b-48af-4954-b6c8-eeb54818b80d.mov



