### PR TITLE
fix(quantic): padding of the feedback options adjusted in the quantic smart snippet component

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippet/quanticSmartSnippet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippet/quanticSmartSnippet.html
@@ -1,6 +1,6 @@
 <template>
   <template if:true={answerFound}>
-    <div class="smart-snippet slds-var-m-bottom_small">
+    <div class="smart-snippet slds-var-m-bottom_xx-small">
       <lightning-card data-cy="smart-snippet-card" title={question}>
         <div class="slds-p-horizontal_medium slds-p-top_small slds-border_top">
           <div class="slds-var-m-bottom_small">
@@ -21,8 +21,10 @@
         </div>
       </lightning-card>
     </div>
-    <c-quantic-feedback success-message={labels.thankYouForFeedback}
+    <div class="slds-var-m-bottom_small">
+      <c-quantic-feedback success-message={labels.thankYouForFeedback}
       hide-explain-why-button={hideExplainWhyFeedbackButton} onlike={like} ondislike={dislike}
       onpressexplainwhy={explainWhy} state={feedbackState}></c-quantic-feedback>
+    </div>
   </template>
 </template>


### PR DESCRIPTION
[SFINT-5017](https://coveord.atlassian.net/browse/SFINT-5017)

Adjusted the padding around the feedback options of the smart snippet component to make this component look good inside the Quantic Insight Panel.

## Before:
<img width="231" alt="Before" src="https://github.com/coveo/ui-kit/assets/86681870/6cf6002d-fe2e-4259-a0d2-e964e47227e5">

## After:
<img width="237" alt="After" src="https://github.com/coveo/ui-kit/assets/86681870/b7c85884-aa25-4f7f-a6bd-9af000db67f3">





[SFINT-5017]: https://coveord.atlassian.net/browse/SFINT-5017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ