### PR TITLE
feat(atomic)!: enable atomic modal in shadow dom

### DIFF
--- a/packages/atomic/cypress/e2e/smart-snippet-feedback-modal-assertions.ts
+++ b/packages/atomic/cypress/e2e/smart-snippet-feedback-modal-assertions.ts
@@ -3,7 +3,7 @@ import {SmartSnippetFeedbackModalSelectors} from './smart-snippet-feedback-modal
 
 export function assertDisplayModal(opened: boolean) {
   it(`${should(opened)} display the smart snippet feedback modal`, () => {
-    cy.get('body').should(
+    cy.get('atomic-search-interface').should(
       opened ? 'have.class' : 'not.have.class',
       'atomic-modal-opened'
     );

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.tsx
@@ -21,7 +21,7 @@ import {once, randomID} from '../../../utils/utils';
 import {AnyBindings} from '../interface/bindings';
 
 /**
- * When the modal is opened, the class `atomic-modal-opened` is added to the body, allowing further customization.
+ * When the modal is opened, the class `atomic-modal-opened` is added to the interfaceElement, allowing further customization.
  *
  * @part backdrop - The transparent backdrop hiding the content behind the modal.
  * @part container - The modal's outermost container with the outline and background.
@@ -74,14 +74,14 @@ export class AtomicModal implements InitializableComponent<AnyBindings> {
 
     if (isOpen) {
       this.wasEverOpened = true;
-      document.body.classList.add(modalOpenedClass);
+      this.bindings.interfaceElement.classList.add(modalOpenedClass);
       await this.waitForAnimationEnded();
       if (watchToggleOpenExecution !== this.currentWatchToggleOpenExecution) {
         return;
       }
       this.focusTrap!.active = true;
     } else {
-      document.body.classList.remove(modalOpenedClass);
+      this.bindings.interfaceElement.classList.remove(modalOpenedClass);
       if (isIOS()) {
         await this.waitForAnimationEnded();
       }

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -53,13 +53,13 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
     const modalOpenedClass = 'atomic-ipx-modal-opened';
 
     if (isOpen) {
-      document.body.classList.add(modalOpenedClass);
+      this.bindings.interfaceElement.classList.add(modalOpenedClass);
       if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
         this.focusTrap!.active = true;
       }
       return;
     }
-    document.body.classList.remove(modalOpenedClass);
+    this.bindings.interfaceElement.classList.remove(modalOpenedClass);
     if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
       this.focusTrap!.active = false;
     }

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -36,7 +36,7 @@ import {SortDropdownOption} from '../atomic-search-interface/store';
 /**
  * The `atomic-refine-modal` is automatically created as a child of the `atomic-search-interface` when the `atomic-refine-toggle` is initialized.
  *
- * When the modal is opened, the class `atomic-modal-opened` is added to the body, allowing further customization.
+ * When the modal is opened, the class `atomic-modal-opened` is added to the interface element, allowing further customization.
  *
  * @part container - The modal's outermost container.
  * @part header-wrapper - The wrapper around the header.


### PR DESCRIPTION
Instead of putting the `atomic-modal-opened` class on document.body, put it inside the interface element so that the classname can be set even when inside a shadow dom. 

I checked also for other things that would be problematic inside a shadow dom and did not find anything else.

https://coveord.atlassian.net/browse/SVCINT-2159