### PR TITLE
test(headless): lazily fixed facet select integration test

### DIFF
--- a/packages/headless/src/integration-tests/search-app.test.ts
+++ b/packages/headless/src/integration-tests/search-app.test.ts
@@ -25,7 +25,6 @@ import {
   buildSort,
   buildCategoryFacet,
   Result,
-  CategoryFacetValue,
   FacetValue,
 } from '../index';
 
@@ -132,16 +131,16 @@ describe('search app', () => {
     });
   });
 
-  describe('Facet: select value', () => {
-    let initialCategoryFacetValues: CategoryFacetValue[];
+  describe('Category Facet: select value', () => {
+    let initialFacetValues: FacetValue[];
     let initialResults: Result[];
 
     beforeAll(async () => {
-      initialCategoryFacetValues = categoryFacet.state.values;
+      initialFacetValues = facet.state.values;
       initialResults = resultList.state.results;
 
-      const [firstFacetValue] = facet.state.values;
-      facet.toggleSelect(firstFacetValue);
+      const [firstFacetValue] = categoryFacet.state.values;
+      categoryFacet.toggleSelect(firstFacetValue);
 
       await sleep(2);
     });
@@ -151,10 +150,8 @@ describe('search app', () => {
       await sleep(2);
     });
 
-    it('updates the category facet values', () => {
-      expect(categoryFacet.state.values).not.toEqual(
-        initialCategoryFacetValues
-      );
+    it('updates the facet values', () => {
+      expect(facet.state.values).not.toEqual(initialFacetValues);
     });
 
     it('updates the results', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2473

Fixed this locally just to verify whether the test was flaky or whether we actually have a bug.

This test is failing every time because all 10 results happen to be from the same author as the first facet value.

Pushing the fix since I already had it locally anyway, and it fails every time.

My fix is just to select a category facet value instead, since that one's in the geographical hierarchy source, which rarely comes up in results, and should consistently change the available authors in the facet.