### PR TITLE
chore: remove eslint 0 warn, promote all manual rules to err

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
       "files": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs"],
       "extends": ["plugin:@cspell/recommended"],
       "rules": {
-        "@cspell/spellchecker": ["warn"]
+        "@cspell/spellchecker": ["error"]
       }
     },
     {
@@ -46,7 +46,7 @@
       },
       "rules": {
         "@typescript-eslint/no-unused-vars": [
-          "warn",
+          "error",
           {
             "ignoreRestSiblings": true,
             "argsIgnorePattern": "^_",

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ module.exports = {
     const filteredFiles = files.filter(
       (file) => !file.includes('/stencil-generated/') || !file.endsWith('.ts')
     );
-    return `eslint --fix --max-warnings=0 ${filteredFiles.join(' ')}`;
+    return `eslint --fix ${filteredFiles.join(' ')}`;
   },
   '**/{*.{scss,css,pcss,html,md},{package,nx,project}.json}': (files) => {
     return `prettier --write ${files.join(' ')}`;


### PR DESCRIPTION
Gen files are sometimes ignored by eslint (that make sense), and this creates a eslint warning because the file is not parsed, making eslint fail, which is a bit silly 😂 

So I removed the max-warn limit and promoted the few warn rules we had to errors.

The gap we create concerns the "warn" rules that we have only through eslint extends, but I feel OK with this.

For example, this blocks React dependency update PR :finnadie: 

KIT-2731