### PR TITLE
feat(atomic): add placeholders for automatic facet

### DIFF
--- a/packages/atomic/cypress/e2e/facets/automatic-facet-builder/automatic-facet-builder-assertions.ts
+++ b/packages/atomic/cypress/e2e/facets/automatic-facet-builder/automatic-facet-builder-assertions.ts
@@ -13,3 +13,7 @@ export function assertCollapseAutomaticFacets(isCollapsed: boolean) {
     .find('[part="values"]')
     .should(isCollapsed ? 'not.exist' : 'be.visible');
 }
+
+export function assertDisplayPlaceholder() {
+  cy.get(automaticFacetBuilderComponent).find('[part="placeholder"]');
+}

--- a/packages/atomic/cypress/e2e/facets/automatic-facet-builder/automatic-facet-builder.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/automatic-facet-builder/automatic-facet-builder.cypress.ts
@@ -7,6 +7,7 @@ import {addAutomaticFacetBuilder} from './automatic-facet-builder-actions';
 import {
   assertCollapseAutomaticFacets,
   assertContainsAutomaticFacet,
+  assertDisplayPlaceholder,
   automaticFacetBuilderComponent,
 } from './automatic-facet-builder-assertions';
 
@@ -66,5 +67,17 @@ describe('Automatic Facet Builder Test Suites', () => {
       )
       .init();
     assertCollapseAutomaticFacets(false);
+  });
+
+  it('should display placeholders when no search has yet been executed', () => {
+    new TestFixture()
+      .with(
+        addAutomaticFacetBuilder({
+          'desired-count': '1',
+        })
+      )
+      .withoutFirstAutomaticSearch()
+      .init();
+    assertDisplayPlaceholder();
   });
 });

--- a/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.pcss
+++ b/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.pcss
@@ -1,0 +1,1 @@
+@import '../../../../global/global.pcss';

--- a/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.tsx
@@ -12,6 +12,7 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
+import {FacetPlaceholder} from '../../../common/facets/facet-placeholder/facet-placeholder';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 
 /**
@@ -25,6 +26,7 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
  */
 @Component({
   tag: 'atomic-automatic-facet-builder',
+  styleUrl: 'atomic-automatic-facet-builder.pcss',
   shadow: false,
 })
 export class AtomicAutomaticFacetBuilder implements InitializableComponent {
@@ -91,6 +93,11 @@ export class AtomicAutomaticFacetBuilder implements InitializableComponent {
         );
       }
     );
+    if (!this.searchStatus.state.firstSearchExecuted) {
+      return Array.from({length: this.desiredCount}, () => (
+        <FacetPlaceholder numberOfValues={8} isCollapsed={this.areCollapsed} />
+      ));
+    }
 
     return automaticFacets;
   }

--- a/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-automatic-facet-builder/atomic-automatic-facet-builder.tsx
@@ -95,7 +95,7 @@ export class AtomicAutomaticFacetBuilder implements InitializableComponent {
     );
     if (!this.searchStatus.state.firstSearchExecuted) {
       return Array.from({length: this.desiredCount}, () => (
-        <FacetPlaceholder numberOfValues={8} isCollapsed={this.areCollapsed} />
+        <FacetPlaceholder numberOfValues={8} isCollapsed={this.areCollapsed} /> //TODO: Change '8' to variable whenever adding the 'numberOfValues' attribute in the AF query
       ));
     }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2615

This PR adds placeholders for automatic facet. In other facet, the placeholder is in the actual facet component. Since the automatic facet component is only accessed after the query, the only way to have placeholders in this case is to show them depending on the `desiredCount` in the `automaticFacetBuilder`.

![Image](https://user-images.githubusercontent.com/132079077/255995120-a1e0b791-64ef-475a-8863-8e3bf898377f.png)
