### PR TITLE
feat(SFINT-4880): Added default searchhub as an example

### DIFF
--- a/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
+++ b/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
@@ -6,7 +6,12 @@ global with sharing class CoveoTokenProvider implements ITokenProvider {
      */
     @AuraEnabled(continuation=true cacheable=false)
     global static String getHeadlessConfiguration() {
-        Map<String, Object> coveoEndpointData = CoveoV2.Globals.getEndpointData();
+        // It's good practice to set a searchHub in the token for secured routing: @see https://docs.coveo.com/en/quantic/latest/usage/safely-set-search-hub/
+        Map<String, Object> coveoEndpointData = CoveoV2.Globals.getEndpointData(
+            new Map<String, Object> {
+                'searchHub' => 'example_coveo'
+            }
+        );
         String searchToken = CoveoV2.Globals.generateSearchToken();
 
         Map<String, String> headlessConfiguration = new Map<String, String>();

--- a/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
+++ b/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
@@ -6,8 +6,8 @@ global with sharing class CoveoTokenProvider implements ITokenProvider {
      */
     @AuraEnabled(continuation=true cacheable=false)
     global static String getHeadlessConfiguration() {
-        // It's good practice to set a searchHub in the token for secured routing: @see https://docs.coveo.com/en/quantic/latest/usage/safely-set-search-hub/
         Map<String, Object> coveoEndpointData = CoveoV2.Globals.getEndpointData();
+        // It's good practice to set a searchHub in the token for secured routing: @see https://docs.coveo.com/en/quantic/latest/usage/safely-set-search-hub/
         String searchToken = CoveoV2.Globals.generateSearchToken(
             new Map<String, Object> {
                 'searchHub' => 'example_coveo'

--- a/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
+++ b/packages/quantic/force-app/coveo-token/main/default/classes/CoveoTokenProvider.cls
@@ -7,12 +7,12 @@ global with sharing class CoveoTokenProvider implements ITokenProvider {
     @AuraEnabled(continuation=true cacheable=false)
     global static String getHeadlessConfiguration() {
         // It's good practice to set a searchHub in the token for secured routing: @see https://docs.coveo.com/en/quantic/latest/usage/safely-set-search-hub/
-        Map<String, Object> coveoEndpointData = CoveoV2.Globals.getEndpointData(
+        Map<String, Object> coveoEndpointData = CoveoV2.Globals.getEndpointData();
+        String searchToken = CoveoV2.Globals.generateSearchToken(
             new Map<String, Object> {
                 'searchHub' => 'example_coveo'
             }
         );
-        String searchToken = CoveoV2.Globals.generateSearchToken();
 
         Map<String, String> headlessConfiguration = new Map<String, String>();
         headlessConfiguration.put('organizationId', (String) coveoEndpointData.get('organization'));


### PR DESCRIPTION
New line to provide an example of how to set a searchHub as part of the Quantic token creation through the Globals method from the Coveo for Salesforce package.

With link to the documentation page.