### PR TITLE
feat(atomic,headless): support custom sort for facets

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -71,13 +71,13 @@ export declare interface AtomicColorFacet extends Components.AtomicColorFacet {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-color-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicColorFacet {
   protected el: HTMLElement;
@@ -153,13 +153,13 @@ export declare interface AtomicFacet extends Components.AtomicFacet {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['allowedValues', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 @Component({
   selector: 'atomic-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['allowedValues', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'displayValuesAs', 'facetId', 'field', 'filterFacetCount', 'headingLevel', 'injectionDepth', 'isCollapsed', 'label', 'numberOfValues', 'sortCriteria', 'withSearch']
 })
 export class AtomicFacet {
   protected el: HTMLElement;
@@ -1577,13 +1577,13 @@ export declare interface AtomicSegmentedFacet extends Components.AtomicSegmented
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'label', 'numberOfValues', 'sortCriteria']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'label', 'numberOfValues', 'sortCriteria']
 })
 @Component({
   selector: 'atomic-segmented-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'label', 'numberOfValues', 'sortCriteria']
+  inputs: ['allowedValues', 'customSort', 'dependsOn', 'facetId', 'field', 'filterFacetCount', 'injectionDepth', 'label', 'numberOfValues', 'sortCriteria']
 })
 export class AtomicSegmentedFacet {
   protected el: HTMLElement;

--- a/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
@@ -668,4 +668,42 @@ describe('Color Facet Test Suites', () => {
       );
     });
   });
+
+  describe('with allowed-values', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addColorFacet({
+            field: 'objecttype',
+            'allowed-values': JSON.stringify(['FAQ', 'File']),
+          })
+        )
+        .init();
+    });
+
+    it('returns only allowed values', () => {
+      ColorFacetSelectors.valueLabel()
+        .should('contain.text', 'FAQ')
+        .should('contain.text', 'File')
+        .should('not.contain.text', 'Message');
+    });
+  });
+
+  describe('with custom-sort', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addColorFacet({
+            field: 'filetype',
+            'custom-sort': JSON.stringify(['txt', 'rssitem']),
+          })
+        )
+        .init();
+    });
+
+    it('returns values sorted in the proper order', () => {
+      ColorFacetSelectors.valueLabel().eq(0).should('contain.text', 'txt');
+      ColorFacetSelectors.valueLabel().eq(1).should('contain.text', 'rssitem');
+    });
+  });
 });

--- a/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
@@ -1075,4 +1075,22 @@ describe('Facet v1 Test Suites', () => {
         .should('not.contain.text', 'Message');
     });
   });
+
+  describe('with custom-sort', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addFacet({
+            field: 'filetype',
+            'custom-sort': JSON.stringify(['txt', 'rssitem']),
+          })
+        )
+        .init();
+    });
+
+    it('returns values sorted in the proper order', () => {
+      FacetSelectors.valueLabel().eq(0).should('contain.text', 'txt');
+      FacetSelectors.valueLabel().eq(1).should('contain.text', 'rssitem');
+    });
+  });
 });

--- a/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
@@ -156,4 +156,44 @@ describe('Segmented Facet Test Suites', () => {
 
     FacetAssertions.assertValuesSortedByOccurrences();
   });
+
+  describe('with allowed-values', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addSegmentedFacet({
+            field: 'objecttype',
+            'allowed-values': JSON.stringify(['FAQ', 'File']),
+          })
+        )
+        .init();
+    });
+
+    it('returns only allowed values', () => {
+      SegmentedFacetSelectors.valueLabel()
+        .should('contain.text', 'FAQ')
+        .should('contain.text', 'File')
+        .should('not.contain.text', 'Message');
+    });
+  });
+
+  describe('with custom-sort', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(
+          addSegmentedFacet({
+            field: 'filetype',
+            'custom-sort': JSON.stringify(['txt', 'rssitem']),
+          })
+        )
+        .init();
+    });
+
+    it('returns values sorted in the proper order', () => {
+      SegmentedFacetSelectors.valueLabel().eq(0).should('contain.text', 'txt');
+      SegmentedFacetSelectors.valueLabel()
+        .eq(1)
+        .should('contain.text', 'rssitem');
+    });
+  });
 });

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -95,6 +95,14 @@ export namespace Components {
     }
     interface AtomicColorFacet {
         /**
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-color=facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-color-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+         */
+        "allowedValues": string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort": string[] | string;
+        /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-color-facet   depends-on-abc   ... ></atomic-color-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-color-facet   depends-on-abc="doc"   ... ></atomic-color-facet> ```
          */
         "dependsOn": Record<string, string>;
@@ -157,9 +165,13 @@ export namespace Components {
     }
     interface AtomicFacet {
         /**
-          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
         "allowedValues": string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort": string[] | string;
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */
@@ -1668,6 +1680,14 @@ export namespace Components {
     }
     interface AtomicSegmentedFacet {
         /**
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+         */
+        "allowedValues": string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort": string[] | string;
+        /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-segmented-facet facet-id="abc" field="objecttype" ...></atomic-segmented-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-segmented-facet   depends-on-abc   ... ></atomic-segmented-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-segmented-facet> ```
          */
         "dependsOn": Record<string, string>;
@@ -2900,6 +2920,14 @@ declare namespace LocalJSX {
     }
     interface AtomicColorFacet {
         /**
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-color=facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-color-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+         */
+        "allowedValues"?: string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort"?: string[] | string;
+        /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-color-facet   depends-on-abc   ... ></atomic-color-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-color-facet   depends-on-abc="doc"   ... ></atomic-color-facet> ```
          */
         "dependsOn"?: Record<string, string>;
@@ -2962,9 +2990,13 @@ declare namespace LocalJSX {
     }
     interface AtomicFacet {
         /**
-          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
          */
         "allowedValues"?: string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort"?: string[] | string;
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-facet facet-id="abc" field="objecttype" ...></atomic-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc   ... ></atomic-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-facet> ```
          */
@@ -4385,6 +4417,14 @@ declare namespace LocalJSX {
         "mobileBreakpoint"?: string;
     }
     interface AtomicSegmentedFacet {
+        /**
+          * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.  If you specify a list of values for this option, the facet uses only these values (if they are available in the current result set).  Example:  The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use those other values.  ```html <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet> ```  The maximum amount of allowed values is 25.  Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+         */
+        "allowedValues"?: string[] | string;
+        /**
+          * Identifies the facet values that must appear at the top, in this order. This parameter can be used in conjunction with the sortCriteria parameter.  Facet values not part of the customSort list will be sorted according to the sortCriteria.
+         */
+        "customSort"?: string[] | string;
         /**
           * The required facets and values for this facet to be displayed. Examples: ```html <atomic-segmented-facet facet-id="abc" field="objecttype" ...></atomic-segmented-facet>  <!-- To show the facet when any value is selected in the facet with id "abc": --> <atomic-segmented-facet   depends-on-abc   ... ></atomic-segmented-facet>  <!-- To show the facet when value "doc" is selected in the facet with id "abc": --> <atomic-facet   depends-on-abc="doc"   ... ></atomic-segmented-facet> ```
          */

--- a/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -26,7 +26,7 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
-import {MapProp} from '../../../../utils/props-utils';
+import {ArrayProp, MapProp} from '../../../../utils/props-utils';
 import {
   BaseFacet,
   parseDependsOn,
@@ -187,6 +187,40 @@ export class AtomicColorFacet
    */
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
 
+  /**
+   * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.
+   *
+   * If you specify a list of values for this option, the facet uses only these values (if they are available in
+   * the current result set).
+   *
+   * Example:
+   *
+   * The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the
+   * current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use
+   * those other values.
+   *
+   * ```html
+   * <atomic-color=facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-color-facet>
+   * ```
+   *
+   * The maximum amount of allowed values is 25.
+   *
+   * Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+   */
+  @ArrayProp()
+  @Prop({mutable: true})
+  public allowedValues: string[] | string = '[]';
+
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  @ArrayProp()
+  @Prop({mutable: true})
+  public customSort: string[] | string = '[]';
+
   @FocusTarget()
   private showLessFocus!: FocusTargetController;
 
@@ -206,16 +240,7 @@ export class AtomicColorFacet
   public initialize() {
     this.validateProps();
     this.searchStatus = buildSearchStatus(this.bindings.engine);
-    const options: FacetOptions = {
-      facetId: this.facetId,
-      field: this.field,
-      numberOfValues: this.numberOfValues,
-      sortCriteria: this.sortCriteria,
-      facetSearch: {numberOfValues: this.numberOfValues},
-      injectionDepth: this.injectionDepth,
-      filterFacetCount: this.filterFacetCount,
-    };
-    this.facet = buildFacet(this.bindings.engine, {options});
+    this.facet = buildFacet(this.bindings.engine, {options: this.facetOptions});
     announceFacetSearchResultsWithAriaLive(
       this.facet,
       this.label,
@@ -462,6 +487,22 @@ export class AtomicColorFacet
         canShowMoreValues={this.facetState.canShowMoreValues}
       ></FacetShowMoreLess>
     );
+  }
+
+  private get facetOptions(): FacetOptions {
+    return {
+      facetId: this.facetId,
+      field: this.field,
+      numberOfValues: this.numberOfValues,
+      sortCriteria: this.sortCriteria,
+      facetSearch: {numberOfValues: this.numberOfValues},
+      injectionDepth: this.injectionDepth,
+      filterFacetCount: this.filterFacetCount,
+      allowedValues: this.allowedValues.length
+        ? [...this.allowedValues]
+        : undefined,
+      customSort: this.customSort.length ? [...this.customSort] : undefined,
+    };
   }
 
   public render() {

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -141,7 +141,6 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    * Default: `1000`
    */
   @Prop() public injectionDepth = 1000;
-  // @Prop() public customSort?: string; TODO: KIT-753 Add customSort option for facet
 
   /**
    * The required facets and values for this facet to be displayed.
@@ -176,7 +175,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
    * those other values.
    *
    * ```html
-   * <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></div>
+   * <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet>
    * ```
    *
    * The maximum amount of allowed values is 25.
@@ -186,6 +185,16 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   @ArrayProp()
   @Prop({mutable: true})
   public allowedValues: string[] | string = '[]';
+
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  @ArrayProp()
+  @Prop({mutable: true})
+  public customSort: string[] | string = '[]';
 
   @FocusTarget()
   private showLessFocus!: FocusTargetController;
@@ -200,20 +209,7 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
   protected facetSearchAriaMessage!: string;
 
   public initialize() {
-    const options: FacetOptions = {
-      facetId: this.facetId,
-      field: this.field,
-      numberOfValues: this.numberOfValues,
-      sortCriteria: this.sortCriteria,
-      facetSearch: {numberOfValues: this.numberOfValues},
-      filterFacetCount: this.filterFacetCount,
-      injectionDepth: this.injectionDepth,
-      allowedValues: this.allowedValues.length
-        ? [...this.allowedValues]
-        : undefined,
-    };
-
-    this.facet = buildFacet(this.bindings.engine, {options});
+    this.facet = buildFacet(this.bindings.engine, {options: this.facetOptions});
     announceFacetSearchResultsWithAriaLive(
       this.facet,
       this.label,
@@ -281,5 +277,21 @@ export class AtomicFacet implements InitializableComponent, BaseFacet<Facet> {
       showMoreFocus: this.showMoreFocus,
       onToggleCollapse: () => (this.isCollapsed = !this.isCollapsed),
     });
+  }
+
+  private get facetOptions(): FacetOptions {
+    return {
+      facetId: this.facetId,
+      field: this.field,
+      numberOfValues: this.numberOfValues,
+      sortCriteria: this.sortCriteria,
+      facetSearch: {numberOfValues: this.numberOfValues},
+      filterFacetCount: this.filterFacetCount,
+      injectionDepth: this.injectionDepth,
+      allowedValues: this.allowedValues.length
+        ? [...this.allowedValues]
+        : undefined,
+      customSort: this.customSort.length ? [...this.customSort] : undefined,
+    };
   }
 }

--- a/packages/atomic/src/components/search/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
@@ -18,7 +18,7 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
-import {MapProp} from '../../../../utils/props-utils';
+import {ArrayProp, MapProp} from '../../../../utils/props-utils';
 import {parseDependsOn} from '../../../common/facets/facet-common';
 import {FacetValuesGroup} from '../../../common/facets/facet-values-group/facet-values-group';
 import {Hidden} from '../../../common/hidden';
@@ -105,23 +105,46 @@ export class AtomicSegmentedFacet implements InitializableComponent {
    * ```
    */
   @MapProp() @Prop() public dependsOn: Record<string, string> = {};
+  /**
+   * Specifies an explicit list of `allowedValues` in the Search API request, as a JSON string representation.
+   *
+   * If you specify a list of values for this option, the facet uses only these values (if they are available in
+   * the current result set).
+   *
+   * Example:
+   *
+   * The following facet only uses the `Contact`, `Account`, and `File` values of the `objecttype` field. Even if the
+   * current result set contains other `objecttype` values, such as `Message`, or `Product`, the facet does not use
+   * those other values.
+   *
+   * ```html
+   * <atomic-facet field="objecttype" allowed-values='["Contact","Account","File"]'></atomic-facet>
+   * ```
+   *
+   * The maximum amount of allowed values is 25.
+   *
+   * Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
+   */
+  @ArrayProp()
+  @Prop({mutable: true})
+  public allowedValues: string[] | string = '[]';
+
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  @ArrayProp()
+  @Prop({mutable: true})
+  public customSort: string[] | string = '[]';
 
   private dependenciesManager!: FacetConditionsManager;
 
   public initialize() {
     this.searchStatus = buildSearchStatus(this.bindings.engine);
-    const options: FacetOptions = {
-      facetId: this.facetId,
-      field: this.field,
-      numberOfValues: this.numberOfValues,
-      sortCriteria: this.sortCriteria,
-      facetSearch: {numberOfValues: this.numberOfValues},
-      filterFacetCount: this.filterFacetCount,
-      injectionDepth: this.injectionDepth,
-      hasBreadcrumbs: false,
-    };
 
-    this.facet = buildFacet(this.bindings.engine, {options});
+    this.facet = buildFacet(this.bindings.engine, {options: this.facetOptions});
     this.facetId = this.facet.state.facetId;
     this.dependenciesManager = buildFacetConditionsManager(
       this.bindings.engine,
@@ -184,6 +207,23 @@ export class AtomicSegmentedFacet implements InitializableComponent {
         {this.label}:
       </b>
     );
+  }
+
+  private get facetOptions(): FacetOptions {
+    return {
+      facetId: this.facetId,
+      field: this.field,
+      numberOfValues: this.numberOfValues,
+      sortCriteria: this.sortCriteria,
+      facetSearch: {numberOfValues: this.numberOfValues},
+      filterFacetCount: this.filterFacetCount,
+      injectionDepth: this.injectionDepth,
+      hasBreadcrumbs: false,
+      allowedValues: this.allowedValues.length
+        ? [...this.allowedValues]
+        : undefined,
+      customSort: this.customSort.length ? [...this.customSort] : undefined,
+    };
   }
 
   public render() {

--- a/packages/headless/src/controllers/core/facets/_common/facet-option-definitions.ts
+++ b/packages/headless/src/controllers/core/facets/_common/facet-option-definitions.ts
@@ -56,3 +56,10 @@ export const allowedValues = new RecordValue({
 });
 
 export const hasBreadcrumbs = new BooleanValue();
+
+export const customSort = new ArrayValue({
+  min: 1,
+  max: 25,
+  required: false,
+  each: new StringValue({emptyAllowed: false, required: true}),
+});

--- a/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet-options.ts
@@ -12,6 +12,7 @@ import {
   facetSearch,
   allowedValues,
   hasBreadcrumbs,
+  customSort,
 } from '../../core/facets/_common/facet-option-definitions';
 
 export interface FacetOptions {
@@ -82,6 +83,14 @@ export interface FacetOptions {
    * @defaultValue `true`
    */
   hasBreadcrumbs?: boolean;
+
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  customSort?: string[];
 }
 
 export interface FacetSearchOptions {
@@ -113,4 +122,5 @@ export const facetOptionsSchema = new Schema<Required<FacetOptions>>({
   facetSearch,
   allowedValues,
   hasBreadcrumbs,
+  customSort,
 });

--- a/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.test.ts
@@ -58,6 +58,7 @@ describe('facet', () => {
       sortCriteria: 'score',
       facetSearch: {},
       allowedValues: ['foo', 'bar'],
+      customSort: ['buzz', 'bar', 'foo'],
     };
 
     state = createMockState();
@@ -103,6 +104,7 @@ describe('facet', () => {
       injectionDepth: 1000,
       numberOfValues: 8,
       allowedValues: {type: 'simple', values: ['foo', 'bar']},
+      customSort: ['buzz', 'bar', 'foo'],
     });
 
     expect(engine.actions).toContainEqual(action);

--- a/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet-options.ts
+++ b/packages/headless/src/controllers/insight/facets/facet/headless-insight-facet-options.ts
@@ -8,6 +8,7 @@ import {
   numberOfValues,
   facetSearch,
   allowedValues,
+  customSort,
 } from '../../../core/facets/_common/facet-option-definitions';
 import {
   FacetOptions as CoreFacetOptions,
@@ -28,6 +29,13 @@ export interface FacetOptions extends CoreFacetOptions {
    * Default value is `undefined`, and the facet uses all available values for its `field` in the current result set.
    */
   allowedValues?: string[];
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  customSort?: string[];
 }
 
 export const facetOptionsSchema = new Schema<Required<FacetOptions>>({
@@ -39,4 +47,5 @@ export const facetOptionsSchema = new Schema<Required<FacetOptions>>({
   sortCriteria: new StringValue({constrainTo: facetSortCriteria}),
   facetSearch,
   allowedValues,
+  customSort,
 });

--- a/packages/headless/src/features/facets/facet-api/request.ts
+++ b/packages/headless/src/features/facets/facet-api/request.ts
@@ -109,3 +109,13 @@ export interface AllowedValues {
     values: string[];
   };
 }
+
+export interface CustomSort {
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  customSort?: string[];
+}

--- a/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-actions.ts
@@ -6,7 +6,10 @@ import {
   Value,
 } from '@coveo/bueno';
 import {createAction} from '@reduxjs/toolkit';
-import {allowedValues} from '../../../controllers/core/facets/_common/facet-option-definitions';
+import {
+  allowedValues,
+  customSort,
+} from '../../../controllers/core/facets/_common/facet-option-definitions';
 import {validatePayload} from '../../../utils/validate-payload';
 import {facetIdDefinition} from '../generic/facet-actions-validation';
 import {facetValueDefinition} from './facet-set-validate-payload';
@@ -73,6 +76,13 @@ export interface RegisterFacetActionCreatorPayload {
     type: 'simple';
     values: string[];
   };
+  /**
+   * Identifies the facet values that must appear at the top, in this order.
+   * This parameter can be used in conjunction with the sortCriteria parameter.
+   *
+   * Facet values not part of the customSort list will be sorted according to the sortCriteria.
+   */
+  customSort?: string[];
 }
 
 const facetRegistrationOptionsDefinition = {
@@ -83,6 +93,7 @@ const facetRegistrationOptionsDefinition = {
   numberOfValues: new NumberValue({required: false, min: 1}),
   sortCriteria: new Value<FacetSortCriterion>({required: false}),
   allowedValues: allowedValues,
+  customSort: customSort,
 };
 
 export const registerFacet = createAction(

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -91,6 +91,7 @@ describe('facet-set slice', () => {
     const options = buildRegistrationOptions({
       sortCriteria: criterion,
       allowedValues: {type: 'simple', values: ['foo', 'bar']},
+      customSort: ['bar', 'buzz', 'foo'],
     });
 
     const action = registerFacet(options);
@@ -99,6 +100,7 @@ describe('facet-set slice', () => {
 
     expect(facetRequest.sortCriteria).toBe(criterion);
     expect(facetRequest.allowedValues?.values).toEqual(['foo', 'bar']);
+    expect(facetRequest.customSort).toEqual(['bar', 'buzz', 'foo']);
   });
 
   it('if a facet request is already registered for an id, it does not overwrite the request', () => {

--- a/packages/headless/src/features/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/request.ts
@@ -7,6 +7,7 @@ import {
   BaseFacetValueRequest,
   Expandable,
   AllowedValues,
+  CustomSort,
 } from '../../facet-api/request';
 
 export const facetSortCriteria: FacetSortCriterion[] = [
@@ -32,6 +33,7 @@ export interface FacetRequest
     Freezable,
     Type<'specific'>,
     AllowedValues,
+    CustomSort,
     SortCriteria<FacetSortCriterion> {
   /** @defaultValue `automatic` */
   sortCriteria: FacetSortCriterion;

--- a/packages/headless/src/test/mock-facet-request.ts
+++ b/packages/headless/src/test/mock-facet-request.ts
@@ -7,6 +7,7 @@ export function buildMockFacetRequest(
     facetId: '',
     field: '',
     currentValues: [],
+    customSort: [],
     filterFacetCount: false,
     freezeCurrentValues: false,
     injectionDepth: 1000,


### PR DESCRIPTION
Add support for `customSort` for all types of facets that relies on "specific facets" at the API level.

The way it works at the API level is that you can send `customSort` parameter as an array. The values that get passed will then be arranged at the top of the list.

You can then mix this parameter with `sortCriteria`.

For example, if you pass in `numberOfValues=10`, `customSort=['foo','bar']`, `sortCriteria=occurrences`, the end result will be a list of 10 values, with the first two being `foo,bar`, and the next 8 values be sorted by number of occurrences.

The main use case for this case of feature is when n implementer wants to order facet values in an order that does not follow a "standard" one (number of occurrences, score, alphabetical).

For example, let's say you have a facet to filter on the status of a JIRA ticket, which could be "New, In Progress, In review, Done". This order in the UI could be respected by using this option.

As a bonus for this PR, I also plugged in support for the `allowed-values` parameter for some facets in atomic where it was missing. The code was present already in Headless, and so it was a simple matter of plugging it.

https://coveord.atlassian.net/browse/KIT-2513