### PR TITLE
test: rewrite search-box-instant-results.cypress.ts with better practices

### DIFF
--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -123,6 +123,7 @@ export function assertRemovesComponent() {
   );
 }
 
+//TODO(a): Remove when every reference now uses assertHasTextWithoutIt
 export function assertAriaLiveMessage(
   selector: () => Cypress.Chainable<JQuery<HTMLElement>>,
   message: string
@@ -130,4 +131,11 @@ export function assertAriaLiveMessage(
   it(`screen readers should read out "${message}".`, () => {
     selector().should('contain.text', message);
   });
+}
+
+export function assertAriaLiveMessageWithoutIt(
+  selector: () => Cypress.Chainable<JQuery<HTMLElement>>,
+  message: string
+) {
+  selector().should('contain.text', message);
 }

--- a/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results-assertions.ts
+++ b/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results-assertions.ts
@@ -1,30 +1,22 @@
 import {InstantResultsSelectors} from './search-box-instant-results-selectors';
 
 export function assertHasResultCount(count: number) {
-  it(`should display ${count} results`, () => {
-    InstantResultsSelectors.results().should('have.length', count);
-  });
+  InstantResultsSelectors.results().should('have.length', count);
 }
 
 export function assertResultIsSelected(index: number) {
-  it(`should have selected result ${index}`, () => {
-    InstantResultsSelectors.results()
-      .eq(index)
-      .invoke('attr', 'part')
-      .should('contain', 'active-suggestion');
-  });
+  InstantResultsSelectors.results()
+    .eq(index)
+    .invoke('attr', 'part')
+    .should('contain', 'active-suggestion');
 }
 
 export function assertNoResultIsSelected() {
-  it('should have no selected result', () => {
-    InstantResultsSelectors.results().each((el) =>
-      expect(el.attr('part')).to.not.contain('active-suggestion')
-    );
-  });
+  InstantResultsSelectors.results().each((el) =>
+    expect(el.attr('part')).to.not.contain('active-suggestion')
+  );
 }
 
 export function assertLogSearchboxAsYouType() {
-  it('should log the SearchboxAsYouType event to UA', () => {
-    cy.expectSearchEvent('searchboxAsYouType');
-  });
+  cy.expectSearchEvent('searchboxAsYouType');
 }

--- a/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results.cypress.ts
@@ -19,7 +19,7 @@ import * as InstantResultsAssertions from './search-box-instant-results-assertio
 import {InstantResultsSelectors} from './search-box-instant-results-selectors';
 
 const delay = (force = false) => ({delay: 400, force});
-const downKeys = (count: number) => Array(count).fill('{downarrow}').join('');
+const downKeys = (count: number) => Array(count).fill('{downArrow}').join('');
 
 const setInstantResults = (count: number) => (fixture: TestFixture) => {
   fixture.withCustomResponse((response) => {
@@ -72,6 +72,7 @@ describe('Instant Results Test Suites', () => {
     const customFieldName = 'custom';
     const customFieldValueForResult = (index: number) => `${index}!`;
     const ariaLabelGeneratorAlias = 'ariaLabelGenerator';
+
     beforeEach(() => {
       new TestFixture()
         .with(setInstantResults(numOfInstantResults))
@@ -101,24 +102,26 @@ describe('Instant Results Test Suites', () => {
           })
         )
         .init();
+    });
+
+    CommonAssertions.assertAccessibility(searchBoxComponent);
+
+    it('uses the generated labels and passes bindings to the generator', () => {
       SearchBoxSelectors.inputBox().type(`${downKeys(2)}`, delay());
       InstantResultsSelectors.results()
         .find(resultTextComponent, {includeShadowDom: true})
         .should(($els) => expect($els.text().trim().length).to.greaterThan(0));
-    });
 
-    CommonAssertions.assertAccessibility(searchBoxComponent);
-    InstantResultsAssertions.assertLogSearchboxAsYouType();
+      InstantResultsAssertions.assertLogSearchboxAsYouType();
 
-    it('uses the generated labels', () => {
+      //uses the generated labels
       InstantResultsSelectors.results().should(([...results]) =>
         results.forEach((result, i) =>
           expect(result.ariaLabel).to.contain(customFieldValueForResult(i))
         )
       );
-    });
 
-    it('passes the bindings to the generator', () => {
+      //passes the bindings to the generator
       cy.get<
         sinon.SinonStub<
           Parameters<AriaLabelGenerator>,
@@ -138,178 +141,123 @@ describe('Instant Results Test Suites', () => {
   });
 
   describe('with keyboard navigation', () => {
-    describe('when navigating from query to results', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          `${downKeys(2)}{rightarrow}`,
-          delay()
-        );
-      });
-      after(() => {
-        SearchBoxSelectors.inputBox().clear({force: true});
-      });
-      SearchBoxAssertions.assertHasSuggestionsCount(
+    beforeEach(() => {
+      setupWithSuggestionsAndRecentQueries();
+    });
+
+    it('should function correctly', () => {
+      SearchBoxSelectors.inputBox().type(`${downKeys(1)}{rightArrow}`, delay());
+
+      //when navigating from query to results
+      SearchBoxAssertions.assertHasSuggestionsCountWithoutIt(
         maxRecentQueriesWithoutQuery
       );
       InstantResultsAssertions.assertHasResultCount(numOfInstantResults);
-      CommonAssertions.assertAriaLiveMessage(
+      CommonAssertions.assertAriaLiveMessageWithoutIt(
         SearchBoxSelectors.searchBoxAriaLive,
         maxRecentQueriesWithoutQuery.toString()
       );
       InstantResultsAssertions.assertResultIsSelected(0);
-      SearchBoxAssertions.assertSuggestionIsHighlighted(1);
-    });
-    describe('when navigating back from result to query', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          `${downKeys(2)}{rightarrow}{leftarrow}`,
-          delay()
-        );
-      });
-      after(() => {
-        SearchBoxSelectors.inputBox().clear({force: true});
-      });
+      SearchBoxAssertions.assertSuggestionIsHighlightedwithoutIt(1);
+
+      //when navigating back from result to query
+      SearchBoxSelectors.inputBox().type(
+        `${downKeys(2)}{leftArrow}{downArrow}`,
+        delay()
+      );
+
       InstantResultsAssertions.assertNoResultIsSelected();
-      SearchBoxAssertions.assertSuggestionIsSelected(0);
-      SearchBoxAssertions.assertHasText('Recent query 0');
-    });
-    describe('when navigating back from result to query', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          `${downKeys(2)}{rightarrow}{leftarrow}`,
-          delay()
-        );
-      });
-      after(() => {
-        SearchBoxSelectors.inputBox().clear({force: true});
-      });
-      InstantResultsAssertions.assertNoResultIsSelected();
-      SearchBoxAssertions.assertSuggestionIsSelected(0);
-      SearchBoxAssertions.assertHasText('Recent query 0');
-    });
-    describe('when pressing enter on a result', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          `${downKeys(2)}{rightarrow}{enter}`,
-          delay()
-        );
-      });
-      it('redirects to new page', () => {
-        cy.window().then((win) => {
-          expect(win.location.href).to.equal('https://example.com/0');
-        });
-      });
-    });
-    describe('when navigating to first suggestion and back with up arrow', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          'Rec{downarrow}{uparrow}{leftarrow}{del}',
-          delay()
-        );
-      });
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(0);
+      SearchBoxAssertions.assertHasTextWithoutIt('Recent query 0');
+
+      //when navigating to first suggestion and back with up arrow
+      SearchBoxSelectors.inputBox().type(`${downKeys(3)}{upArrow}`, delay());
+      SearchBoxSelectors.inputBox().clear({force: true});
+
+      SearchBoxSelectors.inputBox().type(
+        'Rec{downArrow}{upArrow}{leftArrow}{del}',
+        delay()
+      );
 
       SearchBoxAssertions.assertNoSuggestionIsSelected();
-      SearchBoxAssertions.assertHasText('Re');
-    });
+      SearchBoxAssertions.assertHasTextWithoutIt('Re');
 
-    describe('when navigating with the down arrow only', () => {
-      beforeEach(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(downKeys(6), delay());
-      });
+      //when navigating with the down arrow only
+      SearchBoxSelectors.inputBox().clear({force: true});
+      SearchBoxSelectors.inputBox().type(downKeys(6), delay());
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(0);
 
-      SearchBoxAssertions.assertSuggestionIsSelected(0);
-    });
+      //when navigating up from results
+      SearchBoxSelectors.inputBox().type(`${downKeys(2)}{upArrow}`, delay());
+      SearchBoxSelectors.inputBox().clear({force: true});
 
-    describe('when navigating up from results', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type('{moveToStart}');
-        InstantResultsSelectors.results();
-        SearchBoxSelectors.inputBox().type(
-          '{rightarrow}{uparrow}',
-          delay(true)
-        );
-      });
-
+      SearchBoxSelectors.inputBox().type('{moveToStart}');
       SearchBoxAssertions.assertNoSuggestionIsSelected();
       InstantResultsAssertions.assertNoResultIsSelected();
-    });
 
-    describe('when navigating up from input', () => {
-      beforeEach(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type('{moveToStart}{uparrow}', delay());
-      });
+      //when navigating up from input
+      SearchBoxSelectors.inputBox().type('{moveToStart}{upArrow}', delay());
 
-      SearchBoxAssertions.assertSuggestionIsSelected(2);
-    });
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(2);
 
-    describe('when typing when a query is selected', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type(
-          `${downKeys(2)}{backspace}`,
-          delay()
-        );
-      });
+      //when typing when a query is selected
+      SearchBoxSelectors.inputBox().type(`${downKeys(1)}{downArrow}`, delay());
+
+      SearchBoxSelectors.inputBox().type(`${downKeys(2)}{backspace}`, delay());
 
       SearchBoxAssertions.assertNoSuggestionIsSelected();
-      SearchBoxAssertions.assertHasText('Recent query ');
+      SearchBoxAssertions.assertHasTextWithoutIt('Recent query ');
+
+      //when pressing enter on a result
+      cy.wait(500);
+
+      SearchBoxSelectors.inputBox().type(
+        `${downKeys(2)}{rightArrow}{enter}`,
+        delay()
+      );
+
+      cy.window().then((win) => {
+        expect(win.location.href).to.equal('https://example.com/2');
+      });
     });
   });
 
   describe('with mouse navigation', () => {
-    describe('when hovering over a query', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().click();
-        SearchBoxSelectors.querySuggestions().eq(0).trigger('mouseover');
-      });
-      SearchBoxAssertions.assertSuggestionIsSelected(0);
-      SearchBoxAssertions.assertHasText('');
+    beforeEach(() => {
+      setupWithSuggestionsAndRecentQueries();
     });
 
-    describe('when hovering over an instant result', () => {
-      before(() => {
-        setupWithSuggestionsAndRecentQueries(2);
-        SearchBoxSelectors.inputBox().click();
-        InstantResultsSelectors.results().eq(1).trigger('mouseover');
-      });
-      InstantResultsAssertions.assertHasResultCount(2);
+    it('should function correctly', () => {
+      //when hovering over a query
+      SearchBoxSelectors.inputBox().click();
+      SearchBoxSelectors.querySuggestions().eq(0).trigger('mouseover');
+
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(0);
+      SearchBoxAssertions.assertHasTextWithoutIt('');
+
+      //when hovering over an instant result
+      SearchBoxSelectors.inputBox().click();
+      InstantResultsSelectors.results().eq(1).trigger('mouseover');
+
+      InstantResultsAssertions.assertHasResultCount(4);
       InstantResultsAssertions.assertResultIsSelected(1);
-      SearchBoxAssertions.assertSuggestionIsHighlighted(1);
+      SearchBoxAssertions.assertSuggestionIsHighlightedwithoutIt(1);
 
-      describe('when hovering over a different query', () => {
-        before(() => {
-          SearchBoxSelectors.querySuggestions().eq(1).trigger('mouseover');
-        });
-        InstantResultsAssertions.assertHasResultCount(4);
-        InstantResultsAssertions.assertNoResultIsSelected();
-        SearchBoxAssertions.assertSuggestionIsSelected(1);
-      });
-    });
+      //when hovering over a different query
+      SearchBoxSelectors.inputBox().click();
+      InstantResultsSelectors.results().eq(1).trigger('mouseover');
+      SearchBoxSelectors.querySuggestions().eq(1).trigger('mouseover');
 
-    describe('when clicking a result', () => {
-      beforeEach(() => {
-        setupWithSuggestionsAndRecentQueries();
-        SearchBoxSelectors.inputBox().type('{downarrow}', {
-          delay: 400,
-          force: true,
-        });
-        cy.wait(TestFixture.interceptAliases.Search);
-        InstantResultsSelectors.results().eq(1).click();
-      });
+      InstantResultsAssertions.assertHasResultCount(4);
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(1);
 
-      it('redirects to new page', () => {
-        cy.window().then((win) => {
-          expect(win.location.href).to.equal('https://example.com/1');
-        });
+      //when clicking a result
+      cy.wait(500);
+
+      InstantResultsSelectors.results().eq(1).trigger('mouseover').click();
+
+      cy.window().then((win) => {
+        expect(win.location.href).to.equal('https://example.com/1');
       });
     });
   });

--- a/packages/atomic/cypress/e2e/search-box/search-box-assertions.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box-assertions.ts
@@ -7,7 +7,7 @@ export function assertFocusSearchBox(
     searchBoxSelector().should('be.focused');
   });
 }
-
+//TODO(a): Remove when no more references and standalone-search-box + search-box use assertHasTextWithoutIt
 export function assertHasText(
   text: string,
   searchBoxSelector = SearchBoxSelectors.inputBox
@@ -17,6 +17,14 @@ export function assertHasText(
   });
 }
 
+export function assertHasTextWithoutIt(
+  text: string,
+  searchBoxSelector = SearchBoxSelectors.inputBox
+) {
+  searchBoxSelector().should('have.value', text);
+}
+
+//TODO(a): Remove when no more references and search-box use assertHasSuggestionsCountWithoutIt
 export function assertHasSuggestionsCount(count: number) {
   it(`should display ${count} suggestions`, () => {
     SearchBoxSelectors.querySuggestions()
@@ -34,12 +42,19 @@ export function assertHasSuggestionsCount(count: number) {
   });
 }
 
+export function assertHasSuggestionsCountWithoutIt(count: number) {
+  SearchBoxSelectors.querySuggestions()
+    .filter(':visible')
+    .should('have.length', count);
+}
+
 export function assertNoSuggestionGenerated() {
   it('should have no suggestions', () => {
     SearchBoxSelectors.querySuggestions().should('not.exist');
   });
 }
 
+//TODO(a): Remove when no more references and search-box use assertSuggestionIsSelectedWithoutIt
 export function assertSuggestionIsSelected(index: number) {
   it(`should have selected suggestion ${index}`, () => {
     SearchBoxSelectors.querySuggestions()
@@ -49,21 +64,24 @@ export function assertSuggestionIsSelected(index: number) {
   });
 }
 
-export function assertSuggestionIsHighlighted(index: number) {
-  it(`should have highlighted suggestion ${index}`, () => {
-    SearchBoxSelectors.querySuggestions()
-      .eq(index)
-      .invoke('attr', 'class')
-      .should('contain', 'bg-neutral-light');
-  });
+export function assertSuggestionIsSelectedWithoutIt(index: number) {
+  SearchBoxSelectors.querySuggestions()
+    .eq(index)
+    .invoke('attr', 'part')
+    .should('contain', 'active-suggestion');
+}
+
+export function assertSuggestionIsHighlightedwithoutIt(index: number) {
+  SearchBoxSelectors.querySuggestions()
+    .eq(index)
+    .invoke('attr', 'class')
+    .should('contain', 'bg-neutral-light');
 }
 
 export function assertNoSuggestionIsSelected() {
-  it('should have no selected result', () => {
-    SearchBoxSelectors.querySuggestions().each((el) =>
-      expect(el.attr('part')).to.not.contain('active-suggestion')
-    );
-  });
+  SearchBoxSelectors.querySuggestions().each((el) =>
+    expect(el.attr('part')).to.not.contain('active-suggestion')
+  );
 }
 
 export function assertLogSearchFromLink(query: string) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2759

This PR Remove most of the unnecessary 'it' statements. This improves flakiness and also fixes new issues with the update of cypress.

Following the best practices guide on cypress -> https://docs.cypress.io/guides/references/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion

Every assertion that was there before was kept, I just put them all in the same 'it' statement to improve flakiness ! It also makes it much faster
## Before 
<img width="1148" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/17f5a038-35f6-4408-a387-1cc6c6b4ca3f">

## Now
<img width="1250" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/fc0ce669-97a9-403c-a854-6e198cf4c873">
