### PR TITLE
fix: hide ipx if parent is hidden SVCINT-2357

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,6 @@
 
 # Owners of Atomic's Cypress Tests
 /packages/atomic/cypress/ @coveo/search @coveo/search-qa
+
+# Owners of Atomic IPX components
+/packages/atomic/src/components/ipx @coveo/service-integrations

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -672,7 +672,7 @@ export namespace Components {
     }
     interface AtomicIpxBody {
         "displayFooterSlot": boolean;
-        "isOpen": boolean;
+        "isOpen"?: boolean;
     }
     interface AtomicIpxButton {
         /**

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -45,12 +45,11 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
   public render() {
     this.updateBreakpoints();
 
+    const isEmbedded = this.isOpen === undefined;
     return (
       <article
         part="container"
-        class={`${
-          this.isOpen === undefined ? '' : this.isOpen ? 'visible' : 'invisible'
-        }`}
+        class={`${isEmbedded ? '' : this.isOpen ? 'visible' : 'invisible'}`}
         onAnimationEnd={() => this.animationEnded.emit()}
       >
         <style>

--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -31,7 +31,7 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
 
   @Event() animationEnded!: EventEmitter<never>;
 
-  @Prop() isOpen = true;
+  @Prop({mutable: true}) isOpen?: boolean;
 
   @Prop({reflect: true}) displayFooterSlot = true;
 
@@ -48,7 +48,9 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
     return (
       <article
         part="container"
-        class={`${this.isOpen ? 'visible' : 'invisible'}`}
+        class={`${
+          this.isOpen === undefined ? '' : this.isOpen ? 'visible' : 'invisible'
+        }`}
         onAnimationEnd={() => this.animationEnded.emit()}
       >
         <style>


### PR DESCRIPTION
[SVCINT-2357](https://coveord.atlassian.net/browse/SVCINT-2357)

Embedded IPX was always displayed, even when parent was hidden (since we always set the visible/invisible class)

We now only set the class if `isOpen` is set on the ipx-body, which lets us inherit visibility from the parent in the embedded case.

[SVCINT-2357]: https://coveord.atlassian.net/browse/SVCINT-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ