### PR TITLE
feat(atomic): add styling to the ipx scroll bar

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -51,6 +51,34 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
         class={`${this.isOpen ? 'visible' : 'invisible'}`}
         onAnimationEnd={() => this.animationEnded.emit()}
       >
+        <style>
+          {`
+            /* Chrome, Edge & Safari */
+            .scrollbar::-webkit-scrollbar {
+              width: 1rem;
+            }
+
+            .scrollbar::-webkit-scrollbar-track {
+              background: var(--atomic-neutral-light);
+            }
+
+            .scrollbar::-webkit-scrollbar-thumb {
+              background: var(--atomic-primary);
+              border: 0.15rem solid var(--atomic-neutral-light);
+              border-radius: 100vh;
+            }
+
+            .scrollbar::-webkit-scrollbar-thumb:hover {
+              background: var(--atomic-primary-light);
+            }
+
+            /* Firefox */
+            .scrollbar {
+              scrollbar-color: var(--atomic-primary) var(--atomic-neutral-light);
+              scrollbar-width: auto;
+            }
+          `}
+        </style>
         <header part="header-wrapper" class="flex flex-col items-center">
           <div part="header">
             <slot name="header"></slot>
@@ -59,7 +87,7 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
         <hr part="header-ruler" class="border-neutral"></hr>
         <div
           part="body-wrapper"
-          class="overflow-auto grow flex flex-col w-full"
+          class="overflow-auto grow flex flex-col w-full scrollbar"
         >
           <div part="body" class="w-full max-w-lg">
             <slot name="body"></slot>

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -55,16 +55,16 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
           {`
             /* Chrome, Edge & Safari */
             .scrollbar::-webkit-scrollbar {
-              width: 1rem;
+              width: 0.8rem;
             }
 
             .scrollbar::-webkit-scrollbar-track {
-              background: var(--atomic-neutral-light);
+              background: var(--atomic-background);
             }
 
             .scrollbar::-webkit-scrollbar-thumb {
               background: var(--atomic-primary);
-              border: 0.15rem solid var(--atomic-neutral-light);
+              border: 0.15rem solid var(--atomic-background);
               border-radius: 100vh;
             }
 
@@ -74,7 +74,7 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
 
             /* Firefox */
             .scrollbar {
-              scrollbar-color: var(--atomic-primary) var(--atomic-neutral-light);
+              scrollbar-color: var(--atomic-primary) var(--atomic-background);
               scrollbar-width: auto;
             }
           `}


### PR DESCRIPTION
[SVCINT-2279](https://coveord.atlassian.net/browse/SVCINT-2279)

Added some custom styling to the IPX scroll bar:
- make the scrollbar background color the atomic background color
- make the scrollbar color the atomic primary color

Changes available in all browsers except Safari
- make the scrollbar rounded
- make the scrollbar slightly thinner (0.8rem)

Here is an example:

- Chrome
<img width="559" alt="image" src="https://user-images.githubusercontent.com/71142397/234351804-b9d21470-e328-475b-884e-524f69ed058b.png">


[SVCINT-2279]: https://coveord.atlassian.net/browse/SVCINT-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ