### PR TITLE
chore: use release branch(es) as tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ node('heavy && linux && docker') {
         --resolve ATOMIC_HOSTED_PAGE_MAJOR_VERSION=${atomicHostedPageMajor} \
         --resolve ATOMIC_HOSTED_PAGE_MINOR_VERSION=${atomicHostedPageMinor} \
         --resolve ATOMIC_HOSTED_PAGE_PATCH_VERSION=${atomicHostedPagePatch} \
+        --changeset ${env.GIT_COMMIT}
         || true"
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,17 +6,6 @@ def parseSemanticVersion(String version) {
 
 node('heavy && linux && docker') {
   checkout scm
-  def tag = sh(script: "git tag --contains", returnStdout: true).trim()
-  def isBump = !!tag
-  def isOnReleaseBranch = env.BRANCH_NAME == 'master'
-
-  if (!isOnReleaseBranch) {
-    return
-  }
-
-  if (!isBump) {
-    return
-  }
 
   withEnv(['npm_config_cache=npm-cache', 'CI=true', 'NODE_OPTIONS=--max_old_space_size=8192']) {
     withDockerContainer(image: 'node:18', args: '-u=root -e HOME=/tmp -e NPM_CONFIG_PREFIX=/tmp/.npm') {

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -13,6 +13,8 @@ import {
   gitUpdateRef,
   gitPublishBranch,
   gitPull,
+  gitSetRefOnCommit,
+  gitPush,
 } from '@coveo/semantic-monorepo-tools';
 import {createAppAuth} from '@octokit/auth-app';
 import {spawnSync} from 'child_process';
@@ -62,6 +64,17 @@ import {removeWriteAccessRestrictions} from './lock-master.mjs';
 
   // And push them
   await gitPushTags();
+
+  // Current release branch
+  // TODO v3: Bump to release/v3
+  const currentReleaseBranch = 'release/v2';
+  await gitCheckoutBranch('release/v2');
+  await gitSetRefOnCommit(
+    'origin',
+    `refs/heads/${currentReleaseBranch}`,
+    commit
+  );
+  await gitPush({refs: [currentReleaseBranch], force: true});
 
   // Unlock the main branch
   await removeWriteAccessRestrictions();


### PR DESCRIPTION
So, some fix/simplification to the Jenkins shenanigans.
To help Jenkins not get crazy with our thousand tags (indeed, in the long run, Jenkins might choke), I created a little special something: `release/*` branch(es).
This branch is protected and can only be touched by our robot and so are meant to be the absolute source of truth of what should be released.
Pushing on this branch triggers the release in Jenkins (no more logic in the Jenkinsfile, if your branch ain't release/*, Jenkins will not even start a build on it.)

Essentially, now, with that, Jenkins will only check the latest commit of our release branch (yep, no history, the rollout certifier just needs the sha to 👁️ , it can handle itself afterward)

A few boons:
- For v2, we will indeed only have to do a v2 branch on the last v2 commit and the release process will be able to continue smoothly.
- We will have a pointer on the 'latest release v2' even after we moved to v3.
- KISS. IMO, this is simpler.

Jenkins part is tested through replay.
GHA, will be next release.