### PR TITLE
chore(ci): revert to nodejs 18.17.1

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+18.17.1


### PR DESCRIPTION
Pin NodeJS to 18.17.1:
GitHub released a new version of the ubuntu image which include a new release of NodeJS that do have a bug.

Related: https://github.com/nodejs/node/issues/49911

----

KIT-2786