### PR TITLE
feat: add loadClickAnalyticsActions for PLP to fix interactive result

### DIFF
--- a/packages/headless/doc-parser/use-cases/product-listing.ts
+++ b/packages/headless/doc-parser/use-cases/product-listing.ts
@@ -107,6 +107,9 @@ const actionLoaders: ActionLoaderConfiguration[] = [
   {
     initializer: 'loadProductListingActions',
   },
+  {
+    initializer: 'loadClickAnalyticsActions',
+  },
 ];
 
 const engine: EngineConfiguration = {

--- a/packages/headless/src/controllers/product-listing/result-list/headless-product-listing-interactive-result.test.ts
+++ b/packages/headless/src/controllers/product-listing/result-list/headless-product-listing-interactive-result.test.ts
@@ -1,5 +1,5 @@
 import {configuration} from '../../../app/common-reducers';
-import {logDocumentOpen} from '../../../features/product-listing/product-listing-analytics';
+import {logProductRecommendationOpen} from '../../../features/product-listing/product-listing-analytics';
 import {pushRecentResult} from '../../../features/product-listing/product-listing-recent-results';
 import {
   buildMockProductListingEngine,
@@ -29,7 +29,7 @@ describe('InteractiveResult', () => {
       productRecStringParams
     ));
     logDocumentOpenPendingActionType =
-      logDocumentOpen(mockProductRec).pending.type;
+      logProductRecommendationOpen(mockProductRec).pending.type;
     interactiveResult = buildInteractiveResult(engine, {
       options: {result: productRec, selectionDelay: delay},
     });
@@ -46,7 +46,9 @@ describe('InteractiveResult', () => {
   function expectLogDocumentActionPending() {
     const action = findLogDocumentAction();
     expect(action).toEqual(
-      logDocumentOpen(mockProductRec).pending(action!.meta.requestId)
+      logProductRecommendationOpen(mockProductRec).pending(
+        action!.meta.requestId
+      )
     );
   }
 

--- a/packages/headless/src/controllers/product-listing/result-list/headless-product-listing-interactive-result.ts
+++ b/packages/headless/src/controllers/product-listing/result-list/headless-product-listing-interactive-result.ts
@@ -1,4 +1,4 @@
-import {logDocumentOpen} from '../../../features/product-listing/product-listing-analytics';
+import {logProductRecommendationOpen} from '../../../features/product-listing/product-listing-analytics';
 import {pushRecentResult} from '../../../features/product-listing/product-listing-recent-results';
 import {
   ProductListingEngine,
@@ -48,7 +48,7 @@ export function buildInteractiveResult(
       return;
     }
     wasOpened = true;
-    engine.dispatch(logDocumentOpen(props.options.result));
+    engine.dispatch(logProductRecommendationOpen(props.options.result));
   };
 
   const action = () => {

--- a/packages/headless/src/features/product-listing/product-listing-analytics.ts
+++ b/packages/headless/src/features/product-listing/product-listing-analytics.ts
@@ -46,7 +46,7 @@ const documentIdentifier = (
   }
   return {
     contentIDKey: 'permanentid',
-    contentIDValue: productRecommendation.permanentid || '',
+    contentIDValue: productRecommendation.permanentid,
   };
 };
 

--- a/packages/headless/src/features/product-listing/product-listing-analytics.ts
+++ b/packages/headless/src/features/product-listing/product-listing-analytics.ts
@@ -1,16 +1,15 @@
-import {PartialDocumentInformation} from 'coveo.analytics';
+import {Schema} from '@coveo/bueno';
+import {DocumentIdentifier, PartialDocumentInformation} from 'coveo.analytics';
 import {ProductListingAnalyticsProvider} from '../../api/analytics/product-listing-analytics';
-import {ProductRecommendation} from '../../product-listing.index';
+import {ProductRecommendation, Result} from '../../product-listing.index';
 import {ProductListingAppState} from '../../state/product-listing-app-state';
 import {
   AnalyticsType,
-  ClickAction,
   makeAnalyticsAction,
-  ProductListingAction,
-  validateProductRecommendationPayload,
   makeProductListingAnalyticsAction,
+  resultPartialDefinition,
+  ProductListingAction,
 } from '../analytics/analytics-utils';
-import {getPipelineInitialState} from '../pipeline/pipeline-state';
 
 export const logProductListing = (): ProductListingAction =>
   makeProductListingAnalyticsAction(
@@ -20,89 +19,91 @@ export const logProductListing = (): ProductListingAction =>
     (getState) => new ProductListingAnalyticsProvider(getState)
   );
 
-export const logDocumentOpen = (
+export const logProductRecommendationOpen = (
   productRec: ProductRecommendation
-): ClickAction =>
+): ProductListingAction<AnalyticsType.Click> =>
   makeAnalyticsAction(
     'analytics/productListing/open',
     AnalyticsType.Click,
     (client, state) => {
-      validateProductRecommendationPayload(productRec);
+      validateResultPayload(productRec);
       return client.makeDocumentOpen(
-        partialProductRecommendationInformation(productRec, state),
-        {
-          contentIDKey: 'permanentid',
-          contentIDValue: productRec.permanentid,
-        }
+        partialRecommendationInformation(productRec, state),
+        documentIdentifier(productRec)
       );
-    }
+    },
+    (getState) => new ProductListingAnalyticsProvider(getState)
   );
 
-export const partialProductRecommendationInformation = (
-  productRec: ProductRecommendation,
-  state: Partial<ProductListingAppState>
-): PartialDocumentInformation => {
-  const paginationBasedIndex = (index: number) =>
-    index + (state.pagination?.firstResult ?? 0);
-
-  let productRecIndex = -1;
-
-  const parentResults = state.productListing?.products;
-  productRecIndex = findPositionWithPermanentid(productRec, parentResults);
-
-  if (productRecIndex < 0) {
-    productRecIndex = findPositionInChildResults(productRec, parentResults);
+const documentIdentifier = (
+  productRecommendation: ProductRecommendation
+): DocumentIdentifier => {
+  if (!productRecommendation.permanentid) {
+    console.warn(
+      'Missing field permanentid on productRecommendation. This might cause many issues with your Coveo deployment. See https://docs.coveo.com/en/1913 and https://docs.coveo.com/en/1640 for more information.',
+      productRecommendation
+    );
   }
-
-  if (productRecIndex < 0) {
-    // ¯\_(ツ)_/¯
-    productRecIndex = 0;
-  }
-
-  return buildPartialProductRecommendationInformation(
-    productRec,
-    paginationBasedIndex(productRecIndex)
-  );
+  return {
+    contentIDKey: 'permanentid',
+    contentIDValue: productRecommendation.permanentid || '',
+  };
 };
 
-function findPositionWithPermanentid(
-  targetProductRec: ProductRecommendation,
-  productRecs: ProductRecommendation[] = []
-) {
-  return productRecs.findIndex(
-    ({permanentid}) => permanentid === targetProductRec.permanentid
+function mapProductRecommendationToResult(
+  productRecommendation: ProductRecommendation
+): Partial<Result> {
+  return {
+    uniqueId: productRecommendation.permanentid,
+    title: productRecommendation.ec_name || '',
+    uri: productRecommendation.documentUri,
+    clickUri: productRecommendation.clickUri,
+  };
+}
+
+function partialResultPayload(
+  productRecommendation: ProductRecommendation
+): Partial<ProductRecommendation> {
+  const result = mapProductRecommendationToResult(productRecommendation);
+  return Object.assign(
+    {},
+    ...Object.keys(resultPartialDefinition).map((key) => ({
+      [key]: result[key as keyof typeof resultPartialDefinition],
+    }))
   );
 }
 
-function findPositionInChildResults(
-  targetProductRec: ProductRecommendation,
-  parentResults: ProductRecommendation[] = []
-) {
-  for (const [i, parent] of parentResults.entries()) {
-    const children = parent.childResults;
-    const childIndex = findPositionWithPermanentid(targetProductRec, children);
-    if (childIndex !== -1) {
-      return i;
-    }
-  }
+const validateResultPayload = (productRecommendation: ProductRecommendation) =>
+  new Schema(resultPartialDefinition).validate(
+    partialResultPayload(productRecommendation)
+  );
 
-  return -1;
-}
+const partialRecommendationInformation = (
+  result: ProductRecommendation,
+  state: Partial<ProductListingAppState>
+): PartialDocumentInformation => {
+  const resultIndex =
+    state.productListing?.products.findIndex(
+      ({permanentid}) => result.permanentid === permanentid
+    ) || 0;
 
-function buildPartialProductRecommendationInformation(
-  productRec: ProductRecommendation,
+  return buildPartialDocumentInformation(result, resultIndex);
+};
+
+function buildPartialDocumentInformation(
+  productRecommendation: ProductRecommendation,
   resultIndex: number
 ): PartialDocumentInformation {
   return {
     collectionName: '',
     documentAuthor: '',
     documentPosition: resultIndex + 1,
-    documentTitle: productRec.ec_name || '',
-    documentUri: productRec.documentUri,
-    documentUriHash: productRec.documentUriHash,
-    documentUrl: productRec.clickUri,
+    documentTitle: productRecommendation.ec_name || '',
+    documentUri: productRecommendation.documentUri,
+    documentUriHash: productRecommendation.documentUriHash,
+    documentUrl: productRecommendation.clickUri,
     rankingModifier: '',
-    sourceName: '',
-    queryPipeline: getPipelineInitialState(),
+    sourceName: 'unknown',
+    queryPipeline: '',
   };
 }

--- a/packages/headless/src/features/product-listing/product-listing-click-analytics-actions-loader.ts
+++ b/packages/headless/src/features/product-listing/product-listing-click-analytics-actions-loader.ts
@@ -1,0 +1,38 @@
+import {ProductRecommendation} from '../../api/search/search/product-recommendation';
+import {ProductListingEngine} from '../../app/product-listing-engine/product-listing-engine';
+import {
+  AnalyticsType,
+  ProductListingAction,
+} from '../analytics/analytics-utils';
+import {logProductRecommendationOpen} from './product-listing-analytics';
+
+/**
+ * The click analytics action creators.
+ */
+export interface ClickAnalyticsActionCreators {
+  /**
+   * The event to log when a recommendation is selected.
+   *
+   * @param productRecommendation - The selected recommendation.
+   * @returns A dispatchable action.
+   */
+  logProductRecommendationOpen(
+    productRecommendation: ProductRecommendation
+  ): ProductListingAction<AnalyticsType.Click>;
+}
+
+/**
+ * Returns possible click analytics action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the action creators.
+ */
+export function loadClickAnalyticsActions(
+  engine: ProductListingEngine
+): ClickAnalyticsActionCreators {
+  engine.addReducers({});
+
+  return {
+    logProductRecommendationOpen,
+  };
+}

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -25,6 +25,7 @@ export type {LogLevel} from './app/logger';
 export type {ProductRecommendation} from './api/search/search/product-recommendation';
 
 // Actions
+export * from './features/product-listing/product-listing-click-analytics-actions-loader';
 export * from './features/product-listing/product-listing-actions-loader';
 export * from './features/configuration/configuration-actions-loader';
 export * from './features/pagination/pagination-actions-loader';


### PR DESCRIPTION
Jira ticket: https://coveord.atlassian.net/browse/COMSDZ-605

The issue was with the `interactiveResult` was with the missing `loadClickAnalyticsActions` for product listing. We needed to align with Product Recommendation and not Search.