### PR TITLE
fix(atomic-react): bad esm-export

### DIFF
--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -27,9 +27,9 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
+    "./**/*": {
+      "types": "./dist/**/*.d.ts",
+      "default": "./dist/**/*.js"
     }
   },
   "module": "./dist/index.js",

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -21,7 +21,7 @@
     "build:assets": "ncp ../atomic/dist/atomic/assets dist/assets && ncp ../atomic/dist/atomic/lang dist/lang "
   },
   "main": "./dist/cjs/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -21,6 +21,17 @@
     "build:assets": "ncp ../atomic/dist/atomic/assets dist/assets && ncp ../atomic/dist/atomic/lang dist/lang "
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/samples/atomic-react/package.json
+++ b/packages/samples/atomic-react/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/atomic-react-samples",
   "version": "0.0.0",
   "description": "Samples with atomic-react",
+  "type": "module",
   "private": true,
   "dependencies": {
     "@coveo/atomic": "2.30.1",

--- a/packages/samples/atomic-react/webpack.config.js
+++ b/packages/samples/atomic-react/webpack.config.js
@@ -1,6 +1,8 @@
-const path = require('path');
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-module.exports = {
+export default {
   entry: './src/App.tsx',
   module: {
     rules: [
@@ -20,7 +22,7 @@ module.exports = {
   },
   output: {
     filename: 'app.js',
-    path: path.resolve(__dirname, 'public/dist'),
+    path: resolve(__dirname, 'public/dist'),
   },
   devServer: {
     static: './public',


### PR DESCRIPTION
Fixes #2928 
Dangerous change, discussion on Slack, because we need to draw a line in the sand.

My proposal is to only fix the error because it just plain doesn't work and might 💥 stuff.
V3 however, I think we could go wild and simply wipe the slate and redefine the export contract of all public packages.