### PR TITLE
chore(bueno): ensure bueno types are safe-guarded

### DIFF
--- a/packages/bueno/jest.config.js
+++ b/packages/bueno/jest.config.js
@@ -1,3 +1,10 @@
 module.exports = {
-  preset: 'ts-jest',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
+  },
 };

--- a/packages/bueno/tsconfig.json
+++ b/packages/bueno/tsconfig.json
@@ -8,8 +8,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "isolatedModules": true,
+    "types": []
   },
   "include": [
     "src"
-  ]
+  ],
+  "exclude": ["**/*.test.ts"]
 }

--- a/packages/bueno/tsconfig.test.json
+++ b/packages/bueno/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {"types":["jest"]},
+  "exclude": []
+}


### PR DESCRIPTION
Bueno build is more thorough while checking the libs and types.
Bueno does not depend on any `@types` packages, thus it does not need `types`.