### PR TITLE
fix(headless): reset preview content on `fetchMoreResults` and `fetchPage`

### DIFF
--- a/packages/headless/src/features/result-preview/result-preview-slice.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.test.ts
@@ -4,7 +4,8 @@ import {buildMockSearch} from '../../test/mock-search';
 import {buildMockSearchResponse} from '../../test/mock-search-response';
 import {logInterfaceLoad} from '../analytics/analytics-actions';
 import {executeSearch} from '../insight-search/insight-search-actions';
-import {fetchMoreResults} from '../search/search-actions';
+import {logPageNext} from '../pagination/pagination-analytics-actions';
+import {fetchMoreResults, fetchPage} from '../search/search-actions';
 import {
   fetchResultContent,
   nextPreview,
@@ -105,6 +106,20 @@ describe('ResultPreview', () => {
         'fifth',
         'eight',
       ]);
+    });
+  });
+
+  describe('on #fetchPage.fulfilled', () => {
+    it('re-initialize the state to initial when a query returns correctly', () => {
+      state.content = 'content';
+      state.contentURL = 'url';
+      state.isLoading = true;
+      state.uniqueId = 'uniqueId';
+      const action = fetchPage.fulfilled(buildMockSearch(), '', logPageNext());
+
+      const finalState = resultPreviewReducer(state, action);
+
+      expect(finalState).toEqual(getResultPreviewInitialState());
     });
   });
 

--- a/packages/headless/src/features/result-preview/result-preview-slice.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.test.ts
@@ -73,6 +73,18 @@ describe('ResultPreview', () => {
   });
 
   describe('on #fetchMoreResults.fulfilled', () => {
+    it('re-initialize the state to initial when a query returns correctly', () => {
+      state.content = 'content';
+      state.contentURL = 'url';
+      state.isLoading = true;
+      state.uniqueId = 'uniqueId';
+      const action = fetchMoreResults.fulfilled(buildMockSearch(), '');
+
+      const finalState = resultPreviewReducer(state, action);
+
+      expect(finalState).toEqual(getResultPreviewInitialState());
+    });
+
     it('concat #resultsWithPreview property with the new results', () => {
       state.resultsWithPreview = ['first', 'fourth'];
       const search = buildMockSearch({

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -1,4 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {WritableDraft} from 'immer/dist/internal';
 import type {Result} from '../../api/search/search/result';
 import {fetchMoreResults, executeSearch} from '../search/search-actions';
 import {
@@ -8,7 +9,10 @@ import {
   previousPreview,
   updateContentURL,
 } from './result-preview-actions';
-import {getResultPreviewInitialState} from './result-preview-state';
+import {
+  ResultPreviewState,
+  getResultPreviewInitialState,
+} from './result-preview-state';
 
 const getUniqueIdsOfResultsWithHTMLVersion = (
   results: Pick<Result, 'hasHtmlVersion' | 'uniqueId'>[]
@@ -30,18 +34,13 @@ export const resultPreviewReducer = createReducer(
         state.isLoading = false;
       })
       .addCase(executeSearch.fulfilled, (state, action) => {
-        const {content, isLoading, uniqueId, contentURL} =
-          getResultPreviewInitialState();
-        state.content = content;
-        state.isLoading = isLoading;
-        state.uniqueId = uniqueId;
-        state.contentURL = contentURL;
-
+        resetPreviewContentState(state);
         state.resultsWithPreview = getUniqueIdsOfResultsWithHTMLVersion(
           action.payload.response.results
         );
       })
       .addCase(fetchMoreResults.fulfilled, (state, action) => {
+        resetPreviewContentState(state);
         state.resultsWithPreview = state.resultsWithPreview.concat(
           getUniqueIdsOfResultsWithHTMLVersion(action.payload.response.results)
         );
@@ -77,3 +76,12 @@ export const resultPreviewReducer = createReducer(
       });
   }
 );
+
+const resetPreviewContentState = (state: WritableDraft<ResultPreviewState>) => {
+  const {content, isLoading, uniqueId, contentURL} =
+    getResultPreviewInitialState();
+  state.content = content;
+  state.isLoading = isLoading;
+  state.uniqueId = uniqueId;
+  state.contentURL = contentURL;
+};

--- a/packages/headless/src/features/result-preview/result-preview-slice.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.ts
@@ -1,7 +1,10 @@
 import {createReducer} from '@reduxjs/toolkit';
-import {WritableDraft} from 'immer/dist/internal';
 import type {Result} from '../../api/search/search/result';
-import {fetchMoreResults, executeSearch} from '../search/search-actions';
+import {
+  fetchMoreResults,
+  executeSearch,
+  fetchPage,
+} from '../search/search-actions';
 import {
   fetchResultContent,
   nextPreview,
@@ -13,6 +16,15 @@ import {
   ResultPreviewState,
   getResultPreviewInitialState,
 } from './result-preview-state';
+
+const resetPreviewContentState = (state: ResultPreviewState) => {
+  const {content, isLoading, uniqueId, contentURL} =
+    getResultPreviewInitialState();
+  state.content = content;
+  state.isLoading = isLoading;
+  state.uniqueId = uniqueId;
+  state.contentURL = contentURL;
+};
 
 const getUniqueIdsOfResultsWithHTMLVersion = (
   results: Pick<Result, 'hasHtmlVersion' | 'uniqueId'>[]
@@ -45,6 +57,7 @@ export const resultPreviewReducer = createReducer(
           getUniqueIdsOfResultsWithHTMLVersion(action.payload.response.results)
         );
       })
+      .addCase(fetchPage.fulfilled, resetPreviewContentState)
       .addCase(preparePreviewPagination, (state, action) => {
         state.resultsWithPreview = getUniqueIdsOfResultsWithHTMLVersion(
           action.payload.results
@@ -76,12 +89,3 @@ export const resultPreviewReducer = createReducer(
       });
   }
 );
-
-const resetPreviewContentState = (state: WritableDraft<ResultPreviewState>) => {
-  const {content, isLoading, uniqueId, contentURL} =
-    getResultPreviewInitialState();
-  state.content = content;
-  state.isLoading = isLoading;
-  state.uniqueId = uniqueId;
-  state.contentURL = contentURL;
-};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2389
Sames as #2657, but for `fetchMoreResults` and `fetchPage`

This fix the issue because it will make:
https://github.com/coveo/ui-kit/blob/1a358caee72aa50c0bd45a98c0760becbd39829c/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx#L208-L211
be/stay/return false (as it should).

## Testing:
 - [x] UT
 - [x] Manual tests:
    -  `git checkout "@coveo/headless@2.10.1" -f ; npm run build ; npm run dev`
       - Click on Quickview, close quickview, click on load more results: the quickview reopen.
       - Edit `packages/atomic/www/index.html` to replace the `atomic-load-more-results` by `atomic-results-per-page`
       - Click on Quickview, close quickview, click on load more results: the quickview reopen.
    -  `git checkout "fix/KIT-2389" -f ; npm run build ; npm run dev`
       - Click on Quickview, close quickview, click on load more results: the quickview does not reopen.
       - Edit `packages/atomic/www/index.html` to replace the `atomic-load-more-results` by `atomic-results-per-page`
       - Click on Quickview, close quickview, click on load more results: the quickview does not reopen.