### PR TITLE
feat(headless): Add new insight analytics actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51952,7 +51952,7 @@
         "@types/pino": "6.3.12",
         "@types/redux-mock-store": "1.0.3",
         "abab": "2.0.6",
-        "coveo.analytics": "2.28.5",
+        "coveo.analytics": "2.28.7",
         "cross-fetch": "3.1.5",
         "dayjs": "1.11.5",
         "exponential-backoff": "3.1.0",
@@ -51978,9 +51978,9 @@
       }
     },
     "packages/headless/node_modules/coveo.analytics": {
-      "version": "2.28.5",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.28.5.tgz",
-      "integrity": "sha512-v57ESs2odzs+d7vkiAmSkhZg1MU3nx+FUBM8k71IP/v4/TcVocXko+9IwZT10Ao3LEV23m1nkyQRwRWapn0nMg==",
+      "version": "2.28.7",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.28.7.tgz",
+      "integrity": "sha512-F7Ht261XnKzBclRl2DsJXkNQbKLud/iE4KNcaGSM7h/5zyLlHaRL49lgVGcyj4hTKXaKgENYXlDosLVX/7XVRg==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "react-native-get-random-values": "^1.8.0",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -51,7 +51,7 @@
     "@types/pino": "6.3.12",
     "@types/redux-mock-store": "1.0.3",
     "abab": "2.0.6",
-    "coveo.analytics": "2.28.5",
+    "coveo.analytics": "2.28.7",
     "cross-fetch": "3.1.5",
     "dayjs": "1.11.5",
     "exponential-backoff": "3.1.0",

--- a/packages/headless/src/features/analytics/insight-analytics-actions-loader.ts
+++ b/packages/headless/src/features/analytics/insight-analytics-actions-loader.ts
@@ -27,7 +27,11 @@ import {
   logPagePrevious,
 } from '../pagination/pagination-insight-analytics-actions';
 import {SmartSnippetFeedback} from '../question-answering/question-answering-analytics-actions';
-import {logCopyToClipboard} from '../result-actions/result-actions-insight-analytics-actions';
+import {
+  logCopyToClipboard,
+  logCaseSendEmail,
+  logFeedItemTextPost,
+} from '../result-actions/result-actions-insight-analytics-actions';
 import {logResultsSort} from '../sort-criteria/sort-criteria-insight-analytics-actions';
 import {
   LogStaticFilterToggleValueActionCreatorPayload,
@@ -215,6 +219,22 @@ export interface InsightAnalyticsActionCreators {
    * @returns A dispatchable action.
    */
   logCopyToClipboard(result: Result): InsightAction<AnalyticsType.Click>;
+
+  /**
+   * The event to log when the Case Send As Email result action is clicked.
+   *
+   * @param result - The result.
+   * @returns A dispatchable action.
+   */
+  logCaseSendEmail(result: Result): InsightAction<AnalyticsType.Click>;
+
+  /**
+   * The event to log when the Feed Item Text Post result action is clicked.
+   *
+   * @param result - The result.
+   * @returns A dispatchable action.
+   */
+  logFeedItemTextPost(result: Result): InsightAction<AnalyticsType.Click>;
 }
 
 /**
@@ -248,5 +268,7 @@ export function loadInsightAnalyticsActions(
     logResultsSort,
     logStaticFilterDeselect: logInsightStaticFilterDeselect,
     logCopyToClipboard,
+    logCaseSendEmail,
+    logFeedItemTextPost,
   };
 }

--- a/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
@@ -2,14 +2,22 @@ import {buildMockRaw, buildMockResult} from '../../test';
 import {buildMockInsightEngine} from '../../test/mock-engine';
 import {buildMockInsightState} from '../../test/mock-insight-state';
 import {buildMockSearchState} from '../../test/mock-search-state';
-import {logCopyToClipboard} from './result-actions-insight-analytics-actions';
+import {
+  logCaseSendEmail,
+  logCopyToClipboard,
+  logFeedItemTextPost,
+} from './result-actions-insight-analytics-actions';
 
 const mockLogCopyToClipboard = jest.fn();
+const mockLogCaseSendEmail = jest.fn();
+const mockLogFeedItemTextPost = jest.fn();
 
 jest.mock('coveo.analytics', () => {
   const mockCoveoInsightClient = jest.fn(() => ({
     disable: () => {},
     logCopyToClipboard: mockLogCopyToClipboard,
+    logCaseSendEmail: mockLogCaseSendEmail,
+    logFeedItemTextPost: mockLogFeedItemTextPost,
   }));
 
   return {
@@ -70,7 +78,7 @@ const resultParams = {
 
 const testResult = buildMockResult(resultParams);
 
-describe('logExpandToFullUI', () => {
+describe('logCopyToClipboard', () => {
   it('should log #logCopyToClipboard with the right payload', async () => {
     const engine = buildMockInsightEngine({
       state: buildMockInsightState({
@@ -97,6 +105,70 @@ describe('logExpandToFullUI', () => {
       expectedDocumentIdentifier
     );
     expect(mockLogCopyToClipboard.mock.calls[0][2]).toStrictEqual(
+      expectedMetadata
+    );
+  });
+});
+
+describe('logCaseSendAsEmail', () => {
+  it('should log #logCaseSendAsEmail with the right payload', async () => {
+    const engine = buildMockInsightEngine({
+      state: buildMockInsightState({
+        search: buildMockSearchState({
+          results: [testResult],
+        }),
+        insightCaseContext: {
+          caseContext: {
+            Case_Subject: exampleSubject,
+            Case_Description: exampleDescription,
+          },
+          caseId: exampleCaseId,
+          caseNumber: exampleCaseNumber,
+        },
+      }),
+    });
+    await engine.dispatch(logCaseSendEmail(testResult));
+
+    expect(mockLogCaseSendEmail).toBeCalledTimes(1);
+    expect(mockLogCaseSendEmail.mock.calls[0][0]).toStrictEqual(
+      expectedDocumentInfo
+    );
+    expect(mockLogCaseSendEmail.mock.calls[0][1]).toStrictEqual(
+      expectedDocumentIdentifier
+    );
+    expect(mockLogCaseSendEmail.mock.calls[0][2]).toStrictEqual(
+      expectedMetadata
+    );
+  });
+});
+
+describe('logFeedItemTextPost', () => {
+  it('should log #logFeedItemTextPost with the right payload', async () => {
+    const engine = buildMockInsightEngine({
+      state: buildMockInsightState({
+        search: buildMockSearchState({
+          results: [testResult],
+        }),
+        insightCaseContext: {
+          caseContext: {
+            Case_Subject: exampleSubject,
+            Case_Description: exampleDescription,
+          },
+          caseId: exampleCaseId,
+          caseNumber: exampleCaseNumber,
+        },
+      }),
+    });
+    await engine.dispatch(logFeedItemTextPost(testResult));
+
+    expect(mockLogFeedItemTextPost).toBeCalledTimes(1);
+    expect(mockLogFeedItemTextPost.mock.calls[0][0]).toStrictEqual(
+      expectedDocumentInfo
+    );
+    expect(mockLogFeedItemTextPost.mock.calls[0][1]).toStrictEqual(
+      expectedDocumentIdentifier
+    );
+    expect(mockLogFeedItemTextPost.mock.calls[0][2]).toStrictEqual(
       expectedMetadata
     );
   });

--- a/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
@@ -110,8 +110,8 @@ describe('logCopyToClipboard', () => {
   });
 });
 
-describe('logCaseSendAsEmail', () => {
-  it('should log #logCaseSendAsEmail with the right payload', async () => {
+describe('logCaseSendEmail', () => {
+  it('should log #logCaseSendEmail with the right payload', async () => {
     const engine = buildMockInsightEngine({
       state: buildMockInsightState({
         search: buildMockSearchState({

--- a/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.ts
+++ b/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.ts
@@ -27,3 +27,41 @@ export const logCopyToClipboard = (
       );
     }
   );
+
+export const logCaseSendEmail = (
+  result: Result
+): InsightAction<AnalyticsType.Click> =>
+  makeInsightAnalyticsAction(
+    'analytics/resultAction/insight/caseSendEmail',
+    AnalyticsType.Click,
+    (client, state) => {
+      validateResultPayload(result);
+      const metadata = getCaseContextAnalyticsMetadata(
+        state.insightCaseContext
+      );
+      return client.logCaseSendEmail(
+        partialDocumentInformation(result, state),
+        documentIdentifier(result),
+        metadata
+      );
+    }
+  );
+
+export const logFeedItemTextPost = (
+  result: Result
+): InsightAction<AnalyticsType.Click> =>
+  makeInsightAnalyticsAction(
+    'analytics/resultAction/insight/feedItemTextPost',
+    AnalyticsType.Click,
+    (client, state) => {
+      validateResultPayload(result);
+      const metadata = getCaseContextAnalyticsMetadata(
+        state.insightCaseContext
+      );
+      return client.logFeedItemTextPost(
+        partialDocumentInformation(result, state),
+        documentIdentifier(result),
+        metadata
+      );
+    }
+  );


### PR DESCRIPTION
[SFINT-5082]

logCaseSendEmail, logFeedItemTextPost 

Will have to wait until this PR has been released to bump the version of coveo.analytics.js used in ui-kit

https://github.com/coveo/coveo.analytics.js/pull/425

(These two click actionCause have also already been added to the UA valid event schema repo)

[SFINT-5082]: https://coveord.atlassian.net/browse/SFINT-5082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ