### PR TITLE
feat: atomic-product-listing-pager

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -979,6 +979,20 @@ export namespace Components {
          */
         "url"?: string;
     }
+    interface AtomicProductListingPager {
+        /**
+          * The SVG icon to use to display the Next button.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "nextButtonIcon": string;
+        /**
+          * Specifies how many page buttons to display in the pager.
+         */
+        "numberOfPages": number;
+        /**
+          * The SVG icon to use to display the Previous button.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "previousButtonIcon": string;
+    }
     interface AtomicProductListingResult {
         /**
           * The classes to add to the result element.
@@ -1994,6 +2008,10 @@ export interface AtomicPagerCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomicPagerElement;
 }
+export interface AtomicProductListingPagerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLAtomicProductListingPagerElement;
+}
 export interface AtomicQuickviewModalCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAtomicQuickviewModalElement;
@@ -2386,6 +2404,12 @@ declare global {
     var HTMLAtomicProductListingInterfaceElement: {
         prototype: HTMLAtomicProductListingInterfaceElement;
         new (): HTMLAtomicProductListingInterfaceElement;
+    };
+    interface HTMLAtomicProductListingPagerElement extends Components.AtomicProductListingPager, HTMLStencilElement {
+    }
+    var HTMLAtomicProductListingPagerElement: {
+        prototype: HTMLAtomicProductListingPagerElement;
+        new (): HTMLAtomicProductListingPagerElement;
     };
     interface HTMLAtomicProductListingResultElement extends Components.AtomicProductListingResult, HTMLStencilElement {
     }
@@ -2850,6 +2874,7 @@ declare global {
         "atomic-popover": HTMLAtomicPopoverElement;
         "atomic-product-listing": HTMLAtomicProductListingElement;
         "atomic-product-listing-interface": HTMLAtomicProductListingInterfaceElement;
+        "atomic-product-listing-pager": HTMLAtomicProductListingPagerElement;
         "atomic-product-listing-result": HTMLAtomicProductListingResultElement;
         "atomic-product-listing-result-template": HTMLAtomicProductListingResultTemplateElement;
         "atomic-query-error": HTMLAtomicQueryErrorElement;
@@ -3820,6 +3845,21 @@ declare namespace LocalJSX {
           * When set this property will be used instead of the current url.
          */
         "url"?: string;
+    }
+    interface AtomicProductListingPager {
+        /**
+          * The SVG icon to use to display the Next button.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "nextButtonIcon"?: string;
+        /**
+          * Specifies how many page buttons to display in the pager.
+         */
+        "numberOfPages"?: number;
+        "onAtomic/scrollToTop"?: (event: AtomicProductListingPagerCustomEvent<any>) => void;
+        /**
+          * The SVG icon to use to display the Previous button.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "previousButtonIcon"?: string;
     }
     interface AtomicProductListingResult {
         /**
@@ -4810,6 +4850,7 @@ declare namespace LocalJSX {
         "atomic-popover": AtomicPopover;
         "atomic-product-listing": AtomicProductListing;
         "atomic-product-listing-interface": AtomicProductListingInterface;
+        "atomic-product-listing-pager": AtomicProductListingPager;
         "atomic-product-listing-result": AtomicProductListingResult;
         "atomic-product-listing-result-template": AtomicProductListingResultTemplate;
         "atomic-query-error": AtomicQueryError;
@@ -4943,6 +4984,7 @@ declare module "@stencil/core" {
             "atomic-popover": LocalJSX.AtomicPopover & JSXBase.HTMLAttributes<HTMLAtomicPopoverElement>;
             "atomic-product-listing": LocalJSX.AtomicProductListing & JSXBase.HTMLAttributes<HTMLAtomicProductListingElement>;
             "atomic-product-listing-interface": LocalJSX.AtomicProductListingInterface & JSXBase.HTMLAttributes<HTMLAtomicProductListingInterfaceElement>;
+            "atomic-product-listing-pager": LocalJSX.AtomicProductListingPager & JSXBase.HTMLAttributes<HTMLAtomicProductListingPagerElement>;
             "atomic-product-listing-result": LocalJSX.AtomicProductListingResult & JSXBase.HTMLAttributes<HTMLAtomicProductListingResultElement>;
             "atomic-product-listing-result-template": LocalJSX.AtomicProductListingResultTemplate & JSXBase.HTMLAttributes<HTMLAtomicProductListingResultTemplateElement>;
             "atomic-query-error": LocalJSX.AtomicQueryError & JSXBase.HTMLAttributes<HTMLAtomicQueryErrorElement>;

--- a/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.pcss
+++ b/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.pcss
@@ -1,0 +1,1 @@
+@import '../../../global/global.pcss';

--- a/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.tsx
+++ b/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.tsx
@@ -1,4 +1,3 @@
-import {SearchStatus, SearchStatusState} from '@coveo/headless';
 import {
   buildController,
   buildPager,
@@ -7,6 +6,7 @@ import {
   ProductListingEngine,
 } from '@coveo/headless/product-listing';
 import {Component, Event, EventEmitter, h, Prop, State} from '@stencil/core';
+import {ProductListingSearchStatus, ProductListingSearchStatusState} from '../';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import {
@@ -22,16 +22,7 @@ import {PagerCommon} from '../../common/pager/pager-common';
 import {ProductListingBindings} from '../atomic-product-listing-interface/atomic-product-listing-interface';
 
 /**
- * The `atomic-product-listing-pager` provides buttons that allow the end user to navigate through the different result pages.
- *
- * @part buttons - The list of the next/previous buttons and page-buttons.
- * @part page-buttons - The list of page buttons.
- * @part page-button - The page button.
- * @part active-page-button - The active page button.
- * @part previous-button - The previous button.
- * @part next-button - The next button.
- * @part previous-button-icon - Icon of the previous button.
- * @part next-button-icon - Icon of the next button.
+ * @internal
  */
 @Component({
   tag: 'atomic-product-listing-pager',
@@ -43,14 +34,14 @@ export class AtomicProductListingPager
 {
   @InitializeBindings() public bindings!: ProductListingBindings;
   public pager!: Pager;
-  public searchStatus!: SearchStatus;
+  public searchStatus!: ProductListingSearchStatus;
 
   @BindStateToController('pager')
   @State()
   public pagerState!: PagerState;
   @BindStateToController('searchStatus')
   @State()
-  public searchStatusState!: SearchStatusState;
+  public searchStatusState!: ProductListingSearchStatusState;
   @State() error!: Error;
 
   @Event({
@@ -91,7 +82,9 @@ export class AtomicProductListingPager
     });
   }
 
-  private buildSearchStatus(engine: ProductListingEngine): SearchStatus {
+  private buildSearchStatus(
+    engine: ProductListingEngine
+  ): ProductListingSearchStatus {
     const controller = buildController(engine);
     const getState = () => engine.state;
 

--- a/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.tsx
+++ b/packages/atomic/src/components/product-listing/atomic-product-listing-pager/atomic-product-listing-pager.tsx
@@ -1,0 +1,127 @@
+import {SearchStatus, SearchStatusState} from '@coveo/headless';
+import {
+  buildController,
+  buildPager,
+  Pager,
+  PagerState,
+  ProductListingEngine,
+} from '@coveo/headless/product-listing';
+import {Component, Event, EventEmitter, h, Prop, State} from '@stencil/core';
+import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
+import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
+import {
+  FocusTarget,
+  FocusTargetController,
+} from '../../../utils/accessibility-utils';
+import {
+  BindStateToController,
+  InitializableComponent,
+  InitializeBindings,
+} from '../../../utils/initialization-utils';
+import {PagerCommon} from '../../common/pager/pager-common';
+import {ProductListingBindings} from '../atomic-product-listing-interface/atomic-product-listing-interface';
+
+/**
+ * The `atomic-product-listing-pager` provides buttons that allow the end user to navigate through the different result pages.
+ *
+ * @part buttons - The list of the next/previous buttons and page-buttons.
+ * @part page-buttons - The list of page buttons.
+ * @part page-button - The page button.
+ * @part active-page-button - The active page button.
+ * @part previous-button - The previous button.
+ * @part next-button - The next button.
+ * @part previous-button-icon - Icon of the previous button.
+ * @part next-button-icon - Icon of the next button.
+ */
+@Component({
+  tag: 'atomic-product-listing-pager',
+  styleUrl: 'atomic-product-listing-pager.pcss',
+  shadow: true,
+})
+export class AtomicProductListingPager
+  implements InitializableComponent<ProductListingBindings>
+{
+  @InitializeBindings() public bindings!: ProductListingBindings;
+  public pager!: Pager;
+  public searchStatus!: SearchStatus;
+
+  @BindStateToController('pager')
+  @State()
+  public pagerState!: PagerState;
+  @BindStateToController('searchStatus')
+  @State()
+  public searchStatusState!: SearchStatusState;
+  @State() error!: Error;
+
+  @Event({
+    eventName: 'atomic/scrollToTop',
+  })
+  private scrollToTopEvent!: EventEmitter;
+
+  /**
+   * Specifies how many page buttons to display in the pager.
+   */
+  @Prop({reflect: true}) numberOfPages = 5;
+
+  /**
+   * The SVG icon to use to display the Previous button.
+   *
+   * - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location.
+   * - Use a value that starts with `assets://`, to display an icon from the Atomic package.
+   * - Use a stringified SVG to display it directly.
+   */
+  @Prop({reflect: true}) previousButtonIcon = ArrowLeftIcon;
+
+  /**
+   * The SVG icon to use to display the Next button.
+   *
+   * - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location.
+   * - Use a value that starts with `assets://`, to display an icon from the Atomic package.
+   * - Use a stringified SVG to display it directly.
+   */
+  @Prop({reflect: true}) nextButtonIcon = ArrowRightIcon;
+
+  @FocusTarget()
+  private activePage!: FocusTargetController;
+
+  public initialize() {
+    this.searchStatus = this.buildSearchStatus(this.bindings.engine);
+    this.pager = buildPager(this.bindings.engine, {
+      options: {numberOfPages: this.numberOfPages},
+    });
+  }
+
+  private buildSearchStatus(engine: ProductListingEngine): SearchStatus {
+    const controller = buildController(engine);
+    const getState = () => engine.state;
+
+    return {
+      ...controller,
+
+      get state() {
+        const state = getState();
+
+        return {
+          hasError: state.productListing.error !== null,
+          isLoading: state.productListing.isLoading,
+          hasResults: !!state.productListing.products.length,
+          firstSearchExecuted: state.productListing.responseId !== '',
+        };
+      },
+    };
+  }
+  public render() {
+    return (
+      <PagerCommon
+        activePage={this.activePage}
+        bindings={this.bindings}
+        eventEmitter={this.scrollToTopEvent}
+        pager={this.pager}
+        previousButtonIcon={this.previousButtonIcon}
+        nextButtonIcon={this.nextButtonIcon}
+        pagerState={this.pagerState}
+        searchStatusState={this.searchStatusState}
+      />
+    );
+  }
+}

--- a/packages/atomic/src/components/product-listing/index.ts
+++ b/packages/atomic/src/components/product-listing/index.ts
@@ -5,4 +5,6 @@ export {
   Result as ProductListingResult,
   ResultTemplateCondition as ProductListingResultTemplateCondition,
   ResultTemplate as ProductListingResultTemplate,
+  SearchStatus as ProductListingSearchStatus,
+  SearchStatusState as ProductListingSearchStatusState,
 } from '@coveo/headless/product-listing';

--- a/packages/atomic/src/pages/examples/product-listing.html
+++ b/packages/atomic/src/pages/examples/product-listing.html
@@ -87,6 +87,7 @@
           </template>
         </atomic-product-listing-result-template>
       </atomic-product-listing>
+      <atomic-product-listing-pager></atomic-product-listing-pager>
     </atomic-product-listing-interface>
     <script src="../header.js" type="text/javascript"></script>
   </body>


### PR DESCRIPTION
[COMSDZ-550](https://coveord.atlassian.net/browse/COMSDZ-550)

In this PR:

The `atomic-product-listing-pager` component which is the equivalent to the `atomic-pager` for the `ProductListingEngine`


[COMSDZ-550]: https://coveord.atlassian.net/browse/COMSDZ-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ