### PR TITLE
chore(quantic): locker service enabled in e2e environment 

### DIFF
--- a/packages/quantic/cypress/e2e/default-2/recent-results-list/recent-results-list.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/recent-results-list/recent-results-list.cypress.ts
@@ -118,7 +118,7 @@ describe('quantic-recent-results-list', () => {
         visitRecentResultsList({
           isCollapsed: true,
         });
-
+        Expect.labelContains(defaultLabel);
         selectResults();
         Expect.displayResults(false);
       });
@@ -129,6 +129,7 @@ describe('quantic-recent-results-list', () => {
           target: '_blank',
         });
 
+        Expect.labelContains(defaultLabel);
         selectResults();
         Expect.targetContainsAtResult('1', customTarget);
       });

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions-selectors.ts
@@ -38,6 +38,6 @@ export const SmartSnippetSuggestionsSelectors: SmartSnippetSuggestionsSelector =
         .eq(index),
     smartSnippetSuggestionsInlineLink: (index: number) =>
       SmartSnippetSuggestionsSelectors.get()
-        .find('[data-cy="smart-snippet__inline-link"]')
+        .find('[data-cy="smart-snippet__inline-link"] > a')
         .eq(index),
   };

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions.cypress.ts
@@ -16,14 +16,10 @@ import {SmartSnippetSuggestionsActions as Actions} from './smart-snippet-suggest
 import {SmartSnippetSuggestionsExpectations as Expect} from './smart-snippet-suggestions-expectations';
 
 const inactiveLink = 'javascript:void(0);';
+const exampleInlineLink =
+  'https://saas-inspiration-5437-dev-ed.scratch.my.site.com/examples/s/';
 const exampleInlineLinkText = 'Example inline link';
-const exampleInlineLinkUrl = inactiveLink;
-const exampleSmartSnippetAnswer = `
-  <div>
-    <p>Example smart snippet answer</p>
-    <a data-cy="smart-snippet__inline-link" href="${exampleInlineLinkUrl}">${exampleInlineLinkText}</a>
-  </div>
-`;
+const exampleSmartSnippetAnswer = `<div data-cy="smart-snippet__inline-link"><p>Example smart snippet answer</p><a href="${exampleInlineLink}">${exampleInlineLinkText}</a></div>`;
 
 const exampleRelatedQuestions = [
   {
@@ -165,9 +161,10 @@ describe('quantic-smart-snippet-suggestions', () => {
               Expect.logOpenSmartSnippetSuggestionInlineLink({
                 ...exampleRelatedQuestions[index],
                 position: index + 1,
-                linkUrl: exampleInlineLinkUrl,
+                linkUrl: exampleInlineLink,
                 linkText: exampleInlineLinkText,
               });
+              visitPage({useCase: param.useCase});
             }
           );
         });

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet-selectors.ts
@@ -41,7 +41,9 @@ export const SmartSnippetSelectors: SmartSnippetSelector = {
       '[data-cy="expandable-smart-snippet-answer"]'
     ),
   smartSnippetInlineLink: () =>
-    SmartSnippetSelectors.get().find('[data-cy="smart-snippet__inline-link"]'),
+    SmartSnippetSelectors.get().find(
+      '[data-cy="smart-snippet__inline-link"] > a'
+    ),
   smartSnippetLikeButton: () =>
     SmartSnippetSelectors.get().find('[data-cy="feedback__like-button"]'),
   smartSnippetDislikeButton: () =>

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
@@ -25,13 +25,9 @@ const exampleSmartSnippetSourceUri = inactiveLink;
 const exampleSmartSnippetSourceTitle = 'Example result title';
 const examplePermanentId = '123';
 const exampleInlineLinkText = 'Example inline link';
-const exampleInlineLinkUrl = inactiveLink;
-const exampleSmartSnippetAnswer = `
-  <div>
-    <p>Example smart snippet answer</p>
-    <a data-cy="smart-snippet__inline-link" href="${exampleInlineLinkUrl}">${exampleInlineLinkText}</a>
-  </div>
-`;
+const exampleInlineLinkUrl =
+  'https://saas-inspiration-5437-dev-ed.scratch.my.site.com/examples/s/';
+const exampleSmartSnippetAnswer = `<div data-cy="smart-snippet__inline-link"><p>Example smart snippet answer</p><a href="${exampleInlineLinkUrl}">${exampleInlineLinkText}</a></div>`;
 
 const otherOption = 'other';
 const feedbackOptions = [
@@ -101,20 +97,6 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
               Expect.displaySmartSnippetAnswerToggle(false);
             });
 
-            scope(
-              'when an inlink within the smart snippet answer is clicked',
-              () => {
-                Actions.clickSmartSnippetInlineLink();
-                Expect.logOpenSmartSnippetInlineLink({
-                  title: exampleSmartSnippetSourceTitle,
-                  uri: exampleSmartSnippetSourceUri,
-                  permanentId: examplePermanentId,
-                  linkUrl: exampleInlineLinkUrl,
-                  linkText: exampleInlineLinkText,
-                });
-              }
-            );
-
             scope('when the source title is clicked', () => {
               Actions.clickSmartSnippetSourceTitle();
               Expect.logOpenSmartSnippetSource({
@@ -133,6 +115,21 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                 permanentId: examplePermanentId,
               });
             });
+
+            scope(
+              'when an inlink within the smart snippet answer is clicked',
+              () => {
+                Actions.clickSmartSnippetInlineLink();
+                Expect.logOpenSmartSnippetInlineLink({
+                  title: exampleSmartSnippetSourceTitle,
+                  uri: exampleSmartSnippetSourceUri,
+                  permanentId: examplePermanentId,
+                  linkUrl: exampleInlineLinkUrl,
+                  linkText: exampleInlineLinkText,
+                });
+                visitPage({useCase: param.useCase});
+              }
+            );
           });
         });
 

--- a/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
+++ b/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
@@ -73,8 +73,7 @@
         {
           "title": "Bushy Feather Stars",
           "children": [{"title": "Legless Feather Star"}]
-        },
-        {"title": "Klunzinger's Feather Star"}
+        }
       ]
     }
   ]

--- a/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
+++ b/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
@@ -70,6 +70,7 @@
       "title": "Feather Stars",
       "children": [
         {"title": "Antarctic Feather Star"},
+        {"title": "Klunzinger's Feather Star"},
         {
           "title": "Bushy Feather Stars",
           "children": [{"title": "Legless Feather Star"}]

--- a/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
+++ b/packages/quantic/cypress/fixtures/folded-result-list/exampleResultWithMoreChildResults.json
@@ -70,11 +70,11 @@
       "title": "Feather Stars",
       "children": [
         {"title": "Antarctic Feather Star"},
-        {"title": "Klunzinger's Feather Star"},
         {
           "title": "Bushy Feather Stars",
           "children": [{"title": "Legless Feather Star"}]
-        }
+        },
+        {"title": "Klunzinger's Feather Star"}
       ]
     }
   ]

--- a/packages/quantic/quantic-examples-community/experiences/Quantic_Examples1/config/mainAppPage.json
+++ b/packages/quantic/quantic-examples-community/experiences/Quantic_Examples1/config/mainAppPage.json
@@ -3,8 +3,8 @@
   "currentThemeId": "28a631f8-762e-42f8-ae13-8e796217d60f",
   "headMarkup": null,
   "id": "2199ef25-89a9-44a1-ad69-7cb8bd918245",
-  "isLockerServiceEnabled": false,
-  "isRelaxedCSPLevel": true,
+  "isLockerServiceEnabled": true,
+  "isRelaxedCSPLevel": false,
   "label": "main",
   "templateName": "Starter Template",
   "type": "appPage"


### PR DESCRIPTION
[SFINT-5241](https://coveord.atlassian.net/browse/SFINT-5241)

- Locker Service enabled in the Salesforce org used to perform the cypress e2e tests.
- Few adjustments have been made to make the tests pass in  this new environment.

[SFINT-5241]: https://coveord.atlassian.net/browse/SFINT-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ