### PR TITLE
[DRAFT] feat(atomic): implement search box field suggestions

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1606,6 +1606,24 @@ export namespace Components {
          */
         "suggestionTimeout": number;
     }
+    interface AtomicSearchBoxFieldSuggestions {
+        /**
+          * The field by which suggestions will be provided.
+         */
+        "field"?: string;
+        /**
+          * The SVG icon to display.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "icon"?: string;
+        /**
+          * The maximum number of field suggestions that will be displayed if the user has typed something into the input field.
+         */
+        "maxWithQuery"?: number;
+        /**
+          * The maximum number of field suggestions that will be displayed initially when the input field is empty.
+         */
+        "maxWithoutQuery"?: number;
+    }
     interface AtomicSearchBoxInstantResults {
         /**
           * The callback to generate an [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) for a given result so that accessibility tools can fully describe what's visually rendered by a result.  By default, or if an empty string is returned, `result.title` is used.
@@ -2676,6 +2694,12 @@ declare global {
         prototype: HTMLAtomicSearchBoxElement;
         new (): HTMLAtomicSearchBoxElement;
     };
+    interface HTMLAtomicSearchBoxFieldSuggestionsElement extends Components.AtomicSearchBoxFieldSuggestions, HTMLStencilElement {
+    }
+    var HTMLAtomicSearchBoxFieldSuggestionsElement: {
+        prototype: HTMLAtomicSearchBoxFieldSuggestionsElement;
+        new (): HTMLAtomicSearchBoxFieldSuggestionsElement;
+    };
     interface HTMLAtomicSearchBoxInstantResultsElement extends Components.AtomicSearchBoxInstantResults, HTMLStencilElement {
     }
     var HTMLAtomicSearchBoxInstantResultsElement: {
@@ -2914,6 +2938,7 @@ declare global {
         "atomic-result-timespan": HTMLAtomicResultTimespanElement;
         "atomic-results-per-page": HTMLAtomicResultsPerPageElement;
         "atomic-search-box": HTMLAtomicSearchBoxElement;
+        "atomic-search-box-field-suggestions": HTMLAtomicSearchBoxFieldSuggestionsElement;
         "atomic-search-box-instant-results": HTMLAtomicSearchBoxInstantResultsElement;
         "atomic-search-box-query-suggestions": HTMLAtomicSearchBoxQuerySuggestionsElement;
         "atomic-search-box-recent-queries": HTMLAtomicSearchBoxRecentQueriesElement;
@@ -4441,6 +4466,24 @@ declare namespace LocalJSX {
          */
         "suggestionTimeout"?: number;
     }
+    interface AtomicSearchBoxFieldSuggestions {
+        /**
+          * The field by which suggestions will be provided.
+         */
+        "field"?: string;
+        /**
+          * The SVG icon to display.  - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location. - Use a value that starts with `assets://`, to display an icon from the Atomic package. - Use a stringified SVG to display it directly.
+         */
+        "icon"?: string;
+        /**
+          * The maximum number of field suggestions that will be displayed if the user has typed something into the input field.
+         */
+        "maxWithQuery"?: number;
+        /**
+          * The maximum number of field suggestions that will be displayed initially when the input field is empty.
+         */
+        "maxWithoutQuery"?: number;
+    }
     interface AtomicSearchBoxInstantResults {
         /**
           * The callback to generate an [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) for a given result so that accessibility tools can fully describe what's visually rendered by a result.  By default, or if an empty string is returned, `result.title` is used.
@@ -4871,6 +4914,7 @@ declare namespace LocalJSX {
         "atomic-result-timespan": AtomicResultTimespan;
         "atomic-results-per-page": AtomicResultsPerPage;
         "atomic-search-box": AtomicSearchBox;
+        "atomic-search-box-field-suggestions": AtomicSearchBoxFieldSuggestions;
         "atomic-search-box-instant-results": AtomicSearchBoxInstantResults;
         "atomic-search-box-query-suggestions": AtomicSearchBoxQuerySuggestions;
         "atomic-search-box-recent-queries": AtomicSearchBoxRecentQueries;
@@ -5009,6 +5053,7 @@ declare module "@stencil/core" {
             "atomic-result-timespan": LocalJSX.AtomicResultTimespan & JSXBase.HTMLAttributes<HTMLAtomicResultTimespanElement>;
             "atomic-results-per-page": LocalJSX.AtomicResultsPerPage & JSXBase.HTMLAttributes<HTMLAtomicResultsPerPageElement>;
             "atomic-search-box": LocalJSX.AtomicSearchBox & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxElement>;
+            "atomic-search-box-field-suggestions": LocalJSX.AtomicSearchBoxFieldSuggestions & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxFieldSuggestionsElement>;
             "atomic-search-box-instant-results": LocalJSX.AtomicSearchBoxInstantResults & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxInstantResultsElement>;
             "atomic-search-box-query-suggestions": LocalJSX.AtomicSearchBoxQuerySuggestions & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxQuerySuggestionsElement>;
             "atomic-search-box-recent-queries": LocalJSX.AtomicSearchBoxRecentQueries & JSXBase.HTMLAttributes<HTMLAtomicSearchBoxRecentQueriesElement>;

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -81,6 +81,11 @@ import {
  * @part query-suggestion-icon - The icon of a suggestion from the `atomic-search-box-query-suggestions` component.
  * @part query-suggestion-text - The text of a suggestion from the `atomic-search-box-query-suggestions` component.
  *
+ * @part field-suggestion-item - A suggestion from the `atomic-search-box-field-suggestions` component.
+ * @part field-suggestion-content - The contents of a suggestion from the `atomic-search-box-field-suggestions` component.
+ * @part field-suggestion-icon - The icon of a suggestion from the `atomic-search-box-field-suggestions` component.
+ * @part field-suggestion-text - The text of a suggestion from the `atomic-search-box-field-suggestions` component.
+ *
  * @part recent-query-item - A suggestion from the `atomic-search-box-recent-queries` component.
  * @part recent-query-content - The contents of a suggestion from the `atomic-search-box-recent-queries` component.
  * @part recent-query-icon - The icon of a suggestion from the `atomic-search-box-recent-queries` component.
@@ -792,7 +797,7 @@ export class AtomicSearchBox {
       !this.suggestions.length && (
         <slot>
           <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
-          <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+          <atomic-search-box-field-suggestions field="source"></atomic-search-box-field-suggestions>
         </slot>
       ),
     ];

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -798,6 +798,7 @@ export class AtomicSearchBox {
         <slot>
           <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
           <atomic-search-box-field-suggestions field="source"></atomic-search-box-field-suggestions>
+          <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
         </slot>
       ),
     ];

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.stories.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.stories.tsx
@@ -1,0 +1,18 @@
+import defaultStory from 'atomic-storybook/default-story';
+
+const {defaultModuleExport, exportedStory} = defaultStory(
+  'Atomic/Searchbox/QuerySuggestions',
+  'atomic-search-box-query-suggestions',
+  {},
+  {
+    parentElement: () => {
+      return document.createElement('atomic-search-box');
+    },
+  }
+);
+
+export default {
+  ...defaultModuleExport,
+  title: 'Atomic/Searchbox/QuerySuggestions',
+};
+export const DefaultQuerySuggestions = exportedStory;

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.tsx
@@ -9,7 +9,6 @@ import {
   QuerySuggestionSection,
 } from '@coveo/headless/dist/definitions/state/state-sections';
 import {Component, Element, Prop, State, h} from '@stencil/core';
-//import SearchIcon from '../../../../images/search.svg';
 import {encodeForDomAttribute} from '../../../../utils/string-utils';
 import {
   dispatchSearchBoxSuggestionsEvent,
@@ -19,7 +18,9 @@ import {
 } from '../suggestions-common';
 
 /**
- * The `atomic-search-box-field-suggestions` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of query suggestion behavior.
+ * The `atomic-search-box-field-suggestions` component can be added as a child of an `atomic-search-box-query-suggestions` component, allowing for the configuration of field suggestion behavior.
+ * THIS IS THE INTENDED USE CASE! I HAVEN'T ACTUALLY BEEN ABLE TO MAKE THIS WORK... YET!
+ * FOR NOW, THIS COMPONENT IS A CHILD OF THE `atomic-search-box`
  */
 @Component({
   tag: 'atomic-search-box-field-suggestions',
@@ -42,23 +43,22 @@ export class AtomicSearchBoxFieldSuggestions {
   @Prop() public icon?: string;
 
   /**
-   * The field that does the thing
+   * The field by which suggestions will be provided.
    */
   @Prop({reflect: true}) public field?: string;
 
   /**
-   * The maximum number of suggestions that will be displayed if the user has typed something into the input field.
+   * The maximum number of field suggestions that will be displayed if the user has typed something into the input field.
    */
-  @Prop({reflect: true}) public maxWithQuery?: number;
+  @Prop({reflect: true}) public maxWithQuery?: number = 2;
 
   /**
-   * The maximum number of suggestions that will be displayed initially when the input field is empty.
+   * The maximum number of field suggestions that will be displayed initially when the input field is empty.
    */
-  @Prop({reflect: true}) public maxWithoutQuery?: number;
+  @Prop({reflect: true}) public maxWithoutQuery?: number = 0;
 
   componentWillLoad() {
     try {
-      console.log('THIS IS A TEST');
       dispatchSearchBoxSuggestionsEvent((bindings) => {
         this.bindings = bindings;
         return this.initialize();
@@ -95,28 +95,31 @@ export class AtomicSearchBoxFieldSuggestions {
     this.fieldSuggestions.updateText(queryString);
   }
 
-  // private renderIcon() {
-  //   return this.icon || SearchIcon;
-  // }
-
   private renderItems(): SearchBoxSuggestionElement[] {
     const suggestions = this.fieldSuggestions.state.values;
     const hasQuery = this.bindings.searchBoxController.state.value !== '';
     const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
-    console.log(suggestions);
+
     return suggestions
       .slice(0, max)
       .map((suggestion) => this.renderItem(suggestion));
   }
 
   private renderItem(suggestion: FieldSuggestionsValue) {
-    //const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const querySuggestions =
+      this.bindings.searchBoxController.state.suggestions;
+
+    const topQuerySuggestion = querySuggestions.length
+      ? querySuggestions[0]
+      : null;
+
     return {
       part: 'field-suggestion-item',
-      content: (
+      content: topQuerySuggestion && (
         <div part="field-suggestion-content" class="flex items-center">
           <span part="field-suggestion-text" class="break-all line-clamp-2">
-            Test - {suggestion.rawValue}
+            <span innerHTML={topQuerySuggestion.highlightedValue}></span> in{' '}
+            {suggestion.rawValue}
           </span>
         </div>
       ),
@@ -127,7 +130,10 @@ export class AtomicSearchBoxFieldSuggestions {
         interpolation: {escapeValue: false},
       }),
       onSelect: () => {
-        this.fieldSuggestions.select(suggestion);
+        if (topQuerySuggestion) {
+          // Ideally, we would also select the query suggestion here, but I haven't found a way to do both without Headless throwing a temper tantrum.
+          this.fieldSuggestions.select(suggestion);
+        }
       },
     };
   }

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-field-suggestions/atomic-search-box-field-suggestions.tsx
@@ -1,0 +1,145 @@
+import {
+  buildFieldSuggestions,
+  FieldSuggestions,
+  FieldSuggestionsValue,
+  SearchEngine,
+} from '@coveo/headless';
+import {
+  QuerySetSection,
+  QuerySuggestionSection,
+} from '@coveo/headless/dist/definitions/state/state-sections';
+import {Component, Element, Prop, State, h} from '@stencil/core';
+//import SearchIcon from '../../../../images/search.svg';
+import {encodeForDomAttribute} from '../../../../utils/string-utils';
+import {
+  dispatchSearchBoxSuggestionsEvent,
+  SearchBoxSuggestionElement,
+  SearchBoxSuggestions,
+  SearchBoxSuggestionsBindings,
+} from '../suggestions-common';
+
+/**
+ * The `atomic-search-box-field-suggestions` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of query suggestion behavior.
+ */
+@Component({
+  tag: 'atomic-search-box-field-suggestions',
+  shadow: true,
+})
+export class AtomicSearchBoxFieldSuggestions {
+  private bindings!: SearchBoxSuggestionsBindings;
+  private fieldSuggestions!: FieldSuggestions;
+  @Element() private host!: HTMLElement;
+
+  @State() public error!: Error;
+
+  /**
+   * The SVG icon to display.
+   *
+   * - Use a value that starts with `http://`, `https://`, `./`, or `../`, to fetch and display an icon from a given location.
+   * - Use a value that starts with `assets://`, to display an icon from the Atomic package.
+   * - Use a stringified SVG to display it directly.
+   */
+  @Prop() public icon?: string;
+
+  /**
+   * The field that does the thing
+   */
+  @Prop({reflect: true}) public field?: string;
+
+  /**
+   * The maximum number of suggestions that will be displayed if the user has typed something into the input field.
+   */
+  @Prop({reflect: true}) public maxWithQuery?: number;
+
+  /**
+   * The maximum number of suggestions that will be displayed initially when the input field is empty.
+   */
+  @Prop({reflect: true}) public maxWithoutQuery?: number;
+
+  componentWillLoad() {
+    try {
+      console.log('THIS IS A TEST');
+      dispatchSearchBoxSuggestionsEvent((bindings) => {
+        this.bindings = bindings;
+        return this.initialize();
+      }, this.host);
+    } catch (error) {
+      this.error = error as Error;
+    }
+  }
+
+  private initialize(): SearchBoxSuggestions {
+    const engine = this.bindings.engine as SearchEngine<
+      QuerySuggestionSection & QuerySetSection
+    >;
+
+    this.fieldSuggestions = buildFieldSuggestions(engine, {
+      options: {
+        facet: {field: this.field ?? ''},
+      },
+    });
+
+    return {
+      position: Array.from(this.host.parentNode!.children).indexOf(this.host),
+      onInput: () => this.onInput(),
+      renderItems: () => this.renderItems(),
+    };
+  }
+
+  onInput() {
+    const queryString = this.bindings.searchBoxController.state.value;
+    if (queryString === '') {
+      this.fieldSuggestions.clear();
+      return;
+    }
+    this.fieldSuggestions.updateText(queryString);
+  }
+
+  // private renderIcon() {
+  //   return this.icon || SearchIcon;
+  // }
+
+  private renderItems(): SearchBoxSuggestionElement[] {
+    const suggestions = this.fieldSuggestions.state.values;
+    const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
+    console.log(suggestions);
+    return suggestions
+      .slice(0, max)
+      .map((suggestion) => this.renderItem(suggestion));
+  }
+
+  private renderItem(suggestion: FieldSuggestionsValue) {
+    //const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    return {
+      part: 'field-suggestion-item',
+      content: (
+        <div part="field-suggestion-content" class="flex items-center">
+          <span part="field-suggestion-text" class="break-all line-clamp-2">
+            Test - {suggestion.rawValue}
+          </span>
+        </div>
+      ),
+      key: `qs-${encodeForDomAttribute(suggestion.rawValue)}`,
+      query: suggestion.rawValue,
+      ariaLabel: this.bindings.i18n.t('query-suggestion-label', {
+        query: suggestion.rawValue,
+        interpolation: {escapeValue: false},
+      }),
+      onSelect: () => {
+        this.fieldSuggestions.select(suggestion);
+      },
+    };
+  }
+
+  public render() {
+    if (this.error) {
+      return (
+        <atomic-component-error
+          element={this.host}
+          error={this.error}
+        ></atomic-component-error>
+      );
+    }
+  }
+}


### PR DESCRIPTION
The scope (no pun intended) for this is a bit vague. I decided against creating an exact copy of the field suggestions feature that was in JSUI as that use-case is already covered by facet search. What I ended up going with is to implement something that’s more in-line with what is provided by commerce sites like Best Buy:

![Screen Shot 2023-06-28 at 9 28 29 AM](https://github.com/coveo/ui-kit/assets/38883189/381e4bdf-53e2-4578-87fd-b01d528c7f33)

I’ve spent roughly 1 full day developing this feature and have a crude implementation that allows developers to specify a field by which suggestions are provided in the atomic component. Here is an example of it working (sorta) using the source field:

![Screen Shot 2023-06-28 at 1 23 06 PM](https://github.com/coveo/ui-kit/assets/38883189/169dacf1-6def-4953-a87d-fe3bec86ef2c)

I've made a few comments throughout the code explaining that certain things aren't working as intended. Moreover, I plan on updating this component such that it will be a child of the `atomic-search-box-query-suggestions` component rather than the `atomic-search-box` component.

For demo purposes, this feature is enabled and setup to use the `source` field by default, so to test locally, you just need to run atomic and enter a query in the search box that produces field suggestions.