### PR TITLE
chore: isolate nvm, second attempt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,17 +81,11 @@
       "groupSlug": "nx",
       "rangeStrategy": "replace",
       "allowedVersions": "15.x"
-    },
-    {
-      "groupName": "nvm",
-      "groupSlug": "NVM",
-      "fileMatch": [
-        "(^|/)\\.nvmrc$"
-      ],
-      "versioning": "node",
-      "pinDigests": false
     }
   ],
+  "nvm": {
+    "groupName": "NVM"
+  },
   "rangeStrategy": "auto",
   "lockFileMaintenance": {
     "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -84,7 +84,8 @@
     }
   ],
   "nvm": {
-    "groupName": "NVM"
+    "groupName": "NVM",
+    "description": "18.18.0 breaks see KIT-2787"
   },
   "rangeStrategy": "auto",
   "lockFileMaintenance": {


### PR DESCRIPTION
#3266 didn't work because `nvm` is a packageManager for renovate, not a package.
Same same but different...

Was not able to validate locally with validator as it didn't flag the current config as ❌ 

KIT-282