### PR TITLE
feat: add missing exports for headless/product-listing

### DIFF
--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -189,3 +189,15 @@ export type {
   InteractiveResult,
 } from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
 export {buildInteractiveResult} from './controllers/product-listing/result-list/headless-product-listing-interactive-result';
+
+export type {
+  ResultTemplate,
+  ResultTemplateCondition,
+} from './features/result-templates/result-templates';
+
+export type {Result} from './api/search/search/result';
+
+export type {
+  SearchStatus,
+  SearchStatusState,
+} from './controllers/insight/status/headless-insight-status';


### PR DESCRIPTION
These exports were missing for https://github.com/coveo/ui-kit/pull/2964 and https://github.com/coveo/ui-kit/pull/2968