### PR TITLE
fix(quantic): js doc comment of the new quantic generated answer component fixed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -31,7 +31,7 @@ const FEEDBACK_NEUTRAL_STATE = 'neutral';
 
 /**
  * The `QuanticGeneratedAnswer` component automatically generates an answer using Coveo machine learning models to answer the query executed by the user.
- * @category Search
+ * @category Internal
  * @example
  * <c-quantic-generated-answer engine-id={engineId}></c-quantic-generated-answer>
  */


### PR DESCRIPTION
[SFINT-5149](https://coveord.atlassian.net/browse/SFINT-5149)

Category of the component in the JS doc comments updated to be `Internal` instead of `Search` to avoid having this component in the public documentation just yet.