### PR TITLE
style: remove old traces of `@applitools/eyes-cypress`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -8,7 +8,6 @@
   "import": ["@cspell/dict-fr-fr/cspell-ext.json"],
   "words": [
     "adjustednumberoflikes",
-    "applitools",
     "ARROWUP",
     "Artemia",
     "Artemiidae",

--- a/packages/atomic/cypress/support/index.d.ts
+++ b/packages/atomic/cypress/support/index.d.ts
@@ -1,1 +1,0 @@
-import '@applitools/eyes-cypress';

--- a/packages/atomic/cypress/tsconfig.json
+++ b/packages/atomic/cypress/tsconfig.json
@@ -9,6 +9,5 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "include": ["**/*.ts", "**/*.js"],
-  "files": ["../../../node_modules/@applitools/eyes-cypress/index.d.ts"],
+  "include": ["**/*.ts", "**/*.js"]
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2579

This was bugging me. In kept seeing this error pop up in vs code whenever I was in the atomic/cypress folder.
<img width="916" alt="image" src="https://github.com/coveo/ui-kit/assets/132079077/a5cb2653-f5c8-4df8-bb9a-93a61679a119">

`@applitools/eyes-cypress` got removed in #2463 