### PR TITLE
test(atomic): more simplification for smart snippet tests

### DIFF
--- a/packages/atomic/cypress/e2e/smart-snippet.cypress.ts
+++ b/packages/atomic/cypress/e2e/smart-snippet.cypress.ts
@@ -30,458 +30,386 @@ function buildAnswerWithHeight(height: number) {
 }
 
 describe('Smart Snippet Test Suites', () => {
-  describe('with no heading level', () => {
-    beforeEach(() => {
-      new TestFixture().with(addSmartSnippet()).init();
-    });
-    it('should work correctly', () => {
-      cy.log('should fallback to a div for the accessibility heading');
-      SmartSnippetSelectors.accessibilityHeading().should(
-        'have.prop',
-        'tagName',
-        'DIV'
-      );
-      cy.log('should fallback to a div for the question');
-      SmartSnippetSelectors.question().should('have.prop', 'tagName', 'DIV');
-      cy.log('render the correct question');
-      SmartSnippetSelectors.question().should('have.text', defaultQuestion);
-      cy.log('should have links to the source');
-      SmartSnippetSelectors.sourceUrl().should(
-        'have.attr',
-        'href',
-        defaultSourceUrl
-      );
-      SmartSnippetSelectors.sourceUrl().should('have.text', defaultSourceUrl);
-      SmartSnippetSelectors.sourceTitle().should(
-        'have.attr',
-        'href',
-        defaultSourceUrl
-      );
-      SmartSnippetSelectors.sourceTitle().should(
-        'have.text',
-        defaultSourceTitle
-      );
-      SmartSnippetAssertions.assertLikeButtonChecked(false);
-      SmartSnippetAssertions.assertDislikeButtonChecked(false);
-      SmartSnippetAssertions.assertThankYouBanner(false);
-    });
+  it('should work correctly with no heading level', () => {
+    new TestFixture().with(addSmartSnippet()).init();
+
+    cy.log('should fallback to a div for the accessibility heading');
+    SmartSnippetSelectors.accessibilityHeading().should(
+      'have.prop',
+      'tagName',
+      'DIV'
+    );
+    cy.log('should fallback to a div for the question');
+    SmartSnippetSelectors.question().should('have.prop', 'tagName', 'DIV');
+    cy.log('render the correct question');
+    SmartSnippetSelectors.question().should('have.text', defaultQuestion);
+    cy.log('should have links to the source');
+    SmartSnippetSelectors.sourceUrl().should(
+      'have.attr',
+      'href',
+      defaultSourceUrl
+    );
+    SmartSnippetSelectors.sourceUrl().should('have.text', defaultSourceUrl);
+    SmartSnippetSelectors.sourceTitle().should(
+      'have.attr',
+      'href',
+      defaultSourceUrl
+    );
+    SmartSnippetSelectors.sourceTitle().should('have.text', defaultSourceTitle);
+    SmartSnippetAssertions.assertLikeButtonChecked(false);
+    SmartSnippetAssertions.assertDislikeButtonChecked(false);
+    SmartSnippetAssertions.assertThankYouBanner(false);
   });
 
-  describe('with a specific heading level', () => {
+  it('with a specific heading level, should use the correct heading level for heading and question', () => {
     const headingLevel = 5;
-    beforeEach(() => {
-      new TestFixture()
-        .with(addSmartSnippet({props: {'heading-level': headingLevel}}))
-        .init();
-    });
+    new TestFixture()
+      .with(addSmartSnippet({props: {'heading-level': 5}}))
+      .init();
 
-    it('should use the correct heading level for the accessibility heading', () => {
-      SmartSnippetSelectors.accessibilityHeading().should(
-        'have.prop',
-        'tagName',
-        'H' + headingLevel
-      );
-    });
-
-    it('should use the correct heading level for the question', () => {
-      SmartSnippetSelectors.question().should(
-        'have.prop',
-        'tagName',
-        'H' + (headingLevel + 1)
-      );
-    });
+    SmartSnippetSelectors.accessibilityHeading().should(
+      'have.prop',
+      'tagName',
+      'H' + headingLevel
+    );
+    SmartSnippetSelectors.question().should(
+      'have.prop',
+      'tagName',
+      'H' + (headingLevel + 1)
+    );
   });
 
-  describe('when maximumHeight is smaller than collapsedHeight', () => {
-    beforeEach(() => {
-      const value = 50;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            props: {
-              'maximum-height': value - 1,
-              'collapsed-height': value,
-            },
-          })
-        )
-        .init();
-    });
-
-    it('should display errors', () => {
-      CommonAssertions.assertConsoleErrorWithoutIt(true);
-      CommonAssertions.assertContainsComponentErrorWithoutIt(
-        SmartSnippetSelectors,
-        true
-      );
-    });
+  it('when maximumHeight is smaller than collapsedHeight, it should display errors', () => {
+    const value = 50;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          props: {
+            'maximum-height': value - 1,
+            'collapsed-height': value,
+          },
+        })
+      )
+      .init();
+    CommonAssertions.assertConsoleErrorWithoutIt(true);
+    CommonAssertions.assertContainsComponentErrorWithoutIt(
+      SmartSnippetSelectors,
+      true
+    );
   });
 
-  describe('when snippetMaximumHeight is smaller than snippetCollapsedHeight', () => {
-    beforeEach(() => {
-      const value = 50;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            props: {
-              'snippet-maximum-height': value - 1,
-              'snippet-collapsed-height': value,
-            },
-          })
-        )
-        .init();
-    });
+  it('when snippetMaximumHeight is smaller than snippetCollapsedHeight, it should display errors', () => {
+    const value = 50;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          props: {
+            'snippet-maximum-height': value - 1,
+            'snippet-collapsed-height': value,
+          },
+        })
+      )
+      .init();
 
-    it('should display errors', () => {
-      CommonAssertions.assertConsoleErrorWithoutIt(true);
-      CommonAssertions.assertContainsComponentErrorWithoutIt(
-        SmartSnippetSelectors,
-        true
-      );
-    });
+    CommonAssertions.assertConsoleErrorWithoutIt(true);
+    CommonAssertions.assertContainsComponentErrorWithoutIt(
+      SmartSnippetSelectors,
+      true
+    );
   });
 
-  describe('when the snippet height is equal to maximumHeight', () => {
-    beforeEach(() => {
-      const height = 300;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer: buildAnswerWithHeight(height),
-            },
-            props: {
-              'maximum-height': height,
-              'collapsed-height': 150,
-            },
-          })
-        )
-        .init();
-    });
+  it('when the snippet height is equal to maximumHeight, it should not display show more and show less buttons', () => {
+    const height = 300;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer: buildAnswerWithHeight(height),
+          },
+          props: {
+            'maximum-height': height,
+            'collapsed-height': 150,
+          },
+        })
+      )
+      .init();
 
-    it('should not display show more and show less buttons', () => {
-      SmartSnippetAssertions.assertShowMore(false);
-      SmartSnippetAssertions.assertShowLess(false);
-    });
+    SmartSnippetAssertions.assertShowMore(false);
+    SmartSnippetAssertions.assertShowLess(false);
   });
 
-  describe('when the snippet height is equal to snippetMaximumHeight', () => {
-    beforeEach(() => {
-      const height = 300;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer: buildAnswerWithHeight(height),
-            },
-            props: {
-              'snippet-maximum-height': height,
-              'snippet-collapsed-height': 150,
-            },
-          })
-        )
-        .init();
-    });
+  it('when the snippet height is equal to snippetMaximumHeight, it should not display show more and show less buttons', () => {
+    const height = 300;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer: buildAnswerWithHeight(height),
+          },
+          props: {
+            'snippet-maximum-height': height,
+            'snippet-collapsed-height': 150,
+          },
+        })
+      )
+      .init();
 
-    it('should not display show more and show less buttons', () => {
-      SmartSnippetAssertions.assertShowMore(false);
-      SmartSnippetAssertions.assertShowLess(false);
-    });
+    SmartSnippetAssertions.assertShowMore(false);
+    SmartSnippetAssertions.assertShowLess(false);
   });
 
-  describe('when the snippet height is greater than maximumHeight', () => {
+  it('when the snippet height is greater than maximumHeight', () => {
     const height = 300;
     const heightWhenCollapsed = 150;
-    beforeEach(() => {
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer: buildAnswerWithHeight(height),
-            },
-            props: {
-              'maximum-height': height - 1,
-              'collapsed-height': heightWhenCollapsed,
-            },
-          })
-        )
-        .init();
-    });
 
-    it('should render correctly', () => {
-      SmartSnippetAssertions.assertShowMore(true);
-      SmartSnippetAssertions.assertShowLess(false);
-      SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
-    });
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer: buildAnswerWithHeight(height),
+          },
+          props: {
+            'maximum-height': height - 1,
+            'collapsed-height': heightWhenCollapsed,
+          },
+        })
+      )
+      .init();
 
+    // before expand
+    SmartSnippetAssertions.assertShowMore(true);
+    SmartSnippetAssertions.assertShowLess(false);
+    SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
     CommonAssertions.assertAccessibility(smartSnippetComponent);
+    SmartSnippetSelectors.showMoreButton().click();
 
-    it('should work correctly when pressing show more and show less', () => {
-      SmartSnippetSelectors.showMoreButton().click();
-      SmartSnippetSelectors.body().should('have.attr', 'expanded');
-      SmartSnippetAssertions.assertShowMore(false);
-      SmartSnippetAssertions.assertShowLess(true);
-      SmartSnippetAssertions.assertAnswerHeight(height);
-      SmartSnippetSelectors.showLessButton().click();
-      SmartSnippetSelectors.body().should('not.have.attr', 'expanded');
-      SmartSnippetAssertions.assertShowMore(true);
-      SmartSnippetAssertions.assertShowLess(false);
-      SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
-    });
+    // after expand
+    SmartSnippetSelectors.body().should('have.attr', 'expanded');
+    SmartSnippetAssertions.assertShowMore(false);
+    SmartSnippetAssertions.assertShowLess(true);
+    SmartSnippetAssertions.assertAnswerHeight(height);
+    SmartSnippetSelectors.showLessButton().click();
+
+    // after collapse
+    SmartSnippetSelectors.body().should('not.have.attr', 'expanded');
+    SmartSnippetAssertions.assertShowMore(true);
+    SmartSnippetAssertions.assertShowLess(false);
+    SmartSnippetAssertions.assertAnswerHeight(heightWhenCollapsed);
   });
-  describe('when the snippet height is greater than snippetMaximumHeight', () => {
+
+  it('when the snippet height is greater than snippetMaximumHeight', () => {
     const height = 300;
     const heightWhenCollapsed = 150;
-    beforeEach(() => {
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer: buildAnswerWithHeight(height),
-            },
-            props: {
-              'snippet-maximum-height': height - 1,
-              'snippet-collapsed-height': heightWhenCollapsed,
-            },
-          })
-        )
-        .init();
-    });
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer: buildAnswerWithHeight(height),
+          },
+          props: {
+            'snippet-maximum-height': height - 1,
+            'snippet-collapsed-height': heightWhenCollapsed,
+          },
+        })
+      )
+      .init();
 
-    it('should render correctly', () => {
-      SmartSnippetAssertions.assertShowMore(true);
-      SmartSnippetAssertions.assertShowLess(false);
-      SmartSnippetAssertions.assertCollapseWrapperHeight(heightWhenCollapsed);
-    });
-
+    // before expand
+    SmartSnippetAssertions.assertShowMore(true);
+    SmartSnippetAssertions.assertShowLess(false);
+    SmartSnippetAssertions.assertCollapseWrapperHeight(heightWhenCollapsed);
     CommonAssertions.assertAccessibility(smartSnippetComponent);
+    SmartSnippetSelectors.showMoreButton().click();
 
-    it('should work correctly when pressing show more and show less', () => {
-      SmartSnippetSelectors.showMoreButton().click();
-      SmartSnippetSelectors.collapseWrapperComponent().should(
-        'have.class',
-        'expanded'
-      );
-      SmartSnippetAssertions.assertShowMore(false);
-      SmartSnippetAssertions.assertShowLess(true);
-      SmartSnippetAssertions.assertAnswerHeight(height);
-      SmartSnippetSelectors.showLessButton().click();
-      SmartSnippetSelectors.collapseWrapperComponent().should(
-        'not.have.class',
-        'expanded'
-      );
-      SmartSnippetAssertions.assertShowMore(true);
-      SmartSnippetAssertions.assertShowLess(false);
-      SmartSnippetAssertions.assertCollapseWrapperHeight(heightWhenCollapsed);
-      CommonAssertions.assertAccessibility(smartSnippetComponent);
-    });
+    // after expand
+    SmartSnippetSelectors.collapseWrapperComponent().should(
+      'have.class',
+      'expanded'
+    );
+    SmartSnippetAssertions.assertShowMore(false);
+    SmartSnippetAssertions.assertShowLess(true);
+    SmartSnippetAssertions.assertAnswerHeight(height);
+    SmartSnippetSelectors.showLessButton().click();
+
+    // after collapse
+    SmartSnippetSelectors.collapseWrapperComponent().should(
+      'not.have.class',
+      'expanded'
+    );
+    SmartSnippetAssertions.assertShowMore(true);
+    SmartSnippetAssertions.assertShowLess(false);
+    SmartSnippetAssertions.assertCollapseWrapperHeight(heightWhenCollapsed);
+    CommonAssertions.assertAccessibility(smartSnippetComponent);
   });
-  describe('when the snippet starts and ends with inline elements', () => {
-    beforeEach(() => {
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer:
-                '<span class="first">Abc</span><p>def</p><span class="last">ghi</span>',
-            },
-            props: {
-              'maximum-height': Number.MAX_VALUE,
-              'collapsed-height': 0,
-              'snippet-style': 'span { display: block; }',
-            },
-          })
-        )
-        .init();
-    });
+
+  it('when the snippet starts and ends with inline elements', () => {
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer:
+              '<span class="first">Abc</span><p>def</p><span class="last">ghi</span>',
+          },
+          props: {
+            'maximum-height': Number.MAX_VALUE,
+            'collapsed-height': 0,
+            'snippet-style': 'span { display: block; }',
+          },
+        })
+      )
+      .init();
+    SmartSnippetAssertions.assertAnswerTopMargin(remSize, 'first');
+    SmartSnippetAssertions.assertAnswerBottomMargin(remSize, 'last');
+  });
+
+  it('it behaves correctly when the snippet contains elements with margins', () => {
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer:
+              '<p class="first">Paragraph A</p><p>Paragraph B</p><p class="last">Paragraph C</p>',
+          },
+          props: {
+            'maximum-height': Number.MAX_VALUE,
+            'collapsed-height': 0,
+          },
+        })
+      )
+      .init();
 
     SmartSnippetAssertions.assertAnswerTopMargin(remSize, 'first');
     SmartSnippetAssertions.assertAnswerBottomMargin(remSize, 'last');
   });
-  describe('when the snippet contains elements with margins', () => {
-    beforeEach(() => {
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer:
-                '<p class="first">Paragraph A</p><p>Paragraph B</p><p class="last">Paragraph C</p>',
-            },
-            props: {
-              'maximum-height': Number.MAX_VALUE,
-              'collapsed-height': 0,
-            },
-          })
-        )
-        .init();
-    });
+
+  it('it behaves correctly when the snippet contains collapsing margins', () => {
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          snippet: {
+            ...defaultSnippet,
+            answer:
+              '<span><p class="first last">My parent has no margins, but I do!</p></span>',
+          },
+          props: {
+            'maximum-height': Number.MAX_VALUE,
+            'collapsed-height': 0,
+          },
+        })
+      )
+      .init();
 
     SmartSnippetAssertions.assertAnswerTopMargin(remSize, 'first');
     SmartSnippetAssertions.assertAnswerBottomMargin(remSize, 'last');
   });
-  describe('when the snippet contains collapsing margins', () => {
-    beforeEach(() => {
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            snippet: {
-              ...defaultSnippet,
-              answer:
-                '<span><p class="first last">My parent has no margins, but I do!</p></span>',
-            },
-            props: {
-              'maximum-height': Number.MAX_VALUE,
-              'collapsed-height': 0,
-            },
-          })
-        )
-        .init();
-    });
 
-    SmartSnippetAssertions.assertAnswerTopMargin(remSize, 'first');
-    SmartSnippetAssertions.assertAnswerBottomMargin(remSize, 'last');
-  });
-  describe('after pressing the like button', () => {
-    beforeEach(() => {
-      new TestFixture().with(addSmartSnippet()).init();
-      SmartSnippetSelectors.feedbackLikeButton().click();
-    });
+  it('it behaves correctly when pressing the like and dislike button', () => {
+    new TestFixture().with(addSmartSnippet()).init();
+    SmartSnippetSelectors.feedbackLikeButton().click();
 
-    it('should render correctly', () => {
-      SmartSnippetAssertions.assertLikeButtonChecked(true);
-      SmartSnippetAssertions.assertDislikeButtonChecked(false);
-      SmartSnippetAssertions.assertThankYouBanner(true);
-    });
+    SmartSnippetAssertions.assertLikeButtonChecked(true);
+    SmartSnippetAssertions.assertDislikeButtonChecked(false);
+    SmartSnippetAssertions.assertThankYouBanner(true);
 
     SmartSnippetAssertions.assertLogLikeSmartSnippet();
-  });
-  describe('after pressing the dislike button', () => {
-    beforeEach(() => {
-      new TestFixture().with(addSmartSnippet()).init();
-      SmartSnippetSelectors.feedbackDislikeButton().click();
-    });
 
-    it('should render correctly', () => {
-      SmartSnippetAssertions.assertLikeButtonChecked(false);
-      SmartSnippetAssertions.assertDislikeButtonChecked(true);
-      SmartSnippetAssertions.assertThankYouBanner(true);
-    });
+    SmartSnippetSelectors.feedbackDislikeButton().click();
+    SmartSnippetAssertions.assertLikeButtonChecked(false);
+    SmartSnippetAssertions.assertDislikeButtonChecked(true);
+    SmartSnippetAssertions.assertThankYouBanner(true);
 
     SmartSnippetAssertions.assertLogDislikeSmartSnippet();
   });
-  describe('after clicking on the title', () => {
-    let currentQuestion: string;
-    beforeEach(() => {
-      currentQuestion = defaultQuestion;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            get snippet() {
-              return {
-                ...defaultSnippet,
-                question: currentQuestion,
-              };
-            },
-          })
-        )
-        .with(addSearchBox())
-        .init();
-      SmartSnippetSelectors.sourceTitle().rightclick();
-    });
+
+  it('when interacting with the title and the like button', () => {
+    let currentQuestion = defaultQuestion;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          get snippet() {
+            return {
+              ...defaultSnippet,
+              question: currentQuestion,
+            };
+          },
+        })
+      )
+      .with(addSearchBox())
+      .init();
+    SmartSnippetSelectors.sourceTitle().rightclick();
 
     SmartSnippetAssertions.assertLogOpenSmartSnippetSource(true);
 
-    describe('then liking the snippet then clicking the title again', () => {
-      beforeEach(() => {
-        SmartSnippetSelectors.feedbackLikeButton().click();
-        AnalyticsTracker.reset();
-        SmartSnippetSelectors.sourceTitle().rightclick();
-      });
+    //liking the snippet then clicking the title again
+    SmartSnippetSelectors.feedbackLikeButton().click();
+    AnalyticsTracker.reset();
+    SmartSnippetSelectors.sourceTitle().rightclick();
+    SmartSnippetAssertions.assertLogOpenSmartSnippetSource(false);
 
-      SmartSnippetAssertions.assertLogOpenSmartSnippetSource(false);
-    });
-
-    describe('then getting a new snippet and clicking on the title again', () => {
-      beforeEach(() => {
-        currentQuestion = 'Hello, World!';
-        SearchBoxSelectors.submitButton().click();
-        SmartSnippetSelectors.sourceTitle().rightclick();
-      });
-
-      SmartSnippetAssertions.assertLogOpenSmartSnippetSource(true);
-    });
+    // getting a new snippet and clicking on the title again
+    currentQuestion = 'Hello, World!';
+    SearchBoxSelectors.submitButton().click();
+    SmartSnippetSelectors.sourceTitle().rightclick();
+    SmartSnippetAssertions.assertLogOpenSmartSnippetSource(true);
   });
 
-  describe('after clicking on an inline link', () => {
-    let lastClickedLink: InlineLink;
+  it('when interacting with an inline link', () => {
     function click(selector: Cypress.Chainable<JQuery<HTMLAnchorElement>>) {
       selector.rightclick().then(([el]) => {
         lastClickedLink = {linkText: el.innerText, linkURL: el.href};
       });
     }
-
+    let lastClickedLink: InlineLink;
     let currentQuestion: string;
-    beforeEach(() => {
-      currentQuestion = defaultQuestion;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            get snippet() {
-              return {
-                ...defaultSnippet,
-                question: currentQuestion,
-              };
-            },
-          })
-        )
-        .with(addSearchBox())
-        .init();
-      click(SmartSnippetSelectors.answer().find('a').eq(0));
-    });
+
+    currentQuestion = defaultQuestion;
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          get snippet() {
+            return {
+              ...defaultSnippet,
+              question: currentQuestion,
+            };
+          },
+        })
+      )
+      .with(addSearchBox())
+      .init();
+    click(SmartSnippetSelectors.answer().find('a').eq(0));
 
     SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
       () => lastClickedLink
     );
 
-    describe('then liking the snippet then clicking on the same inline link again', () => {
-      beforeEach(() => {
-        SmartSnippetSelectors.feedbackLikeButton().click();
-        AnalyticsTracker.reset();
-        click(SmartSnippetSelectors.answer().find('a').eq(0));
-      });
+    // liking the snippet then clicking on the same inline link again
+    SmartSnippetSelectors.feedbackLikeButton().click();
+    AnalyticsTracker.reset();
+    click(SmartSnippetSelectors.answer().find('a').eq(0));
+    SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(null);
 
-      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(null);
-    });
+    // getting a new snippet and clicking on the same inline link again
+    currentQuestion = 'Hello, World!';
+    SearchBoxSelectors.submitButton().click();
+    AnalyticsTracker.reset();
+    SmartSnippetSelectors.question().should('have.text', currentQuestion);
+    click(SmartSnippetSelectors.answer().find('a').eq(0));
+    SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
+      () => lastClickedLink
+    );
 
-    describe('then getting a new snippet and clicking on the same inline link again', () => {
-      beforeEach(() => {
-        currentQuestion = 'Hello, World!';
-        SearchBoxSelectors.submitButton().click();
-        AnalyticsTracker.reset();
-        SmartSnippetSelectors.question().should('have.text', currentQuestion);
-        click(SmartSnippetSelectors.answer().find('a').eq(0));
-      });
-
-      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
-        () => lastClickedLink
-      );
-    });
-
-    describe('then clicking a different inline link', () => {
-      beforeEach(() => {
-        AnalyticsTracker.reset();
-        click(SmartSnippetSelectors.answer().find('a').eq(1));
-      });
-
-      SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
-        () => lastClickedLink
-      );
-    });
+    // clicking a different inline link
+    AnalyticsTracker.reset();
+    click(SmartSnippetSelectors.answer().find('a').eq(1));
+    SmartSnippetAssertions.assertLogOpenSmartSnippetInlineLink(
+      () => lastClickedLink
+    );
   });
 
   describe('when parts of the snippet change', () => {
@@ -553,63 +481,51 @@ describe('Smart Snippet Test Suites', () => {
     });
   });
 
-  describe('with custom styling in a template element', () => {
-    beforeEach(() => {
-      const styleEl = generateComponentHTML('style');
-      styleEl.innerHTML = `
+  it('with custom styling in a template element', () => {
+    const styleEl = generateComponentHTML('style');
+    styleEl.innerHTML = `
         b {
           color: rgb(84, 170, 255);
         }
       `;
-      const templateEl = generateComponentHTML(
-        'template'
-      ) as HTMLTemplateElement;
-      templateEl.content.appendChild(styleEl);
-      new TestFixture().with(addSmartSnippet({content: templateEl})).init();
-    });
 
-    it('applies the styling to the rendered snippet', () => {
-      SmartSnippetSelectors.answer()
-        .find('b')
-        .invoke('css', 'color')
-        .should('equal', 'rgb(84, 170, 255)');
-    });
+    const templateEl = generateComponentHTML('template') as HTMLTemplateElement;
+    templateEl.content.appendChild(styleEl);
+    new TestFixture().with(addSmartSnippet({content: templateEl})).init();
+
+    SmartSnippetSelectors.answer()
+      .find('b')
+      .invoke('css', 'color')
+      .should('equal', 'rgb(84, 170, 255)');
   });
 
-  describe('with custom styling in an attribute', () => {
-    beforeEach(() => {
-      const style = `
+  it('with custom styling in an attribute', () => {
+    const style = `
         b {
           color: rgb(84, 170, 255);
         }
       `;
-      new TestFixture()
-        .with(
-          addSmartSnippet({
-            props: {'snippet-style': style},
-          })
-        )
-        .init();
-    });
+    new TestFixture()
+      .with(
+        addSmartSnippet({
+          props: {'snippet-style': style},
+        })
+      )
+      .init();
 
-    it('applies the styling to the rendered snippet', () => {
-      SmartSnippetSelectors.answer()
-        .find('b')
-        .invoke('css', 'color')
-        .should('equal', 'rgb(84, 170, 255)');
-    });
+    SmartSnippetSelectors.answer()
+      .find('b')
+      .invoke('css', 'color')
+      .should('equal', 'rgb(84, 170, 255)');
   });
 
-  describe('when there is a valid slot named "source-anchor-attributes"', () => {
-    beforeEach(() => {
-      const slot = generateComponentHTML('a', {
-        target: '_blank',
-        slot: 'source-anchor-attributes',
-      });
-      new TestFixture().with(addSmartSnippet({}, slot)).init();
+  it('when there is a valid slot named "source-anchor-attributes"', () => {
+    const slot = generateComponentHTML('a', {
+      target: '_blank',
+      slot: 'source-anchor-attributes',
     });
-    it('copies the attributes properly', () => {
-      SmartSnippetSelectors.sourceUrl().should('have.attr', 'target', '_blank');
-    });
+    new TestFixture().with(addSmartSnippet({}, slot)).init();
+
+    SmartSnippetSelectors.sourceUrl().should('have.attr', 'target', '_blank');
   });
 });

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -204,6 +204,7 @@ export class TestFixture {
     cy.window().then((win) => {
       Object.defineProperty(win.navigator, 'doNotTrack', {
         get: () => (this.doNotTrack ? '1' : '0'),
+        configurable: true,
       });
     });
 


### PR DESCRIPTION
In general: Remove lots of `describe`/`beforeEach` block (perform the setup directly in the it block when possible) and perform more assertion as part of a single `it` block.


https://coveord.atlassian.net/browse/KIT-2790