### PR TITLE
docs(atomic): fix storybook args 

### DIFF
--- a/utils/atomic-storybook/.storybook/map-props-to-args.ts
+++ b/utils/atomic-storybook/.storybook/map-props-to-args.ts
@@ -1,32 +1,31 @@
 import AtomicDocumentation from '@coveo/atomic/docs/atomic-docs.json';
 import {isNullOrUndefined} from '@coveo/bueno';
-import {JsonDocs, JsonDocsValue} from '@stencil/core/internal';
-import {ArgTypes} from '@storybook/api';
-import {Options} from '@storybook/components';
+import {ArgTypes} from '@storybook/html';
+import {JsonDocsValue} from '@stencil/core/internal';
+
+type foo = ArgTypes['controls']['type'];
 
 const availableControlType = [
-  'radio',
-  'inline-radio',
+  'object',
+  'boolean',
   'check',
   'inline-check',
+  'radio',
+  'inline-radio',
   'select',
   'multi-select',
-  'array',
-  'boolean',
-  'color',
-  'date',
   'number',
   'range',
-  'object',
+  'file',
+  'color',
+  'date',
   'text',
 ] as const;
 
 const excludedPropType = ['ResultTemplateCondition'] as const;
 
-type ControlType = (typeof availableControlType)[number];
-
 export const getDocumentationFromTag = (componentTag: string) => {
-  return (AtomicDocumentation as JsonDocs).components.find(
+  return AtomicDocumentation.components.find(
     (componentDoc) => componentDoc.tag === componentTag
   );
 };
@@ -47,14 +46,18 @@ export const mapPropsToArgTypes = (componentTag: string): ArgTypes => {
         )
     )
     .forEach((prop) => {
-      const {type, options} = determineControlTypeFromJsonValues(prop.values);
+      const {control, options} = determineControlTypeFromJsonValues(
+        prop.values
+      );
       ret[prop.name] = {
         description: `<pre>${prop.docs}</pre>`,
-        table: {
-          defaultValue: {summary: prop.default},
-        },
+        control,
         options,
-        control: {type},
+        table: {
+          defaultValue: {
+            summary: (prop as {default?: string}).default,
+          },
+        },
       };
     });
 
@@ -63,20 +66,20 @@ export const mapPropsToArgTypes = (componentTag: string): ArgTypes => {
 
 const determineControlTypeFromJsonValues = (
   jsonValues: JsonDocsValue[]
-): {type: ControlType; options?: Options} => {
+): {control: any; options?: any} => {
   const noNullOrUndefinedJsonValue = jsonValues.filter(
     (val) => val.type !== 'null' && val.type !== 'undefined'
   );
 
   if (noNullOrUndefinedJsonValue.length === 0) {
-    return {type: 'text'};
+    return {control: 'text'};
   }
 
   if (
     noNullOrUndefinedJsonValue.every((val) => !isNullOrUndefined(val.value))
   ) {
     return {
-      type: 'radio',
+      control: 'radio',
       options: noNullOrUndefinedJsonValue.map((v) => v.value),
     };
   }
@@ -86,6 +89,6 @@ const determineControlTypeFromJsonValues = (
   return availableControlType.find(
     (controlType) => controlType === noNullOrUndefinedJsonValue[0].type
   )
-    ? {type: noNullOrUndefinedJsonValue[0].type as ControlType}
-    : {type: 'text'};
+    ? {control: noNullOrUndefinedJsonValue[0].type}
+    : {control: 'text'};
 };

--- a/utils/atomic-storybook/.storybook/map-props-to-args.ts
+++ b/utils/atomic-storybook/.storybook/map-props-to-args.ts
@@ -3,8 +3,6 @@ import {isNullOrUndefined} from '@coveo/bueno';
 import {ArgTypes} from '@storybook/html';
 import {JsonDocsValue} from '@stencil/core/internal';
 
-type foo = ArgTypes['controls']['type'];
-
 const availableControlType = [
   'object',
   'boolean',
@@ -21,6 +19,7 @@ const availableControlType = [
   'date',
   'text',
 ] as const;
+type ControlType = (typeof availableControlType)[number];
 
 const excludedPropType = ['ResultTemplateCondition'] as const;
 
@@ -66,7 +65,7 @@ export const mapPropsToArgTypes = (componentTag: string): ArgTypes => {
 
 const determineControlTypeFromJsonValues = (
   jsonValues: JsonDocsValue[]
-): {control: any; options?: any} => {
+): {control: ControlType; options?: (string | undefined)[]} => {
   const noNullOrUndefinedJsonValue = jsonValues.filter(
     (val) => val.type !== 'null' && val.type !== 'undefined'
   );
@@ -86,9 +85,8 @@ const determineControlTypeFromJsonValues = (
 
   // TODO: Might want to handle some corner case eventually.
   // eg: Date picker might be more suited in specific cases VS text.
-  return availableControlType.find(
+  const controlType = availableControlType.find(
     (controlType) => controlType === noNullOrUndefinedJsonValue[0].type
-  )
-    ? {control: noNullOrUndefinedJsonValue[0].type}
-    : {control: 'text'};
+  );
+  return controlType ? {control: controlType} : {control: 'text'};
 };

--- a/utils/atomic-storybook/.storybook/map-result-list-props-to-args.ts
+++ b/utils/atomic-storybook/.storybook/map-result-list-props-to-args.ts
@@ -1,5 +1,3 @@
-import {registerStandaloneSearchBox} from '@coveo/headless/dist/definitions/features/standalone-search-box-set/standalone-search-box-set-actions';
-
 export interface ResultSectionWithHighlights {
   name: string;
   highlightColor: string;
@@ -44,36 +42,26 @@ export const resultComponentArgTypes = {
   resultSection: {
     description:
       'In a list or grid layout, result templates may be divided into multiple building blocks called “result sections”. See https://docs.coveo.com/en/atomic/latest/usage/layouts/ for more information.',
-    control: {
-      type: 'radio',
-      table: {
-        defaultValue: {summary: 'none'},
-      },
-      options: resultSections.map((s) => s.name).concat(['none']),
-    },
+    control: 'radio',
+    defaultValue: 'none',
+    options: resultSections.map((s) => s.name).concat(['none']),
   },
   resultListLayout: {
     description:
       'A layout defines how you organize the results of a query. Layouts affect how many results to display per row and how visually distinct they are from each other.  See https://docs.coveo.com/en/atomic/latest/usage/layouts/ for more information',
-    control: {
-      type: 'radio',
-      options: ['grid', 'list'],
-    },
+    control: 'radio',
+    options: ['list', 'grid'],
   },
   resultListDensity: {
     description:
       'The density attribute defines the spacing of various elements in the result list, including the gap between results, the gap between parts of a result, and the font sizes of different parts of a result. See https://docs.coveo.com/en/atomic/latest/usage/displaying-results/list-or-grid/#optional-choosing-a-density for more information',
-    control: {
-      type: 'radio',
-      options: ['comfortable', 'normal', 'compact'],
-    },
+    control: 'radio',
+    options: ['comfortable', 'normal', 'compact'],
   },
   resultListImageSize: {
     description:
       'The image attribute defines the expected size of the image (visual-section). See https://docs.coveo.com/en/atomic/latest/usage/displaying-results/list-or-grid/#optional-choosing-an-image-size for more information',
-    control: {
-      type: 'radio',
-      options: ['none', 'icon', 'small', 'large'],
-    },
+    control: 'radio',
+    options: ['none', 'small', 'normal', 'large'],
   },
 };


### PR DESCRIPTION
Fix an issue with storybook controls not appearing properly for components properties.

ie: We want a radio select for enums component options, toggle select for boolean component options, etc.

This was broken with storybook upgrade.

https://coveord.atlassian.net/browse/KIT-2811