### PR TITLE
feat(headless): added defineResultList SSR controller

### DIFF
--- a/packages/headless/src/controllers/ssr/result-list/headless-ssr-result-list.ts
+++ b/packages/headless/src/controllers/ssr/result-list/headless-ssr-result-list.ts
@@ -1,0 +1,23 @@
+import {SearchEngine} from '../../../app/search-engine/search-engine';
+import {ControllerDefinitionWithoutProps} from '../../../app/ssr-engine/types/common';
+import {
+  ResultList,
+  ResultListProps,
+  buildResultList,
+} from '../../result-list/headless-result-list';
+
+export type {
+  ResultListOptions,
+  ResultListProps,
+  ResultListState,
+  ResultList,
+} from '../../result-list/headless-result-list';
+
+/**
+ * @internal
+ */
+export const defineResultList = (
+  props?: ResultListProps
+): ControllerDefinitionWithoutProps<SearchEngine, ResultList> => ({
+  build: (engine) => buildResultList(engine, props),
+});

--- a/packages/headless/src/ssr.index.ts
+++ b/packages/headless/src/ssr.index.ts
@@ -16,3 +16,11 @@ export type {
 } from './app/ssr-engine/types/core-engine';
 
 export {defineSearchEngine} from './app/ssr-engine/ssr-engine';
+
+export type {
+  ResultList,
+  ResultListOptions,
+  ResultListProps,
+  ResultListState,
+} from './controllers/ssr/result-list/headless-ssr-result-list';
+export {defineResultList} from './controllers/ssr/result-list/headless-ssr-result-list';

--- a/packages/samples/headless-ssr/src/common/engine.ts
+++ b/packages/samples/headless-ssr/src/common/engine.ts
@@ -1,41 +1,17 @@
+import {getSampleSearchEngineConfiguration} from '@coveo/headless';
 import {
-  buildController,
-  Controller,
-  getSampleSearchEngineConfiguration,
-  Result,
-  SearchEngine,
-} from '@coveo/headless';
-import {
-  ControllerDefinitionWithoutProps,
   defineSearchEngine,
+  defineResultList,
   InferInitialState,
   InferLiveState,
 } from '@coveo/headless/ssr';
-
-// Custom controller to fetch results from snapshot
-//  as snapshot doesn't have an engine that can be accessed directly.
-function defineCustomResultList(): ControllerDefinitionWithoutProps<
-  SearchEngine,
-  Controller & {state: {results: Result[]}}
-> {
-  return {
-    build(engine: SearchEngine) {
-      return {
-        ...buildController(engine),
-        get state() {
-          return {results: engine.state.search.results};
-        },
-      };
-    },
-  };
-}
 
 const engineDefinition = defineSearchEngine({
   configuration: {
     ...getSampleSearchEngineConfiguration(),
     analytics: {enabled: false},
   },
-  controllers: {resultList: defineCustomResultList()},
+  controllers: {resultList: defineResultList()},
 });
 
 export type SearchInitialState = InferInitialState<typeof engineDefinition>;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2655

What's important to pay attention to in this PR is the directory structure.

Since the SSR engine file follows the same structure as use case engines like the product listing engine, I did the same for controllers and I created a `ssr` directory in the `controllers` directory. Just like use case controllers and the ssr engine, I added ssr in the name.