### PR TITLE
fix(headless): export missing action loaders from product-listing

### DIFF
--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -40,6 +40,8 @@ export type {
   ProductListingControllerState,
 } from './controllers/product-listing/headless-product-listing';
 export {buildProductListing} from './controllers/product-listing/headless-product-listing';
+// ACTION: PRODUCT-LISTING
+// REDUCER: CONFIGURATION
 
 export type {
   PagerInitialState,
@@ -49,6 +51,10 @@ export type {
   Pager,
 } from './controllers/product-listing/pager/headless-product-listing-pager';
 export {buildPager} from './controllers/product-listing/pager/headless-product-listing-pager';
+// ACTION: PRODUCT-LISTING
+// ACTION: PAGINATION
+// REDUCER: CONFIGURATION
+// REDUCER: PAGINATION
 
 export type {
   ResultsPerPageInitialState,
@@ -57,6 +63,11 @@ export type {
   ResultsPerPage,
 } from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
 export {buildResultsPerPage} from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
+// ACTION: PRODUCT-LISTING
+// ACTION: PAGINATION
+// ACTION: PAGINATION-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: PAGINATION
 
 export type {
   ProductListingSortInitialState,
@@ -75,6 +86,11 @@ export {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
+// ACTION: PAGINATION
+// ACTION: PRODUCT-LISTING
+// ACTION: SORT
+// REDUCER: CONFIGURATION
+// REDUCER: SORT
 
 export type {
   FacetManager,
@@ -82,6 +98,8 @@ export type {
   FacetManagerState,
 } from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
+// REDUCER: PRODUCT-LISTING
+// REDUCER: FACET-OPTIONS
 
 export type {
   CoreFacet,
@@ -98,6 +116,17 @@ export type {
   SpecificFacetSearchResult,
 } from './controllers/product-listing/facet/headless-product-listing-facet';
 export {buildFacet} from './controllers/product-listing/facet/headless-product-listing-facet';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTION
+// ACTION: FACET-SET-CONTROLLER
+// ACTION: FACET-SET
+// ACTION: GENERIC-FACET-SEARCH
+// ACTION: SPECIFIC-FACET-SEARCH
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: FACET-OPTION
+// REDUCER: FACET-SET
+// REDUCER: FACET-SEARCH-SET
 
 export type {
   CategoryFacet,
@@ -113,6 +142,16 @@ export type {
   CoreCategoryFacetState,
 } from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
 export {buildCategoryFacet} from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTIONS
+// ACTION: GENERIC-FACET-SEARCH
+// ACTION: SPECIFIC-FACET-SEARCH
+// ACTION: CATEGORY-FACET-SEARCH
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: PRODUCT-LISTING
+// REDUCER: CATEGORY-FACET-SET
+// REDUCER: CATEGORY-FACET-SEARCH-SET
 
 export type {
   DateFacet,
@@ -128,6 +167,17 @@ export {
   buildDateFacet,
   buildDateRange,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTIONS
+// ACTION: FACET-SET
+// ACTION: RANGE-FACET-SET
+// ACTION: DATE-FACET-CONTROLLER
+// ACTION: DATE-FACET
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: SEARCH
+// REDUCER: FACET-OPTIONS
+// REDUCER: DATE-FACET-SET
 
 export type {
   DateFilter,
@@ -138,6 +188,14 @@ export type {
   DateFilterInitialState,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
 export {buildDateFilter} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTIONS
+// ACTION: DATE-FACET
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: SEARCH
+// REDUCER: FACET-OPTIONS
+// REDUCER: DATE-FACET-SET
 
 export type {
   NumericFacet,
@@ -152,6 +210,17 @@ export {
   buildNumericFacet,
   buildNumericRange,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTIONS
+// ACTION: FACET-SET
+// ACTION: RANGE-FACET
+// ACTION: NUMERIC-FACET-CONTROLLER
+// ACTION: NUMERIC-FACET
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: SEARCH
+// REDUCER: FACET-OPTIONS
+// REDUCER: NUMERIC-FACET-SET
 
 export type {
   NumericFilter,
@@ -162,6 +231,14 @@ export type {
   NumericFilterInitialState,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
 export {buildNumericFilter} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
+// ACTION: PRODUCT-LISTING
+// ACTION: FACET-OPTIONS
+// ACTION: NUMERIC-FACET
+// ACTION: FACET-SET-ANALYTICS
+// REDUCER: CONFIGURATION
+// REDUCER: SEARCH
+// REDUCER: FACET-OPTIONS
+// REDUCER: NUMERIC-FACET-SET
 
 export type {
   Context,
@@ -170,6 +247,8 @@ export type {
   ContextValue,
 } from './controllers/product-listing/context/headless-product-listing-context';
 export {buildContext} from './controllers/product-listing/context/headless-product-listing-context';
+// ACTION: CONTEXT
+// REDUCER: CONTEXT
 
 export type {
   InteractiveResultOptions,
@@ -177,3 +256,4 @@ export type {
   InteractiveResult,
 } from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
 export {buildInteractiveResult} from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
+// REDUCER: CONFIGURATION

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -21,6 +21,26 @@ export type {LogLevel} from './app/logger';
 
 export type {ProductRecommendation} from './api/search/search/product-recommendation';
 
+// Actions
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/pagination/pagination-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/sort/sort-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+// export * from './features/facets/facet-set/facet-set-controller-actions-loader'; // TODO: Create missing actions loader
+export * from './features/facets/facet-set/facet-set-actions-loader';
+// export * from './features/facets/facet-search-set/generic/generic-facet-search-actions-loader'; // TODO: Create missing actions loader (KIT-2375).
+// export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader'; // TODO: Create missing actions loader (KIT-2375).
+// export * from './features/facets/facet-search-set/category/category-facet-search-actions-loader'; // TODO: Create missing actions loader (KIT-2375).
+export * from './features/facets/category-facet-set/category-facet-set-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
+// export * from './features/facets/range-facets/date-facet-set/date-facet-controller-actions-loader'; // TODO: Create missing actions loader
+// export * from './features/search/search-actions-loader'; // TODO: Remove from bundle (KIT-2376).
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
+// export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions-loader'; // TODO: Create missing actions loader
+export * from './features/context/context-actions-loader';
+
 // Controllers
 export type {
   Controller,
@@ -36,8 +56,6 @@ export type {
   ProductListingControllerState,
 } from './controllers/product-listing/headless-product-listing';
 export {buildProductListing} from './controllers/product-listing/headless-product-listing';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
 
 export type {
   PagerInitialState,
@@ -47,10 +65,6 @@ export type {
   Pager,
 } from './controllers/product-listing/pager/headless-product-listing-pager';
 export {buildPager} from './controllers/product-listing/pager/headless-product-listing-pager';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/pagination/pagination-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/pagination/pagination-actions-loader';
 
 export type {
   ResultsPerPageInitialState,
@@ -59,11 +73,6 @@ export type {
   ResultsPerPage,
 } from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
 export {buildResultsPerPage} from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/pagination/pagination-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/pagination/pagination-actions-loader';
 
 export type {
   ProductListingSortInitialState,
@@ -82,11 +91,6 @@ export {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
-export * from './features/pagination/pagination-actions-loader';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/sort/sort-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/sort/sort-actions-loader';
 
 export type {
   FacetManager,
@@ -94,8 +98,6 @@ export type {
   FacetManagerState,
 } from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
 
 export type {
   CoreFacet,
@@ -112,17 +114,6 @@ export type {
   SpecificFacetSearchResult,
 } from './controllers/product-listing/facet/headless-product-listing-facet';
 export {buildFacet} from './controllers/product-listing/facet/headless-product-listing-facet';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-// MISSING: export * from './features/facets/facet-set/facet-set-controller-actions-loader';
-export * from './features/facets/facet-set/facet-set-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/generic/generic-facet-search-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/facet-set/facet-set-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
 
 export type {
   CategoryFacet,
@@ -138,16 +129,6 @@ export type {
   CoreCategoryFacetState,
 } from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
 export {buildCategoryFacet} from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/generic/generic-facet-search-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/category/category-facet-search-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facets/category-facet-set/category-facet-set-actions-loader';
-// MISSING: export * from './features/facets/facet-search-set/category/category-facet-search-actions-loader';
 
 export type {
   DateFacet,
@@ -163,17 +144,6 @@ export {
   buildDateFacet,
   buildDateRange,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/facet-set/facet-set-actions-loader';
-export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
-// MISSING: export * from './features/facets/range-facets/date-facet-set/date-facet-controller-actions-loader';
-export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/search/search-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 
 export type {
   DateFilter,
@@ -184,14 +154,6 @@ export type {
   DateFilterInitialState,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
 export {buildDateFilter} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/search/search-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 
 export type {
   NumericFacet,
@@ -206,17 +168,6 @@ export {
   buildNumericFacet,
   buildNumericRange,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/facet-set/facet-set-actions-loader';
-export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
-// MISSING: export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions-loader';
-export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/search/search-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 
 export type {
   NumericFilter,
@@ -227,14 +178,6 @@ export type {
   NumericFilterInitialState,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
 export {buildNumericFilter} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
-export * from './features/product-listing/product-listing-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
-export * from './features/analytics/search-analytics-actions-loader';
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/search/search-actions-loader';
-export * from './features/facet-options/facet-options-actions-loader';
-export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 
 export type {
   Context,
@@ -243,8 +186,6 @@ export type {
   ContextValue,
 } from './controllers/product-listing/context/headless-product-listing-context';
 export {buildContext} from './controllers/product-listing/context/headless-product-listing-context';
-export * from './features/context/context-actions-loader';
-export * from './features/context/context-actions-loader';
 
 export type {
   InteractiveResultOptions,
@@ -252,4 +193,3 @@ export type {
   InteractiveResult,
 } from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
 export {buildInteractiveResult} from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
-export * from './features/configuration/configuration-actions-loader';

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -21,10 +21,6 @@ export type {LogLevel} from './app/logger';
 
 export type {ProductRecommendation} from './api/search/search/product-recommendation';
 
-// Actions
-export * from './features/configuration/configuration-actions-loader';
-export * from './features/product-listing/product-listing-actions-loader';
-
 // Controllers
 export type {
   Controller,
@@ -40,8 +36,8 @@ export type {
   ProductListingControllerState,
 } from './controllers/product-listing/headless-product-listing';
 export {buildProductListing} from './controllers/product-listing/headless-product-listing';
-// ACTION: PRODUCT-LISTING
-// REDUCER: CONFIGURATION
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
 
 export type {
   PagerInitialState,
@@ -51,10 +47,10 @@ export type {
   Pager,
 } from './controllers/product-listing/pager/headless-product-listing-pager';
 export {buildPager} from './controllers/product-listing/pager/headless-product-listing-pager';
-// ACTION: PRODUCT-LISTING
-// ACTION: PAGINATION
-// REDUCER: CONFIGURATION
-// REDUCER: PAGINATION
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/pagination/pagination-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/pagination/pagination-actions-loader';
 
 export type {
   ResultsPerPageInitialState,
@@ -63,11 +59,11 @@ export type {
   ResultsPerPage,
 } from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
 export {buildResultsPerPage} from './controllers/product-listing/results-per-page/headless-product-listing-results-per-page';
-// ACTION: PRODUCT-LISTING
-// ACTION: PAGINATION
-// ACTION: PAGINATION-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: PAGINATION
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/pagination/pagination-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/pagination/pagination-actions-loader';
 
 export type {
   ProductListingSortInitialState,
@@ -86,11 +82,11 @@ export {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
 } from './controllers/product-listing/sort/headless-product-listing-sort';
-// ACTION: PAGINATION
-// ACTION: PRODUCT-LISTING
-// ACTION: SORT
-// REDUCER: CONFIGURATION
-// REDUCER: SORT
+export * from './features/pagination/pagination-actions-loader';
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/sort/sort-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/sort/sort-actions-loader';
 
 export type {
   FacetManager,
@@ -98,8 +94,8 @@ export type {
   FacetManagerState,
 } from './controllers/product-listing/facet/headless-product-listing-facet-manager';
 export {buildFacetManager} from './controllers/product-listing/facet/headless-product-listing-facet-manager';
-// REDUCER: PRODUCT-LISTING
-// REDUCER: FACET-OPTIONS
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
 
 export type {
   CoreFacet,
@@ -116,17 +112,17 @@ export type {
   SpecificFacetSearchResult,
 } from './controllers/product-listing/facet/headless-product-listing-facet';
 export {buildFacet} from './controllers/product-listing/facet/headless-product-listing-facet';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTION
-// ACTION: FACET-SET-CONTROLLER
-// ACTION: FACET-SET
-// ACTION: GENERIC-FACET-SEARCH
-// ACTION: SPECIFIC-FACET-SEARCH
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: FACET-OPTION
-// REDUCER: FACET-SET
-// REDUCER: FACET-SEARCH-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+// MISSING: export * from './features/facets/facet-set/facet-set-controller-actions-loader';
+export * from './features/facets/facet-set/facet-set-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/generic/generic-facet-search-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/facet-set/facet-set-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
 
 export type {
   CategoryFacet,
@@ -142,16 +138,16 @@ export type {
   CoreCategoryFacetState,
 } from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
 export {buildCategoryFacet} from './controllers/product-listing/category-facet/headless-product-listing-category-facet';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTIONS
-// ACTION: GENERIC-FACET-SEARCH
-// ACTION: SPECIFIC-FACET-SEARCH
-// ACTION: CATEGORY-FACET-SEARCH
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: PRODUCT-LISTING
-// REDUCER: CATEGORY-FACET-SET
-// REDUCER: CATEGORY-FACET-SEARCH-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/generic/generic-facet-search-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/specific/specific-facet-search-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/category/category-facet-search-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facets/category-facet-set/category-facet-set-actions-loader';
+// MISSING: export * from './features/facets/facet-search-set/category/category-facet-search-actions-loader';
 
 export type {
   DateFacet,
@@ -167,17 +163,17 @@ export {
   buildDateFacet,
   buildDateRange,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTIONS
-// ACTION: FACET-SET
-// ACTION: RANGE-FACET-SET
-// ACTION: DATE-FACET-CONTROLLER
-// ACTION: DATE-FACET
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: SEARCH
-// REDUCER: FACET-OPTIONS
-// REDUCER: DATE-FACET-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/facet-set/facet-set-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
+// MISSING: export * from './features/facets/range-facets/date-facet-set/date-facet-controller-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/search/search-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 
 export type {
   DateFilter,
@@ -188,14 +184,14 @@ export type {
   DateFilterInitialState,
 } from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
 export {buildDateFilter} from './controllers/product-listing/range-facet/date-facet/headless-product-listing-date-filter';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTIONS
-// ACTION: DATE-FACET
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: SEARCH
-// REDUCER: FACET-OPTIONS
-// REDUCER: DATE-FACET-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/search/search-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 
 export type {
   NumericFacet,
@@ -210,17 +206,17 @@ export {
   buildNumericFacet,
   buildNumericRange,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-facet';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTIONS
-// ACTION: FACET-SET
-// ACTION: RANGE-FACET
-// ACTION: NUMERIC-FACET-CONTROLLER
-// ACTION: NUMERIC-FACET
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: SEARCH
-// REDUCER: FACET-OPTIONS
-// REDUCER: NUMERIC-FACET-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/facet-set/facet-set-actions-loader';
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
+// MISSING: export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-controller-actions-loader';
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/search/search-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 
 export type {
   NumericFilter,
@@ -231,14 +227,14 @@ export type {
   NumericFilterInitialState,
 } from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
 export {buildNumericFilter} from './controllers/product-listing/range-facet/numeric-facet/headless-product-listing-numeric-filter';
-// ACTION: PRODUCT-LISTING
-// ACTION: FACET-OPTIONS
-// ACTION: NUMERIC-FACET
-// ACTION: FACET-SET-ANALYTICS
-// REDUCER: CONFIGURATION
-// REDUCER: SEARCH
-// REDUCER: FACET-OPTIONS
-// REDUCER: NUMERIC-FACET-SET
+export * from './features/product-listing/product-listing-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
+export * from './features/analytics/search-analytics-actions-loader';
+export * from './features/configuration/configuration-actions-loader';
+export * from './features/search/search-actions-loader';
+export * from './features/facet-options/facet-options-actions-loader';
+export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 
 export type {
   Context,
@@ -247,8 +243,8 @@ export type {
   ContextValue,
 } from './controllers/product-listing/context/headless-product-listing-context';
 export {buildContext} from './controllers/product-listing/context/headless-product-listing-context';
-// ACTION: CONTEXT
-// REDUCER: CONTEXT
+export * from './features/context/context-actions-loader';
+export * from './features/context/context-actions-loader';
 
 export type {
   InteractiveResultOptions,
@@ -256,4 +252,4 @@ export type {
   InteractiveResult,
 } from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
 export {buildInteractiveResult} from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
-// REDUCER: CONFIGURATION
+export * from './features/configuration/configuration-actions-loader';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2374

This problem isn't uniquely the case for product-listing. Other use cases are also missing some action loaders. However, it takes too much time to individually verify every use case. A refactor or some additional CI process will be necessary eventually to avoid this happening again.

I divided this PR into multiple commits that help illustrate why each action loader is necessary:
1. verify where actions are used and reducers are loaded (https://github.com/coveo/ui-kit/commit/b8409fc9cf1cff5e5f0e205d69679c4c7140bddd)
2. replace action and reducer annotations with their respective action loaders (https://github.com/coveo/ui-kit/commit/978a4d27e0a859d8521e97bcb2075348d9221dce)
3. finally, hoist the action loaders to the top of the file and remove duplicates (https://github.com/coveo/ui-kit/commit/a001d808d6db71340c96ce1e818d244ca18bdfc0)