### PR TITLE
Fix undefined bound state

### DIFF
--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -280,7 +280,7 @@ export function BindStateToController(
           component
         );
       }
-
+      this[stateProperty] = this[controllerProperty].state;
       unsubscribeController = this[controllerProperty].subscribe(() => {
         this[stateProperty] = this[controllerProperty].state;
         options?.onUpdateCallbackMethod &&


### PR DESCRIPTION
The subscribed state has to be mapped when the subscription starts, not just when a change is triggered

This is causing race conditions, when the subscribed state is set before the component initialises it remains undefined, and never syncs