### PR TITLE
test: show console errors inside of cypress

### DIFF
--- a/packages/atomic/cypress/fixtures/fixture-common.ts
+++ b/packages/atomic/cypress/fixtures/fixture-common.ts
@@ -44,11 +44,11 @@ export const UrlParts = {
   UASearch: 'https://analytics.cloud.coveo.com/rest/ua/v15/analytics/search',
 };
 
-export function stubConsole() {
+export function spyConsole() {
   cy.window().then((win) => {
-    cy.stub(win.console, 'error').as(ConsoleAliases.error.substring(1));
-    cy.stub(win.console, 'warn').as(ConsoleAliases.warn.substring(1));
-    cy.stub(win.console, 'log').as(ConsoleAliases.log.substring(1));
+    cy.spy(win.console, 'error').as(ConsoleAliases.error.substring(1));
+    cy.spy(win.console, 'warn').as(ConsoleAliases.warn.substring(1));
+    cy.spy(win.console, 'log').as(ConsoleAliases.log.substring(1));
   });
 }
 

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -13,7 +13,7 @@ import {
   SearchResponseModifier,
   SearchResponseModifierPredicate,
   setupIntercept,
-  stubConsole,
+  spyConsole,
   UrlParts,
   TestFeature,
   configureI18n,
@@ -199,7 +199,7 @@ export class TestFixture {
     !this.redirected && cy.visit(buildTestUrl(this.hash));
     cy.injectAxe();
     setupIntercept();
-    stubConsole();
+    spyConsole();
 
     cy.window().then((win) => {
       Object.defineProperty(win.navigator, 'doNotTrack', {

--- a/packages/atomic/cypress/fixtures/test-recs-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-recs-fixture.ts
@@ -9,7 +9,7 @@ import {
   RouteAlias,
   sampleConfig,
   setupIntercept,
-  stubConsole,
+  spyConsole,
   UrlParts,
   TestFeature,
   SearchResponseModifier,
@@ -143,7 +143,7 @@ export class TestRecsFixture {
     cy.visit(buildTestUrl());
     cy.injectAxe();
     setupIntercept();
-    stubConsole();
+    spyConsole();
 
     cy.document().then((doc) => {
       doc.head.appendChild(this.style);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2807

Whenever a component would crash inside of cypress, it would not print in the cypress console. I think this is a feature that broke when updating cypress. I had this problem and felt like it wasn't there before. Then I remembered that @mrrajamanickam-coveo had done this change in his old PR to update to cypress 12. 

<img width="2462" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/421dfb19-9e3a-4e9a-b230-270136118b1c">
