### PR TITLE
fix: screw it, max-height transition !

### DIFF
--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
@@ -8,7 +8,8 @@
   &::part(smart-snippet-collapse-wrapper) {
     @mixin set-font-size var(--atomic-text-lg);
 
-    height: var(--collapsed-size);
+    height: auto;
+    max-height: var(--collapsed-size);
 
     --gradient-start: var(
       --atomic-smart-snippet-gradient-start,
@@ -17,7 +18,7 @@
     color: var(--atomic-on-background);
     mask-image: linear-gradient(black, black var(--gradient-start), transparent 100%);
 
-    transition: height ease-in-out 0.25s;
+    transition: max-height ease-in-out 0.25s;
   }
 
   button atomic-icon {
@@ -27,7 +28,8 @@
 
 :host(.expanded) {
   &::part(smart-snippet-collapse-wrapper) {
-    height: var(--full-height);
+    height: auto;
+    max-height: calc(var(--full-height) + 200px);
     mask-image: none;
   }
 

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
@@ -18,7 +18,7 @@
     color: var(--atomic-on-background);
     mask-image: linear-gradient(black, black var(--gradient-start), transparent 100%);
 
-    transition: max-height cubic-bezier(0, 1, 0.22, 1) calc(var(--full-height-value) * 0.001s);
+    transition: max-height 2s cubic-bezier(0, 1, 0.16, 1) -1.82s;
   }
 
   button atomic-icon {
@@ -29,9 +29,9 @@
 :host(.expanded) {
   &::part(smart-snippet-collapse-wrapper) {
     height: auto;
-    max-height: calc(var(--full-height) + 200px);
+    max-height: 9999999px;
+    transition: max-height 2s cubic-bezier(1, 0, 1, 0) 0s;
     mask-image: none;
-    transition: max-height ease-in-out calc(var(--full-height-value) * 0.001s);
   }
 
   button atomic-icon {

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.pcss
@@ -18,7 +18,7 @@
     color: var(--atomic-on-background);
     mask-image: linear-gradient(black, black var(--gradient-start), transparent 100%);
 
-    transition: max-height ease-in-out 0.25s;
+    transition: max-height cubic-bezier(0, 1, 0.22, 1) calc(var(--full-height-value) * 0.001s);
   }
 
   button atomic-icon {
@@ -31,6 +31,7 @@
     height: auto;
     max-height: calc(var(--full-height) + 200px);
     mask-image: none;
+    transition: max-height ease-in-out calc(var(--full-height-value) * 0.001s);
   }
 
   button atomic-icon {

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.tsx
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.tsx
@@ -54,6 +54,7 @@ export class AtomicSmartSnippetCollapseWrapper {
     this.showButton = this.fullHeight! > this.maximumHeight!;
     this.isExpanded = !this.showButton;
     this.host.style.setProperty('--full-height', `${this.fullHeight}px`);
+    this.host.style.setProperty('--full-height-value', `${this.fullHeight}`);
     this.host.style.setProperty(
       '--collapsed-size',
       `${this.showButton ? this.collapsedHeight : this.fullHeight}px`

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.tsx
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-collapse-wrapper/atomic-smart-snippet-collapse-wrapper.tsx
@@ -53,11 +53,9 @@ export class AtomicSmartSnippetCollapseWrapper {
     this.fullHeight = this.host.getBoundingClientRect().height;
     this.showButton = this.fullHeight! > this.maximumHeight!;
     this.isExpanded = !this.showButton;
-    this.host.style.setProperty('--full-height', `${this.fullHeight}px`);
-    this.host.style.setProperty('--full-height-value', `${this.fullHeight}`);
     this.host.style.setProperty(
       '--collapsed-size',
-      `${this.showButton ? this.collapsedHeight : this.fullHeight}px`
+      this.collapsedHeight + 'px'
     );
   }
 

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -246,7 +246,11 @@
           </atomic-layout-section>
           <atomic-layout-section section="results">
             <atomic-generated-answer></atomic-generated-answer>
-            <atomic-smart-snippet source-url-max-length="50" snippet-maximum-height="50" snippet-collapsed-height="50">
+            <atomic-smart-snippet
+              source-url-max-length="50"
+              snippet-maximum-height="120"
+              snippet-collapsed-height="120"
+            >
               <a slot="source-anchor-attributes" target="_blank" rel="noopener"></a>
             </atomic-smart-snippet>
             <atomic-smart-snippet-suggestions>


### PR DESCRIPTION
Basically doing the same thing as before, except
- use `--full-height` to calculate a `max-height` instead of `height`
- set the `transition` on `max-height` instead of `height`
- set `height` to `auto`

No visual changes except making the expanded height more consistent.

TBH I think that at this point we could just not calculate `--full-height` and use a static value of like 1 Billion pixels, but I kinda want to get my feature working (it has been a while 😬)

https://github.com/coveo/ui-kit/assets/71142397/5574c9ba-2e04-4170-9214-6821785c3fda




Discussed with @btaillon-coveo and we could probably remove code that use this `--full-height` related logic in both smart-snippet components (`collapse-wrapper` and `expandable-answer`) and use `height: auto` everywhere... TBD