### PR TITLE
test: simplify search box instant result

### DIFF
--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -172,6 +172,9 @@ export function assertRemovesComponent() {
   );
 }
 
+/**
+ * @deprecated
+ */
 export function assertAriaLiveMessage(
   selector: () => Cypress.Chainable<JQuery<HTMLElement>>,
   message: string
@@ -179,4 +182,11 @@ export function assertAriaLiveMessage(
   it(`screen readers should read out "${message}".`, () => {
     selector().should('contain.text', message);
   });
+}
+
+export function assertAriaLiveMessageWithoutIt(
+  selector: () => Cypress.Chainable<JQuery<HTMLElement>>,
+  message: string
+) {
+  selector().should('contain.text', message);
 }

--- a/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results-assertions.ts
+++ b/packages/atomic/cypress/e2e/search-box/instant-results/search-box-instant-results-assertions.ts
@@ -1,28 +1,16 @@
 import {InstantResultsSelectors} from './search-box-instant-results-selectors';
 
 export function assertHasResultCount(count: number) {
-  it(`should display ${count} results`, () => {
-    InstantResultsSelectors.results().should('have.length', count);
-  });
+  InstantResultsSelectors.results().should('have.length', count);
 }
 
 export function assertResultIsSelected(index: number) {
-  it(`should have selected result ${index}`, () => {
-    InstantResultsSelectors.results()
-      .eq(index)
-      .invoke('attr', 'part')
-      .should('contain', 'active-suggestion');
-  });
-}
-
-export function assertNoResultIsSelected() {
-  it('should have no selected result', () => {
-    InstantResultsSelectors.activeResult().should('not.exist');
-  });
+  InstantResultsSelectors.results()
+    .eq(index)
+    .invoke('attr', 'part')
+    .should('contain', 'active-suggestion');
 }
 
 export function assertLogSearchboxAsYouType() {
-  it('should log the SearchboxAsYouType event to UA', () => {
-    cy.expectSearchEvent('searchboxAsYouType');
-  });
+  cy.expectSearchEvent('searchboxAsYouType');
 }

--- a/packages/atomic/cypress/e2e/search-box/search-box-assertions.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box-assertions.ts
@@ -8,6 +8,9 @@ export function assertFocusSearchBox(
   });
 }
 
+/**
+ * @deprecated
+ */
 export function assertHasText(
   text: string,
   searchBoxSelector = SearchBoxSelectors.inputBox
@@ -17,6 +20,22 @@ export function assertHasText(
   });
 }
 
+export function assertHasTextWithoutIt(
+  text: string,
+  searchBoxSelector = SearchBoxSelectors.inputBox
+) {
+  searchBoxSelector().should('have.value', text);
+}
+
+export function assertHasSuggestionsCountWithoutIt(count: number) {
+  SearchBoxSelectors.querySuggestions()
+    .filter(':visible')
+    .should('have.length', count);
+}
+
+/**
+ * @deprecated
+ */
 export function assertHasSuggestionsCount(count: number) {
   it(`should display ${count} suggestions`, () => {
     SearchBoxSelectors.querySuggestions()
@@ -40,6 +59,9 @@ export function assertNoSuggestionGenerated() {
   });
 }
 
+/**
+ * @deprecated
+ */
 export function assertSuggestionIsSelected(index: number) {
   it(`should have selected suggestion ${index}`, () => {
     SearchBoxSelectors.querySuggestions()
@@ -49,19 +71,22 @@ export function assertSuggestionIsSelected(index: number) {
   });
 }
 
+export function assertSuggestionIsSelectedWithoutIt(index: number) {
+  SearchBoxSelectors.querySuggestions()
+    .eq(index)
+    .invoke('attr', 'part')
+    .should('contain', 'active-suggestion');
+}
+
 export function assertSuggestionIsHighlighted(index: number) {
-  it(`should have highlighted suggestion ${index}`, () => {
-    SearchBoxSelectors.querySuggestions()
-      .eq(index)
-      .invoke('attr', 'class')
-      .should('contain', 'bg-neutral-light');
-  });
+  SearchBoxSelectors.querySuggestions()
+    .eq(index)
+    .invoke('attr', 'class')
+    .should('contain', 'bg-neutral-light');
 }
 
 export function assertNoSuggestionIsSelected() {
-  it('should have no selected result', () => {
-    SearchBoxSelectors.activeQuerySuggestion().should('not.exist');
-  });
+  SearchBoxSelectors.activeQuerySuggestion().should('not.exist');
 }
 
 export function assertLogSearchFromLink(query: string) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2759

I had already worked on this file 1 month ago, so this did not take a long time.

 I was able to simplify these tests because the main part was looking if you were able to navigate through it using the keyboard and the mouse. These 2 do not need a reinitialization of the component. You can keep the same one and go through every use case. This way, it creates less reloading resulting in less flakiness.  
 
 I also took the time to merge the tests in 'with a custom aria label' for the same reasons. The component did not need to be reinitialized.

### Before
<img width="747" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/ff4e4442-6113-4f52-897b-8da859152bb4">


### After 
<img width="732" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/222a1a4c-4e3f-4ccd-9ad4-ad4749afb811">
