### PR TITLE
chore(Quantic): fix intermittently failing Quantic setup job

### DIFF
--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -212,12 +212,15 @@ async function deployCommunity(
 
       success = true;
     } catch (error) {
-      if (retry === 2) {
+      if (retry === 3) {
         throw error;
       }
+      // The deployment may fail because the community is still being created.
+      // Wait for 10 seconds then retry.
+      await new Promise((resolve) => setTimeout(resolve, 10000));
       retry++;
     }
-  } while (!success && retry <= 2);
+  } while (!success && retry <= 3);
 
   log('Community metadata deployed.');
 }

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -202,8 +202,8 @@ async function deployCommunity(
   // The first deploy attempt may fail.
   let retry = 0;
   let success = false;
+  const maxRetries = 6;
   do {
-    console.log(`retry number ${retry}`)
     try {
       await sfdx.deployCommunityMetadata({
         alias: options.scratchOrg.alias,
@@ -213,7 +213,7 @@ async function deployCommunity(
 
       success = true;
     } catch (error) {
-      if (retry === 6) {
+      if (retry === maxRetries) {
         throw error;
       }
       // The deployment may fail because the community is still being created.
@@ -221,7 +221,7 @@ async function deployCommunity(
       await new Promise((resolve) => setTimeout(resolve, 30000));
       retry++;
     }
-  } while (!success && retry <= 6);
+  } while (!success && retry <= maxRetries);
 
   log('Community metadata deployed.');
 }

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -203,6 +203,7 @@ async function deployCommunity(
   let retry = 0;
   let success = false;
   do {
+    console.log(`retry number ${retry}`)
     try {
       await sfdx.deployCommunityMetadata({
         alias: options.scratchOrg.alias,
@@ -212,15 +213,15 @@ async function deployCommunity(
 
       success = true;
     } catch (error) {
-      if (retry === 3) {
+      if (retry === 5) {
         throw error;
       }
       // The deployment may fail because the community is still being created.
       // Wait for 30 seconds then retry.
-      await new Promise((resolve) => setTimeout(resolve, 30000));
+      await new Promise((resolve) => setTimeout(resolve, 60000));
       retry++;
     }
-  } while (!success && retry <= 3);
+  } while (!success && retry <= 5);
 
   log('Community metadata deployed.');
 }

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -217,7 +217,7 @@ async function deployCommunity(
         throw error;
       }
       // The deployment may fail because the community is still being created.
-      // Wait for 30 seconds then retry.
+      // Wait for 60 seconds then retry.
       await new Promise((resolve) => setTimeout(resolve, 60000));
       retry++;
     }

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -216,8 +216,8 @@ async function deployCommunity(
         throw error;
       }
       // The deployment may fail because the community is still being created.
-      // Wait for 10 seconds then retry.
-      await new Promise((resolve) => setTimeout(resolve, 10000));
+      // Wait for 30 seconds then retry.
+      await new Promise((resolve) => setTimeout(resolve, 30000));
       retry++;
     }
   } while (!success && retry <= 3);

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -213,15 +213,15 @@ async function deployCommunity(
 
       success = true;
     } catch (error) {
-      if (retry === 5) {
+      if (retry === 6) {
         throw error;
       }
       // The deployment may fail because the community is still being created.
-      // Wait for 60 seconds then retry.
-      await new Promise((resolve) => setTimeout(resolve, 60000));
+      // Wait for 30 seconds then retry.
+      await new Promise((resolve) => setTimeout(resolve, 30000));
       retry++;
     }
-  } while (!success && retry <= 5);
+  } while (!success && retry <= 6);
 
   log('Community metadata deployed.');
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-5074

The Quantic setup job was filling  intermittently because we were trying to deploy the content of the community while the community is still being created.

To try to solve this I increased the number of retries and added a 30 seconds delay between each try.