### PR TITLE
docs(atomic,headless): fix various samples documentation to use organizationEndpoints

### DIFF
--- a/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
+++ b/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
@@ -2,7 +2,7 @@ describe('smoke test', () => {
   it('should load atomic-hosted-page component', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3335/').wait('@analytics');
@@ -17,7 +17,7 @@ describe('smoke test', () => {
   it.skip('should load atomic-simple-builder component', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3335/simple-builder.html').wait('@analytics');

--- a/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
+++ b/packages/atomic-hosted-page/cypress/integration/stencil/smoke-test.cypress.ts
@@ -2,7 +2,7 @@ describe('smoke test', () => {
   it('should load atomic-hosted-page component', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/v15/analytics/*',
+      path: '**/rest/ua/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3335/').wait('@analytics');
@@ -17,7 +17,7 @@ describe('smoke test', () => {
   it.skip('should load atomic-simple-builder component', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/v15/analytics/*',
+      path: '**/rest/ua/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3335/simple-builder.html').wait('@analytics');

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -9,8 +9,6 @@
     <script nomodule src="/build/atomic.js"></script>
     <link rel="stylesheet" href="/themes/coveo.css" />
     <script type="module">
-      import {getOrganizationEndpoints} from '/build/headless/headless.esm.js';
-
       async function main() {
         await customElements.whenDefined('atomic-insight-interface');
         const insightInterface = document.querySelector('atomic-insight-interface');
@@ -18,7 +16,6 @@
           insightId: 'fc2ee6e0-8bda-4883-bfc6-ffc1b0ce34c7',
           accessToken: 'xx9446b04d-45d4-44a6-880c-22c6c04573ff',
           organizationId: 'searchuisamples',
-          organizationEndpoints: getOrganizationEndpoints('searchuisamples'),
         });
 
         insightInterface.executeFirstSearch();

--- a/packages/samples/angular/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
+++ b/packages/samples/angular/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
@@ -12,7 +12,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
   it('should load', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:4200/atomic-angular').wait('@analytics');

--- a/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.ts
+++ b/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.ts
@@ -11,11 +11,15 @@ export class AtomicAngularPageComponent implements AfterViewInit {
   searchInterface!: HTMLAtomicSearchInterfaceElement;
 
   constructor() {}
-  ngAfterViewInit(): void {
+  async ngAfterViewInit(): Promise<void> {
     this.searchInterface
       ?.initialize({
         accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
         organizationId: 'electronicscoveodemocomo0n2fu8v',
+        organizationEndpoints:
+          await this.searchInterface.getOrganizationEndpoints(
+            'electronicscoveodemocomo0n2fu8v'
+          ),
       })
       .then(() => {
         this.searchInterface.executeFirstSearch();

--- a/packages/samples/atomic-next/cypress/e2e/smoke-test.cypress.cy.ts
+++ b/packages/samples/atomic-next/cypress/e2e/smoke-test.cypress.cy.ts
@@ -13,7 +13,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
   it('should load', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3000').wait('@analytics', {timeout: 50000});

--- a/packages/samples/atomic-next/pages/index.tsx
+++ b/packages/samples/atomic-next/pages/index.tsx
@@ -43,6 +43,7 @@ import {
   AtomicResultText,
   AtomicText,
   Result,
+  getOrganizationEndpoints,
 } from '@coveo/atomic-react';
 import type {NextPage} from 'next';
 import dynamic from 'next/dynamic';
@@ -55,6 +56,9 @@ const SearchPage: NextPage = () => {
         configuration: {
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId: 'electronicscoveodemocomo0n2fu8v',
+          organizationEndpoints: getOrganizationEndpoints(
+            'electronicscoveodemocomo0n2fu8v'
+          ),
           search: {
             pipeline: 'Search',
             searchHub: 'MainSearch',

--- a/packages/samples/atomic-react/cypress/e2e/smoke-test.cypress.cy.ts
+++ b/packages/samples/atomic-react/cypress/e2e/smoke-test.cypress.cy.ts
@@ -12,7 +12,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
   it('should load', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3000').wait('@analytics');

--- a/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
+++ b/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
@@ -35,6 +35,7 @@ import {
   Result,
   Bindings,
   AtomicSearchBoxQuerySuggestions,
+  getOrganizationEndpoints,
 } from '@coveo/atomic-react';
 import React, {FunctionComponent, useMemo} from 'react';
 
@@ -61,6 +62,7 @@ export const AtomicPageWrapper: FunctionComponent<Props> = ({
         configuration: {
           accessToken,
           organizationId,
+          organizationEndpoints: getOrganizationEndpoints(organizationId),
           search: {
             pipeline: 'Search',
             searchHub: 'MainSearch',

--- a/packages/samples/iife/cypress/e2e/atomic-react-smoke-test.cy.ts
+++ b/packages/samples/iife/cypress/e2e/atomic-react-smoke-test.cy.ts
@@ -13,7 +13,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
   it('should load', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:3000/atomic-react').wait('@analytics', {

--- a/packages/samples/iife/www/atomic-react.html
+++ b/packages/samples/iife/www/atomic-react.html
@@ -23,7 +23,7 @@
       'use strict';
 
       const {useMemo} = React;
-      const {buildSearchEngine} = CoveoHeadless;
+      const {buildSearchEngine, getOrganizationEndpoints} = CoveoHeadless;
       const {
         AtomicBreadbox,
         AtomicColorFacet,
@@ -136,6 +136,7 @@
               configuration: {
                 accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
                 organizationId: 'electronicscoveodemocomo0n2fu8v',
+                organizationEndpoints: getOrganizationEndpoints('electronicscoveodemocomo0n2fu8v'),
                 search: {
                   pipeline: 'Search',
                   searchHub: 'MainSearch',

--- a/packages/samples/vuejs/cypress/integration/atomic-angular/smoke-test.cypress.ts
+++ b/packages/samples/vuejs/cypress/integration/atomic-angular/smoke-test.cypress.ts
@@ -12,7 +12,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
   it('should load', () => {
     cy.intercept({
       method: 'POST',
-      path: '**/rest/ua/v15/analytics/*',
+      path: '**/rest/v15/analytics/*',
     }).as('analytics');
 
     cy.visit('http://localhost:8080/').wait('@analytics');

--- a/packages/samples/vuejs/src/components/ResultTextFieldMultivalue.vue
+++ b/packages/samples/vuejs/src/components/ResultTextFieldMultivalue.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps({
+  label: String,
+  field: String,
+});
+</script>
+
+<template>
+  <atomic-text :value="props.label"></atomic-text>:
+  <atomic-result-multi-value-text
+    :field="props.field"
+  ></atomic-result-multi-value-text>
+</template>

--- a/packages/samples/vuejs/src/components/SearchPage.vue
+++ b/packages/samples/vuejs/src/components/SearchPage.vue
@@ -14,6 +14,7 @@ async function initInterface() {
   await searchInterface.initialize({
     accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
     organizationId: 'electronicscoveodemocomo0n2fu8v',
+    organizationEndpoints: await searchInterface.getOrganizationEndpoints('electronicscoveodemocomo0n2fu8v')
   });
 
   // Trigger a first search

--- a/packages/samples/vuejs/src/main.ts
+++ b/packages/samples/vuejs/src/main.ts
@@ -3,6 +3,7 @@ import {applyPolyfills, defineCustomElements} from '@coveo/atomic/loader';
 import {createApp, defineCustomElement} from 'vue';
 import App from './App.vue';
 import ResultTextField from './components/ResultTextField.vue';
+import ResultTextFieldMultivalue from './components/ResultTextFieldMultivalue.vue';
 
 applyPolyfills().then(() => {
   defineCustomElements(window);
@@ -10,6 +11,13 @@ applyPolyfills().then(() => {
 
 const app = createApp(App);
 const resultTextField = defineCustomElement(ResultTextField);
+const resultTextFieldMultivalue = defineCustomElement(
+  ResultTextFieldMultivalue
+);
 customElements.define('result-text-field', resultTextField);
+customElements.define(
+  'result-text-field-multivalue',
+  resultTextFieldMultivalue
+);
 
 app.mount('#app');

--- a/packages/samples/vuejs/src/templates/result-template.html
+++ b/packages/samples/vuejs/src/templates/result-template.html
@@ -31,7 +31,7 @@
         <result-text-field label="Condition" field="cat_condition"></result-text-field>
       </atomic-field-condition>
       <atomic-field-condition class="field" if-defined="cat_categories">
-        <result-text-field label="Tags" field="cat_categories"></result-text-field>
+        <result-text-field-multivalue label="Tags" field="cat_categories"></result-text-field-multivalue>
       </atomic-field-condition>
     </atomic-result-fields-list>
   </atomic-result-section-bottom-metadata>


### PR DESCRIPTION
Adjust some samples not using the `organizationEndpoints`. 

Samples were still working properly, but this is to silence the warnings and showcase the best practice in our own samples/documentation.

There's going to be more of those type of PR in various adjacent tooling (ie: CLI).

https://coveord.atlassian.net/browse/KIT-2388