### PR TITLE
fix(headless): allow preloading state of non-default reducers

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -254,6 +254,7 @@
     "ytlikecount",
     "ytvideoduration",
     "ytvideoid",
-    "ytviewcount"
+    "ytviewcount",
+    "btoashim"
   ]
 }

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -1,8 +1,14 @@
+import {
+  StateFromReducersMapObject,
+  createAction,
+  createReducer,
+} from '@reduxjs/toolkit';
 import {getOrganizationEndpoints} from '../api/platform-client';
 import * as Store from '../app/store';
 import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments';
 import {configuration} from './common-reducers';
 import {buildEngine, CoreEngine, EngineOptions} from './engine';
+import {getSampleEngineConfiguration} from './engine-configuration';
 
 jest.mock('pino', () => ({
   ...jest.requireActual('pino'),
@@ -174,5 +180,83 @@ describe('engine', () => {
         'There is a mismatch between the `organizationId` option (a) and the organization configured in the `organizationEndpoints` option (https://b.org.coveo.com).'
       )
     );
+  });
+
+  describe('with preloaded state', () => {
+    const testAction = createAction('increment');
+    const testReducer = createReducer(0, (builder) =>
+      builder.addCase(testAction, (value) => value + 1)
+    );
+    const reducers = {testReducer};
+    let preloadedState: StateFromReducersMapObject<typeof reducers>;
+
+    beforeEach(() => {
+      const temporaryEngine = buildEngine(
+        {
+          configuration: getSampleEngineConfiguration(),
+          reducers: {testReducer},
+        },
+        buildMockThunkExtraArguments()
+      );
+      temporaryEngine.dispatch(testAction());
+      preloadedState = temporaryEngine.state;
+    });
+
+    describe('with all needed reducers', () => {
+      let resumedEngine: CoreEngine<typeof preloadedState>;
+      beforeEach(() => {
+        resumedEngine = buildEngine(
+          {
+            configuration: getSampleEngineConfiguration(),
+            preloadedState,
+            reducers,
+          },
+          buildMockThunkExtraArguments()
+        );
+      });
+
+      it('should be able to resume the preloaded state', () => {
+        resumedEngine.dispatch(testAction());
+        expect(resumedEngine.state.testReducer).toEqual(2);
+      });
+    });
+
+    describe('with a missing reducer', () => {
+      let resumedEngine: CoreEngine<Partial<typeof preloadedState>>;
+      beforeEach(() => {
+        resumedEngine = buildEngine(
+          {
+            configuration: getSampleEngineConfiguration(),
+            preloadedState,
+            reducers: {},
+          },
+          buildMockThunkExtraArguments()
+        );
+      });
+
+      it('should have the preloaded state', () => {
+        expect(resumedEngine.state.testReducer).toEqual(1);
+      });
+
+      it("should not update the missing reducer's state when an action from the missing reducer is dispatched", () => {
+        resumedEngine.dispatch(testAction());
+        expect(resumedEngine.state.testReducer).toEqual(1);
+      });
+
+      describe('after adding the missing reducer', () => {
+        beforeEach(() => {
+          resumedEngine.addReducers(reducers);
+        });
+
+        it('should not reset the state', () => {
+          expect(resumedEngine.state.testReducer).toEqual(1);
+        });
+
+        it('should update the preloaded state after dispatching an action', () => {
+          resumedEngine.dispatch(testAction());
+          expect(resumedEngine.state.testReducer).toEqual(2);
+        });
+      });
+    });
   });
 });

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -228,7 +228,10 @@ function buildCoreEngine<
   thunkExtraArguments: ExtraArguments
 ): CoreEngine<StateFromReducersMapObject<Reducers>, ExtraArguments> {
   const {reducers} = options;
-  const reducerManager = createReducerManager({...coreReducers, ...reducers});
+  const reducerManager = createReducerManager(
+    {...coreReducers, ...reducers},
+    options.preloadedState ?? {}
+  );
   if (options.crossReducer) {
     reducerManager.addCrossReducer(options.crossReducer);
   }

--- a/packages/headless/src/app/reducer-manager.test.ts
+++ b/packages/headless/src/app/reducer-manager.test.ts
@@ -5,7 +5,7 @@ import {createReducerManager} from './reducer-manager';
 
 describe('ReducerManager', () => {
   it('when a key does not exist, #add stores the key-reducer pair', () => {
-    const manager = createReducerManager({});
+    const manager = createReducerManager({}, {});
     manager.add({pagination});
 
     const state = manager.combinedReducer(undefined, {type: ''});
@@ -13,7 +13,7 @@ describe('ReducerManager', () => {
   });
 
   it('when a key exists, calling #add with the same key does not overwrite the existing reducer', () => {
-    const manager = createReducerManager({pagination});
+    const manager = createReducerManager({pagination}, {});
     manager.add({pagination: search});
 
     const state = manager.combinedReducer(undefined, {type: ''});
@@ -21,17 +21,17 @@ describe('ReducerManager', () => {
   });
 
   it('when all keys exist, #containsAll returns true', () => {
-    const manager = createReducerManager({pagination, search});
+    const manager = createReducerManager({pagination, search}, {});
     expect(manager.containsAll({pagination, search})).toBe(true);
   });
 
   it('when only some keys exist, #containsAll returns false', () => {
-    const manager = createReducerManager({pagination});
+    const manager = createReducerManager({pagination}, {});
     expect(manager.containsAll({pagination, search})).toBe(false);
   });
 
   it('should call root reducer when configured', () => {
-    const manager = createReducerManager({pagination});
+    const manager = createReducerManager({pagination}, {});
     const rootReducer = jest.fn();
     manager.addCrossReducer(rootReducer);
     manager.combinedReducer(undefined, {type: ''});

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -5,6 +5,7 @@ import {
   AnyAction,
   StateFromReducersMapObject,
 } from '@reduxjs/toolkit';
+import {fromEntries} from '../utils/utils';
 
 export interface ReducerManager {
   combinedReducer: Reducer;
@@ -14,7 +15,8 @@ export interface ReducerManager {
 }
 
 export function createReducerManager(
-  initialReducers: ReducersMapObject
+  initialReducers: ReducersMapObject,
+  preloadedState: object
 ): ReducerManager {
   const reducers = {...initialReducers};
   let crossReducer: Reducer;
@@ -33,7 +35,14 @@ export function createReducerManager(
 
   return {
     get combinedReducer() {
-      return rootReducer(combineReducers(reducers));
+      const placeholderReducers = fromEntries(
+        Object.entries(preloadedState)
+          .filter(([key]) => !(key in reducers))
+          .map(([key, value]) => [key, <Reducer>(() => value)])
+      );
+      return rootReducer(
+        combineReducers({...placeholderReducers, ...reducers})
+      );
     },
 
     containsAll(newReducers: ReducersMapObject) {

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -64,3 +64,13 @@ export function doNotTrack() {
     win.doNotTrack,
   ].some((value) => doNotTrackValues.has(value));
 }
+
+export function fromEntries<K extends keyof object, V>(
+  values: [K, V][]
+): Record<K, V> {
+  const newObject: Partial<Record<K, V>> = {};
+  for (const [key, value] of values) {
+    newObject[key] = value;
+  }
+  return newObject as Record<K, V>;
+}

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -65,7 +65,7 @@ export function doNotTrack() {
   ].some((value) => doNotTrackValues.has(value));
 }
 
-export function fromEntries<K extends keyof object, V>(
+export function fromEntries<K extends PropertyKey, V>(
   values: [K, V][]
 ): Record<K, V> {
   const newObject: Partial<Record<K, V>> = {};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2539

One issue this causes is that, when server-side rendering a page with a facet, it's impossible to load the preloaded state on the client-side with the facet since facet-set is not a default reducer.

My fix was to add temporary "placeholder" reducers for each preloaded state value that doesn't have a reducer. These are later replaced when we load the real reducers.

Tests in this PR failed until I added the fix.