### PR TITLE
fix(headless): consider only selected value ancestry for analytics, history and breadcrumbs 

### DIFF
--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
@@ -44,7 +44,7 @@ jest.mock(
 );
 
 const {
-  findActiveValueAncestry: actualfindActiveValueAncestry,
+  findActiveValueAncestry: actualFindActiveValueAncestry,
   partitionIntoParentsAndValues: actualPartitionIntoParentsAndValues,
 } = jest.requireActual(
   '../../../../features/facets/category-facet-set/category-facet-utils'
@@ -78,7 +78,7 @@ describe('category facet', () => {
       field: 'geography',
     };
     findActiveValueAncestryMock.mockImplementation(
-      actualfindActiveValueAncestry
+      actualFindActiveValueAncestry
     );
     partitionIntoParentsAndValuesMock.mockImplementation(
       actualPartitionIntoParentsAndValues

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
@@ -11,7 +11,7 @@ import {
 import {categoryFacetSetReducer as categoryFacetSet} from '../../../../features/facets/category-facet-set/category-facet-set-slice';
 import {defaultCategoryFacetOptions} from '../../../../features/facets/category-facet-set/category-facet-set-slice';
 import {
-  getActiveValueFromValueTree,
+  findActiveValueAncestry,
   partitionIntoParentsAndValues,
 } from '../../../../features/facets/category-facet-set/category-facet-utils';
 import {
@@ -44,7 +44,7 @@ jest.mock(
 );
 
 const {
-  getActiveValueFromValueTree: actualGetActiveValueFromValueTree,
+  findActiveValueAncestry: actualfindActiveValueAncestry,
   partitionIntoParentsAndValues: actualPartitionIntoParentsAndValues,
 } = jest.requireActual(
   '../../../../features/facets/category-facet-set/category-facet-utils'
@@ -56,9 +56,7 @@ describe('category facet', () => {
   let state: SearchAppState;
   let engine: MockSearchEngine;
   let categoryFacet: CoreCategoryFacet;
-  const getActiveValueFromValueTreeMock = jest.mocked(
-    getActiveValueFromValueTree
-  );
+  const findActiveValueAncestryMock = jest.mocked(findActiveValueAncestry);
   const partitionIntoParentsAndValuesMock = jest.mocked(
     partitionIntoParentsAndValues
   );
@@ -79,8 +77,8 @@ describe('category facet', () => {
       facetId,
       field: 'geography',
     };
-    getActiveValueFromValueTreeMock.mockImplementation(
-      actualGetActiveValueFromValueTree
+    findActiveValueAncestryMock.mockImplementation(
+      actualfindActiveValueAncestry
     );
     partitionIntoParentsAndValuesMock.mockImplementation(
       actualPartitionIntoParentsAndValues
@@ -135,13 +133,13 @@ describe('category facet', () => {
     expect(categoryFacet.subscribe).toBeDefined();
   });
 
-  it('#state.activeValue is the return value of #getActiveValueFromValueTree', () => {
+  it('#state.activeValue is the return value of #findActiveValueAncestry', () => {
     const referencedReturnValue = buildMockCategoryFacetValue();
-    getActiveValueFromValueTreeMock.mockReturnValueOnce(referencedReturnValue);
+    findActiveValueAncestryMock.mockReturnValueOnce([referencedReturnValue]);
 
     initCategoryFacet();
 
-    expect(getActiveValueFromValueTree).toBeCalledTimes(1);
+    expect(findActiveValueAncestry).toBeCalledTimes(1);
     expect(categoryFacet.state.activeValue).toBe(referencedReturnValue);
   });
 
@@ -279,6 +277,12 @@ describe('category facet', () => {
 
     it('#state.parents contains the selected leaf value', () => {
       expect(categoryFacet.state.parents).toEqual([selectedValue]);
+    });
+
+    it('#state.selectedValueAncestry contains the selected leaf value', () => {
+      expect(categoryFacet.state.selectedValueAncestry).toEqual([
+        selectedValue,
+      ]);
     });
 
     it('#state.values is an empty array', () => {

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
@@ -23,7 +23,10 @@ import {
   partitionIntoParentsAndValues,
 } from '../../../../features/facets/category-facet-set/category-facet-utils';
 import {CategoryFacetSortCriterion} from '../../../../features/facets/category-facet-set/interfaces/request';
-import {CategoryFacetValue} from '../../../../features/facets/category-facet-set/interfaces/response';
+import {
+  CategoryFacetValue,
+  CategoryFacetValueCommon,
+} from '../../../../features/facets/category-facet-set/interfaces/response';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {defaultFacetSearchOptions} from '../../../../features/facets/facet-search-set/facet-search-reducer-helpers';
 import {isFacetLoadingResponseSelector} from '../../../../features/facets/facet-set/facet-set-selectors';
@@ -50,6 +53,7 @@ import {
 } from './headless-core-category-facet-options';
 
 export type {
+  CategoryFacetValueCommon,
   CategoryFacetValue,
   CategoryFacetOptions,
   CategoryFacetSearchOptions,

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.ts
@@ -19,8 +19,7 @@ import {categoryFacetRequestSelector} from '../../../../features/facets/category
 import {defaultCategoryFacetOptions} from '../../../../features/facets/category-facet-set/category-facet-set-slice';
 import {categoryFacetSetReducer as categoryFacetSet} from '../../../../features/facets/category-facet-set/category-facet-set-slice';
 import {
-  getActiveValueAncestry,
-  getActiveValueFromValueTree,
+  findActiveValueAncestry,
   partitionIntoParentsAndValues,
 } from '../../../../features/facets/category-facet-set/category-facet-utils';
 import {CategoryFacetSortCriterion} from '../../../../features/facets/category-facet-set/interfaces/request';
@@ -393,11 +392,10 @@ export function buildCoreCategoryFacet(
       const isHierarchical =
         valuesAsTrees.some((value) => value.children.length > 0) ?? false;
       const {parents, values} = partitionIntoParentsAndValues(response?.values);
-      const activeValue = getActiveValueFromValueTree(valuesAsTrees);
-      const ancestryMap = new Map<CategoryFacetValue, CategoryFacetValue>();
-      const selectedValueAncestry = activeValue
-        ? getActiveValueAncestry(activeValue, ancestryMap)
-        : [];
+      const selectedValueAncestry = findActiveValueAncestry(valuesAsTrees);
+      const activeValue = selectedValueAncestry.length
+        ? selectedValueAncestry[selectedValueAncestry.length - 1]
+        : undefined;
       const hasActiveValues = !!activeValue;
       const canShowMoreValues =
         activeValue?.moreValuesAvailable ??

--- a/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/core/search-parameter-manager/headless-core-search-parameter-manager.ts
@@ -1,6 +1,6 @@
 import {RecordValue, Schema} from '@coveo/bueno';
 import {CoreEngine} from '../../../app/engine';
-import {partitionIntoParentsAndValues} from '../../../features/facets/category-facet-set/category-facet-utils';
+import {findActiveValueAncestry} from '../../../features/facets/category-facet-set/category-facet-utils';
 import {FacetValueRequest} from '../../../features/facets/facet-set/interfaces/request';
 import {RangeValueRequest} from '../../../features/facets/range-facets/generic/interfaces/range-facet';
 import {getQueryInitialState} from '../../../features/query/query-state';
@@ -222,9 +222,7 @@ function getCategoryFacets(state: Partial<SearchParametersState>) {
   const cf = Object.entries(state.categoryFacetSet)
     .filter(([facetId]) => state.facetOptions?.facets[facetId]?.enabled ?? true)
     .map(([facetId, slice]) => {
-      const {parents} = partitionIntoParentsAndValues(
-        slice.request.currentValues
-      );
+      const parents = findActiveValueAncestry(slice.request.currentValues);
       const selectedValues = parents.map((p) => p.value);
 
       return selectedValues.length ? {[facetId]: selectedValues} : {};

--- a/packages/headless/src/controllers/insight/facets/category-facet/headless-insight-category-facet.ts
+++ b/packages/headless/src/controllers/insight/facets/category-facet/headless-insight-category-facet.ts
@@ -23,11 +23,13 @@ import {
   CategoryFacetSearchState,
   CategoryFacetState,
   CategoryFacetValue,
+  CategoryFacetValueCommon,
   CoreCategoryFacet,
   CoreCategoryFacetState,
 } from '../../../core/facets/category-facet/headless-core-category-facet';
 
 export type {
+  CategoryFacetValueCommon,
   CategoryFacetValue,
   CategoryFacetOptions,
   CategoryFacetSearchOptions,

--- a/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet.ts
+++ b/packages/headless/src/controllers/product-listing/category-facet/headless-product-listing-category-facet.ts
@@ -2,7 +2,10 @@ import {configuration} from '../../../app/common-reducers';
 import {ProductListingEngine} from '../../../app/product-listing-engine/product-listing-engine';
 import {categoryFacetSetReducer as categoryFacetSet} from '../../../features/facets/category-facet-set/category-facet-set-slice';
 import {CategoryFacetSortCriterion} from '../../../features/facets/category-facet-set/interfaces/request';
-import {CategoryFacetValue} from '../../../features/facets/category-facet-set/interfaces/response';
+import {
+  CategoryFacetValue,
+  CategoryFacetValueCommon,
+} from '../../../features/facets/category-facet-set/interfaces/response';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {
   logFacetClearAll,
@@ -40,6 +43,7 @@ import {buildCategoryFacetSearch} from './headless-product-listing-category-face
 
 export type {
   CategoryFacetValue,
+  CategoryFacetValueCommon,
   CategoryFacetOptions,
   CategoryFacetSearchOptions,
   CategoryFacetProps,

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-selectors.ts
@@ -4,7 +4,7 @@ import {
   FacetResponseSection,
 } from '../facet-set/facet-set-selectors';
 import {AnyFacetResponse} from '../generic/interfaces/generic-facet-response';
-import {partitionIntoParentsAndValues} from './category-facet-utils';
+import {findActiveValueAncestry} from './category-facet-utils';
 import {CategoryFacetResponse} from './interfaces/response';
 
 function isCategoryFacetResponse(
@@ -38,8 +38,7 @@ export const categoryFacetResponseSelectedValuesSelector = (
   facetId: string
 ) => {
   const facetResponse = categoryFacetResponseSelector(state, facetId);
-  const parentsAndValues = partitionIntoParentsAndValues(facetResponse?.values);
-  return parentsAndValues.parents;
+  return findActiveValueAncestry(facetResponse?.values ?? []);
 };
 
 export const categoryFacetRequestSelectedValuesSelector = (
@@ -47,8 +46,5 @@ export const categoryFacetRequestSelectedValuesSelector = (
   facetId: string
 ) => {
   const facetRequest = categoryFacetRequestSelector(state, facetId);
-  const parentsAndValues = partitionIntoParentsAndValues(
-    facetRequest?.currentValues
-  );
-  return parentsAndValues.parents;
+  return findActiveValueAncestry(facetRequest?.currentValues ?? []);
 };

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -25,7 +25,7 @@ import {
   CategoryFacetSetState,
   getCategoryFacetSetInitialState,
 } from './category-facet-set-state';
-import {partitionIntoParentsAndValues} from './category-facet-utils';
+import {findActiveValueAncestry} from './category-facet-utils';
 import {CategoryFacetOptionalParameters} from './interfaces/options';
 import {
   CategoryFacetRequest,
@@ -285,11 +285,7 @@ function isRequestInvalid(
   request: CategoryFacetRequest,
   response: CategoryFacetResponse
 ) {
-  const requestParents = partitionIntoParentsAndValues(
-    request.currentValues
-  ).parents;
-  const responseParents = partitionIntoParentsAndValues(
-    response.values
-  ).parents;
+  const requestParents = findActiveValueAncestry(request.currentValues);
+  const responseParents = findActiveValueAncestry(response.values);
   return requestParents.length !== responseParents.length;
 }

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.test.ts
@@ -29,7 +29,7 @@ describe('#findActiveValueAncestry', () => {
       ],
     ];
 
-    it('should return an array containing only the selected Value if the selected Value is at the root', () => {
+    it('should return an array containing only the selected Value if the selected value is at the root', () => {
       expect(findActiveValueAncestry([selectedValue])).toEqual([selectedValue]);
     });
 

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.test.ts
@@ -1,57 +1,58 @@
 import {buildMockCategoryFacetValue} from '../../../test/mock-category-facet-value';
-import {getActiveValueFromValueTree} from './category-facet-utils';
+import {findActiveValueAncestry} from './category-facet-utils';
 import {CategoryFacetValue} from './interfaces/response';
 
-describe('#getActiveValueFromValueTree', () => {
-  it("should return undefined if there's no selected values", () => {
-    expect(getActiveValueFromValueTree([])).toBeUndefined();
+describe('#findActiveValueAncestry', () => {
+  it("should return an empty array if there's no selected values", () => {
+    expect(findActiveValueAncestry([])).toEqual([]);
   });
 
-  it.each([
-    {
-      caseName: 'doubleRootValues',
-      getValues: (expectedValue: CategoryFacetValue) => [
-        expectedValue,
-        buildMockCategoryFacetValue({state: 'selected'}),
-      ],
-    },
-    {
-      caseName: 'rootAndNestedValues',
-      getValues: (expectedValue: CategoryFacetValue) => [
-        buildMockCategoryFacetValue({children: [expectedValue]}),
-        buildMockCategoryFacetValue({state: 'selected'}),
-      ],
-    },
-    {
-      caseName: 'doubleNestedValues',
-      getValues: (expectedValue: CategoryFacetValue) => [
-        buildMockCategoryFacetValue({children: [expectedValue]}),
-        buildMockCategoryFacetValue({
-          children: [buildMockCategoryFacetValue({state: 'selected'})],
-        }),
-      ],
-    },
-    {
-      caseName: 'singleNestedValue',
-      getValues: (expectedValue: CategoryFacetValue) => [
-        buildMockCategoryFacetValue({children: [expectedValue]}),
-      ],
-    },
-    {
-      caseName: 'singleRootValue',
-      getValues: (expectedValue: CategoryFacetValue) => [expectedValue],
-    },
-  ])(
-    'should return the first selected values found while doing a depth first search - $caseName',
-    ({getValues}) => {
-      const expectedValues = buildMockCategoryFacetValue({
-        state: 'selected',
-        value: 'A',
-      });
+  describe('when there is a value selected', () => {
+    const selectedValue = buildMockCategoryFacetValue({
+      state: 'selected',
+      value: 'A',
+    });
+    const notAncestorValue = buildMockCategoryFacetValue();
 
-      const values: CategoryFacetValue[] = getValues(expectedValues);
+    const buildAncestor = (children: CategoryFacetValue[]) => {
+      return buildMockCategoryFacetValue({children});
+    };
 
-      expect(getActiveValueFromValueTree(values)).toBe(expectedValues);
-    }
-  );
+    const hierarchicalTestCases = [
+      () => [notAncestorValue, buildAncestor([selectedValue])],
+      () => [buildAncestor([notAncestorValue, selectedValue])],
+      () => [
+        buildAncestor([
+          notAncestorValue,
+          buildAncestor([selectedValue, notAncestorValue]),
+        ]),
+      ],
+    ];
+
+    it('should return an array containing only the selected Value if the selected Value is at the root', () => {
+      expect(findActiveValueAncestry([selectedValue])).toEqual([selectedValue]);
+    });
+
+    it.each(hierarchicalTestCases)(
+      'should return an array containing the selected value whole ancestry',
+      (generateValues) => {
+        expect(findActiveValueAncestry(generateValues())).not.toContain(
+          notAncestorValue
+        );
+      }
+    );
+
+    it.each(hierarchicalTestCases)(
+      'should return an array containing the ancestors in order, from the root to the selected value',
+      (generateValue) => {
+        const ancestry = findActiveValueAncestry(generateValue());
+
+        expect(ancestry.pop()).toBe(selectedValue);
+        expect(ancestry[ancestry.length - 1].children).toContain(selectedValue);
+        for (let i = 0; i < ancestry.length - 2; i++) {
+          expect(ancestry[i].children).toContain(ancestry[i + 1]);
+        }
+      }
+    );
+  });
 });

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
@@ -1,3 +1,4 @@
+import {CategoryFacetValueCommon} from './interfaces/commons';
 import {CategoryFacetValueRequest} from './interfaces/request';
 import {CategoryFacetValue} from './interfaces/response';
 
@@ -33,43 +34,52 @@ export function partitionIntoParentsAndValues<
   return {parents, values};
 }
 
-export function findActiveValueAncestry<T extends GenericCategoryFacetValue>(
-  valuesAsTree: T[]
-): T[] {
-  const ancestryMap = new Map<T, T>();
+export function findActiveValueAncestry(
+  valuesAsTress: CategoryFacetValueRequest[]
+): CategoryFacetValueRequest[];
+export function findActiveValueAncestry(
+  valuesAsTress: CategoryFacetValue[]
+): CategoryFacetValue[];
+export function findActiveValueAncestry(
+  valuesAsTree: CategoryFacetValueCommon[]
+): CategoryFacetValueCommon[] {
+  const ancestryMap = new Map<
+    CategoryFacetValueCommon,
+    CategoryFacetValueCommon
+  >();
   const activeValue = getActiveValueFromValueTree(valuesAsTree, ancestryMap);
   return activeValue ? getActiveValueAncestry(activeValue, ancestryMap) : [];
 }
 
-function getActiveValueFromValueTree<TValue extends GenericCategoryFacetValue>(
-  valuesAsTrees: TValue[],
-  ancestryMap?: Map<TValue, TValue>
-): TValue | undefined {
-  const valueToVisit = [...valuesAsTrees];
+function getActiveValueFromValueTree(
+  valuesAsTrees: CategoryFacetValueCommon[],
+  ancestryMap?: Map<CategoryFacetValueCommon, CategoryFacetValueCommon>
+): CategoryFacetValueCommon | undefined {
+  const valueToVisit: CategoryFacetValueCommon[] = [...valuesAsTrees];
   while (valueToVisit.length > 0) {
-    const currentValue = valueToVisit.shift()!;
+    const currentValue: CategoryFacetValueCommon = valueToVisit.shift()!;
     if (currentValue.state === 'selected') {
       return currentValue;
     }
     if (ancestryMap) {
       for (const childValue of currentValue.children) {
-        ancestryMap.set(childValue as TValue, currentValue);
+        ancestryMap.set(childValue, currentValue);
       }
     }
-    valueToVisit.unshift(...(currentValue.children as TValue[]));
+    valueToVisit.unshift(...currentValue.children);
   }
   return undefined;
 }
 
-function getActiveValueAncestry<TValue extends GenericCategoryFacetValue>(
-  activeValue: TValue | undefined,
-  valueToParentMap: Map<TValue, TValue>
-): TValue[] {
-  const activeValueAncestry: TValue[] = [];
+function getActiveValueAncestry(
+  activeValue: CategoryFacetValueCommon | undefined,
+  valueToParentMap: Map<CategoryFacetValueCommon, CategoryFacetValueCommon>
+): CategoryFacetValueCommon[] {
+  const activeValueAncestry: CategoryFacetValueCommon[] = [];
   if (!activeValue) {
     return [];
   }
-  let lastParent: TValue | undefined = activeValue;
+  let lastParent: CategoryFacetValueCommon | undefined = activeValue;
   do {
     activeValueAncestry.unshift(lastParent);
     lastParent = valueToParentMap.get(lastParent);

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
@@ -43,23 +43,23 @@ export function findActiveValueAncestry(
 export function findActiveValueAncestry(
   valuesAsTree: CategoryFacetValueCommon[]
 ): CategoryFacetValueCommon[] {
+  const {activeValue, ancestryMap} =
+    getActiveValueAndAncestryFromValueTree(valuesAsTree);
+  return activeValue ? getActiveValueAncestry(activeValue, ancestryMap) : [];
+}
+
+function getActiveValueAndAncestryFromValueTree(
+  valuesAsTrees: CategoryFacetValueCommon[]
+) {
+  const valueToVisit: CategoryFacetValueCommon[] = [...valuesAsTrees];
   const ancestryMap = new Map<
     CategoryFacetValueCommon,
     CategoryFacetValueCommon
   >();
-  const activeValue = getActiveValueFromValueTree(valuesAsTree, ancestryMap);
-  return activeValue ? getActiveValueAncestry(activeValue, ancestryMap) : [];
-}
-
-function getActiveValueFromValueTree(
-  valuesAsTrees: CategoryFacetValueCommon[],
-  ancestryMap?: Map<CategoryFacetValueCommon, CategoryFacetValueCommon>
-): CategoryFacetValueCommon | undefined {
-  const valueToVisit: CategoryFacetValueCommon[] = [...valuesAsTrees];
   while (valueToVisit.length > 0) {
     const currentValue: CategoryFacetValueCommon = valueToVisit.shift()!;
     if (currentValue.state === 'selected') {
-      return currentValue;
+      return {activeValue: currentValue, ancestryMap};
     }
     if (ancestryMap) {
       for (const childValue of currentValue.children) {
@@ -68,7 +68,7 @@ function getActiveValueFromValueTree(
     }
     valueToVisit.unshift(...currentValue.children);
   }
-  return undefined;
+  return {};
 }
 
 function getActiveValueAncestry(

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-utils.ts
@@ -8,14 +8,6 @@ type CategoryFacetValuePartition<T extends GenericCategoryFacetValue> = {
   values: T[];
 };
 
-export function findActiveValueAncestry<T extends GenericCategoryFacetValue>(
-  valuesAsTree: T[]
-): T[] {
-  const ancestryMap = new Map<T, T>();
-  const activeValue = getActiveValueFromValueTree(valuesAsTree, ancestryMap);
-  return activeValue ? getActiveValueAncestry(activeValue, ancestryMap) : [];
-}
-
 export function partitionIntoParentsAndValues<
   T extends GenericCategoryFacetValue
 >(nestedValues: T[] | undefined): CategoryFacetValuePartition<T> {
@@ -41,9 +33,15 @@ export function partitionIntoParentsAndValues<
   return {parents, values};
 }
 
-export function getActiveValueFromValueTree<
-  TValue extends GenericCategoryFacetValue
->(
+export function findActiveValueAncestry<T extends GenericCategoryFacetValue>(
+  valuesAsTree: T[]
+): T[] {
+  const ancestryMap = new Map<T, T>();
+  const activeValue = getActiveValueFromValueTree(valuesAsTree, ancestryMap);
+  return activeValue ? getActiveValueAncestry(activeValue, ancestryMap) : [];
+}
+
+function getActiveValueFromValueTree<TValue extends GenericCategoryFacetValue>(
   valuesAsTrees: TValue[],
   ancestryMap?: Map<TValue, TValue>
 ): TValue | undefined {
@@ -63,9 +61,7 @@ export function getActiveValueFromValueTree<
   return undefined;
 }
 
-export function getActiveValueAncestry<
-  TValue extends GenericCategoryFacetValue
->(
+function getActiveValueAncestry<TValue extends GenericCategoryFacetValue>(
   activeValue: TValue | undefined,
   valueToParentMap: Map<TValue, TValue>
 ): TValue[] {

--- a/packages/headless/src/features/facets/category-facet-set/interfaces/commons.ts
+++ b/packages/headless/src/features/facets/category-facet-set/interfaces/commons.ts
@@ -1,0 +1,16 @@
+import {FacetValueState} from '../../facet-api/value';
+
+export interface CategoryFacetValueCommon {
+  /**
+   * The facet value.
+   */
+  value: string;
+  /**
+   * The children of this facet value.
+   */
+  children: CategoryFacetValueCommon[];
+  /**
+   * Whether a facet value is filtering results (`selected`) or not (`idle`).
+   */
+  state: FacetValueState;
+}

--- a/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
@@ -6,6 +6,7 @@ import {
   SortCriteria,
   BaseFacetValueRequest,
 } from '../../facet-api/request';
+import {CategoryFacetValueCommon} from './commons';
 
 export const categoryFacetSortCriteria: CategoryFacetSortCriterion[] = [
   'alphanumeric',
@@ -13,8 +14,9 @@ export const categoryFacetSortCriteria: CategoryFacetSortCriterion[] = [
 ];
 export type CategoryFacetSortCriterion = 'alphanumeric' | 'occurrences';
 
-export interface CategoryFacetValueRequest extends BaseFacetValueRequest {
-  value: string;
+export interface CategoryFacetValueRequest
+  extends BaseFacetValueRequest,
+    CategoryFacetValueCommon {
   children: CategoryFacetValueRequest[];
   retrieveChildren: boolean;
   retrieveCount: number;

--- a/packages/headless/src/features/facets/category-facet-set/interfaces/response.ts
+++ b/packages/headless/src/features/facets/category-facet-set/interfaces/response.ts
@@ -1,12 +1,8 @@
 import {BaseFacetResponse} from '../../facet-api/response';
-import {FacetValueState} from '../../facet-api/value';
+import {CategoryFacetValueCommon} from './commons';
 
-export interface CategoryFacetValue {
-  /**
-   * Whether a facet value is filtering results (`selected`) or not (`idle`).
-   * */
-  state: FacetValueState;
-
+export type {CategoryFacetValueCommon} from './commons';
+export interface CategoryFacetValue extends CategoryFacetValueCommon {
   /**
    * The number of results that match the facet value.
    * */
@@ -27,10 +23,6 @@ export interface CategoryFacetValue {
    * */
   moreValuesAvailable: boolean;
 
-  /**
-   * The facet value.
-   * */
-  value: string;
   /**
    * When the hierarchical value has no children, this property is true.
    */

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions-utils.test.ts
@@ -106,7 +106,7 @@ describe('facet-set-analytics-action-utils', () => {
           field,
           currentValues: [
             buildMockCategoryFacetValueRequest({
-              state: 'selected',
+              state: 'idle',
               value: 'should appear',
               children: [
                 buildMockCategoryFacetValueRequest({

--- a/packages/headless/src/features/history/history-slice.ts
+++ b/packages/headless/src/features/history/history-slice.ts
@@ -7,7 +7,7 @@ import {ContextState} from '../context/context-state';
 import {DictionaryFieldContextState} from '../dictionary-field-context/dictionary-field-context-state';
 import {AutomaticFacetSetState} from '../facets/automatic-facet-set/automatic-facet-set-state';
 import {CategoryFacetSetState} from '../facets/category-facet-set/category-facet-set-state';
-import {partitionIntoParentsAndValues} from '../facets/category-facet-set/category-facet-utils';
+import {findActiveValueAncestry} from '../facets/category-facet-set/category-facet-utils';
 import {FacetValue} from '../facets/facet-set/interfaces/response';
 import {AnyFacetSetState} from '../facets/generic/interfaces/generic-facet-section';
 import {PaginationState} from '../pagination/pagination-state';
@@ -137,12 +137,12 @@ const isCategoryFacetsEqual = (
       return false;
     }
 
-    const currentSelectedValues = partitionIntoParentsAndValues(
+    const currentSelectedValues = findActiveValueAncestry(
       current[key]?.request.currentValues
-    ).parents.map(({value}) => value);
-    const nextSelectedValues = partitionIntoParentsAndValues(
+    ).map(({value}) => value);
+    const nextSelectedValues = findActiveValueAncestry(
       value?.request.currentValues
-    ).parents.map(({value}) => value);
+    ).map(({value}) => value);
 
     if (
       JSON.stringify(currentSelectedValues) !==

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -116,8 +116,11 @@ export type {
   CategoryFacetValueRequest,
   CategoryFacetSortCriterion,
 } from './features/facets/category-facet-set/interfaces/request';
-export type {CategoryFacetValue} from './features/facets/category-facet-set/interfaces/response';
 export type {DateRangeRequest} from './features/facets/range-facets/date-facet-set/interfaces/request';
+export type {
+  CategoryFacetValue,
+  CategoryFacetValueCommon,
+} from './features/facets/category-facet-set/interfaces/response';
 export type {DateFacetValue} from './features/facets/range-facets/date-facet-set/interfaces/response';
 export type {
   FacetValueRequest,

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -98,6 +98,7 @@ export type {
   CategoryFacetState,
   CategoryFacet,
   CategoryFacetValue,
+  CategoryFacetValueCommon,
   CategoryFacetSearch,
   CategoryFacetSearchState,
   CategoryFacetSearchResult,

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -121,6 +121,7 @@ export type {
   CategoryFacetSearchState,
   CategoryFacetState,
   CategoryFacetValue,
+  CategoryFacetValueCommon,
   CategoryFacetSearchResult,
   CoreCategoryFacet,
   CoreCategoryFacetState,


### PR DESCRIPTION
Essentially, this PR replaces *both* `getActiveValueFromValueTree` and `partitionIntoParentsAndValues` (partially) with `findActiveValueAncestry`.

The first one is a method I introduced in #3105, and I could have left it there. However, in an effort to ease the deprecation of `categoryFacetState.parents`, I decided to use it in the CategoryFacetController.

However, `parents` is not entirely based on the notion of whether a value is selected or not (which IMHO is not the best because when a value is selected, it represents user intent) contrary to the new `selectedValueAncestry`, so I decided to create the latter to replace the former definitively in v3.

The second one is the historical method that doesn't work well with "multi-root-values" hierarchies, which leads to similar symptoms (i.e. children's root values or whatnot leaking into the parents' hierarchy, leading to bad analytics, bad history slice, and so on)

The logic of `findActiveValueAncestry` is simple:
 - Use the logic of `getActiveValueFromTree` BUT as you queue up new values, keep a note of what is their parent in a Map, where the child value is the key and the parent value is the value.
 - Once the activeValue is found, "rewind" the ancestry using the Map and compute the ancestry as we go
 
 
 ------
 
 KIT-2696