### PR TITLE
fix(atomic): do not overwrite analyticsClientMiddleware

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-interface/analytics-config.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/analytics-config.ts
@@ -25,6 +25,7 @@ export function getAnalyticsConfig(
     return {
       ...defaultConfiguration,
       ...searchEngineConfig.analytics,
+      analyticsClientMiddleware,
     };
   }
   return defaultConfiguration;

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/analytics-config.ts
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/analytics-config.ts
@@ -28,6 +28,7 @@ export function getAnalyticsConfig(
     return {
       ...defaultAnalyticsConfig,
       ...recsConfig.analytics,
+      analyticsClientMiddleware,
     };
   }
   return defaultAnalyticsConfig;

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -78,7 +78,7 @@ describe('analyticsConfig', () => {
       );
     });
 
-    it('it augment analytics payload with Atomic version', () => {
+    it('augments analytics payload with Atomic version', () => {
       const resultingConfig = getAnalyticsConfig(config, true, store);
       const out = resultingConfig.analyticsClientMiddleware!('an_event', {
         customData: {},
@@ -86,7 +86,7 @@ describe('analyticsConfig', () => {
       expect(out.customData).toHaveProperty('coveoAtomicVersion');
     });
 
-    it('it augment analytics payload with facet title, with any type of facet registered to the store', () => {
+    it('augments analytics payload with facet title, with any type of facet registered to the store', () => {
       const resultingConfig = getAnalyticsConfig(config, true, store);
       (
         ['facets', 'numericFacets', 'dateFacets', 'categoryFacets'] as const
@@ -109,7 +109,7 @@ describe('analyticsConfig', () => {
       });
     });
 
-    it('it does not augment analytics payload with a facet title when a facet is unavailable from the store', () => {
+    it('does not augment analytics payload with a facet title when a facet is unavailable from the store', () => {
       const result = getAnalyticsConfig(config, true, store);
       const out = result.analyticsClientMiddleware!('an_event', {
         customData: {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -14,90 +14,112 @@ describe('analyticsConfig', () => {
     Object.defineProperty(document, 'referrer', {value, configurable: true});
   };
 
-  beforeEach(() => {
-    config = getSampleSearchEngineConfiguration();
-    store = createAtomicStore();
-  });
-
-  afterEach(() => {
-    Object.defineProperty(document, 'referrer', {value: originalReferrer});
-  });
-
-  it('should provide out of the box values for analytics config', () => {
-    setReferrer('foo');
-    const resultingConfig = getAnalyticsConfig(config, true, store);
-    expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
-    expect(resultingConfig.originLevel3).toBe('foo');
-  });
-
-  it('merges provided engine analytics config', () => {
-    setReferrer('foo');
+  const getConfigWithCustomAnalyticsClientMiddleware = () => {
+    const config = getSampleSearchEngineConfiguration();
     config.analytics = {
-      enabled: true,
-      originContext: 'something',
-      originLevel3: 'bar',
+      ...config.analytics,
+      analyticsClientMiddleware: (_: string, payload: any) => {
+        payload['foo'] = 'bar';
+        return payload;
+      },
     };
-    const resultingConfig = getAnalyticsConfig(config, false, store);
-    expect(resultingConfig.enabled).toBe(true);
-    expect(resultingConfig.originContext).toBe('something');
-    expect(resultingConfig.originLevel3).toBe('bar');
-  });
+    return config;
+  };
 
-  it('use existing analytics middleware if available', () => {
-    const analyticsClientMiddleware = (_: string, payload: any) => {
-      payload['foo'] = 'bar';
-      return payload;
-    };
+  describe.each([
+    {
+      describeName:
+        'when the searchEngineConfig does not have a custom analyticsClientMiddleware',
+      getSearchEngineConfig: getSampleSearchEngineConfiguration,
+    },
+    {
+      describeName:
+        'when the searchEngineConfig does have a custom analyticsClientMiddleware',
+      getSearchEngineConfig: getConfigWithCustomAnalyticsClientMiddleware,
+    },
+  ])('$describeName', ({getSearchEngineConfig}) => {
+    beforeEach(() => {
+      config = getSearchEngineConfig();
+      store = createAtomicStore();
+    });
 
-    config.analytics = {analyticsClientMiddleware};
-    const resultingConfig = getAnalyticsConfig(config, true, store);
-    const out = resultingConfig.analyticsClientMiddleware!('an_event', {
-      buzz: 'bazz',
-    }) as any;
-    expect(out.foo).toBe('bar');
-  });
+    afterEach(() => {
+      Object.defineProperty(document, 'referrer', {value: originalReferrer});
+    });
 
-  it('it augment analytics payload with Atomic version', () => {
-    const resultingConfig = getAnalyticsConfig(config, true, store);
-    const out = resultingConfig.analyticsClientMiddleware!('an_event', {
-      customData: {},
-    }) as any;
-    expect(out.customData).toHaveProperty('coveoAtomicVersion');
-  });
+    it('should provide out of the box values for analytics config', () => {
+      setReferrer('foo');
+      const resultingConfig = getAnalyticsConfig(config, true, store);
+      expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
+      expect(resultingConfig.originLevel3).toBe('foo');
+    });
 
-  it('it augment analytics payload with facet title, with any type of facet registered to the store', () => {
-    const resultingConfig = getAnalyticsConfig(config, true, store);
-    (
-      ['facets', 'numericFacets', 'dateFacets', 'categoryFacets'] as const
-    ).forEach((typeOfFacet) => {
-      store.registerFacet(typeOfFacet, {
-        facetId: 'some_id',
-        label: () => 'This is a label',
-        element: document.createElement('div'),
-      });
+    it('merges provided engine analytics config', () => {
+      setReferrer('foo');
+      config.analytics = {
+        enabled: true,
+        originContext: 'something',
+        originLevel3: 'bar',
+      };
+      const resultingConfig = getAnalyticsConfig(config, false, store);
+      expect(resultingConfig.enabled).toBe(true);
+      expect(resultingConfig.originContext).toBe('something');
+      expect(resultingConfig.originLevel3).toBe('bar');
+    });
 
+    it('use the existing analytic middleware if available', () => {
+      const resultingConfig = getAnalyticsConfig(config, true, store);
       const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+        buzz: 'bazz',
+      }) as any;
+
+      expect(out.foo).toBe(
+        config.analytics?.analyticsClientMiddleware ? 'bar' : undefined
+      );
+    });
+
+    it('it augment analytics payload with Atomic version', () => {
+      const resultingConfig = getAnalyticsConfig(config, true, store);
+      const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+        customData: {},
+      }) as any;
+      expect(out.customData).toHaveProperty('coveoAtomicVersion');
+    });
+
+    it('it augment analytics payload with facet title, with any type of facet registered to the store', () => {
+      const resultingConfig = getAnalyticsConfig(config, true, store);
+      (
+        ['facets', 'numericFacets', 'dateFacets', 'categoryFacets'] as const
+      ).forEach((typeOfFacet) => {
+        store.registerFacet(typeOfFacet, {
+          facetId: 'some_id',
+          label: () => 'This is a label',
+          element: document.createElement('div'),
+        });
+
+        const out = resultingConfig.analyticsClientMiddleware!('an_event', {
+          customData: {
+            facetId: 'some_id',
+            facetTitle: 'some_title',
+          },
+          facetState: [{title: 'some_title', id: 'some_id'}],
+        }) as any;
+        expect(out.customData.facetTitle).toBe('This is a label');
+        expect(out.facetState[0].title).toBe('This is a label');
+      });
+    });
+
+    it('it does not augment analytics payload with a facet title when a facet is unavailable from the store', () => {
+      const result = getAnalyticsConfig(config, true, store);
+      const out = result.analyticsClientMiddleware!('an_event', {
         customData: {
           facetId: 'some_id',
           facetTitle: 'some_title',
         },
         facetState: [{title: 'some_title', id: 'some_id'}],
       }) as any;
-      expect(out.customData.facetTitle).toBe('This is a label');
-      expect(out.facetState[0].title).toBe('This is a label');
+      expect(out.customData.facetTitle).toBe('some_title');
+      expect(out.facetState[0].title).toBe('some_title');
     });
-  });
-
-  it('it does not augment analytics payload with a facet title when a facet is unavailable from the store', () => {
-    const result = getAnalyticsConfig(config, true, store);
-    const out = result.analyticsClientMiddleware!('an_event', {
-      customData: {
-        facetId: 'some_id',
-        facetTitle: 'some_title',
-      },
-      facetState: [{title: 'some_title', id: 'some_id'}],
-    }) as any;
-    expect(out.customData.facetTitle).toBe('some_title');
-    expect(out.facetState[0].title).toBe('some_title');
   });
 });

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.ts
@@ -30,6 +30,7 @@ export function getAnalyticsConfig(
     return {
       ...defaultConfiguration,
       ...searchEngineConfig.analytics,
+      analyticsClientMiddleware,
     };
   }
   return defaultConfiguration;


### PR DESCRIPTION
The spread merge was removing the augment included by default, mainly for this issue the `coveoAtomicVersion` metadata.
The handling of a custom analytisClientMiddleware is actually handled at the beginning of `getAnalyticsConfig`, e.g.:
https://github.com/coveo/ui-kit/blob/b15f42c19194152801d4435e2518a50dce8308d0/packages/atomic/src/components/insight/atomic-insight-interface/analytics-config.ts#L12-L15

For the testing, I decided to use a `.each` to reuse the existing tests that ran on the 'simple analytics config' by adding another case where there's an analytics middleware.