### PR TITLE
fix(genAI): set loading dots to atomic-primary

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.pcss
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.pcss
@@ -98,7 +98,7 @@
   width: 8px;
   float: left;
   margin: 0 4px;
-  background-color: #1372ec;
+  background-color: var(--atomic-primary);
   display: block;
   border-radius: 50%;
   opacity: 0.4;


### PR DESCRIPTION
Huge change to set loading icon to atomic-primary instead of the hardcoded `#1372ec`. The default color of atomic-primary is also `#1372ec`.
https://coveord.atlassian.net/browse/SVCINT-2527