### PR TITLE
chore: fix scope of cspell plugin only to the relevant section

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
     "jest": true,
     "es6": true
   },
-  "extends": ["plugin:prettier/recommended", "plugin:@cspell/recommended"],
+  "extends": ["plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
@@ -31,6 +31,7 @@
     },
     {
       "files": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs"],
+      "extends": ["plugin:@cspell/recommended"],
       "rules": {
         "@cspell/spellchecker": ["warn"]
       }


### PR DESCRIPTION
* Turn spell checker plugin only in the required eslint config section and not globally for all files
* Currently eslint spell checker plugin is turned on in the global scope making it run on package-lock.json etc.
https://coveord.atlassian.net/browse/KIT-2550