### PR TITLE
fix: hide footer when empty

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -661,6 +661,7 @@ export namespace Components {
         "withDatePicker": boolean;
     }
     interface AtomicIpxBody {
+        "displayFooterSlot": boolean;
         "isOpen": boolean;
     }
     interface AtomicIpxButton {
@@ -3321,6 +3322,7 @@ declare namespace LocalJSX {
         "withDatePicker"?: boolean;
     }
     interface AtomicIpxBody {
+        "displayFooterSlot"?: boolean;
         "isOpen"?: boolean;
         "onAnimationEnded"?: (event: AtomicIpxBodyCustomEvent<never>) => void;
     }

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -33,6 +33,8 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
 
   @Prop() isOpen = true;
 
+  @Prop({reflect: true}) displayFooterSlot = true;
+
   public componentDidLoad() {
     const id = this.host.id || randomID('atomic-ipx-body-');
     this.host.id = id;
@@ -65,7 +67,9 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
         </div>
         <footer
           part="footer-wrapper"
-          class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
+          class={`border-neutral border-t bg-background z-10 flex flex-col items-center w-full ${
+            this.displayFooterSlot ? 'visible' : 'invisible'
+          }`}
         >
           <div part="footer" class="max-w-lg">
             <slot name="footer"></slot>

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -65,16 +65,16 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
             <slot name="body"></slot>
           </div>
         </div>
-        <footer
-          part="footer-wrapper"
-          class={`border-neutral border-t bg-background z-10 flex flex-col items-center w-full ${
-            this.displayFooterSlot ? 'visible' : 'invisible'
-          }`}
-        >
-          <div part="footer" class="max-w-lg">
-            <slot name="footer"></slot>
-          </div>
-        </footer>
+        {this.displayFooterSlot && (
+          <footer
+            part="footer-wrapper"
+            class="border-neutral border-t bg-background z-10 flex flex-col items-center w-full"
+          >
+            <div part="footer" class="max-w-lg">
+              <slot name="footer"></slot>
+            </div>
+          </footer>
+        )}
       </article>
     );
   }

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.tsx
@@ -37,6 +37,12 @@ export class AtomicIPXEmbedded implements InitializableComponent<AnyBindings> {
 
   @Event() animationEnded!: EventEmitter<never>;
 
+  @State() private hasFooterSlotElements = true;
+
+  public componentWillLoad(): void | Promise<void> {
+    this.hasFooterSlotElements = !!this.host.querySelector('[slot="footer"]');
+  }
+
   public componentDidLoad() {
     const id = this.host.id || randomID('atomic-ipx-embedded-');
     this.host.id = id;
@@ -50,7 +56,7 @@ export class AtomicIPXEmbedded implements InitializableComponent<AnyBindings> {
     return (
       <Host>
         <div part="backdrop">
-          <atomic-ipx-body>
+          <atomic-ipx-body displayFooterSlot={this.hasFooterSlotElements}>
             <slot name="header" slot="header" />
             <slot name="body" slot="body" />
             <slot name="footer" slot="footer" />

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -42,9 +42,10 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
   @Event() animationEnded!: EventEmitter<never>;
 
+  @State() private hasFooterSlotElements = true;
+
   private focusTrap?: HTMLAtomicFocusTrapElement;
   private currentWatchToggleOpenExecution = 0;
-  private hasFooterSlotElements = true;
 
   @Watch('isOpen')
   async watchToggleOpen(isOpen: boolean) {

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -44,6 +44,7 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
   private focusTrap?: HTMLAtomicFocusTrapElement;
   private currentWatchToggleOpenExecution = 0;
+  private hasFooterSlotElements = true;
 
   @Watch('isOpen')
   async watchToggleOpen(isOpen: boolean) {
@@ -79,6 +80,10 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     this.isOpen && e.preventDefault();
   }
 
+  public componentWillLoad(): void | Promise<void> {
+    this.hasFooterSlotElements = !!this.host.querySelector('[slot="footer"]');
+  }
+
   public componentDidLoad() {
     const id = this.host.id || randomID('atomic-ipx-modal-');
     this.host.id = id;
@@ -91,7 +96,10 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     this.updateBreakpoints();
 
     const Body = () => (
-      <atomic-ipx-body isOpen={this.isOpen}>
+      <atomic-ipx-body
+        isOpen={this.isOpen}
+        displayFooterSlot={this.hasFooterSlotElements}
+      >
         <slot name="header" slot="header" />
         <slot name="body" slot="body" />
         <slot name="footer" slot="footer" />


### PR DESCRIPTION
[SVCINT-2179](https://coveord.atlassian.net/browse/SVCINT-2179)

This PR adds a check inside `atomic-ipx-modal` that looks for elements mounted inside the `footer` slot. If none are found, a prop is set on the `atomic-ipx-body` which hides the footer wrapper.

I tried to find a pure CSS solution, but there doesn't seem to be one... [yet](https://github.com/WICG/webcomponents/issues/701#issuecomment-368430226) 

[SVCINT-2179]: https://coveord.atlassian.net/browse/SVCINT-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ