### PR TITLE
test(headless-ssr): add tests for the defineSearchParameterManager function

### DIFF
--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ssr.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ssr.test.ts
@@ -20,6 +20,7 @@ type SearchParameterManagerDefinitionType = ControllerDefinitionWithProps<
   SearchParameterManager,
   SearchParameterManagerBuildProps
 >;
+
 describe('define search parameter manager', () => {
   let searchParameterManagerDefinition: SearchParameterManagerDefinitionType;
 

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ssr.test.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ssr.test.ts
@@ -1,0 +1,50 @@
+import {SSRSearchEngine} from '../../app/search-engine/search-engine.ssr';
+import {ControllerDefinitionWithProps} from '../../app/ssr-engine/types/common';
+import {buildMockSSRSearchEngine} from '../../test/mock-engine';
+import {
+  SearchParameterManager,
+  buildSearchParameterManager,
+} from './headless-search-parameter-manager';
+import {
+  SearchParameterManagerBuildProps,
+  defineSearchParameterManager,
+} from './headless-search-parameter-manager.ssr';
+
+jest.mock('./headless-search-parameter-manager');
+const buildSearchParameterManagerMock = jest.mocked(
+  buildSearchParameterManager
+);
+
+type SearchParameterManagerDefinitionType = ControllerDefinitionWithProps<
+  SSRSearchEngine,
+  SearchParameterManager,
+  SearchParameterManagerBuildProps
+>;
+describe('define search parameter manager', () => {
+  let searchParameterManagerDefinition: SearchParameterManagerDefinitionType;
+
+  beforeEach(() => {
+    searchParameterManagerDefinition = defineSearchParameterManager();
+    buildSearchParameterManagerMock.mockClear();
+  });
+
+  it('defineSearchParameterManager returns the proper type', () => {
+    expect(
+      searchParameterManagerDefinition
+    ).toMatchObject<SearchParameterManagerDefinitionType>({
+      buildWithProps: expect.any(Function),
+    });
+  });
+
+  it("buildWithProps should pass it's parameters to the buildSearchParameterManager", () => {
+    const engine: SSRSearchEngine = buildMockSSRSearchEngine();
+    const props: SearchParameterManagerBuildProps =
+      {} as unknown as SearchParameterManagerBuildProps;
+
+    searchParameterManagerDefinition.buildWithProps(engine, {
+      initialState: props.initialState,
+    });
+
+    expect(buildSearchParameterManagerMock).toBeCalledWith(engine, props);
+  });
+});

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -23,6 +23,7 @@ import {ProductListingEngine} from '../app/product-listing-engine/product-listin
 import {ProductRecommendationEngine} from '../app/product-recommendation-engine/product-recommendation-engine';
 import {RecommendationEngine} from '../app/recommendation-engine/recommendation-engine';
 import {SearchEngine} from '../app/search-engine/search-engine';
+import {SearchCompletedAction} from '../app/search-engine/search-engine.ssr';
 import {SearchThunkExtraArguments} from '../app/search-thunk-extra-arguments';
 import {CaseAssistEngine} from '../case-assist.index';
 import {CaseAssistAppState} from '../state/case-assist-app-state';
@@ -71,6 +72,24 @@ interface MockEngine {
 }
 
 type DispatchExts = ThunkDispatch<AppState, void, AnyAction>;
+
+export interface MockSSRSearchEngine extends MockSearchEngine {
+  waitForSearchCompletedAction(): Promise<SearchCompletedAction>;
+}
+
+/**
+ * For internal use only.
+ *
+ * Returns a non-functional `SSRSearchEngine`.
+ * To be used only for unit testing SSR controllers, not for functional tests.
+ */
+export function buildMockSSRSearchEngine(): MockSSRSearchEngine {
+  const engine = buildMockSearchAppEngine();
+  return {
+    ...engine,
+    waitForSearchCompletedAction: jest.fn(),
+  };
+}
 
 export interface MockSearchEngine
   extends SearchEngine<SearchAppState>,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2715

I tried to make sure only the defineSearchParameterManager function was tested and the rest was properly mocked.