### PR TITLE
chore: removed @storybook/addon-a11y

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,6 @@
   "ignoreDeps": [
     "esbuild",
     "@monaco-editor/react",
-    "@storybook/addon-a11y",
     "@storybook/addon-controls",
     "@storybook/addon-docs",
     "@storybook/addon-essentials",

--- a/utils/atomic-storybook/.storybook/main.js
+++ b/utils/atomic-storybook/.storybook/main.js
@@ -17,7 +17,6 @@ module.exports = {
   addons: [
     '@storybook/addon-controls',
     '@storybook/addon-viewport',
-    '@storybook/addon-a11y',
     './preset.js',
   ],
   /** @type {import('webpack')['config']['getNormalizedWebpackOptions']} */

--- a/utils/atomic-storybook/package-lock.json
+++ b/utils/atomic-storybook/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/preset-react": "7.18.6",
         "@babel/preset-typescript": "7.21.4",
         "@monaco-editor/react": "4.3.1",
-        "@storybook/addon-a11y": "7.0.7",
         "@storybook/addon-controls": "7.0.7",
         "@storybook/addon-essentials": "7.0.7",
         "@storybook/addon-interactions": "7.0.7",
@@ -2484,42 +2483,6 @@
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
       "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
-    },
-    "node_modules/@storybook/addon-a11y": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.0.7.tgz",
-      "integrity": "sha512-juLmRgUh1quGoqHyG7Ttpvj/2nIyIhcuidDKXo5ot7IbJ/g80e4o2BFPbMUT1Qdq9TL/ahbNxeP7QjV0oRJKxQ==",
-      "dependencies": {
-        "@storybook/addon-highlight": "7.0.7",
-        "@storybook/channels": "7.0.7",
-        "@storybook/client-logger": "7.0.7",
-        "@storybook/components": "7.0.7",
-        "@storybook/core-events": "7.0.7",
-        "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "7.0.7",
-        "@storybook/preview-api": "7.0.7",
-        "@storybook/theming": "7.0.7",
-        "@storybook/types": "7.0.7",
-        "axe-core": "^4.2.0",
-        "lodash": "^4.17.21",
-        "react-resize-detector": "^7.1.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@storybook/addon-actions": {
       "version": "7.0.7",
@@ -5897,14 +5860,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/babel-core": {
@@ -11751,18 +11706,6 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-resize-detector": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
-      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-pkg": {

--- a/utils/atomic-storybook/package.json
+++ b/utils/atomic-storybook/package.json
@@ -7,7 +7,6 @@
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.21.4",
     "@monaco-editor/react": "4.3.1",
-    "@storybook/addon-a11y": "7.0.7",
     "@storybook/addon-controls": "7.0.7",
     "@storybook/addon-essentials": "7.0.7",
     "@storybook/addon-interactions": "7.0.7",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2487

`@storybook/addon-a11y` has a prod dependency on `axe-core`, whose license (MPL-2.0) may be incompatible with ours due to being a weak copy-left license and us displaying addon-a11y in our docs. See https://github.com/dequelabs/axe-core/blob/develop/LICENSE for more details.

Here's a failed dependency-review-action run for reference: https://github.com/coveo/ui-kit/actions/runs/5029760617/jobs/9021704320

Discussion on Storybook's repo for reference: https://github.com/storybookjs/storybook/discussions/15777