### PR TITLE
feat(quantic): new property fetchOnInit added to the Quantic Case Classification

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
@@ -164,13 +164,13 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
         .logDetail('should log the "ticket_classification_click" UA event');
     },
 
-    fetchClassificationsAfterValueChange: () => {
+    fetchClassifications: () => {
       cy.wait(InterceptAliases.CaseClassification).logDetail(
         'should fetch new case classifications after the value changes'
       );
     },
 
-    fetchDocumentsAfterValueChange: () => {
+    fetchDocumentSuggestions: () => {
       cy.wait(InterceptAliases.DocumentSuggestion).logDetail(
         'should fetch new document suggestions after the value changes'
       );

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
@@ -166,7 +166,7 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
 
     fetchClassifications: () => {
       cy.wait(InterceptAliases.CaseClassification).logDetail(
-        'should fetch new case classifications after the value changes'
+        'should fetch new case classifications'
       );
     },
 

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-expectations.ts
@@ -172,7 +172,7 @@ function caseClassificationExpectations(selector: CaseClassificationSelector) {
 
     fetchDocumentSuggestions: () => {
       cy.wait(InterceptAliases.DocumentSuggestion).logDetail(
-        'should fetch new document suggestions after the value changes'
+        'should fetch new document suggestions'
       );
     },
   };

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
@@ -22,6 +22,7 @@ interface CaseClassificationOptions {
   coveoFieldName: string;
   fetchClassificationOnChange: boolean;
   fetchDocumentSuggestionOnChange: boolean;
+  fetchOnInit: boolean;
 }
 
 const incorrectSfFielNameError = (value: string) => {
@@ -935,7 +936,7 @@ describe('quantic-case-classification', () => {
             clickedIndex
           );
           Expect.correctValue(allOptions[clickedIndex].value);
-          Expect.fetchClassificationsAfterValueChange();
+          Expect.fetchClassifications();
         });
       });
     });
@@ -984,7 +985,7 @@ describe('quantic-case-classification', () => {
           Expect.correctValue(
             allOptions[clickedIndex + suggestionsCount].value
           );
-          Expect.fetchClassificationsAfterValueChange();
+          Expect.fetchClassifications();
         });
       });
     });
@@ -1031,7 +1032,7 @@ describe('quantic-case-classification', () => {
             coveoDefaultField,
             clickedIndex
           );
-          Expect.fetchClassificationsAfterValueChange();
+          Expect.fetchClassifications();
         });
       });
     });
@@ -1080,7 +1081,7 @@ describe('quantic-case-classification', () => {
             coveoDefaultField,
             clickedIndex
           );
-          Expect.fetchDocumentsAfterValueChange();
+          Expect.fetchDocumentSuggestions();
         });
       });
     });
@@ -1131,7 +1132,7 @@ describe('quantic-case-classification', () => {
           Expect.correctValue(
             allOptions[clickedIndex + suggestionsCount].value
           );
-          Expect.fetchDocumentsAfterValueChange();
+          Expect.fetchDocumentSuggestions();
         });
       });
     });
@@ -1180,8 +1181,33 @@ describe('quantic-case-classification', () => {
             coveoDefaultField,
             clickedIndex
           );
-          Expect.fetchDocumentsAfterValueChange();
+          Expect.fetchDocumentSuggestions();
         });
+      });
+    });
+  });
+
+  describe('when the fetchOnInit property is set to true', () => {
+    it('should automatically fetch classification during initialization', () => {
+      const suggestionsCount = 3;
+      const firstSuggestionIndex = 0;
+      mockCaseClassification(
+        coveoDefaultField,
+        allOptions.slice(0, suggestionsCount)
+      );
+      visitCaseClassification({
+        fetchOnInit: true,
+      });
+
+      scope('when loading the page', () => {
+        Expect.fetchClassifications();
+        Expect.displaySelectTitle(true);
+        Expect.displaySelectInput(false);
+        Expect.numberOfSuggestions(suggestionsCount);
+        Expect.correctSugestionsOrder(allOptions.slice(0, suggestionsCount));
+        Expect.numberOfInlineOptions(0);
+        Expect.logClickedSuggestion(firstSuggestionIndex, true);
+        Expect.correctValue(allOptions[firstSuggestionIndex].value);
       });
     });
   });

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
@@ -1188,7 +1188,7 @@ describe('quantic-case-classification', () => {
   });
 
   describe('when the fetchOnInit property is set to true', () => {
-    it('should automatically fetch classification during initialization', () => {
+    it('should automatically fetch classifications during initialization', () => {
       const suggestionsCount = 3;
       const firstSuggestionIndex = 0;
       mockCaseClassification(

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.html
@@ -33,6 +33,7 @@
         message-when-value-missing={config.messageWhenValueMissing}
         fetch-classification-on-change={config.fetchClassificationOnChange}
         fetch-document-suggestion-on-change={config.fetchDocumentSuggestionOnChange}
+        fetch-on-init={config.fetchOnInit}
       >
       </c-quantic-case-classification>
     </c-quantic-case-assist-interface>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.js
@@ -74,6 +74,13 @@ export default class ExampleQuanticCaseClassification extends LightningElement {
         'Whether the QuanticCaseClassification component should automatically fetch new document suggestions when its field values changes',
       defaultValue: false,
     },
+    {
+      attribute: 'fetchOnInit',
+      label: 'Fetch on init',
+      description:
+        'Whether or not the component should fetch classifications during initialization.',
+      defaultValue: false,
+    },
   ];
 
   async handleTryItNow(evt) {

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.js
@@ -132,6 +132,13 @@ export default class QuanticCaseClassification extends LightningElement {
    * @defaultValue `false`
    */
   @api fetchDocumentSuggestionOnChange = false;
+  /**
+   * Whether or not the component should fetch classifications during initialization.
+   * @api
+   * @type {boolean}
+   * @defaultValue `false`
+   */
+  @api fetchOnInit = false;
 
   /** @type {Array<object>} */
   @track classifications = [];
@@ -197,6 +204,10 @@ export default class QuanticCaseClassification extends LightningElement {
       ...CoveoHeadlessCaseAssist.loadCaseAssistAnalyticsActions(engine),
       ...CoveoHeadlessCaseAssist.loadCaseFieldActions(engine),
     };
+
+    if (this.fetchOnInit) {
+      engine.dispatch(this.actions.fetchCaseClassifications());
+    }
   };
 
   disconnectedCallback() {


### PR DESCRIPTION
[SFINT-5029](https://coveord.atlassian.net/browse/SFINT-5029)

Added a new property `fetchOnInit` to the Quantic Case Classifications  component, this property, when set to `true`, will trigger a request to fetch classifications during the initialization of the component.

## Demo from the Case Assist Cookbook:

https://github.com/coveo/ui-kit/assets/86681870/f55eb59b-7807-4ebf-9e1f-5c1d73e2434a



[SFINT-5029]: https://coveord.atlassian.net/browse/SFINT-5029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ