### PR TITLE
fix(headless): fixed analytics metadata for instant results search

### DIFF
--- a/packages/headless/src/api/analytics/instant-result-analytics.ts
+++ b/packages/headless/src/api/analytics/instant-result-analytics.ts
@@ -1,3 +1,5 @@
+import {getQueryInitialState} from '../../features/query/query-state';
+import {getSearchInitialState} from '../../features/search/search-state';
 import {InstantResultSection} from '../../state/state-sections';
 import {
   SearchAnalyticsProvider,
@@ -40,14 +42,30 @@ export class InstantResultsAnalyticsProvider extends SearchAnalyticsProvider {
     return null;
   }
 
+  protected get results() {
+    return this.activeInstantResultCache?.results;
+  }
+
+  protected get queryText() {
+    return this.activeInstantResultQuery ?? getQueryInitialState().q;
+  }
+
+  protected get responseTime() {
+    return (
+      this.activeInstantResultCache?.duration ??
+      getSearchInitialState().duration
+    );
+  }
+
+  protected get numberOfResults() {
+    return (
+      this.activeInstantResultCache?.totalCountFiltered ??
+      getSearchInitialState().response.totalCountFiltered
+    );
+  }
+
   public getSearchUID(): string {
     const searchUid = this.activeInstantResultCache?.searchUid;
     return searchUid || super.getSearchUID();
-  }
-
-  public getSearchEventRequestPayload() {
-    const payload = super.getSearchEventRequestPayload();
-    const queryText = this.activeInstantResultQuery || payload.queryText;
-    return {...payload, queryText};
   }
 }

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -47,7 +47,7 @@ export class SearchAnalyticsProvider
     return {
       queryText: this.queryText,
       responseTime: this.responseTime,
-      results: this.mapResultsToAnalyticsDocument(),
+      results: this.resultURIs,
       numberOfResults: this.numberOfResults,
     };
   }
@@ -90,22 +90,26 @@ export class SearchAnalyticsProvider
     return baseObject;
   }
 
-  private mapResultsToAnalyticsDocument() {
-    return this.state.search?.response.results.map((r) => ({
+  private get resultURIs() {
+    return this.results?.map((r) => ({
       documentUri: r.uri,
       documentUriHash: r.raw.urihash,
     }));
   }
 
-  private get queryText() {
+  protected get results() {
+    return this.state.search?.response.results;
+  }
+
+  protected get queryText() {
     return this.state.query?.q || getQueryInitialState().q;
   }
 
-  private get responseTime() {
+  protected get responseTime() {
     return this.state.search?.duration || getSearchInitialState().duration;
   }
 
-  private get numberOfResults() {
+  protected get numberOfResults() {
     return (
       this.state.search?.response.totalCountFiltered ||
       getSearchInitialState().response.totalCountFiltered

--- a/packages/headless/src/features/instant-results/instant-results-actions.ts
+++ b/packages/headless/src/features/instant-results/instant-results-actions.ts
@@ -82,6 +82,8 @@ export interface FetchInstantResultsActionCreatorPayload {
 export interface FetchInstantResultsThunkReturn {
   results: Result[];
   searchUid: string;
+  totalCountFiltered: number;
+  duration: number;
 }
 
 export type StateNeededByInstantResults = StateNeededByExecuteSearch &

--- a/packages/headless/src/features/instant-results/instant-results-slice.test.ts
+++ b/packages/headless/src/features/instant-results/instant-results-slice.test.ts
@@ -28,6 +28,8 @@ const initialEmptyCache: () => InstantResultCache = () => ({
   expiresAt: 0,
   isActive: true,
   searchUid: '',
+  totalCountFiltered: 0,
+  duration: 0,
 });
 
 describe('instant results slice', () => {
@@ -190,7 +192,12 @@ describe('instant results slice', () => {
       it('updates results in correct searchbox and query cache', () => {
         const query = 'some_query';
         const action = fetchInstantResults.fulfilled(
-          {results: [buildMockResult()], searchUid: 'someid'},
+          {
+            results: [buildMockResult()],
+            searchUid: 'someid',
+            totalCountFiltered: 1,
+            duration: 2,
+          },
           'req_id',
           {
             id: id1,
@@ -218,6 +225,8 @@ describe('instant results slice', () => {
           expiresAt: 0,
           isActive: true,
           searchUid: 'someid',
+          totalCountFiltered: 1,
+          duration: 2,
         });
 
         expect(instantResultsReducer(initialState, action)).toEqual(
@@ -227,7 +236,12 @@ describe('instant results slice', () => {
       it('sets correct isLoading, error and expiresAt properties', () => {
         const query = 'some_query';
         const action = fetchInstantResults.fulfilled(
-          {results: [buildMockResult()], searchUid: 'someid'},
+          {
+            results: [buildMockResult()],
+            searchUid: 'someid',
+            duration: 1,
+            totalCountFiltered: 2,
+          },
           'req_id',
           {
             id: id1,
@@ -252,6 +266,8 @@ describe('instant results slice', () => {
           expiresAt: Date.now() + 10000,
           isActive: true,
           searchUid: 'someid',
+          duration: 1,
+          totalCountFiltered: 2,
         });
 
         expect(instantResultsReducer(initialState, action)).toEqual(

--- a/packages/headless/src/features/instant-results/instant-results-slice.ts
+++ b/packages/headless/src/features/instant-results/instant-results-slice.ts
@@ -56,7 +56,7 @@ export const instantResultsReducer = createReducer(
       cached!.error = null;
     });
     builder.addCase(fetchInstantResults.fulfilled, (state, action) => {
-      const {results, searchUid} = action.payload;
+      const {results, searchUid, totalCountFiltered, duration} = action.payload;
       const {cacheTimeout} = action.meta.arg;
       const cached = getCached(state, action.meta);
 
@@ -66,6 +66,8 @@ export const instantResultsReducer = createReducer(
       cached!.error = null;
       cached!.results = results;
       cached!.expiresAt = cacheTimeout ? cacheTimeout + Date.now() : 0;
+      cached!.totalCountFiltered = totalCountFiltered;
+      cached!.duration = duration;
     });
     builder.addCase(fetchInstantResults.rejected, (state, action) => {
       const cached = getCached(state, action.meta);
@@ -88,6 +90,8 @@ const makeEmptyCache = (
     expiresAt: 0,
     isActive: true,
     searchUid: '',
+    totalCountFiltered: 0,
+    duration: 0,
   };
 };
 

--- a/packages/headless/src/features/instant-results/instant-results-state.ts
+++ b/packages/headless/src/features/instant-results/instant-results-state.ts
@@ -9,6 +9,8 @@ export type InstantResultCache = {
   results: Result[];
   isActive: boolean;
   searchUid: string;
+  totalCountFiltered: number;
+  duration: number;
 };
 
 export type InstantResultsState = Record<

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -246,6 +246,8 @@ export const fetchInstantResults = createAsyncThunk<
         results: processed.response.results,
         searchUid: processed.response.searchUid,
         analyticsAction: processed.analyticsAction,
+        totalCountFiltered: processed.response.totalCountFiltered,
+        duration: processed.duration,
       };
     }
     return processed as ReturnType<typeof config.rejectWithValue>;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2609

In the above issue, it was identified that some analytics events had `numberOfResults: 0`, and eventually that this specifically happened for instant results on a standalone search page.

It turns out that analytics events for instant results were logging the `numberOfResults`, `results` and `responseTime` of the last submitted search request, not the instant results search request.

This PR changes the instant results analytics provider to instead use the values from the last cached instant results response.

I tried to compare this behaviour with JSUI, but it was complicated and not worth elaborating here. In a nutshell, we already decided when adding instant results to Headless that we'd send a different analytics event, so the comparison would be irrelevant.