### PR TITLE
fix(headless): Issues when loading a collection from different pages in the HIP

### DIFF
--- a/packages/headless/src/features/folding/insight-folding-actions.ts
+++ b/packages/headless/src/features/folding/insight-folding-actions.ts
@@ -16,7 +16,7 @@ import {
 import {ResultWithFolding} from '../folding/folding-slice';
 import {CollectionId} from '../folding/folding-state';
 import {fetchFromAPI} from '../insight-search/insight-search-actions';
-import {buildInsightSearchRequest} from '../insight-search/insight-search-request';
+import {buildInsightLoadCollectionRequest} from '../insight-search/insight-search-request';
 
 export type {
   RegisterFoldingActionCreatorPayload,
@@ -45,7 +45,7 @@ export const loadCollection = createAsyncThunk<
     {getState, rejectWithValue, extra: {apiClient}}
   ) => {
     const state = getState();
-    const baseRequest = buildInsightSearchRequest(state);
+    const baseRequest = buildInsightLoadCollectionRequest(state);
     const actualRequest = {
       ...baseRequest,
       request: {

--- a/packages/headless/src/features/insight-search/insight-search-request.ts
+++ b/packages/headless/src/features/insight-search/insight-search-request.ts
@@ -64,6 +64,57 @@ export const buildInsightSearchRequest = (
   });
 };
 
+export const buildInsightLoadCollectionRequest = (
+  state: StateNeededBySearchRequest
+): MappedSearchRequest<InsightQueryRequest> => {
+  const cq = buildConstantQuery(state);
+  const facets = getAllFacets(state);
+  const getNumberOfResultsWithinIndexLimit = () => {
+    if (!state.pagination) {
+      return undefined;
+    }
+
+    const isOverIndexLimit =
+      state.pagination.firstResult + state.pagination.numberOfResults >
+      maximumNumberOfResultsFromIndex;
+
+    if (isOverIndexLimit) {
+      return maximumNumberOfResultsFromIndex - state.pagination.firstResult;
+    }
+    return state.pagination.numberOfResults;
+  };
+  return mapSearchRequest<InsightQueryRequest>({
+    accessToken: state.configuration.accessToken,
+    organizationId: state.configuration.organizationId,
+    url: state.configuration.platformUrl,
+    insightId: state.insightConfiguration.insightId,
+    q: state.query?.q,
+    ...(facets.length && {facets}),
+    caseContext: state.insightCaseContext?.caseContext,
+    ...(state.pagination && {
+      numberOfResults: getNumberOfResultsWithinIndexLimit(),
+    }),
+    ...(cq && {cq}),
+    ...(state.fields &&
+      !state.fields.fetchAllFields && {
+        fieldsToInclude: state.fields.fieldsToInclude,
+      }),
+    ...(state.didYouMean && {
+      enableDidYouMean: state.didYouMean.enableDidYouMean,
+    }),
+    ...(state.sortCriteria && {
+      sortCriteria: state.sortCriteria,
+    }),
+    tab: state.configuration.analytics.originLevel2,
+    ...(state.folding && {
+      filterField: state.folding.fields.collection,
+      childField: state.folding.fields.parent,
+      parentField: state.folding.fields.child,
+      filterFieldRange: state.folding.filterFieldRange,
+    }),
+  });
+};
+
 export const buildInsightFetchMoreResultsRequest = async (
   state: StateNeededBySearchRequest
 ): Promise<MappedSearchRequest<InsightQueryRequest>> => {


### PR DESCRIPTION
[SFINT-5091](https://coveord.atlassian.net/browse/SFINT-5091)

**ISSUE:**
We are getting this error when loading a collection in a different page of the HIP, it seems to come from headless.
`headless.js:45 Uncaught (in promise) Error: Unable to create collection 0376d6346384d4dbb6121cacd4665105aaec0d278dd4cde25a5102ff2f73 from received results: []. Folding most probably in an invalid state... 
`

It is because the results were passing an empty array when creating a collection from results. This was caused by the `firstResult` passed in the `buildInsightSearchRequest ` method which was setting it to 5 from the state instead of 0 (the default).

See doc: https://docs.coveo.com/en/13/api-reference/search-api#tag/Search-V2/operation/searchUsingGet

**FIX:**

- Removed the `firstResult` parameter from the `buildInsightSearchRequest ` request
- Created a seperate `buildInsightLoadCollectionRequest` method for the `loadCollection` action so that if other parameters are to be added/changed in the future, it can be done on the new request instead of overriding parameters in `buildInsightSearchRequest`.


**DEMO:**

https://github.com/coveo/ui-kit/assets/73316533/5eee6fe2-c9ee-4171-b45c-7a65c91cff51




