### PR TITLE
ci: remove force push from version bump logic

### DIFF
--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -12,11 +12,11 @@ import {
   gitCommitTree,
   gitUpdateRef,
   gitPublishBranch,
-  gitSetRefOnCommit,
-  gitPush,
+  gitPull,
 } from '@coveo/semantic-monorepo-tools';
 import {createAppAuth} from '@octokit/auth-app';
 import {spawnSync} from 'child_process';
+import {randomUUID} from 'crypto';
 import {readFileSync} from 'fs';
 import {Octokit} from 'octokit';
 import {dedent} from 'ts-dedent';
@@ -26,8 +26,6 @@ import {
   REPO_OWNER,
 } from './common/constants.mjs';
 import {removeWriteAccessRestrictions} from './lock-master.mjs';
-
-const GIT_SSH_REMOTE = 'deploy';
 
 // Commit, tag and push
 (async () => {
@@ -81,7 +79,7 @@ async function commitChanges(commitMessage, octokit) {
   const mainBranchCurrentSHA = await getSHA1fromRef(mainBranchName);
 
   // Create a temporary branch and check it out.
-  const tempBranchName = `release/${mainBranchCurrentSHA}`;
+  const tempBranchName = `release/${randomUUID()}`;
   await gitCreateBranch(tempBranchName);
   await gitCheckoutBranch(tempBranchName);
   runPrecommit();
@@ -113,13 +111,15 @@ async function commitChanges(commitMessage, octokit) {
   /**
    * We then update the mainBranch to this new verified commit.
    */
-  await gitSetRefOnCommit(
-    GIT_SSH_REMOTE,
-    `refs/heads/${mainBranchName}`,
-    commit.data.sha,
-    true
-  );
-  await gitPush({remote: GIT_SSH_REMOTE, refs: [mainBranchName], force: true});
+  await octokit.rest.git.updateRef({
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    ref: `heads/${mainBranchName}`,
+    sha: commit.data.sha,
+    force: true, // Needed since the remote main branch contains a "lock" commit.
+  });
+  await gitCheckoutBranch(mainBranchName);
+  await gitPull();
 
   // Delete the temp branch
   await gitDeleteRemoteBranch('origin', tempBranchName);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2510

We can't force push to `master` with a deploy key. We can, however, update the remote `master` branch using Octokit.