### PR TITLE
[CAPI-92] Export right sort types

### DIFF
--- a/packages/headless/src/controllers/commerce/product-listing/sort/headless-product-listing-sort.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/sort/headless-product-listing-sort.ts
@@ -3,9 +3,6 @@ import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
 import {CoreEngine} from '../../../../app/engine';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
-import {applySort} from '../../../../features/commerce/sort/sort-actions';
-import {sortReducer as commerceSort} from '../../../../features/commerce/sort/sort-slice';
-import {updatePage} from '../../../../features/pagination/pagination-actions';
 import {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
@@ -16,7 +13,10 @@ import {
   SortCriterion,
   SortDirection,
   sortCriterionDefinition,
-} from '../../../../features/sort/sort';
+} from '../../../../features/commerce/sort/sort';
+import {applySort} from '../../../../features/commerce/sort/sort-actions';
+import {sortReducer as commerceSort} from '../../../../features/commerce/sort/sort-slice';
+import {updatePage} from '../../../../features/pagination/pagination-actions';
 import {ProductListingV2Section} from '../../../../state/state-sections';
 import {loadReducerError} from '../../../../utils/errors';
 import {validateInitialState} from '../../../../utils/validate-payload';


### PR DESCRIPTION
Instead of exporting the product listing sort types, the core sort ones were exported.
[CAPI-92]

[CAPI-92]: https://coveord.atlassian.net/browse/CAPI-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ