### PR TITLE
ci: fixed CI repo strings and extracted common constants

### DIFF
--- a/utils/release/bump-package.mjs
+++ b/utils/release/bump-package.mjs
@@ -17,6 +17,12 @@ import {appendFileSync, readFileSync, writeFileSync} from 'node:fs';
 import {dirname, resolve, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {gt, SemVer} from 'semver';
+import {
+  REPO_FS_ROOT,
+  REPO_HOST,
+  REPO_NAME,
+  REPO_OWNER,
+} from './common/constants.mjs';
 
 /**
  * Check if the package json in the provided folder has changed since the last commit
@@ -58,7 +64,6 @@ const modifyPackageJson = (packageDir, modifyPackageJsonCallback) => {
   writeFileSync(packageJsonPath, JSON.stringify(newPackageJson || packageJson));
 };
 
-const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const isPrerelease = process.env.IS_PRERELEASE === 'true';
 
 // Run on each package, it generate the changelog, install the latest dependencies that are part of the workspace, publish the package.
@@ -108,16 +113,16 @@ await (async () => {
       parsedCommits,
       newVersion,
       {
-        host: 'https://github.com',
-        owner: 'coveo',
-        repository: 'ui-kit',
+        host: REPO_HOST,
+        owner: REPO_OWNER,
+        repository: REPO_NAME,
       },
       convention.writerOpts
     );
     await writeChangelog(PATH, changelog);
   }
   appendFileSync(
-    join(rootFolder, '.git-message'),
+    join(REPO_FS_ROOT, '.git-message'),
     `${packageJson.name}@${newVersion}\n`
   );
 })();
@@ -128,7 +133,7 @@ await (async () => {
  */
 async function updateWorkspaceDependent(version) {
   const topology = JSON.parse(
-    readFileSync(join(rootFolder, 'topology.json'), {encoding: 'utf-8'})
+    readFileSync(join(REPO_FS_ROOT, 'topology.json'), {encoding: 'utf-8'})
   );
   const dependencyPackageJson = JSON.parse(
     readFileSync('package.json', {encoding: 'utf-8'})
@@ -153,7 +158,7 @@ async function updateWorkspaceDependent(version) {
 
   for (const dependentPackage of dependentPackages) {
     modifyPackageJson(
-      join(rootFolder, topology.graph.nodes[dependentPackage].data.root),
+      join(REPO_FS_ROOT, topology.graph.nodes[dependentPackage].data.root),
       (packageJson) => {
         updateDependency(packageJson, dependencyPackageJson.name, version);
       }

--- a/utils/release/bump-package.mjs
+++ b/utils/release/bump-package.mjs
@@ -14,8 +14,7 @@ import {
 import angularChangelogConvention from 'conventional-changelog-angular';
 import {spawnSync} from 'node:child_process';
 import {appendFileSync, readFileSync, writeFileSync} from 'node:fs';
-import {dirname, resolve, join} from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {resolve, join} from 'node:path';
 import {gt, SemVer} from 'semver';
 import {
   REPO_FS_ROOT,

--- a/utils/release/common/constants.mjs
+++ b/utils/release/common/constants.mjs
@@ -1,0 +1,13 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export const REPO_HOST = 'https://github.com';
+export const REPO_OWNER = 'coveo';
+export const REPO_NAME = 'ui-kit';
+export const REPO_MAIN_BRANCH = 'master';
+export const REPO_FS_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..'
+);

--- a/utils/release/git-lock.mjs
+++ b/utils/release/git-lock.mjs
@@ -11,6 +11,7 @@ import {
 import {spawnSync} from 'node:child_process';
 import {writeFileSync} from 'node:fs';
 import {dedent} from 'ts-dedent';
+import {REPO_MAIN_BRANCH, REPO_NAME, REPO_OWNER} from './common/constants.mjs';
 import {
   limitWriteAccessToBot,
   removeWriteAccessRestrictions,
@@ -18,8 +19,6 @@ import {
 
 const isPrerelease = process.env.IS_PRERELEASE === 'true';
 const PATH = '.';
-const REPO_OWNER = 'coveo';
-const REPO_NAME = 'cli';
 const GIT_SSH_REMOTE = 'deploy';
 
 const ensureUpToDateBranch = async () => {
@@ -27,9 +26,9 @@ const ensureUpToDateBranch = async () => {
   await limitWriteAccessToBot();
 
   // Verify master has not changed
-  const local = await getSHA1fromRef('master');
+  const local = await getSHA1fromRef(REPO_MAIN_BRANCH);
   await gitPull();
-  const remote = await getSHA1fromRef('master');
+  const remote = await getSHA1fromRef(REPO_MAIN_BRANCH);
   if (local !== remote) {
     await removeWriteAccessRestrictions();
     throw new Error(dedent`

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -22,10 +22,9 @@ import {spawnSync} from 'child_process';
 import {readFileSync} from 'fs';
 import {Octokit} from 'octokit';
 import {dedent} from 'ts-dedent';
+import {REPO_NAME, REPO_OWNER} from './common/constants.mjs';
 import {removeWriteAccessRestrictions} from './lock-master.mjs';
 
-const REPO_OWNER = 'coveo';
-const REPO_NAME = 'ui-kit';
 const GIT_SSH_REMOTE = 'deploy';
 
 // Commit, tag and push

--- a/utils/release/install-npm-proxy.mjs
+++ b/utils/release/install-npm-proxy.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import {startVerdaccio} from '@coveo/verdaccio-starter';
 import {readFileSync, writeFileSync} from 'node:fs';
-import {resolve, dirname} from 'node:path';
-import {fileURLToPath} from 'node:url';
-
-const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+import {resolve} from 'node:path';
+import {REPO_FS_ROOT} from './common/constants.mjs';
 
 /**
  * @param {[K, V][]} entries
@@ -25,7 +23,7 @@ function fromEntries(entries) {
  * @param {(config: Record<string, string>) => Record<string, string>} callback
  */
 function modifyNpmRc(callback) {
-  const npmRcLocation = resolve(rootFolder, '.npmrc');
+  const npmRcLocation = resolve(REPO_FS_ROOT, '.npmrc');
   const npmRcContents = readFileSync(npmRcLocation).toString();
   const npmRcEntries = fromEntries(
     // @ts-ignore

--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -3,14 +3,12 @@
  * it needs to reserve the branch when running, so that no 'new commits' come up.
  */
 import {Octokit} from 'octokit';
+import {REPO_MAIN_BRANCH, REPO_NAME, REPO_OWNER} from './common/constants.mjs';
 
-const REPO_OWNER = 'coveo';
-const REPO_NAME = 'cli';
-const MAIN_BRANCH_NAME = 'master';
-const COVEO_CLI_MASTER = {
+const REPO_MAIN_BRANCH_PARAMS = {
   owner: REPO_OWNER,
   repo: REPO_NAME,
-  branch: MAIN_BRANCH_NAME,
+  branch: REPO_MAIN_BRANCH,
 };
 export const limitWriteAccessToBot = () => changeBranchRestrictions(true);
 
@@ -26,7 +24,7 @@ async function changeBranchRestrictions(onlyBot) {
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
   // Requires branches to be up to date before merging
   await octokit.rest.repos.updateStatusCheckProtection({
-    ...COVEO_CLI_MASTER,
+    ...REPO_MAIN_BRANCH_PARAMS,
     strict: onlyBot,
   });
 }

--- a/utils/release/reify.mjs
+++ b/utils/release/reify.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import Arborist from '@npmcli/arborist';
 import {DepGraph} from 'dependency-graph';
-import {dirname, resolve} from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {REPO_FS_ROOT} from './common/constants.mjs';
 
 /**
  * Current strategy: reify each package (along with their dependants transitively) in topological (parents->dependants) order.
@@ -68,7 +67,7 @@ function buildDependencyGraph(rootNode) {
 async function initArborist() {
   const arb = new Arborist({
     savePrefix: '',
-    path: rootFolder,
+    path: REPO_FS_ROOT,
     registry: process.env.npm_config_registry,
     _authToken: 'invalid', // TODO: Remove when removing Lerna
   });
@@ -77,7 +76,6 @@ async function initArborist() {
   return arb;
 }
 
-const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const graph = buildDependencyGraph(
   /** @type {Arborist.Node} */ ((await initArborist()).virtualTree)
 );

--- a/utils/release/tsconfig.json
+++ b/utils/release/tsconfig.json
@@ -7,6 +7,7 @@
     "checkJs": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "noUnusedLocals": true,
     "lib": ["ESNext"]
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2470

I went too fast and didn't pay enough attention, I repeatedly missed some constants that referred to the CLI repo.

I decided to extract some common constants in a new file & directory (`./common/constants.mjs`) to avoid this happening again.

I was also tempted to extract secrets/env variables, but those are searchable anyway.