### PR TITLE
chore(atomic): fix build on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,6 @@
         "utils/*",
         "!utils/atomic-storybook"
       ],
-      "dependencies": {
-        "patch-package": "8.0.0"
-      },
       "devDependencies": {
         "@actions/core": "1.9.1",
         "@actions/github": "5.1.1",
@@ -62,6 +59,7 @@
         "jest": "27.5.1",
         "lint-staged": "13.1.0",
         "nx": "15.7.0",
+        "patch-package": "8.0.0",
         "prettier": "2.7.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -71,7 +69,7 @@
         "typescript": "4.6.4"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=18.0.0",
         "npm": ">=8.6.0"
       }
     },
@@ -132,7 +130,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10989,32 +10986,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
       "devOptional": true,
@@ -11288,7 +11259,6 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -11727,6 +11697,7 @@
     },
     "node_modules/autoprefixer": {
       "version": "10.4.8",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15518,13 +15489,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
@@ -15631,21 +15595,6 @@
     "node_modules/detect-port-alt/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
-    },
-    "node_modules/detective": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.869402",
@@ -17982,6 +17931,7 @@
     },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -22202,7 +22152,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.1.tgz",
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -22534,6 +22483,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
       "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
       "dependencies": {
         "jsonify": "^0.0.1"
       },
@@ -22584,6 +22534,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -22909,6 +22860,7 @@
     },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -25525,7 +25477,6 @@
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -26883,6 +26834,7 @@
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27290,6 +27242,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
       "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
@@ -27317,6 +27270,7 @@
     },
     "node_modules/patch-package/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -27327,6 +27281,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -27339,6 +27294,7 @@
     },
     "node_modules/patch-package/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -27359,6 +27315,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -27368,6 +27325,7 @@
     },
     "node_modules/patch-package/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -27378,6 +27336,7 @@
     },
     "node_modules/patch-package/node_modules/open": {
       "version": "7.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -27392,6 +27351,7 @@
     },
     "node_modules/patch-package/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -27404,6 +27364,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -27416,6 +27377,7 @@
     },
     "node_modules/patch-package/node_modules/slash": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -27423,6 +27385,7 @@
     },
     "node_modules/patch-package/node_modules/tmp": {
       "version": "0.0.33",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -27434,12 +27397,14 @@
     "node_modules/patch-package/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/patch-package/node_modules/yaml": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -27551,7 +27516,6 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28252,7 +28216,6 @@
     },
     "node_modules/postcss-import": {
       "version": "14.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -30533,7 +30496,6 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -44409,7 +44371,6 @@
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
       "integrity": "sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -44431,7 +44392,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -44441,7 +44401,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -44450,7 +44409,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -44469,14 +44427,12 @@
     "node_modules/sucrase/node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/sucrase/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -44651,65 +44607,39 @@
       "dev": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.0.23",
-      "license": "MIT",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
+      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
       "dependencies": {
-        "arg": "^5.0.1",
-        "chalk": "^4.1.2",
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
         "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
-        "cosmiconfig": "^7.0.1",
-        "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
+        "jiti": "^1.18.2",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
-        "object-hash": "^2.2.0",
-        "postcss": "^8.4.6",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.0",
-        "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "autoprefixer": "^10.0.2",
-        "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tapable": {
@@ -45095,7 +45025,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -45103,7 +45032,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -45393,8 +45321,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-jest": {
       "version": "27.1.5",
@@ -47763,6 +47690,7 @@
     "node_modules/xtend": {
       "version": "4.0.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -51096,114 +51024,11 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "packages/atomic/node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/atomic/node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "packages/atomic/node_modules/postcss-load-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
-      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
-      "dev": true,
-      "dependencies": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^2.1.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "packages/atomic/node_modules/tailwindcss": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
-      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
-      "dev": true,
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
-        "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "packages/atomic/node_modules/tailwindcss/node_modules/postcss-import": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -51220,7 +51045,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
       "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.11"
       },
@@ -51233,15 +51058,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
-      }
-    },
-    "packages/atomic/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "packages/auth": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "release:phase1-3": "nx run-many --targets=release:phase2 --all --parallel=false --output-style=stream && npx -p=@coveo/release reify",
     "release:phase4": "npx -p=@coveo/release git-publish-all"
   },
-  "dependencies": {
-    "patch-package": "8.0.0"
-  },
   "devDependencies": {
     "@actions/core": "1.9.1",
     "@actions/github": "5.1.1",
@@ -66,6 +63,7 @@
     "jest": "27.5.1",
     "lint-staged": "13.1.0",
     "nx": "15.7.0",
+    "patch-package": "8.0.0",
     "prettier": "2.7.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/patches/tailwindcss+3.3.3.patch
+++ b/patches/tailwindcss+3.3.3.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/tailwindcss/lib/lib/expandTailwindAtRules.js b/node_modules/tailwindcss/lib/lib/expandTailwindAtRules.js
+index 43c3240..212bfc1 100644
+--- a/node_modules/tailwindcss/lib/lib/expandTailwindAtRules.js
++++ b/node_modules/tailwindcss/lib/lib/expandTailwindAtRules.js
+@@ -165,12 +165,21 @@ function expandTailwindAtRules(context) {
+         //   getClassCandidatesOxide(file, transformer(content), extractor, candidates, seen)
+         // }
+         } else {
+-            await Promise.all(context.changedContent.map(async ({ file , content , extension  })=>{
+-                let transformer = getTransformer(context.tailwindConfig, extension);
+-                let extractor = getExtractor(context, extension);
+-                content = file ? await _fs.default.promises.readFile(file, "utf8") : content;
+-                getClassCandidates(transformer(content), extractor, candidates, seen);
+-            }));
++            if(process.platform === 'win32') {
++                for (let { file, content, extension } of context.changedContent) {
++                    let transformer = getTransformer(context.tailwindConfig, extension)
++                    let extractor = getExtractor(context, extension)
++                    content = file ? _fs.default.readFileSync(file, 'utf8') : content
++                    getClassCandidates(transformer(content), extractor, candidates, seen)
++                }
++            } else {
++                await Promise.all(context.changedContent.map(async ({ file , content , extension  })=>{
++                    let transformer = getTransformer(context.tailwindConfig, extension);
++                    let extractor = getExtractor(context, extension);
++                    content = file ? await _fs.default.promises.readFile(file, "utf8") : content;
++                    getClassCandidates(transformer(content), extractor, candidates, seen);
++                }));
++            }
+         }
+         env.DEBUG && console.timeEnd("Reading changed files");
+         // ---


### PR DESCRIPTION
Empirical fix, I didn't trace back exactly where it goes haywire.
Gut feeling: too much parallelism made using fs.promises, which in turn leads to Windows to :rage4: because lower limits for opened files.

Solution: Reuse the synchronous code on Windows, and let Linux be Linux.
I prefer to not invest more, will prolly be fixed when Oxide (Tailwind not-so-secret Rust sauce that should come 🔜 ™️) will land.

https://coveord.atlassian.net/browse/KIT-2691