### PR TITLE
fix(headless): fix pino logging incorrectly

### DIFF
--- a/packages/headless/src/app/logger.ts
+++ b/packages/headless/src/app/logger.ts
@@ -14,6 +14,8 @@ export interface LoggerOptions {
   logFormatter?: (object: {}) => {};
   /**
    * Function which will be called after writing the log message in the browser.
+   *
+   * @deprecated This option is deprecated and will be removed in a future version.
    */
   browserPostLogHook?: (level: LogLevel, logEvent: LogEvent) => void;
 }
@@ -24,11 +26,6 @@ export function buildLogger(options: LoggerOptions | undefined) {
     level: options?.level || 'warn',
     formatters: {
       log: options?.logFormatter,
-    },
-    browser: {
-      transmit: {
-        send: options?.browserPostLogHook || (() => {}),
-      },
     },
   });
 }


### PR DESCRIPTION
Seems there's been some changes in Pino, and how they decide to log browser message to the console.

The symptom: By default, we set Pino level to `warn` -> We would still see `trace` or `info` level message appearing in the browser.

As soon as you use the `transmit` option, the message gets printed to the console, no matter what logging level is configured. This seems like intended behaviour from the maintainer of the library, from what I could read on their Github issues.

I've taken the editorial choice of just deprecating the `browserPostLogHook` function, which is something I'd be very surprised is used by anyone.

https://coveord.atlassian.net/browse/KIT-2858