### PR TITLE
feat(organizationendpoints): support organization endpoints for hosted-pages components

### DIFF
--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@coveo/bueno": "0.43.1",
-    "@stencil/core": "2.17.3"
+    "@stencil/core": "2.17.3",
+    "@coveo/headless": "2.13.0"
   },
   "devDependencies": {
     "cypress": "9.7.0"

--- a/packages/atomic-hosted-page/src/components.d.ts
+++ b/packages/atomic-hosted-page/src/components.d.ts
@@ -5,11 +5,24 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { PlatformEnvironment } from "@coveo/headless";
 export namespace Components {
     interface AtomicHostedPage {
+        /**
+          * Returns the unique, organization-specific endpoint(s)
+          * @param organizationId
+          * @param env
+         */
+        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment) => Promise<{ platform: string; analytics: string; search: string; admin: string; }>;
         "initialize": (options: AtomicHostedPageInitializationOptions) => Promise<void>;
     }
     interface AtomicSimpleBuilder {
+        /**
+          * Returns the unique, organization-specific endpoint(s)
+          * @param organizationId
+          * @param env
+         */
+        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment) => Promise<{ platform: string; analytics: string; search: string; admin: string; }>;
         "initialize": (options: AtomicSimpleBuilderInitializationOptions) => Promise<void>;
     }
 }

--- a/packages/atomic-hosted-page/src/components/utils/options-utils.ts
+++ b/packages/atomic-hosted-page/src/components/utils/options-utils.ts
@@ -1,0 +1,52 @@
+import {Schema, SchemaValue, StringValue} from '@coveo/bueno';
+import {getOrganizationEndpoints} from '@coveo/headless';
+
+export interface InitializationOptions {
+  /**
+   * The unique identifier of the target Coveo Cloud organization (e.g., `mycoveocloudorganizationg8tp8wu3`)
+   */
+  organizationId: string;
+  /**
+   * The access token to use to authenticate requests against the Coveo Cloud endpoints. Typically, this will be an API key or search token that grants the privileges to execute queries and push usage analytics data in the target Coveo Cloud organization.
+   */
+  accessToken: string;
+  /**
+   * The Plaform URL to use. (e.g., https://platform.cloud.coveo.com)
+   * The platformUrl() helper method can be useful to know what url is available.
+   * @defaultValue `https://platform.cloud.coveo.com`
+   *
+   * @deprecated Coveo recommends using organizationEndpoints instead, since it has resiliency benefits and simplifies the overall configuration for multi-region deployments.
+   */
+  platformUrl?: string;
+  /**
+   * The endpoints to use.
+   *
+   * For example: `https://orgid.admin.org.coveo.com`
+   *
+   * The [getOrganizationEndpoints](https://github.com/coveo/ui-kit/blob/master/packages/headless/src/api/platform-client.ts) helper function can be useful to create the appropriate object.
+   *
+   * We recommend using this option, since it has resiliency benefits and simplifies the overall configuration for multi-region deployments.
+   */
+  organizationEndpoints?: ReturnType<typeof getOrganizationEndpoints>;
+}
+
+export const validateOptions = (
+  opts: InitializationOptions,
+  additionalSchemaValidation: Record<string, SchemaValue<unknown>>
+) => {
+  try {
+    new Schema({
+      organizationId: new StringValue({required: true, emptyAllowed: false}),
+      accessToken: new StringValue({required: true, emptyAllowed: false}),
+      platformUrl: new StringValue({required: false, emptyAllowed: false}),
+      ...additionalSchemaValidation,
+    }).validate(opts);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+export const extractPlatformUrl = (options: InitializationOptions) =>
+  options.platformUrl ||
+  options.organizationEndpoints?.admin ||
+  `https://${options.organizationId}.org.coveo.com`;

--- a/packages/atomic-hosted-page/src/pages/index.html
+++ b/packages/atomic-hosted-page/src/pages/index.html
@@ -16,7 +16,7 @@
           pageId: '4d4af944-1a6e-4be3-9c04-9c772e031956',
           accessToken: 'xxa6e9ee50-2dcf-4062-890f-c63d57b061ab',
           organizationId: 'qaregression2',
-          platformUrl: 'https://platformstg.cloud.coveo.com',
+          organizationEndpoints: await page.getOrganizationEndpoints('qaregression2', 'stg'),
         });
       })();
     </script>

--- a/packages/atomic-hosted-page/src/pages/index.html
+++ b/packages/atomic-hosted-page/src/pages/index.html
@@ -13,10 +13,10 @@
         const page = document.querySelector('atomic-hosted-page');
         // TODO: switch for prod - searchuisamples
         await page.initialize({
-          pageId: '4d4af944-1a6e-4be3-9c04-9c772e031956',
-          accessToken: 'xxa6e9ee50-2dcf-4062-890f-c63d57b061ab',
-          organizationId: 'qaregression2',
-          organizationEndpoints: await page.getOrganizationEndpoints('qaregression2', 'stg'),
+          pageId: '88411b30-39fb-4bd3-8663-2d1af2b27659',
+          accessToken: 'xx71d82ce9-f6fe-4be0-9209-c0e43f6fae81',
+          organizationId: 'searchuisamples',
+          organizationEndpoints: await page.getOrganizationEndpoints('searchuisamples'),
         });
       })();
     </script>

--- a/packages/atomic-hosted-page/src/pages/simple-builder.html
+++ b/packages/atomic-hosted-page/src/pages/simple-builder.html
@@ -11,14 +11,8 @@
         await customElements.whenDefined('atomic-simple-builder');
 
         const builder = document.querySelector('atomic-simple-builder');
-        /*
-          TODO: switch for following values when route in prod
-          interfaceId: '0c9eaa4a-8dab-4c11-83d6-24dd1feb961e',
-          accessToken: 'xx71d82ce9-f6fe-4be0-9209-c0e43f6fae81',
-          organizationId: 'searchuisamples',
-        */
         await builder.initialize({
-          interfaceId: '0c9eaa4a-8dab-4c11-83d6-24dd1feb961e',
+          interfaceId: '5be6b830-8605-40e4-8e7a-5c56aa7c750c',
           accessToken: 'xx71d82ce9-f6fe-4be0-9209-c0e43f6fae81',
           organizationId: 'searchuisamples',
           organizationEndpoints: await builder.getOrganizationEndpoints('searchuisamples'),

--- a/packages/atomic-hosted-page/src/pages/simple-builder.html
+++ b/packages/atomic-hosted-page/src/pages/simple-builder.html
@@ -18,10 +18,10 @@
           organizationId: 'searchuisamples',
         */
         await builder.initialize({
-          interfaceId: '45f9a933-b329-491e-bb15-64105eeea7e7',
-          accessToken: 'xx4bf05218-829b-4839-ab16-6ef044146909',
-          organizationId: 'hostedsearchpagetest5ftf64ka',
-          platformUrl: 'https://platformdev.cloud.coveo.com',
+          interfaceId: '0c9eaa4a-8dab-4c11-83d6-24dd1feb961e',
+          accessToken: 'xx71d82ce9-f6fe-4be0-9209-c0e43f6fae81',
+          organizationId: 'searchuisamples',
+          organizationEndpoints: await builder.getOrganizationEndpoints('searchuisamples'),
         });
       })();
     </script>

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -422,7 +422,7 @@ export namespace Components {
           * @param organizationId
           * @param env
          */
-        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironmentInsight) => Promise<{ platform: string; analytics: string; search: string; }>;
+        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironmentInsight) => Promise<{ platform: string; analytics: string; search: string; admin: string; }>;
         /**
           * The service insight interface i18next instance.
          */
@@ -1019,7 +1019,7 @@ export namespace Components {
           * A list of non-default fields to include in the query results.  Specify the property as an array using a JSON string representation: ```html <atomic-recs-interface fields-to-include='["fieldA", "fieldB"]'></atomic-recs-interface> ```
          */
         "fieldsToInclude": string[] | string;
-        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment) => Promise<{ platform: string; analytics: string; search: string; }>;
+        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment) => Promise<{ platform: string; analytics: string; search: string; admin: string; }>;
         /**
           * Fetches new recommendations.
          */
@@ -1567,7 +1567,7 @@ export namespace Components {
           * @param organizationId
           * @param env
          */
-        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment1) => Promise<{ platform: string; analytics: string; search: string; }>;
+        "getOrganizationEndpoints": (organizationId: string, env?: PlatformEnvironment1) => Promise<{ platform: string; analytics: string; search: string; admin: string; }>;
         /**
           * The search interface i18next instance.
          */

--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -46,6 +46,7 @@ describe('url helper', () => {
         platform: 'https://foo.orgdev.coveo.com',
         search: 'https://foo.orgdev.coveo.com/rest/search/v2',
         analytics: 'https://foo.analytics.orgdev.coveo.com',
+        admin: 'https://foo.admin.orgdev.coveo.com',
       },
     },
     {
@@ -55,6 +56,7 @@ describe('url helper', () => {
         platform: 'https://foo.orgstg.coveo.com',
         search: 'https://foo.orgstg.coveo.com/rest/search/v2',
         analytics: 'https://foo.analytics.orgstg.coveo.com',
+        admin: 'https://foo.admin.orgstg.coveo.com',
       },
     },
     {
@@ -64,6 +66,7 @@ describe('url helper', () => {
         platform: 'https://foo.org.coveo.com',
         search: 'https://foo.org.coveo.com/rest/search/v2',
         analytics: 'https://foo.analytics.org.coveo.com',
+        admin: 'https://foo.admin.org.coveo.com',
       },
     },
     {
@@ -73,6 +76,7 @@ describe('url helper', () => {
         platform: 'https://foo.orghipaa.coveo.com',
         search: 'https://foo.orghipaa.coveo.com/rest/search/v2',
         analytics: 'https://foo.analytics.orghipaa.coveo.com',
+        admin: 'https://foo.admin.orghipaa.coveo.com',
       },
     },
   ] as Array<{orgId: string; env: PlatformEnvironment; organizationEndpoints: ReturnType<typeof getOrganizationEndpoints>}>)(

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -142,8 +142,9 @@ export function getOrganizationEndpoints(
   const platform = `https://${orgId}.org${envSuffix}.coveo.com`;
   const analytics = `https://${orgId}.analytics.org${envSuffix}.coveo.com`;
   const search = `${platform}/rest/search/v2`;
+  const admin = `https://${orgId}.admin.org${envSuffix}.coveo.com`;
 
-  return {platform, analytics, search};
+  return {platform, analytics, search, admin};
 }
 
 /**


### PR DESCRIPTION
* Add `admin` endpoint in Headless > `getOrganizationEndpoints` utility function
* Leverage it to load the pages inside `<atomic-hosted-pages>` and `<atomic-simple-builder>`

https://coveord.atlassian.net/browse/KIT-2405
https://coveord.atlassian.net/browse/CDX-1410