### PR TITLE
fix(atomic): made smart snippet source title re-render when changed (#2795

### DIFF
--- a/packages/atomic/cypress/e2e/smart-snippet-actions.ts
+++ b/packages/atomic/cypress/e2e/smart-snippet-actions.ts
@@ -1,6 +1,14 @@
 import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
 import {toArray} from '../utils/arrayUtils';
 
+export interface AddSmartSnippetMockSnippet {
+  question: string;
+  answer: string;
+  sourceTitle: string;
+  sourceUrl: string;
+  id: string;
+}
+
 export interface AddSmartSnippetOptions {
   remSize?: number;
   props?: {
@@ -10,32 +18,56 @@ export interface AddSmartSnippetOptions {
     'snippet-style'?: string;
   };
   content?: HTMLElement | HTMLElement[];
-  question?: string;
-  answer?: string;
-  sourceTitle?: string;
-  sourceUrl?: string;
+  snippet?: AddSmartSnippetMockSnippet;
 }
+
+export const defaultSnippets = [
+  {
+    question: 'Where does the name "Nurse Sharks" come from?',
+    answer: `
+  <p>
+    The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the <a href="https://en.wikipedia.org/wiki/Catshark">catsharks</a> of the family Scyliorhinidae.
+  </p>
+  <p>
+    The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the <a href="https://en.wikipedia.org/wiki/Greek_language">Greek</a> words <i>ginglymos</i> (<a href="https://en.wiktionary.org/wiki/%CE%B3%CE%AF%CE%B3%CE%B3%CE%BB%CF%85%CE%BC%CE%BF%CF%82#Ancient_Greek">γίγγλυμος</a>) meaning "<b>hinge</b>" and <i>stoma</i> (<a href="https://en.wiktionary.org/wiki/%CF%83%CF%84%CF%8C%CE%BC%CE%B1#Ancient_Greek">στόμα</a>) meaning "<b>mouth</b>". 
+  </p>
+`,
+    sourceTitle: 'Nurse Sharks',
+    sourceUrl: 'https://www.inaturalist.org/taxa/49968',
+    id: 'nurse-sharks',
+  },
+  {
+    question: 'What are sea monkeys?',
+    answer: `
+  <p>
+    Breeds of Artemia are sold as novelty gifts under the marketing name <a href="https://en.wikipedia.org/wiki/Sea-Monkeys">Sea-Monkeys</a>. 
+  </p>
+  <p>
+    <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. It is the only genus in the <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> <b>Artemiidae</b>.
+  </p>
+`,
+    sourceTitle: 'Brine Shrimp',
+    sourceUrl: 'https://www.inaturalist.org/taxa/86651',
+    id: 'brine-shrimp',
+  },
+  {
+    question: 'What is a dove snail?',
+    answer: `
+  <p>
+    The <b>Columbellidae</b>, the dove snails or dove shells, are a <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> of minute to small <a href="https://en.wikipedia.org/wiki/Sea_snail">sea snails</a>, <a href="https://en.wikipedia.org/wiki/Marine_(ocean)">marine</a> <a href="https://en.wikipedia.org/wiki/Gastropod">gastropod</a> <a href="https://en.wikipedia.org/wiki/Mollusk">mollusks</a> in the order <a href="https://en.wikipedia.org/wiki/Neogastropoda">Neogastropoda</a>.
+  </p>
+`,
+    sourceTitle: 'Dove Snails',
+    sourceUrl: 'https://www.inaturalist.org/taxa/50704',
+    id: 'dove-snail',
+  },
+];
 
 export const addSmartSnippetDefaultOptions: Required<AddSmartSnippetOptions> = {
   remSize: 12,
   props: {},
   content: [],
-  question: 'Creating an In-Product Experience (IPX)',
-  answer: `
-    <ol>
-      <li>On the <a href="https://platform.cloud.coveo.com/admin/#/orgid/search/in-app-widgets/">In-Product Experiences</a> page, click Add <b>In-Product Experience</b>.</li>
-      <li>In the Configuration tab, fill the Basic settings section.</li>
-      <li>(Optional) Use the Design and Content access tabs to <a href="https://docs.coveo.com/en/3160/#customizing-an-ipx-interface">customize your <b>IPX</b> interface</a>.</li>
-      <li>Click Save.</li>
-      <li>In the Loader snippet panel that appears, you may click Copy to save the loader snippet for your <b>IPX</b> to your clipboard, and then click Save.  You can Always retrieve the loader snippet later.</li>
-    </ol>
-
-    <p>
-      You're now ready to <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications">embed your IPX interface</a>. However, we recommend that you <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#configuring-query-pipelines-for-an-ipx-interface-recommended">configure query pipelines for your IPX interface</a> before.
-    </p>
-  `,
-  sourceTitle: 'Manage the Coveo In-Product Experiences (IPX)',
-  sourceUrl: 'https://docs.coveo.com/en/3160',
+  snippet: defaultSnippets[0],
 };
 
 export const addSmartSnippet =
@@ -57,17 +89,18 @@ export const addSmartSnippet =
       .withElement(element)
       .withCustomResponse((response) => {
         const [result] = response.results;
-        result.title =
-          options.sourceTitle ?? addSmartSnippetDefaultOptions.sourceTitle;
-        result.clickUri =
-          options.sourceUrl ?? addSmartSnippetDefaultOptions.sourceUrl;
+        const snippet =
+          options.snippet ?? addSmartSnippetDefaultOptions.snippet;
+        result.title = snippet.sourceTitle;
+        result.clickUri = snippet.sourceUrl;
+        result.uniqueId = JSON.stringify(snippet);
         response.questionAnswer = {
           documentId: {
             contentIdKey: 'permanentid',
             contentIdValue: result.raw.permanentid!,
           },
-          question: options.question ?? addSmartSnippetDefaultOptions.question,
-          answerSnippet: options.answer ?? addSmartSnippetDefaultOptions.answer,
+          question: snippet.question,
+          answerSnippet: snippet.answer,
           relatedQuestions: [],
           score: 1337,
         };

--- a/packages/atomic/cypress/e2e/smart-snippet-suggestions-actions.ts
+++ b/packages/atomic/cypress/e2e/smart-snippet-suggestions-actions.ts
@@ -1,23 +1,18 @@
-import {
-  generateComponentHTML,
-  SearchResponseModifierPredicate,
-  TestFixture,
-} from '../fixtures/test-fixture';
+import {SearchResponseModifierPredicate} from '../fixtures/fixture-common';
+import {generateComponentHTML, TestFixture} from '../fixtures/test-fixture';
 import {toArray} from '../utils/arrayUtils';
-import {addSmartSnippetDefaultOptions} from './smart-snippet-actions';
+import {
+  addSmartSnippetDefaultOptions,
+  AddSmartSnippetMockSnippet,
+  defaultSnippets,
+} from './smart-snippet-actions';
 
-export interface GetResponseModifierWithSmartSnippetSuggestionsOptions {
-  relatedQuestions?: {
-    question: string;
-    answer: string;
-    sourceTitle: string;
-    sourceUrl: string;
-    id: string;
-  }[];
+export interface AddSmartSnippetSuggestionsMockRelatedQuestions {
+  relatedQuestions?: AddSmartSnippetMockSnippet[];
 }
 
 export interface AddSmartSnippetSuggestionsOptions
-  extends GetResponseModifierWithSmartSnippetSuggestionsOptions {
+  extends AddSmartSnippetSuggestionsMockRelatedQuestions {
   remSize?: number;
   props?: {
     'heading-level'?: number;
@@ -27,49 +22,9 @@ export interface AddSmartSnippetSuggestionsOptions
   timesToIntercept?: number;
 }
 
-export const getResponseModifierWithSmartSnippetSuggestionsDefaultOptions: Required<GetResponseModifierWithSmartSnippetSuggestionsOptions> =
+export const getResponseModifierWithSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetSuggestionsMockRelatedQuestions> =
   {
-    relatedQuestions: [
-      {
-        question: 'Where does the name "Nurse Sharks" come from?',
-        answer: `
-      <p>
-        The name nurse shark is thought to be a corruption of <b>nusse</b>, a name which once referred to the <a href="https://en.wikipedia.org/wiki/Catshark">catsharks</a> of the family Scyliorhinidae.
-      </p>
-      <p>
-        The nurse shark family name, <b>Ginglymostomatidae</b>, derives from the <a href="https://en.wikipedia.org/wiki/Greek_language">Greek</a> words <i>ginglymos</i> (<a href="https://en.wiktionary.org/wiki/%CE%B3%CE%AF%CE%B3%CE%B3%CE%BB%CF%85%CE%BC%CE%BF%CF%82#Ancient_Greek">γίγγλυμος</a>) meaning "<b>hinge</b>" and <i>stoma</i> (<a href="https://en.wiktionary.org/wiki/%CF%83%CF%84%CF%8C%CE%BC%CE%B1#Ancient_Greek">στόμα</a>) meaning "<b>mouth</b>". 
-      </p>
-    `,
-        sourceTitle: 'Nurse Sharks',
-        sourceUrl: 'https://www.inaturalist.org/taxa/49968',
-        id: 'nurse-sharks',
-      },
-      {
-        question: 'What are sea monkeys?',
-        answer: `
-      <p>
-        Breeds of Artemia are sold as novelty gifts under the marketing name <a href="https://en.wikipedia.org/wiki/Sea-Monkeys">Sea-Monkeys</a>. 
-      </p>
-      <p>
-        <b>Artemia</b> is a genus of aquatic crustaceans also known as <b>brine shrimp</b>. It is the only genus in the <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> <b>Artemiidae</b>.
-      </p>
-    `,
-        sourceTitle: 'Brine Shrimp',
-        sourceUrl: 'https://www.inaturalist.org/taxa/86651',
-        id: 'brine-shrimp',
-      },
-      {
-        question: 'What is a dove snail?',
-        answer: `
-      <p>
-        The <b>Columbellidae</b>, the dove snails or dove shells, are a <a href="https://en.wikipedia.org/wiki/Family_(biology)">family</a> of minute to small <a href="https://en.wikipedia.org/wiki/Sea_snail">sea snails</a>, <a href="https://en.wikipedia.org/wiki/Marine_(ocean)">marine</a> <a href="https://en.wikipedia.org/wiki/Gastropod">gastropod</a> <a href="https://en.wikipedia.org/wiki/Mollusk">mollusks</a> in the order <a href="https://en.wikipedia.org/wiki/Neogastropoda">Neogastropoda</a>.
-      </p>
-    `,
-        sourceTitle: 'Dove Snails',
-        sourceUrl: 'https://www.inaturalist.org/taxa/50704',
-        id: 'dove-snail',
-      },
-    ],
+    relatedQuestions: defaultSnippets,
   };
 
 export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetSuggestionsOptions> =
@@ -82,7 +37,7 @@ export const addSmartSnippetSuggestionsDefaultOptions: Required<AddSmartSnippetS
   };
 
 export const getResponseModifierWithSmartSnippetSuggestions: (
-  options: GetResponseModifierWithSmartSnippetSuggestionsOptions
+  options: AddSmartSnippetSuggestionsMockRelatedQuestions
 ) => SearchResponseModifierPredicate = (options) => (response) => {
   const relatedQuestions =
     options.relatedQuestions ??
@@ -96,14 +51,15 @@ export const getResponseModifierWithSmartSnippetSuggestions: (
       ...firstResult.raw,
       permanentid: relatedQuestion.id,
     },
+    uniqueId: JSON.stringify(relatedQuestion),
   }));
   response.questionAnswer = {
     documentId: {
       contentIdKey: 'permanentid',
       contentIdValue: firstResult.raw.permanentid!,
     },
-    question: addSmartSnippetDefaultOptions.question,
-    answerSnippet: addSmartSnippetDefaultOptions.answer,
+    question: addSmartSnippetDefaultOptions.snippet.question,
+    answerSnippet: addSmartSnippetDefaultOptions.snippet.answer,
     relatedQuestions: relatedQuestions.map((relatedQuestion, i) => ({
       documentId: {
         contentIdKey: 'permanentid',

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-source.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet-source.tsx
@@ -71,6 +71,7 @@ export class AtomicSmartSnippetSource implements InitializableComponent {
           <atomic-result-text
             field="title"
             default="no-title"
+            key={this.source.uniqueId}
           ></atomic-result-text>
         </LinkWithResultAnalytics>
       </Host>

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -191,6 +191,31 @@ export class AtomicSmartSnippet implements InitializableComponent {
     );
   }
 
+  private renderFooter() {
+    const {source} = this.smartSnippetState;
+
+    return (
+      <footer
+        part="footer"
+        aria-label={this.bindings.i18n.t('smart-snippet-source')}
+      >
+        {source && (
+          <atomic-smart-snippet-source
+            source={source}
+            onSelectSource={() => this.smartSnippet.selectSource()}
+            onBeginDelayedSelectSource={() =>
+              this.smartSnippet.beginDelayedSelectSource()
+            }
+            onCancelPendingSelectSource={() =>
+              this.smartSnippet.cancelPendingSelectSource()
+            }
+          ></atomic-smart-snippet-source>
+        )}
+        {this.renderFeedbackBanner()}
+      </footer>
+    );
+  }
+
   public componentWillUpdate() {
     if (!(this.smartSnippetState.liked || this.smartSnippetState.disliked)) {
       this.feedbackSent = false;
@@ -223,24 +248,7 @@ export class AtomicSmartSnippet implements InitializableComponent {
         >
           {this.renderQuestion()}
           {this.renderContent()}
-          <footer
-            part="footer"
-            aria-label={this.bindings.i18n.t('smart-snippet-source')}
-          >
-            {this.smartSnippetState.source && (
-              <atomic-smart-snippet-source
-                source={this.smartSnippetState.source}
-                onSelectSource={() => this.smartSnippet.selectSource()}
-                onBeginDelayedSelectSource={() =>
-                  this.smartSnippet.beginDelayedSelectSource()
-                }
-                onCancelPendingSelectSource={() =>
-                  this.smartSnippet.cancelPendingSelectSource()
-                }
-              ></atomic-smart-snippet-source>
-            )}
-            {this.renderFeedbackBanner()}
-          </footer>
+          {this.renderFooter()}
         </article>
       </aside>
     );

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -191,31 +191,6 @@ export class AtomicSmartSnippet implements InitializableComponent {
     );
   }
 
-  private renderFooter() {
-    const {source} = this.smartSnippetState;
-
-    return (
-      <footer
-        part="footer"
-        aria-label={this.bindings.i18n.t('smart-snippet-source')}
-      >
-        {source && (
-          <atomic-smart-snippet-source
-            source={source}
-            onSelectSource={() => this.smartSnippet.selectSource()}
-            onBeginDelayedSelectSource={() =>
-              this.smartSnippet.beginDelayedSelectSource()
-            }
-            onCancelPendingSelectSource={() =>
-              this.smartSnippet.cancelPendingSelectSource()
-            }
-          ></atomic-smart-snippet-source>
-        )}
-        {this.renderFeedbackBanner()}
-      </footer>
-    );
-  }
-
   public componentWillUpdate() {
     if (!(this.smartSnippetState.liked || this.smartSnippetState.disliked)) {
       this.feedbackSent = false;
@@ -248,7 +223,24 @@ export class AtomicSmartSnippet implements InitializableComponent {
         >
           {this.renderQuestion()}
           {this.renderContent()}
-          {this.renderFooter()}
+          <footer
+            part="footer"
+            aria-label={this.bindings.i18n.t('smart-snippet-source')}
+          >
+            {this.smartSnippetState.source && (
+              <atomic-smart-snippet-source
+                source={this.smartSnippetState.source}
+                onSelectSource={() => this.smartSnippet.selectSource()}
+                onBeginDelayedSelectSource={() =>
+                  this.smartSnippet.beginDelayedSelectSource()
+                }
+                onCancelPendingSelectSource={() =>
+                  this.smartSnippet.cancelPendingSelectSource()
+                }
+              ></atomic-smart-snippet-source>
+            )}
+            {this.renderFeedbackBanner()}
+          </footer>
         </article>
       </aside>
     );


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2237

I also refactored the default snippets test logic, and I made sure that analytics tests are contained within `beforeEach` blocks because they were flaky.