### PR TITLE
folding bug fixed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultChildren/__tests__/quanticResultChildren.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultChildren/__tests__/quanticResultChildren.test.js
@@ -81,6 +81,10 @@ const exampleCollectionWithAdditionalGrandChild = {
   isLoadingMoreResults: false,
   moreResultsAvailable: false,
 };
+const exampleCollectionWithNoMoreResults = {
+  ...exampleCollection,
+  moreResultsAvailable: false,
+};
 
 const defaultOptions = {
   engineId: exampleEngineId,
@@ -287,6 +291,49 @@ describe('c-quantic-result-children', () => {
         expectProperChildResultsDisplay(element, exampleCollection);
         expect(foldedResultToggleButton).toBeNull();
         expect(noMoreChildrenMessage).not.toBeNull();
+      });
+    });
+
+    describe('when executing a search query after loading the child results', () => {
+      it('should no longer display the no more child results message and display the child results toggle', async () => {
+        const element = createTestComponent();
+        await flushPromises();
+
+        await clickFoldedResultToggleButton(element, loadRelatedItems);
+
+        expect(functionsMocks.loadCollection).toHaveBeenCalledTimes(1);
+        element.collection = exampleCollectionWithNoMoreResults;
+        await flushPromises();
+
+        let foldedResultToggleButton = element.shadowRoot.querySelector(
+          selectors.toggleButton
+        );
+        let noMoreChildrenMessage = element.shadowRoot.querySelector(
+          selectors.noMoreChildrenMessage
+        );
+
+        expectProperChildResultsDisplay(
+          element,
+          exampleCollectionWithNoMoreResults
+        );
+        expect(foldedResultToggleButton).toBeNull();
+        expect(noMoreChildrenMessage).not.toBeNull();
+
+        // Simulates new search query
+        element.collection = exampleCollection;
+        await flushPromises();
+
+        foldedResultToggleButton = element.shadowRoot.querySelector(
+          selectors.toggleButton
+        );
+        noMoreChildrenMessage = element.shadowRoot.querySelector(
+          selectors.noMoreChildrenMessage
+        );
+
+        expectProperChildResultsDisplay(element, exampleCollection);
+        expect(foldedResultToggleButton).not.toBeNull();
+        expect(noMoreChildrenMessage).toBeNull();
+        expect(foldedResultToggleButton.label).toBe(loadRelatedItems);
       });
     });
   });

--- a/packages/quantic/force-app/main/default/lwc/quanticResultChildren/quanticResultChildren.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultChildren/quanticResultChildren.js
@@ -1,12 +1,11 @@
 import hideRelatedItems from '@salesforce/label/c.quantic_HideRelatedItems';
 import loadRelatedItems from '@salesforce/label/c.quantic_LoadRelatedItems';
 import noRelatedItems from '@salesforce/label/c.quantic_NoRelatedItems';
-import { LightningElement, api } from 'lwc';
+import {LightningElement, api} from 'lwc';
 // @ts-ignore
 import loadingTemplate from './loading.html';
 // @ts-ignore
 import resultChildrenTemplate from './quanticResultChildren.html';
-
 
 /** @typedef {import("coveo").FoldedCollection} FoldedCollection */
 /** @typedef {import("coveo").FoldedResult} FoldedResult */
@@ -65,7 +64,7 @@ export default class QuanticResultChildren extends LightningElement {
   /** @type {boolean} */
   areAllChildResultsLoaded = false;
   /** @type {boolean} */
-  areChildResultsExpanded = false;
+  _areChildResultsExpanded = false;
   /** @type {Array<FoldedResult>} */
   firstChildrenPartition;
 
@@ -84,6 +83,10 @@ export default class QuanticResultChildren extends LightningElement {
     return this?.collection?.moreResultsAvailable;
   }
 
+  get areChildResultsExpanded() {
+    return this._areChildResultsExpanded && !this.areMoreResultsAvailable;
+  }
+
   handleToggleChildResults() {
     if (this.areChildResultsExpanded) {
       this.showLessFoldedResults();
@@ -99,13 +102,13 @@ export default class QuanticResultChildren extends LightningElement {
   }
 
   showLessFoldedResults() {
-    this.areChildResultsExpanded = false;
+    this._areChildResultsExpanded = false;
     this.foldedResultListController.logShowLessFoldedResults();
   }
 
   showMoreFoldedResults() {
-    this.areChildResultsExpanded = true;
-    if (!this.areAllChildResultsLoaded) {
+    this._areChildResultsExpanded = true;
+    if (this.areMoreResultsAvailable) {
       this.loadAllFoldedResults();
     } else {
       this.foldedResultListController.logShowMoreFoldedResults(
@@ -177,7 +180,11 @@ export default class QuanticResultChildren extends LightningElement {
     if (!this.isFirstLevelChildCollection) {
       return false;
     }
-    return this.areAllChildResultsLoaded && !this.moreResultsFound;
+    return (
+      this.areAllChildResultsLoaded &&
+      !this.moreResultsFound &&
+      !this.areMoreResultsAvailable
+    );
   }
 
   render() {


### PR DESCRIPTION
[SFINT-5127](https://coveord.atlassian.net/browse/SFINT-5127)

### Before

http://somup.com/c0iObJzmGp


### After

https://github.com/coveo/ui-kit/assets/86681870/237f015c-bcbe-4047-9e81-cb95abe8a8f9

### Explanation
When a new search query is made, the results are fetched again which means the state of the results is reinitialized: if a result had all his collection loaded, after the search query this loaded collection is discarded from the state and the attribute `areMoreResultsAvailable ` is reset to `true`.

That's why this attribute `areMoreResultsAvailable` needs to be taken in consideration when checking whether the no more child results message should be displayed. 

