### PR TITLE
feat(atomic): removed border around loading state

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.pcss
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.pcss
@@ -1,9 +1,5 @@
 @import '../../../global/global.pcss';
 
-[part='container'] {
-  box-shadow: 0px 4px 8px rgba(4, 8, 31, 0.08), inset 0px 0px 0px 1px var(--atomic-neutral);
-}
-
 [part='header-label'] {
   color: var(--atomic-primary);
 }

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -67,7 +67,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   private get loadingClasses() {
-    return 'p-4';
+    return 'mt-4';
   }
 
   private get contentClasses() {
@@ -124,13 +124,13 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   public render() {
-    const {isLoading} = this.generatedAnswerState;
+    const isLoading = true;
     if (this.shouldBeHidden) {
       return null;
     }
     return (
       <aside
-        class={` mt-0 mx-auto mb-4 ${
+        class={`mt-0 mx-auto mb-4 ${
           isLoading ? this.loadingClasses : this.contentClasses
         }`}
         part="container"

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -67,11 +67,11 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   private get loadingClasses() {
-    return 'mt-4';
+    return 'my-3';
   }
 
   private get contentClasses() {
-    return 'border border-neutral shadow-lg p-6 bg-background rounded-lg p-6 text-on-background';
+    return 'mt-0 mb-4 border border-neutral shadow-lg p-6 bg-background rounded-lg p-6 text-on-background';
   }
 
   private renderContent() {
@@ -124,13 +124,13 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   public render() {
-    const isLoading = true;
+    const {isLoading} = this.generatedAnswerState;
     if (this.shouldBeHidden) {
       return null;
     }
     return (
       <aside
-        class={`mt-0 mx-auto mb-4 ${
+        class={`mx-auto ${
           isLoading ? this.loadingClasses : this.contentClasses
         }`}
         part="container"

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -66,6 +66,14 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
     );
   }
 
+  private get loadingClasses() {
+    return 'p-4';
+  }
+
+  private get contentClasses() {
+    return 'border border-neutral shadow-lg p-6 bg-background rounded-lg p-6 text-on-background';
+  }
+
   private renderContent() {
     return (
       <div part="generated-content">
@@ -116,23 +124,18 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   public render() {
+    const {isLoading} = this.generatedAnswerState;
     if (this.shouldBeHidden) {
       return null;
     }
     return (
       <aside
-        class="bg-background border-neutral rounded-lg p-6 text-on-background mt-0 mx-auto mb-4"
+        class={` mt-0 mx-auto mb-4 ${
+          isLoading ? this.loadingClasses : this.contentClasses
+        }`}
         part="container"
       >
-        <article>
-          {this.generatedAnswerState.isLoading ? (
-            <TypingLoader
-              loadingLabel={this.bindings.i18n.t('generated-answer-loading')}
-            />
-          ) : (
-            this.renderContent()
-          )}
-        </article>
+        <article>{isLoading ? <TypingLoader /> : this.renderContent()}</article>
       </aside>
     );
   }

--- a/packages/atomic/src/components/search/atomic-generated-answer/generated-content.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/generated-content.tsx
@@ -13,7 +13,7 @@ export const GeneratedContent: FunctionalComponent<GeneratedContentProps> = (
   props
 ) => (
   <div class="mt-6">
-    <p part="generated-text" class="mt-2 mb-0 whitespace-pre-wrap leading-7">
+    <p part="generated-text" class="mb-0 whitespace-pre-wrap leading-7">
       {props.answer}
     </p>
     <SourceCitations

--- a/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
@@ -1,18 +1,9 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
-interface TypingLoaderProps {
-  loadingLabel: string;
-}
-
-export const TypingLoader: FunctionalComponent<TypingLoaderProps> = (props) => (
-  <div>
-    <div class="typing-indicator" aria-hidden="true">
-      <span></span>
-      <span></span>
-      <span></span>
-    </div>
-    <div class="mx-auto text-center mt-4 text-neutral-dark">
-      {props.loadingLabel}
-    </div>
+export const TypingLoader: FunctionalComponent = () => (
+  <div class="typing-indicator" aria-hidden="true">
+    <span></span>
+    <span></span>
+    <span></span>
   </div>
 );


### PR DESCRIPTION
The design has been revised to no longer show a border when the component is loading so it's more subtle.

Loading
<img width="1115" alt="Screenshot 2023-07-05 at 2 34 30 PM" src="https://github.com/coveo/ui-kit/assets/16785453/442c3274-081f-4e3e-9854-75c77fd96a58">

Loaded
<img width="1117" alt="Screenshot 2023-07-05 at 2 06 23 PM" src="https://github.com/coveo/ui-kit/assets/16785453/e17fa128-2604-40e9-a2b6-284b01dd00c1">
