### PR TITLE
fix: pre-process svg inside of atomic-ipx-button

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
@@ -8,6 +8,8 @@ import {
 import {Button} from '../../common/button';
 import {Bindings} from '../../search/atomic-search-interface/atomic-search-interface';
 
+const numberOrPixelValuePattern = new RegExp(/^(?=.*(?:\d+|px)$).*$/);
+
 /**
  * @internal
  */
@@ -126,10 +128,38 @@ export class AtomicIPXButton implements InitializableComponent {
   private getIcon(icon: string) {
     const initialDiv = document.createElement('div')!;
     initialDiv.innerHTML = icon;
-    initialDiv
-      .querySelector('svg')
-      ?.setAttribute('fill', 'var(--atomic-on-primary)');
-
+    const iconElement = initialDiv.querySelector('svg');
+    if (!iconElement) {
+      return initialDiv.innerHTML; // handle null case from .querySelector
+    }
+    const iconWidth = this.getIconWidth(iconElement);
+    const iconHeight = this.getIconHeight(iconElement);
+    this.cleanupSVGStyles(iconElement); // cleanup styles so that they don't interfere with the viewBox we are setting and let the icon fill up the provided space
+    if (iconWidth && iconHeight) {
+      iconElement.setAttribute('viewBox', `0 0 ${iconWidth} ${iconHeight}`); // set viewBox equal to icon size (following advice from @btaillon)
+    }
     return initialDiv.innerHTML;
+  }
+
+  private cleanupSVGStyles(iconElement: SVGSVGElement) {
+    iconElement.removeAttribute('style');
+    iconElement.removeAttribute('width');
+    iconElement.removeAttribute('height');
+  }
+
+  private getIconWidth(icon: SVGSVGElement) {
+    const width = icon.getAttribute('width') ?? '';
+    if (numberOrPixelValuePattern.test(width)) {
+      return width;
+    }
+    return null;
+  }
+
+  private getIconHeight(icon: SVGSVGElement) {
+    const height = icon.getAttribute('height') ?? '';
+    if (numberOrPixelValuePattern.test(height)) {
+      return height;
+    }
+    return null;
   }
 }

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.tsx
@@ -130,13 +130,14 @@ export class AtomicIPXButton implements InitializableComponent {
     initialDiv.innerHTML = icon;
     const iconElement = initialDiv.querySelector('svg');
     if (!iconElement) {
-      return initialDiv.innerHTML; // handle null case from .querySelector
+      return initialDiv.innerHTML;
     }
+    // here, we grab the icon width and height to set a viewbox (which keeps the svg looking normal), then remove styles from the icon to let the icon stretch into the space it is given.
     const iconWidth = this.getIconWidth(iconElement);
     const iconHeight = this.getIconHeight(iconElement);
-    this.cleanupSVGStyles(iconElement); // cleanup styles so that they don't interfere with the viewBox we are setting and let the icon fill up the provided space
+    this.cleanupSVGStyles(iconElement);
     if (iconWidth && iconHeight) {
-      iconElement.setAttribute('viewBox', `0 0 ${iconWidth} ${iconHeight}`); // set viewBox equal to icon size (following advice from @btaillon)
+      iconElement.setAttribute('viewBox', `0 0 ${iconWidth} ${iconHeight}`);
     }
     return initialDiv.innerHTML;
   }


### PR DESCRIPTION
[SVCINT-2203](https://coveord.atlassian.net/browse/SVCINT-2203)

Updated the `atomic-ipx-button` component to pre-process svg.
It will: 
- Load the provided svg in the dom
- Check if it is actually an svg
- Compute the svg's width and height if set
- Strip all the styles from the svg (including width and height) since we want the svg to adapt to the button size
- If the svg had a width and height set, set the svg's viewBox to the given width and height

<img width="152" alt="image" src="https://user-images.githubusercontent.com/71142397/234332140-25aec85d-0170-4899-854e-874ee719fbd9.png">


[SVCINT-2203]: https://coveord.atlassian.net/browse/SVCINT-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ