### PR TITLE
test(headless-ssr): split search parameter tests in both 'generic' and 'react' route

### DIFF
--- a/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
+++ b/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
@@ -6,7 +6,7 @@ import {
 } from './utils';
 
 const searchStateKey = 'search-state';
-const routes = ['generic', 'react'];
+const routes = ['generic', 'react'] as const;
 
 routes.forEach((route) => {
   describe(`${route} Headless ssr with search parameter manager example`, () => {

--- a/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
+++ b/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
@@ -8,11 +8,13 @@ import {
 const searchStateKey = 'search-state';
 
 describe('headless ssr with search parameter manager example', () => {
-  describe('generic', () => {
-    test('/generic');
+  const generic = '/generic';
+  const react = '/react';
+  describe(`when using the ${generic} route`, () => {
+    test(generic);
   });
-  describe('react', () => {
-    test('/react');
+  describe(`when using the ${react} route`, () => {
+    test(react);
   });
 });
 

--- a/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
+++ b/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
@@ -6,180 +6,174 @@ import {
 } from './utils';
 
 const searchStateKey = 'search-state';
+const routes = ['generic', 'react'];
 
-describe('headless ssr with search parameter manager example', () => {
-  const generic = '/generic';
-  const react = '/react';
-  describe(`when using the ${generic} route`, () => {
-    test(generic);
-  });
-  describe(`when using the ${react} route`, () => {
-    test(react);
-  });
-});
+routes.forEach((route) => {
+  describe(`${route} Headless ssr with search parameter manager example`, () => {
+    describe('when loading a page without search parameters, after hydration', () => {
+      beforeEach(() => {
+        spyOnConsole();
+        cy.visit(route);
+        waitForHydration();
+        getResultTitles()
+          .should('have.length.greaterThan', 0)
+          .as('initial-results');
+      });
 
-function test(route: string) {
-  describe('when loading a page without search parameters, after hydration', () => {
-    beforeEach(() => {
-      spyOnConsole();
-      cy.visit(route);
-      waitForHydration();
-      getResultTitles()
-        .should('have.length.greaterThan', 0)
-        .as('initial-results');
-    });
+      it('should not update the search parameters', () => {
+        cy.url().should((href) =>
+          expect(new URL(href).searchParams.size).to.equal(0)
+        );
+      });
 
-    it('should not update the search parameters', () => {
-      cy.url().should((href) =>
-        expect(new URL(href).searchParams.size).to.equal(0)
-      );
-    });
+      describe('after submitting a search', () => {
+        const query = 'abc';
+        beforeEach(() =>
+          cy.get('.search-box input').focus().type(`${query}{enter}`)
+        );
 
-    describe('after submitting a search', () => {
-      const query = 'abc';
-      beforeEach(() =>
-        cy.get('.search-box input').focus().type(`${query}{enter}`)
-      );
-
-      describe('after the url was updated', () => {
-        beforeEach(() => {
-          cy.url().should((href) =>
-            expect(new URL(href).searchParams.has(searchStateKey)).to.equal(
-              true
-            )
-          );
-          cy.get<string>('@initial-results').then((initialResults) => {
-            getResultTitles().should('not.deep.equal', initialResults);
+        describe('after the url was updated', () => {
+          beforeEach(() => {
+            cy.url().should((href) =>
+              expect(new URL(href).searchParams.has(searchStateKey)).to.equal(
+                true
+              )
+            );
+            cy.get<string>('@initial-results').then((initialResults) => {
+              getResultTitles().should('not.deep.equal', initialResults);
+            });
           });
-        });
 
-        it('should have the correct search parameters', () => {
-          cy.url().should((href) => {
-            const searchState = new URL(href).searchParams.get(searchStateKey);
-            expect(searchState && JSON.parse(searchState)).to.deep.equal({
-              q: query,
+          it('should have the correct search parameters', () => {
+            cy.url().should((href) => {
+              const searchState = new URL(href).searchParams.get(
+                searchStateKey
+              );
+              expect(searchState && JSON.parse(searchState)).to.deep.equal({
+                q: query,
+              });
+            });
+          });
+
+          it('has only two history states', () => {
+            cy.go('back');
+            cy.go('back');
+            cy.url().should('eq', 'about:blank');
+          });
+
+          describe('after pressing the back button', () => {
+            beforeEach(() => cy.go('back'));
+
+            it('should remove the search parameters', () => {
+              cy.url().should((href) =>
+                expect(new URL(href).searchParams.size).to.be.equal(0)
+              );
+            });
+
+            it('should update the page', () => {
+              cy.get('.search-box input').should('have.value', '');
+              cy.get<string>('@initial-results').then((initialResults) => {
+                getResultTitles().should('deep.equal', initialResults);
+              });
+            });
+
+            it('should not log an error nor warning', () => {
+              cy.get(ConsoleAliases.error).should('not.be.called');
+              cy.get(ConsoleAliases.warn).should('not.be.called');
             });
           });
         });
+      });
+    });
 
-        it('has only two history states', () => {
-          cy.go('back');
+    describe('when loading a page with search parameters', () => {
+      const query = 'def';
+      function getInitialUrl() {
+        const searchParams = new URLSearchParams({
+          [searchStateKey]: JSON.stringify({q: query}),
+        });
+        return `${route}?${searchParams.toString()}`;
+      }
+
+      it('renders page in SSR as expected', () => {
+        cy.intercept(`${route}/**`, (req) => {
+          req.continue((resp) => {
+            const dom = new DOMParser().parseFromString(resp.body, 'text/html');
+            expect(dom.querySelector('.search-box input')).to.have.value(query);
+          });
+        });
+        cy.visit(getInitialUrl());
+        waitForHydration();
+      });
+
+      describe('after hydration', () => {
+        beforeEach(() => {
+          cy.visit(getInitialUrl());
+          waitForHydration();
+        });
+
+        // TODO: Enable after URL management investigation https://coveord.atlassian.net/browse/KIT-2735
+        it.skip("doesn't update the page", () => {
+          cy.wait(1000);
+          cy.get('.search-box input').should('have.value', query);
+        });
+
+        // TODO: Enable after URL management investigation https://coveord.atlassian.net/browse/KIT-2735
+        it.skip('should not update the parameters', () => {
+          cy.wait(1000);
+          cy.url().should((href) => {
+            expect(href.endsWith(getInitialUrl())).to.equal(true);
+          });
+        });
+
+        it('has only one history state', () => {
           cy.go('back');
           cy.url().should('eq', 'about:blank');
         });
-
-        describe('after pressing the back button', () => {
-          beforeEach(() => cy.go('back'));
-
-          it('should remove the search parameters', () => {
-            cy.url().should((href) =>
-              expect(new URL(href).searchParams.size).to.be.equal(0)
-            );
-          });
-
-          it('should update the page', () => {
-            cy.get('.search-box input').should('have.value', '');
-            cy.get<string>('@initial-results').then((initialResults) => {
-              getResultTitles().should('deep.equal', initialResults);
-            });
-          });
-
-          it('should not log an error nor warning', () => {
-            cy.get(ConsoleAliases.error).should('not.be.called');
-            cy.get(ConsoleAliases.warn).should('not.be.called');
-          });
-        });
       });
     });
-  });
 
-  describe('when loading a page with search parameters', () => {
-    const query = 'def';
-    function getInitialUrl() {
-      const searchParams = new URLSearchParams({
-        [searchStateKey]: JSON.stringify({q: query}),
-      });
-      return `${route}?${searchParams.toString()}`;
-    }
-
-    it('renders page in SSR as expected', () => {
-      cy.intercept(`${route}/**`, (req) => {
-        req.continue((resp) => {
-          const dom = new DOMParser().parseFromString(resp.body, 'text/html');
-          expect(dom.querySelector('.search-box input')).to.have.value(query);
+    describe('when loading a page with invalid search parameters', () => {
+      function getInitialUrl() {
+        const searchParams = new URLSearchParams({
+          [searchStateKey]: JSON.stringify({q: ''}),
         });
-      });
-      cy.visit(getInitialUrl());
-      waitForHydration();
-    });
+        return `${route}?${searchParams.toString()}`;
+      }
 
-    describe('after hydration', () => {
-      beforeEach(() => {
+      it('renders page in SSR as expected', () => {
+        cy.intercept(`${route}/**`, (req) => {
+          req.continue((resp) => {
+            const dom = new DOMParser().parseFromString(resp.body, 'text/html');
+            expect(dom.querySelector('.search-box input')).to.have.value('');
+          });
+        });
         cy.visit(getInitialUrl());
         waitForHydration();
       });
 
-      // TODO: Enable after URL management investigation https://coveord.atlassian.net/browse/KIT-2735
-      it.skip("doesn't update the page", () => {
-        cy.wait(1000);
-        cy.get('.search-box input').should('have.value', query);
-      });
-
-      // TODO: Enable after URL management investigation https://coveord.atlassian.net/browse/KIT-2735
-      it.skip('should not update the parameters', () => {
-        cy.wait(1000);
-        cy.url().should((href) => {
-          expect(href.endsWith(getInitialUrl())).to.equal(true);
+      describe('after hydration', () => {
+        beforeEach(() => {
+          cy.visit(getInitialUrl());
+          waitForHydration();
         });
-      });
 
-      it('has only one history state', () => {
-        cy.go('back');
-        cy.url().should('eq', 'about:blank');
+        it("doesn't update the page", () => {
+          cy.wait(1000);
+          cy.get('.search-box input').should('have.value', '');
+        });
+
+        it('should correct the parameters', () => {
+          cy.url().should((href) => {
+            expect(new URL(href).searchParams.size).to.equal(0);
+          });
+        });
+
+        it('has only one history state', () => {
+          cy.go('back');
+          cy.url().should('eq', 'about:blank');
+        });
       });
     });
   });
-
-  describe('when loading a page with invalid search parameters', () => {
-    function getInitialUrl() {
-      const searchParams = new URLSearchParams({
-        [searchStateKey]: JSON.stringify({q: ''}),
-      });
-      return `${route}?${searchParams.toString()}`;
-    }
-
-    it('renders page in SSR as expected', () => {
-      cy.intercept(`${route}/**`, (req) => {
-        req.continue((resp) => {
-          const dom = new DOMParser().parseFromString(resp.body, 'text/html');
-          expect(dom.querySelector('.search-box input')).to.have.value('');
-        });
-      });
-      cy.visit(getInitialUrl());
-      waitForHydration();
-    });
-
-    describe('after hydration', () => {
-      beforeEach(() => {
-        cy.visit(getInitialUrl());
-        waitForHydration();
-      });
-
-      it("doesn't update the page", () => {
-        cy.wait(1000);
-        cy.get('.search-box input').should('have.value', '');
-      });
-
-      it('should correct the parameters', () => {
-        cy.url().should((href) => {
-          expect(new URL(href).searchParams.size).to.equal(0);
-        });
-      });
-
-      it('has only one history state', () => {
-        cy.go('back');
-        cy.url().should('eq', 'about:blank');
-      });
-    });
-  });
-}
+});

--- a/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
+++ b/packages/samples/headless-ssr/cypress/e2e/ssr-search-parameter-manager.cy.ts
@@ -8,7 +8,15 @@ import {
 const searchStateKey = 'search-state';
 
 describe('headless ssr with search parameter manager example', () => {
-  const route = '/generic';
+  describe('generic', () => {
+    test('/generic');
+  });
+  describe('react', () => {
+    test('/react');
+  });
+});
+
+function test(route: string) {
   describe('when loading a page without search parameters, after hydration', () => {
     beforeEach(() => {
       spyOnConsole();
@@ -93,7 +101,7 @@ describe('headless ssr with search parameter manager example', () => {
     }
 
     it('renders page in SSR as expected', () => {
-      cy.intercept('/generic/**', (req) => {
+      cy.intercept(`${route}/**`, (req) => {
         req.continue((resp) => {
           const dom = new DOMParser().parseFromString(resp.body, 'text/html');
           expect(dom.querySelector('.search-box input')).to.have.value(query);
@@ -139,7 +147,7 @@ describe('headless ssr with search parameter manager example', () => {
     }
 
     it('renders page in SSR as expected', () => {
-      cy.intercept('/generic/**', (req) => {
+      cy.intercept(`${route}/**`, (req) => {
         req.continue((resp) => {
           const dom = new DOMParser().parseFromString(resp.body, 'text/html');
           expect(dom.querySelector('.search-box input')).to.have.value('');
@@ -172,4 +180,4 @@ describe('headless ssr with search parameter manager example', () => {
       });
     });
   });
-});
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2835

Could also make two separate files but I think it is fine this way. The tests are pretty fast.

<img width="571" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/d6b1a9c5-baef-4487-91de-cff15182edc8">
