### PR TITLE
fix(atomic-react): fix for Vite by enabling import injection

### DIFF
--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -196,4 +196,7 @@ export const config: Config = {
       isDevWatch && replaceHeadlessMap(),
     ],
   },
+  extras: {
+    enableImportInjection: true,
+  },
 };


### PR DESCRIPTION
fix #3310 

https://stenciljs.com/docs/react#typeerror-cannot-read-properties-of-undefined-reading-isproxied

Docs warns that this might increase bundle size. I checked and it increased by 45kb in a 55.6mb total (for atomic) 😅 