### PR TITLE
fix(quantic): fixed a problem when deselecting breadcrumb values 

### DIFF
--- a/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager-actions.ts
+++ b/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager-actions.ts
@@ -25,6 +25,13 @@ function breadcrumbManagerActions(selector: BreadcrumbManagerSelector) {
         .click({force: true})
         .logAction('when clicking the first value numeric facet breadcrumb');
     },
+    clickFirstValueFacetBreadcrumb: () => {
+      selector
+        .facet()
+        .firstBreadcrumbValueLabel()
+        .click({force: true})
+        .logAction('when clicking the first value facet breadcrumb');
+    },
     clickCategoryFacetBreadcrumb: () => {
       selector
         .categoryFacet()

--- a/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager-selectors.ts
+++ b/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager-selectors.ts
@@ -10,7 +10,7 @@ export interface BreadcrumbSelector extends ComponentSelector {
   firstBreadcrumbAltText: () => CypressSelector;
 }
 
-interface BreadcrumbManagerSelector extends ComponentSelector {
+export interface BreadcrumbManagerSelector extends ComponentSelector {
   facet: () => BreadcrumbSelector;
   categoryFacet: () => BreadcrumbSelector;
   numericFacet: () => BreadcrumbSelector;

--- a/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/breadcrumb-manager/breadcrumb-manager.cypress.ts
@@ -27,6 +27,7 @@ describe('quantic-breadcrumb-manager', () => {
     useCase: string;
     categoryDivider: string;
     collapseThreshold: number;
+    displayFacetValuesAs: 'link' | 'checkbox';
   }
 
   function visitBreadcrumbManager(
@@ -205,6 +206,41 @@ describe('quantic-breadcrumb-manager', () => {
             cy.wait(getQueryAlias(param.useCase));
 
             Expect.facetBreadcrumb.numberOfValues(1);
+          });
+        });
+      });
+
+      describe('when facet values are displayed as checkboxes', () => {
+        it('should properly display the breadcrumb values', () => {
+          visitBreadcrumbManager({
+            useCase: param.useCase,
+            displayFacetValuesAs: 'checkbox',
+          });
+
+          scope('when selecting values in facet', () => {
+            cy.then(Actions.facet.selectFirstLinkValue)
+              .wait(InterceptAliases.UA.Facet.Select)
+              .then((interception) => {
+                Expect.facetBreadcrumb.firstBreadcrumbValueLabelContains(
+                  interception.request.body.customData.facetValue
+                );
+              });
+            Expect.facetBreadcrumb.displayBreadcrumb(true);
+            Expect.facetBreadcrumb.labelContains('File Type');
+            Expect.facetBreadcrumb.displayValues(true);
+            Expect.facetBreadcrumb.numberOfValues(1);
+            Actions.facet.clickShowMoreButton();
+            cy.wait(getQueryAlias(param.useCase));
+            Actions.facet.selectLastLinkValue();
+            cy.wait(getQueryAlias(param.useCase));
+            Expect.facetBreadcrumb.numberOfValues(2);
+          });
+
+          scope('when clearing the values', () => {
+            Actions.clickFirstValueFacetBreadcrumb();
+            Expect.facetBreadcrumb.numberOfValues(1);
+            Actions.clickFirstValueFacetBreadcrumb();
+            Expect.facetBreadcrumb.displayBreadcrumb(false);
           });
         });
       });

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticBreadcrumbManager/exampleQuanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticBreadcrumbManager/exampleQuanticBreadcrumbManager.html
@@ -14,7 +14,7 @@
       <div class="slds-grid slds-gutters_direct slds-wrap main slds-grid_align-center">
         <div class="slds-col slds-order_2 slds-large-order_1 slds-size_1-of-1 slds-large-size_6-of-12">
           <c-quantic-facet-manager engine-id={engineId}>
-            <c-quantic-facet display-values-as="link" field="filetype" label="File Type" engine-id={engineId}></c-quantic-facet>
+            <c-quantic-facet display-values-as={config.displayFacetValuesAs} field="filetype" label="File Type" engine-id={engineId}></c-quantic-facet>
             <c-quantic-numeric-facet field="ytlikecount" label="Youtube Likes" with-input="integer" engine-id={engineId}></c-quantic-numeric-facet>
             <c-quantic-timeframe-facet engine-id={engineId} field="date" label="Date">
               <c-quantic-timeframe unit="week"></c-quantic-timeframe>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticBreadcrumbManager/exampleQuanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticBreadcrumbManager/exampleQuanticBreadcrumbManager.js
@@ -31,6 +31,13 @@ export default class ExampleQuanticFacetManager extends LightningElement {
         'Define which use case to test. Possible values are: search, insight',
       defaultValue: 'search',
     },
+    {
+      attribute: 'displayFacetValuesAs',
+      label: 'Display Facet Values as',
+      description:
+        'Indicates whether to display the facet values as checkboxes (multiple selection) or links (single selection).',
+      defaultValue: 'link',
+    },
   ];
 
   get notConfigured() {

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -8,7 +8,7 @@
               <span class="slds-col breadcrumb-manager__field-name">{breadcrumb.label}{labels.colon} </span>
               <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                 <template for:each={breadcrumb.values} for:item="breadcrumbValue">
-                  <li key={breadcrumbValue.value} class="breadcrumb__container">
+                  <li key={breadcrumbValue.value.value} class="breadcrumb__container">
                     <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                   </li>
                 </template>


### PR DESCRIPTION
[SFINT-4938](https://coveord.atlassian.net/browse/SFINT-4938)
## The issue: 
When you have two facet values in the Quantic Breadcrumb component, and you remove the first value, removing the second value will make the first value reappear like the following:

https://user-images.githubusercontent.com/86681870/227228447-2bdd4c9f-bc8d-4b45-95ed-ad22d472a0d7.mov


## The source of the issue:
The facet values in the Quantic Breadcrumb component were displayed in the HTML like the following:
```
<template for:each={breadcrumb.values} for:item="breadcrumbValue">
     <li key={breadcrumbValue.value}>
          <c-quantic-pill ondeselect={breadcrumbValue.deselect}></c-quantic-pill>
     </li>
</template>
```
The problem is that the key passed to the `li` tag is invalid.

the object `breadcrumbValue` has the following structure: 
```
{
    formattedValue: 'some formatted value',
    value: 
    {
         value: 'some value',
         state: 'selected',
    }
}
```
which makes `breadcrumbValue.value` an object, which is an invalid value to give for the `key` attribute.

### Bottom line is that with invalid key values, the component completely lost track of which  `deselect` event listener to execute when this event is executed.

## The solution:
- #### `breadcrumbValue.value.value` used instead of `breadcrumbValue.value`.
- #### New e2e test created to avoid facing this issue again. 


https://user-images.githubusercontent.com/86681870/227233211-18b211fa-6a2a-4b55-9f03-9fe54c521439.mov



[SFINT-4938]: https://coveord.atlassian.net/browse/SFINT-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ