### PR TITLE
fix(quantic): missing documentation for the slot "children" added

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultTemplate/quanticResultTemplate.js
@@ -16,6 +16,7 @@ import {LightningElement, api} from 'lwc';
  *   <div slot="emphasized"></div>
  *   <div slot="excerpt"></div>
  *   <div slot="bottom-metadata"></div>
+ *   <div slot="children"></div>
  * </c-quantic-result-template>
  */
 export default class QuanticResultTemplate extends LightningElement {


### PR DESCRIPTION
[SFINT-5069](https://coveord.atlassian.net/browse/SFINT-5069)

-  Missing documentation for the slot "children" added to the Quantic Result Template component.

[SFINT-5069]: https://coveord.atlassian.net/browse/SFINT-5069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ