### PR TITLE
fix(quantic): Fixed the misalignment of 1px in citations titles

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSourceCitations/quanticSourceCitations.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSourceCitations/quanticSourceCitations.css
@@ -1,6 +1,6 @@
 .source-citations__label {
   height: 1.875rem;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--lwc-colorTextPlaceholder, #747474);
 }
 
@@ -42,5 +42,5 @@
 .citation__title {
   font-weight: var(--lwc-fontWeightRegular, 400);
   color: var(--lwc-colorTextPlaceholder, #747474);
-  font-size: 14px;
+  font-size: 13px;
 }


### PR DESCRIPTION
[SFINT-5150](https://coveord.atlassian.net/browse/SFINT-5150)

Issue:

There was a misalignment between the citations titles and the index of the citations. This was due to different font sizes (13px for the index and 14px for the citation title)

Solution: 

Set the title, label to the same font-size as index. It is now pixel perfectly aligned.


BEFORE:

<img width="621" alt="image" src="https://github.com/coveo/ui-kit/assets/73316533/7b5c1262-79c5-4062-b3d7-4be6d9e822e9">



AFTER:

![image](https://github.com/coveo/ui-kit/assets/73316533/cc7adaa5-a36f-4ccf-8960-593e5bc58357)



[SFINT-5150]: https://coveord.atlassian.net/browse/SFINT-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ