### PR TITLE
fix(headless): add warning on configuration mismatch between organizationId and organizationEndpoint

### DIFF
--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -161,7 +161,7 @@ describe('engine', () => {
     expect(engine.logger.warn).not.toHaveBeenCalled();
   });
 
-  it('should log warnings when the organizationId option does not match what is configured on organizationEndpoints option is set and platformUrl is not set', () => {
+  it('should log warnings when the organizationId option does not match what is configured on organizationEndpoints option.', () => {
     options.configuration = {
       ...options.configuration,
       organizationId: 'a',

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -160,4 +160,19 @@ describe('engine', () => {
     initEngine();
     expect(engine.logger.warn).not.toHaveBeenCalled();
   });
+
+  it('should log warnings when the organizationId option does not match what is configured on organizationEndpoints option is set and platformUrl is not set', () => {
+    options.configuration = {
+      ...options.configuration,
+      organizationId: 'a',
+      organizationEndpoints: getOrganizationEndpoints('b'),
+      platformUrl: undefined,
+    };
+    initEngine();
+    expect(engine.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'There is a mismatch between the `organizationId` option (a) and the organization configured on the `organizationEndpoints` option (https://b.org.coveo.com).'
+      )
+    );
+  });
 });

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -154,7 +154,7 @@ describe('engine', () => {
   it('should not log warnings when the organizationEndpoints option is set and platformUrl is not set', () => {
     options.configuration = {
       ...options.configuration,
-      organizationEndpoints: getOrganizationEndpoints('myorg'),
+      organizationEndpoints: getOrganizationEndpoints('orgId'),
       platformUrl: undefined,
     };
     initEngine();

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -171,7 +171,7 @@ describe('engine', () => {
     initEngine();
     expect(engine.logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        'There is a mismatch between the `organizationId` option (a) and the organization configured on the `organizationEndpoints` option (https://b.org.coveo.com).'
+        'There is a mismatch between the `organizationId` option (a) and the organization configured in the `organizationEndpoints` option (https://b.org.coveo.com).'
       )
     );
   });

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -197,7 +197,7 @@ export function buildEngine<
     )
   ) {
     engine.logger.warn(
-      `There is a mismatch between the \`organizationId\` option (${options.configuration.organizationId}) and the organization configured on the \`organizationEndpoints\` option (${options.configuration.organizationEndpoints?.platform}). This could lead to issues that are complex to troubleshoot. Please make sure both values are equivalent.`
+      `There is a mismatch between the \`organizationId\` option (${options.configuration.organizationId}) and the organization configured in the \`organizationEndpoints\` option (${options.configuration.organizationEndpoints?.platform}). This could lead to issues that are complex to troubleshoot. Please make sure both values match.`
     );
   }
 

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -197,7 +197,7 @@ export function buildEngine<
     )
   ) {
     engine.logger.warn(
-      `There is a mismatch between the \`organizationId\` option (${options.configuration.organizationId}) and the organization configured on the \`organizationEndpoints\` option (${options.configuration.organizationEndpoints?.platform}). This could lead to hard to troubleshoot behaviour. Please make sure both values are equivalent.`
+      `There is a mismatch between the \`organizationId\` option (${options.configuration.organizationId}) and the organization configured on the \`organizationEndpoints\` option (${options.configuration.organizationEndpoints?.platform}). This could lead to issues that are complex to troubleshoot. Please make sure both values are equivalent.`
     );
   }
 

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -18,6 +18,7 @@ import {
   updateBasicConfiguration,
 } from '../features/configuration/configuration-actions';
 import {SearchParametersState} from '../state/search-app-state';
+import {matchCoveoOrganizationEndpointUrlAnyOrganization} from '../utils/url-utils';
 import {doNotTrack} from '../utils/utils';
 import {analyticsMiddleware} from './analytics-middleware';
 import {EngineConfiguration} from './engine-configuration';
@@ -190,6 +191,16 @@ export function buildEngine<
     );
   }
 
+  if (
+    shouldWarnAboutMismatchBetweenOrganizationIDAndOrganizationEndpoints(
+      options
+    )
+  ) {
+    engine.logger.warn(
+      `There is a mismatch between the \`organizationId\` option (${options.configuration.organizationId}) and the organization configured on the \`organizationEndpoints\` option (${options.configuration.organizationEndpoints?.platform}). This could lead to hard to troubleshoot behaviour. Please make sure both values are equivalent.`
+    );
+  }
+
   if (organizationEndpoints?.platform) {
     platformUrl = organizationEndpoints.platform;
   }
@@ -307,4 +318,16 @@ function shouldWarnAboutOrganizationEndpoints(
 
 function shouldWarnAboutPlatformURL(options: EngineOptions<ReducersMapObject>) {
   return !isNullOrUndefined(options.configuration.platformUrl);
+}
+
+function shouldWarnAboutMismatchBetweenOrganizationIDAndOrganizationEndpoints(
+  options: EngineOptions<ReducersMapObject>
+) {
+  if (isUndefined(options.configuration.organizationEndpoints)) {
+    return false;
+  }
+  const match = matchCoveoOrganizationEndpointUrlAnyOrganization(
+    options.configuration.organizationEndpoints.platform
+  );
+  return match && match.organizationId !== options.configuration.organizationId;
 }

--- a/packages/headless/src/utils/url-utils.ts
+++ b/packages/headless/src/utils/url-utils.ts
@@ -51,12 +51,15 @@ export const matchCoveoOrganizationEndpointUrl = (
   url: string,
   organizationId: string
 ): {organizationId?: string; environment?: PlatformEnvironment} | null => {
+  const match = matchCoveoOrganizationEndpointUrlAnyOrganization(url);
+  return match && match.organizationId === organizationId ? match : null;
+};
+
+export const matchCoveoOrganizationEndpointUrlAnyOrganization = (
+  url: string
+): {organizationId?: string; environment?: PlatformEnvironment} | null => {
   const match = url.match(
     /^https:\/\/(?<organizationId>\w+)\.org(?<environment>dev|stg|hipaa)?\.coveo\.com/
   );
-  if (!match?.groups) {
-    return null;
-  }
-  const isOrgMatching = match.groups.organizationId === organizationId;
-  return isOrgMatching ? match.groups : null;
+  return match?.groups ? match.groups : null;
 };


### PR DESCRIPTION
This will log a warning if an implementer configure the engine like so:

```typescript
buildSearchEngine({
     organizationId: 'some-org-id',
     organizationEndpoints: getOrganizationEndpoints('another-org-id')
})
```
https://coveord.atlassian.net/browse/KIT-2403