### PR TITLE
feat(headless): isUserActionView property added to the result interface

### DIFF
--- a/packages/headless/src/api/search/search/result.ts
+++ b/packages/headless/src/api/search/search/result.ts
@@ -174,7 +174,7 @@ export interface Result {
   rankingModifier?: string;
 
   /**
-   * Whether the result item has been previously viewed by one of the users specified in the `canSeeUserProfileOf` section of the search token [search token](https://docs.coveo.com/en/13/api-reference/search-api#tag/Search-V2/operation/token) generated to perform the search request.
+   * Whether the result item has been previously viewed by one of the users specified in the `canSeeUserProfileOf` section of the [search token](https://docs.coveo.com/en/13/api-reference/search-api#tag/Search-V2/operation/token) generated to perform the search request.
    */
   isUserActionView: boolean;
 }

--- a/packages/headless/src/api/search/search/result.ts
+++ b/packages/headless/src/api/search/search/result.ts
@@ -174,7 +174,7 @@ export interface Result {
   rankingModifier?: string;
 
   /**
-   * Whether the result item was previously viewed by the user specified in the request of the query.
+   * Whether the result item has been previously viewed by one of the users specified in the `canSeeUserProfileOf` section of the search token [search token](https://docs.coveo.com/en/13/api-reference/search-api#tag/Search-V2/operation/token) generated to perform the search request.
    */
   isUserActionView: boolean;
 }

--- a/packages/headless/src/api/search/search/result.ts
+++ b/packages/headless/src/api/search/search/result.ts
@@ -172,4 +172,9 @@ export interface Result {
    * TopResult
    */
   rankingModifier?: string;
+
+  /**
+   * Whether the result item was previously viewed by the user specified in the request of the query.
+   */
+  isUserActionView: boolean;
 }

--- a/packages/headless/src/test/mock-result.ts
+++ b/packages/headless/src/test/mock-result.ts
@@ -32,6 +32,7 @@ export function buildMockResult(config: Partial<Result> = {}): Result {
     summaryHighlights: [],
     absentTerms: [],
     raw: buildMockRaw(),
+    isUserActionView: false,
     ...config,
   };
 }


### PR DESCRIPTION
[SFINT-5101](https://coveord.atlassian.net/browse/SFINT-5101)


The property `isUserActionView` is now added to the Result interface in Headless.

I described this property as documented in the search-ui repo: https://github.com/coveo/search-ui/blob/a39c8bec0515809812b9917917167e2751dfd0d0/src/rest/QueryResult.ts#L109-L112

In Quantic we rely on this property to display a `viewed by customer badge` component on the results viewed by a given user.

<img width="469" alt="1" src="https://github.com/coveo/ui-kit/assets/86681870/2fb93bd8-f66b-4908-bdda-bd493095b303">


[SFINT-5101]: https://coveord.atlassian.net/browse/SFINT-5101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ