### PR TITLE
chore(quantic): Update deprecated cypress plugin in Quantic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14731,16 +14731,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
-      "dev": true,
-      "dependencies": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -19576,21 +19566,11 @@
         "cypress": "^10 || ^11 || ^12 || ^13"
       }
     },
-    "node_modules/cypress-plugin-tab": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
-      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
-      "dev": true,
-      "dependencies": {
-        "ally.js": "^1.4.1"
-      }
-    },
     "node_modules/cypress-real-events": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.10.3.tgz",
       "integrity": "sha512-YN3fn+CJIAM638sE6uMvv2/n3PsWowdd0rOiN6ZoyezNAMyENfuQHvccLKZpN+apGfQZYetCml6QXLYgDid2fg==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
@@ -36698,12 +36678,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
-      "dev": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -84284,7 +84258,7 @@
         "chalk": "4.1.2",
         "change-case": "4.1.2",
         "cypress": "10.8.0",
-        "cypress-plugin-tab": "1.0.5",
+        "cypress-real-events": "1.10.3",
         "cypress-repeat": "2.3.3",
         "dotenv": "16.3.1",
         "eslint-plugin-jest": "27.2.3",

--- a/packages/quantic/cypress/e2e/default-1/tab/tab-actions.ts
+++ b/packages/quantic/cypress/e2e/default-1/tab/tab-actions.ts
@@ -10,12 +10,15 @@ function tabActions(selector: TabSelector) {
       }
     },
     findTabPressTabPressSpace: (value: string) => {
-      // .tab() is equivalent to pressing the Tab; .type(' ') is equivalent to pressing the space bar;
-      selector.tab().contains(value).tab().type(' ');
+      // This is equivalent to pressing the Tab key twice and then pressing the Space bar.
+      selector.tab().contains(value).realPress(['Tab', 'Tab', 'Space']);
     },
     findTabPressShiftTabPressSpace: (value: string) => {
-      // tab({shift: true}) is equivalent to pressing the Shift and the Tab; .type(' ') is equivalent to pressing the space bar;
-      selector.tab().contains(value).tab({shift: true}).type(' ');
+      // This is equivalent to holding the Shift key while pressing the Tab key twice and then pressing the Space bar.
+      selector
+        .tab()
+        .contains(value)
+        .realPress(['Shift', 'Tab', 'Tab', 'Space']);
     },
   };
 }

--- a/packages/quantic/cypress/e2e/facets-1/facet-common-actions.ts
+++ b/packages/quantic/cypress/e2e/facets-1/facet-common-actions.ts
@@ -55,7 +55,7 @@ export const baseFacetActions = (selector: BaseFacetSelector) => {
       selector.expandButton().click();
     },
     selectFirstFacetValueWithKeyboardTab: () => {
-      selector.searchInput().tab().type('{Enter}', {force: true});
+      selector.searchInput().realPress(['Tab', 'Enter']);
     },
   };
 };

--- a/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-actions.ts
+++ b/packages/quantic/cypress/e2e/facets-2/numeric-facet/numeric-facet-actions.ts
@@ -19,10 +19,10 @@ const numericFacetActions = (selector: AllFacetSelectors) => {
       selector.searchForm().submit();
     },
     selectFirstNumericFacetValueWithKeyboardTab: () => {
-      selector.collapseButton().tab().type(' ', {force: true});
+      selector.collapseButton().realPress(['Tab', 'Space']);
     },
     selectFirstNumericFacetValueWithKeyboardEnter: () => {
-      selector.collapseButton().tab().type('{Enter}', {force: true});
+      selector.collapseButton().realPress(['Tab', 'Enter']);
     },
   };
 };

--- a/packages/quantic/cypress/support/e2e.ts
+++ b/packages/quantic/cypress/support/e2e.ts
@@ -1,5 +1,5 @@
-import 'cypress-plugin-tab';
 import './commands';
+import 'cypress-real-events';
 
 Cypress.on('uncaught:exception', (err) => {
   if (

--- a/packages/quantic/cypress/tsconfig.json
+++ b/packages/quantic/cypress/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "../node_modules",
     "target": "es6",
     "lib": ["esnext", "dom"],
-    "types": ["node", "cypress", "cypress-plugin-tabs/src"]
+    "types": ["node", "cypress", "cypress-real-events"]
   },
   "include": ["**/*.ts", "**/*.js"]
 }

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -62,7 +62,7 @@
     "chalk": "4.1.2",
     "change-case": "4.1.2",
     "cypress": "10.8.0",
-    "cypress-plugin-tab": "1.0.5",
+    "cypress-real-events": "1.10.3",
     "cypress-repeat": "2.3.3",
     "dotenv": "16.3.1",
     "eslint-plugin-jest": "27.2.3",


### PR DESCRIPTION
[SFINT-5173](https://coveord.atlassian.net/browse/SFINT-5173)

**In this PR:**

- Updated the Quantic Package to use the [Cypress real events plugin](https://github.com/dmtrKovalenko/cypress-real-events/tree/main) instead of the [cypress plugin tab](https://github.com/kuceb/cypress-plugin-tab)
- Fixed the e2e tests that were failing

We were stuck on Cypress 10 because Quantic relies on this dependency plugin: [cypress plugin tab](https://github.com/kuceb/cypress-plugin-tab) to trigger keyboard tab events in cypress.

Note: Certain tests affected by the change were skipped previously, so I made the syntax change, but left them skipped for now as they will eventually be fixed as part of this [issue](https://coveord.atlassian.net/browse/SFINT-4875)