### PR TITLE
chore(quantic): Updated lwc-jest to 1.4.1 & conditional rendering checks to lwc:if

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4730,7 +4730,6 @@
       "version": "29.6.0",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
       "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -4904,13 +4903,14 @@
       "license": "MIT"
     },
     "node_modules/@lwc/babel-plugin-component": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-2.42.0.tgz",
+      "integrity": "sha512-JqMM7vxKCUypgxnjxizfSFmm1hPRw8blFIyY1sxiBSrwXhZXTHxtstLRCZkATRsG4dAjj4wQ7SrNRhd7oQXD9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "~7.16.7",
-        "@lwc/errors": "2.11.8",
-        "@lwc/shared": "2.11.8",
+        "@babel/helper-module-imports": "~7.18.6",
+        "@lwc/errors": "2.42.0",
+        "@lwc/shared": "2.42.0",
         "line-column": "~1.0.2"
       },
       "peerDependencies": {
@@ -4918,50 +4918,53 @@
       }
     },
     "node_modules/@lwc/babel-plugin-component/node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@lwc/compiler": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-2.42.0.tgz",
+      "integrity": "sha512-0NJFUAFVp4I/TI4GHvSwS86tyv7GuduxHLVsZ0Q42rAdvJmbMBvD8jIlCflhHLgzT0ePSD6pkoq9aKjks03RnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/core": "~7.17.4",
-        "@babel/plugin-proposal-class-properties": "~7.16.7",
-        "@babel/plugin-proposal-object-rest-spread": "~7.17.3",
-        "@lwc/babel-plugin-component": "2.11.8",
-        "@lwc/errors": "2.11.8",
-        "@lwc/shared": "2.11.8",
-        "@lwc/style-compiler": "2.11.8",
-        "@lwc/template-compiler": "2.11.8"
+        "@babel/core": "~7.21.0",
+        "@babel/plugin-proposal-class-properties": "~7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "~7.20.2",
+        "@lwc/babel-plugin-component": "2.42.0",
+        "@lwc/errors": "2.42.0",
+        "@lwc/shared": "2.42.0",
+        "@lwc/style-compiler": "2.42.0",
+        "@lwc/template-compiler": "2.42.0"
       }
     },
     "node_modules/@lwc/compiler/node_modules/@babel/core": {
-      "version": "7.17.12",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.12",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helpers": "^7.17.9",
-        "@babel/parser": "^7.17.12",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.12",
-        "@babel/types": "^7.17.12",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.5",
+        "@babel/helper-compilation-targets": "^7.21.5",
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helpers": "^7.21.5",
+        "@babel/parser": "^7.21.8",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -4972,56 +4975,33 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@lwc/compiler/node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.16.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@lwc/compiler/node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.17.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.17.12"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@lwc/compiler/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@lwc/engine-dom": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.42.0.tgz",
+      "integrity": "sha512-yLo+C8MsLfDPrpAiHN8ktdVi2we2z1fryfXNYu9TMIaXwro/Bdw8PMzpIz5Q0E19KruGaAmixAzaLxymhwj2gQ==",
+      "dev": true
+    },
+    "node_modules/@lwc/engine-server": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-server/-/engine-server-3.1.2.tgz",
+      "integrity": "sha512-SLbsOpvXqfw7P2PbKetzO38Io5XF4UrkAxwhqpEQgNAvaQH/bQmsdG5lrttvdBlsNyBI/kGsCofpv7AHfaMi2w==",
       "dev": true,
-      "license": "MIT"
+      "peer": true
     },
     "node_modules/@lwc/errors": {
-      "version": "2.11.8",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.42.0.tgz",
+      "integrity": "sha512-byCYjSXoV8B3s9d+rPwpQwGZ2y4u6Gh+QJkDT6ZGgcXhBCWeQLPp87rnZdhTau3Da0P7319G+ivOp57smbk/Eg==",
+      "dev": true
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "1.6.2",
@@ -5065,13 +5045,14 @@
       }
     },
     "node_modules/@lwc/jest-preset": {
-      "version": "11.4.0",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-11.8.0.tgz",
+      "integrity": "sha512-BHb246V3LGm8q1HPYKFEZIgHwgFi8X5lN2R0FZavfyt1lnGhSa4ilS/zpLAgTHhyTOUhXkR4BKTDauCGLl4brw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lwc/jest-resolver": "11.4.0",
-        "@lwc/jest-serializer": "11.4.0",
-        "@lwc/jest-transformer": "11.4.0"
+        "@lwc/jest-resolver": "11.8.0",
+        "@lwc/jest-serializer": "11.8.0",
+        "@lwc/jest-transformer": "11.8.0"
       },
       "engines": {
         "node": ">=10"
@@ -5079,55 +5060,46 @@
       "peerDependencies": {
         "@lwc/compiler": "*",
         "@lwc/engine-dom": "*",
+        "@lwc/engine-server": ">=2",
         "@lwc/synthetic-shadow": "*",
-        "jest": "^26 || ^27 || ^28"
+        "jest": "^26 || ^27 || ^28 || ^29"
       }
     },
     "node_modules/@lwc/jest-resolver": {
-      "version": "11.4.0",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-11.8.0.tgz",
+      "integrity": "sha512-mN5tXW1jko671GUE/yZP/xbZ1ECpnZo40dLMzFctIUF9kOmMjRMv/xdsBTtBnI59W2WKMYDs8G7pywdMFBeZvw==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@lwc/jest-shared": "11.8.0"
+      },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "jest": "^26 || ^27 || ^28"
+        "jest": "^26 || ^27 || ^28 || ^29"
       }
     },
     "node_modules/@lwc/jest-serializer": {
-      "version": "11.4.0",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-11.8.0.tgz",
+      "integrity": "sha512-bjIywlnvTkfEvBNKOrb/DHMvTw/V78ZSgNwry2eCHcDFI93adj6HkAx+Qq214uprnT/lZUtxosJBTcc/DkjrpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "pretty-format": "^28.1.0"
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "jest": "^26 || ^27 || ^28"
+        "jest": "^26 || ^27 || ^28 || ^29"
       }
-    },
-    "node_modules/@lwc/jest-serializer/node_modules/@jest/schemas": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@lwc/jest-serializer/node_modules/@sinclair/typebox": {
-      "version": "0.24.51",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@lwc/jest-serializer/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5136,109 +5108,187 @@
       }
     },
     "node_modules/@lwc/jest-serializer/node_modules/pretty-format": {
-      "version": "28.1.3",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
+      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^28.1.3",
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.6.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@lwc/jest-serializer/node_modules/react-is": {
       "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/@lwc/jest-shared": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@lwc/jest-shared/-/jest-shared-11.8.0.tgz",
+      "integrity": "sha512-g4xgbD5+NC75omjZ6YZZ/tJhhrBnFEj2Lx/oY/yLtKUDXRX//PiWmGGcdlUbM5X8T8Bx9VR1wFttlB2Ta26VPQ==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@lwc/jest-transformer": {
-      "version": "11.4.0",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-11.8.0.tgz",
+      "integrity": "sha512-qEyQnw95I7NtFugoTbIRlxN7jXiKCsrEo6ZvMOtyVAAJeKjbv02j+2XCSp15e8usnH5UFNY7DKm2wTxMfr991A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.17.10",
-        "@babel/plugin-proposal-dynamic-import": "^7.16.7",
+        "@babel/core": "^7.21.3",
+        "@babel/plugin-proposal-dynamic-import": "^7.18.6",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-decorators": "^7.17.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.17.9",
-        "@babel/preset-typescript": "^7.16.7",
-        "babel-preset-jest": "^27.4.0"
+        "@babel/plugin-syntax-decorators": "^7.21.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/preset-typescript": "^7.21.0",
+        "@lwc/jest-shared": "11.8.0",
+        "babel-preset-jest": "^29.5.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
         "@lwc/compiler": "*",
-        "jest": "^26 || ^27 || ^28"
+        "jest": "^26 || ^27 || ^28 || ^29"
+      }
+    },
+    "node_modules/@lwc/jest-transformer/node_modules/@babel/core": {
+      "version": "7.22.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
+      "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.9",
+        "@babel/helper-compilation-targets": "^7.22.9",
+        "@babel/helper-module-transforms": "^7.22.9",
+        "@babel/helpers": "^7.22.6",
+        "@babel/parser": "^7.22.7",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@lwc/jest-transformer/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
+      "integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@lwc/jest-transformer/node_modules/babel-preset-jest": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
+      "integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.5.0",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@lwc/jest-transformer/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@lwc/module-resolver": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-2.42.0.tgz",
+      "integrity": "sha512-pwtgFNm/sNIS7daRnLCNLY4CqO/B31/ZwsqQd3Hs5eaH9iSFrGnoUm4sTVFyLljVAy7CXKdakwkvcj3JKjsO+w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "resolve": "~1.22.0"
+        "resolve": "~1.22.1"
       }
     },
     "node_modules/@lwc/shared": {
-      "version": "2.11.8",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.42.0.tgz",
+      "integrity": "sha512-YSI9VObp3fJ5yyg6vE4tDRB8dqKRT5ZYmKL03lzQh6+NMcjqv+EyW48Q2pPcv2ghsg0mJHvHBl7+hFGe5Z03OQ==",
+      "dev": true
     },
     "node_modules/@lwc/style-compiler": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-2.42.0.tgz",
+      "integrity": "sha512-8p9YKqiNqK9XlblLgHYigRfNFsohmKYl400w/t5uewaMlLx/DoPlxcUmeEhGtibqkGEK7uqnuvLZDsO99Tuylw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lwc/shared": "2.11.8",
-        "postcss": "~8.4.6",
-        "postcss-selector-parser": "~6.0.9",
+        "@lwc/shared": "2.42.0",
+        "postcss": "~8.4.20",
+        "postcss-selector-parser": "~6.0.11",
         "postcss-value-parser": "~4.2.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.8"
       }
     },
     "node_modules/@lwc/synthetic-shadow": {
-      "version": "2.11.8",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/synthetic-shadow/-/synthetic-shadow-2.42.0.tgz",
+      "integrity": "sha512-UgtQqoyoIH8qi2Tv05PuX3FGRjeASyBb8Ylqmn4qed7nCOeek5uUbWh2sX2Ck/lK73qVqk4jiH8xsK9MIrQvoQ==",
+      "dev": true
     },
     "node_modules/@lwc/template-compiler": {
-      "version": "2.11.8",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.42.0.tgz",
+      "integrity": "sha512-IMmm50fJUVG4kiX8gVptT6V/amtGMIi1dbcCU7rixjoBxd/F20lhZN3yHSPiWGFmoBWri16cFd+5hu3YYPRJdw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lwc/errors": "2.11.8",
-        "@lwc/shared": "2.11.8",
-        "acorn": "~8.7.0",
-        "astring": "~1.8.1",
+        "@lwc/errors": "2.42.0",
+        "@lwc/shared": "2.42.0",
+        "acorn": "~8.8.2",
+        "astring": "~1.8.3",
         "estree-walker": "~2.0.2",
         "he": "~1.2.0",
         "parse5": "~6.0.1"
       }
     },
-    "node_modules/@lwc/template-compiler/node_modules/acorn": {
-      "version": "8.7.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/@lwc/template-compiler/node_modules/parse5": {
       "version": "6.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "node_modules/@lwc/wire-service": {
-      "version": "2.11.8",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-2.42.0.tgz",
+      "integrity": "sha512-ZUY+8tYRxSYP5Murcb9tHZYXfMas4gNGfnt50Z/FxMX2kEC8Snp6sPyUTV1k4q+zTNu0zJ+WYHVpMgB+QfUc+w==",
+      "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.29.3",
@@ -8110,9 +8160,10 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/wire-service-jest-util": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/wire-service-jest-util/-/wire-service-jest-util-4.0.1.tgz",
+      "integrity": "sha512-6u3ZGXDCeRnKSX8WHRpVQAXmGiee6NkhmQb0gXmcPAm8zW/Q7o7lRJNvXKnxnXY7qyiKXVYDQAFKJjtGpaCfjw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@lwc/engine-dom": "^2.0.0"
       }
@@ -8157,8 +8208,7 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "peer": true
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -9416,11 +9466,6 @@
       "version": "4.0.0",
       "license": "MIT"
     },
-    "node_modules/@types/parse5": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/pino": {
       "version": "6.3.12",
       "license": "MIT",
@@ -9609,7 +9654,9 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.3",
@@ -11701,9 +11748,10 @@
       }
     },
     "node_modules/astring": {
-      "version": "1.8.5",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
+      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "astring": "bin/astring"
       }
@@ -21161,8 +21209,9 @@
     },
     "node_modules/isobject": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
       },
@@ -23322,8 +23371,9 @@
     },
     "node_modules/line-column": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "isarray": "^1.0.0",
         "isobject": "^2.0.0"
@@ -51308,7 +51358,7 @@
         "@octokit/graphql-schema": "10.74.2",
         "@salesforce/eslint-config-lwc": "3.3.3",
         "@salesforce/eslint-plugin-lightning": "1.0.0",
-        "@salesforce/sfdx-lwc-jest": "1.1.2",
+        "@salesforce/sfdx-lwc-jest": "1.4.1",
         "@types/strip-color": "0.1.0",
         "@types/wait-on": "5.3.1",
         "chalk": "4.1.2",
@@ -51334,592 +51384,61 @@
         "node": ">=14.0.0"
       }
     },
-    "packages/quantic/node_modules/@jest/console": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/core": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/reporters": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^28.1.3",
-        "jest-config": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-resolve-dependencies": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "rimraf": "^3.0.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/@jest/environment": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "jest-mock": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/expect": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^28.1.3",
-        "jest-snapshot": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/expect-utils": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^28.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/fake-timers": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@types/node": "*",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/globals": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/types": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/reporters": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/@jest/schemas": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/source-map": {
-      "version": "28.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.13",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/test-result": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/test-sequencer": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^28.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/transform": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/@jest/types": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^28.1.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
     "packages/quantic/node_modules/@salesforce/sfdx-lwc-jest": {
-      "version": "1.1.2",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/sfdx-lwc-jest/-/sfdx-lwc-jest-1.4.1.tgz",
+      "integrity": "sha512-BYKt4FxBJfKkWUKvSC2Yxb+mnIcP+6URbawsX8aeo1pKRnz6TDusiNZE8bR+8ZRWwnmeUC0fzKlZEi3xIqzMRg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@lwc/compiler": "2.11.8",
-        "@lwc/engine-dom": "2.11.8",
-        "@lwc/jest-preset": "^11.4.0",
-        "@lwc/jest-resolver": "^11.4.0",
-        "@lwc/jest-serializer": "^11.4.0",
-        "@lwc/jest-transformer": "^11.4.0",
-        "@lwc/module-resolver": "2.11.8",
-        "@lwc/synthetic-shadow": "2.11.8",
-        "@lwc/wire-service": "2.11.8",
-        "@salesforce/wire-service-jest-util": "4.0.0",
+        "@lwc/compiler": "2.42.0",
+        "@lwc/engine-dom": "2.42.0",
+        "@lwc/jest-preset": "11.8.0",
+        "@lwc/jest-resolver": "11.8.0",
+        "@lwc/jest-serializer": "11.8.0",
+        "@lwc/jest-transformer": "11.8.0",
+        "@lwc/module-resolver": "2.42.0",
+        "@lwc/synthetic-shadow": "2.42.0",
+        "@lwc/wire-service": "2.42.0",
+        "@salesforce/wire-service-jest-util": "4.0.1",
         "chalk": "^4.1.2",
-        "fast-glob": "^3.2.10",
-        "jest": "^28.1.0",
-        "jest-environment-jsdom": "^28.1.0",
-        "yargs": "~17.5.1"
+        "fast-glob": "^3.2.12",
+        "jest": "27.4.7",
+        "yargs": "~17.6.2"
       },
       "bin": {
         "lwc-jest": "bin/sfdx-lwc-jest",
         "sfdx-lwc-jest": "bin/sfdx-lwc-jest"
       }
     },
-    "packages/quantic/node_modules/@sinclair/typebox": {
-      "version": "0.24.51",
+    "packages/quantic/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "packages/quantic/node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "packages/quantic/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/quantic/node_modules/@types/jsdom": {
-      "version": "16.2.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/parse5": "^6.0.3",
-        "@types/tough-cookie": "*"
-      }
-    },
-    "packages/quantic/node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "packages/quantic/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/quantic/node_modules/babel-jest": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "^28.1.3",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^28.1.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
-    "packages/quantic/node_modules/babel-plugin-jest-hoist": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/babel-preset-jest": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^28.1.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "packages/quantic/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "packages/quantic/node_modules/cssom": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/quantic/node_modules/data-urls": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/domexception": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/emittery": {
-      "version": "0.10.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "packages/quantic/node_modules/execa": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "packages/quantic/node_modules/expect": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/form-data": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/quantic/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/quantic/node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/quantic/node_modules/human-signals": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "packages/quantic/node_modules/is-stream": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/quantic/node_modules/jest": {
-      "version": "28.1.3",
+      "version": "27.4.7",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.7.tgz",
+      "integrity": "sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/core": "^27.4.7",
         "import-local": "^3.0.2",
-        "jest-cli": "^28.1.3"
+        "jest-cli": "^27.4.7"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -51928,795 +51447,21 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "packages/quantic/node_modules/jest-changed-files": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-circus": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-cli": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "import-local": "^3.0.2",
-        "jest-config": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "prompts": "^2.0.1",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/jest-config": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "babel-jest": "^28.1.3",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^28.1.3",
-        "jest-environment-node": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/jest-diff": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-docblock": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-each": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-environment-jsdom": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/jsdom": "^16.2.4",
-        "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jsdom": "^19.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-environment-node": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-haste-map": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "packages/quantic/node_modules/jest-leak-detector": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-matcher-utils": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-message-util": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^28.1.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-mock": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-regex-util": {
-      "version": "28.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-resolve": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-resolve-dependencies": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "^28.0.2",
-        "jest-snapshot": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-runner": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/environment": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^28.1.1",
-        "jest-environment-node": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-leak-detector": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-resolve": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "jest-worker": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-runtime": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/globals": "^28.1.3",
-        "@jest/source-map": "^28.1.2",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-snapshot": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/babel__traverse": "^7.0.6",
-        "@types/prettier": "^2.1.5",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^28.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-haste-map": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^28.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-util": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-validate": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "leven": "^3.1.0",
-        "pretty-format": "^28.1.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-watcher": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
-        "jest-util": "^28.1.3",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jest-worker": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/jsdom": {
-      "version": "19.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.5",
-        "acorn": "^8.5.0",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.1",
-        "decimal.js": "^10.3.1",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^3.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0",
-        "ws": "^8.2.3",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/quantic/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/quantic/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/quantic/node_modules/onetime": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/quantic/node_modules/parse5": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/quantic/node_modules/pretty-format": {
-      "version": "28.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^28.1.3",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "packages/quantic/node_modules/punycode": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/quantic/node_modules/react-is": {
-      "version": "18.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/quantic/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/quantic/node_modules/source-map-support": {
-      "version": "0.5.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "packages/quantic/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/quantic/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "packages/quantic/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/quantic/node_modules/tr46": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/universalify": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "packages/quantic/node_modules/v8-to-istanbul": {
-      "version": "9.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "packages/quantic/node_modules/w3c-xmlserializer": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/whatwg-url": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/quantic/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "packages/quantic/node_modules/ws": {
-      "version": "8.13.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "packages/quantic/node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12"
       }
     },
     "packages/quantic/node_modules/yargs": {
-      "version": "17.5.1",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -52724,8 +51469,9 @@
     },
     "packages/quantic/node_modules/yargs-parser": {
       "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -58610,11 +57356,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "packages/samples/headless-ssr/node_modules/exponential-backoff": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.0.tgz",
-      "integrity": "sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA=="
-    },
     "packages/samples/headless-ssr/node_modules/globals": {
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -58733,11 +57474,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "packages/samples/headless-ssr/node_modules/ts-debounce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-3.0.0.tgz",
-      "integrity": "sha512-7jiRWgN4/8IdvCxbIwnwg2W0bbYFBH6BxFqBjMKk442t7+liF2Z1H6AUCcl8e/pD93GjPru+axeiJwFmRww1WQ=="
     },
     "packages/samples/headless-ssr/node_modules/type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -76,13 +76,7 @@
   },
   "overrides": {
     "@coveo/quantic": {
-      "@lwc/compiler": "2.11.8",
-      "@salesforce/sfdx-lwc-jest@1.1.2": {
-        "@lwc/jest-preset": "11.4.0",
-        "@lwc/jest-resolver": "11.4.0",
-        "@lwc/jest-serializer": "11.4.0",
-        "@lwc/jest-transformer": "11.4.0"
-      }
+      "@lwc/compiler": "2.11.8"
     }
   },
   "workspaces": [

--- a/packages/quantic/force-app/examples/main/lwc/actionPerformSearch/actionPerformSearch.html
+++ b/packages/quantic/force-app/examples/main/lwc/actionPerformSearch/actionPerformSearch.html
@@ -1,6 +1,6 @@
 <template>
   <div class="slds-grid slds-gutters">
-    <template if:true={withInput}>
+    <template lwc:if={withInput}>
       <div class="slds-col">
         <lightning-input
           disabled={disabled}

--- a/packages/quantic/force-app/examples/main/lwc/eventListener/eventListener.html
+++ b/packages/quantic/force-app/examples/main/lwc/eventListener/eventListener.html
@@ -1,11 +1,11 @@
 <template>
-  <template if:true={expectsEvents}>
+  <template lwc:if={expectsEvents}>
     <div class="slds-m-bottom_small">
       <c-quantic-card-container title="Events">
         <template for:each={events} for:item="event">
           <div key={event.type} class="slds-card__body_inner">
             <div class="grid slds-grid_vertical-align-center slds-m-bottom_xx-small">
-              <template if:true={event.received}>
+              <template lwc:if={event.received}>
                 <div class="event__received grid slds-grid_vertical-align-center slds-m-bottom_xx-small">
                   <lightning-icon icon-name="utility:check" alternative-text="Received" title="Received" variant="success" size="xx-small" class="slds-m-right_x-small"></lightning-icon>
                   {event.type}

--- a/packages/quantic/force-app/examples/main/lwc/exampleInsightPanel/resultTemplates/childResultTemplate.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleInsightPanel/resultTemplates/childResultTemplate.html
@@ -22,7 +22,7 @@
         result={result}
       ></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview
         slot="actions"
         engine-id={engineId}

--- a/packages/quantic/force-app/examples/main/lwc/exampleInsightPanel/resultTemplates/parentResultTemplate.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleInsightPanel/resultTemplates/parentResultTemplate.html
@@ -23,7 +23,7 @@
           result={result}
         ></c-quantic-result-badge>
       </div>
-      <template if:true={resultHasPreview}>
+      <template lwc:if={resultHasPreview}>
         <c-quantic-result-quickview
           slot="actions"
           engine-id={engineId}

--- a/packages/quantic/force-app/examples/main/lwc/exampleLayout/exampleLayout.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleLayout/exampleLayout.html
@@ -15,7 +15,7 @@
       </div>
     </div>
     <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-2 slds-large-size_1-of-2">
-      <template if:true={showPreview}>
+      <template lwc:if={showPreview}>
         <c-event-listener expected-events={expectedEvents}>
           <c-quantic-card-container title="Preview">
             <div class="slds-card__body_inner slds-p-top_small">

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticRefineToggle/templateWithFacetsWithoutInputs.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticRefineToggle/templateWithFacetsWithoutInputs.html
@@ -36,7 +36,7 @@
     </c-configurator>
     <c-quantic-search-interface slot="preview" engine-id={engineId}>
       <c-quantic-facet-manager engine-id={engineId}>
-        <template if:true={facetWithoutInputs}>
+        <template lwc:if={facetWithoutInputs}>
           <c-quantic-facet-manager engine-id={engineId}>
             <c-quantic-facet
               engine-id={engineId}

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/caseResultTemplate.html
@@ -12,7 +12,7 @@
       </div>
       <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
     </template>
     <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/chatterResultTemplate.html
@@ -7,7 +7,7 @@
       </div>
       <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
     </template>
     <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/childTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/childTemplate.html
@@ -7,7 +7,7 @@
       </div>
       <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
     </template>
     <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/parentTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/parentTemplate.html
@@ -9,7 +9,7 @@
         </div>
         <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
       </div>
-      <template if:true={resultHasPreview}>
+      <template lwc:if={resultHasPreview}>
         <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
       </template>
       <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
+++ b/packages/quantic/force-app/main/default/lwc/exampleSearch/resultTemplates/youtubeResultTemplate.html
@@ -7,7 +7,7 @@
       </div>
       <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
     </template>
     <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasBreadcrumbs}>
+    <template lwc:if={hasBreadcrumbs}>
       <div class="slds-grid slds-grid_vertical-align-start slds-size_1-of-1 slds-var-m-vertical_x-small">
         <div class="slds-col slds-truncate slds-col_bump-right breadcrumb-manager__column">
           <ul>
@@ -17,7 +17,7 @@
                       <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                     </li>
                   </template>
-                  <template if:true={breadcrumb.showMoreButton}>
+                  <template lwc:if={breadcrumb.showMoreButton}>
                     <li>
                       <button onclick={breadcrumb.expandButtonClick} class="slds-grid slds-button slds-var-m-around_xxx-small slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</button>
                     </li>
@@ -34,7 +34,7 @@
                       <c-quantic-pill label={breadcrumbValue.formattedValue} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                     </li>
                   </template>
-                  <template if:true={breadcrumb.showMoreButton}>
+                  <template lwc:if={breadcrumb.showMoreButton}>
                     <li>
                       <button onclick={breadcrumb.expandButtonClick} class="slds-grid slds-button slds-var-m-around_xxx-small slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</button>
                     </li>
@@ -61,7 +61,7 @@
                       <c-quantic-pill label={breadcrumbValue.value} ondeselect={breadcrumbValue.deselect} group-name={breadcrumb.label} action-name={labels.clearFilter}></c-quantic-pill>
                     </li>
                   </template>
-                  <template if:true={breadcrumb.showMoreButton}>
+                  <template lwc:if={breadcrumb.showMoreButton}>
                     <li>
                       <button onclick={breadcrumb.expandButtonClick} class="slds-grid slds-button slds-var-m-around_xxx-small slds-p-horizontal_x-small slds-p-vertical_xx-small slds-text-color_default breadcrumb-manager__more-button">{breadcrumb.showMoreButtonText}</button>
                     </li>

--- a/packages/quantic/force-app/main/default/lwc/quanticCarousel/quanticCarousel.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCarousel/quanticCarousel.html
@@ -1,12 +1,12 @@
 <template>
-  <template if:true={errorMessage}>
+  <template lwc:if={errorMessage}>
     <c-quantic-component-error
       component-name={template.host.localName}
       message={errorMessage}
     >
     </c-quantic-component-error>
   </template>
-  <template if:false={errorMessage}>
+  <template lwc:else>
     <section role="region" aria-roledescription={labels.carousel} aria-label={label}>
       <div class="slds-grid carousel__container slds-is-relative">
         <lightning-button-icon

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
@@ -8,7 +8,7 @@
       <legend class="slds-form-element__legend slds-form-element__label slds-text-heading_small">
         {label}
       </legend>
-      <template if:true={loading}>
+      <template lwc:if={loading}>
         <div class="loading-holder slds-var-m-top_x-small">
           <lightning-spinner alternative-text={labels.loading} size="small"></lightning-spinner>
         </div>
@@ -33,13 +33,13 @@
                 </div>
               </template>
             </template>
-            <template if:true={isMoreOptionsVisible}>
+            <template lwc:if={isMoreOptionsVisible}>
               <template if:false={isSelectVisible}>
                 <lightning-button class="slds-var-m-top_x-small" variant="base" label={selectPlaceholder}
                   title={selectPlaceholder} onclick={showSelect}>
                 </lightning-button>
               </template>
-              <template if:true={isSelectVisible}>
+              <template lwc:if={isSelectVisible}>
                 <lightning-combobox class="slds-var-m-top_x-small" value={value} variant="label-hidden"
                   placeholder={selectPlaceholder} options={options} onchange={handleSelectChange}></lightning-combobox>
               </template>
@@ -63,7 +63,7 @@
             </template>
           </div>
         </div>
-        <template if:true={hasError}>
+        <template lwc:if={hasError}>
           <div class="slds-form-element__help" id="case-classification-error-message">
             {errorMessage}
           </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacet/quanticCategoryFacet.html
@@ -4,10 +4,10 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows={numberOfValues}></c-quantic-placeholder>
     </template>
-    <template if:true={hasParentsOrValues}>
+    <template lwc:if={hasParentsOrValues}>
       <c-quantic-card-container title={label} onheaderclick={toggleFacetVisibility} onheaderkeydown={toggleFacetVisibility}>
         <lightning-button-icon
           class={actionButtonCssClasses}
@@ -22,7 +22,7 @@
         </lightning-button-icon>
         <template if:false={isCollapsed}>
           <ul class="slds-has-dividers_around-space slds-m-top_medium">
-            <template if:true={withSearch}>
+            <template lwc:if={withSearch}>
               <div onchange={handleKeyUp} class="slds-size_1-of-1">
                 <lightning-input
                   class="facet__searchbox-input slds-p-horizontal_x-small slds-var-p-bottom_x-small"
@@ -35,7 +35,7 @@
               </div>
             </template>
             <template if:false={isFacetSearchActive}>
-              <template if:true={hasParents}>
+              <template lwc:if={hasParents}>
                 <li class="facet__value-option slds-size_1-of-1 slds-p-around_x-small">
                   <div
                     role="button"
@@ -59,7 +59,7 @@
                   ></c-quantic-category-facet-value>
                 </li>
               </template>
-              <template if:true={activeParent}>
+              <template lwc:if={activeParent}>
                 <li class="facet__active-parent slds-grid slds-grid_vertical-align-center slds-p-around_x-small slds-m-left_medium">
                   <div
                     role="button"
@@ -90,8 +90,8 @@
                 </fieldset>
               </li>
             </template>
-            <template if:true={isFacetSearchActive}>
-              <template if:true={hasSearchResults}>
+            <template lwc:if={isFacetSearchActive}>
+              <template lwc:if={hasSearchResults}>
                 <template for:each={facetSearchResults} for:item="result">
                   <c-quantic-category-facet-value
                     key={result.index}
@@ -110,7 +110,7 @@
                     </span>
                   </li>
                 </template>
-                <template if:true={canShowMoreSearchResults}>
+                <template lwc:if={canShowMoreSearchResults}>
                   <li>
                     <span class="slds-truncate facet__search-results_more-matches">{moreMatchesForLabel}</span>
                   </li>
@@ -119,12 +119,12 @@
             </template>
           </ul>
           <div class="facet__show slds-m-top_x-small slds-p-horizontal_x-small">
-            <template if:true={canShowLess}>
+            <template lwc:if={canShowLess}>
               <button variant="base" class="facet__show-less slds-p-around_none" onclick={showLess} aria-label={showLessFacetValuesLabel} title={showLessFacetValuesLabel}>
                 <span class="facet__show-less_text">{labels.showLess}</span>
               </button>
             </template>
-            <template if:true={canShowMore}>
+            <template lwc:if={canShowMore}>
               <button variant="base" class="facet__show-more slds-p-around_none" onclick={showMore} aria-label={showMoreFacetValuesLabel} title={showMoreFacetValuesLabel}>
                 <span class="facet__show-more_text">{labels.showMore}</span>
               </button>

--- a/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCategoryFacetValue/quanticCategoryFacetValue.html
@@ -8,7 +8,7 @@
     onkeydown={onKeyDown}
     aria-label={ariaLabelValue}
   >
-    <template if:true={nonActiveParent}>
+    <template lwc:if={nonActiveParent}>
       <div
         class="facet__parent-value-option facet__value-option slds-grid slds-truncate slds-grid_vertical-align-center slds-size_1-of-1 slds-p-around_x-small"
       >
@@ -26,7 +26,7 @@
           <span class="facet__number-of-results slds-var-m-left_xx-small">({numberOfResults})</span>
         </div>
       </template>
-      <template if:true={isSearchResult}>
+      <template lwc:if={isSearchResult}>
         <div class="facet__value-option slds-size_1-of-1 slds-p-around_x-small slds-text-color_default">
           <div class="slds-grid slds-grid_vertical slds-size_1-of-1">
             <div

--- a/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticColoredResultBadge/quanticColoredResultBadge.html
@@ -1,11 +1,11 @@
 <template>
-  <template if:true={error}>
+  <template lwc:if={error}>
     <div class="error-message slds-text-color_destructive">{error}</div>
   </template>
-  <template if:true={isValid}>
-    <template if:true={hasTextToDisplay}>
+  <template lwc:if={isValid}>
+    <template lwc:if={hasTextToDisplay}>
       <div class="slds-badge slds-var-p-horizontal_medium slds-truncate result-badge">
-        <template if:true={hasLabel}>
+        <template lwc:if={hasLabel}>
           {label}
         </template>
         <template if:false={hasLabel}>

--- a/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDateFacet/quanticDateFacet.html
@@ -4,10 +4,10 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows={numberOfValues}></c-quantic-placeholder>
     </template>
-    <template if:true={hasValues}>
+    <template lwc:if={hasValues}>
       <div class="slds-size_1-of-1">
         <c-quantic-card-container title={label} onheaderclick={toggleFacetVisibility} onheaderkeydown={toggleFacetVisibility}>
           <lightning-button-icon
@@ -21,7 +21,7 @@
             aria-hidden="true"
           >
           </lightning-button-icon>
-          <template if:true={hasActiveValues}>
+          <template lwc:if={hasActiveValues}>
             <button
               class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small slds-m-top_small"
               onclick={clearSelections}

--- a/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDidYouMean/quanticDidYouMean.html
@@ -4,8 +4,8 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasQueryCorrection}>
-      <template if:true={wasAutomaticallyCorrected}>
+    <template lwc:if={hasQueryCorrection}>
+      <template lwc:if={wasAutomaticallyCorrected}>
         <div class="slds-var-m-vertical_x-small">
           <p class="mb-1">
             <lightning-formatted-rich-text

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -4,13 +4,13 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={loading}>
+    <template lwc:if={loading}>
       <div class="loading-holder">
         <lightning-spinner alternative-text={labels.loading}></lightning-spinner>
       </div>
     </template>
     <template if:false={loading}>
-      <template if:true={hasSuggestions}>
+      <template lwc:if={hasSuggestions}>
         <div class="slds-card">
           <lightning-accordion active-section-name={openedDocuments} allow-multiple-sections-open
             class="slds-p-vertical_xx-small">
@@ -27,7 +27,7 @@
                     ">
                     <p class="excerpt">{it.value.excerpt}</p>
                     <div class="row slds-var-p-top_medium">
-                      <template if:true={showQuickview}>
+                      <template lwc:if={showQuickview}>
                         <c-quantic-result-quickview engine-id={engineId}
                           preview-button-icon="utility:new_window" preview-button-label={labels.readMore}
                           preview-button-variant="outline-brand" result={it.value}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -4,13 +4,13 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder
         variant="card"
         number-of-rows={numberOfValues}
       ></c-quantic-placeholder>
     </template>
-    <template if:true={hasValues}>
+    <template lwc:if={hasValues}>
       <div class="slds-size_1-of-1">
         <c-quantic-card-container
           title={label}
@@ -28,7 +28,7 @@
             aria-hidden="true"
           >
           </lightning-button-icon>
-          <template if:true={hasActiveValues}>
+          <template lwc:if={hasActiveValues}>
             <button
               class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small slds-m-top_small"
               onclick={clearSelections}
@@ -48,7 +48,7 @@
           </template>
           <template if:false={isCollapsed}>
             <div class="slds-has-dividers_around-space slds-m-top_medium">
-              <template if:true={displaySearch}>
+              <template lwc:if={displaySearch}>
                 <div onchange={handleKeyUp} class="slds-size_1-of-1">
                   <lightning-input
                     class="facet__searchbox-input slds-p-horizontal_x-small slds-p-bottom_x-small"
@@ -84,7 +84,7 @@
                 <div
                   class="facet__show slds-m-top_x-small slds-p-horizontal_x-small"
                 >
-                  <template if:true={canShowLess}>
+                  <template lwc:if={canShowLess}>
                     <button
                       variant="base"
                       class="facet__show-less slds-p-around_none"
@@ -97,7 +97,7 @@
                       >
                     </button>
                   </template>
-                  <template if:true={canShowMore}>
+                  <template lwc:if={canShowMore}>
                     <button
                       variant="base"
                       class="facet__show-more slds-p-around_none"
@@ -113,8 +113,8 @@
                 </div>
               </template>
 
-              <template if:true={isFacetSearchActive}>
-                <template if:true={hasSearchResults}>
+              <template lwc:if={isFacetSearchActive}>
+                <template lwc:if={hasSearchResults}>
                   <template for:each={facetSearchResults} for:item="result">
                     <c-quantic-facet-value
                       onselectvalue={onSelectValue}
@@ -137,7 +137,7 @@
                       </span>
                     </li>
                   </template>
-                  <template if:true={canShowMoreSearchResults}>
+                  <template lwc:if={canShowMoreSearchResults}>
                     <li>
                       <span
                         class="slds-truncate facet__search-results_more-matches"

--- a/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacetValue/quanticFacetValue.html
@@ -21,7 +21,7 @@
         checked={isChecked}
       ></lightning-input>
     </template>
-    <template if:true={isChecked}>
+    <template lwc:if={isChecked}>
       <span
         class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small facet__value-text facet__value_selected"
         title={formattedFacetValue}
@@ -33,7 +33,7 @@
       </span>
     </template>
     <template if:false={isChecked}>
-      <template if:true={isStandardFacet}>
+      <template lwc:if={isStandardFacet}>
         <span
           class="slds-truncate slds-var-m-right_xx-small slds-var-m-top_xxx-small facet__value-text facet__value_idle"
           title={formattedFacetValue}

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
@@ -13,7 +13,7 @@
       <span class="feedback__button-label slds-var-m-left_xx-small">{labels.no}</span>
     </button>
   </div>
-  <template if:true={displaySuccessMessage}>
+  <template lwc:if={displaySuccessMessage}>
     <div class="slds-grid feedback__success-message">
       <span class="slds-var-p-vertical_x-small">{successMessage}</span>
       <template if:false={hideExplainWhyButton}>

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedbackModal/feedbackForm.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedbackModal/feedbackForm.html
@@ -1,5 +1,5 @@
 <template>
-  <template if:true={isValidated}>
+  <template lwc:if={isValidated}>
     <lightning-modal-header label={labels.explainWhy}></lightning-modal-header>
     <lightning-modal-body>
       <div class="slds-var-p-around_x-large">
@@ -7,7 +7,7 @@
           options={options} value={feedbackValue} type="radio" onchange={handleFeedbackChange}
           message-when-value-missing={labels.selectOneOfOptions}></lightning-radio-group>
         <div class="details-input__container">
-          <template if:true={shouldDisplayDetailsInput}>
+          <template lwc:if={shouldDisplayDetailsInput}>
             <lightning-textarea data-cy="feedback-modal-body__details-input" required={detailsAreRequired} value={detailsValue} label={labels.provideDetails}
               message-when-value-missing={labels.fillOutField} onchange={handleDetailsChange}></lightning-textarea>
           </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="resultList" number-of-rows={numberOfResults}></c-quantic-placeholder>
     </template>
     <template for:each={collections} for:item="collection">

--- a/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.html
@@ -1,5 +1,5 @@
 <template>
-  <template if:true={renderingError}>
+  <template lwc:if={renderingError}>
     <div class="error-message slds-text-color_destructive">
       {renderingError}
     </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNoResults/quanticNoResults.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showNoResultsPanel}>
+    <template lwc:if={showNoResultsPanel}>
       <div class="slds-grid slds-grid_vertical">
         <div
           class="slds-col slds-size_12-of-12 slds-var-m-vertical_x-large slds-illustration slds-illustration_small"
@@ -21,7 +21,7 @@
             ></lightning-formatted-rich-text>
           </div>
           <p class="slds-text-body_small slds-text-align_center">
-            <template if:true={hasBreadcrumbs}>
+            <template lwc:if={hasBreadcrumbs}>
               <lightning-formatted-rich-text
                 value={labels.noResultsWithFilters}
               ></lightning-formatted-rich-text>
@@ -33,7 +33,7 @@
             </template>
           </p>
         </div>
-        <template if:true={showUndoButton}>
+        <template lwc:if={showUndoButton}>
           <div class="slds-m-vertical_x-large slds-align_absolute-center">
             <lightning-button
               variant="brand"

--- a/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.html
@@ -4,10 +4,10 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows={numberOfValues}></c-quantic-placeholder>
     </template>
-    <template if:true={shouldRenderFacet}>
+    <template lwc:if={shouldRenderFacet}>
       <div data-cy="numeric-facet__card" class="slds-size_1-of-1">
         <c-quantic-card-container title={label} onheaderclick={toggleFacetVisibility} onheaderkeydown={toggleFacetVisibility}>
           <lightning-button-icon
@@ -21,7 +21,7 @@
             aria-hidden="true"
           >
           </lightning-button-icon>
-          <template if:true={hasActiveValues}>
+          <template lwc:if={hasActiveValues}>
             <button
               class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-var-p-horizontal_x-small slds-m-top_small"
               onclick={clearSelections}
@@ -39,7 +39,7 @@
           </template>
           <template if:false={isCollapsed}>
             <div class="slds-has-dividers_around-space slds-var-m-top_medium">
-              <template if:true={withInput}>
+              <template lwc:if={withInput}>
                 <div class="slds-p-horizontal_x-small">
                   <form
                     onsubmit={onApply}
@@ -87,7 +87,7 @@
                   </form>
                 </div>
               </template>
-              <template if:true={showValues}>
+              <template lwc:if={showValues}>
                 <fieldset>
                   <legend class="slds-assistive-text">{field}</legend>
                   <ul>

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/quanticPager.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasResults}>
+    <template lwc:if={hasResults}>
       <lightning-button-group>
         <lightning-button
           variant="base"

--- a/packages/quantic/force-app/main/default/lwc/quanticPlaceholder/quanticPlaceholder.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticPlaceholder/quanticPlaceholder.html
@@ -1,7 +1,7 @@
 <template>
-  <template if:true={shouldDisplay}>
+  <template lwc:if={shouldDisplay}>
     <div class="slds-p-horizontal_x-small">
-      <template if:true={isCardVariant}>
+      <template lwc:if={isCardVariant}>
         <div class="placeholder__card-container slds-grid_vertical">
           <div class="slds-col slds-m-bottom_large">
             <div class="grey placeholder__card-header placeholder__rounded placeholder__animation"></div>
@@ -14,7 +14,7 @@
           </template>
         </div>
       </template>
-      <template if:true={isResultListVariant}>
+      <template lwc:if={isResultListVariant}>
         <template for:each={rows} for:item="row">
           <div key={row.index} class="placeholder__result-container slds-grid slds-gutters slds-grid_vertical-align-start">
             <div class="slds-col slds-m-bottom_large">

--- a/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticQueryError/quanticQueryError.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasError}>
+    <template lwc:if={hasError}>
       <div
         class="slds-grid slds-grid_align-center slds-gutters slds-grid_vertical"
       >
@@ -16,7 +16,7 @@
           </div>
           <p class="slds-text-align_center">{description}</p>
         </div>
-        <template if:true={link}>
+        <template lwc:if={link}>
           <a
             class="slds-var-m-vertical_x-small slds-align_absolute-center"
             href={link}
@@ -39,7 +39,7 @@
             </div>
           </template>
         </template>
-        <template if:true={showMoreInfo}>
+        <template lwc:if={showMoreInfo}>
           <div class="slds-var-m-top_medium">
             <div
               class="slds-rich-text-editor slds-grid slds-grid_vertical slds-nowrap"

--- a/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewDefault.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewDefault.html
@@ -5,7 +5,7 @@
       class="quickview__spinner-container slds-is-relative wrapper"
     >
       <lightning-spinner
-        if:true={isLoading}
+        lwc:if={isLoading}
         alternative-text="Loading"
         size="large"
       ></lightning-spinner>

--- a/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewYoutube.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewYoutube.html
@@ -5,7 +5,7 @@
       class="quickview__spinner-container slds-is-relative wrapper"
     >
       <lightning-spinner
-        if:true={isLoading}
+        lwc:if={isLoading}
         alternative-text="Loading"
         size="large"
       ></lightning-spinner>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentQueriesList/quanticRecentQueriesList.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows={maxLength}></c-quantic-placeholder>
     </template>
     <template if:false={showPlaceholder}>

--- a/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecentResultsList/quanticRecentResultsList.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows={maxLength}></c-quantic-placeholder>
     </template>
     <template if:false={showPlaceholder}>

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/templates/disabledDynamicNavigation.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/templates/disabledDynamicNavigation.html
@@ -12,14 +12,14 @@
         ></c-quantic-sort>
       </div>
     </template>
-    <template if:true={hasFacets}>
+    <template lwc:if={hasFacets}>
       <div
         class="slds-align_absolute-center filters-header slds-var-m-bottom_small"
       >
-        <template if:true={someFacetsRendered}>
+        <template lwc:if={someFacetsRendered}>
           <div class="slds-text-heading_small">{labels.filters}</div>
         </template>
-        <template if:true={hasActiveFilters}>
+        <template lwc:if={hasActiveFilters}>
           <lightning-button
             variant="base"
             label={labels.clearAllFilters}
@@ -29,7 +29,7 @@
         </template>
       </div>
       <template for:each={facets} for:item="facet">
-        <template if:true={facet.isNumeric}>
+        <template lwc:if={facet.isNumeric}>
           <c-quantic-numeric-facet
             engine-id={engineId}
             facet-id={facet.facetId}
@@ -44,7 +44,7 @@
             is-collapsed
           ></c-quantic-numeric-facet>
         </template>
-        <template if:true={facet.isCategory}>
+        <template lwc:if={facet.isCategory}>
           <c-quantic-category-facet
             engine-id={engineId}
             facet-id={facet.facetId}
@@ -61,7 +61,7 @@
             is-collapsed
           ></c-quantic-category-facet>
         </template>
-        <template if:true={facet.isTimeframe}>
+        <template lwc:if={facet.isTimeframe}>
           <c-quantic-timeframe-facet
             engine-id={engineId}
             facet-id={facet.facetId}
@@ -84,7 +84,7 @@
             </template>
           </c-quantic-timeframe-facet>
         </template>
-        <template if:true={facet.isDate}>
+        <template lwc:if={facet.isDate}>
           <c-quantic-date-facet
             engine-id={engineId}
             facet-id={facet.facetId}
@@ -96,7 +96,7 @@
             is-collapsed
           ></c-quantic-date-facet>
         </template>
-        <template if:true={facet.isDefault}>
+        <template lwc:if={facet.isDefault}>
           <c-quantic-facet
             engine-id={engineId}
             facet-id={facet.facetId}

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/templates/dynamicNavigation.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineModalContent/templates/dynamicNavigation.html
@@ -12,14 +12,14 @@
         ></c-quantic-sort>
       </div>
     </template>
-    <template if:true={hasFacets}>
+    <template lwc:if={hasFacets}>
       <div
         class="slds-align_absolute-center filters-header slds-var-m-bottom_small"
       >
-        <template if:true={someFacetsRendered}>
+        <template lwc:if={someFacetsRendered}>
           <div class="slds-text-heading_small">{labels.filters}</div>
         </template>
-        <template if:true={hasActiveFilters}>
+        <template lwc:if={hasActiveFilters}>
           <lightning-button
             variant="base"
             label={labels.clearAllFilters}
@@ -30,7 +30,7 @@
       </div>
       <c-quantic-facet-manager engine-id={engineId}>
         <template for:each={facets} for:item="facet">
-          <template if:true={facet.isNumeric}>
+          <template lwc:if={facet.isNumeric}>
             <c-quantic-numeric-facet
               engine-id={engineId}
               facet-id={facet.facetId}
@@ -45,7 +45,7 @@
               is-collapsed
             ></c-quantic-numeric-facet>
           </template>
-          <template if:true={facet.isCategory}>
+          <template lwc:if={facet.isCategory}>
             <c-quantic-category-facet
               engine-id={engineId}
               facet-id={facet.facetId}
@@ -62,7 +62,7 @@
               is-collapsed
             ></c-quantic-category-facet>
           </template>
-          <template if:true={facet.isTimeframe}>
+          <template lwc:if={facet.isTimeframe}>
             <c-quantic-timeframe-facet
               engine-id={engineId}
               facet-id={facet.facetId}
@@ -85,7 +85,7 @@
               </template>
             </c-quantic-timeframe-facet>
           </template>
-          <template if:true={facet.isDate}>
+          <template lwc:if={facet.isDate}>
             <c-quantic-date-facet
               engine-id={engineId}
               facet-id={facet.facetId}
@@ -97,7 +97,7 @@
               is-collapsed
             ></c-quantic-date-facet>
           </template>
-          <template if:true={facet.isDefault}>
+          <template lwc:if={facet.isDefault}>
             <c-quantic-facet
               engine-id={engineId}
               facet-id={facet.facetId}

--- a/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticRefineToggle/quanticRefineToggle.html
@@ -12,7 +12,7 @@
         class="slds-current-color slds-var-p-vertical_x-small slds-button__icon_right">
       </lightning-icon>
     </slot>
-    <template if:true={activeFiltersCount}>
+    <template lwc:if={activeFiltersCount}>
       <div
         class="refine-button_filters-badge slds-is-absolute slds-align_absolute-center slds-text-title slds-var-p-around_xxx-small">
         <span class="slds-truncate">{activeFiltersCount}</span>
@@ -32,7 +32,7 @@
     </div>
     <div class="slds-align_absolute-center" slot="content">
       <div class="refine-modal__content">
-        <template if:true={refineButtonDisabled}>
+        <template lwc:if={refineButtonDisabled}>
           <div class="slds-align_absolute-center slds-text-color_weak refine-modal__empty-message">
             {labels.noFilterForCurrentTab}
           </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.html
@@ -7,7 +7,7 @@
       </div>
       <c-quantic-result-badge variant="featured" result={result}></c-quantic-result-badge>
     </div>
-    <template if:true={resultHasPreview}>
+    <template lwc:if={resultHasPreview}>
       <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
     </template>
     <p slot="date" class="slds-size_xx-small">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.css
@@ -1,1 +1,1 @@
-@import 'c/quanticResultActionStyles';
+@import '../quanticResultActionStyles/quanticResultActionStyles.css';

--- a/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.css
@@ -1,1 +1,1 @@
-@import '../quanticResultActionStyles/quanticResultActionStyles.css';
+@import 'c/quanticResultActionStyles';

--- a/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultAction/quanticResultAction.html
@@ -1,6 +1,6 @@
 <template>
   <div class="slds-is-relative slds-show_inline result-action_container result-action_white-container">
-    <template if:true={loading}>
+    <template lwc:if={loading}>
       <button class={loadingClasses} aria-label={displayedLabel}>
         <div class="slds-spinner_container slds-var-m-around_xx-small">
           <div role="status" class="slds-spinner slds-spinner_xx-small">
@@ -15,7 +15,7 @@
         class={resultActionOrderClasses} icon-name={displayedIcon} selected={_selected}>
       </lightning-button-icon-stateful>
     </template>
-    <template if:true={displayedLabel}>
+    <template lwc:if={displayedLabel}>
       <div class="slds-popover slds-popover_tooltip slds-nubbin_bottom-left result-action_tooltip slds-fall-into-ground"
         aria-hidden="true">
         <div class="slds-popover__body">{displayedLabel}</div>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultBadge/quanticResultBadge.html
@@ -1,8 +1,8 @@
 <template>
-  <template if:true={error}>
+  <template lwc:if={error}>
     <div class="error-message slds-text-color_destructive">{error}</div>
   </template>
-  <template if:true={shouldDisplayBadge}>
+  <template lwc:if={shouldDisplayBadge}>
     <span class="result-badge slds-badge slds-text-color_inverse">
       <lightning-icon icon-name={icon} size="xx-small" class="slds-current-color slds-m-right_xx-small"></lightning-icon>
       <span>{label}</span>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultChildren/quanticResultChildren.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultChildren/quanticResultChildren.html
@@ -1,6 +1,6 @@
 <template>
   <div class="slds-var-m-left_medium">
-    <template if:true={shouldDisplayChildren}>
+    <template lwc:if={shouldDisplayChildren}>
       <div class="slds-var-m-top_medium">
         <slot name="before-children"></slot>
         <div class="slds-var-p-left_medium slds-border_left">
@@ -19,7 +19,7 @@
         <slot name="after-children"></slot>
       </div>
     </template>
-    <template if:true={shouldDisplayChildResultsToggle}>
+    <template lwc:if={shouldDisplayChildResultsToggle}>
       <div class="slds-grid slds-grid_align-end result-children__toggle-button">
         <lightning-button
           data-cy="result-children__toggle-button"
@@ -32,7 +32,7 @@
       </div>
     </template>
 
-    <template if:true={shouldDisplayNoChildrenMessage}>
+    <template lwc:if={shouldDisplayNoChildrenMessage}>
       <div
         data-cy="result-children__no-more-children-message"
         class="result-children__no-more-children-message slds-grid slds-grid_align-end slds-var-p-vertical_x-small slds-text-color_weak"

--- a/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.html
@@ -1,8 +1,8 @@
 <template>
-  <template if:true={error}>
+  <template lwc:if={error}>
     <div class="error-message slds-text-color_destructive">{error}</div>
   </template>
-  <template if:true={isValid}>
+  <template lwc:if={isValid}>
     <c-quantic-result-text result={result} field={field} label={label} formatting-function={formattingFunction}></c-quantic-result-text>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
@@ -8,9 +8,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticResultDate` component displays a given result date field value.
  * @category Result Template
  * @example
- * <template lwc:if={result.raw.date}>
- *   <c-quantic-result-date result={result} label="Date" field="date"></c-quantic-result-date>
- * </template>
+ * <c-quantic-result-date result={result} label="Date" field="date"></c-quantic-result-date>
  */
 export default class QuanticResultDate extends LightningElement {
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
@@ -8,7 +8,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticResultDate` component displays a given result date field value.
  * @category Result Template
  * @example
- * <template if:true={result.raw.date}>
+ * <template lwc:if={result.raw.date}>
  *   <c-quantic-result-date result={result} label="Date" field="date"></c-quantic-result-date>
  * </template>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultField/quanticResultField.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultField/quanticResultField.js
@@ -16,7 +16,7 @@ import stringTemplate from './stringTemplate.html';
  * The `QuanticResultField` component properly displays a given result field according to its type.
  * @category Result Template
  * @example
- * <template if:true={result.raw.source}>
+ * <template lwc:if={result.raw.source}>
  *   <c-quantic-result-field result={result} label="Source" field="source" type="string"></c-quantic-result-field>
  * </template>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLabel/quanticResultLabel.html
@@ -1,6 +1,6 @@
 <template>
   <div class="result__label slds-grid slds-grid_vertical-align-center">
-    <template if:true={error}>
+    <template lwc:if={error}>
       <div class="error-message slds-text-color_destructive">{error}</div>
     </template>
     <template if:false={error}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder
         variant="resultList"
         number-of-rows={numberOfResults}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.html
@@ -1,10 +1,10 @@
 <template>
   <div class="slds-grid slds-grid_vertical-align-center">
-    <template if:true={error}>
+    <template lwc:if={error}>
       <div class="error-message slds-text-color_destructive">{error}</div>
     </template>
-    <template if:true={isValid}>
-      <template if:true={label}>
+    <template lwc:if={isValid}>
+      <template lwc:if={label}>
         <span class="result-text__label slds-m-right_xx-small">{label}:</span>
       </template>
       <span class="result-text__value">{valueToDisplay}</span>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.js
@@ -9,7 +9,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticResultMultiValueText` component displays a given result multi-value field value.
  * @category Result Template
  * @example
- * <template if:true={result.raw.language}>
+ * <template lwc:if={result.raw.language}>
  *   <c-quantic-result-multi-value-text result={result} label="Languages" field="language" max-values-to-display="4"></c-quantic-result-multi-value-text>
  * </template>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.html
@@ -1,8 +1,8 @@
 <template>
-  <template if:true={error}>
+  <template lwc:if={error}>
     <div class="error-message slds-text-color_destructive">{error}</div>
   </template>
-  <template if:true={isValid}>
+  <template lwc:if={isValid}>
     <c-quantic-result-text result={result} field={field} label={label} formatting-function={formattingFunction}></c-quantic-result-text>
   </template>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.js
@@ -8,7 +8,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticResultNumber` component displays a given result number field value.
  * @category Result Template
  * @example
- * <template if:true={result.raw.ytlikecount}>
+ * <template lwc:if={result.raw.ytlikecount}>
  *   <c-quantic-result-number result={result} label="Likes" field="ytlikecount"></c-quantic-result-number>
  * </template>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -1,12 +1,12 @@
 <template>
   <div class="slds-wrap slds-grid_vertical-align-center slds-size_1-of-1 slds-list_horizontal">
-    <template if:true={error}>
+    <template lwc:if={error}>
       <div class="error-message slds-text-color_destructive">{error}</div>
     </template>
     <template if:false={error}>
       <template for:each={foldedParents} for:item="parent">
         <div class="result-parenturi__container slds-grid slds-grid_vertical-align-center" key={parent.id}>
-          <template if:true={parent.isFolded}>
+          <template lwc:if={parent.isFolded}>
             <button class="slds-button expand-parenturi__container" variant="base" label="..." title="Expand URI" aria-label="Expand URI" onclick={expandParents}>...</button>
           </template>
           <template if:false={parent.isFolded}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -2,21 +2,21 @@
   <div class={buttonContainerClass}>
     <button aria-hidden={isQuickviewOpen} class={buttonClass} onclick={openQuickview} title={buttonTitle}
       disabled={hasNoPreview} aria-label={buttonAriaLabelValue}>
-      <template if:true={hasButtonLabel}> {previewButtonLabel} </template>
-      <template if:true={hasIcon}>
+      <template lwc:if={hasButtonLabel}> {previewButtonLabel} </template>
+      <template lwc:if={hasIcon}>
         <lightning-icon size="x-small" icon-name={previewButtonIcon} alternative-text={buttonLabel}
           class={buttonIconClass}>
         </lightning-icon>
       </template>
     </button>
-    <template if:true={tooltip}>
+    <template lwc:if={tooltip}>
       <div class="slds-popover slds-popover_tooltip slds-nubbin_bottom-left result-action_tooltip slds-fall-into-ground"
         aria-hidden="true">
         <div class="slds-popover__body">{tooltip}</div>
       </div>
     </template>
   </div>
-  <template if:true={isQuickviewOpen}>
+  <template lwc:if={isQuickviewOpen}>
     <section onclick={closeQuickview} role="dialog" tabindex="-1" aria-labelledby="quickview-modal-heading"
       aria-modal="true" aria-describedby="quickview__content-container"
       class="slds-modal slds-modal_medium slds-fade-in-open">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.html
@@ -1,10 +1,10 @@
 <template>
     <div class="slds-grid slds-grid_vertical-align-center">
-      <template if:true={error}>
+      <template lwc:if={error}>
         <div class="error-message slds-text-color_destructive">{error}</div>
       </template>
-      <template if:true={isValid}>
-        <template if:true={label}>
+      <template lwc:if={isValid}>
+        <template lwc:if={label}>
           <span class="result-text__label slds-m-right_xx-small">{label}:</span>
         </template>
         <span class="result-text__value slds-truncate">{valueToDisplay}</span>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -7,7 +7,7 @@ import {LightningElement, api} from 'lwc';
  * The `QuanticResultText` component displays a given result field value.
  * @category Result Template
  * @example
- * <template if:true={result.raw.source}>
+ * <template lwc:if={result.raw.source}>
  *   <c-quantic-result-text result={result} label="Source" field="source"></c-quantic-result-text>
  * </template>
  */

--- a/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultsPerPage/quanticResultsPerPage.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasResults}>
+    <template lwc:if={hasResults}>
       <div class="slds-float_right">
         <template for:each={choicesObjects} for:item="choice">
           <c-quantic-number-button

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.css
@@ -1,1 +1,1 @@
-@import 'c/searchBoxStyle';
+@import '../searchBoxStyle/searchBoxStyle.css';

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.css
@@ -1,1 +1,1 @@
-@import '../searchBoxStyle/searchBoxStyle.css';
+@import 'c/searchBoxStyle';

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBox/quanticSearchBox.html
@@ -15,7 +15,7 @@
           >
             <div class="searchbox__container">
               <div class={searchBoxContainerClass} role="none">
-                <template if:true={withoutSubmitButton}>
+                <template lwc:if={withoutSubmitButton}>
                   <lightning-icon
                     class="slds-icon slds-input__icon slds-input__icon_left"
                     icon-name="utility:search"

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
@@ -12,7 +12,7 @@
                     onclick={handleSuggestionSelection}
                     onmouseover={handleSuggestionHover}
                     onmousedown={preventDefault}>
-                    <template if:true={suggestion.isSelected}>
+                    <template lwc:if={suggestion.isSelected}>
                         <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small slds-has-focus" role="option" aria-selected="true">
                             <span class="slds-media__figure slds-listbox__option-icon"></span>
                             <span class="slds-media__body">

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippet/quanticSmartSnippet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippet/quanticSmartSnippet.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={answerFound}>
+    <template lwc:if={answerFound}>
       <div class="smart-snippet slds-var-m-bottom_xx-small">
         <lightning-card data-cy="smart-snippet-card" title={question}>
           <div class="slds-p-horizontal_medium slds-p-top_small slds-border_top">
@@ -14,7 +14,7 @@
                   actions={smartSnippetAnswerActions}></c-quantic-smart-snippet-answer>
               </div>
             </div>
-            <template if:true={snippetHeightExceedsMaxHeight}>
+            <template lwc:if={snippetHeightExceedsMaxHeight}>
               <div class="slds-align_absolute-center slds-var-m-bottom_small">
                 <lightning-button data-cy="smart-snippet-answer-toggle" icon-name={toggleSmartSnippetAnswerIcon}
                   variant="base" label={toggleSmartSnippetAnswerLabel} title={toggleSmartSnippetAnswerLabel}

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
@@ -13,7 +13,7 @@ const selectors = {
 };
 
 const exampleAnswer =
-  '<div class="smart-snippet-answer" data-cy="smart-snippet-answer" x-test_quanticsmartsnippetanswer=""><div x-test_quanticsmartsnippetanswer=""><p x-test_quanticsmartsnippetanswer="">Example smart snippet answer</p><a href="#" x-test_quanticsmartsnippetanswer="">Example inline link</a></div></div>';
+  '<div x-test_quanticsmartsnippetanswer=""><p x-test_quanticsmartsnippetanswer="">Example smart snippet answer</p><a href="#" x-test_quanticsmartsnippetanswer="">Example inline link</a></div>';
 const exampleAnswerWithInvalidLink =
   '<div><a>Example invalid inline link</a></div>';
 const exampleActions = {

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
@@ -108,8 +108,8 @@ describe('c-quantic-smart-snippet-answer', () => {
   });
 
   describe('when invalid inline links are returned in the answer of the smart snippet', () => {
-    const expectedRenderedAnswer =
-      '<div><a class="inline-link--disabled">Example invalid inline link</a></div>';
+    // const expectedRenderedAnswer =
+    //   '<div><a class="inline-link--disabled">Example invalid inline link</a></div>';
 
     it('should properly assign the disabled CSS class to the invalid inline link', async () => {
       const element = createTestComponent({
@@ -119,12 +119,13 @@ describe('c-quantic-smart-snippet-answer', () => {
       await flushPromises();
 
       const answer = element.shadowRoot.querySelector(
-        selectors.smartSnippetAnswer
+        'a'
       );
 
       expect(answer).not.toBeNull();
-      // eslint-disable-next-line @lwc/lwc/no-inner-html
-      expect(answer.innerHTML).toBe(expectedRenderedAnswer);
+      // // eslint-disable-next-line @lwc/lwc/no-inner-html
+      // expect(answer.innerHTML).toBe(expectedRenderedAnswer);
+      expect(answer).toHaveClass('inline-link--disabled');
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
@@ -8,10 +8,6 @@ const functionsMocks = {
   exampleCancelPendingSelect: jest.fn(() => {}),
 };
 
-const selectors = {
-  smartSnippetAnswer: '.smart-snippet-answer',
-};
-
 const exampleAnswer =
   '<div x-test_quanticsmartsnippetanswer=""><p x-test_quanticsmartsnippetanswer="">Example smart snippet answer</p><a href="#" x-test_quanticsmartsnippetanswer="">Example inline link</a></div>';
 const exampleAnswerWithInvalidLink =
@@ -71,13 +67,17 @@ describe('c-quantic-smart-snippet-answer', () => {
     const element = createTestComponent();
     await flushPromises();
 
-    const answer = element.shadowRoot.querySelector(
-      selectors.smartSnippetAnswer
-    );
-
+    const answer = element.shadowRoot.querySelector('div > p');
     expect(answer).not.toBeNull();
+
+    const answerLink = element.shadowRoot.querySelector('div > a');
+    expect(answerLink).not.toBeNull();
+
     // eslint-disable-next-line @lwc/lwc/no-inner-html
-    expect(answer.innerHTML).toBe(exampleAnswer);
+    expect(answer.innerHTML).toEqual('Example smart snippet answer');
+
+    // eslint-disable-next-line @lwc/lwc/no-inner-html
+    expect(answerLink.innerHTML).toEqual('Example inline link');
   });
 
   describe('the analytics bindings of the inline links within the smart snippet answer', () => {
@@ -92,7 +92,7 @@ describe('c-quantic-smart-snippet-answer', () => {
         expect(action).toHaveBeenCalledTimes(1);
       });
 
-      it(`should not execute the proper action when the ${eventName} is triggered on an ivalid link`, async () => {
+      it(`should not execute the proper action when the ${eventName} is triggered on an invalid link`, async () => {
         const element = createTestComponent({
           ...defaultOptions,
           answer: exampleAnswerWithInvalidLink,
@@ -120,7 +120,6 @@ describe('c-quantic-smart-snippet-answer', () => {
       );
 
       expect(answer).not.toBeNull();
-      expect(answer).toBeTruthy();
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetAnswer/__tests__/quanticSmartSnippetAnswer.test.js
@@ -13,7 +13,7 @@ const selectors = {
 };
 
 const exampleAnswer =
-  '<div><p>Example smart snippet answer</p><a href="#">Example inline link</a></div>';
+  '<div class="smart-snippet-answer" data-cy="smart-snippet-answer" x-test_quanticsmartsnippetanswer=""><div x-test_quanticsmartsnippetanswer=""><p x-test_quanticsmartsnippetanswer="">Example smart snippet answer</p><a href="#" x-test_quanticsmartsnippetanswer="">Example inline link</a></div></div>';
 const exampleAnswerWithInvalidLink =
   '<div><a>Example invalid inline link</a></div>';
 const exampleActions = {
@@ -108,9 +108,6 @@ describe('c-quantic-smart-snippet-answer', () => {
   });
 
   describe('when invalid inline links are returned in the answer of the smart snippet', () => {
-    // const expectedRenderedAnswer =
-    //   '<div><a class="inline-link--disabled">Example invalid inline link</a></div>';
-
     it('should properly assign the disabled CSS class to the invalid inline link', async () => {
       const element = createTestComponent({
         ...defaultOptions,
@@ -119,13 +116,11 @@ describe('c-quantic-smart-snippet-answer', () => {
       await flushPromises();
 
       const answer = element.shadowRoot.querySelector(
-        'a'
+        'div .inline-link--disabled'
       );
 
       expect(answer).not.toBeNull();
-      // // eslint-disable-next-line @lwc/lwc/no-inner-html
-      // expect(answer.innerHTML).toBe(expectedRenderedAnswer);
-      expect(answer).toHaveClass('inline-link--disabled');
+      expect(answer).toBeTruthy();
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSuggestions/quanticSmartSnippetSuggestions.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSmartSnippetSuggestions/quanticSmartSnippetSuggestions.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={shouldDisplaySmartSnippetSuggestions}>
+    <template lwc:if={shouldDisplaySmartSnippetSuggestions}>
       <div data-cy="smart-snippet-suggestions-card" class="slds-card">
         <p
           class="slds-text-heading_small slds-var-p-around_small slds-border_bottom smart-snippet-suggestions__title"

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasResults}>
+    <template lwc:if={hasResults}>
       <div class="sort__container">
         <lightning-layout-item class="sort__header slds-var-p-right_small">
           <lightning-formatted-text value={labels.sortBy}></lightning-formatted-text>

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/quanticStandaloneSearchBox.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={isStandalone}>
+    <template lwc:if={isStandalone}>
       <c-quantic-search-interface engine-id={standaloneEngineId} search-hub={searchHub} pipeline={pipeline} skip-first-search disable-state-in-url>
         <div class="slds-form-element">
           <div class="slds-form-element__control">
@@ -17,7 +17,7 @@
               >
                 <div class="searchbox__container">
                   <div class={searchBoxContainerClass} role="none">
-                    <template if:true={withoutSubmitButton}>
+                    <template lwc:if={withoutSubmitButton}>
                       <lightning-icon
                         class="slds-icon slds-input__icon slds-input__icon_left searchbox__search-icon"
                         icon-name="utility:search"

--- a/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSummary/quanticSummary.html
@@ -4,7 +4,7 @@
     </c-quantic-component-error>
   </template>
   <template lwc:else>
-    <template if:true={hasResults}>
+    <template lwc:if={hasResults}>
       <p class="slds-text-color_weak">
         <lightning-formatted-rich-text value={summaryLabel} disable-linkify></lightning-formatted-rich-text>
       </p>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -6,11 +6,11 @@
   <template lwc:else>
     <slot><!-- Timeframes --></slot>
 
-    <template if:true={showPlaceholder}>
+    <template lwc:if={showPlaceholder}>
       <c-quantic-placeholder variant="card" number-of-rows="5"></c-quantic-placeholder>
     </template>
     <template if:false={showPlaceholder}>
-      <template if:true={showFacet}>
+      <template lwc:if={showFacet}>
         <c-quantic-card-container title={label} onheaderclick={toggleFacetVisibility} onheaderkeydown={toggleFacetVisibility}>
           <lightning-button-icon
             slot="actions"
@@ -23,7 +23,7 @@
             aria-hidden="true"
           ></lightning-button-icon>
   
-          <template if:true={hasActiveValues}>
+          <template lwc:if={hasActiveValues}>
             <button
               class="facet__clear-filter slds-button slds-grid slds-grid_vertical-align-center slds-p-horizontal_x-small slds-m-top_small"
               onclick={clearSelections}
@@ -41,7 +41,7 @@
           </template>
   
           <template if:false={isCollapsed}>
-            <template if:true={withDatePicker}>
+            <template lwc:if={withDatePicker}>
               <div class="slds-grid slds-gutters slds-grid_vertical slds-p-around_x-small">
                 <form onsubmit={handleApply}>
                   <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center">
@@ -96,7 +96,7 @@
               </div>
             </template>
   
-            <template if:true={showValues}>
+            <template lwc:if={showValues}>
               <fieldset>
                 <legend class="slds-assistive-text">{field}</legend>
                 <ul class="slds-has-dividers_around-space slds-m-top_medium">

--- a/packages/quantic/force-app/main/default/lwc/quanticViewedByCustomerBadge/quanticViewedByCustomerBadge.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticViewedByCustomerBadge/quanticViewedByCustomerBadge.html
@@ -1,9 +1,9 @@
 <template>
-  <template if:true={hasInitializationError}>
+  <template lwc:if={hasInitializationError}>
     <c-quantic-component-error component-name={template.host.localName}>
     </c-quantic-component-error>
   </template>
-  <template if:true={shouldDisplayBadge}>
+  <template lwc:if={shouldDisplayBadge}>
     <div class="slds-align_absolute-center">
       <lightning-icon
         icon-name="utility:profile_alt"

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -56,7 +56,7 @@
     "@octokit/graphql-schema": "10.74.2",
     "@salesforce/eslint-config-lwc": "3.3.3",
     "@salesforce/eslint-plugin-lightning": "1.0.0",
-    "@salesforce/sfdx-lwc-jest": "1.1.2",
+    "@salesforce/sfdx-lwc-jest": "1.4.1",
     "@types/strip-color": "0.1.0",
     "@types/wait-on": "5.3.1",
     "chalk": "4.1.2",


### PR DESCRIPTION
[SFINT-5132](https://coveord.atlassian.net/browse/SFINT-5132)

In this PR:

- updated LWC-Jest from 1.1.2 to 1.4.1 (this is needed since it allows the new conditional rendering in LWC (ie: lwc:if) to be supported in the unit tests)
- Fixed 2 tests that were failing following the update
- Fixed the import of CSS files that were no longer found using the c namespace
- Changed the uses of if:true for the new lwc:if since Salesforce will deprecate the uses of if:true, if:false


**NOTE:**

I wanted to change the if:false uses as well, however, I couldn't find a simple way to do it. We will likely have to do it in a seperate PR since it will maybe require more changes.

According to the [documentation](https://www.apexhours.com/conditional-rendering-in-lwc-using-lwcif-and-lwcelse/#:~:text=You%20can%E2%80%99t%20precede,your%20JavaScript%20class.) we can't just use : `lwc:if={!condition}` so I could think of the 2 following solutions:

1) Write an empty lwc:if and then another tag with lwc:else with my actual elements (simple and quicker but ugly)

ie: 
`
<template lwc:if={myStatement}>
    <!--I have nothing to render here because I have to render my components only when myStatement is false
</template>
<template lwc:else>
    <!--my elements -->
</template>
`

2) Create a new getter for the false condition and replace the if:false by lwc:if with the new getter condition (more complex + time consuming, cleaner)


[SFINT-5132]: https://coveord.atlassian.net/browse/SFINT-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ