### PR TITLE
feat(headless): support static filter value exclusion

### DIFF
--- a/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
@@ -192,7 +192,7 @@ describe('Static Filter', () => {
       expect(filter.isValueSelected(value)).toBe(true);
     });
 
-    it('when the value state is excluded, it returns true', () => {
+    it('when the value state is excluded, it returns false', () => {
       const value = buildMockStaticFilterValue({state: 'excluded'});
       expect(filter.isValueSelected(value)).toBe(false);
     });
@@ -209,7 +209,7 @@ describe('Static Filter', () => {
       expect(filter.isValueExcluded(value)).toBe(true);
     });
 
-    it('when the value state is selected, it returns true', () => {
+    it('when the value state is selected, it returns false', () => {
       const value = buildMockStaticFilterValue({state: 'selected'});
       expect(filter.isValueExcluded(value)).toBe(false);
     });
@@ -237,6 +237,15 @@ describe('Static Filter', () => {
     it('when at least one value is selected, it is true', () => {
       const id = options.id;
       const value = buildMockStaticFilterValue({state: 'selected'});
+      const slice = buildMockStaticFilterSlice({values: [value]});
+      engine.state.staticFilterSet = {[id]: slice};
+
+      expect(filter.state.hasActiveValues).toBe(true);
+    });
+
+    it('when at least one value is excluded, it is true', () => {
+      const id = options.id;
+      const value = buildMockStaticFilterValue({state: 'excluded'});
       const slice = buildMockStaticFilterSlice({values: [value]});
       engine.state.staticFilterSet = {[id]: slice};
 

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
@@ -2,6 +2,7 @@ import {executeSearch} from '../../features/search/search-actions';
 import {
   deselectAllStaticFilterValues,
   registerStaticFilter,
+  toggleExcludeStaticFilterValue,
   toggleSelectStaticFilterValue,
 } from '../../features/static-filter-set/static-filter-set-actions';
 import {staticFilterSetReducer as staticFilterSet} from '../../features/static-filter-set/static-filter-set-slice';
@@ -71,6 +72,24 @@ describe('Static Filter', () => {
     });
   });
 
+  describe('#toggleExclude', () => {
+    it('dispatches #toggleStaticFilterValue', () => {
+      const value = buildMockStaticFilterValue();
+      filter.toggleExclude(value);
+
+      const action = toggleExcludeStaticFilterValue({id: options.id, value});
+      expect(engine.actions).toContainEqual(action);
+    });
+
+    it('dispatches #executeSearch', () => {
+      const value = buildMockStaticFilterValue();
+      filter.toggleExclude(value);
+
+      const action = engine.findAsyncAction(executeSearch.pending);
+      expect(action).toBeTruthy();
+    });
+  });
+
   describe('#deselectAll', () => {
     it('dispatches #deselectAllStaticFilterValues', () => {
       filter.deselectAll();
@@ -120,15 +139,84 @@ describe('Static Filter', () => {
     });
   });
 
+  describe('#toggleSingleExcluded', () => {
+    it('with an idle value, it deselects all values and toggle excludes the value', () => {
+      const {id} = options;
+      const value = buildMockStaticFilterValue({state: 'idle'});
+      filter.toggleSingleExclude(value);
+
+      expect(engine.actions).toContainEqual(deselectAllStaticFilterValues(id));
+      expect(engine.actions).toContainEqual(
+        toggleExcludeStaticFilterValue({id, value})
+      );
+    });
+
+    it('with a selected value, it only toggle excludes the value', () => {
+      const {id} = options;
+      const value = buildMockStaticFilterValue({state: 'selected'});
+      filter.toggleSingleExclude(value);
+
+      expect(engine.actions).not.toContainEqual(
+        deselectAllStaticFilterValues(id)
+      );
+      expect(engine.actions).toContainEqual(
+        toggleExcludeStaticFilterValue({id, value})
+      );
+    });
+
+    it('with an excluded value, it only toggle excludes the value', () => {
+      const {id} = options;
+      const value = buildMockStaticFilterValue({state: 'excluded'});
+      filter.toggleSingleExclude(value);
+
+      expect(engine.actions).not.toContainEqual(
+        deselectAllStaticFilterValues(id)
+      );
+      expect(engine.actions).toContainEqual(
+        toggleExcludeStaticFilterValue({id, value})
+      );
+    });
+
+    it('dispatches #executeSearch', () => {
+      const value = buildMockStaticFilterValue();
+      filter.toggleSingleSelect(value);
+
+      const action = engine.findAsyncAction(executeSearch.pending);
+      expect(action).toBeTruthy();
+    });
+  });
+
   describe('#isValueSelected', () => {
     it('when the value state is selected, it returns true', () => {
       const value = buildMockStaticFilterValue({state: 'selected'});
       expect(filter.isValueSelected(value)).toBe(true);
     });
 
+    it('when the value state is excluded, it returns true', () => {
+      const value = buildMockStaticFilterValue({state: 'excluded'});
+      expect(filter.isValueSelected(value)).toBe(false);
+    });
+
     it('when the value state is idle, it returns false', () => {
       const value = buildMockStaticFilterValue({state: 'idle'});
       expect(filter.isValueSelected(value)).toBe(false);
+    });
+  });
+
+  describe('#isValueExcluded', () => {
+    it('when the value state is excluded, it returns true', () => {
+      const value = buildMockStaticFilterValue({state: 'excluded'});
+      expect(filter.isValueExcluded(value)).toBe(true);
+    });
+
+    it('when the value state is selected, it returns true', () => {
+      const value = buildMockStaticFilterValue({state: 'selected'});
+      expect(filter.isValueExcluded(value)).toBe(false);
+    });
+
+    it('when the value state is idle, it returns false', () => {
+      const value = buildMockStaticFilterValue({state: 'idle'});
+      expect(filter.isValueExcluded(value)).toBe(false);
     });
   });
 

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.test.ts
@@ -55,7 +55,7 @@ describe('Static Filter', () => {
     );
   });
   describe('#toggleSelect', () => {
-    it('dispatches #toggleStaticFilterValue', () => {
+    it('dispatches #toggleSelectStaticFilterValue', () => {
       const value = buildMockStaticFilterValue();
       filter.toggleSelect(value);
 
@@ -73,7 +73,7 @@ describe('Static Filter', () => {
   });
 
   describe('#toggleExclude', () => {
-    it('dispatches #toggleStaticFilterValue', () => {
+    it('dispatches #toggleExcludeStaticFilterValue', () => {
       const value = buildMockStaticFilterValue();
       filter.toggleExclude(value);
 

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.ts
@@ -7,6 +7,7 @@ import {
   logStaticFilterDeselect,
   logStaticFilterSelect,
   registerStaticFilter,
+  toggleExcludeStaticFilterValue,
   toggleSelectStaticFilterValue,
 } from '../../features/static-filter-set/static-filter-set-actions';
 import {
@@ -70,11 +71,25 @@ export interface StaticFilter extends Controller {
   toggleSelect(value: StaticFilterValue): void;
 
   /**
+   * Excludes the specified static filter value.
+   *
+   * @param value - The static filter value to toggle.
+   */
+  toggleExclude(value: StaticFilterValue): void;
+
+  /**
    * Toggles the specified static filter value, deselecting others.
    *
    * @param value - The static filter value to toggle.
    */
   toggleSingleSelect(value: StaticFilterValue): void;
+
+  /**
+   * Excludes the specified static filter value, deselecting others.
+   *
+   * @param value - The static filter value to toggle exclusion.
+   */
+  toggleSingleExclude(value: StaticFilterValue): void;
 
   /**
    * Deselects all static filter values.
@@ -88,6 +103,14 @@ export interface StaticFilter extends Controller {
    * @returns Whether the specified static filter value is selected.
    */
   isValueSelected(value: StaticFilterValue): boolean;
+
+  /**
+   * Checks whether the specified static filter value is excluded.
+   *
+   * @param value - The static filter value to check.
+   * @returns Whether the specified static filter value is excluded.
+   */
+  isValueExcluded(value: StaticFilterValue): boolean;
 
   /**
    * A state of the `StaticFilter` controller.
@@ -160,6 +183,24 @@ export function buildStaticFilter(
       dispatch(executeSearch(analytics));
     },
 
+    toggleExclude(value: StaticFilterValue) {
+      const analytics = getAnalyticsActionForToggledValue(id, value);
+
+      dispatch(toggleExcludeStaticFilterValue({id, value}));
+      dispatch(executeSearch(analytics));
+    },
+
+    toggleSingleExclude(value: StaticFilterValue) {
+      const analytics = getAnalyticsActionForToggledValue(id, value);
+
+      if (value.state === 'idle') {
+        dispatch(deselectAllStaticFilterValues(id));
+      }
+
+      dispatch(toggleExcludeStaticFilterValue({id, value}));
+      dispatch(executeSearch(analytics));
+    },
+
     deselectAll() {
       const analytics = logStaticFilterClearAll({staticFilterId: id});
 
@@ -169,6 +210,10 @@ export function buildStaticFilter(
 
     isValueSelected(value: StaticFilterValue) {
       return value.state === 'selected';
+    },
+
+    isValueExcluded(value: StaticFilterValue) {
+      return value.state === 'excluded';
     },
 
     get state() {

--- a/packages/headless/src/features/static-filter-set/static-filter-set-actions-loader.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-actions-loader.ts
@@ -7,6 +7,7 @@ import {
   toggleSelectStaticFilterValue,
   ToggleSelectStaticFilterValueActionCreatorPayload,
   deselectAllStaticFilterValues,
+  toggleExcludeStaticFilterValue,
 } from './static-filter-set-actions';
 
 export type {
@@ -39,6 +40,16 @@ export interface StaticFilterSetActionCreators {
   ): PayloadAction<ToggleSelectStaticFilterValueActionCreatorPayload>;
 
   /**
+   * Excludes a static filter value.
+   *
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  toggleExcludeStaticFilterValue(
+    payload: ToggleSelectStaticFilterValueActionCreatorPayload
+  ): PayloadAction<ToggleSelectStaticFilterValueActionCreatorPayload>;
+
+  /**
    * Deselects all values of a filter.
    *
    * @param id - The unique identifier of the static filter (e.g., `"abc"`).
@@ -61,6 +72,7 @@ export function loadStaticFilterSetActions(
   return {
     registerStaticFilter,
     toggleSelectStaticFilterValue,
+    toggleExcludeStaticFilterValue,
     deselectAllStaticFilterValues,
   };
 }

--- a/packages/headless/src/features/static-filter-set/static-filter-set-actions.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-actions.ts
@@ -60,6 +60,18 @@ export const toggleSelectStaticFilterValue = createAction(
   }
 );
 
+export const toggleExcludeStaticFilterValue = createAction(
+  'staticFilter/toggleExclude',
+  (payload: ToggleSelectStaticFilterValueActionCreatorPayload) => {
+    const schema = {
+      id: staticFilterIdSchema,
+      value: staticFilterValueSchema,
+    };
+
+    return validatePayload(payload, schema);
+  }
+);
+
 export const deselectAllStaticFilterValues = createAction(
   'staticFilter/deselectAllFilterValues',
   (payload: string) => {

--- a/packages/headless/src/features/static-filter-set/static-filter-set-schema.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-schema.ts
@@ -13,7 +13,7 @@ export const staticFilterValueSchema = new RecordValue({
     caption: requiredEmptyAllowedString,
     expression: requiredEmptyAllowedString,
     state: new StringValue<StaticFilterValueState>({
-      constrainTo: ['idle', 'selected'],
+      constrainTo: ['idle', 'selected', 'excluded'],
     }),
   },
 });

--- a/packages/headless/src/features/static-filter-set/static-filter-set-slice.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-slice.ts
@@ -4,6 +4,7 @@ import {restoreSearchParameters} from '../search-parameters/search-parameter-act
 import {
   deselectAllStaticFilterValues,
   registerStaticFilter,
+  toggleExcludeStaticFilterValue,
   toggleSelectStaticFilterValue,
 } from './static-filter-set-actions';
 import {getStaticFilterSetInitialState} from './static-filter-set-state';
@@ -38,6 +39,23 @@ export const staticFilterSetReducer = createReducer(
 
         const isSelected = target.state === 'selected';
         target.state = isSelected ? 'idle' : 'selected';
+      })
+      .addCase(toggleExcludeStaticFilterValue, (state, action) => {
+        const {id, value} = action.payload;
+        const filter = state[id];
+
+        if (!filter) {
+          return;
+        }
+
+        const target = filter.values.find((v) => v.caption === value.caption);
+
+        if (!target) {
+          return;
+        }
+
+        const isExcluded = target.state === 'excluded';
+        target.state = isExcluded ? 'idle' : 'excluded';
       })
       .addCase(deselectAllStaticFilterValues, (state, action) => {
         const id = action.payload;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2587

I got part-way through implementing value exclusion for the breadcrumb manager before realizing that I hadn't accounted  for static filters, so this PR addresses that 🙂

This is all fairly derivative of my other exclusion PRs, so you'll see many similar patterns/methods/UTs throughout (`toggleExclude`,`toggleSingleExclude`, `isValueExcluded`, etc)