### PR TITLE
docs(atomic): Update docs for field property of atomic-result-badge

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1239,7 +1239,7 @@ export namespace Components {
     }
     interface AtomicResultBadge {
         /**
-          * The field to display in the badge.  Not compatible with `label`, slotted elements and multi-value fields.
+          * The field to display in the badge.  Not compatible with `label`, slotted elements nor multi-value fields.
          */
         "field"?: string;
         /**
@@ -3916,7 +3916,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultBadge {
         /**
-          * The field to display in the badge.  Not compatible with `label`, slotted elements and multi-value fields.
+          * The field to display in the badge.  Not compatible with `label`, slotted elements nor multi-value fields.
          */
         "field"?: string;
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1239,7 +1239,7 @@ export namespace Components {
     }
     interface AtomicResultBadge {
         /**
-          * The field to display in the badge.  Not compatible with `label` nor slotted elements.
+          * The field to display in the badge.  Not compatible with `label`, slotted elements and multi-value fields.
          */
         "field"?: string;
         /**
@@ -3912,7 +3912,7 @@ declare namespace LocalJSX {
     }
     interface AtomicResultBadge {
         /**
-          * The field to display in the badge.  Not compatible with `label` nor slotted elements.
+          * The field to display in the badge.  Not compatible with `label`, slotted elements and multi-value fields.
          */
         "field"?: string;
         /**

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -14,7 +14,6 @@ import {ResultContext} from '../result-template-decorators';
  * ```html
  * <atomic-result-badge field="objecttype"></atomic-result-badge>
  * ```
- *
  * * An icon:
  * ```html
  * <atomic-result-badge icon="https://my-website.fake/star.svg"></atomic-result-badge>
@@ -26,7 +25,7 @@ import {ResultContext} from '../result-template-decorators';
  * </atomic-result-badge>
  * ```
  *
- * The content of a multi-value field can be displayed as follows:
+ * The contents of a multi-value field can be displayed as in the following example:
  * ```html
  * <atomic-result-badge icon="https://my-website.fake/language.svg">
  *    <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
@@ -49,7 +48,7 @@ export class AtomicResultBadge {
   /**
    * The field to display in the badge.
    *
-   * Not compatible with `label`, slotted elements and multi-value fields.
+   * Not compatible with `label`, slotted elements nor multi-value fields.
    */
   @Prop({reflect: true}) public field?: string;
 

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -10,9 +10,15 @@ import {ResultContext} from '../result-template-decorators';
  * ```html
  * <atomic-result-badge label="trending"></atomic-result-badge>
  * ```
- * * The contents of a field:
+ * * The contents of a single-value field:
  * ```html
  * <atomic-result-badge field="objecttype"></atomic-result-badge>
+ * ```
+ * * The contents of a multi-value field:
+ * ```html
+ * <atomic-result-badge icon="https://my-website.fake/language.svg">
+      <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
+   </atomic-result-badge>
  * ```
  * * An icon:
  * ```html
@@ -41,7 +47,7 @@ export class AtomicResultBadge {
   /**
    * The field to display in the badge.
    *
-   * Not compatible with `label` nor slotted elements.
+   * Not compatible with `label`, slotted elements and multi-value fields.
    */
   @Prop({reflect: true}) public field?: string;
 

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-badge/atomic-result-badge.tsx
@@ -14,12 +14,7 @@ import {ResultContext} from '../result-template-decorators';
  * ```html
  * <atomic-result-badge field="objecttype"></atomic-result-badge>
  * ```
- * * The contents of a multi-value field:
- * ```html
- * <atomic-result-badge icon="https://my-website.fake/language.svg">
-      <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
-   </atomic-result-badge>
- * ```
+ *
  * * An icon:
  * ```html
  * <atomic-result-badge icon="https://my-website.fake/star.svg"></atomic-result-badge>
@@ -28,6 +23,13 @@ import {ResultContext} from '../result-template-decorators';
  * ```html
  * <atomic-result-badge icon="https://my-website.fake/stopwatch.svg">
  *     Deal ends in <my-dynamic-countdown></my-dynamic-countdown>
+ * </atomic-result-badge>
+ * ```
+ *
+ * The content of a multi-value field can be displayed as follows:
+ * ```html
+ * <atomic-result-badge icon="https://my-website.fake/language.svg">
+ *    <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
  * </atomic-result-badge>
  * ```
  *


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-12604

Multi-value field was causing errors in code sandbox when trying to be displayed within field properties of badges.
Added an example for multi-value field.