### PR TITLE
test(cypress): wait for resources in cypress tests

### DIFF
--- a/packages/atomic/cypress/e2e/breadbox-assertions.ts
+++ b/packages/atomic/cypress/e2e/breadbox-assertions.ts
@@ -1,3 +1,4 @@
+import {TestFixture} from '../fixtures/test-fixture';
 import {deselectBreadcrumbAtIndex} from './breadbox-actions';
 import {BreadboxSelectors} from './breadbox-selectors';
 import {should} from './common-assertions';
@@ -61,15 +62,17 @@ export function assertRemoveBreadcrumbShowMoreInDOM() {
 
 export function assertDisplayBreadcrumbClearIcon() {
   it('should display a "Clear" icon next to each facetValue', () => {
-    BreadboxSelectors.breadcrumbClearFacetValueButton()
-      .its('length')
-      .then((count) => {
-        for (let i = 0; i < count; i++) {
-          BreadboxSelectors.breadcrumbClearFacetValueButtonAtIndex(i).should(
-            'be.visible'
-          );
-        }
-      });
+    cy.wait(TestFixture.interceptAliases.Build).then(() =>
+      BreadboxSelectors.breadcrumbClearFacetValueButton()
+        .its('length')
+        .then((count) => {
+          for (let i = 0; i < count; i++) {
+            BreadboxSelectors.breadcrumbClearFacetValueButtonAtIndex(i).should(
+              'be.visible'
+            );
+          }
+        })
+    );
   });
 }
 

--- a/packages/atomic/cypress/e2e/breadbox-selectors.ts
+++ b/packages/atomic/cypress/e2e/breadbox-selectors.ts
@@ -12,7 +12,7 @@ export const BreadboxSelectors = {
   breadcrumbValueAtIndex: (index: number) =>
     BreadboxSelectors.breadcrumbButtonValue().eq(index),
   breadcrumbClearFacetValueButton: () =>
-    BreadboxSelectors.breadcrumbButton().find('atomic-icon'),
+    BreadboxSelectors.breadcrumbButton().find('atomic-icon', {timeout: 8000}),
   breadcrumbClearFacetValueButtonAtIndex: (index: number) =>
     BreadboxSelectors.breadcrumbClearFacetValueButton().eq(index),
   clearAllButton: () => BreadboxSelectors.shadow().find('[part="clear"]'),

--- a/packages/atomic/cypress/e2e/breadbox-selectors.ts
+++ b/packages/atomic/cypress/e2e/breadbox-selectors.ts
@@ -1,3 +1,5 @@
+import {TestFixture} from '../fixtures/test-fixture';
+
 export const breadboxComponent = 'atomic-breadbox';
 export const BreadboxSelectors = {
   shadow: () => cy.get(breadboxComponent).shadow(),
@@ -12,7 +14,9 @@ export const BreadboxSelectors = {
   breadcrumbValueAtIndex: (index: number) =>
     BreadboxSelectors.breadcrumbButtonValue().eq(index),
   breadcrumbClearFacetValueButton: () =>
-    BreadboxSelectors.breadcrumbButton().find('atomic-icon', {timeout: 8000}),
+    cy
+      .wait(TestFixture.interceptAliases.Build)
+      .then(() => BreadboxSelectors.breadcrumbButton().find('atomic-icon')),
   breadcrumbClearFacetValueButtonAtIndex: (index: number) =>
     BreadboxSelectors.breadcrumbClearFacetValueButton().eq(index),
   clearAllButton: () => BreadboxSelectors.shadow().find('[part="clear"]'),

--- a/packages/atomic/cypress/e2e/facets/automatic-facet/automatic-facet-selectors.ts
+++ b/packages/atomic/cypress/e2e/facets/automatic-facet/automatic-facet-selectors.ts
@@ -35,13 +35,13 @@ export const AutomaticFacetSelectors = {
     return this.shadow().find('[part="label-button"]');
   },
   labelButtonIcon() {
-    return this.shadow().find('[part="label-button-icon"]');
+    return this.shadow().find('[part="label-button-icon"]', {timeout: 8000});
   },
   clearButton() {
     return this.shadow().find('[part="clear-button"]');
   },
   clearButtonIcon() {
-    return this.shadow().find('[part="clear-button-icon"]');
+    return this.shadow().find('[part="clear-button-icon"]', {timeout: 8000});
   },
   values() {
     return this.shadow().find('[part="values"]');
@@ -62,7 +62,7 @@ export const AutomaticFacetSelectors = {
     return this.shadow().find('[part="value-checkbox-label"]');
   },
   valueCheckboxIcon() {
-    return this.shadow().find('[part="value-checkbox-icon"]');
+    return this.shadow().find('[part="value-checkbox-icon"]', {timeout: 8000});
   },
   facetValueLabelAtIndex(index: number) {
     return this.valueLabel().eq(index);

--- a/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.cypress.ts
@@ -942,6 +942,7 @@ describe('Facet v1 Test Suites', () => {
           setupSelectedFacet();
           cy.wait(TestFixture.interceptAliases.Search);
         });
+
         CommonAssertions.assertAccessibility(breadboxComponent);
         BreadboxAssertions.assertDisplayBreadcrumb(true);
         BreadboxAssertions.assertDisplayBreadcrumbClearAllButton(true);

--- a/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet-selectors.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet-selectors.ts
@@ -1,3 +1,5 @@
+import {TestFixture} from '../../../fixtures/test-fixture';
+
 export const ratingFacetComponent = 'atomic-rating-facet';
 export const RatingFacetSelectors = {
   withId(id: string) {
@@ -76,6 +78,8 @@ export const RatingFacetSelectors = {
     return this.valueRating().eq(index);
   },
   starsIconAtIndex(index: number) {
-    return this.facetValueAtIndex(index).find('atomic-icon');
+    return cy
+      .wait(TestFixture.interceptAliases.Build)
+      .then(() => this.facetValueAtIndex(index).find('atomic-icon'));
   },
 };

--- a/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet-selectors.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet-selectors.ts
@@ -1,3 +1,5 @@
+import {TestFixture} from '../../../fixtures/test-fixture';
+
 export const ratingRangeFacetComponent = 'atomic-rating-range-facet';
 export const RatingRangeFacetSelectors = {
   withId(id: string) {
@@ -61,6 +63,8 @@ export const RatingRangeFacetSelectors = {
     return this.valueLabel().eq(index);
   },
   starsIconAtIndex(index: number) {
-    return this.facetValueAtIndex(index).find('atomic-icon');
+    return cy
+      .wait(TestFixture.interceptAliases.Build)
+      .then(() => this.facetValueAtIndex(index).find('atomic-icon'));
   },
 };

--- a/packages/atomic/cypress/e2e/pager.cypress.ts
+++ b/packages/atomic/cypress/e2e/pager.cypress.ts
@@ -152,17 +152,26 @@ describe('Pager Test Suites', () => {
 
   describe('Should allow customization of', () => {
     const iconTypes = ['previous', 'next'];
+    const testCustomIcon =
+      'https://raw.githubusercontent.com/coveo/ui-kit/master/packages/atomic/src/images/arrow-top-rounded.svg';
+
+    beforeEach(() => {
+      cy.intercept({
+        method: 'GET',
+        url: testCustomIcon,
+      }).as('custom-logo');
+    });
+
     iconTypes.forEach((iconType) => {
       it(`${iconType} icon`, () => {
         const iconSelector = `${iconType}-button-icon`;
-        const testCustomIcon =
-          'https://raw.githubusercontent.com/coveo/ui-kit/master/packages/atomic/src/images/arrow-top-rounded.svg';
 
         new TestFixture()
           .with(addPager({[iconSelector]: testCustomIcon}))
           .init();
 
-        cy.get('atomic-pager')
+        cy.wait('@custom-logo')
+          .get('atomic-pager')
           .shadow()
           .find(`[part="${iconSelector}"]`)
           .should('have.attr', 'icon')

--- a/packages/atomic/cypress/e2e/query-error-selectors.ts
+++ b/packages/atomic/cypress/e2e/query-error-selectors.ts
@@ -1,3 +1,4 @@
+import {TestFixture} from '../fixtures/test-fixture';
 import {AriaLiveSelectors} from './aria-live-selectors';
 
 export const queryErrorComponent = 'atomic-query-error';
@@ -7,7 +8,10 @@ export const QueryErrorSelectors = {
     QueryErrorSelectors.shadow().find('[part="more-info-btn"]'),
   moreInfoMessage: () =>
     QueryErrorSelectors.shadow().find('[part="error-info"]'),
-  icon: () => QueryErrorSelectors.shadow().find('atomic-icon'),
+  icon: () =>
+    cy
+      .wait(TestFixture.interceptAliases.Build)
+      .then(() => QueryErrorSelectors.shadow().find('atomic-icon')),
   errorTitle: () => QueryErrorSelectors.shadow().find('[part="title"]'),
   errorDescription: () =>
     QueryErrorSelectors.shadow().find('[part="description"]'),

--- a/packages/atomic/cypress/fixtures/fixture-common.ts
+++ b/packages/atomic/cypress/fixtures/fixture-common.ts
@@ -29,6 +29,7 @@ export const RouteAlias = {
   Quickview: '@coveoQuickview',
   Locale: '@locale',
   GenQAStream: '@genQAStream',
+  Build: '@build',
 };
 
 export const ConsoleAliases = {
@@ -80,8 +81,8 @@ export function setupIntercept() {
 
   cy.intercept({
     method: 'GET',
-    path: '/build/lang/**.json',
-  }).as(RouteAlias.Locale.substring(1));
+    url: /.*\/build\/[\w|-]+-[\d|\w]+\.js/,
+  }).as(RouteAlias.Build.substring(1));
 }
 
 export function getUABody() {

--- a/packages/atomic/cypress/fixtures/fixture-common.ts
+++ b/packages/atomic/cypress/fixtures/fixture-common.ts
@@ -83,6 +83,11 @@ export function setupIntercept() {
     method: 'GET',
     url: /.*\/build\/[\w|-]+-[\d|\w]+\.js/,
   }).as(RouteAlias.Build.substring(1));
+
+  cy.intercept({
+    method: 'GET',
+    path: '/build/lang/**.json',
+  }).as(RouteAlias.Locale.substring(1));
 }
 
 export function getUABody() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2848

Couldn't recreate this issue locally. Researched many best practices for this type of problem and pretty much everywhere I looked suggested that this was a matter of sequencing (e.g., we should be checking the component at every level rather than checking most of the component, and then jumping straight to an icon that's nested a couple of levels down).

I wanted to avoid rewriting a bunch of tests, so I instead decided to instead setup an intercept for any resources requests and make cypress wait for the requests to resolve before searching for the shadow element.

Note that I have to rely on a regex for because resources are loaded through webpack as JS files with hashes appended to the file name. Unfortunately, this means we end up waiting for some extra non-icon-related stuff to load before executing **_some_** tests. Thankfully, the amount of time it takes to wait for everything to load is quite minor and I suspect it will have an impact on the execution time of only a few seconds across our entire test-suite. Will closely compare these test executions with main and other branches to get an idea as to whether the impact is noticeable.