### PR TITLE
fix(headless): fix structuredClone for locker service

### DIFF
--- a/packages/headless-react/jest.config.mjs
+++ b/packages/headless-react/jest.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
   testEnvironment: 'jsdom',
-  setupFiles: ['./jest.setup.structured.clone.js'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/packages/headless-react/jest.setup.structured.clone.js
+++ b/packages/headless-react/jest.setup.structured.clone.js
@@ -1,1 +1,0 @@
-global.structuredClone = (val) => JSON.parse(JSON.stringify(val));

--- a/packages/headless/src/api/analytics/coveo-analytics-utils.ts
+++ b/packages/headless/src/api/analytics/coveo-analytics-utils.ts
@@ -6,6 +6,7 @@ import {
 } from 'coveo.analytics';
 import {Logger} from 'pino';
 import {PreprocessRequest} from '../preprocess-request';
+import {clone} from '../../utils/utils';
 
 export const getVisitorID = (options: {
   runtimeEnvironment?: IRuntimeEnvironment;
@@ -27,7 +28,7 @@ export const wrapPreprocessRequest = (
 ) => {
   return typeof preprocessRequest === 'function'
     ? (...args: Parameters<PreprocessRequest>) => {
-        const untaintedOutput = structuredClone(args[0]);
+        const untaintedOutput = clone(args[0]);
         try {
           return preprocessRequest.apply(preprocessRequest, args);
         } catch (e) {
@@ -46,7 +47,7 @@ export const wrapAnalyticsClientSendEventHook = (
   hook: AnalyticsClientSendEventHook
 ) => {
   return (...args: Parameters<AnalyticsClientSendEventHook>) => {
-    const untaintedOutput = structuredClone(args[1]);
+    const untaintedOutput = clone(args[1]);
     try {
       return hook.apply(hook, args);
     } catch (e) {

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -10,6 +10,7 @@ import {
   PreprocessRequest,
   RequestMetadata,
 } from './preprocess-request';
+import {clone} from '../utils/utils';
 
 export type HttpMethods = 'POST' | 'GET' | 'DELETE' | 'PUT';
 export type HTTPContentType =
@@ -104,9 +105,7 @@ export class PlatformClient {
   ) {
     const {origin, preprocessRequest, logger, requestMetadata} = options;
     const {signal, ...withoutSignal} = defaultRequestOptions;
-    const untaintedOutput: PlatformRequestOptions =
-      structuredClone(withoutSignal);
-    untaintedOutput.signal = signal;
+    const untaintedOutput: PlatformRequestOptions = clone(withoutSignal);
 
     try {
       const processedRequest = await preprocessRequest(

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -98,7 +98,8 @@ export function mapObject<TKey extends string, TInitialValue, TNewValue>(
   ) as Record<TKey, TNewValue>;
 }
 
-// TODO: replace with `structuredClone` when upgrading the supported node version to node 17+.
+// TODO: Cloud eventually be replaced with `structuredClone`.
+// However, this is not compatible with locker service.
 export function clone<T>(value: T): T {
   if (typeof value !== 'object') {
     return value;
@@ -106,7 +107,13 @@ export function clone<T>(value: T): T {
   if (!value) {
     return value;
   }
-  return JSON.parse(JSON.stringify(value));
+  // JSON parse/stringify can fail in some cases (ie: recursive objects)
+  // add defensive code to prevent the whole app from crashing
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (e) {
+    return value;
+  }
 }
 
 function createDeferredPromise<T>(): {


### PR DESCRIPTION
`structuredClone` is not supported by the "old locker service":" the one I had tested for was actually locker web security.

https://coveord.atlassian.net/browse/SFINT-5193