### PR TITLE
chore(ci): limiting number of quantic package versions retrieved

### DIFF
--- a/packages/quantic/scripts/build/create-package.ts
+++ b/packages/quantic/scripts/build/create-package.ts
@@ -34,7 +34,7 @@ function ensureEnvVariables() {
 }
 
 async function getMatchingPackageVersion(versionNumber: string) {
-  return (await sfdx.getPackageVersionList()).result.find(
+  return (await sfdx.getPackageVersionList(30)).result.find(
     (pkg) =>
       pkg.Version === versionNumber ||
       pkg.Version.slice(0, -2) === versionNumber
@@ -151,7 +151,7 @@ async function createGithubDiscussionPost(
   packageVersionId: string
 ) {
   const token = process.env.GITHUB_TOKEN || '';
-  const packageDetails = (await sfdx.getPackageVersionList()).result.find(
+  const packageDetails = (await sfdx.getPackageVersionList(0)).result.find(
     (pack) => pack.SubscriberPackageVersionId === packageVersionId
   );
   const discussionTitle = `${packageDetails.Package2Name} v${options.packageVersion}`;

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -327,6 +327,10 @@ export async function promotePackageVersion(
   );
 }
 
-export async function getPackageVersionList(): Promise<SfdxGetPackageListResponse> {
-  return await sfdx<SfdxGetPackageListResponse>('force:package:version:list');
+export async function getPackageVersionList(
+  createdlastdays: number
+): Promise<SfdxGetPackageListResponse> {
+  return await sfdx<SfdxGetPackageListResponse>(
+    `force:package:version:list -c ${createdlastdays}`
+  );
 }

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -328,9 +328,9 @@ export async function promotePackageVersion(
 }
 
 export async function getPackageVersionList(
-  createdlastdays: number
+  createdLastDays: number
 ): Promise<SfdxGetPackageListResponse> {
   return await sfdx<SfdxGetPackageListResponse>(
-    `force:package:version:list -c ${createdlastdays}`
+    `force:package:version:list -c ${createdLastDays}`
   );
 }

--- a/packages/quantic/scripts/build/util/sfdx.ts
+++ b/packages/quantic/scripts/build/util/sfdx.ts
@@ -31,8 +31,10 @@ export function sfdx<T = SfdxResponse>(command: string): Promise<T> {
           try {
             jsonOutput = JSON.parse(strip(stdout));
             if (error) {
-              console.error(jsonOutput);
-              console.error(error);
+              console.error({
+                error,
+                jsonOutput,
+              });
               reject(jsonOutput || error);
             }
             resolve(jsonOutput as T);


### PR DESCRIPTION
Limit retrieval to last 30 days. Given we have a nightly build that creates a version this should be way enough and shortens the JSON size by a huge amount.


SFINT-5094