### PR TITLE
fix: unsubscribe component on disconnected callback

### DIFF
--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -289,8 +289,7 @@ export function BindStateToController(
 
     component.disconnectedCallback = function () {
       !getElement(this).isConnected &&
-        this.unsubscribeController &&
-        this.unsubscribeController();
+        this.unsubscribeController?.();
       disconnectedCallback && disconnectedCallback.call(this);
     };
   };

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -255,7 +255,6 @@ export function BindStateToController(
     stateProperty: string
   ) => {
     const {disconnectedCallback, initialize} = component;
-    let unsubscribeController = () => {};
 
     component.initialize = function () {
       initialize && initialize.call(this);
@@ -281,7 +280,7 @@ export function BindStateToController(
         );
       }
 
-      unsubscribeController = this[controllerProperty].subscribe(() => {
+      this.unsubscribeController = this[controllerProperty].subscribe(() => {
         this[stateProperty] = this[controllerProperty].state;
         options?.onUpdateCallbackMethod &&
           this[options.onUpdateCallbackMethod]();
@@ -289,7 +288,9 @@ export function BindStateToController(
     };
 
     component.disconnectedCallback = function () {
-      !getElement(this).isConnected && unsubscribeController();
+      !getElement(this).isConnected &&
+        this.unsubscribeController &&
+        this.unsubscribeController();
       disconnectedCallback && disconnectedCallback.call(this);
     };
   };


### PR DESCRIPTION
This was essentially caused by a closure/scope issue. 

When you look at what happens internally in redux when the `unsubscribe` function is called, there's a closure flag (`isSubscribed`) that changes when unsubscribe is called for the first time. Any subsequent call to the same function will be a no-op that returns immediately.

We need to make sure we are referencing different instances of the unsubscribe function when a component gets removed from the page. A simple solution is to simply tack it on the component instance.

https://coveord.atlassian.net/browse/KIT-2569