### PR TITLE
fix: import immer only as type

### DIFF
--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -1,5 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
-import {WritableDraft} from 'immer/dist/internal';
+import type {Draft as WritableDraft} from 'immer';
 import {
   deselectAllBreadcrumbs,
   deselectAllNonBreadcrumbs,


### PR DESCRIPTION
We don't need use/need immer, and this pollute our bundles. Shoo.