### PR TITLE
fix(atomic): support limited version of quickview when sandbox allow-same-origin not present

### DIFF
--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview-modal/atomic-quickview-modal.tsx
@@ -152,6 +152,8 @@ export class AtomicQuickviewModal implements InitializableComponent {
         </div>
         <div class="overflow-auto relative">
           <QuickviewIframe
+            logger={this.logger}
+            src={this.quickviewSrc}
             sandbox={this.sandbox}
             result={this.result}
             content={this.content}
@@ -211,6 +213,14 @@ export class AtomicQuickviewModal implements InitializableComponent {
 
   private get highlightScriptId() {
     return 'CoveoDisableHighlightStyle';
+  }
+
+  private get logger() {
+    return this.bindings.engine.logger;
+  }
+
+  private get quickviewSrc() {
+    return this.bindings.engine.state.resultPreview?.contentURL;
   }
 
   private enableHighlights() {

--- a/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.tsx
+++ b/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.tsx
@@ -1,4 +1,4 @@
-import {Result} from '@coveo/headless';
+import {Result, SearchEngine} from '@coveo/headless';
 import {FunctionalComponent, h} from '@stencil/core';
 
 const documentIdentifierInIframe = 'CoveoDocIdentifier';
@@ -37,12 +37,20 @@ const ensureSameResultIsNotOverwritten = (
   documentWriter.body.appendChild(docIdentifier);
 };
 
+const warnAboutLimitedUsageQuickview = (logger?: SearchEngine['logger']) => {
+  logger?.warn(
+    'Quickview initialized in restricted mode due to incompatible sandboxing environment. Keywords hit navigation will be disabled.'
+  );
+};
+
 export const QuickviewIframe: FunctionalComponent<{
   content?: string;
   onSetIframeRef: (ref: HTMLIFrameElement) => void;
   result?: Result;
   sandbox?: string;
-}> = ({onSetIframeRef, result, content, sandbox}) => {
+  src?: string;
+  logger?: SearchEngine['logger'];
+}> = ({onSetIframeRef, result, content, sandbox, src, logger}) => {
   // When a document is written with document.open/document.write/document.close
   // it is not synchronous and the content of the iframe is only available to be queried at the end of the current call stack.
   // This add a "wait" (setTimeout 0) before calling the `onSetIframeRef` from the parent modal quickview
@@ -64,6 +72,11 @@ export const QuickviewIframe: FunctionalComponent<{
 
         const documentWriter = iframeRef.contentDocument;
         if (!documentWriter) {
+          if (src) {
+            warnAboutLimitedUsageQuickview(logger);
+            iframeRef.src = src;
+          }
+
           return;
         }
         if (currentResultAlreadyWrittenToDocument(documentWriter, result)) {

--- a/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
+++ b/packages/headless/src/controllers/core/quickview/headless-core-quickview.ts
@@ -145,21 +145,24 @@ export function buildCoreQuickview(
   };
 
   const onFetchContent = (uniqueId: string) => {
-    props.options.onlyContentURL
-      ? dispatch(
-          updateContentURL({
-            uniqueId,
-            requestedOutputSize: maximumPreviewSize,
-            buildResultPreviewRequest,
-            path,
-          })
-        )
-      : dispatch(
-          fetchResultContent({
-            uniqueId,
-            requestedOutputSize: maximumPreviewSize,
-          })
-        );
+    dispatch(
+      updateContentURL({
+        uniqueId,
+        requestedOutputSize: maximumPreviewSize,
+        buildResultPreviewRequest,
+        path,
+      })
+    );
+
+    if (!props.options.onlyContentURL) {
+      dispatch(
+        fetchResultContent({
+          uniqueId,
+          requestedOutputSize: maximumPreviewSize,
+        })
+      );
+    }
+
     if (fetchResultContentCallback) {
       fetchResultContentCallback();
     }


### PR DESCRIPTION
When the environment hosting the search page does not have the necessary sandbox attributes (`allow-same-origin`), advanced quickview capabilities to perform keyword highlight navigation cannot function.

We can however still have a limited capability Quickview by setting the proper source on the iframe, instead of "writing" and interacting directly with the iframe document in JavaScript

https://coveord.atlassian.net/browse/KIT-2442