### PR TITLE
feat(smart-snippet): allow link _target modifs

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1840,6 +1840,7 @@ export namespace Components {
         "source"?: HTMLElement;
     }
     interface AtomicSmartSnippetSource {
+        "attributes"?: Attr[];
         "source": Result;
     }
     interface AtomicSmartSnippetSuggestions {
@@ -4697,6 +4698,7 @@ declare namespace LocalJSX {
         "source"?: HTMLElement;
     }
     interface AtomicSmartSnippetSource {
+        "attributes"?: Attr[];
         "onBeginDelayedSelectSource"?: (event: AtomicSmartSnippetSourceCustomEvent<any>) => void;
         "onCancelPendingSelectSource"?: (event: AtomicSmartSnippetSourceCustomEvent<any>) => void;
         "onSelectSource"?: (event: AtomicSmartSnippetSourceCustomEvent<any>) => void;

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-source.tsx
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-source.tsx
@@ -31,6 +31,7 @@ export class AtomicSmartSnippetSource
 {
   @InitializeBindings() public bindings!: AnyBindings;
   @Prop({reflect: true, mutable: true}) source!: Result;
+  @Prop() attributes?: Attr[];
 
   @Event() selectSource!: EventEmitter;
   @Event() beginDelayedSelectSource!: EventEmitter;
@@ -55,6 +56,7 @@ export class AtomicSmartSnippetSource
           href={this.source.clickUri}
           className="block"
           part="source-url"
+          attributes={this.attributes}
           onSelect={() => this.selectSource.emit()}
           onBeginDelayedSelect={() => this.beginDelayedSelectSource.emit()}
           onCancelPendingSelect={() => this.cancelPendingSelectSource.emit()}
@@ -64,6 +66,7 @@ export class AtomicSmartSnippetSource
         <LinkWithResultAnalytics
           title={this.source.title}
           href={this.source.clickUri}
+          attributes={this.attributes}
           className="block"
           part="source-title"
           onSelect={() => this.selectSource.emit()}

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-suggestions/smart-snippet-suggestions-common.tsx
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-suggestions/smart-snippet-suggestions-common.tsx
@@ -13,6 +13,7 @@ import {AnyBindings} from '../../interface/bindings';
 
 interface SmartSnippetSuggestionProps {
   id: string;
+  attributes?: Attr[];
   getHost: () => HTMLElement;
   getBindings: () => AnyBindings;
   getHeadingLevel: () => number;
@@ -128,6 +129,7 @@ export class SmartSnippetSuggestionCommon {
         {
           <atomic-smart-snippet-source
             source={source}
+            attributes={this.props.attributes}
             onSelectSource={() =>
               this.props
                 .getQuestionsList()

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet/smart-snippet-common.tsx
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet/smart-snippet-common.tsx
@@ -12,6 +12,7 @@ type FeedBackModalElement =
 interface SmartSnippetProps {
   id: string;
   modalTagName: string;
+  attributes?: Attr[];
   getHost: () => HTMLElement;
   getBindings: () => AnyBindings;
   getModalRef: () => FeedBackModalElement | undefined;
@@ -152,6 +153,7 @@ export class SmartSnippetCommon {
           >
             {source && (
               <atomic-smart-snippet-source
+                attributes={this.props.attributes}
                 source={source}
                 onSelectSource={this.props.getSmartSnippet().selectSource}
                 onBeginDelayedSelectSource={

--- a/packages/atomic/src/components/search/smart-snippets/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.tsx
+++ b/packages/atomic/src/components/search/smart-snippets/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.tsx
@@ -11,6 +11,7 @@ import {
   BindStateToController,
 } from '../../../../utils/initialization-utils';
 import {randomID} from '../../../../utils/utils';
+import {getAttributesFromLinkSlot} from '../../../common/result-link/attributes-slot';
 import {SmartSnippetSuggestionCommon} from '../../../common/smart-snippets/atomic-smart-snippet-suggestions/smart-snippet-suggestions-common';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 
@@ -91,6 +92,7 @@ export class AtomicSmartSnippetSuggestions implements InitializableComponent {
 
     this.smartSnippetSuggestionListCommon = new SmartSnippetSuggestionCommon({
       id: this.id,
+      attributes: getAttributesFromLinkSlot(this.host, 'attributes'),
       getHost: () => this.host,
       getBindings: () => this.bindings,
       getHeadingLevel: () => this.headingLevel,

--- a/packages/atomic/src/components/search/smart-snippets/atomic-smart-snippet/atomic-smart-snippet.tsx
+++ b/packages/atomic/src/components/search/smart-snippets/atomic-smart-snippet/atomic-smart-snippet.tsx
@@ -10,6 +10,7 @@ import {
   BindStateToController,
 } from '../../../../utils/initialization-utils';
 import {randomID} from '../../../../utils/utils';
+import {getAttributesFromLinkSlot} from '../../../common/result-link/attributes-slot';
 import {SmartSnippetCommon} from '../../../common/smart-snippets/atomic-smart-snippet/smart-snippet-common';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 
@@ -102,6 +103,7 @@ export class AtomicSmartSnippet implements InitializableComponent {
     this.smartSnippetCommon = new SmartSnippetCommon({
       id: this.id,
       modalTagName: 'atomic-smart-snippet-feedback-modal',
+      attributes: getAttributesFromLinkSlot(this.host, 'attributes'),
       getHost: () => this.host,
       getBindings: () => this.bindings,
       getModalRef: () => this.modalRef,

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -174,6 +174,17 @@
         top: 10px;
         left: 5px;
       }
+      atomic-did-you-mean,
+      atomic-notifications,
+      atomic-smart-snippet,
+      atomic-smart-snippet-suggestions {
+        padding-bottom: 1rem;
+      }
+
+      atomic-smart-snippet::part(source-url),
+      atomic-smart-snippet-suggestions::part(source-url) {
+        word-wrap: break-word;
+      }
     </style>
   </head>
 
@@ -231,8 +242,13 @@
             <atomic-notifications></atomic-notifications>
           </atomic-layout-section>
           <atomic-layout-section section="results">
-            <atomic-smart-snippet></atomic-smart-snippet>
-            <atomic-smart-snippet-suggestions></atomic-smart-snippet-suggestions>
+            <atomic-generated-answer></atomic-generated-answer>
+            <atomic-smart-snippet>
+              <a slot="attributes" target="_blank"></a>
+            </atomic-smart-snippet>
+            <atomic-smart-snippet-suggestions>
+              <a slot="attributes" target="_blank"></a>
+            </atomic-smart-snippet-suggestions>
             <atomic-result-list image-size="none">
               <atomic-result-template>
                 <template>


### PR DESCRIPTION
Allows the modification of the _target attribute in the <a> tags inside smart snippets and smart snippets suggestions. Uses the same mechanism as result links.

Demo:
https://github.com/coveo/ui-kit/assets/64476861/0e4b9c31-cc7a-4048-908e-3d3f88f385fa

