### PR TITLE
fix(atomic): code defensively around triggers notifications state

### DIFF
--- a/packages/atomic/src/components/search/atomic-notification/atomic-notifications.tsx
+++ b/packages/atomic/src/components/search/atomic-notification/atomic-notifications.tsx
@@ -112,8 +112,6 @@ export class AtomicNotifyTrigger implements InitializableComponent {
   }
 
   private get notifications(): string[] {
-    return (
-      this.notifyTriggerState?.notifications || []
-    );
+    return this.notifyTriggerState?.notifications || [];
   }
 }


### PR DESCRIPTION
`headless-notifications` uses a `strictListener` pattern, which check for changes in the array of notifications coming from the search API before calling subscribers functions.

What this means is that, for example on first page load, the array of notifications received is empty, which then gets compared with the initial state when the engine is created (also an empty array), so subscribers do not get called.

This is slightly different from how other controllers behave. They generally gets called back on initialization.

The actual proper fix could potentially be to change the `strictListener` pattern to ensure it gets called at least once on creation, like other controllers. However it's a bit more risky, as it does introduce a subtle behaviour change, so potentially breaking. This change has been identified for V3 here: https://coveord.atlassian.net/browse/KIT-2380

So, instead, add some defensive code in Atomic around that controller, since the state is potentially undefined when the render function gets executed.

This issue was reproducible with the IPX page in local, and had been reported by a client building a custom app with React.

For tests, I wasn't sure what to do exactly, since it's not easy to reproduce with our tests suite with Cypress: You need to "force" a re-render of the component, without any underlying state change.

I could add some random smoke tests for the IPX page specifically I guess, which verifies that there's no error message regarding notifications in the console 😂 But this seems pretty forced. What do you think ?


https://coveord.atlassian.net/browse/KIT-2382