### PR TITLE
ci: added missing octokit secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
   release:
     environment: 'Release'
     runs-on: ubuntu-latest
+    env:
+      GITHUB_CREDENTIALS: ${{ secrets.ADMIN_GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     environment: 'Release'
     runs-on: ubuntu-latest
     env:
-      GITHUB_CREDENTIALS: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+      GITHUB_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2472

I copy and pasted most things from the CLI, but somehow missed this one...

I'm taking a chance and using the `ADMIN_GITHUB_TOKEN` we already have, which was used in our old release process to checkout the repo.