### PR TITLE
feat(commerce): make commerce team owners of commerce sub-package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,3 +17,4 @@
 /packages/headless/commerce/ @coveo/commerce-routemasters
 /packages/headless/src/**/commerce/ @coveo/commerce-routemasters
 /packages/headless/src/app/commerce-engine/ @coveo/commerce-routemasters
+/packages/headless/src/commerce.index.ts @coveo/commerce-routemasters

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,8 @@
 
 # Owners of Atomic IPX components
 /packages/atomic/src/components/ipx @coveo/service-integrations
+
+# Owners of the Commerce headless sub-package
+/packages/headless/commerce/ @coveo/commerce-routemasters
+/packages/headless/src/**/commerce/ @coveo/commerce-routemasters
+/packages/headless/src/app/commerce-engine/ @coveo/commerce-routemasters

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,5 +17,6 @@
 /packages/headless/commerce/ @coveo/commerce-routemasters
 /packages/headless/src/**/commerce/ @coveo/commerce-routemasters
 /packages/headless/src/app/commerce-engine/ @coveo/commerce-routemasters
+/packages/headless/src/state/commerce-app-state.ts @coveo/commerce-routemasters
 /packages/headless/src/commerce.index.ts @coveo/commerce-routemasters
 /packages/headless/src/test/**commerce** @coveo/commerce-routemasters

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,4 @@
 /packages/headless/src/**/commerce/ @coveo/commerce-routemasters
 /packages/headless/src/app/commerce-engine/ @coveo/commerce-routemasters
 /packages/headless/src/commerce.index.ts @coveo/commerce-routemasters
+/packages/headless/src/test/**commerce** @coveo/commerce-routemasters


### PR DESCRIPTION
Since the commerce team works on the headless commerce sub-package, it makes sense for us to own the related files. 

[CAPI-83]

[CAPI-83]: https://coveord.atlassian.net/browse/CAPI-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ