### PR TITLE
docs(atomic): storybook: use performatted text block for options description

### DIFF
--- a/utils/atomic-storybook/.storybook/map-props-to-args.ts
+++ b/utils/atomic-storybook/.storybook/map-props-to-args.ts
@@ -3,7 +3,6 @@ import {isNullOrUndefined} from '@coveo/bueno';
 import {JsonDocs, JsonDocsValue} from '@stencil/core/internal';
 import {ArgTypes} from '@storybook/api';
 import {Options} from '@storybook/components';
-import {escape} from 'lodash';
 
 const availableControlType = [
   'radio',

--- a/utils/atomic-storybook/.storybook/map-props-to-args.ts
+++ b/utils/atomic-storybook/.storybook/map-props-to-args.ts
@@ -3,6 +3,7 @@ import {isNullOrUndefined} from '@coveo/bueno';
 import {JsonDocs, JsonDocsValue} from '@stencil/core/internal';
 import {ArgTypes} from '@storybook/api';
 import {Options} from '@storybook/components';
+import {escape} from 'lodash';
 
 const availableControlType = [
   'radio',
@@ -48,7 +49,7 @@ export const mapPropsToArgTypes = (componentTag: string): ArgTypes => {
     )
     .forEach((prop) => {
       ret[prop.name] = {
-        description: prop.docs,
+        description: `<pre>${prop.docs}</pre>`,
         table: {
           defaultValue: {summary: prop.default},
         },


### PR DESCRIPTION
Some option description would be improperly formatted when we use markdown for the JSDoc.

https://coveord.atlassian.net/browse/KIT-2464