### PR TITLE
feat(headless): include the loadgenericanalyticsactions action loader in the case assist & insight headless bundle

### DIFF
--- a/packages/headless/doc-parser/use-cases/case-assist.ts
+++ b/packages/headless/doc-parser/use-cases/case-assist.ts
@@ -34,6 +34,9 @@ const actionLoaders: ActionLoaderConfiguration[] = [
   {
     initializer: 'loadCaseAssistAnalyticsActions',
   },
+  {
+    initializer: 'loadGenericAnalyticsActions',
+  },
 ];
 
 const engine: EngineConfiguration = {

--- a/packages/headless/doc-parser/use-cases/insight.ts
+++ b/packages/headless/doc-parser/use-cases/insight.ts
@@ -97,16 +97,34 @@ const actionLoaders: ActionLoaderConfiguration[] = [
     initializer: 'loadInsightSearchActions',
   },
   {
+    initializer: 'loadQuerySetActions',
+  },
+  {
     initializer: 'loadInsightAnalyticsActions',
   },
   {
-    initializer: 'loadInsightSearchAnalyticsActions',
+    initializer: 'loadDateFacetSetActions',
   },
   {
     initializer: 'loadNumericFacetSetActions',
   },
   {
+    initializer: 'loadRecentResultsActions',
+  },
+  {
+    initializer: 'loadDateFacetSetActions',
+  },
+  {
     initializer: 'loadCaseContextActions',
+  },
+  {
+    initializer: 'loadInsightSearchAnalyticsActions',
+  },
+  {
+    initializer: 'loadFieldActions',
+  },
+  {
+    initializer: 'loadAttachedResultsActions',
   },
   {
     initializer: 'loadGenericAnalyticsActions',

--- a/packages/headless/doc-parser/use-cases/insight.ts
+++ b/packages/headless/doc-parser/use-cases/insight.ts
@@ -108,6 +108,9 @@ const actionLoaders: ActionLoaderConfiguration[] = [
   {
     initializer: 'loadCaseContextActions',
   },
+  {
+    initializer: 'loadGenericAnalyticsActions',
+  },
 ];
 
 const engine: EngineConfiguration = {

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -24,6 +24,7 @@ export * from './features/case-input/case-input-actions-loader';
 export * from './features/case-field/case-field-actions-loader';
 export * from './features/document-suggestion/document-suggestion-actions-loader';
 export * from './features/case-assist/case-assist-analytics-actions-loader';
+export * from './features/analytics/generic-analytics-actions-loader';
 
 // Controllers
 export type {

--- a/packages/headless/src/features/attached-results/attached-results-actions-loader.ts
+++ b/packages/headless/src/features/attached-results/attached-results-actions-loader.ts
@@ -5,7 +5,9 @@ import {
   setAttachedResults,
   SetAttachedResultsActionCreatorPayload,
 } from './attached-results-actions';
+import {AttachedResult} from './attached-results-state';
 
+export type {SetAttachedResultsActionCreatorPayload, AttachedResult};
 export interface AttachedResultsActionCreators {
   /**
    * Creates an action that sets the attached results to a record.
@@ -20,6 +22,7 @@ export interface AttachedResultsActionCreators {
    *
    * @param attachedResults - The attached results records corresponding to this record.
    * @param loading - Optional state of loading.
+   * @param payload - The action creator payload.
    * @returns A dispatchable action.
    */
   setAttachedResults(

--- a/packages/headless/src/features/recent-queries/recent-queries-actions-loader.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-actions-loader.ts
@@ -14,6 +14,7 @@ export interface RecentQueriesActionCreators {
   /**
    * Initializes the `recentQueries` state.
    * @param payload (RegisterRecentQueriesCreatorPayload) The initial state and options.
+   * @returns A dispatchable action.
    */
   registerRecentQueries(
     payload: RegisterRecentQueriesCreatorPayload
@@ -21,6 +22,7 @@ export interface RecentQueriesActionCreators {
 
   /**
    * Clears the recent queries list.
+   * @returns A dispatchable action.
    */
   clearRecentQueries(): PayloadAction;
 }

--- a/packages/headless/src/features/recent-results/recent-results-actions-loader.ts
+++ b/packages/headless/src/features/recent-results/recent-results-actions-loader.ts
@@ -9,6 +9,7 @@ import {
   pushRecentResult,
 } from './recent-results-actions';
 
+export type {RegisterRecentResultsCreatorPayload};
 /**
  * The RecentResults action creators
  */
@@ -16,6 +17,7 @@ export interface RecentResultsActionCreators {
   /**
    * Initialize the `recentResults` state.
    * @param payload (RegisterRecentResultsCreatorPayload) The initial state and options.
+   * @returns A dispatchable action.
    */
   registerRecentResults(
     payload: RegisterRecentResultsCreatorPayload
@@ -23,12 +25,14 @@ export interface RecentResultsActionCreators {
 
   /**
    * Clear the recent results list.
+   * @returns A dispatchable action.
    */
   clearRecentResults(): PayloadAction;
 
   /**
    * Add the recent result to the list.
    * @param payload (Result) The result to add.
+   * @returns A dispatchable action.
    */
   pushRecentResult(payload: Result): PayloadAction<Result>;
 }

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -24,6 +24,7 @@ export * from './features/insight-interface/insight-interface-actions-loader';
 export * from './features/insight-search/insight-search-actions-loader';
 export * from './features/insight-search/insight-query-set-actions-loader';
 export * from './features/analytics/insight-analytics-actions-loader';
+export * from './features/analytics/generic-analytics-actions-loader';
 export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 export * from './features/recent-results/recent-results-actions-loader';

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -24,7 +24,6 @@ export * from './features/insight-interface/insight-interface-actions-loader';
 export * from './features/insight-search/insight-search-actions-loader';
 export * from './features/insight-search/insight-query-set-actions-loader';
 export * from './features/analytics/insight-analytics-actions-loader';
-export * from './features/analytics/generic-analytics-actions-loader';
 export * from './features/facets/range-facets/date-facet-set/date-facet-actions-loader';
 export * from './features/facets/range-facets/numeric-facet-set/numeric-facet-actions-loader';
 export * from './features/recent-results/recent-results-actions-loader';
@@ -33,6 +32,7 @@ export * from './features/case-context/case-context-actions-loader';
 export * from './features/insight-search/insight-search-analytics-actions-loader';
 export * from './features/fields/fields-actions-loader';
 export * from './features/attached-results/attached-results-actions-loader';
+export * from './features/analytics/generic-analytics-actions-loader';
 
 // Controllers
 export type {


### PR DESCRIPTION
[SFINT-4918](https://coveord.atlassian.net/browse/SFINT-4918)

I want to be able to send my own custom analytics events when using Quantic to implement my case assist flow.

- loadGenericAnalyticsActions function is currently included only in the search bundle, we need to include it in the Headless bundle of other use cases.
- we need to expose loadGenericAnalyticsActions for the insight use case as well

As you can see below, we can have access to loadGenericAnalyticsActions

CASE ASSIST: 

<img width="1161" alt="Screenshot 2023-04-17 at 5 29 35 PM" src="https://user-images.githubusercontent.com/73316533/232618673-e4b219af-3556-4c30-82d8-feff154e26d2.png">

INSIGHT: 

<img width="1092" alt="Screenshot 2023-04-17 at 5 29 10 PM" src="https://user-images.githubusercontent.com/73316533/232618601-99e21434-57c3-4ac0-a762-24e0a3bfbd13.png">
ericAnalyticsActions in quantic in case assist & insight components

[SFINT-4918]: https://coveord.atlassian.net/browse/SFINT-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ