### PR TITLE
ci: remove force push from version bump logic

### DIFF
--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -85,7 +85,7 @@ async function commitChanges(commitMessage, octokit) {
     repo: REPO_NAME,
     ref: `heads/${mainBranchName}`,
     sha: newCommitSHA,
-    force: true,
+    force: true, // Needed since the remote main branch contains a "lock" commit.
   });
 
   // Delete the temp branch


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2510

Old commit logic:
1. Create temporary branch.
2. Checkout temporary branch.
3. Lint all files.
4. Stage all files.
5. Create git tree (from staged files).
6. Create temporary commit ([example](https://github.com/coveo/ui-kit/commit/7810f4b78139697f6e4e9488c926fbba47cd62d6))
    * tree: version bump tree
    * parent: temporary branch
    * message: "tempcommit"
7. Checkout new commit.
8. Push temporary branch using deploy key (doesn't error).
9. Create remote commit using GItHub API
    * tree: version bump tree
    * parent: main branch
    * message: "[Version Bump][skip ci] ..."
10. Set local main branch to reference new remote commit.
11. Force-push local main branch reference using deploy key (currently errors due to main branch protections).
12. Remove temporary branch.

New commit logic:
1. Create temporary branch.
2. Checkout temporary branch.
3. Commit regularly (runs all git hooks).
    * Also stages all files.
    * Also runs all git hooks, including `lint-staged`.
    * Also updates branch to new commit.
    * Message is "[Version Bump][skip ci] ..."
4. Push temporary branch with commit using deploy key.
5. Fetch current HEAD SHA.
6. Force-update `master` branch reference to current HEAD SHA (new commit on temporary branch).
7. Remove temporary branch.