### PR TITLE
fix(quantic): fixed case classification cypress test

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
@@ -47,11 +47,11 @@ describe('quantic-case-classification', () => {
   const coveoDefaultField = 'sfpriority';
   const nonCorrespondingCoveoField = 'sforigin';
   const allOptions = [
-    {id: '0', value: 'Very low', label: 'Very low'},
-    {id: '1', value: 'Low', label: 'Low'},
-    {id: '2', value: 'Medium', label: 'Medium'},
-    {id: '3', value: 'High', label: 'High'},
-    {id: '4', value: 'Very high', label: 'Very high'},
+    {id: '0', value: 'Very low', label: 'Very low', validFor: []},
+    {id: '1', value: 'Low', label: 'Low', validFor: []},
+    {id: '2', value: 'Medium', label: 'Medium', validFor: []},
+    {id: '3', value: 'High', label: 'High', validFor: []},
+    {id: '4', value: 'Very high', label: 'Very high', validFor: []},
   ];
   const nonCorrespondingSuggestions = [
     {id: '0', value: 'Web', label: 'Web'},


### PR DESCRIPTION
[SFINT-5240](https://coveord.atlassian.net/browse/SFINT-5240)

Apparently Salesforce changed the structure of the objects returned when using the `getPicklistValuesByRecordType` wire adapter used to get a all picklist values of a field of a given object.

This change cause an issue in the mock function we used to mock this wire adapter call causing the failure of the cypress tests.

Adjusting the mock function to return exactly what's expected solved the issue.

[SFINT-5240]: https://coveord.atlassian.net/browse/SFINT-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ