### PR TITLE
feat(atomic): changed translation key in `atomic-did-you-mean`

### DIFF
--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -53,8 +53,7 @@ export class AtomicDidYouMean implements InitializableComponent {
 
   private withQuery(
     key:
-      | 'no-results-for'
-      | 'no-results-for-dym'
+      | 'no-results-for-did-you-mean'
       | 'query-auto-corrected-to'
       | 'showing-results-for',
     query: string
@@ -105,15 +104,13 @@ export class AtomicDidYouMean implements InitializableComponent {
   }
 
   private renderDidYouMeanAutomaticallyCorrected() {
-    const doesNoResultsForDymExist =
-      this.bindings.i18n.exists('no-results-for-dym');
-    const noResultsKey = doesNoResultsForDymExist
-      ? 'no-results-for-dym'
-      : 'no-results-for';
     return (
       <Fragment>
         <p class="text-on-background mb-1" part="no-results">
-          {this.withQuery(noResultsKey, this.didYouMeanState!.originalQuery)}
+          {this.withQuery(
+            'no-results-for-did-you-mean',
+            this.didYouMeanState!.originalQuery
+          )}
         </p>
         <p class="text-on-background" part="auto-corrected">
           {this.withQuery(

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -52,7 +52,11 @@ export class AtomicDidYouMean implements InitializableComponent {
   }
 
   private withQuery(
-    key: 'no-results-for' | 'query-auto-corrected-to' | 'showing-results-for',
+    key:
+      | 'no-results-for'
+      | 'no-results-for-dym'
+      | 'query-auto-corrected-to'
+      | 'showing-results-for',
     query: string
   ) {
     return (
@@ -101,13 +105,15 @@ export class AtomicDidYouMean implements InitializableComponent {
   }
 
   private renderDidYouMeanAutomaticallyCorrected() {
+    const doesNoResultsForDymExist =
+      this.bindings.i18n.exists('no-results-for-dym');
+    const noResultsKey = doesNoResultsForDymExist
+      ? 'no-results-for-dym'
+      : 'no-results-for';
     return (
       <Fragment>
         <p class="text-on-background mb-1" part="no-results">
-          {this.withQuery(
-            'no-results-for',
-            this.didYouMeanState!.originalQuery
-          )}
+          {this.withQuery(noResultsKey, this.didYouMeanState!.originalQuery)}
         </p>
         <p class="text-on-background" part="auto-corrected">
           {this.withQuery(

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -655,6 +655,33 @@
     "zh-cn": "没有找到与 {{query}} 相关的结果",
     "zh-tw": "沒有找到與 {{query}} 相關的結果"
   },
+  "no-results-for-did-you-mean": {
+    "en": "We couldn't find anything for {{query}}",
+    "fr": "Nous n'avons rien trouvé pour {{query}}",
+    "cs": "Pro dotaz {{query}} nebyly nalezeny žádné výsledky",
+    "da": "Ingen resultater for {{query}}",
+    "de": "Keine Ergebnisse für {{query}}",
+    "el": "Κανένα αποτέλεσμα για {{query}}",
+    "es": "No hay resultados para {{query}}",
+    "fi": "Ei tuloksia kohteelle {{query}}",
+    "hu": "Nincs eredmény: {{query}}",
+    "id": "Tidak ada hasil untuk {{query}}",
+    "it": "Nessun risultato per {{query}}",
+    "ja": "{{query}}に該当する結果なし",
+    "ko": "{{query}}에 대한 검색 결과가 없습니다",
+    "nl": "Geen resultaten voor {{query}}",
+    "no": "Ingen resultater for {{query}}",
+    "pl": "Brak wyników dla zapytania {{query}}",
+    "pt": "Nenhum resultado para {{query}}",
+    "pt-br": "Nenhum resultado para {{query}}",
+    "ru": "Нет результатов по {{query}}",
+    "sv": "Inga resultat för {{query}}",
+    "th": "ไม่พบผลลัพธ์สำหรับ {{query}}",
+    "tr": "{{query}} için sonuç yok",
+    "zh": "没有找到与 {{query}} 相关的结果",
+    "zh-cn": "没有找到与 {{query}} 相关的结果",
+    "zh-tw": "沒有找到與 {{query}} 相關的結果"
+  },
   "showing-results-for": {
     "en": "Showing results for {{query}}",
     "fr": "Résultats affichés pour {{query}}"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1426

Adds a condition that checks if the `no-results-for-dym` key exist. If it does, it uses it for the localized string.

### RFC 
 
 #### Breaking change problem
This avoids a breaking change by leaving the `no-results-for` key as the default value. However, this is bad code. The new key (`no-results-for-dym`) does not show in the `i18n.getResourceBundle()` function. The correct way to do this would be to have a breaking change and create an entirely new key in locales.json. 

#### My Solution
- Merge this bandaid PR 
- Add a spike/story in the [V3 update epic ](https://coveord.atlassian.net/browse/KIT-2157) to look for other places in the code where splitting translation keys would be useful. 
- In the spike/story, add a child issue to revert this PR changes and simply add a new key in locales.json.