### PR TITLE
fix(atomic): remove focus trap props in IPX modal

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -44,29 +44,19 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
 
   @State() private hasFooterSlotElements = true;
 
-  private focusTrap?: HTMLAtomicFocusTrapElement;
-  private currentWatchToggleOpenExecution = 0;
-
   @Watch('isOpen')
   async watchToggleOpen(isOpen: boolean) {
-    const watchToggleOpenExecution = ++this.currentWatchToggleOpenExecution;
     const modalOpenedClass = 'atomic-ipx-modal-opened';
 
     if (isOpen) {
       //TODO: remove the addition of a class to the body in atomicV3
       document.body.classList.add(modalOpenedClass);
       this.bindings.interfaceElement.classList.add(modalOpenedClass);
-      if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
-        this.focusTrap!.active = true;
-      }
       return;
     }
     //TODO: remove the removal of a class to the body in atomicV3
     document.body.classList.remove(modalOpenedClass);
     this.bindings.interfaceElement.classList.remove(modalOpenedClass);
-    if (watchToggleOpenExecution === this.currentWatchToggleOpenExecution) {
-      this.focusTrap!.active = false;
-    }
   }
 
   private getClasses() {


### PR DESCRIPTION
Forgot to remove focus trap references in the IPX-modal in my other PR https://github.com/coveo/ui-kit/pull/2805/files. This removes all focus trap related props and calls from the IPX-modal
https://coveord.atlassian.net/browse/SVCINT-2161