### PR TITLE
fix(atomic): add automatic facets to atomic refine modal

### DIFF
--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -208,9 +208,11 @@ export class AtomicRefineModal implements InitializableComponent {
     if (!isFacetElements && !isAutomaticFacets) {
       return;
     }
-
+    const amountToCollapseNext =
+      this.collapseFacetsAfter - this.bindings.store.getFacetElements().length;
     const automaticFacets = isAutomaticFacets
-      ? this.automaticFacetBuilderState.automaticFacets.map((facet) => {
+      ? this.automaticFacetBuilderState.automaticFacets.map((facet, index) => {
+          const isCollapsed = index >= amountToCollapseNext;
           return (
             <atomic-automatic-facet
               key={facet.state.field}
@@ -218,7 +220,7 @@ export class AtomicRefineModal implements InitializableComponent {
               facetId={facet.state.field}
               facet={facet}
               searchStatus={this.searchStatus}
-              isCollapsed={true}
+              isCollapsed={isCollapsed}
             ></atomic-automatic-facet>
           );
         })


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2623

After adding this, I tested the edge cases for the atomic refine modal where there is either no automatic facets or no normal facets and I found a bug [KIT-2627](https://coveord.atlassian.net/browse/KIT-2627) whenever there was no normal facets. I reproduced the bug in the master branch so my changes have no impact on it. I will fix it in a subsequent PR.

To open the refine modal:

1. Put browser window in mobile mode when the 'sort and filter' button appears at the right.
2. Click on it to open the modal

[KIT-2627]: https://coveord.atlassian.net/browse/KIT-2627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ