### PR TITLE
fix: use tab label as id

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.tsx
@@ -5,7 +5,6 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
-import {randomID} from '../../../utils/utils';
 import {Button} from '../../common/button';
 import {Bindings} from '../../search/atomic-search-interface/atomic-search-interface';
 
@@ -19,7 +18,6 @@ import {Bindings} from '../../search/atomic-search-interface/atomic-search-inter
 })
 export class AtomicIPXTab implements InitializableComponent {
   private tab!: Tab;
-  private tabId = randomID('ipx-tab');
 
   @InitializeBindings() public bindings!: Bindings;
 
@@ -47,7 +45,7 @@ export class AtomicIPXTab implements InitializableComponent {
 
   public initialize() {
     this.tab = buildTab(this.bindings.engine, {
-      options: {expression: this.expression, id: this.tabId},
+      options: {expression: this.expression, id: this.label},
       initialState: {isActive: this.active},
     });
   }


### PR DESCRIPTION
[SVCINT-2270](https://coveord.atlassian.net/browse/SVCINT-2270)

The tabId used was random, which is not a great experience for users, analytics, queryPipelines, etc.

We're using the tab's label now, which is way more straightforward !

[SVCINT-2270]: https://coveord.atlassian.net/browse/SVCINT-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ