### PR TITLE
fix(atomic): fixed styling of insight folded results when children ar…

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.pcss
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.pcss
@@ -26,4 +26,9 @@
       @apply top-0;
     }
   }
+
+  atomic-load-more-children-results::part(button) {
+    margin-bottom: 0;
+    padding: 0.2rem 0.5rem;
+  }
 }

--- a/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.pcss
+++ b/packages/atomic/src/components/insight/atomic-insight-result/atomic-insight-result.pcss
@@ -1,11 +1,5 @@
 @import '../../common/result/result.pcss';
 
-atomic-result-section-children {
-  margin-top: 0.875rem;
-  border-left: 1px solid var(--atomic-neutral);
-  padding-left: 1rem;
-}
-
 :host {
   @apply relative;
 

--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children/atomic-insight-result-children.pcss
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children/atomic-insight-result-children.pcss
@@ -1,1 +1,7 @@
 @import '../../../../components/common/result-children/result-children.pcss';
+
+[part='children-root'] {
+  border-left: 1px solid var(--atomic-neutral);
+  padding-left: 1rem;
+  margin-top: 1rem;
+}

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -181,6 +181,11 @@
                   .result-root.image-large atomic-result-section-visual {
                     border-radius: var(--atomic-border-radius-xl);
                   }
+
+                  atomic-load-more-children-results::part(button) {
+                    margin-bottom: 0;
+                    padding: 0.2rem 0.5rem;
+                  }
                 </style>
                 <atomic-insight-result-action-bar>
                   <atomic-insight-result-action tooltip="test"></atomic-insight-result-action>
@@ -243,6 +248,11 @@
                           .field-label {
                             font-weight: bold;
                             margin-right: 0.25rem;
+                          }
+
+                          atomic-load-more-children-results::part(show-hide-button) {
+                            margin-bottom: 0;
+                            padding: 0.2rem 0.5rem;
                           }
                         </style>
                         <atomic-result-section-title>

--- a/packages/atomic/src/pages/examples/insights.html
+++ b/packages/atomic/src/pages/examples/insights.html
@@ -181,11 +181,6 @@
                   .result-root.image-large atomic-result-section-visual {
                     border-radius: var(--atomic-border-radius-xl);
                   }
-
-                  atomic-load-more-children-results::part(button) {
-                    margin-bottom: 0;
-                    padding: 0.2rem 0.5rem;
-                  }
                 </style>
                 <atomic-insight-result-action-bar>
                   <atomic-insight-result-action tooltip="test"></atomic-insight-result-action>
@@ -248,11 +243,6 @@
                           .field-label {
                             font-weight: bold;
                             margin-right: 0.25rem;
-                          }
-
-                          atomic-load-more-children-results::part(show-hide-button) {
-                            margin-bottom: 0;
-                            padding: 0.2rem 0.5rem;
                           }
                         </style>
                         <atomic-result-section-title>


### PR DESCRIPTION
Insight only
- Put the padding and left border on the rendered child result rather than the child result section so they wouldn't show when there are no child results.

Looking good 🎨 
<img width="576" alt="Screenshot 2023-08-02 at 2 23 06 PM" src="https://github.com/coveo/ui-kit/assets/16785453/ce7d7fd6-a181-49cc-b36d-3869763af868">