### PR TITLE
chore: remove direct dependency on redux

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,12 +4,8 @@
   "cache": {
     "useCache": true
   },
-  "ignorePaths": [
-    "CHANGELOG.md"
-  ],
-  "import": [
-    "@cspell/dict-fr-fr/cspell-ext.json"
-  ],
+  "ignorePaths": ["CHANGELOG.md"],
+  "import": ["@cspell/dict-fr-fr/cspell-ext.json"],
   "words": [
     "adjustednumberoflikes",
     "applitools",
@@ -19,6 +15,7 @@
     "attachtocase",
     "bazz",
     "behaviour",
+    "bloup",
     "btoashim",
     "cfcomment",
     "cfpage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51959,7 +51959,6 @@
         "fast-equals": "2.0.4",
         "node-abort-controller": "^1.1.0",
         "pino": "8.11.0",
-        "redux": "4.2.0",
         "redux-mock-store": "1.5.4",
         "redux-thunk": "2.4.1",
         "ts-debounce": "3.0.0",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -58,7 +58,6 @@
     "fast-equals": "2.0.4",
     "node-abort-controller": "^1.1.0",
     "pino": "8.11.0",
-    "redux": "4.2.0",
     "redux-mock-store": "1.5.4",
     "redux-thunk": "2.4.1",
     "ts-debounce": "3.0.0",

--- a/packages/headless/src/app/analytics-middleware.ts
+++ b/packages/headless/src/app/analytics-middleware.ts
@@ -1,4 +1,4 @@
-import {Middleware} from 'redux';
+import {Middleware} from '@reduxjs/toolkit';
 
 export const analyticsMiddleware: Middleware = (api) => (next) => (action) => {
   // Why all these shenanigans ?

--- a/packages/headless/src/app/instantly-callable-middleware.ts
+++ b/packages/headless/src/app/instantly-callable-middleware.ts
@@ -1,4 +1,4 @@
-import {Middleware} from 'redux';
+import {Middleware} from '@reduxjs/toolkit';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isInstantlyCallableThunkAction(action: any): boolean {

--- a/packages/headless/src/app/logger-middlewares.ts
+++ b/packages/headless/src/app/logger-middlewares.ts
@@ -1,6 +1,6 @@
 import {SerializedError} from '@reduxjs/toolkit';
+import {Middleware} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
-import {Middleware} from 'redux';
 
 export const logActionErrorMiddleware: (logger: Logger) => Middleware =
   (logger) => () => (next) => (action) => {

--- a/packages/headless/src/app/logger-middlewares.ts
+++ b/packages/headless/src/app/logger-middlewares.ts
@@ -1,5 +1,4 @@
-import {SerializedError} from '@reduxjs/toolkit';
-import {Middleware} from '@reduxjs/toolkit';
+import {Middleware, SerializedError} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
 
 export const logActionErrorMiddleware: (logger: Logger) => Middleware =

--- a/packages/headless/src/app/renew-access-token-middleware.test.ts
+++ b/packages/headless/src/app/renew-access-token-middleware.test.ts
@@ -1,5 +1,5 @@
+import {Middleware, MiddlewareAPI} from '@reduxjs/toolkit';
 import pino, {Logger} from 'pino';
-import {Middleware, MiddlewareAPI} from 'redux';
 import {updateBasicConfiguration} from '../features/configuration/configuration-actions';
 import {ExpiredTokenError} from '../utils/errors';
 import {createRenewAccessTokenMiddleware} from './renew-access-token-middleware';

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -1,5 +1,5 @@
+import {StateFromReducersMapObject} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
-import {StateFromReducersMapObject} from 'redux';
 import {NoopPreprocessRequest} from '../../api/preprocess-request';
 import {SearchAPIClient} from '../../api/search/search-api-client';
 import {

--- a/packages/headless/src/app/undoable.test.ts
+++ b/packages/headless/src/app/undoable.test.ts
@@ -1,4 +1,4 @@
-import {AnyAction, Reducer} from 'redux';
+import {AnyAction, Reducer} from '@reduxjs/toolkit';
 import {makeHistory, undoable} from './undoable';
 
 describe('undoable', () => {

--- a/packages/headless/src/app/undoable.ts
+++ b/packages/headless/src/app/undoable.ts
@@ -1,4 +1,4 @@
-import {Reducer, AnyAction} from 'redux';
+import {Reducer, AnyAction} from '@reduxjs/toolkit';
 
 export const makeHistory = <State>(state?: State): StateWithHistory<State> => ({
   past: [],

--- a/packages/headless/src/controllers/core/context/headless-core-context.test.ts
+++ b/packages/headless/src/controllers/core/context/headless-core-context.test.ts
@@ -1,4 +1,4 @@
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {
   setContext,
   addContext,

--- a/packages/headless/src/controllers/core/facets/facet-conditions-manager/headless-facet-conditions-manager.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet-conditions-manager/headless-facet-conditions-manager.test.ts
@@ -1,4 +1,4 @@
-import {AnyAction} from 'redux';
+import {AnyAction} from '@reduxjs/toolkit';
 import {
   disableFacet,
   enableFacet,

--- a/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
+++ b/packages/headless/src/controllers/product-listing/headless-product-listing.test.ts
@@ -1,4 +1,4 @@
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {configuration} from '../../app/common-reducers';
 import {
   fetchProductListing,

--- a/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.test.ts
+++ b/packages/headless/src/controllers/product-recommendations/headless-base-product-recommendations.test.ts
@@ -1,4 +1,4 @@
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {configuration} from '../../app/common-reducers';
 import {
   getProductRecommendations,

--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.test.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.test.ts
@@ -1,5 +1,5 @@
 import {NumberValue} from '@coveo/bueno';
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {deselectAllBreadcrumbs} from '../../features/breadcrumb/breadcrumb-actions';
 import {updatePage} from '../../features/pagination/pagination-actions';
 import {updateQuery} from '../../features/query/query-actions';

--- a/packages/headless/src/controllers/recent-results-list/headless-recent-results-list.test.ts
+++ b/packages/headless/src/controllers/recent-results-list/headless-recent-results-list.test.ts
@@ -1,4 +1,4 @@
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {
   clearRecentResults,
   registerRecentResults,

--- a/packages/headless/src/controllers/recommendation/headless-recommendation.test.ts
+++ b/packages/headless/src/controllers/recommendation/headless-recommendation.test.ts
@@ -1,4 +1,4 @@
-import {Action} from 'redux';
+import {Action} from '@reduxjs/toolkit';
 import {configuration} from '../../app/common-reducers';
 import {updateNumberOfResults} from '../../features/pagination/pagination-actions';
 import {

--- a/packages/headless/src/controllers/triggers/headless-query-trigger.test.ts
+++ b/packages/headless/src/controllers/triggers/headless-query-trigger.test.ts
@@ -1,4 +1,4 @@
-import {AnyAction} from 'redux';
+import {AnyAction} from '@reduxjs/toolkit';
 import {updateQuery} from '../../features/query/query-actions';
 import {queryReducer as query} from '../../features/query/query-slice';
 import {executeSearch} from '../../features/search/search-actions';

--- a/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
@@ -1,4 +1,4 @@
-import {AnyAction} from 'redux';
+import {AnyAction} from '@reduxjs/toolkit';
 import {buildMockFacetResponse} from '../../../test/mock-facet-response';
 import {buildMockSearch} from '../../../test/mock-search';
 import {buildMockSearchResponse} from '../../../test/mock-search-response';

--- a/packages/headless/src/features/folding/folding-slice.test.ts
+++ b/packages/headless/src/features/folding/folding-slice.test.ts
@@ -1,4 +1,4 @@
-import {AnyAction} from 'redux';
+import {AnyAction} from '@reduxjs/toolkit';
 import {PlatformClient} from '../../api/platform-client';
 import {Result} from '../../api/search/search/result';
 import {

--- a/packages/headless/src/features/history/history-slice.test.ts
+++ b/packages/headless/src/features/history/history-slice.test.ts
@@ -1,4 +1,4 @@
-import {Reducer} from 'redux';
+import {Reducer} from '@reduxjs/toolkit';
 import {undoable, StateWithHistory, makeHistory} from '../../app/undoable';
 import {buildMockAdvancedSearchQueriesState} from '../../test/mock-advanced-search-queries-state';
 import {buildMockCategoryFacetRequest} from '../../test/mock-category-facet-request';

--- a/packages/headless/src/features/search/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/search/search-actions-thunk-processor.ts
@@ -1,4 +1,4 @@
-import {AnyAction} from 'redux';
+import {AnyAction} from '@reduxjs/toolkit';
 import {ThunkDispatch} from 'redux-thunk';
 import {StateNeededBySearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {


### PR DESCRIPTION
* Changing imports to go through RTK instead of redux

[Why Redux Toolkit is How To Use Redux Today | Redux](https://redux.js.org/introduction/why-rtk-is-redux-today#why-we-want-you-to-use-redux-toolkit) 

> The redux core package still works, but today we consider it to be obsolete. All of its APIs are also re-exported from @reduxjs/toolkit

> we strongly encourage you to switch over to @reduxjs/toolkit, and update your code to use the Redux Toolkit APIs instead!

https://coveord.atlassian.net/browse/KIT-2564