### PR TITLE
feat(atomic): change padding in result list

### DIFF
--- a/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.pcss
+++ b/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.pcss
@@ -2,5 +2,5 @@
 @import '../styles/list-display.pcss';
 
 .list-root {
-  padding: 1.5rem 1.5rem 0 1.5rem;
+  @apply p-0;
 }


### PR DESCRIPTION
[SVCC-3079](https://coveord.atlassian.net/browse/SVCC-3079)

Add the padding change made previously on `atomic-insight-folded-result-list` to `atomic-insight-result-list` to be consistent for the moment. and so that the hover works properly as we are still using `atomic-insight-result-list` instead of `atomic-insight-folded-result-list`

**BEFORE:** When using `atomic-insight-result-list `
![Screenshot 2023-07-13 at 9 57 48 AM](https://github.com/coveo/ui-kit/assets/119955059/57d2cb7b-a64d-402a-bbd5-59ca06a2e7a0)

**AFTER:**

![Screenshot 2023-07-13 at 9 57 13 AM](https://github.com/coveo/ui-kit/assets/119955059/82b502a6-1886-4084-a880-49dcde38d36c)

[SVCC-3079]: https://coveord.atlassian.net/browse/SVCC-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ