### PR TITLE
chore(headless): initial work to cleanup headless bundles

### DIFF
--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -1,6 +1,6 @@
 import {build} from 'esbuild';
 import alias from 'esbuild-plugin-alias';
-import {readFileSync, promises} from 'node:fs';
+import {readFileSync, promises, writeFileSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {umdWrapper} from '../../scripts/bundle/umd.mjs';
 import {apacheLicense} from '../../scripts/license/apache.mjs';
@@ -64,13 +64,16 @@ const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map(
     const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
     const outfile = `${outDir}/headless.esm.js`;
 
-    return buildBrowserConfig({
-      entryPoints: [entryPoint],
-      outfile,
-      format: 'esm',
-      watch: devMode,
-      minify: false,
-    });
+    return buildBrowserConfig(
+      {
+        entryPoints: [entryPoint],
+        outfile,
+        format: 'esm',
+        watch: devMode,
+        minify: false,
+      },
+      outDir
+    );
   }
 );
 
@@ -79,11 +82,14 @@ const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const outDir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${outDir}/headless.esm.js`;
 
-  return buildBrowserConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'esm',
-  });
+  return buildBrowserConfig(
+    {
+      entryPoints: [entryPoint],
+      outfile,
+      format: 'esm',
+    },
+    outDir
+  );
 });
 
 const browserUmd = Object.entries(useCaseEntries).map((entry) => {
@@ -94,29 +100,33 @@ const browserUmd = Object.entries(useCaseEntries).map((entry) => {
   const globalName = getUmdGlobalName(useCase);
   const umd = umdWrapper(globalName);
 
-  return buildBrowserConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'cjs',
-    banner: {
-      js: `${base.banner.js}\n${umd.header}`,
+  return buildBrowserConfig(
+    {
+      entryPoints: [entryPoint],
+      outfile,
+      format: 'cjs',
+      banner: {
+        js: `${base.banner.js}\n${umd.header}`,
+      },
+      footer: {
+        js: umd.footer,
+      },
     },
-    footer: {
-      js: umd.footer,
-    },
-  });
+    outDir
+  );
 });
 
 /**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
-function buildBrowserConfig(options) {
-  return build({
+async function buildBrowserConfig(options, outDir) {
+  const out = await build({
     ...base,
     platform: 'browser',
     minify: true,
     sourcemap: true,
+    metafile: true,
     external: ['crypto'],
     plugins: [
       alias({
@@ -131,17 +141,22 @@ function buildBrowserConfig(options) {
     ],
     ...options,
   });
+  outputMetafile(`browser.${options.format}`, outDir, out.metafile);
+  return out;
 }
 
 const nodeCjs = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.js`;
-  return buildNodeConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'cjs',
-  });
+  return buildNodeConfig(
+    {
+      entryPoints: [entryPoint],
+      outfile,
+      format: 'cjs',
+    },
+    dir
+  );
 });
 
 const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
@@ -149,21 +164,26 @@ const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
   const dir = getUseCaseDir('dist/', useCase);
   const outfile = `${dir}/headless.esm.js`;
 
-  return buildNodeConfig({
-    entryPoints: [entryPoint],
-    outfile,
-    format: 'esm',
-  });
+  return buildNodeConfig(
+    {
+      entryPoints: [entryPoint],
+      outfile,
+      format: 'esm',
+    },
+    dir
+  );
 });
 
 /**
  * @param {import('esbuild').BuildOptions} options
  * @returns {Promise<import('esbuild').BuildResult>}
  */
-function buildNodeConfig(options) {
-  return build({
+async function buildNodeConfig(options, outDir) {
+  const out = await build({
     ...base,
+    metafile: true,
     platform: 'node',
+    treeShaking: true,
     plugins: [
       alias({
         'coveo.analytics': resolve(
@@ -176,6 +196,10 @@ function buildNodeConfig(options) {
     ],
     ...options,
   });
+
+  outputMetafile(`node.${options.format}`, outDir, out.metafile);
+
+  return out;
 }
 
 // https://github.com/coveo/ui-kit/issues/1616
@@ -200,6 +224,12 @@ function getNodeEsmBundlePaths() {
     const dir = getUseCaseDir('dist/', useCase);
     return `${dir}/headless.esm.js`;
   });
+}
+
+function outputMetafile(platform, outDir, metafile) {
+  console.log(outDir);
+  const outFile = resolve(outDir, `${platform}.stats.json`);
+  writeFileSync(outFile, JSON.stringify(metafile));
 }
 
 async function main() {

--- a/packages/headless/src/app/analytics-middleware.ts
+++ b/packages/headless/src/app/analytics-middleware.ts
@@ -1,7 +1,4 @@
 import {Middleware} from 'redux';
-import {getProductRecommendations} from '../features/product-recommendations/product-recommendations-actions';
-import {getRecommendations} from '../features/recommendation/recommendation-actions';
-import {executeSearch} from '../features/search/search-actions';
 
 export const analyticsMiddleware: Middleware = (api) => (next) => (action) => {
   // Why all these shenanigans ?
@@ -17,11 +14,17 @@ export const analyticsMiddleware: Middleware = (api) => (next) => (action) => {
 
   const ret = next(action);
 
-  if (action.type === executeSearch.fulfilled.type && analytics === undefined) {
+  if (
+    action.type === 'search/executeSearch/fullfilled' &&
+    analytics === undefined
+  ) {
     console.error('No analytics action associated with search:', action);
   }
 
-  if (action.type === getRecommendations.fulfilled && analytics === undefined) {
+  if (
+    action.type === 'recommendation/get/fullfilled' &&
+    analytics === undefined
+  ) {
     console.error(
       'No analytics action associated with recommendation:',
       action
@@ -29,7 +32,7 @@ export const analyticsMiddleware: Middleware = (api) => (next) => (action) => {
   }
 
   if (
-    action.type === getProductRecommendations.fulfilled &&
+    action.type === 'productRecommendations/get/fullfilled' &&
     analytics === undefined
   ) {
     console.error(

--- a/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
+++ b/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine.ts
@@ -18,7 +18,8 @@ import {
   ExternalEngineOptions,
 } from '../engine';
 import {buildLogger} from '../logger';
-import {productRecommendations, searchHub} from '../reducers';
+import {productRecommendations} from '../product-recommendation-reducers';
+import {searchHub} from '../reducers';
 import {SearchThunkExtraArguments} from '../search-thunk-extra-arguments';
 import {buildThunkExtraArguments} from '../thunk-extra-arguments';
 import {

--- a/packages/headless/src/app/product-recommendation-reducers.ts
+++ b/packages/headless/src/app/product-recommendation-reducers.ts
@@ -1,0 +1,3 @@
+import {productRecommendationsReducer} from '../features/product-recommendations/product-recommendations-slice';
+
+export const productRecommendations = productRecommendationsReducer;

--- a/packages/headless/src/app/reducers.ts
+++ b/packages/headless/src/app/reducers.ts
@@ -30,7 +30,6 @@ import {instantResultsReducer} from '../features/instant-results/instant-results
 import {paginationReducer} from '../features/pagination/pagination-slice';
 import {pipelineReducer} from '../features/pipeline/pipeline-slice';
 import {productListingReducer} from '../features/product-listing/product-listing-slice';
-import {productRecommendationsReducer} from '../features/product-recommendations/product-recommendations-slice';
 import {querySetReducer} from '../features/query-set/query-set-slice';
 import {querySuggestReducer} from '../features/query-suggest/query-suggest-slice';
 import {queryReducer} from '../features/query/query-slice';
@@ -95,7 +94,7 @@ export const history = undoable({
   reducer: historyReducer,
 });
 export const recommendation = recommendationReducer;
-export const productRecommendations = productRecommendationsReducer;
+
 export const productListing = productListingReducer;
 export const sort = sortReducer;
 

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.ts
@@ -1,7 +1,7 @@
 import {ArrayValue, Schema, StringValue} from '@coveo/bueno';
 import {ProductListingAPIErrorStatusResponse} from '../../api/commerce/product-listings/product-listing-api-client';
 import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
-import {configuration, productListing} from '../../app/reducers';
+import {productListing, configuration} from '../../app/reducers';
 import {
   fetchProductListing,
   setAdditionalFields,

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.ts
@@ -1,6 +1,7 @@
 import {ArrayValue, NumberValue, Schema, SchemaValues} from '@coveo/bueno';
 import {ProductRecommendationEngine} from '../../app/product-recommendation-engine/product-recommendation-engine';
-import {configuration, productRecommendations} from '../../app/reducers';
+import {productRecommendations} from '../../app/product-recommendation-reducers';
+import {configuration} from '../../app/reducers';
 import {
   getProductRecommendations as updateProductRecommendations,
   setProductRecommendationsSkus,

--- a/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
+++ b/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
@@ -1,6 +1,7 @@
 import {PayloadAction} from '@reduxjs/toolkit';
 import {RecommendationEngine} from '../../app/recommendation-engine/recommendation-engine';
-import {configuration, pipeline, searchHub} from '../../app/reducers';
+import {configuration} from '../../app/reducers';
+import {pipeline, searchHub} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {
   updateSearchConfiguration,

--- a/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
+++ b/packages/headless/src/features/configuration/search-configuration-actions-loader.ts
@@ -1,7 +1,6 @@
 import {PayloadAction} from '@reduxjs/toolkit';
 import {RecommendationEngine} from '../../app/recommendation-engine/recommendation-engine';
-import {configuration} from '../../app/reducers';
-import {pipeline, searchHub} from '../../app/reducers';
+import {configuration, pipeline, searchHub} from '../../app/reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {
   updateSearchConfiguration,

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions-loader.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions-loader.ts
@@ -1,7 +1,7 @@
 import {AsyncThunkAction, PayloadAction} from '@reduxjs/toolkit';
 import {AsyncThunkSearchOptions} from '../../api/search/search-api-client';
 import {ProductRecommendationEngine} from '../../app/product-recommendation-engine/product-recommendation-engine';
-import {productRecommendations} from '../../app/reducers';
+import {productRecommendations} from '../../app/product-recommendation-reducers';
 import {
   getProductRecommendations,
   GetProductRecommendationsThunkReturn,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -1,5 +1,4 @@
 import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
-import * as TestUtils from './test';
 import * as HighlightUtils from './utils/highlight';
 
 polyfillCryptoNode();
@@ -62,7 +61,7 @@ export * from './features/analytics/index';
 
 // Types & Helpers
 export {API_DATE_FORMAT} from './api/search/date/date-format';
-export {TestUtils, HighlightUtils};
+export {HighlightUtils};
 export type {Result} from './api/search/search/result';
 export type {FieldDescription} from './api/search/fields/fields-response';
 export type {Raw} from './api/search/search/raw';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -1,5 +1,18 @@
 import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
+import {
+  buildMockRaw,
+  buildMockSearchAppEngine,
+  buildMockResult,
+  createMockState,
+} from './test';
 import * as HighlightUtils from './utils/highlight';
+
+const TestUtils = {
+  buildMockRaw,
+  buildMockSearchAppEngine,
+  buildMockResult,
+  createMockState,
+};
 
 polyfillCryptoNode();
 
@@ -61,7 +74,7 @@ export * from './features/analytics/index';
 
 // Types & Helpers
 export {API_DATE_FORMAT} from './api/search/date/date-format';
-export {HighlightUtils};
+export {TestUtils, HighlightUtils};
 export type {Result} from './api/search/search/result';
 export type {FieldDescription} from './api/search/fields/fields-response';
 export type {Raw} from './api/search/search/raw';


### PR DESCRIPTION
So I've done quite a bit of testing around the work that will be necessary to make our bundles leaner.

One thing I've realized is everything around three shaking will require quite a lot of manual work to help bundle tools (esbuild, webpack, rollup)  identify functions/modules/classes that do not have side effects ( https://esbuild.github.io/api/#tree-shaking // https://esbuild.github.io/api/#pure ). Right now, I'd say only about 5 to 10% of Headless package is tree shakable, which is far lower that what is should be.

In the first phase, what I'd like to achieve is to simply changes the way we do imports so that we can shake off some weights from each produced bundles, notwithstanding any tree shaking capabilities.

This in itself will be a lot of work, as we need to juggle some imports that are used in hundreds of files.

This PR contains: 
* Adding "metafile" when we build packages. These files contains information about how esbuild built the project. This is what I've been using to manually identify the import chain so I can start refactoring how we do imports internally. I've put them in the `dist` bundle, which means we would now ship those. This can be helpful I think, to add tooling down the line around all of this, when we do a release. Downside is that we add weights to npm install. An alternative would be to put them in a different folder, which we could git ignore. Open to any idea you guys would have.

* Starting to do some minor import changes, in order to remove `productRecommendation` use case from `searchPage` use case.

https://coveord.atlassian.net/browse/KIT-2452