### PR TITLE
feat(atomic): mark searchbox as input for deprecation in favour of textarea

### DIFF
--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -207,6 +207,8 @@ export class AtomicSearchBox {
    *   }
    * </style>
    * ```
+   *
+   * NB: The textarea attribute will be enforced on the next major version of Atomic (3.0.0)
    */
   @Prop({reflect: true}) public textarea = false;
 
@@ -240,6 +242,12 @@ export class AtomicSearchBox {
     this.id = randomID('atomic-search-box-');
     this.querySetActions = loadQuerySetActions(this.bindings.engine);
     this.isSearchDisabled = this.disableSearch || this.minimumQueryLength > 0;
+    if (!this.textarea) {
+      this.bindings.engine.logger.warn(
+        'As of Atomic version 3.0.0, the searchbox will be enabled as a text area by default. To remove this warning, set textarea="true" on the search box.',
+        this.host
+      );
+    }
 
     const searchBoxOptions: SearchBoxOptions = {
       id: this.id,

--- a/packages/atomic/src/pages/accessibility/commerce-full.html
+++ b/packages/atomic/src/pages/accessibility/commerce-full.html
@@ -195,7 +195,7 @@
             </select>
           </div>
           <h1 class="accessibility-header">Search</h1>
-          <atomic-search-box>
+          <atomic-search-box textarea>
             <atomic-search-box-recent-queries> </atomic-search-box-recent-queries>
             <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
             <atomic-search-box-instant-results image-size="small">

--- a/packages/atomic/src/pages/examples/external.html
+++ b/packages/atomic/src/pages/examples/external.html
@@ -54,7 +54,7 @@
       <div>
         <h1>External components of interface #2</h1>
         <atomic-external selector="#interface-2">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
           <atomic-query-summary></atomic-query-summary>
           <atomic-facet field="author" label="Author"></atomic-facet>
         </atomic-external>
@@ -71,7 +71,7 @@
           <atomic-numeric-facet field="ec_price" label="Cost" with-input="integer">
             <atomic-format-currency currency="USD"></atomic-format-currency>
           </atomic-numeric-facet>
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
           <atomic-result-list></atomic-result-list>
         </atomic-search-interface>
       </div>

--- a/packages/atomic/src/pages/examples/fashion.html
+++ b/packages/atomic/src/pages/examples/fashion.html
@@ -91,7 +91,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box>
+          <atomic-search-box textarea>
             <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
             <atomic-search-box-instant-results image-size="small">
               <atomic-result-template>

--- a/packages/atomic/src/pages/examples/folding.html
+++ b/packages/atomic/src/pages/examples/folding.html
@@ -57,7 +57,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>

--- a/packages/atomic/src/pages/examples/headless.html
+++ b/packages/atomic/src/pages/examples/headless.html
@@ -48,7 +48,7 @@
   </head>
   <body>
     <atomic-search-interface>
-      <atomic-search-box></atomic-search-box>
+      <atomic-search-box textarea></atomic-search-box>
       <atomic-query-summary></atomic-query-summary>
       <atomic-result-list></atomic-result-list>
     </atomic-search-interface>

--- a/packages/atomic/src/pages/examples/horizontal-facets.html
+++ b/packages/atomic/src/pages/examples/horizontal-facets.html
@@ -44,7 +44,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="main">
           <atomic-layout-section section="horizontal-facets">

--- a/packages/atomic/src/pages/examples/ipx.html
+++ b/packages/atomic/src/pages/examples/ipx.html
@@ -203,7 +203,7 @@
       <atomic-ipx-modal is-open="true">
         <div slot="header">
           <atomic-layout-section class="search-section" section="search">
-            <atomic-search-box class="search-box"></atomic-search-box>
+            <atomic-search-box class="search-box" textarea></atomic-search-box>
             <atomic-ipx-refine-toggle></atomic-ipx-refine-toggle>
             <atomic-ipx-tabs>
               <atomic-ipx-tab label="All" expression="" active></atomic-ipx-tab>

--- a/packages/atomic/src/pages/examples/slack.html
+++ b/packages/atomic/src/pages/examples/slack.html
@@ -65,7 +65,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>

--- a/packages/atomic/src/pages/examples/standalone-results.html
+++ b/packages/atomic/src/pages/examples/standalone-results.html
@@ -48,7 +48,7 @@
     <atomic-search-interface>
       <atomic-search-layout>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>

--- a/packages/atomic/src/pages/examples/standalone.html
+++ b/packages/atomic/src/pages/examples/standalone.html
@@ -23,7 +23,7 @@
   </head>
   <body>
     <atomic-search-interface>
-      <atomic-search-box redirection-url="/examples/standalone-results.html"></atomic-search-box>
+      <atomic-search-box textarea redirection-url="/examples/standalone-results.html"></atomic-search-box>
     </atomic-search-interface>
     <script src="../header.js" type="text/javascript"></script>
   </body>

--- a/packages/atomic/src/pages/examples/suggestions.html
+++ b/packages/atomic/src/pages/examples/suggestions.html
@@ -98,7 +98,7 @@
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="search">
-          <atomic-search-box suggestion-timeout="1000">
+          <atomic-search-box textarea suggestion-timeout="1000">
             <custom-suggestions></custom-suggestions>
             <atomic-search-box-query-suggestions> </atomic-search-box-query-suggestions>
             <atomic-search-box-recent-queries icon="assets://xml.svg"> </atomic-search-box-recent-queries>

--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -137,7 +137,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>

--- a/packages/atomic/src/pages/visualTests.html
+++ b/packages/atomic/src/pages/visualTests.html
@@ -136,7 +136,7 @@
       <atomic-search-layout>
         <div class="header-bg"></div>
         <atomic-layout-section section="search">
-          <atomic-search-box></atomic-search-box>
+          <atomic-search-box textarea></atomic-search-box>
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>


### PR DESCRIPTION
For next major version, we would like to only support one mode (textarea, which allows input to expand).

Add warnings for future deprecation notice.

https://coveord.atlassian.net/browse/KIT-2688