### PR TITLE
fix(headless): toggleSelected should toggle both ways (select&deselect)

### DIFF
--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -589,6 +589,25 @@ describe('category facet slice', () => {
           expect(currentValues).toEqual([parent]);
         });
       });
+
+      describe('when the selected value is the parent', () => {
+        const selection = buildMockCategoryFacetValue({
+          value: 'A',
+          state: 'selected',
+        });
+        const action = toggleSelectCategoryFacetValue({
+          facetId,
+          selection,
+          retrieveCount,
+        });
+
+        it('sets the parent/selected value state to idle', () => {
+          const finalState = categoryFacetSetReducer(state, action);
+          expect(finalState[facetId]?.request.currentValues[0].state).toBe(
+            'idle'
+          );
+        });
+      });
     });
 
     describe('when #currentValues contains two parents', () => {

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -91,7 +91,7 @@ export const categoryFacetSetReducer = createReducer(
         if (!request) {
           return;
         }
-
+        const newState = selection.state === 'selected' ? 'idle' : 'selected';
         const {path} = selection;
         const pathToSelection = path.slice(0, path.length - 1);
         const children = ensurePathAndReturnChildren(
@@ -104,7 +104,7 @@ export const categoryFacetSetReducer = createReducer(
           const lastSelectedParent = children[0];
 
           lastSelectedParent.retrieveChildren = true;
-          lastSelectedParent.state = 'selected';
+          lastSelectedParent.state = newState;
           lastSelectedParent.children = [];
           return;
         }
@@ -113,7 +113,7 @@ export const categoryFacetSetReducer = createReducer(
           selection.value,
           retrieveCount
         );
-        newParent.state = 'selected';
+        newParent.state = newState;
         children.push(newParent);
         request.numberOfValues = 1;
       })


### PR DESCRIPTION
The category facet is the only facet that does not actually toggle off the value. With that change, now it does.

https://coveord.atlassian.net/browse/KIT-2695