### PR TITLE
ci: add e2e pipeline to electronics org samples

### DIFF
--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -173,8 +173,8 @@
 
   <body>
     <atomic-search-interface
-      pipeline="Search"
-      search-hub="MainSearch"
+      pipeline="UI_KIT_E2E"
+      search-hub="UI_KIT_E2E"
       fields-to-include='["ec_price", "ec_rating", "ec_images", "ec_brand", "cat_platform", "cat_condition", "cat_categories", "cat_review_count", "cat_color"]'
     >
       <atomic-search-layout>

--- a/packages/atomic/src/pages/examples/external.html
+++ b/packages/atomic/src/pages/examples/external.html
@@ -61,7 +61,12 @@
       </div>
       <div>
         <h1>Interface #1, not linked to url</h1>
-        <atomic-search-interface id="interface-1" reflect-state-in-url="false">
+        <atomic-search-interface
+          id="interface-1"
+          pipeline="UI_KIT_E2E"
+          search-hub="UI_KIT_E2E"
+          reflect-state-in-url="false"
+        >
           <atomic-query-summary></atomic-query-summary>
           <atomic-numeric-facet field="ec_price" label="Cost" with-input="integer">
             <atomic-format-currency currency="USD"></atomic-format-currency>
@@ -72,7 +77,7 @@
       </div>
       <div>
         <h1>Interface #2, linked to url</h1>
-        <atomic-search-interface id="interface-2">
+        <atomic-search-interface id="interface-2" pipeline="UI_KIT_E2E" search-hub="UI_KIT_E2E">
           <atomic-query-summary></atomic-query-summary>
           <atomic-result-list></atomic-result-list>
         </atomic-search-interface>

--- a/packages/atomic/src/pages/examples/external.html
+++ b/packages/atomic/src/pages/examples/external.html
@@ -77,7 +77,7 @@
       </div>
       <div>
         <h1>Interface #2, linked to url</h1>
-        <atomic-search-interface id="interface-2" pipeline="UI_KIT_E2E" search-hub="UI_KIT_E2E">
+        <atomic-search-interface id="interface-2">
           <atomic-query-summary></atomic-query-summary>
           <atomic-result-list></atomic-result-list>
         </atomic-search-interface>

--- a/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
+++ b/packages/samples/angular/src/app/atomic-angular-page/atomic-angular-page.component.html
@@ -1,7 +1,7 @@
 <atomic-search-interface
   #searchInterface
-  searchHub="MainSearch"
-  pipeline="Search"
+  searchHub="UI_KIT_E2E"
+  pipeline="UI_KIT_E2E"
   fieldsToInclude='["ec_price","ec_rating","ec_images","ec_brand","cat_platform","cat_condition","cat_categories","cat_review_count","cat_color"]'
 >
   <div class="search">

--- a/packages/samples/atomic-next/pages/index.tsx
+++ b/packages/samples/atomic-next/pages/index.tsx
@@ -60,8 +60,8 @@ const SearchPage: NextPage = () => {
             'electronicscoveodemocomo0n2fu8v'
           ),
           search: {
-            pipeline: 'Search',
-            searchHub: 'MainSearch',
+            pipeline: 'UI_KIT_E2E',
+            searchHub: 'UI_KIT_E2E',
           },
         },
       }),

--- a/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
+++ b/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
@@ -37,8 +37,8 @@ import {
   AtomicSearchBoxQuerySuggestions,
   getOrganizationEndpoints,
   SearchEngineConfiguration,
+  getSampleSearchEngineConfiguration,
 } from '@coveo/atomic-react';
-import {getSampleEngineConfiguration} from '@coveo/headless/dist/definitions/app/engine-configuration';
 import React, {FunctionComponent, useMemo} from 'react';
 
 type Sample = 'service' | 'electronics';
@@ -69,7 +69,7 @@ function getElectronicsConfiguration(): SearchEngineConfiguration {
 function getConfigurationForSample(sample: Sample) {
   switch (sample) {
     case 'service':
-      return getSampleEngineConfiguration();
+      return getSampleSearchEngineConfiguration();
     case 'electronics':
       return getElectronicsConfiguration();
   }

--- a/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
+++ b/packages/samples/atomic-react/src/components/AtomicPageWrapper.tsx
@@ -36,40 +36,56 @@ import {
   Bindings,
   AtomicSearchBoxQuerySuggestions,
   getOrganizationEndpoints,
+  SearchEngineConfiguration,
 } from '@coveo/atomic-react';
+import {getSampleEngineConfiguration} from '@coveo/headless/dist/definitions/app/engine-configuration';
 import React, {FunctionComponent, useMemo} from 'react';
+
+type Sample = 'service' | 'electronics';
 
 type Options = {
   instantResults?: boolean;
   recentQueries?: boolean;
 };
 type Props = {
-  accessToken: string;
-  organizationId: string;
+  sample: Sample;
   children: React.ReactNode;
   options?: Options;
 };
 
+function getElectronicsConfiguration(): SearchEngineConfiguration {
+  const accessToken = 'xxc23ce82a-3733-496e-b37e-9736168c4fd9';
+  const organizationId = 'electronicscoveodemocomo0n2fu8v';
+  const pipeline = 'UI_KIT_E2E';
+  const searchHub = 'UI_KIT_E2E';
+  return {
+    accessToken,
+    organizationId,
+    organizationEndpoints: getOrganizationEndpoints(organizationId),
+    search: {pipeline, searchHub},
+  };
+}
+
+function getConfigurationForSample(sample: Sample) {
+  switch (sample) {
+    case 'service':
+      return getSampleEngineConfiguration();
+    case 'electronics':
+      return getElectronicsConfiguration();
+  }
+}
+
 export const AtomicPageWrapper: FunctionComponent<Props> = ({
-  accessToken,
-  organizationId,
+  sample,
   children,
   options = {},
 }) => {
   const engine = useMemo(
     () =>
       buildSearchEngine({
-        configuration: {
-          accessToken,
-          organizationId,
-          organizationEndpoints: getOrganizationEndpoints(organizationId),
-          search: {
-            pipeline: 'Search',
-            searchHub: 'MainSearch',
-          },
-        },
+        configuration: getConfigurationForSample(sample),
       }),
-    [accessToken, organizationId]
+    [sample]
   );
 
   return (

--- a/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/FoldedResultListPage.tsx
@@ -21,10 +21,7 @@ import {AtomicPageWrapper} from '../components/AtomicPageWrapper';
 
 export const FoldedResultListPage: FunctionComponent = () => {
   return (
-    <AtomicPageWrapper
-      accessToken="xx564559b1-0045-48e1-953c-3addd1ee4457"
-      organizationId="searchuisamples"
-    >
+    <AtomicPageWrapper sample="service">
       <AtomicFoldedResultList imageSize="large" template={MyTemplate} />
     </AtomicPageWrapper>
   );

--- a/packages/samples/atomic-react/src/pages/InstantResultsPage.tsx
+++ b/packages/samples/atomic-react/src/pages/InstantResultsPage.tsx
@@ -4,8 +4,7 @@ import {AtomicPageWrapper} from '../components/AtomicPageWrapper';
 export const InstantResultsPage: FunctionComponent = () => {
   return (
     <AtomicPageWrapper
-      accessToken="xxc23ce82a-3733-496e-b37e-9736168c4fd9"
-      organizationId="electronicscoveodemocomo0n2fu8v"
+      sample="electronics"
       options={{recentQueries: true, instantResults: true}}
     >
       <p>No result list</p>

--- a/packages/samples/atomic-react/src/pages/RecsPage.tsx
+++ b/packages/samples/atomic-react/src/pages/RecsPage.tsx
@@ -32,8 +32,8 @@ export const RecsPage: FunctionComponent = () => {
         configuration: {
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId: 'electronicscoveodemocomo0n2fu8v',
-          pipeline: 'Search',
-          searchHub: 'MainSearch',
+          pipeline: 'UI_KIT_E2E',
+          searchHub: 'UI_KIT_E2E',
         },
       }),
     []

--- a/packages/samples/atomic-react/src/pages/ResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/ResultListPage.tsx
@@ -26,10 +26,7 @@ import {AtomicPageWrapper} from '../components/AtomicPageWrapper';
 
 export const ResultListPage: FunctionComponent = () => {
   return (
-    <AtomicPageWrapper
-      accessToken="xxc23ce82a-3733-496e-b37e-9736168c4fd9"
-      organizationId="electronicscoveodemocomo0n2fu8v"
-    >
+    <AtomicPageWrapper sample="electronics">
       <AtomicResultList
         display="grid"
         imageSize="large"

--- a/packages/samples/atomic-react/src/pages/TableResultListPage.tsx
+++ b/packages/samples/atomic-react/src/pages/TableResultListPage.tsx
@@ -19,10 +19,7 @@ import {AtomicPageWrapper} from '../components/AtomicPageWrapper';
 
 export const TableResultListPage: FunctionComponent = () => {
   return (
-    <AtomicPageWrapper
-      accessToken="xxc23ce82a-3733-496e-b37e-9736168c4fd9"
-      organizationId="electronicscoveodemocomo0n2fu8v"
-    >
+    <AtomicPageWrapper sample="electronics">
       <AtomicResultList
         display="table"
         imageSize="large"

--- a/packages/samples/headless-react/src/pages/ProductRecommendationsPage.tsx
+++ b/packages/samples/headless-react/src/pages/ProductRecommendationsPage.tsx
@@ -16,6 +16,7 @@ export function ProductRecommendationsPage() {
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId: 'electronicscoveodemocomo0n2fu8v',
           platformUrl: 'https://platform.cloud.coveo.com',
+          searchHub: 'UI_KIT_E2E',
         },
       }),
     []

--- a/packages/samples/iife/www/atomic-react.html
+++ b/packages/samples/iife/www/atomic-react.html
@@ -138,8 +138,8 @@
                 organizationId: 'electronicscoveodemocomo0n2fu8v',
                 organizationEndpoints: getOrganizationEndpoints('electronicscoveodemocomo0n2fu8v'),
                 search: {
-                  pipeline: 'Search',
-                  searchHub: 'MainSearch',
+                  pipeline: 'UI_KIT_E2E',
+                  searchHub: 'UI_KIT_E2E',
                 },
               },
             }),

--- a/packages/samples/vuejs/src/components/SearchPage.vue
+++ b/packages/samples/vuejs/src/components/SearchPage.vue
@@ -25,7 +25,7 @@ onMounted(initInterface);
 </script>
 
 <template>
-  <atomic-search-interface search-hub="MainSearch" pipeline="Search" fields-to-include='["ec_price","ec_rating","ec_images","ec_brand","cat_platform","cat_condition","cat_categories","cat_review_count","cat_color"]'>
+  <atomic-search-interface search-hub="UI_KIT_E2E" pipeline="UI_KIT_E2E" fields-to-include='["ec_price","ec_rating","ec_images","ec_brand","cat_platform","cat_condition","cat_categories","cat_review_count","cat_color"]'>
     <atomic-search-layout>
       <atomic-layout-section section="search">
         <atomic-search-box></atomic-search-box>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2648

Also added a searchHub with the same name.

Note that the product recommendations engine can only be specified a search hub, it cannot be specified a pipeline.

**Warning**: auto-merge is enabled on this PR.