### PR TITLE
feat(genAI): add parts

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -9,20 +9,20 @@ import {
   GeneratedAnswerCitation,
 } from '@coveo/headless';
 import {Component, h, State, Element} from '@stencil/core';
+import {buildCustomEvent} from '../../../utils/event-utils';
 import {
   BindStateToController,
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
 import {Heading} from '../../common/heading';
+import {LinkWithResultAnalytics} from '../../common/result-link/result-link';
 import {Bindings} from '../atomic-search-interface/atomic-search-interface';
 import {FeedbackButton} from './feedback-button';
-import {RetryPrompt} from './retry-prompt';
-import {TypingLoader} from './typing-loader';
-import {SourceCitations} from './source-citations';
 import {GeneratedContentContainer} from './generated-content-container';
-import {LinkWithResultAnalytics} from '../../common/result-link/result-link';
-import {buildCustomEvent} from '../../../utils/event-utils';
+import {RetryPrompt} from './retry-prompt';
+import {SourceCitations} from './source-citations';
+import {TypingLoader} from './typing-loader';
 
 /**
  * @internal
@@ -120,10 +120,15 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
               }
               stopPropagation={this.stopPropagation}
             >
-              <div class="citation-index rounded-full font-medium rounded-full flex items-center text-bg-blue shrink-0">
+              <div
+                part="citation-index"
+                class="citation-index rounded-full font-medium rounded-full flex items-center text-bg-blue shrink-0"
+              >
                 <div class="mx-auto">{index + 1}</div>
               </div>
-              <span class="citation-title truncate mx-1">{citation.title}</span>
+              <span part="citation-title" class="citation-title truncate mx-1">
+                {citation.title}
+              </span>
             </LinkWithResultAnalytics>
           </li>
         );

--- a/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
@@ -1,9 +1,9 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
 export const TypingLoader: FunctionalComponent = () => (
-  <div class="typing-indicator" aria-hidden="true">
-    <span></span>
-    <span></span>
-    <span></span>
+  <div part="container-background" class="typing-indicator" aria-hidden="true">
+    <span part="container-dot"></span>
+    <span part="container-dot"></span>
+    <span part="container-dot"></span>
   </div>
 );

--- a/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/typing-loader.tsx
@@ -1,9 +1,9 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
 export const TypingLoader: FunctionalComponent = () => (
-  <div part="container-background" class="typing-indicator" aria-hidden="true">
-    <span part="container-dot"></span>
-    <span part="container-dot"></span>
-    <span part="container-dot"></span>
+  <div part="typing-animation" class="typing-indicator" aria-hidden="true">
+    <span part="typing-animation-dot"></span>
+    <span part="typing-animation-dot"></span>
+    <span part="typing-animation-dot"></span>
   </div>
 );


### PR DESCRIPTION
[SVCINT-2527](https://coveord.atlassian.net/browse/SVCINT-2527)

Adds parts to some genAI components. 

In the Search page builder, we need to override the loading bullets and the citations index colors. We need to add parts for that since its inside a shadow dom. 


[SVCINT-2527]: https://coveord.atlassian.net/browse/SVCINT-2527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ