### PR TITLE
ci: removed root package version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           DEBUG: ${{ inputs.debug && '*' || '' }}
-          GITHUB_CREDENTIALS: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          RELEASER_APP_ID: ${{ secrets.RELEASER_APP_ID }}
+          RELEASER_PRIVATE_KEY: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          RELEASER_CLIENT_ID: ${{ secrets.RELEASER_CLIENT_ID }}
+          RELEASER_CLIENT_SECRET: ${{ secrets.RELEASER_CLIENT_SECRET }}
+          RELEASER_INSTALLATION_ID: ${{ secrets.RELEASER_INSTALLATION_ID }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -28,16 +28,7 @@ const GIT_SSH_REMOTE = 'deploy';
 
 // Commit, tag and push
 (async () => {
-  const PATH = '.';
-
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
-
-  // Define release # andversion
-  const currentVersionTag = getCurrentVersion(PATH);
-  currentVersionTag.inc('prerelease');
-  const npmNewVersion = currentVersionTag.format();
-  // Write release version in the root package.json
-  await npmBumpVersion(npmNewVersion, PATH);
 
   // Find all packages that have been released in this release.
   const packagesReleased = readFileSync('.git-message', {

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -17,18 +17,26 @@ import {
   gitSetRefOnCommit,
   gitPush,
 } from '@coveo/semantic-monorepo-tools';
+import {createAppAuth} from '@octokit/auth-app';
 import {spawnSync} from 'child_process';
 import {readFileSync} from 'fs';
 import {Octokit} from 'octokit';
 import {dedent} from 'ts-dedent';
-import {REPO_NAME, REPO_OWNER} from './common/constants.mjs';
+import {
+  RELEASER_AUTH_SECRETS,
+  REPO_NAME,
+  REPO_OWNER,
+} from './common/constants.mjs';
 import {removeWriteAccessRestrictions} from './lock-master.mjs';
 
 const GIT_SSH_REMOTE = 'deploy';
 
 // Commit, tag and push
 (async () => {
-  const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
+  const octokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: RELEASER_AUTH_SECRETS,
+  });
 
   // Find all packages that have been released in this release.
   const packagesReleased = readFileSync('.git-message', {

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 import {
-  getCurrentVersion,
   getCurrentBranchName,
   gitTag,
   gitDeleteRemoteBranch,
   gitPushTags,
-  npmBumpVersion,
   getSHA1fromRef,
   gitCreateBranch,
   gitCheckoutBranch,

--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -2,8 +2,14 @@
  * Because our release process creates release commits on our main branch,
  * it needs to reserve the branch when running, so that no 'new commits' come up.
  */
+import {createAppAuth} from '@octokit/auth-app';
 import {Octokit} from 'octokit';
-import {REPO_MAIN_BRANCH, REPO_NAME, REPO_OWNER} from './common/constants.mjs';
+import {
+  RELEASER_AUTH_SECRETS,
+  REPO_MAIN_BRANCH,
+  REPO_NAME,
+  REPO_OWNER,
+} from './common/constants.mjs';
 
 const REPO_MAIN_BRANCH_PARAMS = {
   owner: REPO_OWNER,
@@ -21,7 +27,10 @@ export const removeWriteAccessRestrictions = () =>
  * @param {boolean} onlyBot
  */
 async function changeBranchRestrictions(onlyBot) {
-  const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
+  const octokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: RELEASER_AUTH_SECRETS,
+  });
   // Requires branches to be up to date before merging
   await octokit.rest.repos.updateStatusCheckProtection({
     ...REPO_MAIN_BRANCH_PARAMS,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2489

I accidentally missed that when copy and pasting code from the CI...

We don't need to update the root `package.json`'s version.

In this PR, I'm also bringing back the application tokens instead of the personal access tokens.