### PR TITLE
doc(quantic): added internal jsdoc tag

### DIFF
--- a/packages/quantic/docs/jsdoc-guidelines.md
+++ b/packages/quantic/docs/jsdoc-guidelines.md
@@ -30,6 +30,7 @@ Each component should be given one or more category values using the `@category`
 - **Insight Panel**: Components pertaining to the Insight Panel use case
 - **Result Template**: Components meant to be used within result templates.
 - **Utility**: Components providing a generic utility without pertaining to any specific Coveo Headless use-case.
+- **Internal** Components that are not to be publicly documented.
   If there are more than one relevant category, each should be specified with its own tag.
   If a new category is required it should be discussed with the code owners and adjustements must be made to the parsing script.
 

--- a/packages/quantic/docs/template/lwc-json/publish.js
+++ b/packages/quantic/docs/template/lwc-json/publish.js
@@ -115,6 +115,7 @@ const categoryMap = {
   caseAssist: 'Case Assist',
   utility: 'Utility',
   insightPanel: 'Insight Panel',
+  internal: 'Internal',
 };
 
 function parseClass(element, parentNode, childNodes) {
@@ -141,9 +142,14 @@ function parseClass(element, parentNode, childNodes) {
     },
   };
 
+  if (thisClass.categories.includes(categoryMap.internal)) {
+    return;
+  }
+
   const categoryKeys = Object.keys(categoryMap).filter((key) =>
     thisClass.categories.includes(categoryMap[key])
   );
+
   if (!categoryKeys.length) {
     throw new Error(
       `JsDoc parsing FAILED: Invalid or missing category value(s) on component ${thisClass.name}.`


### PR DESCRIPTION
Added an "Internal" category to be used to exclude quantic components from the generated doc.