### PR TITLE
docs: build storybook on release

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -41,7 +41,7 @@
     "e2e:snapshots:watch": "cypress open --config-file cypress-screenshots.config.ts --browser chrome",
     "e2e:insight": "cypress run --config-file cypress-insight-panel.config.ts --browser chrome",
     "e2e:insight:watch": "cypress open --config-file cypress-insight-panel.config.ts --browser chrome",
-    "release:phase1": "npx -p=@coveo/release bump",
+    "release:phase1": "npm run build --prefix ../../utils/atomic-storybook && npm npx -p=@coveo/release bump",
     "release:phase2": "npx -p=@coveo/release npm-publish",
     "promote:npm:latest": "node ../../scripts/deploy/update-npm-tag.mjs latest",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts"


### PR DESCRIPTION
The problem for storybook is that when you look at what's available in s3, it's on old version without recent bugfixes done in the storybook project.

I *think* it's because we did not rebuild it on release. I'll try a release to see if it fixes...

https://coveord.atlassian.net/browse/KIT-2574