### PR TITLE
ci: fix `lint-staged` failures when committing generated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     ]
   },
   "lint-staged": {
-    "**/*.{ts?(x),?(m)js}": [
+    "**/*.{ts?(x),?(m)js} !(**/stencil-generated/*.ts)": [
       "eslint --fix --max-warnings=0"
     ],
     "**/{*.{scss,css,pcss,html,md},{package,nx,project}.json}": [


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2573

Long talk about this problem in this eslint [issue](https://github.com/eslint/eslint/issues/15010). A proper solution never got merged in the core eslint so I used the last comment solution to directly exclude the files from the `lint-staged`. 