### PR TITLE
docs(atomic): fix sort-expression storybook

### DIFF
--- a/packages/atomic/src/components/search/atomic-sort-expression/atomic-sort-expression.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-expression/atomic-sort-expression.stories.tsx
@@ -4,7 +4,11 @@ const {defaultModuleExport, exportedStory} = defaultStory(
   'Atomic/SortDropdown/SortExpression',
   'atomic-sort-expression',
   {label: 'Relevance', expression: 'relevancy'},
-  {parentElement: () => document.createElement('atomic-sort-dropdown')}
+  {
+    parentElement: () => {
+      return document.createElement('atomic-sort-dropdown');
+    },
+  }
 );
 
 export default {


### PR DESCRIPTION
Problem originally introduced with upgrade to storybook 7. 

Deep in the storybook codebase, there's an `eval` that gets executed with the "sanitized" inline source for the story (please don't ask me why it does that, I have no idea 😂).

The sanitized string would be invalid JavaScript in that case.

Anyway, I did not go too deep on that one, I just applied a quickfix by simply rewriting the inline code a bit.


https://coveord.atlassian.net/browse/KIT-2474