### PR TITLE
feat(atomic): add a part on `facet-value-checkbox > atomic-icon`

### DIFF
--- a/packages/atomic/src/components/common/checkbox.tsx
+++ b/packages/atomic/src/components/common/checkbox.tsx
@@ -9,6 +9,7 @@ export interface CheckboxProps {
   class?: string;
   text?: string;
   part?: string;
+  iconPart?: string;
   ariaLabel?: string;
   ariaCurrent?: string;
   ref?(element?: HTMLElement): void;
@@ -55,6 +56,7 @@ export const Checkbox: FunctionalComponent<CheckboxProps> = (props) => {
       <atomic-icon
         class={`w-3/5 svg-checkbox ${props.checked ? 'block' : 'hidden'}`}
         icon={Tick}
+        part={props.iconPart}
       ></atomic-icon>
     </button>
   );

--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -30,7 +30,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
         onMouseDown={(e) =>
           createRipple(e, {color: 'neutral', parent: labelRef})
         }
-        icon-part="value-checkbox-icon"
+        iconPart="value-checkbox-icon"
       />
       <label
         ref={(ref) => (labelRef = ref!)}

--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -30,6 +30,7 @@ export const FacetValueCheckbox: FunctionalComponent<FacetValueProps> = (
         onMouseDown={(e) =>
           createRipple(e, {color: 'neutral', parent: labelRef})
         }
+        icon-part="value-checkbox-icon"
       />
       <label
         ref={(ref) => (labelRef = ref!)}

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -58,6 +58,7 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
+ * @part value-checkbox-icon - The facet value checkbox icon, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  * @part value-link-selected - The selected facet value when display is 'link'.
  * @part value-box - The facet value when display is 'box'.

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -57,6 +57,7 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
+ * @part value-checkbox-icon - The facet value checkbox icon, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  * @part value-link-selected - The selected facet value when display is 'link'.
 

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -62,6 +62,7 @@ import {initializePopover} from '../atomic-popover/popover-type';
  * @part value-checkbox - The facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-checked - The checked facet value checkbox, available when display is 'checkbox'.
  * @part value-checkbox-label - The facet value checkbox clickable label, available when display is 'checkbox'.
+ * @part value-checkbox-icon - The facet value checkbox icon, available when display is 'checkbox'.
  * @part value-link - The facet value when display is 'link'.
  * @part value-link-selected - The selected facet value when display is 'link'.
  */


### PR DESCRIPTION
[KIT-2412](https://coveord.atlassian.net/browse/KIT-2412)


### Summary
This PR adds a part for  the atomic-icon within facet checkboxes.


### Possible problem
Currently, the tick icon in the SVG has a default stroke color of white and I haven't found a way to override it. If a user wanted to change the tick icon to another color, they would not be able to.

### Two solutions 

- Add custom icons to the checkbox
- Remove directly the default stroke in the tick SVG


[KIT-2412]: https://coveord.atlassian.net/browse/KIT-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ