### PR TITLE
chore(workflows): don't use always() in workflows

### DIFF
--- a/.github/actions/e2e-atomic-screenshots/action.yml
+++ b/.github/actions/e2e-atomic-screenshots/action.yml
@@ -18,7 +18,7 @@ runs:
         install: false
         record: false
     - uses: actions/upload-artifact@v3
-      if: always()
+      if: cancelled() || failure() || success()
       with:
         name: cypress-result-lists-screenshots
         path: packages/atomic/cypress/screenshots

--- a/.github/workflows/manual-package.yml
+++ b/.github/workflows/manual-package.yml
@@ -180,7 +180,7 @@ jobs:
       - 'e2e-atomic-test'
       - 'e2e-quantic-test'
     runs-on: ubuntu-latest
-    if: always()
+    if: cancelled() || failure() || success()
     steps:
       - name: fail if unit test failed
         if: ${{ needs.unit-test.result == 'failure' }}

--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -153,7 +153,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           spec: ${{ matrix.spec }}
   e2e-quantic-cleanup:
-    if: always()
+    if: cancelled() || failure() || success()
     needs: e2e-quantic-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -163,7 +163,7 @@ jobs:
         with:
           spec: ${{ matrix.spec }}
   e2e-quantic-cleanup:
-    if: always()
+    if: cancelled() || failure() || success()
     needs: e2e-quantic-test
     runs-on: ubuntu-latest
     steps:
@@ -183,7 +183,7 @@ jobs:
     steps:
       - run: echo 'All required jobs have passed'
   is-valid:
-    if: always()
+    if: cancelled() || failure() || success()
     name: 'Confirm build is valid'
     needs:
       - 'required-jobs'


### PR DESCRIPTION
Related Issue
DT-5750

## Hi, what's this?
👋 We have come across a problem with using `if: always()` in workflows. The basic gist is that these steps become un-cancellable, possibly creating all sorts of unexpected problems. This is less frequent with GitHub hosted runners, but it can happen.

This PR introduces and workaround this problem by explicitly defining the different states the step can face.
Namely:
* `success()`
* `cancelled()`
* `failure()`

This way, you get the `always()` behaviour without it's possible caveats.

## I don't want this change
In a way, this is more of a "we really recommend this" kind of PR. That is because you may never face the problem I'm talking about, but when you do, you'll want this workaround.

If you decide against merging this, please make sure you mention this if you need support in the future to help us identify this issue faster.

## Final notes
Please review and merge this PR. Since this is a CI change, you don't need to release this change.

This PR is created as part of a large batch. I would appreciate it if you could merge this yourself to ease the amount of followup on my end.

## References
* https://coveo.slack.com/archives/CBP3GTFTQ/p1679495407426389 (Coveo internal)
* https://github.com/orgs/community/discussions/26303