### PR TITLE
fix(atomic-storybook): add missing dependency to target dev when runn…

### DIFF
--- a/utils/atomic-storybook/project.json
+++ b/utils/atomic-storybook/project.json
@@ -46,7 +46,11 @@
       }
     },
     "dev": {
-      "dependsOn": ["^build", "validate:storybook"],
+      "dependsOn": [
+        "^build",
+        "validate:storybook",
+        "build:storybook:assets-list"
+      ],
       "inputs": [],
       "outputs": [],
       "executor": "nx:run-commands",

--- a/utils/atomic-storybook/project.json
+++ b/utils/atomic-storybook/project.json
@@ -31,12 +31,16 @@
         "cwd": "packages/atomic"
       }
     },
-    "build": {
+    "prepare-and-validate": {
       "dependsOn": [
         "^build",
         "validate:storybook",
         "build:storybook:assets-list"
       ],
+      "executor": "nx:noop"
+    },
+    "build": {
+      "dependsOn": ["prepare-and-validate"],
       "inputs": [],
       "outputs": [],
       "executor": "nx:run-commands",
@@ -46,11 +50,7 @@
       }
     },
     "dev": {
-      "dependsOn": [
-        "^build",
-        "validate:storybook",
-        "build:storybook:assets-list"
-      ],
+      "dependsOn": ["prepare-and-validate"],
       "inputs": [],
       "outputs": [],
       "executor": "nx:run-commands",


### PR DESCRIPTION
…ing atomic-storybook:dev

"dev" target was missing a dependency. When running `npx nx run atomic-storybook:dev` before every building, assets.json was never created.

Since "dev" and "build" are basically the same except for the command, I wonder if there is a way to refactor the two so they use the same dependencies.

https://coveord.atlassian.net/browse/KIT-2457
