### PR TITLE
fix(headless): reset pagination when toggling automatic facet

### DIFF
--- a/packages/headless/src/features/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.test.ts
@@ -2,6 +2,7 @@ import {Action} from '@reduxjs/toolkit';
 import {buildFetchProductListingResponse} from '../../test/mock-product-listing';
 import {buildMockSearch} from '../../test/mock-search';
 import {deselectAllBreadcrumbs} from '../breadcrumb/breadcrumb-actions';
+import {toggleSelectAutomaticFacetValue} from '../facets/automatic-facet-set/automatic-facet-set-actions';
 import {
   deselectAllCategoryFacetValues,
   toggleSelectCategoryFacetValue,
@@ -299,6 +300,10 @@ describe('pagination slice', () => {
 
     it('when date facet values are updated, #firstResult is set to 0', () => {
       testResetPagination(updateNumericFacetValues);
+    });
+
+    it('when automatic facet values are updated, #firstResult is set to 0', () => {
+      testResetPagination(toggleSelectAutomaticFacetValue);
     });
   });
 });

--- a/packages/headless/src/features/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.ts
@@ -1,5 +1,6 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {deselectAllBreadcrumbs} from '../breadcrumb/breadcrumb-actions';
+import {toggleSelectAutomaticFacetValue} from '../facets/automatic-facet-set/automatic-facet-set-actions';
 import {
   deselectAllCategoryFacetValues,
   toggleSelectCategoryFacetValue,
@@ -132,6 +133,9 @@ export const paginationReducer = createReducer(
         handlePaginationReset(state);
       })
       .addCase(selectFacetSearchResult, (state) => {
+        handlePaginationReset(state);
+      })
+      .addCase(toggleSelectAutomaticFacetValue, (state) => {
         handlePaginationReset(state);
       });
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2617

This PR adds a case in the pagination slice to reset pagination to 0 whenever an automatic facet is toggled.