### PR TITLE
chore(renovate): isolate nvm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,15 @@
       "groupSlug": "nx",
       "rangeStrategy": "replace",
       "allowedVersions": "15.x"
+    },
+    {
+      "groupName": "nvm",
+      "groupSlug": "NVM",
+      "fileMatch": [
+        "(^|/)\\.nvmrc$"
+      ],
+      "versioning": "node",
+      "pinDigests": false
     }
   ],
   "rangeStrategy": "auto",


### PR DESCRIPTION
Node 18.18.0 has an issue with some webpack packages, we're waiting for Node 18.19.0 or 20 LTS. However Renovate does try to update it, let's isolate it.

(This would have been exactly the same regardless of the tool used to manage Node, like Volta :P )

KIT-282