### PR TITLE
ci: fixed 404 error in publish phase

### DIFF
--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -9,7 +9,16 @@ import {readFileSync} from 'node:fs';
  * @param {string} tag
  */
 async function isPublished(name, version, tag = version) {
-  return (await describeNpmTag(name, tag)) === version;
+  try {
+    const publishedVersion = await describeNpmTag(name, tag);
+    return publishedVersion === version;
+  } catch (e) {
+    const message = /** @type {{error?: string}} */ (e).error;
+    if (message && message.includes('code E404')) {
+      return false;
+    }
+    throw e;
+  }
 }
 
 const isPrerelease = process.env.IS_PRERELEASE === 'true';

--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -13,7 +13,7 @@ async function isPublished(name, version, tag = version) {
     const publishedVersion = await describeNpmTag(name, tag);
     return publishedVersion === version;
   } catch (e) {
-    const message = /** @type {{error?: string}} */ (e).error;
+    const message = /** @type {{stderr?: string}} */ (e).stderr;
     if (message && message.includes('code E404')) {
       return false;
     }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2465

# Context
Unlike the CLI, we run `npm publish` in a separate phase which always runs after the bump phase. That means that we must verify whether the version was bumped before publishing.

Simply verifying whether the `package.json` was modified would not work since it also gets modified when its dependencies are updated. Therefore, I decided to do what felt like the next easiest thing and just verify whether a package is already published before publishing it.

# Error
When verifying whether the version was published, `describeNpmTag` throws a 404 error if no package was published, because it simply runs `npm view REF version.

# The fix
I copy and pasted the same assertion we did in our old process to verify whether a package is already published. If the thrown error contains a `error` property which contains `code E404`, then we assume the package isn't published.