### PR TITLE
chore: isolate stencil for dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,12 @@
       "rangeStrategy": "replace"
     },
     {
+      "matchPackagePatterns": ["^@stencil/*"],
+      "groupName": "Stencil",
+      "groupSlug": "stencil",
+      "rangeStrategy": "replace"
+    },
+    {
       "matchFileNames": ["packages/atomic/package.json"],
       "matchPackagePatterns": [
         "^jest$",


### PR DESCRIPTION
Stencil due to its patch-package is troublesome to update, let's isolate it