### PR TITLE
ci: replace ubuntu-latest with ubuntu-20.04

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -12,7 +12,7 @@ defaults:
 jobs:
   create-and-promote-quantic-package:
     name: Create Quantic Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Use Node.js 14.x

--- a/.github/workflows/manual-package.yml
+++ b/.github/workflows/manual-package.yml
@@ -47,14 +47,14 @@ on:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
   lint-check:
     name: 'Check with linter'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -63,7 +63,7 @@ jobs:
     name: 'Run unit tests'
     if: ${{ github.event.inputs.skipUnitTests != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -72,7 +72,7 @@ jobs:
     name: 'Run e2e tests on Atomic'
     if: ${{ github.event.inputs.skipAtomicE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -84,7 +84,7 @@ jobs:
     name: 'Run e2e tests on Quantic'
     if: ${{ github.event.inputs.skipQuanticE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -98,7 +98,7 @@ jobs:
     name: 'Run e2e tests on Atomic React'
     if: ${{ github.event.inputs.skipAtomicReactE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -108,7 +108,7 @@ jobs:
     name: 'Run e2e tests on Atomic Angular'
     if: ${{ github.event.inputs.skipAtomicAngularE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -117,7 +117,7 @@ jobs:
     name: 'Run e2e tests on Vue.js sample'
     if: ${{ github.event.inputs.skipAtomicVueJsE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -126,7 +126,7 @@ jobs:
     name: 'Run e2e tests on Atomic insight panel'
     if: ${{ github.event.inputs.skipAtomicInsightsPanelE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -136,7 +136,7 @@ jobs:
     name: 'Run e2e tests on Stencil.js sample'
     if: ${{ github.event.inputs.skipAtomicStencilE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -146,7 +146,7 @@ jobs:
     name: 'Runs Cypress tests for Atomic Hosted Page'
     if: ${{ github.event.inputs.skipAtomicHostedPageE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -156,7 +156,7 @@ jobs:
     name: 'Run e2e tests on Atomic React NextJS'
     if: ${{ github.event.inputs.skipAtomicReactNextJSE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -166,7 +166,7 @@ jobs:
     name: 'Run e2e tests for IIFE'
     if: ${{ github.event.inputs.skipIIFEE2E != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -179,7 +179,7 @@ jobs:
       - 'unit-test'
       - 'e2e-atomic-test'
       - 'e2e-quantic-test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: cancelled() || failure() || success()
     steps:
       - name: fail if unit test failed

--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
   lint-check:
     name: 'Check with linter'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -22,7 +22,7 @@ jobs:
   unit-test:
     name: 'Run unit tests'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
   e2e-atomic-test:
     name: 'Run e2e tests on Atomic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
   e2e-atomic-screenshots:
     name: 'Run e2e screenshots tests on Atomic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -60,7 +60,7 @@ jobs:
   e2e-atomic-angular-test:
     name: 'Run e2e tests on Atomic Angular'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -68,7 +68,7 @@ jobs:
   e2e-atomic-vuejs-test:
     name: 'Run e2e tests on Vue.js sample'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -76,7 +76,7 @@ jobs:
   e2e-atomic-stencil-test:
     name: 'Run e2e tests on Stencil.js sample'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -84,7 +84,7 @@ jobs:
   e2e-atomic-hosted-page-test:
     name: 'Runs Cypress tests for Atomic Hosted Page'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -92,7 +92,7 @@ jobs:
   e2e-atomic-react-test:
     name: 'Run e2e tests on Atomic React'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -100,7 +100,7 @@ jobs:
   e2e-atomic-react-nextjs-test:
     name: 'Run e2e tests on Atomic React NextJS'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -108,7 +108,7 @@ jobs:
   e2e-iife-test:
     name: 'Run e2e tests for IIFE'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -116,7 +116,7 @@ jobs:
   e2e-atomic-insight-panel-test:
     name: 'Run e2e tests on Atomic Insight Panel'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -124,7 +124,7 @@ jobs:
   e2e-quantic-setup:
     name: 'Setup e2e tests on Quantic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -135,7 +135,7 @@ jobs:
   e2e-quantic-test:
     name: 'Run e2e tests on Quantic'
     needs: e2e-quantic-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
   e2e-quantic-cleanup:
     if: cancelled() || failure() || success()
     needs: e2e-quantic-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -172,7 +172,7 @@ jobs:
     #   - 'unit-test'
     #   - 'e2e-atomic-test'
     #   - 'e2e-quantic-test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: 'Prerelease'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package-lock-root-fail.yml
+++ b/.github/workflows/package-lock-root-fail.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   lockfile-outside-of-root:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: exit 1

--- a/.github/workflows/package-lock-root-success.yml
+++ b/.github/workflows/package-lock-root-success.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   lockfile-outside-of-root:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: exit 0

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   report-size:
     name: 'Report bundle size'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
       NODE_OPTIONS: --max_old_space_size=4096
@@ -18,7 +18,7 @@ jobs:
       - run: npm run pr:report
   build:
     name: 'Build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -26,7 +26,7 @@ jobs:
   lint-check:
     name: 'Check with linter'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -34,7 +34,7 @@ jobs:
   unit-test:
     name: 'Run unit tests'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -42,7 +42,7 @@ jobs:
   e2e-atomic-test:
     name: 'Run e2e tests on Atomic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
   e2e-atomic-screenshots:
     name: 'Run e2e screenshots tests on Atomic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -71,7 +71,7 @@ jobs:
   e2e-atomic-react-test:
     name: 'Run e2e tests on Atomic React'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -79,7 +79,7 @@ jobs:
   e2e-atomic-react-nextjs-test:
     name: 'Run e2e tests on Atomic React NextJS'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -87,7 +87,7 @@ jobs:
   e2e-iife-test:
     name: 'Run e2e tests for IIFE'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -95,7 +95,7 @@ jobs:
   e2e-atomic-angular-test:
     name: 'Run e2e tests on Atomic Angular'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -103,7 +103,7 @@ jobs:
   e2e-atomic-vuejs-test:
     name: 'Run e2e tests on Vue.js sample'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -111,7 +111,7 @@ jobs:
   e2e-atomic-stencil-test:
     name: 'Run e2e tests on Stencil.js sample'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -119,7 +119,7 @@ jobs:
   e2e-atomic-hosted-page-test:
     name: 'Runs Cypress tests for Atomic Hosted Page'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -127,7 +127,7 @@ jobs:
   e2e-atomic-insight-panel-test:
     name: 'Run e2e tests on Atomic insight panel'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -135,7 +135,7 @@ jobs:
   e2e-quantic-setup:
     name: 'Setup e2e tests on Quantic'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -146,7 +146,7 @@ jobs:
   e2e-quantic-test:
     name: 'Run e2e tests on Quantic'
     needs: e2e-quantic-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
   e2e-quantic-cleanup:
     if: cancelled() || failure() || success()
     needs: e2e-quantic-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
@@ -179,7 +179,7 @@ jobs:
       - 'unit-test'
       - 'e2e-atomic-test'
       - 'e2e-quantic-test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: echo 'All required jobs have passed'
   is-valid:
@@ -187,7 +187,7 @@ jobs:
     name: 'Confirm build is valid'
     needs:
       - 'required-jobs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: |
           success="${{ needs.required-jobs.result == 'success' }}"

--- a/.github/workflows/release-old.yml
+++ b/.github/workflows/release-old.yml
@@ -3,7 +3,7 @@ on: [workflow_dispatch]
 
 jobs:
   relese-using-lerna:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     environment: 'Release'
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2472

For some reason, when the CI tries to use the deploy key I created, it throws this error:
```log
2023-05-19T20:41:19.031Z @coveo/semantic-monorepo-tools:git git commit -m lock master finished with code 0 and signal 'null'
2023-05-19T20:41:19.031Z @coveo/semantic-monorepo-tools:git executing "git push deploy"
2023-05-19T20:41:19.724Z @coveo/semantic-monorepo-tools:git STDERR: Load key "/home/runner/.ssh/id_rsa": error in libcrypto
git@github.com: Permission denied (publickey).
```

I tried the key locally using `ssh -T`, and without even specifying `coveo/ui-kit`, it told me that the key was successful for `coveo/ui-kit`.

One of my suspicions is that this error could be caused by a different package version between Ubuntu 22.04 (what `coveo/ui-kit` uses) and Ubuntu 20.04 (what `coveo/cli` uses).