### PR TITLE
fix(quantic): Added tooltips for quantic feedback component

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/__tests__/quanticFeedback.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/__tests__/quanticFeedback.test.js
@@ -15,8 +15,8 @@ const defaultLikeLabel = 'yes';
 const defaultDislikeIconName = 'utility:clear';
 const defaultDislikeLabel = 'no';
 const defaultSize = 'xx-small';
-const tooltipLikeLabel = 'This answer was helpful';
-const tooltipDislikeLabel = 'This answer was not helpful';
+const specifiedLikeLabel = 'This answer was helpful';
+const specifiedDislikeLabel = 'This answer was not helpful';
 
 jest.mock(
   '@salesforce/label/c.quantic_Yes',
@@ -32,21 +32,6 @@ jest.mock(
     virtual: true,
   }
 );
-jest.mock(
-  '@salesforce/label/c.quantic_ThisAnswerWasHelpful',
-  () => ({default: tooltipLikeLabel}),
-  {
-    virtual: true,
-  }
-);
-jest.mock(
-  '@salesforce/label/c.quantic_ThisAnswerWasNotHelpful',
-  () => ({default: tooltipDislikeLabel}),
-  {
-    virtual: true,
-  }
-);
-
 
 const selectors = {
   feedbackQuestion: '.feedback__question',
@@ -65,6 +50,8 @@ const defaultOptions = {
   question: exampleQuestion,
   hideExplainWhyButton: false,
   successMessage: exampleSuccessMessage,
+  likeLabel: defaultLikeLabel,
+  dislikeLabel: defaultDislikeLabel,
 };
 
 function setupEventListeners(element) {
@@ -172,22 +159,48 @@ describe('c-quantic-feedback', () => {
       expect(successMessage).toBeNull();
     });
 
-    it('should have a title attribute with the right label on the like button', async () => {
+    it('should have a title attribute with the default label on the like button', async () => {
       const element = createTestComponent();
       await flushPromises();
 
       const button = element.shadowRoot.querySelector(selectors.likeButton);
 
-      expect(button.title).toEqual(tooltipLikeLabel);
+      expect(button.title).toEqual(defaultLikeLabel);
     });
 
-    it('should have a title attribute with the right label on the dislike button', async () => {
+    it('should have a title attribute with the default label on the dislike button', async () => {
       const element = createTestComponent();
       await flushPromises();
 
       const button = element.shadowRoot.querySelector(selectors.dislikeButton);
 
-      expect(button.title).toEqual(tooltipDislikeLabel);
+      expect(button.title).toEqual(defaultDislikeLabel);
+    });
+
+    describe('When labels are specified as properties to the quanticFeedback component', () => {
+      it('should have a title attribute with the specified title on the like button', async () => {
+        const element = createTestComponent({
+          ...defaultOptions,
+          likeLabel: specifiedLikeLabel,
+        });
+        await flushPromises();
+
+        const button = element.shadowRoot.querySelector(selectors.likeButton);
+
+        expect(button.title).toEqual(specifiedLikeLabel);
+      });
+
+      it('should have a title attribute with the specified title on the dislike button', async () => {
+        const element = createTestComponent({
+          ...defaultOptions,
+          likeLabel: specifiedDislikeLabel,
+        });
+        await flushPromises();
+
+        const button = element.shadowRoot.querySelector(selectors.likeButton);
+
+        expect(button.title).toEqual(specifiedDislikeLabel);
+      });
     });
 
     describe('when the like button is clicked', () => {
@@ -239,7 +252,6 @@ describe('c-quantic-feedback', () => {
         });
         await flushPromises();
 
-
         const likeButton = element.shadowRoot.querySelector(
           selectors.likeButton
         );
@@ -276,10 +288,9 @@ describe('c-quantic-feedback', () => {
       it('should display the feedback buttons properly', async () => {
         const element = createTestComponent({
           ...defaultOptions,
-          hideLabels: true
+          hideLabels: true,
         });
         await flushPromises();
-
 
         const likeButton = element.shadowRoot.querySelector(
           selectors.likeButton

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/__tests__/quanticFeedback.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/__tests__/quanticFeedback.test.js
@@ -15,6 +15,8 @@ const defaultLikeLabel = 'yes';
 const defaultDislikeIconName = 'utility:clear';
 const defaultDislikeLabel = 'no';
 const defaultSize = 'xx-small';
+const tooltipLikeLabel = 'This answer was helpful';
+const tooltipDislikeLabel = 'This answer was not helpful';
 
 jest.mock(
   '@salesforce/label/c.quantic_Yes',
@@ -30,6 +32,21 @@ jest.mock(
     virtual: true,
   }
 );
+jest.mock(
+  '@salesforce/label/c.quantic_ThisAnswerWasHelpful',
+  () => ({default: tooltipLikeLabel}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_ThisAnswerWasNotHelpful',
+  () => ({default: tooltipDislikeLabel}),
+  {
+    virtual: true,
+  }
+);
+
 
 const selectors = {
   feedbackQuestion: '.feedback__question',
@@ -153,6 +170,24 @@ describe('c-quantic-feedback', () => {
       );
 
       expect(successMessage).toBeNull();
+    });
+
+    it('should have a title attribute with the right label on the like button', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const button = element.shadowRoot.querySelector(selectors.likeButton);
+
+      expect(button.title).toEqual(tooltipLikeLabel);
+    });
+
+    it('should have a title attribute with the right label on the dislike button', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const button = element.shadowRoot.querySelector(selectors.dislikeButton);
+
+      expect(button.title).toEqual(tooltipDislikeLabel);
     });
 
     describe('when the like button is clicked', () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
@@ -2,7 +2,7 @@
   <div class="slds-grid feedback__main-section">
     <span class="slds-var-p-right_medium slds-text-color_weak feedback__question"
       id="feedback__question">{question}</span>
-    <button aria-label={likeLabel} data-cy="feedback__like-button" aria-describedby="feedback__question" onclick={handleLike}
+    <button aria-label={likeLabel} data-cy="feedback__like-button" title={labels.thisAnswerWasHelpful} aria-describedby="feedback__question" onclick={handleLike}
       class={likeButtonClass}>
       <lightning-icon aria-hidden="true" class={likeIconClass} icon-name={likeIconName} size={size}
         variant={likeIconVariant}></lightning-icon>
@@ -10,7 +10,7 @@
         <span class="feedback__button-label slds-var-m-left_xx-small">{likeLabel}</span>
       </template>
     </button>
-    <button aria-label={dislikeLabel} data-cy="feedback__dislike-button" aria-describedby="feedback__question" onclick={handleDislike}
+    <button aria-label={dislikeLabel} data-cy="feedback__dislike-button" title={labels.thisAnswerWasNotHelpful} aria-describedby="feedback__question" onclick={handleDislike}
       class={dislikeButtonClass}>
       <lightning-icon aria-hidden="true" class={dislikeIconClass} icon-name={dislikeIconName} size={size}
         variant={dislikeIconVariant}></lightning-icon>

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.html
@@ -2,7 +2,7 @@
   <div class="slds-grid feedback__main-section">
     <span class="slds-var-p-right_medium slds-text-color_weak feedback__question"
       id="feedback__question">{question}</span>
-    <button aria-label={likeLabel} data-cy="feedback__like-button" title={labels.thisAnswerWasHelpful} aria-describedby="feedback__question" onclick={handleLike}
+    <button aria-label={likeLabel} data-cy="feedback__like-button" title={likeLabel} aria-describedby="feedback__question" onclick={handleLike}
       class={likeButtonClass}>
       <lightning-icon aria-hidden="true" class={likeIconClass} icon-name={likeIconName} size={size}
         variant={likeIconVariant}></lightning-icon>
@@ -10,7 +10,7 @@
         <span class="feedback__button-label slds-var-m-left_xx-small">{likeLabel}</span>
       </template>
     </button>
-    <button aria-label={dislikeLabel} data-cy="feedback__dislike-button" title={labels.thisAnswerWasNotHelpful} aria-describedby="feedback__question" onclick={handleDislike}
+    <button aria-label={dislikeLabel} data-cy="feedback__dislike-button" title={dislikeLabel} aria-describedby="feedback__question" onclick={handleDislike}
       class={dislikeButtonClass}>
       <lightning-icon aria-hidden="true" class={dislikeIconClass} icon-name={dislikeIconName} size={size}
         variant={dislikeIconVariant}></lightning-icon>

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.js
@@ -1,6 +1,4 @@
 import explainWhy from '@salesforce/label/c.quantic_ExplainWhy';
-import thisAnswerWasHelpful from '@salesforce/label/c.quantic_ThisAnswerWasHelpful';
-import thisAnswerWasNotHelpful from '@salesforce/label/c.quantic_ThisAnswerWasNotHelpful';
 import no from '@salesforce/label/c.quantic_No';
 import wasThisUseful from '@salesforce/label/c.quantic_WasThisUseful';
 import yes from '@salesforce/label/c.quantic_Yes';
@@ -19,9 +17,7 @@ export default class QuanticFeedback extends LightningElement {
     yes,
     no,
     wasThisUseful,
-    explainWhy,
-    thisAnswerWasHelpful,
-    thisAnswerWasNotHelpful
+    explainWhy
   };
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFeedback/quanticFeedback.js
@@ -1,4 +1,6 @@
 import explainWhy from '@salesforce/label/c.quantic_ExplainWhy';
+import thisAnswerWasHelpful from '@salesforce/label/c.quantic_ThisAnswerWasHelpful';
+import thisAnswerWasNotHelpful from '@salesforce/label/c.quantic_ThisAnswerWasNotHelpful';
 import no from '@salesforce/label/c.quantic_No';
 import wasThisUseful from '@salesforce/label/c.quantic_WasThisUseful';
 import yes from '@salesforce/label/c.quantic_Yes';
@@ -18,6 +20,8 @@ export default class QuanticFeedback extends LightningElement {
     no,
     wasThisUseful,
     explainWhy,
+    thisAnswerWasHelpful,
+    thisAnswerWasNotHelpful
   };
 
   /**


### PR DESCRIPTION
[SFINT-5142](https://coveord.atlassian.net/browse/SFINT-5142)

Added tooltips for the quantic Feedback component. I used the labels `thisAnswerWasHelpful` & `thisAnswerWasNotHelpful`

DEMO:

DISLIKE TOOLTIP:

<img width="214" alt="Screenshot 2023-08-25 at 11 03 22 AM" src="https://github.com/coveo/ui-kit/assets/73316533/0074269d-b31f-43fe-8ec8-eb49b13f2298">

LIKE TOOLTIP:

<img width="170" alt="Screenshot 2023-08-25 at 11 03 11 AM" src="https://github.com/coveo/ui-kit/assets/73316533/e6da8d61-2e25-42c6-b17a-91467e9759b7">


DEMO IN smart snippet:

If you set like-label property to something like patate, the tooltip will be the same as label

![image](https://github.com/coveo/ui-kit/assets/73316533/e4fa7271-5bb8-4b40-b44b-7558d9cf89b8)


DEMO IN Generated answer:

![image](https://github.com/coveo/ui-kit/assets/73316533/7e3ec102-d2db-4db3-91dc-4fdb9e470e50)


[SFINT-5142]: https://coveord.atlassian.net/browse/SFINT-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ