### PR TITLE
fix(atomic): Grid cell results prevent interaction with clickable children

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -1080,14 +1080,14 @@ export declare interface AtomicResultList extends Components.AtomicResultList {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['density', 'display', 'imageSize'],
+  inputs: ['density', 'display', 'imageSize', 'target'],
   methods: ['setRenderFunction']
 })
 @Component({
   selector: 'atomic-result-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['density', 'display', 'imageSize']
+  inputs: ['density', 'display', 'imageSize', 'target']
 })
 export class AtomicResultList {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -9,7 +9,7 @@ import { AutomaticFacet, CategoryFacetSortCriterion, FacetSortCriterion, FoldedR
 import { AnyBindings } from "./components/common/interface/bindings";
 import { DateFilter, DateFilterState, NumericFilter, NumericFilterState, RelativeDateUnit } from "./components/common/types";
 import { NumberInputType } from "./components/common/facets/facet-number-input/number-input-type";
-import { ResultDisplayBasicLayout, ResultDisplayDensity, ResultDisplayImageSize, ResultDisplayLayout } from "./components/common/layout/display-options";
+import { ResultDisplayBasicLayout, ResultDisplayDensity, ResultDisplayImageSize, ResultDisplayLayout, ResultTarget } from "./components/common/layout/display-options";
 import { ResultRenderingFunction } from "./components/common/result-list/result-list-common-interface";
 import { InsightEngine, InsightFacetSortCriterion, InsightFoldedResult, InsightInteractiveResult, InsightLogLevel, InsightRangeFacetRangeAlgorithm, InsightRangeFacetSortCriterion, InsightResult, InsightResultTemplate, InsightResultTemplateCondition, PlatformEnvironmentInsight } from "./components/insight";
 import { FacetDisplayValues } from "./components/common/facets/facet-common";
@@ -322,6 +322,11 @@ export namespace Components {
           * Sets a rendering function to bypass the standard HTML template mechanism for rendering results. You can use this function while working with web frameworks that don't use plain HTML syntax, e.g., React, Angular or Vue.  Do not use this method if you integrate Atomic in a plain HTML deployment.
          */
         "setRenderFunction": (resultRenderingFunction: ResultRenderingFunction) => Promise<void>;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target": ResultTarget;
     }
     interface AtomicFormatCurrency {
         /**
@@ -455,6 +460,11 @@ export namespace Components {
           * Sets a rendering function to bypass the standard HTML template mechanism for rendering results. You can use this function while working with web frameworks that don't use plain HTML syntax, e.g., React, Angular or Vue.  Do not use this method if you integrate Atomic in a plain HTML deployment.
          */
         "setRenderFunction": (resultRenderingFunction: ResultRenderingFunction) => Promise<void>;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target": ResultTarget;
     }
     interface AtomicInsightFullSearchButton {
         "tooltip": string;
@@ -690,6 +700,11 @@ export namespace Components {
           * @param resultRenderingFunction
          */
         "setRenderFunction": (resultRenderingFunction: ResultRenderingFunction) => Promise<void>;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target": ResultTarget;
     }
     interface AtomicInsightResultTemplate {
         /**
@@ -1250,6 +1265,11 @@ export namespace Components {
           * @param resultRenderingFunction
          */
         "setRenderFunction": (resultRenderingFunction: ResultRenderingFunction) => Promise<void>;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target": ResultTarget;
     }
     interface AtomicRecsResult {
         /**
@@ -1476,6 +1496,11 @@ export namespace Components {
           * @param resultRenderingFunction
          */
         "setRenderFunction": (resultRenderingFunction: ResultRenderingFunction) => Promise<void>;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target": ResultTarget;
     }
     interface AtomicResultLocalizedText {
         /**
@@ -3295,6 +3320,11 @@ declare namespace LocalJSX {
           * @defaultValue `foldingparent`
          */
         "parentField"?: string;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target"?: ResultTarget;
     }
     interface AtomicFormatCurrency {
         /**
@@ -3424,6 +3454,11 @@ declare namespace LocalJSX {
           * @defaultValue `foldingparent`
          */
         "parentField"?: string;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target"?: ResultTarget;
     }
     interface AtomicInsightFullSearchButton {
         "tooltip"?: string;
@@ -3633,6 +3668,11 @@ declare namespace LocalJSX {
           * The expected size of the image displayed in the results.
          */
         "imageSize"?: ResultDisplayImageSize;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target"?: ResultTarget;
     }
     interface AtomicInsightResultTemplate {
         /**
@@ -4162,6 +4202,11 @@ declare namespace LocalJSX {
           * The Recommendation identifier used by the Coveo platform to retrieve recommended documents. Make sure to set a different value for each atomic-recs-list in your page.
          */
         "recommendation"?: string;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target"?: ResultTarget;
     }
     interface AtomicRecsResult {
         /**
@@ -4376,6 +4421,11 @@ declare namespace LocalJSX {
           * The expected size of the image displayed in the results.
          */
         "imageSize"?: ResultDisplayImageSize;
+        /**
+          * Where to open the result link.
+          * @defaultValue `_blank`
+         */
+        "target"?: ResultTarget;
     }
     interface AtomicResultLocalizedText {
         /**

--- a/packages/atomic/src/components/common/button.tsx
+++ b/packages/atomic/src/components/common/button.tsx
@@ -8,7 +8,7 @@ import {
 
 export interface ButtonProps {
   style: ButtonStyle;
-  onClick?(): void;
+  onClick?(event?: MouseEvent): void;
   class?: string;
   text?: string;
   part?: string;

--- a/packages/atomic/src/components/common/layout/display-options.ts
+++ b/packages/atomic/src/components/common/layout/display-options.ts
@@ -4,6 +4,7 @@ export type ResultDisplayBasicLayout = 'list' | 'grid';
 export type ResultDisplayLayout = ResultDisplayBasicLayout | 'table';
 export type ResultDisplayDensity = 'comfortable' | 'normal' | 'compact';
 export type ResultDisplayImageSize = 'large' | 'small' | 'icon' | 'none';
+export type ResultTarget = '_self' | '_blank' | '_parent' | '_top';
 
 function getDisplayClass(display: ResultDisplayLayout) {
   switch (display) {

--- a/packages/atomic/src/components/common/result-list/grid-display-results.tsx
+++ b/packages/atomic/src/components/common/result-list/grid-display-results.tsx
@@ -1,6 +1,5 @@
 import {FunctionalComponent, h} from '@stencil/core';
 import {extractUnfoldedResult} from '../interface/result';
-import {LinkWithResultAnalytics} from '../result-link/result-link';
 import {ResultListDisplayProps} from './result-list-common-interface';
 
 export const GridDisplayResults: FunctionalComponent<ResultListDisplayProps> = (
@@ -14,17 +13,12 @@ export const GridDisplayResults: FunctionalComponent<ResultListDisplayProps> = (
       <div
         part="result-list-grid-clickable-container outline"
         ref={(element) => props.setNewResultRef(element!, index)}
+        onClick={(event) => {
+          event.preventDefault();
+          interactiveResult.select();
+          location.assign(unfoldedResult.clickUri);
+        }}
       >
-        <LinkWithResultAnalytics
-          part="result-list-grid-clickable"
-          onSelect={() => interactiveResult.select()}
-          onBeginDelayedSelect={() => interactiveResult.beginDelayedSelect()}
-          onCancelPendingSelect={() => interactiveResult.cancelPendingSelect()}
-          href={unfoldedResult.clickUri}
-          title={unfoldedResult.title}
-          tabIndex={-1}
-          ariaHidden={true}
-        />
         {props.renderResult({
           key: props.getResultId(result),
           result: result,

--- a/packages/atomic/src/components/common/result-list/grid-display-results.tsx
+++ b/packages/atomic/src/components/common/result-list/grid-display-results.tsx
@@ -16,7 +16,7 @@ export const GridDisplayResults: FunctionalComponent<ResultListDisplayProps> = (
         onClick={(event) => {
           event.preventDefault();
           interactiveResult.select();
-          location.assign(unfoldedResult.clickUri);
+          window.open(unfoldedResult.clickUri, props.target);
         }}
       >
         {props.renderResult({

--- a/packages/atomic/src/components/common/result-list/result-list-common-interface.ts
+++ b/packages/atomic/src/components/common/result-list/result-list-common-interface.ts
@@ -8,6 +8,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayLayout,
+  ResultTarget,
 } from '../layout/display-options';
 import {ResultTemplateProvider} from './result-template-provider';
 
@@ -25,6 +26,7 @@ export interface ResultListCommonProps<
   loadingFlag: string;
   resultTemplateProvider: ResultTemplateProvider;
   nextNewResultTarget: FocusTargetController;
+  target: ResultTarget;
   getLayoutDisplay(): ResultDisplayLayout;
   getResultDisplay(): ResultDisplayLayout;
   getDensity(): ResultDisplayDensity;

--- a/packages/atomic/src/components/common/result-list/styles/mixins.pcss
+++ b/packages/atomic/src/components/common/result-list/styles/mixins.pcss
@@ -150,6 +150,7 @@
         &:hover {
           border: 1px solid var(--atomic-neutral);
           box-shadow: 0px 10px 25px var(--atomic-neutral);
+          cursor: pointer;
         }
       }
     }

--- a/packages/atomic/src/components/insight/result-lists/atomic-insight-folded-result-list/atomic-insight-folded-result-list.tsx
+++ b/packages/atomic/src/components/insight/result-lists/atomic-insight-folded-result-list/atomic-insight-folded-result-list.tsx
@@ -33,6 +33,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayLayout,
+  ResultTarget,
 } from '../../../common/layout/display-options';
 import {ResultListCommon} from '../../../common/result-list/result-list-common';
 import {ResultRenderingFunction} from '../../../common/result-list/result-list-common-interface';
@@ -81,6 +82,11 @@ export class AtomicInsightFoldedResultList
    * The expected size of the image displayed in the results.
    */
   @Prop({reflect: true}) imageSize: ResultDisplayImageSize = 'icon';
+  /**
+   * Where to open the result link.
+   * @defaultValue `_blank`
+   */
+  @Prop() target: ResultTarget = '_blank';
   /**
    * The name of the field on which to do the folding. The folded result list component will use the values of this field to resolve the collections of result items.
    *
@@ -154,6 +160,7 @@ export class AtomicInsightFoldedResultList
       getNumberOfPlaceholders: () => this.resultsPerPageState.numberOfResults,
       host: this.host,
       bindings: this.bindings,
+      target: this.target,
       getDensity: () => this.density,
       getResultDisplay: () => this.display,
       getLayoutDisplay: () => this.display,

--- a/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.tsx
+++ b/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.tsx
@@ -25,6 +25,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayLayout,
+  ResultTarget,
 } from '../../../common/layout/display-options';
 import {ResultListCommon} from '../../../common/result-list/result-list-common';
 import {ResultRenderingFunction} from '../../../common/result-list/result-list-common-interface';
@@ -74,6 +75,12 @@ export class AtomicInsightResultList
   @Prop({reflect: true}) imageSize: ResultDisplayImageSize = 'icon';
 
   /**
+   * Where to open the result link.
+   * @defaultValue `_blank`
+   */
+  @Prop() target: ResultTarget = '_blank';
+
+  /**
    * Sets a rendering function to bypass the standard HTML template mechanism for rendering results.
    * You can use this function while working with web frameworks that don't use plain HTML syntax, e.g., React, Angular or Vue.
    *
@@ -116,6 +123,7 @@ export class AtomicInsightResultList
       getNumberOfPlaceholders: () => this.resultsPerPageState.numberOfResults,
       host: this.host,
       bindings: this.bindings,
+      target: this.target,
       getDensity: () => this.density,
       getResultDisplay: () => this.display,
       getLayoutDisplay: () => this.display,

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
@@ -32,6 +32,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayBasicLayout,
+  ResultTarget,
 } from '../../common/layout/display-options';
 import {ResultListCommon} from '../../common/result-list/result-list-common';
 import {
@@ -90,6 +91,11 @@ export class AtomicRecsList implements InitializableComponent<RecsBindings> {
    * To modify the number of recommendations per column, modify the --atomic-recs-number-of-columns CSS variable.
    */
   @Prop({reflect: true}) public display: ResultDisplayBasicLayout = 'list';
+  /**
+   * Where to open the result link.
+   * @defaultValue `_blank`
+   */
+  @Prop() target: ResultTarget = '_blank';
   /**
    * The spacing of various elements in the result list, including the gap between results, the gap between parts of a result, and the font sizes of different parts in a result.
    */
@@ -190,6 +196,7 @@ export class AtomicRecsList implements InitializableComponent<RecsBindings> {
         this.numberOfRecommendationsPerPage ?? this.numberOfRecommendations,
       host: this.host,
       bindings: this.bindings,
+      target: this.target,
       getDensity: () => this.density,
       getLayoutDisplay: () => 'grid',
       getResultDisplay: () => this.display,

--- a/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.tsx
@@ -33,6 +33,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayLayout,
+  ResultTarget,
 } from '../../../common/layout/display-options';
 import {ResultListCommon} from '../../../common/result-list/result-list-common';
 import {ResultRenderingFunction} from '../../../common/result-list/result-list-common-interface';
@@ -82,6 +83,11 @@ export class AtomicFoldedResultList implements InitializableComponent {
    * The expected size of the image displayed in the results.
    */
   @Prop({reflect: true}) imageSize: ResultDisplayImageSize = 'icon';
+  /**
+   * Where to open the result link.
+   * @defaultValue `_blank`
+   */
+  @Prop() target: ResultTarget = '_blank';
   /**
    * The name of the field on which to do the folding. The folded result list component will use the values of this field to resolve the collections of result items.
    *
@@ -161,6 +167,7 @@ export class AtomicFoldedResultList implements InitializableComponent {
       getImageSize: () => this.imageSize,
       nextNewResultTarget: this.nextNewResultTarget,
       loadingFlag: this.loadingFlag,
+      target: this.target,
       getResultListState: () => this.foldedResultListState,
       getResultRenderingFunction: () => this.resultRenderingFunction,
       renderResult: (props) => <atomic-result {...props}></atomic-result>,

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -23,6 +23,7 @@ import {
   ResultDisplayDensity,
   ResultDisplayImageSize,
   ResultDisplayLayout,
+  ResultTarget,
 } from '../../../common/layout/display-options';
 import {ResultListCommon} from '../../../common/result-list/result-list-common';
 import {ResultRenderingFunction} from '../../../common/result-list/result-list-common-interface';
@@ -81,6 +82,13 @@ export class AtomicResultList implements InitializableComponent {
    * The spacing of various elements in the result list, including the gap between results, the gap between parts of a result, and the font sizes of different parts in a result.
    */
   @Prop({reflect: true}) public density: ResultDisplayDensity = 'normal';
+
+  /**
+   * Where to open the result link.
+   * @defaultValue `_blank`
+   */
+  @Prop() target: ResultTarget = '_blank';
+
   /**
    * The expected size of the image displayed in the results.
    */
@@ -128,6 +136,7 @@ export class AtomicResultList implements InitializableComponent {
     this.resultListCommon = new ResultListCommon({
       resultTemplateProvider,
       getNumberOfPlaceholders: () => this.resultsPerPageState.numberOfResults,
+      target: this.target,
       host: this.host,
       bindings: this.bindings,
       getDensity: () => this.density,

--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -126,7 +126,8 @@ export class AtomicQuickview implements InitializableComponent {
     }
   }
 
-  private onClick() {
+  private onClick(event?: MouseEvent) {
+    event?.stopPropagation();
     this.quickview.fetchResultContent();
   }
 
@@ -139,7 +140,7 @@ export class AtomicQuickview implements InitializableComponent {
           title={this.bindings.i18n.t('quickview')}
           style="outline-primary"
           class="p-2"
-          onClick={() => this.onClick()}
+          onClick={(event) => this.onClick(event)}
           ref={this.buttonFocusTarget.setTarget}
         >
           <atomic-icon class="w-5" icon={QuickviewIcon}></atomic-icon>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2597

Originally, the quickview button was un-clickable when using the grid display for `atomic-result-list`. At first, I was thinking about fixing this by simply using z-index such that the button gets rendered above the card, but this could introduce problems for implementers, so I instead went with the [W3C approach](https://design-system.w3.org/components/cards.html). This means we open links programatically, which ensures that when a child container is clicked, it doesn't also trigger the parent container `onClick` event.

One problem I had was having to add the `target` property to the `ResultListCommonProps` interface such that implementers are able to specify a `target` attribute as a part of the `atomic-result-list` tag. Implementing this was fine, but I'm not super happy about adding an attribute/property to a bunch of different components just so we're able to pass that prop all the way down to the grid result list item. Curious to hear if there are any better ways to approach this such that implementers can specify the target without having so much overhead...

To test:
1. Replace the `atomic-result-list` tag in `index.html` with the following:
```
<atomic-result-list display="grid" target="_blank">
```
2. Run the atomic dev setup
3. ???
4. Approve