### PR TITLE
test(quantic): tests added for smart snippet components in the insight use case

### DIFF
--- a/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
@@ -1,14 +1,21 @@
+import {performSearch} from '../../../page-objects/actions/action-perform-search';
 import {configure} from '../../../page-objects/configurator';
 import {
   interceptSearch,
   mockSearchWithSmartSnippet,
   mockSearchWithoutSmartSnippet,
 } from '../../../page-objects/search';
+import {
+  useCaseEnum,
+  useCaseParamTest,
+  InsightInterfaceExpectations as InsightInterfaceExpect,
+} from '../../../page-objects/use-case';
 import {scope} from '../../../reporters/detailed-collector';
 import {SmartSnippetActions as Actions} from './smart-snippet-actions';
 import {SmartSnippetExpectations as Expect} from './smart-snippet-expectations';
 
 interface smartSnippetOptions {
+  useCase: string;
   maximumSnippetHeight: number;
 }
 
@@ -38,165 +45,180 @@ describe('quantic-smart-snippet', () => {
   const pageUrl = 's/quantic-smart-snippet';
 
   function visitPage(
-    withoutSmartSnippet = false,
-    options: Partial<smartSnippetOptions> = {}
+    options: Partial<smartSnippetOptions> = {},
+    withoutSmartSnippet = false
   ) {
     interceptSearch();
     if (withoutSmartSnippet) {
-      mockSearchWithoutSmartSnippet();
+      mockSearchWithoutSmartSnippet(options.useCase);
     } else {
-      mockSearchWithSmartSnippet({
-        question: exampleSmartSnippetQuestion,
-        answer: exampleSmartSnippetAnswer,
-        title: exampleSmartSnippetSourceTitle,
-        uri: exampleSmartSnippetSourceUri,
-        permanentId: examplePermanentId,
-      });
+      mockSearchWithSmartSnippet(
+        {
+          question: exampleSmartSnippetQuestion,
+          answer: exampleSmartSnippetAnswer,
+          title: exampleSmartSnippetSourceTitle,
+          uri: exampleSmartSnippetSourceUri,
+          permanentId: examplePermanentId,
+        },
+        options.useCase
+      );
     }
     cy.visit(pageUrl);
     configure(options);
+    if (options.useCase === useCaseEnum.insight) {
+      InsightInterfaceExpect.isInitialized();
+      performSearch();
+    }
   }
 
-  describe('when the query does not return a smart snippet', () => {
-    it('should not display the smart snippet', () => {
-      visitPage(true);
+  useCaseParamTest.forEach((param) => {
+    describe(param.label, () => {
+      describe('when the query does not return a smart snippet', () => {
+        it('should not display the smart snippet', () => {
+          visitPage({useCase: param.useCase}, true);
 
-      scope('when loading the page', () => {
-        Expect.displaySmartSnippetCard(false);
-      });
-    });
-  });
-
-  describe('when the query returns a smart snippet', () => {
-    describe('when the smart snippet answer is not collapsed', () => {
-      it('should properly display the smart snippet', () => {
-        visitPage();
-
-        scope('when loading the page', () => {
-          Expect.displaySmartSnippetCard(true);
-          Expect.displaySmartSnippetQuestion(exampleSmartSnippetQuestion);
-          Expect.displaySmartSnippetAnswer(exampleSmartSnippetAnswer);
-          Expect.displaySmartSnippetSourceUri(exampleSmartSnippetSourceUri);
-          Expect.displaySmartSnippetSourceTitle(exampleSmartSnippetSourceTitle);
-          Expect.displayCollapsedSmartSnippetAnswer(false);
-          Expect.displayExpandedSmartSnippetAnswer(false);
-          Expect.displaySmartSnippetAnswerToggle(false);
+          scope('when loading the page', () => {
+            Expect.displaySmartSnippetCard(false);
+          });
         });
+      });
 
-        scope(
-          'when an inlink within the smart snippet answer is clicked',
-          () => {
-            Actions.clickSmartSnippetInlineLink();
-            Expect.logOpenSmartSnippetInlineLink({
-              title: exampleSmartSnippetSourceTitle,
-              uri: exampleSmartSnippetSourceUri,
-              permanentId: examplePermanentId,
-              linkUrl: exampleInlineLinkUrl,
-              linkText: exampleInlineLinkText,
+      describe('when the query returns a smart snippet', () => {
+        describe('when the smart snippet answer is not collapsed', () => {
+          it('should properly display the smart snippet', () => {
+            visitPage({useCase: param.useCase});
+
+            scope('when loading the page', () => {
+              Expect.displaySmartSnippetCard(true);
+              Expect.displaySmartSnippetQuestion(exampleSmartSnippetQuestion);
+              Expect.displaySmartSnippetAnswer(exampleSmartSnippetAnswer);
+              Expect.displaySmartSnippetSourceUri(exampleSmartSnippetSourceUri);
+              Expect.displaySmartSnippetSourceTitle(
+                exampleSmartSnippetSourceTitle
+              );
+              Expect.displayCollapsedSmartSnippetAnswer(false);
+              Expect.displayExpandedSmartSnippetAnswer(false);
+              Expect.displaySmartSnippetAnswerToggle(false);
             });
-          }
-        );
 
-        scope('when the source title is clicked', () => {
-          Actions.clickSmartSnippetSourceTitle();
-          Expect.logOpenSmartSnippetSource({
-            title: exampleSmartSnippetSourceTitle,
-            uri: exampleSmartSnippetSourceUri,
-            permanentId: examplePermanentId,
+            scope(
+              'when an inlink within the smart snippet answer is clicked',
+              () => {
+                Actions.clickSmartSnippetInlineLink();
+                Expect.logOpenSmartSnippetInlineLink({
+                  title: exampleSmartSnippetSourceTitle,
+                  uri: exampleSmartSnippetSourceUri,
+                  permanentId: examplePermanentId,
+                  linkUrl: exampleInlineLinkUrl,
+                  linkText: exampleInlineLinkText,
+                });
+              }
+            );
+
+            scope('when the source title is clicked', () => {
+              Actions.clickSmartSnippetSourceTitle();
+              Expect.logOpenSmartSnippetSource({
+                title: exampleSmartSnippetSourceTitle,
+                uri: exampleSmartSnippetSourceUri,
+                permanentId: examplePermanentId,
+              });
+            });
+
+            scope('when the source uri is clicked', () => {
+              visitPage({useCase: param.useCase});
+              Actions.clickSmartSnippetSourceUri();
+              Expect.logOpenSmartSnippetSource({
+                title: exampleSmartSnippetSourceTitle,
+                uri: exampleSmartSnippetSourceUri,
+                permanentId: examplePermanentId,
+              });
+            });
           });
         });
 
-        scope('when the source uri is clicked', () => {
-          visitPage();
-          Actions.clickSmartSnippetSourceUri();
-          Expect.logOpenSmartSnippetSource({
-            title: exampleSmartSnippetSourceTitle,
-            uri: exampleSmartSnippetSourceUri,
-            permanentId: examplePermanentId,
+        describe('when the smart snippet answer is collapsed', () => {
+          it('should properly display the smart snippet', () => {
+            visitPage({useCase: param.useCase, maximumSnippetHeight: 0}, false);
+
+            scope('when loading the page', () => {
+              Expect.displaySmartSnippetCard(true);
+              Expect.displaySmartSnippetQuestion(exampleSmartSnippetQuestion);
+              Expect.displaySmartSnippetSourceUri(exampleSmartSnippetSourceUri);
+              Expect.displaySmartSnippetSourceTitle(
+                exampleSmartSnippetSourceTitle
+              );
+              Expect.displayCollapsedSmartSnippetAnswer(true);
+              Expect.displayExpandedSmartSnippetAnswer(false);
+              Expect.displaySmartSnippetShowMoreButton(true);
+            });
+
+            scope('when expanding the smart snippet answer', () => {
+              Actions.toggleSmartSnippetAnswer();
+              Expect.displayCollapsedSmartSnippetAnswer(false);
+              Expect.displayExpandedSmartSnippetAnswer(true);
+              Expect.displaySmartSnippetShowLessButton(true);
+              Expect.logExpandSmartSnippet();
+            });
+
+            scope('when collapsing the smart snippet answer', () => {
+              Actions.toggleSmartSnippetAnswer();
+              Expect.displayCollapsedSmartSnippetAnswer(true);
+              Expect.displayExpandedSmartSnippetAnswer(false);
+              Expect.displaySmartSnippetShowMoreButton(true);
+              Expect.logCollapseSmartSnippet();
+            });
           });
         });
-      });
-    });
 
-    describe('when the smart snippet answer is collapsed', () => {
-      it('should properly display the smart snippet', () => {
-        visitPage(false, {maximumSnippetHeight: 0});
+        describe('when clicking the feedback like button', () => {
+          it('should properly log the analytics', () => {
+            visitPage({useCase: param.useCase});
 
-        scope('when loading the page', () => {
-          Expect.displaySmartSnippetCard(true);
-          Expect.displaySmartSnippetQuestion(exampleSmartSnippetQuestion);
-          Expect.displaySmartSnippetSourceUri(exampleSmartSnippetSourceUri);
-          Expect.displaySmartSnippetSourceTitle(exampleSmartSnippetSourceTitle);
-          Expect.displayCollapsedSmartSnippetAnswer(true);
-          Expect.displayExpandedSmartSnippetAnswer(false);
-          Expect.displaySmartSnippetShowMoreButton(true);
-        });
-
-        scope('when expanding the smart snippet answer', () => {
-          Actions.toggleSmartSnippetAnswer();
-          Expect.displayCollapsedSmartSnippetAnswer(false);
-          Expect.displayExpandedSmartSnippetAnswer(true);
-          Expect.displaySmartSnippetShowLessButton(true);
-          Expect.logExpandSmartSnippet();
-        });
-
-        scope('when collapsing the smart snippet answer', () => {
-          Actions.toggleSmartSnippetAnswer();
-          Expect.displayCollapsedSmartSnippetAnswer(true);
-          Expect.displayExpandedSmartSnippetAnswer(false);
-          Expect.displaySmartSnippetShowMoreButton(true);
-          Expect.logCollapseSmartSnippet();
-        });
-      });
-    });
-
-    describe('when clicking the feedback like button', () => {
-      it('should properly log the analytics', () => {
-        visitPage();
-
-        scope('when clicking the like button', () => {
-          Expect.displaySmartSnippetCard(true);
-          Actions.clickSmartSnippetLikeButton();
-          Expect.logLikeSmartSnippet();
-          Expect.displayExplainWhyButton(false);
-        });
-      });
-    });
-
-    describe('when clicking the feedback dislike button', () => {
-      it('should properly log the analytics', () => {
-        visitPage();
-
-        scope('when clicking the dislike button', () => {
-          Expect.displaySmartSnippetCard(true);
-          Actions.clickSmartSnippetDislikeButton();
-          Expect.logDislikeSmartSnippet();
-          Expect.displayExplainWhyButton(true);
-        });
-
-        scope('when clicking the explain why button', () => {
-          Actions.clickSmartSnippetExplainWhyButton();
-          Expect.logOpenSmartSnippetFeedbackModal();
-        });
-
-        scope('when closing the feedback modal', () => {
-          Actions.clickFeedbackCancelButton();
-          Expect.logCloseSmartSnippetFeedbackModal();
-        });
-
-        scope('when selecting a feedback option', () => {
-          const exampleDetails = 'example details';
-          Actions.clickSmartSnippetExplainWhyButton();
-          Expect.logOpenSmartSnippetFeedbackModal();
-          Actions.clickFeedbackOption(feedbackOptions.indexOf(otherOption));
-          Actions.typeInFeedbackDetailsInput(exampleDetails);
-          Actions.clickFeedbackSubmitButton();
-          Expect.logSendSmartSnippetReason({
-            reason: otherOption,
-            details: exampleDetails,
+            scope('when clicking the like button', () => {
+              Expect.displaySmartSnippetCard(true);
+              Actions.clickSmartSnippetLikeButton();
+              Expect.logLikeSmartSnippet();
+              Expect.displayExplainWhyButton(false);
+            });
           });
-          Actions.clickFeedbackDoneButton();
-          Expect.logCloseSmartSnippetFeedbackModal();
+        });
+
+        describe('when clicking the feedback dislike button', () => {
+          it('should properly log the analytics', () => {
+            visitPage({useCase: param.useCase});
+
+            scope('when clicking the dislike button', () => {
+              Expect.displaySmartSnippetCard(true);
+              Actions.clickSmartSnippetDislikeButton();
+              Expect.logDislikeSmartSnippet();
+              Expect.displayExplainWhyButton(true);
+            });
+
+            scope('when clicking the explain why button', () => {
+              Actions.clickSmartSnippetExplainWhyButton();
+              Expect.logOpenSmartSnippetFeedbackModal();
+            });
+
+            scope('when closing the feedback modal', () => {
+              Actions.clickFeedbackCancelButton();
+              Expect.logCloseSmartSnippetFeedbackModal();
+            });
+
+            scope('when selecting a feedback option', () => {
+              const exampleDetails = 'example details';
+              Actions.clickSmartSnippetExplainWhyButton();
+              Expect.logOpenSmartSnippetFeedbackModal();
+              Actions.clickFeedbackOption(feedbackOptions.indexOf(otherOption));
+              Actions.typeInFeedbackDetailsInput(exampleDetails);
+              Actions.clickFeedbackSubmitButton();
+              Expect.logSendSmartSnippetReason({
+                reason: otherOption,
+                details: exampleDetails,
+              });
+              Actions.clickFeedbackDoneButton();
+              Expect.logCloseSmartSnippetFeedbackModal();
+            });
+          });
         });
       });
     });

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -275,15 +275,18 @@ export function mockSearchWithoutAnyFacetValues(useCase: string) {
   }).as(InterceptAliases.Search.substring(1));
 }
 
-export function mockSearchWithSmartSnippet(smartSnippetOptions: {
-  question: string;
-  answer: string;
-  title: string;
-  uri: string;
-  permanentId: string;
-}) {
+export function mockSearchWithSmartSnippet(
+  smartSnippetOptions: {
+    question: string;
+    answer: string;
+    title: string;
+    uri: string;
+    permanentId: string;
+  },
+  useCase?: string
+) {
   const {question, answer, title, uri, permanentId} = smartSnippetOptions;
-  cy.intercept(routeMatchers.search, (req) => {
+  cy.intercept(getRoute(useCase), (req) => {
     req.continue((res) => {
       res.body.questionAnswer = {
         answerFound: true,
@@ -293,6 +296,7 @@ export function mockSearchWithSmartSnippet(smartSnippetOptions: {
           contentIdKey: 'permanentid',
           contentIdValue: permanentId,
         },
+        relatedQuestions: [],
       };
       res.body.results = [
         {
@@ -309,11 +313,12 @@ export function mockSearchWithSmartSnippet(smartSnippetOptions: {
   }).as(InterceptAliases.Search.substring(1));
 }
 
-export function mockSearchWithoutSmartSnippet() {
-  cy.intercept(routeMatchers.search, (req) => {
+export function mockSearchWithoutSmartSnippet(useCase?: string) {
+  cy.intercept(getRoute(useCase), (req) => {
     req.continue((res) => {
       res.body.questionAnswer = {
         answerFound: false,
+        relatedQuestions: [],
       };
       res.send();
     });
@@ -330,12 +335,17 @@ export function mockSearchWithSmartSnippetSuggestions(
       contentIdKey: string;
       contentIdValue: string;
     };
-  }>
+  }>,
+  useCase?: string
 ) {
-  cy.intercept(routeMatchers.search, (req) => {
+  cy.intercept(getRoute(useCase), (req) => {
     req.continue((res) => {
       res.body.questionAnswer = {
         relatedQuestions: relatedQuestions,
+        documentId: {
+          contentIdKey: 'permanentid',
+          contentIdValue: 'example permanentId',
+        },
       };
       res.body.results = relatedQuestions.map(({title, uri, documentId}) => ({
         uri,
@@ -350,8 +360,8 @@ export function mockSearchWithSmartSnippetSuggestions(
   }).as(InterceptAliases.Search.substring(1));
 }
 
-export function mockSearchWithoutSmartSnippetSuggestions() {
-  cy.intercept(routeMatchers.search, (req) => {
+export function mockSearchWithoutSmartSnippetSuggestions(useCase?: string) {
+  cy.intercept(getRoute(useCase), (req) => {
     req.continue((res) => {
       res.body.questionAnswer = {
         relatedQuestions: [],

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippet/exampleQuanticSmartSnippet.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippet/exampleQuanticSmartSnippet.html
@@ -6,6 +6,7 @@
   
     <div slot="configuration">
       <c-configurator options={options} ontryitnow={handleTryItNow}>
+        <c-action-perform-search slot="actions" disabled={notConfigured} engine-id={engineId}></c-action-perform-search>
       </c-configurator>
     </div>
 

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippet/exampleQuanticSmartSnippet.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippet/exampleQuanticSmartSnippet.js
@@ -10,6 +10,13 @@ export default class ExampleQuanticSmartSnippet extends LightningElement {
     'The Quantic Smart Snippet displays the excerpt of a document that would be most likely to answer a particular query.';
   options = [
     {
+      attribute: 'useCase',
+      label: 'Use Case',
+      description:
+        'Define which use case to test. Possible values are: search, insight',
+      defaultValue: 'search',
+    },
+    {
       attribute: 'maximumSnippetHeight',
       label: 'Maximum snippet height',
       description:

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippetSuggestions/exampleQuanticSmartSnippetSuggestions.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippetSuggestions/exampleQuanticSmartSnippetSuggestions.html
@@ -3,6 +3,7 @@
 
     <div slot="configuration">
       <c-configurator options={options} ontryitnow={handleTryItNow}>
+        <c-action-perform-search slot="actions" disabled={notConfigured} engine-id={engineId}></c-action-perform-search>
       </c-configurator>
     </div>
 

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippetSuggestions/exampleQuanticSmartSnippetSuggestions.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSmartSnippetSuggestions/exampleQuanticSmartSnippetSuggestions.js
@@ -8,7 +8,15 @@ export default class ExampleQuanticSmartSnippetSuggestions extends LightningElem
   pageTitle = 'Quantic Smart Snippet Suggestions';
   pageDescription =
     'The QuanticSmartSnippetSuggestions component displays additional queries for which a Coveo Smart Snippets model can provide relevant excerpts.';
-  options = [];
+  options = [
+    {
+      attribute: 'useCase',
+      label: 'Use Case',
+      description:
+        'Define which use case to test. Possible values are: search, insight',
+      defaultValue: 'search',
+    },
+  ];
 
   get notConfigured() {
     return !this.isConfigured;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-4852

- E2E tests for the two components: Quantic Smart Snippet and Quantic Smart Snippet Suggestions are now updated to contain tests in the insight use case.

PS: This PR can only be merged after the merging the PR about adding the new smart snippet suggestions Headless controller in the insight use case.