### PR TITLE
fix(atomic): fixed leaky styling from tab components

### DIFF
--- a/packages/atomic/cypress/integration-insight-panel/insight-panel-selectors.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel-selectors.ts
@@ -29,10 +29,12 @@ export const InsightPanelsSelectors = {
   historyToggle: () =>
     InsightPanelsSelectors.interface().find('atomic-insight-history-toggle'),
   tabs: () => InsightPanelsSelectors.interface().find('atomic-insight-tabs'),
-  tabPopoverButton: () =>
-    InsightPanelsSelectors.tabs()
-      .find('tab-bar')
-      .shadow()
-      .find('[part="popover-button"]'),
   tabBar: () => InsightPanelsSelectors.tabs().find('tab-bar').shadow(),
+  tabPopover: () =>
+    InsightPanelsSelectors.tabBar().find('tab-popover').shadow(),
+  tabPopoverButton: () =>
+    InsightPanelsSelectors.tabPopover().find('[part="popover-button"]'),
+  layoutStyleTags: () =>
+    InsightPanelsSelectors.interface().find('atomic-insight-layout > style'),
+  topLevelStyleTags: () => cy.get('style[data-styles]'),
 };

--- a/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
@@ -30,6 +30,24 @@ describe('Insight Panel test suites', () => {
         .should('have.length.at.least', 1);
     });
 
+    it('should not add any unexpected style tags', () => {
+      const numTopLevelStyleTags = 2;
+      const numLayoutStyleTags = 1;
+
+      cy.get('style').should(
+        'have.length',
+        numTopLevelStyleTags + numLayoutStyleTags
+      );
+      InsightPanelsSelectors.topLevelStyleTags().should(
+        'have.length',
+        numTopLevelStyleTags
+      );
+      InsightPanelsSelectors.layoutStyleTags().should(
+        'have.length',
+        numLayoutStyleTags
+      );
+    });
+
     it('should display results', () => {
       InsightPanelsSelectors.results()
         .should('exist')
@@ -198,7 +216,7 @@ describe('Insight Panel test suites', () => {
 
       InsightPanelsSelectors.tabPopoverButton().click();
       InsightPanelsSelectors.tabBar()
-        .find('[part="overflow-tabs"]')
+        .find('tab-popover')
         .find('[part="popover-tab"]')
         .eq(0)
         .should('have.text', 'Salesforce')

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1813,7 +1813,7 @@ export namespace Components {
     interface TabBar {
     }
     interface TabPopover {
-        "hide": boolean;
+        "setButtonVisibility": (isVisible: boolean) => Promise<void>;
         "togglePopover": () => Promise<void>;
     }
 }
@@ -4472,7 +4472,6 @@ declare namespace LocalJSX {
     interface TabBar {
     }
     interface TabPopover {
-        "hide"?: boolean;
     }
     interface IntrinsicElements {
         "atomic-aria-live": AtomicAriaLive;

--- a/packages/atomic/src/components/common/tabs/tab-bar.pcss
+++ b/packages/atomic/src/components/common/tabs/tab-bar.pcss
@@ -4,4 +4,6 @@
   white-space: nowrap;
   width: 100%;
   overflow-x: visible;
+  display: flex;
+  position: relative;
 }

--- a/packages/atomic/src/components/common/tabs/tab-bar.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-bar.tsx
@@ -175,7 +175,7 @@ export class TabBar {
   public render = () => {
     this.updateTabsDisplay();
     return (
-      <Host class={'flex relative'}>
+      <Host>
         <slot></slot>
         <tab-popover hide={!this.overflowingTabs.length}>
           {this.popoverTabs}

--- a/packages/atomic/src/components/common/tabs/tab-bar.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-bar.tsx
@@ -160,6 +160,7 @@ export class TabBar {
     this.updateTabVisibility(this.overflowingTabs, false);
     this.updateTabVisibility(this.displayedTabs, true);
     this.updatePopoverPosition();
+    this.tabPopover?.setButtonVisibility(!!this.overflowingTabs.length);
   };
 
   @Listen('atomic/tabRendered')
@@ -169,7 +170,7 @@ export class TabBar {
   }
 
   public componentDidLoad() {
-    window.addEventListener('resize', this.render);
+    new ResizeObserver(this.render).observe(this.host);
   }
 
   public render = () => {
@@ -177,9 +178,7 @@ export class TabBar {
     return (
       <Host>
         <slot></slot>
-        <tab-popover hide={!this.overflowingTabs.length}>
-          {this.popoverTabs}
-        </tab-popover>
+        <tab-popover>{this.popoverTabs}</tab-popover>
       </Host>
     );
   };

--- a/packages/atomic/src/components/common/tabs/tab-bar.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-bar.tsx
@@ -16,6 +16,8 @@ export class TabBar {
   @State()
   private popoverTabs: typeof Button[] = [];
 
+  private resizeObserver: ResizeObserver | undefined;
+
   private get tabsFromSlot(): TabCommonElement[] {
     const isTab = (tagName: string) => /atomic-.+-tab$/i.test(tagName);
     return Array.from(this.host.querySelectorAll<TabCommonElement>('*')).filter(
@@ -170,7 +172,12 @@ export class TabBar {
   }
 
   public componentDidLoad() {
-    new ResizeObserver(this.render).observe(this.host);
+    this.resizeObserver = new ResizeObserver(this.render);
+    this.resizeObserver.observe(this.host);
+  }
+
+  public disconnectedCallback() {
+    this.resizeObserver?.disconnect();
   }
 
   public render = () => {

--- a/packages/atomic/src/components/common/tabs/tab-popover.pcss
+++ b/packages/atomic/src/components/common/tabs/tab-popover.pcss
@@ -1,10 +1,10 @@
 @import '../../../global/global.pcss';
 
-tab-popover {
+:host {
   position: absolute;
 }
 
-.visibility-hidden {
+:host(.visibility-hidden) {
   visibility: hidden;
 }
 

--- a/packages/atomic/src/components/common/tabs/tab-popover.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-popover.tsx
@@ -26,6 +26,7 @@ import {Button} from '../button';
  */
 @Component({
   tag: 'tab-popover',
+  shadow: true,
   styleUrl: 'tab-popover.pcss',
 })
 export class TabPopover implements InitializableComponent {

--- a/packages/atomic/src/components/common/tabs/tab-popover.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-popover.tsx
@@ -10,7 +10,6 @@ import {
   State,
   Element,
   Host,
-  Prop,
   Method,
 } from '@stencil/core';
 import ArrowBottomIcon from '../../../images/arrow-bottom-rounded.svg';
@@ -34,8 +33,8 @@ export class TabPopover implements InitializableComponent {
 
   @InitializeBindings() public bindings!: Bindings;
 
-  @Prop()
-  public hide = false;
+  @State()
+  public show = false;
 
   @State()
   public error!: Error;
@@ -72,6 +71,11 @@ export class TabPopover implements InitializableComponent {
   @Method()
   public async togglePopover() {
     this.isOpen = !this.isOpen;
+  }
+
+  @Method()
+  public async setButtonVisibility(isVisible: boolean) {
+    this.show = isVisible;
   }
 
   private renderDropdownButton() {
@@ -157,8 +161,8 @@ export class TabPopover implements InitializableComponent {
   public render() {
     return (
       <Host
-        class={this.hide ? 'visibility-hidden' : ''}
-        aria-hidden={this.hide}
+        class={this.show ? '' : 'visibility-hidden'}
+        aria-hidden={!this.show}
       >
         <atomic-focus-trap
           source={this.buttonRef}

--- a/packages/atomic/src/components/insight/atomic-insight-tabs/atomic-insight-tabs.pcss
+++ b/packages/atomic/src/components/insight/atomic-insight-tabs/atomic-insight-tabs.pcss
@@ -1,1 +1,0 @@
-@import '../../../global/global.pcss';

--- a/packages/atomic/src/components/insight/atomic-insight-tabs/atomic-insight-tabs.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-tabs/atomic-insight-tabs.tsx
@@ -10,7 +10,6 @@ import {InsightBindings} from '../atomic-insight-interface/atomic-insight-interf
  */
 @Component({
   tag: 'atomic-insight-tabs',
-  styleUrl: './atomic-insight-tabs.pcss',
 })
 export class AtomicInsightTabs
   implements InitializableComponent<InsightBindings>

--- a/packages/atomic/src/components/ipx/atomic-ipx-tabs/atomic-ipx-tabs.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-tabs/atomic-ipx-tabs.pcss
@@ -1,5 +1,0 @@
-@import '../../../global/global.pcss';
-
-:host {
-  width: 100%;
-}

--- a/packages/atomic/src/components/ipx/atomic-ipx-tabs/atomic-ipx-tabs.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-tabs/atomic-ipx-tabs.tsx
@@ -10,7 +10,6 @@ import {Bindings} from '../../search/atomic-search-interface/atomic-search-inter
  */
 @Component({
   tag: 'atomic-ipx-tabs',
-  styleUrl: './atomic-ipx-tabs.pcss',
 })
 export class AtomicIPXTabs implements InitializableComponent {
   @InitializeBindings() public bindings!: Bindings;

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -24,7 +24,7 @@
 
       main();
     </script>
-    <style>
+    <style data-styles>
       atomic-insight-interface:not([widget='false']),
       atomic-insight-layout:not([widget='false']) {
         width: 500px;

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -198,6 +198,8 @@
               <atomic-ipx-tab label="HTML" expression="@filetype==html"></atomic-ipx-tab>
               <atomic-ipx-tab label="PDF" expression="@filetype==pdf"></atomic-ipx-tab>
               <atomic-ipx-tab label="Spreadsheet" expression="@filetype==xls"></atomic-ipx-tab>
+              <atomic-ipx-tab label="Spreadsheet2" expression="@filetype==xls"></atomic-ipx-tab>
+              <atomic-ipx-tab label="Spreadsheet3" expression="@filetype==xls"></atomic-ipx-tab>
               <atomic-ipx-tab label="Word" expression="@filetype==doc"></atomic-ipx-tab>
             </atomic-ipx-tabs>
           </atomic-layout-section>

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -198,8 +198,6 @@
               <atomic-ipx-tab label="HTML" expression="@filetype==html"></atomic-ipx-tab>
               <atomic-ipx-tab label="PDF" expression="@filetype==pdf"></atomic-ipx-tab>
               <atomic-ipx-tab label="Spreadsheet" expression="@filetype==xls"></atomic-ipx-tab>
-              <atomic-ipx-tab label="Spreadsheet2" expression="@filetype==xls"></atomic-ipx-tab>
-              <atomic-ipx-tab label="Spreadsheet3" expression="@filetype==xls"></atomic-ipx-tab>
               <atomic-ipx-tab label="Word" expression="@filetype==doc"></atomic-ipx-tab>
             </atomic-ipx-tabs>
           </atomic-layout-section>


### PR DESCRIPTION
Some ipx and atomic tabs components were leaking global css outside of the shadow DOM. To fix I did 2 things:
1. Enabled shadow dom to `tab-popover` component
2. Removed unnecessary css from `ipx-tabs` and `insight-tabs` components which was leaking due to those components not using shadow-dom. It's necessary to the proper functioning of the `tab-bar` component they have as a child that these do not use a shadow-dom.

Added a rudimentary test to the insight test suite to check that only the expected number of script tags are added. I want to create a better test that validates script tags added by any component but currently the atomic insight use case doesn't have a good per-component test setup. That'll require more work I deem out of scope of this fix. We'll do it in the near future though, especially before we start offering a production-grade atomic insight panel.