### PR TITLE
fix(quantic): fixed a problem with the quantic tab bar component when there is no active tab

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTabBar/quanticTabBar.js
@@ -193,6 +193,7 @@ export default class QuanticTabBar extends LightningElement {
       this.container.getBoundingClientRect().right;
     const selectedTabRelativeRightPosition =
       this.selectedTab?.getBoundingClientRect().right;
+
     return this.getTabsFromSlot().filter((element) => {
       const tabPositionedBeforeSelectedTab =
         selectedTabRelativeRightPosition >


### PR DESCRIPTION
[SFINT-4919](https://coveord.atlassian.net/browse/SFINT-4919)

When no active tab has been specified in the Quantic Tab Bar component like so:
```
<c-quantic-tab-bar>
  <c-quantic-tab label="All" engine-id={engineId}></c-quantic-tab>
  <c-quantic-tab label="Articles" expression="exampleExpression" engine-id={engineId}>
</c-quantic-tab>
```
the following occurs in the Salesforce Community Builder:

![938a1655cf3771272f7c28f98182eed2ddf6496e (1)](https://user-images.githubusercontent.com/86681870/226926113-4f80b8e9-ed94-42d7-9080-1ef495954d7a.png)

note: The issue occurs only in the Salesforce Community Builder and not in the community page because after initializing the page, the active tab is selected by default and the issue disappear.


[SFINT-4919]: https://coveord.atlassian.net/browse/SFINT-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ