### PR TITLE
chore: remove nvm restriction

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,10 +83,6 @@
       "allowedVersions": "15.x"
     }
   ],
-  "nvm": {
-    "groupName": "NVM",
-    "description": "18.18.0 breaks see KIT-2787"
-  },
   "rangeStrategy": "auto",
   "lockFileMaintenance": {
     "enabled": false


### PR DESCRIPTION
KIT-2787
fresh fix: https://github.com/nodejs/node/releases/tag/v18.18.1