### PR TITLE
ci: make smoke tests assert a number of results above 1 instead of exactly 10

### DIFF
--- a/packages/samples/angular/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
+++ b/packages/samples/angular/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
@@ -27,7 +27,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
       .should('exist')
       .shadow()
       .find('div[part="container"]')
-      .contains('Results 1-10')
+      .contains(/^Results 1-[1-9]/)
       .contains('for test');
 
     cy.get('atomic-result-list')

--- a/packages/samples/atomic-next/cypress/e2e/smoke-test.cypress.cy.ts
+++ b/packages/samples/atomic-next/cypress/e2e/smoke-test.cypress.cy.ts
@@ -28,7 +28,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
       .should('exist')
       .shadow()
       .find('div[part="container"]')
-      .contains('Results 1-10')
+      .contains(/^Results 1-[1-9]/)
       .contains('for test');
 
     cy.get('atomic-result-list')

--- a/packages/samples/atomic-react/cypress/e2e/smoke-test.cypress.cy.ts
+++ b/packages/samples/atomic-react/cypress/e2e/smoke-test.cypress.cy.ts
@@ -27,7 +27,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
       .should('exist')
       .shadow()
       .find('div[part="container"]')
-      .contains('Results 1-10')
+      .contains(/^Results 1-[1-9]/)
       .contains('for test');
 
     cy.get('atomic-result-list')

--- a/packages/samples/iife/cypress/e2e/atomic-react-smoke-test.cy.ts
+++ b/packages/samples/iife/cypress/e2e/atomic-react-smoke-test.cy.ts
@@ -30,7 +30,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
       .should('exist')
       .shadow()
       .find('div[part="container"]')
-      .contains('Results 1-10')
+      .contains(/^Results 1-[1-9]/)
       .contains('for test');
 
     cy.get('atomic-result-list')

--- a/packages/samples/stencil/cypress/e2e/stencil/smoke-test.cypress.ts
+++ b/packages/samples/stencil/cypress/e2e/stencil/smoke-test.cypress.ts
@@ -34,7 +34,7 @@ describe('smoke test', () => {
         .should('exist')
         .shadow()
         .find('div[part="container"]')
-        .contains('Results 1-10')
+        .contains(/^Results 1-[1-9]/)
         .contains('for test');
 
       cy.get('atomic-result-list')

--- a/packages/samples/vuejs/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
+++ b/packages/samples/vuejs/cypress/e2e/atomic-angular/smoke-test.cypress.cy.ts
@@ -27,7 +27,7 @@ describe('smoke test', {viewportHeight: 2000, viewportWidth: 2000}, () => {
       .should('exist')
       .shadow()
       .find('div[part="container"]')
-      .contains('Results 1-10')
+      .contains(/^Results 1-[1-9]/)
       .contains('for test');
 
     cy.get('atomic-result-list')


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2775

The regexp only checks that the first digit is 1-9. 0 would be unexpected (and usually should be a "no results" page anyway). The digit before the dash should always be 1, since we didn't press anything on the pager.