### PR TITLE
refactor(headless): add types to request and responses to support automatic facets

### DIFF
--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -124,6 +124,11 @@ export interface ExcerptLength {
 export interface AuthenticationParam {
   authentication?: string;
 }
+export interface AutomaticFacetsParams {
+  generateAutomaticFacets?: {
+    desiredCount?: number;
+  };
+}
 
 export const baseSearchRequest = (
   req: BaseParam & AuthenticationParam,

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -126,7 +126,7 @@ export interface AuthenticationParam {
 }
 export interface AutomaticFacetsParams {
   generateAutomaticFacets?: {
-    desiredCount?: number;
+    desiredCount: number;
   };
 }
 

--- a/packages/headless/src/api/search/search/automatic-facets.ts
+++ b/packages/headless/src/api/search/search/automatic-facets.ts
@@ -1,0 +1,8 @@
+import {AutomaticFacetResponse} from '../../../features/facets/facet-set/interfaces/response';
+
+export interface AutomaticFacets {
+  /**
+   * The facets returned by the Automatic Facets feature.
+   */
+  facets: AutomaticFacetResponse[];
+}

--- a/packages/headless/src/api/search/search/search-request.ts
+++ b/packages/headless/src/api/search/search/search-request.ts
@@ -22,6 +22,7 @@ import {
   FacetsParam,
   FieldsToIncludeParam,
   FirstResultParam,
+  AutomaticFacetsParams,
   LargeQueryParam,
   PipelineParam,
   QueryParam,
@@ -60,4 +61,5 @@ export type SearchRequest = BaseParam &
   AnalyticsParam &
   ExcerptLength &
   ActionsHistoryParam &
-  AuthenticationParam;
+  AuthenticationParam &
+  AutomaticFacetsParams;

--- a/packages/headless/src/api/search/search/search-response.ts
+++ b/packages/headless/src/api/search/search/search-response.ts
@@ -14,7 +14,7 @@ import {SecurityIdentity} from './security-identity';
 import {PhrasesToHighlight, TermsToHighlight} from './stemming';
 
 export interface SearchResponseSuccess {
-  generateAutomaticFacets: AutomaticFacets;
+  generateAutomaticFacets?: AutomaticFacets;
   termsToHighlight: TermsToHighlight;
   phrasesToHighlight: PhrasesToHighlight;
   results: Result[];

--- a/packages/headless/src/api/search/search/search-response.ts
+++ b/packages/headless/src/api/search/search/search-response.ts
@@ -4,6 +4,7 @@ import {
   SearchAPIErrorWithStatusCode,
 } from '../search-api-error-response';
 import {Trigger} from './../trigger';
+import {AutomaticFacets} from './automatic-facets';
 import {ExecutionReport} from './execution-report';
 import {QueryCorrection} from './query-corrections';
 import {QueryRankingExpression} from './query-ranking-expression';
@@ -13,6 +14,7 @@ import {SecurityIdentity} from './security-identity';
 import {PhrasesToHighlight, TermsToHighlight} from './stemming';
 
 export interface SearchResponseSuccess {
+  generateAutomaticFacets: AutomaticFacets;
   termsToHighlight: TermsToHighlight;
   phrasesToHighlight: PhrasesToHighlight;
   results: Result[];

--- a/packages/headless/src/features/facets/facet-set/interfaces/response.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/response.ts
@@ -5,3 +5,8 @@ export interface FacetValue extends BaseFacetValue {
 }
 
 export type FacetResponse = BaseFacetResponse<FacetValue>;
+
+export type AutomaticFacetResponse = Omit<
+  BaseFacetResponse<FacetValue>,
+  'facetId'
+>;

--- a/packages/headless/src/features/search/search-state.ts
+++ b/packages/headless/src/features/search/search-state.ts
@@ -65,6 +65,7 @@ export function getSearchInitialState(): SearchState {
       searchUid: '',
       totalCountFiltered: 0,
       facets: [],
+      generateAutomaticFacets: {facets: []},
       queryCorrections: [],
       triggers: [],
       questionAnswer: emptyQuestionAnswer(),

--- a/packages/headless/src/test/mock-search-response.ts
+++ b/packages/headless/src/test/mock-search-response.ts
@@ -13,6 +13,7 @@ export function buildMockSearchResponse(
     searchUid: '',
     totalCountFiltered: 0,
     facets: [],
+    generateAutomaticFacets: {facets: []},
     queryCorrections: [emptyCorrection()],
     triggers: [],
     questionAnswer: emptyQuestionAnswer(),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2523

This PR adds necessary types to support the automatic facets feature. 

I used `refactor` to not trigger semantic versioning. 