### PR TITLE
feat(atomic): interactive RGA citations

### DIFF
--- a/packages/atomic/cypress/e2e/generated-answer-assertions.ts
+++ b/packages/atomic/cypress/e2e/generated-answer-assertions.ts
@@ -1,0 +1,15 @@
+import {AnalyticsTracker} from '../utils/analyticsUtils';
+import {should} from './common-assertions';
+
+export function assertLogOpenGeneratedAnswerSource(log: boolean) {
+  it(`${should(log)} log a openGeneratedAnswerSource click event`, () => {
+    if (log) {
+      cy.expectCustomEvent('generatedAnswer', 'openGeneratedAnswerSource');
+    } else {
+      cy.wait(50);
+      cy.wrap(AnalyticsTracker)
+        .invoke('getLastCustomEvent')
+        .should('not.exist');
+    }
+  });
+}

--- a/packages/atomic/cypress/e2e/generated-answer.cypress.ts
+++ b/packages/atomic/cypress/e2e/generated-answer.cypress.ts
@@ -1,4 +1,5 @@
 import {TestFixture} from '../fixtures/test-fixture';
+import {AnalyticsTracker} from '../utils/analyticsUtils';
 import {
   addGeneratedAnswer,
   getStreamInterceptAlias,
@@ -6,6 +7,7 @@ import {
   mockStreamResponse,
 } from './generated-answer-actions';
 import {GeneratedAnswerSelectors} from './generated-answer-selectors';
+import * as GeneratedAnswerAssertions from './generated-answer-assertions';
 
 describe('Generated Answer Test Suites', () => {
   describe('Generated Answer', () => {
@@ -100,6 +102,26 @@ describe('Generated Answer Test Suites', () => {
             'href',
             testCitation.clickUri
           );
+        });
+
+        describe('when a citation is clicked', () => {
+          beforeEach(() => {
+            AnalyticsTracker.reset();
+            GeneratedAnswerSelectors.citation()
+              .invoke('removeAttr', 'target') // Otherwise opens a new tab that messes with the tests
+              .click();
+          });
+
+          GeneratedAnswerAssertions.assertLogOpenGeneratedAnswerSource(true);
+        });
+
+        describe('when a citation is right-clicked', () => {
+          beforeEach(() => {
+            AnalyticsTracker.reset();
+            GeneratedAnswerSelectors.citation().rightclick();
+          });
+
+          GeneratedAnswerAssertions.assertLogOpenGeneratedAnswerSource(true);
         });
       });
 

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AutomaticFacet, CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, InlineLink, InteractiveResult, LogLevel, PlatformEnvironment as PlatformEnvironment1, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine, SearchStatus } from "@coveo/headless";
+import { AutomaticFacet, CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, GeneratedAnswerCitation, InlineLink, InteractiveResult, LogLevel, PlatformEnvironment as PlatformEnvironment1, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine, SearchStatus } from "@coveo/headless";
 import { AnyBindings } from "./components/common/interface/bindings";
 import { DateFilter, DateFilterState, NumericFilter, NumericFilterState, RelativeDateUnit } from "./components/common/types";
 import { NumberInputType } from "./components/common/facets/facet-number-input/number-input-type";
@@ -28,7 +28,7 @@ import { RedirectionPayload } from "./components/search/atomic-search-box/redire
 import { AriaLabelGenerator } from "./components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results";
 import { InitializationOptions } from "./components/search/atomic-search-interface/atomic-search-interface";
 import { StandaloneSearchBoxData } from "./utils/local-storage-utils";
-export { AutomaticFacet, CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, InlineLink, InteractiveResult, LogLevel, PlatformEnvironment as PlatformEnvironment1, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine, SearchStatus } from "@coveo/headless";
+export { AutomaticFacet, CategoryFacetSortCriterion, FacetSortCriterion, FoldedResult, GeneratedAnswerCitation, InlineLink, InteractiveResult, LogLevel, PlatformEnvironment as PlatformEnvironment1, RangeFacetRangeAlgorithm, RangeFacetSortCriterion, Result, ResultTemplate, ResultTemplateCondition, SearchEngine, SearchStatus } from "@coveo/headless";
 export { AnyBindings } from "./components/common/interface/bindings";
 export { DateFilter, DateFilterState, NumericFilter, NumericFilterState, RelativeDateUnit } from "./components/common/types";
 export { NumberInputType } from "./components/common/facets/facet-number-input/number-input-type";
@@ -2345,6 +2345,11 @@ export namespace Components {
          */
         "label": string;
     }
+    interface AtomicSourceCitation {
+        "citation": GeneratedAnswerCitation;
+        "href": string;
+        "index": number;
+    }
     /**
      * The `atomic-table-element` element defines a table column in a result list.
      */
@@ -3728,6 +3733,12 @@ declare global {
         prototype: HTMLAtomicSortExpressionElement;
         new (): HTMLAtomicSortExpressionElement;
     };
+    interface HTMLAtomicSourceCitationElement extends Components.AtomicSourceCitation, HTMLStencilElement {
+    }
+    var HTMLAtomicSourceCitationElement: {
+        prototype: HTMLAtomicSourceCitationElement;
+        new (): HTMLAtomicSourceCitationElement;
+    };
     /**
      * The `atomic-table-element` element defines a table column in a result list.
      */
@@ -3911,6 +3922,7 @@ declare global {
         "atomic-smart-snippet-suggestions": HTMLAtomicSmartSnippetSuggestionsElement;
         "atomic-sort-dropdown": HTMLAtomicSortDropdownElement;
         "atomic-sort-expression": HTMLAtomicSortExpressionElement;
+        "atomic-source-citation": HTMLAtomicSourceCitationElement;
         "atomic-table-element": HTMLAtomicTableElementElement;
         "atomic-text": HTMLAtomicTextElement;
         "atomic-timeframe": HTMLAtomicTimeframeElement;
@@ -6129,6 +6141,11 @@ declare namespace LocalJSX {
          */
         "label": string;
     }
+    interface AtomicSourceCitation {
+        "citation": GeneratedAnswerCitation;
+        "href": string;
+        "index": number;
+    }
     /**
      * The `atomic-table-element` element defines a table column in a result list.
      */
@@ -6360,6 +6377,7 @@ declare namespace LocalJSX {
         "atomic-smart-snippet-suggestions": AtomicSmartSnippetSuggestions;
         "atomic-sort-dropdown": AtomicSortDropdown;
         "atomic-sort-expression": AtomicSortExpression;
+        "atomic-source-citation": AtomicSourceCitation;
         "atomic-table-element": AtomicTableElement;
         "atomic-text": AtomicText;
         "atomic-timeframe": AtomicTimeframe;
@@ -6921,6 +6939,7 @@ declare module "@stencil/core" {
              * The `atomic-sort-expression` component defines a sort expression. This component must be inside an `atomic-sort-dropdown` component.
              */
             "atomic-sort-expression": LocalJSX.AtomicSortExpression & JSXBase.HTMLAttributes<HTMLAtomicSortExpressionElement>;
+            "atomic-source-citation": LocalJSX.AtomicSourceCitation & JSXBase.HTMLAttributes<HTMLAtomicSourceCitationElement>;
             /**
              * The `atomic-table-element` element defines a table column in a result list.
              */

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-source-citation.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-source-citation.tsx
@@ -49,6 +49,7 @@ export class AtomicSourceCitation implements InitializableComponent<Bindings> {
     return (
       <LinkWithResultAnalytics
         href={this.href}
+        title={this.citation.title}
         part="citation"
         target="_blank"
         rel="noopener"

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-source-citation.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-source-citation.tsx
@@ -1,0 +1,72 @@
+import {
+  GeneratedAnswerCitation,
+  InteractiveCitation,
+  buildInteractiveCitation,
+} from '@coveo/headless';
+import {Component, Prop, Element, h} from '@stencil/core';
+import {Bindings} from '../../../components';
+import {
+  InitializableComponent,
+  InitializeBindings,
+} from '../../../utils/initialization-utils';
+import {buildCustomEvent} from '../../../utils/event-utils';
+import {LinkWithResultAnalytics} from '../../common/result-link/result-link';
+
+@Component({
+  tag: 'atomic-source-citation',
+  shadow: false,
+})
+export class AtomicSourceCitation implements InitializableComponent<Bindings> {
+  @InitializeBindings() public bindings!: Bindings;
+  public error!: Error;
+
+  @Prop({reflect: true}) citation!: GeneratedAnswerCitation;
+  @Prop() index!: number;
+  @Prop() href!: string;
+
+  @Element() private host!: HTMLElement;
+
+  private interactiveCitation!: InteractiveCitation;
+  private stopPropagation?: boolean;
+
+  public initialize() {
+    this.host.dispatchEvent(
+      buildCustomEvent(
+        'atomic/resolveStopPropagation',
+        (stopPropagation: boolean) => {
+          this.stopPropagation = stopPropagation;
+        }
+      )
+    );
+    this.interactiveCitation = buildInteractiveCitation(this.bindings.engine, {
+      options: {
+        citation: this.citation,
+      },
+    });
+  }
+
+  public render() {
+    return (
+      <LinkWithResultAnalytics
+        href={this.href}
+        part="citation"
+        target="_blank"
+        rel="noopener"
+        className="flex items-center p-1 bg-background btn-text-neutral border rounded-full border-neutral text-on-background"
+        onSelect={() => this.interactiveCitation.select()}
+        onBeginDelayedSelect={() =>
+          this.interactiveCitation.beginDelayedSelect()
+        }
+        onCancelPendingSelect={() =>
+          this.interactiveCitation.cancelPendingSelect()
+        }
+        stopPropagation={this.stopPropagation}
+      >
+        <div class="citation-index rounded-full font-medium rounded-full flex items-center text-bg-blue shrink-0">
+          <div class="mx-auto">{this.index + 1}</div>
+        </div>
+        <span class="citation-title truncate mx-1">{this.citation.title}</span>
+      </LinkWithResultAnalytics>
+    );
+  }
+}

--- a/packages/atomic/src/components/search/atomic-generated-answer/source-citations.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/source-citations.tsx
@@ -22,22 +22,11 @@ export const SourceCitations: FunctionalComponent<SourceCitationsProps> = (
         {props.citations.map(
           (citation: GeneratedAnswerCitation, index: number) => (
             <li key={citation.id}>
-              <a
-                title={citation.title}
+              <atomic-source-citation
+                index={index}
+                citation={citation}
                 href={citation.clickUri ?? citation.uri}
-                target="_blank"
-                rel="noopener"
-                onClick={() => props.onCitationClick(citation)}
-                part="citation"
-                class="flex items-center p-1 bg-background btn-text-neutral border rounded-full border-neutral text-on-background"
-              >
-                <div class="citation-index rounded-full font-medium rounded-full flex items-center text-bg-blue shrink-0">
-                  <div class="mx-auto">{index + 1}</div>
-                </div>
-                <span class="citation-title truncate mx-1">
-                  {citation.title}
-                </span>
-              </a>
+              ></atomic-source-citation>
             </li>
           )
         )}

--- a/packages/headless/src/controllers/generated-answer/headless-interactive-citation.test.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-interactive-citation.test.ts
@@ -1,0 +1,62 @@
+import {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload';
+import {configuration} from '../../app/common-reducers';
+import {logOpenGeneratedAnswerSource} from '../../features/generated-answer/generated-answer-analytics-actions';
+import {buildMockCitation} from '../../test/mock-citation';
+import {
+  buildMockSearchAppEngine,
+  MockSearchEngine,
+} from '../../test/mock-engine';
+import {
+  buildInteractiveCitation,
+  InteractiveCitation,
+} from './headless-interactive-citation';
+
+describe('InteractiveCitation', () => {
+  let engine: MockSearchEngine;
+  let mockCitation: GeneratedAnswerCitation;
+  let interactiveCitation: InteractiveCitation;
+  let logCitationOpenPendingActionType: string;
+
+  function initializeInteractiveResult(delay?: number) {
+    mockCitation = buildMockCitation({
+      id: 'some-test-id',
+    });
+    logCitationOpenPendingActionType = logOpenGeneratedAnswerSource(
+      mockCitation.id
+    ).pending.type;
+    interactiveCitation = buildInteractiveCitation(engine, {
+      options: {citation: mockCitation, selectionDelay: delay},
+    });
+  }
+
+  function findLogDocumentAction() {
+    return (
+      engine.actions.find(
+        (action) => action.type === logCitationOpenPendingActionType
+      ) ?? null
+    );
+  }
+
+  function expectLogActionPending() {
+    const action = findLogDocumentAction();
+    expect(action).toEqual(
+      logOpenGeneratedAnswerSource(mockCitation.id).pending(
+        action!.meta.requestId
+      )
+    );
+  }
+
+  beforeEach(() => {
+    engine = buildMockSearchAppEngine();
+    initializeInteractiveResult();
+  });
+
+  it('it adds the correct reducers to engine', () => {
+    expect(engine.addReducers).toHaveBeenCalledWith({configuration});
+  });
+
+  it('when calling select(), logs openGeneratedAnswerSource', () => {
+    interactiveCitation.select();
+    expectLogActionPending();
+  });
+});

--- a/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
@@ -1,0 +1,57 @@
+import {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload';
+import {SearchEngine} from '../../app/search-engine/search-engine';
+import {logOpenGeneratedAnswerSource} from '../../features/generated-answer/generated-answer-analytics-actions';
+import {
+  buildInteractiveResultCore,
+  InteractiveResultCore,
+  InteractiveResultCoreOptions,
+  InteractiveResultCoreProps,
+} from '../core/interactive-result/headless-core-interactive-result';
+
+export interface InteractiveCitationOptions
+  extends InteractiveResultCoreOptions {
+  /**
+   * The generated answer citation.
+   */
+  citation: GeneratedAnswerCitation;
+}
+
+export interface InteractiveCitationProps extends InteractiveResultCoreProps {
+  /**
+   * The options for the `InteractiveResult` controller.
+   * */
+  options: InteractiveCitationOptions;
+}
+
+/**
+ * The `InteractiveCitation` controller provides an interface for triggering desirable side effects, such as logging UA events to the Coveo Platform, when a user selects a generated answer citation.
+ */
+export interface InteractiveCitation extends InteractiveResultCore {}
+
+/**
+ * Creates an `InteractiveCitation` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `InteractiveCitation` properties.
+ * @returns An `InteractiveCitation` controller instance.
+ */
+export function buildInteractiveCitation(
+  engine: SearchEngine,
+  props: InteractiveCitationProps
+): InteractiveCitation {
+  let wasOpened = false;
+
+  const logAnalyticsIfNeverOpened = () => {
+    if (wasOpened) {
+      return;
+    }
+    wasOpened = true;
+    engine.dispatch(logOpenGeneratedAnswerSource(props.options.citation.id));
+  };
+
+  const action = () => {
+    logAnalyticsIfNeverOpened();
+  };
+
+  return buildInteractiveResultCore(engine, props, action);
+}

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -428,3 +428,10 @@ export type {
   GeneratedAnswerCitation,
 } from './generated-answer/headless-generated-answer';
 export {buildGeneratedAnswer} from './generated-answer/headless-generated-answer';
+
+export type {
+  InteractiveCitationOptions,
+  InteractiveCitationProps,
+  InteractiveCitation,
+} from './generated-answer/headless-interactive-citation';
+export {buildInteractiveCitation} from './generated-answer/headless-interactive-citation';


### PR DESCRIPTION
Added a controller for better event binding on RGA citation anchors.
Updated the citations in Atomic to leverage the new controller.

The event dispatched on citation click should now occur on more mouse interactions just like we have for result links, smart snippets, etc.