### PR TITLE
ci: temporarily use personal access token instead of github app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,5 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           DEBUG: ${{ inputs.debug && '*' || '' }}
-          RELEASER_APP_ID: ${{ secrets.RELEASER_APP_ID }}
-          RELEASER_PRIVATE_KEY: ${{ secrets.RELEASER_PRIVATE_KEY }}
-          RELEASER_CLIENT_ID: ${{ secrets.RELEASER_CLIENT_ID }}
-          RELEASER_CLIENT_SECRET: ${{ secrets.RELEASER_CLIENT_SECRET }}
-          RELEASER_INSTALLATION_ID: ${{ secrets.RELEASER_INSTALLATION_ID }}
+          GITHUB_CREDENTIALS: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -17,16 +17,11 @@ import {
   gitSetRefOnCommit,
   gitPush,
 } from '@coveo/semantic-monorepo-tools';
-import {createAppAuth} from '@octokit/auth-app';
 import {spawnSync} from 'child_process';
 import {readFileSync} from 'fs';
 import {Octokit} from 'octokit';
 import {dedent} from 'ts-dedent';
-import {
-  RELEASER_AUTH_SECRETS,
-  REPO_NAME,
-  REPO_OWNER,
-} from './common/constants.mjs';
+import {REPO_NAME, REPO_OWNER} from './common/constants.mjs';
 import {removeWriteAccessRestrictions} from './lock-master.mjs';
 
 const GIT_SSH_REMOTE = 'deploy';
@@ -35,10 +30,7 @@ const GIT_SSH_REMOTE = 'deploy';
 (async () => {
   const PATH = '.';
 
-  const octokit = new Octokit({
-    authStrategy: createAppAuth,
-    auth: RELEASER_AUTH_SECRETS,
-  });
+  const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
 
   // Define release # andversion
   const currentVersionTag = getCurrentVersion(PATH);

--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -2,14 +2,8 @@
  * Because our release process creates release commits on our main branch,
  * it needs to reserve the branch when running, so that no 'new commits' come up.
  */
-import {createAppAuth} from '@octokit/auth-app';
 import {Octokit} from 'octokit';
-import {
-  RELEASER_AUTH_SECRETS,
-  REPO_MAIN_BRANCH,
-  REPO_NAME,
-  REPO_OWNER,
-} from './common/constants.mjs';
+import {REPO_MAIN_BRANCH, REPO_NAME, REPO_OWNER} from './common/constants.mjs';
 
 const REPO_MAIN_BRANCH_PARAMS = {
   owner: REPO_OWNER,
@@ -27,10 +21,7 @@ export const removeWriteAccessRestrictions = () =>
  * @param {boolean} onlyBot
  */
 async function changeBranchRestrictions(onlyBot) {
-  const octokit = new Octokit({
-    authStrategy: createAppAuth,
-    auth: RELEASER_AUTH_SECRETS,
-  });
+  const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
   // Requires branches to be up to date before merging
   await octokit.rest.repos.updateStatusCheckProtection({
     ...REPO_MAIN_BRANCH_PARAMS,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2478

Going to revert this later when we know that the release process works. I'm not 100% sure that the personal access token will work either, but I manually granted it the permissions it should need (admin and content).