### PR TITLE
translations for recent queries added

### DIFF
--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -572,4 +572,12 @@
       <label>Filtre d'inclusion sur {{0}}; aucun résultat</label>
       <name>quantic_InclusionFilter_zero</name>
     </customLabels>
+    <customLabels>
+      <label>Requêtes récentes</label>
+      <name>quantic_RecentQueries</name>
+    </customLabels>
+    <customLabels>
+      <label>Vos requêtes récentes s'afficheront ici.</label>
+      <name>quantic_EmptyRecentQueriesListLabel</name>
+    </customLabels>
 </Translations>


### PR DESCRIPTION
[SFINT-4951](https://coveord.atlassian.net/browse/SFINT-4951)

### Issue:
Missing french translations of the labels used in Quantic Recent Queries component:
<img width="1704" alt="Issue" src="https://user-images.githubusercontent.com/86681870/228662450-ea3e761d-ece5-453b-8247-0b2fd80a06c5.png">


### Solution:
French translations added:
<img width="1631" alt="Solution" src="https://user-images.githubusercontent.com/86681870/228662431-afeceb71-6e32-4a94-8393-1a972258802c.png">
