### PR TITLE
ci: lint staged files before creating version bump commits

### DIFF
--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -84,9 +84,10 @@ async function commitChanges(commitMessage, octokit) {
   const tempBranchName = `release/${mainBranchCurrentSHA}`;
   await gitCreateBranch(tempBranchName);
   await gitCheckoutBranch(tempBranchName);
-  runPrecommit();
   // Stage all the changes...
   await gitAdd('.');
+  // Lint staged files
+  runPrecommit();
   //... and create a Git tree object with the changes. The Tree SHA will be used with GitHub APIs.
   const treeSHA = await gitWriteTree();
   // Create a new commit that references the Git tree object.


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2509

I made a mistake. Only staged files are linted, so this was doing nothing. Woops.