### PR TITLE
feat(headless): send clientId instead of visitorId in case assist

### DIFF
--- a/packages/headless/src/api/platform-service-params.ts
+++ b/packages/headless/src/api/platform-service-params.ts
@@ -24,8 +24,8 @@ export interface NumberOfResultsParam {
   numberOfResults?: number;
 }
 
-export interface VisitorIDParam {
-  visitorId?: string;
+export interface ClientIDParam {
+  clientId?: string;
 }
 
 export interface FoldingParam {

--- a/packages/headless/src/api/platform-service-params.ts
+++ b/packages/headless/src/api/platform-service-params.ts
@@ -28,6 +28,10 @@ export interface ClientIDParam {
   clientId?: string;
 }
 
+export interface VisitorIDParam {
+  visitorId?: string;
+}
+
 export interface FoldingParam {
   filterField?: string;
   parentField?: string;

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
@@ -73,7 +73,7 @@ describe('case assist api client', () => {
         accessToken: request.accessToken,
         origin: 'caseAssistApiFetch',
         requestParams: {
-          visitorId: request.clientId,
+          clientId: request.clientId,
           locale: request.locale,
           fields: request.fields,
         },
@@ -191,7 +191,7 @@ describe('case assist api client', () => {
         accessToken: request.accessToken,
         origin: 'caseAssistApiFetch',
         requestParams: {
-          visitorId: request.clientId,
+          clientId: request.clientId,
           locale: request.locale,
           fields: request.fields,
           context: {

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
@@ -13,7 +13,7 @@ describe('case assist api client', () => {
   const accessToken = 'some access token';
   const locale = 'en-CA';
   const caseAssistId = 'some case assist id';
-  const visitorId = 'some visitor id';
+  const clientId = 'some client id';
 
   let client: CaseAssistAPIClient;
   let platformCallMock: jest.Mock;
@@ -41,7 +41,7 @@ describe('case assist api client', () => {
       organizationId: orgId,
       accessToken: accessToken,
       caseAssistId: caseAssistId,
-      visitorId: visitorId,
+      clientId: clientId,
       locale: locale,
       fields: {},
       debug: false,
@@ -73,7 +73,7 @@ describe('case assist api client', () => {
         accessToken: request.accessToken,
         origin: 'caseAssistApiFetch',
         requestParams: {
-          visitorId: request.visitorId,
+          visitorId: request.clientId,
           locale: request.locale,
           fields: request.fields,
         },
@@ -156,7 +156,7 @@ describe('case assist api client', () => {
       organizationId: orgId,
       accessToken: accessToken,
       caseAssistId: caseAssistId,
-      visitorId: visitorId,
+      clientId: clientId,
       locale: locale,
       fields: {},
       debug: false,
@@ -191,7 +191,7 @@ describe('case assist api client', () => {
         accessToken: request.accessToken,
         origin: 'caseAssistApiFetch',
         requestParams: {
-          visitorId: request.visitorId,
+          visitorId: request.clientId,
           locale: request.locale,
           fields: request.fields,
           context: {

--- a/packages/headless/src/api/service/case-assist/get-case-classifications/get-case-classifications-request.ts
+++ b/packages/headless/src/api/service/case-assist/get-case-classifications/get-case-classifications-request.ts
@@ -1,9 +1,9 @@
 import {
   BaseParam,
+  ClientIDParam,
   ContextParam,
   DebugParam,
   LocaleParam,
-  VisitorIDParam,
 } from '../../../platform-service-params';
 import {
   baseCaseAssistRequest,
@@ -14,7 +14,7 @@ import {
 
 export type GetCaseClassificationsRequest = BaseParam &
   CaseAssistIdParam &
-  VisitorIDParam &
+  ClientIDParam &
   LocaleParam &
   FieldsParam &
   ContextParam &
@@ -40,7 +40,7 @@ export const buildGetCaseClassificationsRequest = (
 };
 
 const prepareRequestParams = (req: GetCaseClassificationsRequest) => ({
-  visitorId: req.visitorId,
+  clientId: req.clientId,
   locale: req.locale,
   fields: prepareSuggestionRequestFields(req.fields),
 });

--- a/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-request.ts
+++ b/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-request.ts
@@ -1,10 +1,10 @@
 import {
   BaseParam,
+  ClientIDParam,
   ContextParam,
   DebugParam,
   LocaleParam,
   NumberOfResultsParam,
-  VisitorIDParam,
 } from '../../../platform-service-params';
 import {
   baseCaseAssistRequest,
@@ -15,7 +15,7 @@ import {
 
 export type GetDocumentSuggestionsRequest = BaseParam &
   CaseAssistIdParam &
-  VisitorIDParam &
+  ClientIDParam &
   LocaleParam &
   FieldsParam &
   ContextParam &
@@ -46,7 +46,7 @@ export const buildGetDocumentSuggestionsRequest = (
 };
 
 const prepareRequestParams = (req: GetDocumentSuggestionsRequest) => ({
-  visitorId: req.visitorId,
+  clientId: req.clientId,
   locale: req.locale,
   fields: prepareSuggestionRequestFields(req.fields),
   context: req.context,

--- a/packages/headless/src/features/case-field/case-field-actions.ts
+++ b/packages/headless/src/features/case-field/case-field-actions.ts
@@ -88,7 +88,7 @@ export const buildFetchClassificationRequest = async (
   url: state.configuration.platformUrl,
   caseAssistId: state.caseAssistConfiguration.caseAssistId,
   ...(state.configuration.analytics.enabled && {
-    visitorId: await getVisitorID(state.configuration.analytics),
+    clientId: await getVisitorID(state.configuration.analytics),
   }),
   fields: state.caseInput,
   context: state.caseField

--- a/packages/headless/src/features/document-suggestion/document-suggestion-actions.ts
+++ b/packages/headless/src/features/document-suggestion/document-suggestion-actions.ts
@@ -57,7 +57,7 @@ export const buildFetchDocumentSuggestionsRequest = async (
   url: state.configuration.platformUrl,
   caseAssistId: state.caseAssistConfiguration.caseAssistId,
   ...(state.configuration.analytics.enabled && {
-    visitorId: await getVisitorID(state.configuration.analytics),
+    clientId: await getVisitorID(state.configuration.analytics),
   }),
   fields: state.caseInput,
   context: state.caseField


### PR DESCRIPTION
The customer service api now accepts `clientId` or `visitorId`.
We want to favour `clientId` to phase out the other so after this PR the case assist client will send that instead.