### PR TITLE
test: freeze time in `search-mapping.test.ts`

### DIFF
--- a/packages/headless/src/features/search/search-mappings.test.ts
+++ b/packages/headless/src/features/search/search-mappings.test.ts
@@ -31,6 +31,16 @@ const getExpectedMappings = () => ({
 });
 
 describe('#mapSearchRequest', () => {
+  beforeAll(() => {
+    const frozenInTime = new Date();
+    jest.useFakeTimers();
+    jest.setSystemTime(frozenInTime);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('should return the full request along with mappings', () => {
     const originalRequest = buildMockSearchRequest();
     const {request, mappings} = mapSearchRequest(originalRequest);
@@ -79,6 +89,16 @@ describe('#mapSearchRequest', () => {
 });
 
 describe('#mapSearchResponse', () => {
+  beforeAll(() => {
+    const frozenInTime = new Date();
+    jest.useFakeTimers();
+    jest.setSystemTime(frozenInTime);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('should return the full response', () => {
     expect(
       mapSearchResponse(


### PR DESCRIPTION
This makes sure the Act & Assert are both executed during the same epoch second
https://coveord.atlassian.net/browse/KIT-2825