### PR TITLE
refactor: change automatic facet set pattern to 'slice' 

### DIFF
--- a/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.test.ts
@@ -2,6 +2,7 @@ import {restoreSearchParameters} from '../../../features/search-parameters/searc
 import {initialSearchParameterSelector} from '../../../features/search-parameters/search-parameter-selectors';
 import {buildMockSearchAppEngine, MockSearchEngine} from '../../../test';
 import {buildMockAutomaticFacetResponse} from '../../../test/mock-automatic-facet-response';
+import {buildMockAutomaticFacetSlice} from '../../../test/mock-automatic-facet-slice';
 import {buildMockCategoryFacetRequest} from '../../../test/mock-category-facet-request';
 import {buildMockCategoryFacetSlice} from '../../../test/mock-category-facet-slice';
 import {buildMockCategoryFacetValueRequest} from '../../../test/mock-category-facet-value-request';
@@ -232,16 +233,17 @@ describe('search parameter manager', () => {
       const idle = buildMockFacetValue({value: 'b', state: 'idle'});
 
       const currentValues = [selected, idle];
-      engine.state.automaticFacetSet.facets = {
-        author: buildMockAutomaticFacetResponse({values: currentValues}),
-      };
+      const slice = buildMockAutomaticFacetSlice({
+        response: buildMockAutomaticFacetResponse({values: currentValues}),
+      });
+      engine.state.automaticFacetSet.set = {author: slice};
 
       expect(manager.state.parameters.af).toEqual({author: ['a']});
     });
 
     it('is not included when there are no facets with selected values', () => {
-      engine.state.automaticFacetSet.facets = {
-        author: buildMockAutomaticFacetResponse(),
+      engine.state.automaticFacetSet.set = {
+        author: buildMockAutomaticFacetSlice(),
       };
       expect(manager.state.parameters).not.toContain('af');
     });
@@ -304,9 +306,10 @@ describe('search parameter manager', () => {
     engine.state.tabSet = {a: tab};
 
     const automaticFacetValues = [buildMockFacetValue({state: 'selected'})];
-    engine.state.automaticFacetSet.facets = {
-      a: buildMockAutomaticFacetResponse({values: automaticFacetValues}),
-    };
+    const slice = buildMockAutomaticFacetSlice({
+      response: buildMockAutomaticFacetResponse({values: automaticFacetValues}),
+    });
+    engine.state.automaticFacetSet.set = {a: slice};
 
     engine.state.query.q = 'a';
     engine.state.sortCriteria = 'qre';

--- a/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.ts
@@ -117,7 +117,7 @@ export function enrichParameters(
 export function validateParams(
   engine: CoreEngine,
   parameters: Required<SearchParameters>
-): Boolean {
+): boolean {
   return validateTab(engine, parameters);
 }
 
@@ -148,7 +148,7 @@ function getQ(state: Partial<SearchParametersState>) {
 }
 
 function getTab(state: Partial<SearchParametersState>) {
-  const activeTab = Object.values(state.tabSet || {}).find(
+  const activeTab = Object.values(state.tabSet ?? {}).find(
     (tab) => tab.isActive
   );
 
@@ -214,7 +214,7 @@ function getCategoryFacets(state: Partial<SearchParametersState>) {
     .filter(([facetId]) => state.facetOptions?.facets[facetId]?.enabled ?? true)
     .map(([facetId, slice]) => {
       const {parents} = partitionIntoParentsAndValues(
-        slice!.request.currentValues
+        slice.request.currentValues
       );
       const selectedValues = parents.map((p) => p.value);
 
@@ -262,12 +262,13 @@ function getSelectedRanges<T extends RangeValueRequest>(ranges: T[]) {
 }
 
 function getAutomaticFacets(state: Partial<SearchParametersState>) {
-  if (state.automaticFacetSet?.facets === undefined) {
+  const set = state.automaticFacetSet?.set;
+  if (set === undefined) {
     return {};
   }
-  const af = Object.entries(state.automaticFacetSet.facets)
-    .map(([facetId, {values}]) => {
-      const selectedValues = getSelectedValues(values);
+  const af = Object.entries(set)
+    .map(([facetId, {response}]) => {
+      const selectedValues = getSelectedValues(response.values);
       return selectedValues.length ? {[facetId]: selectedValues} : {};
     })
     .reduce((acc, obj) => ({...acc, ...obj}), {});

--- a/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.test.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.test.ts
@@ -9,7 +9,7 @@ import {
   buildMockSearchAppEngine,
   createMockState,
 } from '../../../test';
-import {buildMockAutomaticFacetResponse} from '../../../test/mock-automatic-facet-response';
+import {buildMockAutomaticFacetSlice} from '../../../test/mock-automatic-facet-slice';
 import {buildMockFacetValue} from '../../../test/mock-facet-value';
 
 describe('automatic facet', () => {
@@ -27,7 +27,7 @@ describe('automatic facet', () => {
   }
 
   function setAutomaticFacet() {
-    state.automaticFacetSet.facets[field] = buildMockAutomaticFacetResponse();
+    state.automaticFacetSet.set[field] = buildMockAutomaticFacetSlice();
   }
 
   beforeEach(() => {

--- a/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
@@ -88,7 +88,8 @@ export function buildAutomaticFacet(
   const controller = buildController(engine);
 
   const {field} = props;
-  const getFacetResponse = () => engine.state.automaticFacetSet?.facets[field];
+  const getFacetResponse = () =>
+    engine.state.automaticFacetSet?.set[field]?.response;
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.test.ts
@@ -3,6 +3,7 @@ import {initialSearchParameterSelector} from '../../features/search-parameters/s
 import {executeSearch} from '../../features/search/search-actions';
 import {buildMockSearchAppEngine, MockSearchEngine} from '../../test';
 import {buildMockAutomaticFacetResponse} from '../../test/mock-automatic-facet-response';
+import {buildMockAutomaticFacetSlice} from '../../test/mock-automatic-facet-slice';
 import {buildMockCategoryFacetRequest} from '../../test/mock-category-facet-request';
 import {buildMockCategoryFacetSlice} from '../../test/mock-category-facet-slice';
 import {buildMockCategoryFacetValueRequest} from '../../test/mock-category-facet-value-request';
@@ -205,8 +206,12 @@ describe('search parameter manager', () => {
     engine.state.tabSet = {a: tab};
 
     const automaticFacetValues = [buildMockFacetValue({state: 'selected'})];
-    engine.state.automaticFacetSet.facets = {
-      a: buildMockAutomaticFacetResponse({values: automaticFacetValues}),
+    engine.state.automaticFacetSet.set = {
+      a: buildMockAutomaticFacetSlice({
+        response: buildMockAutomaticFacetResponse({
+          values: automaticFacetValues,
+        }),
+      }),
     };
 
     engine.state.query.q = 'a';

--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
@@ -1,4 +1,5 @@
 import {buildMockAutomaticFacetResponse} from '../../../test/mock-automatic-facet-response';
+import {buildMockAutomaticFacetSlice} from '../../../test/mock-automatic-facet-slice';
 import {buildMockFacetValue} from '../../../test/mock-facet-value';
 import {buildMockSearch} from '../../../test/mock-search';
 import {logSearchEvent} from '../../analytics/analytics-actions';
@@ -13,6 +14,7 @@ import {
 import {automaticFacetSetReducer} from './automatic-facet-set-slice';
 import {
   AutomaticFacetSetState,
+  AutomaticFacetSlice,
   getAutomaticFacetSetInitialState,
 } from './automatic-facet-set-state';
 import {AutomaticFacetResponse} from './interfaces/response';
@@ -45,14 +47,14 @@ describe('automatic-facet-set slice', () => {
       const facets: AutomaticFacetResponse[] = [
         buildMockAutomaticFacetResponse(),
       ];
-      const facetsRecord: Record<string, AutomaticFacetResponse> = {
-        [facets[0].field]: facets[0],
+      const facetsRecord: Record<string, AutomaticFacetSlice> = {
+        [facets[0].field]: {response: facets[0]},
       };
       const action = buildExecuteSearchAction(facets);
 
       const finalState = automaticFacetSetReducer(state, action);
 
-      expect(finalState.facets).toEqual(facetsRecord);
+      expect(finalState.set).toEqual(facetsRecord);
     });
   });
 
@@ -74,14 +76,16 @@ describe('automatic-facet-set slice', () => {
 
       const finalState = automaticFacetSetReducer(state, action);
 
-      expect(finalState.facets).toEqual(state.facets);
+      expect(finalState.set).toEqual(state.set);
     });
 
     it('does nothing if it cannot find the value', () => {
-      const facet = buildMockAutomaticFacetResponse({
+      const response = buildMockAutomaticFacetResponse({
         values: [buildMockFacetValue({value: 'valuePresent'})],
       });
-      state.facets = {[facet.field]: facet};
+      const slice = buildMockAutomaticFacetSlice({response});
+
+      state.set = {[response.field]: slice};
       const action = toggleSelectAutomaticFacetValue({
         field: 'fieldPresent',
         selection: buildMockFacetValue({value: 'valueNotPresent'}),
@@ -89,7 +93,7 @@ describe('automatic-facet-set slice', () => {
 
       const finalState = automaticFacetSetReducer(state, action);
 
-      expect(finalState.facets).toEqual(state.facets);
+      expect(finalState.set).toEqual(state.set);
     });
 
     describe('toggles the value if', () => {
@@ -102,11 +106,13 @@ describe('automatic-facet-set slice', () => {
         });
       }
       function addFacetToState(valueState: FacetValueState) {
-        const facet = buildMockAutomaticFacetResponse({
+        const response = buildMockAutomaticFacetResponse({
           field,
           values: [buildMockFacetValue({value, state: valueState})],
         });
-        state.facets[field] = facet;
+        const slice = buildMockAutomaticFacetSlice({response});
+
+        state.set[field] = slice;
       }
 
       it('is "selected"', () => {
@@ -114,7 +120,7 @@ describe('automatic-facet-set slice', () => {
         const action = buildToggleSelectAutomaticFacetValueAction();
 
         const finalState = automaticFacetSetReducer(state, action);
-        const targetValue = finalState.facets[field].values.find(
+        const targetValue = finalState.set[field].response.values.find(
           (req) => req.value === value
         );
 
@@ -126,7 +132,7 @@ describe('automatic-facet-set slice', () => {
         const action = buildToggleSelectAutomaticFacetValueAction();
 
         const finalState = automaticFacetSetReducer(state, action);
-        const targetValue = finalState.facets[field].values.find(
+        const targetValue = finalState.set[field].response.values.find(
           (req) => req.value === value
         );
 
@@ -141,23 +147,25 @@ describe('automatic-facet-set slice', () => {
 
       const finalState = automaticFacetSetReducer(state, action);
 
-      expect(finalState.facets).toEqual(state.facets);
+      expect(finalState.set).toEqual(state.set);
     });
 
     it('puts all values to "idle"', () => {
       const field = 'field';
-      const facet = buildMockAutomaticFacetResponse({
+      const response = buildMockAutomaticFacetResponse({
         field,
         values: [
           buildMockFacetValue({value: 'value1', state: 'selected'}),
           buildMockFacetValue({value: 'value2', state: 'selected'}),
         ],
       });
-      state.facets[field] = facet;
+      const slice = buildMockAutomaticFacetSlice({response});
+
+      state.set[field] = slice;
       const action = deselectAllAutomaticFacetValues(field);
 
       const finalState = automaticFacetSetReducer(state, action);
-      const targetValues = finalState.facets[field].values;
+      const targetValues = finalState.set[field].response.values;
 
       expect(targetValues.every((value) => value.state === 'idle')).toEqual(
         true
@@ -176,7 +184,7 @@ describe('automatic-facet-set slice', () => {
       const finalState = automaticFacetSetReducer(state, action);
       const selectedValue = buildMockFacetValue({value, state: 'selected'});
 
-      expect(finalState.facets[field].values).toEqual([selectedValue]);
+      expect(finalState.set[field].response.values).toEqual([selectedValue]);
     });
   });
 });

--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.ts
@@ -15,11 +15,11 @@ export const automaticFacetSetReducer = createReducer(
   (builder) => {
     builder
       .addCase(executeSearch.fulfilled, (state, action) => {
-        state.facets = {};
+        state.set = {};
 
         const facets = action.payload.response.generateAutomaticFacets?.facets;
-        facets?.forEach((facet) => {
-          state.facets[facet.field] = facet;
+        facets?.forEach((response) => {
+          state.set[response.field] = {response};
         });
       })
       .addCase(setDesiredCount, (state, action) => {
@@ -27,7 +27,7 @@ export const automaticFacetSetReducer = createReducer(
       })
       .addCase(toggleSelectAutomaticFacetValue, (state, action) => {
         const {field, selection} = action.payload;
-        const facet = state.facets[field];
+        const facet = state.set[field]?.response;
 
         if (!facet) {
           return;
@@ -43,7 +43,7 @@ export const automaticFacetSetReducer = createReducer(
       })
       .addCase(deselectAllAutomaticFacetValues, (state, action) => {
         const field = action.payload;
-        const facet = state.facets[field];
+        const facet = state.set[field]?.response;
 
         if (!facet) {
           return;
@@ -62,7 +62,7 @@ export const automaticFacetSetReducer = createReducer(
           );
           response.values.push(...values);
 
-          state.facets[field] = response;
+          state.set[field] = {response};
         }
       });
   }

--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-state.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-state.ts
@@ -1,5 +1,9 @@
 import {AutomaticFacetResponse} from './interfaces/response';
 
+export type AutomaticFacetSlice = {
+  response: AutomaticFacetResponse;
+};
+
 export type AutomaticFacetSetState = {
   /**
    * The desired count of facets.
@@ -7,14 +11,14 @@ export type AutomaticFacetSetState = {
    */
   desiredCount: number;
   /**
-   * A map of automatic facet field to an automatic facet response.
+   * A map of automatic facet field to an automatic facet slice containing the response.
    */
-  facets: Record<string, AutomaticFacetResponse>;
+  set: Record<string, AutomaticFacetSlice>;
 };
 
 export function getAutomaticFacetSetInitialState(): AutomaticFacetSetState {
   return {
     desiredCount: 1,
-    facets: {},
+    set: {},
   };
 }

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.ts
@@ -186,7 +186,9 @@ const getFacetRequests = (state: SectionNeededForFacetMetadata) => {
 const getAutomaticFacets = (
   state: SectionNeededForFacetMetadata
 ): AutomaticFacetResponse[] => {
-  return [...Object.values(state.automaticFacetSet.facets)];
+  return [...Object.values(state.automaticFacetSet.set)].map(
+    (facet) => facet.response
+  );
 };
 
 const mapFacetValueToAnalytics = (
@@ -286,7 +288,7 @@ const getFacetRequest = (
     state.categoryFacetSet[facetId]?.request ||
     state.dateFacetSet[facetId]?.request ||
     state.numericFacetSet[facetId]?.request ||
-    state.automaticFacetSet.facets[facetId]
+    state.automaticFacetSet.set[facetId]?.response
   );
 };
 

--- a/packages/headless/src/features/history/history-slice.test.ts
+++ b/packages/headless/src/features/history/history-slice.test.ts
@@ -1,6 +1,7 @@
 import {Reducer} from '@reduxjs/toolkit';
 import {undoable, StateWithHistory, makeHistory} from '../../app/undoable';
 import {buildMockAdvancedSearchQueriesState} from '../../test/mock-advanced-search-queries-state';
+import {buildMockAutomaticFacetSlice} from '../../test/mock-automatic-facet-slice';
 import {buildMockCategoryFacetRequest} from '../../test/mock-category-facet-request';
 import {buildMockCategoryFacetSlice} from '../../test/mock-category-facet-slice';
 import {buildMockCategoryFacetValueRequest} from '../../test/mock-category-facet-value-request';
@@ -80,7 +81,10 @@ describe('history slice', () => {
       numericFacetSet: {bar: buildMockNumericFacetSlice()},
       dateFacetSet: {foo: buildMockDateFacetSlice()},
       categoryFacetSet: {foo: buildMockCategoryFacetSlice()},
-      automaticFacetSet: {desiredCount: 5, facets: {}},
+      automaticFacetSet: {
+        desiredCount: 5,
+        set: {foo: buildMockAutomaticFacetSlice()},
+      },
       facetOptions: {freezeFacetOrder: false, facets: {}},
       pagination: {
         firstResult: 123,

--- a/packages/headless/src/features/search/search-request.ts
+++ b/packages/headless/src/features/search/search-request.ts
@@ -77,10 +77,12 @@ function getFacets(state: StateNeededBySearchRequest) {
 }
 
 function getAutomaticFacets(state: StateNeededBySearchRequest) {
-  const facets = state.automaticFacetSet?.facets;
+  const facets = state.automaticFacetSet?.set;
 
   return facets
-    ? Object.values(facets).map(responseToAutomaticFacetRequest)
+    ? Object.values(facets)
+        .map((facet) => facet.response)
+        .map(responseToAutomaticFacetRequest)
     : undefined;
 }
 function responseToAutomaticFacetRequest(

--- a/packages/headless/src/test/mock-automatic-facet-slice.ts
+++ b/packages/headless/src/test/mock-automatic-facet-slice.ts
@@ -1,0 +1,11 @@
+import {AutomaticFacetSlice} from '../features/facets/automatic-facet-set/automatic-facet-set-state';
+import {buildMockAutomaticFacetResponse} from './mock-automatic-facet-response';
+
+export function buildMockAutomaticFacetSlice(
+  config: Partial<AutomaticFacetSlice> = {}
+): AutomaticFacetSlice {
+  return {
+    response: buildMockAutomaticFacetResponse(),
+    ...config,
+  };
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2596

During the implementation of the breadbox, I came across the type AnyFacetSlice and there was no ‘slice’ in my implementation. I think its better if it all matches the pattern even though it is a extra object (slice and response).

This PR has the url manager pull request #3033  as a base. I will wait for it to be merged before than switching the base to master and merging it.

Right now : 
```
automaticFacetSet.facets : Record<string, AutomaticFacetResponse>;
```

change it to 
```
automaticFacetSet.set : Record<string, AutomaticFacetSlice>;

AutomaticFacetSlice {
    response: AutomaticFacetResponse;
}
```