### PR TITLE
fix(quantic): fixed bug with the target property of the quantic result link

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/__tests__/quanticResultLink.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/__tests__/quanticResultLink.test.js
@@ -1,8 +1,8 @@
 import * as mockHeadlessLoader from 'c/quanticHeadlessLoader';
 // @ts-ignore
-import { getNavigateCalledWith } from 'lightning/navigation';
+import {getNavigateCalledWith} from 'lightning/navigation';
 // @ts-ignore
-import { createElement } from 'lwc';
+import {createElement} from 'lwc';
 import QuanticResultLink from '../quanticResultLink';
 // @ts-ignore
 import mockDefaultResult from './data/defaultResult.json';
@@ -10,7 +10,6 @@ import mockDefaultResult from './data/defaultResult.json';
 import mockKnowledgeArticleResult from './data/knowledgeArticleResult.json';
 // @ts-ignore
 import mockSalesforceResult from './data/salesforceResult.json';
-
 
 jest.mock('c/quanticHeadlessLoader');
 
@@ -97,6 +96,7 @@ describe('c-quantic-result-link', () => {
       });
     });
   });
+
   describe('when the result is NOT of type salesforce', () => {
     it('should open the result link in the current browser tab', async () => {
       const element = createTestComponent({...mockDefaultResult});
@@ -109,5 +109,20 @@ describe('c-quantic-result-link', () => {
       );
       expect(link.getAttribute('target')).toEqual('_self');
     });
+
+    describe('with a custom value for the target property', () => {
+      it('should open the result link based on the value of the target property', async () => {
+        const customTarget = "_blank";
+        const element = createTestComponent({...mockDefaultResult, target: customTarget});
+        await flushPromises();
+  
+        const link = element.shadowRoot.querySelector('a');
+  
+        expect(link.getAttribute('href')).toEqual(
+          mockDefaultResult.result.clickUri
+        );
+        expect(link.getAttribute('target')).toEqual(customTarget);
+      });
+    })
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -145,7 +145,7 @@ export default class QuanticResultLink extends NavigationMixin(LightningElement)
     if (this.isSalesforceLink) {
       return '_blank';
     }
-    return '_self';
+    return this.target;
   }
 
   /**


### PR DESCRIPTION
[SFINT-5023](https://coveord.atlassian.net/browse/SFINT-5023)

## The issue
The `target` property was not passed properly to the anchor tag used in the HTML template of the Quantic Result Link component.
The link was always opened in the same current browser tab regardless of the values passed to the property target.

[SFINT-5023]: https://coveord.atlassian.net/browse/SFINT-5023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ