### PR TITLE
feat(headless): new logCitationHover method added to the generated answer controller

### DIFF
--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
@@ -16,7 +16,7 @@ import {
   logGeneratedAnswerFeedback,
   logGeneratedAnswerHideAnswers,
   logGeneratedAnswerShowAnswers,
-  logHoverGeneratedAnswerSource,
+  logHoverCitation,
   logLikeGeneratedAnswer,
   logOpenGeneratedAnswerSource,
 } from '../../features/generated-answer/generated-answer-analytics-actions';
@@ -168,7 +168,7 @@ describe('generated answer', () => {
 
     generatedAnswer.logCitationHover(testCitation.id, exampleDuration);
     const action = engine.findAsyncAction(
-      logHoverGeneratedAnswerSource(testCitation.id, exampleDuration).pending
+      logHoverCitation(testCitation.id, exampleDuration).pending
     );
 
     expect(action).toBeTruthy();

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
@@ -16,6 +16,7 @@ import {
   logGeneratedAnswerFeedback,
   logGeneratedAnswerHideAnswers,
   logGeneratedAnswerShowAnswers,
+  logHoverGeneratedAnswerSource,
   logLikeGeneratedAnswer,
   logOpenGeneratedAnswerSource,
 } from '../../features/generated-answer/generated-answer-analytics-actions';
@@ -156,6 +157,18 @@ describe('generated answer', () => {
     generatedAnswer.logCitationClick(testCitation.id);
     const action = engine.findAsyncAction(
       logOpenGeneratedAnswerSource(testCitation.id).pending
+    );
+
+    expect(action).toBeTruthy();
+  });
+
+  it('#logCitationHover dispatches analytics action', () => {
+    const testCitation = buildMockCitation();
+    const exampleDuration = 100;
+
+    generatedAnswer.logCitationHover(testCitation.id, exampleDuration);
+    const action = engine.findAsyncAction(
+      logHoverGeneratedAnswerSource(testCitation.id, exampleDuration).pending
     );
 
     expect(action).toBeTruthy();

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -22,6 +22,7 @@ import {
   logGeneratedAnswerShowAnswers,
   logGeneratedAnswerHideAnswers,
   logCopyGeneratedAnswer,
+  logHoverGeneratedAnswerSource,
 } from '../../features/generated-answer/generated-answer-analytics-actions';
 import {generatedAnswerReducer as generatedAnswer} from '../../features/generated-answer/generated-answer-slice';
 import {GeneratedAnswerState} from '../../features/generated-answer/generated-answer-state';
@@ -92,6 +93,12 @@ export interface GeneratedAnswer extends Controller {
    * Logs a custom event indicating the generated answer was copied to the clipboard.
    */
   logCopyToClipboard(): void;
+  /**
+   * Logs a custom event indicating a cited source link was hovered.
+   * @param citationId The ID of the clicked citation.
+   * @param citationHoverTimeMs The number of milliseconds spent hovering over the citation.
+   */
+  logCitationHover(citationId: string, citationHoverTimeMs: number): void;
 }
 
 export interface GeneratedAnswerProps {
@@ -216,6 +223,10 @@ export function buildGeneratedAnswer(
 
     logCitationClick(citationId: string) {
       dispatch(logOpenGeneratedAnswerSource(citationId));
+    },
+
+    logCitationHover(citationId: string, citationHoverTimeMs: number) {
+      dispatch(logHoverGeneratedAnswerSource(citationId, citationHoverTimeMs));
     },
 
     rephrase(responseFormat: GeneratedResponseFormat) {

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -22,7 +22,7 @@ import {
   logGeneratedAnswerShowAnswers,
   logGeneratedAnswerHideAnswers,
   logCopyGeneratedAnswer,
-  logHoverGeneratedAnswerSource,
+  logHoverCitation,
 } from '../../features/generated-answer/generated-answer-analytics-actions';
 import {generatedAnswerReducer as generatedAnswer} from '../../features/generated-answer/generated-answer-slice';
 import {GeneratedAnswerState} from '../../features/generated-answer/generated-answer-state';
@@ -226,7 +226,7 @@ export function buildGeneratedAnswer(
     },
 
     logCitationHover(citationId: string, citationHoverTimeMs: number) {
-      dispatch(logHoverGeneratedAnswerSource(citationId, citationHoverTimeMs));
+      dispatch(logHoverCitation(citationId, citationHoverTimeMs));
     },
 
     rephrase(responseFormat: GeneratedResponseFormat) {

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -55,6 +55,28 @@ export const logOpenGeneratedAnswerSource = (
     }
   );
 
+export const logHoverGeneratedAnswerSource = (
+  citationId: string,
+  citationHoverTimeMs: number
+): CustomAction =>
+  makeAnalyticsAction(
+    'analytics/generatedAnswer/hoverAnswerSource',
+    (client, state) => {
+      const generativeQuestionAnsweringId =
+        generativeQuestionAnsweringIdSelector(state);
+      const citation = citationSourceSelector(state, citationId);
+      if (!generativeQuestionAnsweringId || !citation) {
+        return null;
+      }
+      return client.makeGeneratedAnswerSourceHover({
+        generativeQuestionAnsweringId,
+        permanentId: citation.permanentid,
+        citationId: citation.id,
+        citationHoverTimeMs,
+      });
+    }
+  );
+
 export const logLikeGeneratedAnswer = (): CustomAction =>
   makeAnalyticsAction('analytics/generatedAnswer/like', (client, state) => {
     const generativeQuestionAnsweringId =

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -55,12 +55,12 @@ export const logOpenGeneratedAnswerSource = (
     }
   );
 
-export const logHoverGeneratedAnswerSource = (
+export const logHoverCitation = (
   citationId: string,
   citationHoverTimeMs: number
 ): CustomAction =>
   makeAnalyticsAction(
-    'analytics/generatedAnswer/hoverAnswerSource',
+    'analytics/generatedAnswer/hoverCitation',
     (client, state) => {
       const generativeQuestionAnsweringId =
         generativeQuestionAnsweringIdSelector(state);


### PR DESCRIPTION
[SFINT-5252](https://coveord.atlassian.net/browse/SFINT-5252)

- New `logCitationHover` method added to the generated answer controller.
- This new method will be called from the UI libraries (Atomic/Quantic) on hover over a citation of a generated answer for a given amount of time.

[SFINT-5252]: https://coveord.atlassian.net/browse/SFINT-5252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ