### PR TITLE
test: apply test isolation to e2e result-list, facet test suites

### DIFF
--- a/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
@@ -92,7 +92,7 @@ describe('Facet DependsOn Test Suites', () => {
     };
 
     describe('with no fulfilled dependency', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addThreeLevelDependantFacet())
           .withHash('')
@@ -103,7 +103,7 @@ describe('Facet DependsOn Test Suites', () => {
     });
 
     describe('with a fulfilled two-level dependency in the hash', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addThreeLevelDependantFacet())
           .withHash(hashToDisplayFacets(true, false))
@@ -140,7 +140,7 @@ describe('Facet DependsOn Test Suites', () => {
     });
 
     describe('with a fulfilled three-level dependency in the hash', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addThreeLevelDependantFacet())
           .withHash(hashToDisplayFacets(true, true))
@@ -150,7 +150,7 @@ describe('Facet DependsOn Test Suites', () => {
       assertFacetsDisplayed(4);
 
       describe('when deselecting the root of the dependency tree', () => {
-        before(() => {
+        beforeEach(() => {
           pressClearButton(ColorFacetSelectors.withId(level0FacetId));
         });
 
@@ -163,7 +163,7 @@ describe('Facet DependsOn Test Suites', () => {
     });
 
     describe('with an invalid state in the hash', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addThreeLevelDependantFacet())
           .withHash(hashToDisplayFacets(false, true))
@@ -175,7 +175,7 @@ describe('Facet DependsOn Test Suites', () => {
   });
 
   describe('without reflectStateInUrl', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addThreeLevelDependantFacet())
         .withoutStateInUrl()
@@ -185,7 +185,7 @@ describe('Facet DependsOn Test Suites', () => {
     assertFacetsDisplayed(1);
 
     describe('when selecting an unrelated value in the level 0 facet', () => {
-      before(() => {
+      beforeEach(() => {
         const level0Selectors = ColorFacetSelectors.withId(level0FacetId);
         typeFacetSearchQuery(level0Selectors, level0FacetUnexpectedValue, true);
         selectIdleBoxValueAt(0);
@@ -195,7 +195,7 @@ describe('Facet DependsOn Test Suites', () => {
     });
 
     describe('when selecting the dependended-on value in the level 0 facet', () => {
-      before(() => {
+      beforeEach(() => {
         const level0Selectors = ColorFacetSelectors.withId(level0FacetId);
         typeFacetSearchQuery(level0Selectors, level0FacetExpectedValue, true);
         selectIdleBoxValueAt(0);

--- a/packages/atomic/cypress/e2e/facets/popover-facet/popover-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/popover-facet/popover-facet.cypress.ts
@@ -11,19 +11,18 @@ import {PopoverSelectors} from './popover-facet-selectors';
 
 describe('Popover Facet Test Suites', () => {
   function testSuites() {
-    PopoverAssertions.assertLabelContains(label);
-    PopoverAssertions.assertFacetIsHidden();
+    beforeEach(() => {
+      PopoverAssertions.assertLabelContains(label);
+      PopoverAssertions.assertFacetIsHidden();
+      PopoverSelectors.popoverButton().click();
+    });
 
     describe('when clicking the facet button', () => {
-      before(() => {
-        PopoverSelectors.popoverButton().click();
-      });
-
       PopoverAssertions.assertFacetIsVisible();
     });
 
     describe('when clicking the facet button a second time', () => {
-      before(() => {
+      beforeEach(() => {
         PopoverSelectors.popoverButton().click();
       });
 
@@ -31,8 +30,7 @@ describe('Popover Facet Test Suites', () => {
     });
 
     describe('when clicking outside the facet after opening it', () => {
-      before(() => {
-        PopoverSelectors.popoverButton().click();
+      beforeEach(() => {
         PopoverSelectors.backdrop().click();
       });
 
@@ -40,8 +38,7 @@ describe('Popover Facet Test Suites', () => {
     });
 
     describe('when clicking inside the facet after opening it', () => {
-      before(() => {
-        PopoverSelectors.popoverButton().click();
+      beforeEach(() => {
         PopoverSelectors.facet().click({force: true});
       });
 
@@ -50,7 +47,7 @@ describe('Popover Facet Test Suites', () => {
   }
 
   describe('with an atomic-facet', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addPopover('atomic-facet', {field: facetField, label}))
         .init();
@@ -60,7 +57,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-numeric-facet with ranges', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-numeric-facet', {field: numericFacetField, label})
@@ -72,7 +69,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-numeric-facet without ranges', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-numeric-facet', {
@@ -89,7 +86,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-timeframe-facet with ranges', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover(
@@ -107,7 +104,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-timeframe-facet without ranges', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-timeframe-facet', {
@@ -122,7 +119,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-color-facet', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-color-facet', {
@@ -137,7 +134,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-category-facet', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-category-facet', {
@@ -152,7 +149,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-rating-facet', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-rating-facet', {
@@ -167,7 +164,7 @@ describe('Popover Facet Test Suites', () => {
   });
 
   describe('with an atomic-rating-range-facet', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addPopover('atomic-rating-range-facet', {

--- a/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
@@ -20,7 +20,7 @@ describe('Segmented Facet Test Suites', () => {
   }
 
   describe('verify rendering', () => {
-    before(setupSegmentedFacet);
+    beforeEach(setupSegmentedFacet);
 
     CommonAssertions.assertAccessibility(segmentedFacetComponent);
     CommonAssertions.assertContainsComponentError(
@@ -44,14 +44,14 @@ describe('Segmented Facet Test Suites', () => {
     }
 
     describe('verify rendering', () => {
-      before(setupSelectSegmentedFacet);
+      beforeEach(setupSelectSegmentedFacet);
 
       CommonAssertions.assertAccessibility(segmentedFacetComponent);
       FacetAssertions.assertNumberOfSelectedBoxValues(1);
       FacetAssertions.assertNumberOfIdleBoxValues(defaultNumberOfValues - 1);
     });
     describe('verify analytics', () => {
-      before(setupSelectSegmentedFacet);
+      beforeEach(setupSelectSegmentedFacet);
       FacetAssertions.assertLogFacetSelect(field, selectionIndex);
     });
   });
@@ -71,7 +71,7 @@ describe('Segmented Facet Test Suites', () => {
     }
 
     describe('verify rendering', () => {
-      before(setupCustomSegmentedFacet);
+      beforeEach(setupCustomSegmentedFacet);
 
       CommonAssertions.assertAccessibility(segmentedFacetComponent);
       CommonFacetAssertions.assertLabelContains(
@@ -83,7 +83,7 @@ describe('Segmented Facet Test Suites', () => {
   });
 
   describe('when no search has yet been executed', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addSegmentedFacet({field, label}))
         .withoutFirstAutomaticSearch()
@@ -103,7 +103,7 @@ describe('Segmented Facet Test Suites', () => {
     }
 
     describe('verify rendering', () => {
-      before(setupSegmentedFacetNoLabel);
+      beforeEach(setupSegmentedFacetNoLabel);
 
       CommonAssertions.assertAccessibility(segmentedFacetComponent);
       CommonFacetAssertions.assertDisplayFacet(SegmentedFacetSelectors, true);
@@ -113,7 +113,7 @@ describe('Segmented Facet Test Suites', () => {
   });
 
   describe('when field returns no results', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addSegmentedFacet({field: 'notanactualfield', label}))
         .init();
@@ -131,7 +131,7 @@ describe('Segmented Facet Test Suites', () => {
   });
 
   describe('with a selected path in the URL', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addSegmentedFacet({field, label}))
         .withHash(`f-${field}=Cervantes`)
@@ -148,7 +148,7 @@ describe('Segmented Facet Test Suites', () => {
   });
 
   describe('with custom #sortCriteria, occurrences', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(addSegmentedFacet({field, label, 'sort-criteria': 'occurrences'}))
         .init();

--- a/packages/atomic/cypress/e2e/result-list/folded-result-list.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/folded-result-list.cypress.ts
@@ -152,15 +152,14 @@ describe('Folded Result List Component', () => {
       cy.wait(TestFixture.interceptAliases.UA);
     }
 
-    before(() => {
+    beforeEach(() => {
       setupCollection();
     });
 
     assertRendersWholeCollection();
 
     describe('should restore initial results when collapsing collection', () => {
-      before(() => {
-        setupCollection();
+      beforeEach(() => {
         FoldedResultListSelectors.collapseButton().click();
         cy.wait(200);
       });
@@ -170,7 +169,7 @@ describe('Folded Result List Component', () => {
   });
 
   describe('with an invalid configuration', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(setSourceAndSortCriteria)
         .with(

--- a/packages/atomic/cypress/e2e/result-list/result-components/quickview.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/quickview.cypress.ts
@@ -45,8 +45,13 @@ describe('Quickview Component', () => {
         .init();
     });
 
-    CommonAssertions.assertAccessibility(QuickviewSelectors.firstInResult);
-    CommonAssertions.assertConsoleError(false);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(QuickviewSelectors.firstInResult);
+    });
+
+    it('should not log error to console', () => {
+      CommonAssertions.assertConsoleError(false);
+    });
 
     it('should display a header title', () => {
       openModal();

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-badge.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-badge.cypress.ts
@@ -82,10 +82,11 @@ describe('Result Badge Component', () => {
         it('renders the localized text', () => {
           ResultBadgeSelectors.resultText().should('have.text', localizedText);
         });
-
-        CommonAssertions.assertAccessibility(
-          ResultBadgeSelectors.firstInResult
-        );
+        it('should be accessible', () => {
+          CommonAssertions.assertAccessibility(
+            ResultBadgeSelectors.firstInResult
+          );
+        });
       });
 
       describe('when a label is specified', () => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-date.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-date.cypress.ts
@@ -82,7 +82,9 @@ describe('Result Date Component', () => {
       ResultDateSelectors.firstInResult().should('have.text', '2021-09-03');
     });
 
-    CommonAssertions.assertAccessibility(ResultDateSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultDateSelectors.firstInResult);
+    });
   });
 
   describe('when using relative time', () => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-fields-list.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-fields-list.cypress.ts
@@ -92,5 +92,7 @@ describe('Result Fields Component', () => {
       .should('have.length.above', 0);
   });
 
-  CommonAssertions.assertAccessibility(FieldsListSelectors.firstInResult);
+  it('should be accessible', () => {
+    CommonAssertions.assertAccessibility(FieldsListSelectors.firstInResult);
+  });
 });

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-icon.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-icon.cypress.ts
@@ -47,7 +47,9 @@ describe('Result Icon Component', () => {
       'user'
     );
 
-    CommonAssertions.assertAccessibility(ResultIconSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultIconSelectors.firstInResult);
+    });
   });
 
   describe('when the "objecttype" field value matches picklist_type.svg', () => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-image.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-image.cypress.ts
@@ -50,7 +50,9 @@ describe('Result Image Component', () => {
       ResultImageSelectors.resultImage().should('have.attr', 'src', image);
     });
 
-    CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    });
   });
 
   describe('when the field does not exist', () => {
@@ -62,7 +64,9 @@ describe('Result Image Component', () => {
       ResultImageSelectors.resultImage().should('have.attr', 'src', fallback);
     });
 
-    CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    });
   });
 
   describe('when the url is not a string', () => {
@@ -77,7 +81,9 @@ describe('Result Image Component', () => {
       ResultImageSelectors.resultImage().should('have.attr', 'src', fallback);
     });
 
-    CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    });
   });
 
   describe('when the image url is not valid', () => {
@@ -92,6 +98,8 @@ describe('Result Image Component', () => {
       ResultImageSelectors.resultImage().should('have.attr', 'src', fallback);
     });
 
-    CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultImageSelectors.firstInResult);
+    });
   });
 });

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-link.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-link.cypress.ts
@@ -72,8 +72,9 @@ describe('Result Link Component', () => {
         .find('a')
         .should('have.attr', 'href', clickUri);
     });
-
-    CommonAssertions.assertAccessibility(ResultLinkSelectors.firstInResult);
+    it('should be accessible', () => {
+      CommonAssertions.assertAccessibility(ResultLinkSelectors.firstInResult);
+    });
 
     describe('when there is no default slot', () => {
       beforeEach(() => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
@@ -204,9 +204,11 @@ describe('Result MultiValueText Component', () => {
 
           assertShouldRenderValues(localizedValues.slice(0, 1));
           assertDisplaysXMoreLabel(3);
-          CommonAssertions.assertAccessibility(
-            ResultMultiValueTextSelectors.firstInResult
-          );
+          it('should be accessible', () => {
+            CommonAssertions.assertAccessibility(
+              ResultMultiValueTextSelectors.firstInResult
+            );
+          });
         });
 
         describe('with max-values-to-display=2', () => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-number.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-number.cypress.ts
@@ -107,8 +107,11 @@ describe('Result Number Component', () => {
         prepareExistingFieldValue(value).withLanguage('en').init();
         ResultNumberSelectors.firstInResult().should('have.text', '1,234.5');
       });
-
-      CommonAssertions.assertAccessibility(ResultNumberSelectors.firstInResult);
+      it('should be accessible', () => {
+        CommonAssertions.assertAccessibility(
+          ResultNumberSelectors.firstInResult
+        );
+      });
     });
 
     describe('with a format', () => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
@@ -40,7 +40,7 @@ const addUriParentsInResponse =
 
 describe('Result Printable Uri Component', () => {
   describe('when not used inside a result template', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with((e) => addTag(e, resultPrintableUriComponent, {}))
         .init();
@@ -53,7 +53,7 @@ describe('Result Printable Uri Component', () => {
   });
 
   describe('when the "max-number-of-parts" prop is not a number', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addResultList(
@@ -74,7 +74,7 @@ describe('Result Printable Uri Component', () => {
   });
 
   describe('when the "max-number-of-parts" prop is less than 3', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addResultList(
@@ -95,7 +95,7 @@ describe('Result Printable Uri Component', () => {
   });
 
   describe('when there is no "parents" property in the result object', () => {
-    before(() => {
+    beforeEach(() => {
       new TestFixture()
         .with(
           addResultList(
@@ -142,7 +142,7 @@ describe('Result Printable Uri Component', () => {
       };
 
     describe('when the number of parts is 3', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addResultListWithPrintableUri())
           .with(addUriParentsInResponse(3))
@@ -162,7 +162,7 @@ describe('Result Printable Uri Component', () => {
     });
 
     describe('when the number of parts is 4', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addResultListWithPrintableUri())
           .with(addUriParentsInResponse(4))
@@ -176,7 +176,7 @@ describe('Result Printable Uri Component', () => {
       );
 
       describe('after clicking on the ellipsis', () => {
-        before(() => {
+        beforeEach(() => {
           ResultPrintableUriSelectors.ellipsisButton().click();
         });
 
@@ -187,7 +187,7 @@ describe('Result Printable Uri Component', () => {
     });
 
     describe('when the number of parts is 20', () => {
-      before(() => {
+      beforeEach(() => {
         new TestFixture()
           .with(addResultListWithPrintableUri())
           .with(addUriParentsInResponse(20))
@@ -199,7 +199,7 @@ describe('Result Printable Uri Component', () => {
     });
 
     describe('when there is a valid slot named "attributes"', () => {
-      before(() => {
+      beforeEach(() => {
         const attributesSlot = generateComponentHTML('a', {
           download: 'test',
           target: '_self',

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-printable-uri.cypress.ts
@@ -171,9 +171,12 @@ describe('Result Printable Uri Component', () => {
 
       ResultPrintableUriAssertions.assertDisplayEllipsis(true);
       ResultPrintableUriAssertions.assertDisplayParentsCount(2);
-      CommonAssertions.assertAccessibility(
-        ResultPrintableUriSelectors.firstInResult
-      );
+
+      it('should be accessible', () => {
+        CommonAssertions.assertAccessibility(
+          ResultPrintableUriSelectors.firstInResult
+        );
+      });
 
       describe('after clicking on the ellipsis', () => {
         beforeEach(() => {

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-text.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-text.cypress.ts
@@ -147,8 +147,9 @@ describe('Result Text Component', () => {
         ResultTextSelectors.firstInResult().should('have.text', rawValue);
         ResultTextSelectors.highlight().should('have.text', highlightedValue);
       });
-
-      CommonAssertions.assertAccessibility(ResultTextSelectors.firstInResult);
+      it('should be accessible', () => {
+        CommonAssertions.assertAccessibility(ResultTextSelectors.firstInResult);
+      });
     });
 
     describe('when the "shouldHighlight" prop is false', () => {

--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -143,13 +143,13 @@ describe('Search Box Test Suites', () => {
             })
           )
           .init();
+        cy.get(searchBoxComponent).invoke('attr', 'redirection-url', '');
+        cy.wait(100);
+
+        SearchBoxSelectors.inputBox().click();
+        SearchBoxSelectors.querySuggestion('query-suggestion-1').click();
       });
 
-      cy.get(searchBoxComponent).invoke('attr', 'redirection-url', '');
-      cy.wait(100);
-
-      SearchBoxSelectors.inputBox().click();
-      SearchBoxSelectors.querySuggestion('query-suggestion-1').click();
       SearchBoxAssertions.assertHasText('query-suggestion-1');
     });
 

--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -143,13 +143,13 @@ describe('Search Box Test Suites', () => {
             })
           )
           .init();
-        cy.get(searchBoxComponent).invoke('attr', 'redirection-url', '');
-        cy.wait(100);
-
-        SearchBoxSelectors.inputBox().click();
-        SearchBoxSelectors.querySuggestion('query-suggestion-1').click();
       });
 
+      cy.get(searchBoxComponent).invoke('attr', 'redirection-url', '');
+      cy.wait(100);
+
+      SearchBoxSelectors.inputBox().click();
+      SearchBoxSelectors.querySuggestion('query-suggestion-1').click();
       SearchBoxAssertions.assertHasText('query-suggestion-1');
     });
 

--- a/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
+++ b/packages/atomic/cypress/integration-insight-panel/insight-panel.cypress.ts
@@ -16,7 +16,6 @@ describe('Insight Panel test suites', () => {
   const setupPage = () => {
     interceptInsightSearch();
     cy.visit(host);
-    cy.injectAxe();
     cy.wait(insightSearchAlias);
   };
 
@@ -25,7 +24,12 @@ describe('Insight Panel test suites', () => {
   });
 
   describe('when there is nothing written in the search box', () => {
-    before(setupPage);
+    beforeEach(setupPage);
+
+    it('should be accessible', () => {
+      cy.injectAxe();
+      CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
+    });
 
     it('should display placeholder while loading', () => {
       InsightPanelsSelectors.resultsPlaceholder()
@@ -199,17 +203,20 @@ describe('Insight Panel test suites', () => {
         .find('button[aria-pressed="true"]')
         .should('have.text', 'Youtube');
     });
-
-    CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
   });
 
   describe('when there is something written in the search box', () => {
-    before(() => {
+    beforeEach(() => {
       setupPage();
       InsightPanelsSelectors.results()
         .its('length')
         .should('be.greaterThan', 0);
       InsightPanelActions.executeQuery('test');
+    });
+
+    it('should be accessible', () => {
+      cy.injectAxe();
+      CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
     });
 
     it('displays a query summary', () => {
@@ -219,8 +226,6 @@ describe('Insight Panel test suites', () => {
         .should('contain.text', 'Results 1-5')
         .should('contain.text', 'for test');
     });
-
-    CommonAssertions.assertAccessibility(InsightPanelsSelectors.searchbox);
   });
 
   describe('when there is a custom salesforce result template', () => {

--- a/packages/samples/stencil/cypress/e2e/stencil/smoke-test.cypress.ts
+++ b/packages/samples/stencil/cypress/e2e/stencil/smoke-test.cypress.ts
@@ -81,7 +81,7 @@ describe('smoke test', () => {
   }
 
   describe('when navigating directly to the /search', () => {
-    before(() => {
+    beforeEach(() => {
       setup();
     });
 
@@ -89,7 +89,7 @@ describe('smoke test', () => {
   });
 
   describe('when navigating back to the /search', () => {
-    before(() => {
+    beforeEach(() => {
       setup();
 
       cy.get('a#home').click();
@@ -101,7 +101,7 @@ describe('smoke test', () => {
   });
 
   describe('testing the /hsp sample', () => {
-    before(() => {
+    beforeEach(() => {
       setupHSP();
     });
 


### PR DESCRIPTION
In prep for Cypress 12 upgrade https://github.com/coveo/ui-kit/pull/2935 apply test isolation to result-list, facet, insight-panel and stencil smoke test suites.

https://coveord.atlassian.net/browse/KIT-2432