### PR TITLE
chore(headless): replace deprecated platform-client functions

### DIFF
--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -4,7 +4,7 @@ import fetch from '@coveo/please-give-me-fetch';
 import {backOff} from 'exponential-backoff';
 import {Logger} from 'pino';
 import {DisconnectedError, ExpiredTokenError} from '../utils/errors';
-import {PlatformCombination, PlatformEnvironment} from '../utils/url-utils';
+import {PlatformEnvironment} from '../utils/url-utils';
 import {clone} from '../utils/utils';
 import {canBeFormUrlEncoded, encodeAsFormUrl} from './form-url-encoder';
 import {
@@ -129,7 +129,7 @@ export class PlatformClient {
   }
 }
 
-interface URLOptions<E extends PlatformEnvironment> {
+/*interface URLOptions<E extends PlatformEnvironment> {
   environment?: E;
   region?: Extract<PlatformCombination, {env: E}>['region'];
   multiRegionSubDomain?: string;
@@ -149,7 +149,7 @@ function coveoCloudURL<E extends PlatformEnvironment>(
       : `-${options.region}`;
 
   return `https://${subdomain}${urlEnv}${urlRegion}.cloud.coveo.com`;
-}
+}*/
 
 /**
  * Returns the unique endpoint(s) for a given organization identifier.
@@ -169,36 +169,6 @@ export function getOrganizationEndpoints(
   const admin = `https://${orgId}.admin.org${envSuffix}.coveo.com`;
 
   return {platform, analytics, search, admin};
-}
-
-/**
- * Returns the base Coveo platform URL, based on environment and region.
- * @deprecated Coveo now offers organization-specific endpoints. Consider using the getOrganizationEndpoints utility function instead.
- *
- * @param options
- * @returns string
- */
-export function platformUrl<E extends PlatformEnvironment>(
-  options?: URLOptions<E>
-) {
-  if (options?.multiRegionSubDomain) {
-    return `https://${options.multiRegionSubDomain}.org.coveo.com`;
-  }
-
-  return coveoCloudURL('platform', options);
-}
-
-/**
- * Returns the Coveo analytics platform URL, based on environment and region.
- * @deprecated Coveo now offers organization-specific endpoints. Consider using the getOrganizationEndpoints utility function instead.
- *
- * @param options
- * @returns
- */
-export function analyticsUrl<E extends PlatformEnvironment = 'prod'>(
-  options?: URLOptions<E>
-) {
-  return coveoCloudURL('analytics', options);
 }
 
 function buildDefaultRequestOptions(

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -129,28 +129,6 @@ export class PlatformClient {
   }
 }
 
-/*interface URLOptions<E extends PlatformEnvironment> {
-  environment?: E;
-  region?: Extract<PlatformCombination, {env: E}>['region'];
-  multiRegionSubDomain?: string;
-}
-
-function coveoCloudURL<E extends PlatformEnvironment>(
-  subdomain: string,
-  options?: URLOptions<E>
-) {
-  const urlEnv =
-    !options || !options.environment || options.environment === 'prod'
-      ? ''
-      : options.environment;
-  const urlRegion =
-    !options || !options.region || options.region === 'us'
-      ? ''
-      : `-${options.region}`;
-
-  return `https://${subdomain}${urlEnv}${urlRegion}.cloud.coveo.com`;
-}*/
-
 /**
  * Returns the unique endpoint(s) for a given organization identifier.
  * @param orgId The organization identifier.

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -2,7 +2,8 @@ import {IRuntimeEnvironment} from 'coveo.analytics';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import {analyticsUrl, platformUrl} from '../../api/platform-client';
+import {getOrganizationEndpoints} from '../../api/platform-client';
+import {getSampleEngineConfiguration} from '../../app/engine-configuration';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -134,28 +135,33 @@ export interface AnalyticsState {
 export const searchAPIEndpoint = '/rest/search/v2';
 export const analyticsAPIEndpoint = '/rest/ua';
 
-export const getConfigurationInitialState: () => ConfigurationState = () => ({
-  organizationId: '',
-  accessToken: '',
-  platformUrl: platformUrl(),
-  search: {
-    apiBaseUrl: `${platformUrl()}${searchAPIEndpoint}`,
-    locale: 'en-US',
-    timezone: dayjs.tz.guess(),
-    authenticationProviders: [],
-  },
-  analytics: {
-    enabled: true,
-    apiBaseUrl: `${analyticsUrl()}${analyticsAPIEndpoint}`,
-    nextApiBaseUrl: '',
-    originContext: 'Search',
-    originLevel2: 'default',
-    originLevel3: 'default',
-    anonymous: false,
-    deviceId: '',
-    userDisplayName: '',
-    documentLocation: '',
-    trackingId: '',
-    analyticsMode: 'legacy',
-  },
-});
+export const getConfigurationInitialState: () => ConfigurationState = () => {
+  const defaultEndpoints = getOrganizationEndpoints(
+    getSampleEngineConfiguration().organizationId
+  );
+  return {
+    organizationId: '',
+    accessToken: '',
+    platformUrl: defaultEndpoints.platform,
+    search: {
+      apiBaseUrl: defaultEndpoints.search,
+      locale: 'en-US',
+      timezone: dayjs.tz.guess(),
+      authenticationProviders: [],
+    },
+    analytics: {
+      enabled: true,
+      apiBaseUrl: defaultEndpoints.analytics,
+      nextApiBaseUrl: '',
+      originContext: 'Search',
+      originLevel2: 'default',
+      originLevel3: 'default',
+      anonymous: false,
+      deviceId: '',
+      userDisplayName: '',
+      documentLocation: '',
+      trackingId: '',
+      analyticsMode: 'legacy',
+    },
+  };
+};

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -106,11 +106,7 @@ export type {
   ResultTemplate,
   ResultTemplateCondition,
 } from './features/result-templates/result-templates';
-export {
-  platformUrl,
-  analyticsUrl,
-  getOrganizationEndpoints,
-} from './api/platform-client';
+export {getOrganizationEndpoints} from './api/platform-client';
 export type {PlatformEnvironment} from './utils/url-utils';
 export type {
   CategoryFacetValueRequest,

--- a/packages/headless/src/ssr.index.ts
+++ b/packages/headless/src/ssr.index.ts
@@ -111,11 +111,7 @@ export type {
   ResultTemplate,
   ResultTemplateCondition,
 } from './features/result-templates/result-templates';
-export {
-  platformUrl,
-  analyticsUrl,
-  getOrganizationEndpoints,
-} from './api/platform-client';
+export {getOrganizationEndpoints} from './api/platform-client';
 export type {PlatformEnvironment} from './utils/url-utils';
 export type {
   CategoryFacetValueRequest,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2379

The scope is to remove all exported deprecated functions, and I only found 2; `platformUrl` and `analyticsUrl` within `platform-client`. I was also able to remove `coveoCloudURL` and `URLOptions` since they were exclusively used within these deprecated functions.

Seeing as we're moving to a URL scheme that depends on an orgId, but the place that still uses these deprecated functions (`configuration-state.ts`) doesn't have access to any orgId, I decided to have it fallback on the defaults provided by `getSampleEngineConfiguration`.