### PR TITLE
chore(doc-tools): log failing entrypoint

### DIFF
--- a/packages/headless/doc-parser/doc-parser.ts
+++ b/packages/headless/doc-parser/doc-parser.ts
@@ -68,6 +68,7 @@ const useCases: UseCase[] = [
 
 function resolveUseCase(useCase: UseCase): ResolvedUseCase {
   const {name, entryFile, config} = useCase;
+  process.env['currentUseCaseName'] = name;
   const apiModel = new ApiModel();
   const apiPackage = apiModel.loadPackage(entryFile);
   const entryPoint = apiPackage.entryPoints[0];

--- a/packages/headless/doc-parser/src/api-finder.ts
+++ b/packages/headless/doc-parser/src/api-finder.ts
@@ -5,7 +5,10 @@ export function findApi(entry: ApiEntryPoint, apiName: string) {
   const [result] = entry.findMembersByName(canonicalName);
 
   if (!result) {
-    throw new Error(`No api found for ${canonicalName}`);
+    const currentUseCaseName: string = process.env['currentUseCaseName']!;
+    throw new Error(
+      `No api found for ${canonicalName} while processing ${currentUseCaseName}. Ensure ${canonicalName} is exported in the entrypoint of ${currentUseCaseName}.`
+    );
   }
 
   return result;


### PR DESCRIPTION
When adding an interface, it's confusing to know all the nooks and crannies where you should expose it.
This helps by telling you where you forgot to export it. (it is quite lazy, but it works).

------

KIT-2698