### PR TITLE
[CAPI-223] POC commerce search

### DIFF
--- a/packages/headless/src/app/commerce-engine/commerce-engine.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ts
@@ -21,6 +21,7 @@ import {
   CommerceEngineConfiguration,
   commerceEngineConfigurationSchema,
 } from './commerce-engine-configuration';
+import {searchReducer} from '../../features/commerce/search/search-slice';
 
 export type {CommerceEngineConfiguration};
 
@@ -29,6 +30,7 @@ const commerceEngineReducers = {
   commercePagination: paginationReducer,
   commerceSort: sortReducer,
   commerceContext: contextReducer,
+  commerceSearch: searchReducer,
   cart: cartReducer,
 };
 type CommerceEngineReducers = typeof commerceEngineReducers;

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -79,10 +79,10 @@ export type {
   SortByFields,
   SortByFieldsFields,
   SortCriterion,
-  SortProps,
-  SortInitialState,
+  CoreSortProps,
+  CoreSortInitialState,
   Sort,
-  SortState,
+  CoreSortState,
 } from './controllers/commerce/product-listing/sort/headless-product-listing-sort';
 export {
   buildSort,

--- a/packages/headless/src/controllers/commerce/search/headless-search.tsx
+++ b/packages/headless/src/controllers/commerce/search/headless-search.tsx
@@ -1,0 +1,92 @@
+import {logInterfaceLoad, logOmniboxFromLink, logSearchFromLink} from '../../../features/analytics/analytics-actions';
+import {
+  StandaloneSearchBoxAnalytics
+} from '../../../features/standalone-search-box-set/standalone-search-box-set-state';
+import {loadReducerError} from '../../../utils/errors';
+import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
+import {buildController, Controller} from '../../controller/headless-controller';
+import {contextReducer as commerceContext} from '../../../features/commerce/context/context-slice';
+import {searchReducer as commerceSearch} from '../../../features/commerce/search/search-slice';
+import {configuration} from '../../../app/common-reducers';
+import {SearchAction} from '../../../features/analytics/analytics-utils';
+import {executeSearch} from '../../../features/commerce/search/search-actions';
+import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
+import {CommerceAPIErrorStatusResponse} from '../../../api/commerce/commerce-api-error-response';
+
+export interface Search extends Controller {
+  /**
+   * Executes the first search.
+   *
+   * @param analyticsEvent - The analytics event to log in association with the first search. If unspecified, `logInterfaceLoad` will be used.
+   */
+  executeFirstSearch(analyticsEvent?: SearchAction): void;
+
+  /**
+   * Executes the first search, and logs the analytics event that triggered a redirection from a standalone search box.
+   *
+   * @param analytics - The standalone search box analytics data.
+   */
+  executeFirstSearchAfterStandaloneSearchBoxRedirect(
+    analytics: StandaloneSearchBoxAnalytics
+  ): void;
+
+  /**
+   * A scoped and simplified part of the headless state that is relevant to the `Search` controller.
+   */
+  state: SearchState
+}
+
+export interface SearchState {
+  products: ProductRecommendation[];
+  error: CommerceAPIErrorStatusResponse | null;
+  isLoading: boolean;
+  responseId: string;
+}
+
+export function buildSearch(engine: CommerceEngine): Search {
+  if (!loadBaseSearchReducers(engine)) {
+    throw loadReducerError;
+  }
+
+  const controller = buildController(engine);
+  const {dispatch} = engine;
+  const getState = () => engine.state;
+
+  return {
+    ...controller,
+
+    get state() {
+      return getState().commerceSearch;
+    },
+
+    executeFirstSearch(analyticsEvent = logInterfaceLoad()) {
+      const firstSearchExecuted = engine.state.commerceSearch.responseId !== '';
+
+      if (firstSearchExecuted) {
+        return;
+      }
+
+      const action = executeSearch(analyticsEvent);
+      dispatch(action);
+    },
+
+    executeFirstSearchAfterStandaloneSearchBoxRedirect(
+      analytics: StandaloneSearchBoxAnalytics
+    ) {
+      const {cause, metadata} = analytics;
+      const event =
+        metadata && cause === 'omniboxFromLink'
+          ? logOmniboxFromLink(metadata)
+          : logSearchFromLink();
+
+      this.executeFirstSearch(event);
+    },
+  };
+}
+
+function loadBaseSearchReducers(
+  engine: CommerceEngine
+): engine is CommerceEngine {
+  engine.addReducers({commerceContext, configuration, commerceSearch});
+  return true;
+}

--- a/packages/headless/src/controllers/commerce/search/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/commerce/search/search-box/headless-search-box.ts
@@ -1,0 +1,54 @@
+import {logSearchboxSubmit} from '../../../../features/query/query-analytics-actions';
+import {executeSearch, fetchQuerySuggestions} from '../../../../features/commerce/search/search-actions';
+import {SuggestionHighlightingOptions, Delimiters} from '../../../../utils/highlight';
+import {
+  buildCoreSearchBox, SearchBox,
+  SearchBoxState,
+  Suggestion,
+} from '../../../core/search-box/headless-core-search-box';
+import {SearchBoxOptions} from '../../../core/search-box/headless-core-search-box-options';
+import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+
+export type {
+  SearchBoxOptions,
+  SearchBoxState,
+  SuggestionHighlightingOptions,
+  Suggestion,
+  SearchBox,
+  Delimiters,
+};
+
+export interface SearchBoxProps {
+  /**
+   * The `SearchBox` controller options.
+   */
+  options?: SearchBoxOptions;
+}
+
+/**
+ * Creates a commerce `SearchBox` controller instance.
+ *
+ * @param engine - The commerce engine.
+ * @param props - The configurable `SearchBox` properties.
+ * @returns A `SearchBox` controller instance.
+ */
+export function buildSearchBox(
+  engine: CommerceEngine,
+  props: SearchBoxProps = {}
+): SearchBox {
+  const searchBox = buildCoreSearchBox(engine, {
+    ...props,
+    executeSearchActionCreator: executeSearch,
+    fetchQuerySuggestionsActionCreator: fetchQuerySuggestions,
+  });
+
+  return {
+    ...searchBox,
+    submit() {
+      searchBox.submit(logSearchboxSubmit());
+    },
+    get state() {
+      return searchBox.state;
+    },
+  };
+}

--- a/packages/headless/src/controllers/commerce/search/sort/headless-search-sort.ts
+++ b/packages/headless/src/controllers/commerce/search/sort/headless-search-sort.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
 import {
   buildFieldsSortCriterion,
   buildRelevanceSortCriterion,
@@ -11,9 +10,8 @@ import {
   SortDirection,
 } from '../../../../features/commerce/sort/sort';
 import {buildCoreSort, CoreSortProps, CoreSortInitialState, CoreSort, CoreSortState} from '../../sort/headless-sort';
-import {applySort} from '../../../../features/commerce/sort/sort-actions';
-import {updatePage} from '../../../../features/pagination/pagination-actions';
-import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
+import {searchReducer as commerceSearch} from '../../../../features/commerce/search/search-slice';
+import {executeSearch} from '../../../../features/commerce/search/search-actions';
 
 export type {
   SortByRelevance, SortByFields, SortByFieldsFields, SortCriterion,
@@ -31,21 +29,21 @@ export {
 export type Sort = CoreSort;
 
 /**
- * Creates a `Sort` controller instance for the product listing.
+ * Creates a `Sort` controller instance for the search.
  *
  * @param engine - The headless engine.
  * @param props - The configurable `Sort` controller properties.
  * @returns A `Sort` controller instance.
  */
 export function buildSort(engine: CommerceEngine, props: CoreSortProps = {}): Sort {
-  const controller = buildCoreSort(engine, props, {productListing});
+  const controller = buildCoreSort(engine, props, {commerceSearch})
 
   return {
     ...controller,
 
     sortBy(criterion: SortCriterion) {
       controller.sortBy(criterion);
-      engine.dispatch(fetchProductListing());
+      engine.dispatch(executeSearch());
     },
   }
 }

--- a/packages/headless/src/controllers/commerce/sort/headless-sort.ts
+++ b/packages/headless/src/controllers/commerce/sort/headless-sort.ts
@@ -1,0 +1,161 @@
+import {Schema} from '@coveo/bueno';
+import {
+  buildFieldsSortCriterion,
+  buildRelevanceSortCriterion,
+  SortBy,
+  SortByFields,
+  SortByFieldsFields,
+  SortByRelevance,
+  SortCriterion,
+  SortDirection,
+  sortCriterionDefinition,
+} from '../../../features/commerce/sort/sort';
+import {applySort} from '../../../features/commerce/sort/sort-actions';
+import {sortReducer as commerceSort} from '../../../features/commerce/sort/sort-slice';
+import {updatePage} from '../../../features/pagination/pagination-actions';
+import {loadReducerError} from '../../../utils/errors';
+import {validateInitialState} from '../../../utils/validate-payload';
+import {
+  buildController,
+  Controller,
+} from '../../controller/headless-controller';
+import { ReducersMapObject } from '@reduxjs/toolkit';
+import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
+import {fetchProductListing} from '../../../features/commerce/product-listing/product-listing-actions';
+import {executeSearch} from '../../../features/commerce/search/search-actions';
+
+export type {SortByRelevance, SortByFields, SortByFieldsFields, SortCriterion};
+export {
+  SortBy,
+  SortDirection,
+  buildRelevanceSortCriterion,
+  buildFieldsSortCriterion,
+};
+
+export interface CoreSortProps {
+  /**
+   * The initial state that should be applied to this `Sort` controller.
+   */
+  initialState?: CoreSortInitialState;
+}
+
+export interface CoreSortInitialState {
+  /**
+   * The initial sort criterion to register in state.
+   */
+  criterion?: SortCriterion;
+}
+
+function validateSortInitialState(
+  engine: CommerceEngine,
+  state: CoreSortInitialState | undefined
+) {
+  if (!state) {
+    return;
+  }
+
+  const schema = new Schema<CoreSortInitialState>({
+    criterion: sortCriterionDefinition,
+  });
+
+  validateInitialState(engine, schema, state, 'buildSort');
+}
+
+export interface CoreSort extends Controller {
+  /**
+   * Updates the sort criterion.
+   *
+   * @param criterion - The new sort criterion.
+   */
+  sortBy(criterion: SortCriterion): void;
+
+  /**
+   * Checks whether the specified sort criterion matches the value in state.
+   *
+   * @param criterion - The criterion to compare.
+   * @returns `true` if the passed sort criterion matches the value in state, and `false` otherwise.
+   */
+  isSortedBy(criterion: SortCriterion): boolean;
+
+  /**
+   * Checks whether the specified sort criterion is available.
+   *
+   * @param criterion - The criterion to check for.
+   * @returns `true` if the passed sort criterion is available, and `false` otherwise.
+   */
+  isAvailable(criterion: SortCriterion): boolean;
+
+  /**
+   * A scoped and simplified part of the headless state that is relevant to the `Sort` controller.
+   */
+  state: CoreSortState;
+}
+
+export interface CoreSortState {
+  /**
+   * The current sort criterion.
+   */
+  appliedSort: SortCriterion;
+
+  /**
+   * The available sort criteria.
+   */
+  availableSorts: SortCriterion[];
+}
+
+/**
+ * Creates a `CoreSort` controller instance.
+ *
+ * @param engine - The headless engine.
+ * @param props - The configurable `Sort` controller properties.
+ * @param reducers - The reducers to apply on the `Sort` controller state.
+ * @returns A `Sort` controller instance.
+ */
+export function buildCoreSort(engine: CommerceEngine, props: CoreSortProps = {}, reducers: ReducersMapObject): CoreSort {
+  if (!loadSortReducers(engine, reducers)) {
+    throw loadReducerError;
+  }
+
+  const {dispatch} = engine;
+  const controller = buildController(engine);
+  const getState = () => engine.state;
+
+  validateSortInitialState(engine, props.initialState);
+
+  const criterion = props.initialState?.criterion;
+
+  if (criterion) {
+    dispatch(applySort(criterion));
+  }
+
+  return {
+    ...controller,
+
+    get state() {
+      return getState().commerceSort;
+    },
+
+    sortBy(criterion: SortCriterion) {
+      dispatch(applySort(criterion));
+      dispatch(updatePage(0));
+    },
+
+    isSortedBy(criterion: SortCriterion) {
+      return (
+        JSON.stringify(this.state.appliedSort) === JSON.stringify(criterion)
+      );
+    },
+
+    isAvailable(criterion: SortCriterion) {
+      return this.state.availableSorts.some(
+        (availableCriterion) =>
+          JSON.stringify(availableCriterion) === JSON.stringify(criterion)
+      );
+    },
+  };
+}
+
+export function loadSortReducers(engine: CommerceEngine, reducers: ReducersMapObject): engine is CommerceEngine {
+  engine.addReducers({commerceSort, ...reducers});
+  return true;
+}

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -136,6 +136,9 @@ export type ProductListingAction =
 export type ProductListingV2Action =
   PreparableAnalyticsAction<StateNeededByCommerceAnalyticsProvider>;
 
+export type CommerceSearchAction =
+  PreparableAnalyticsAction<StateNeededByCommerceAnalyticsProvider>;
+
 export interface AsyncThunkAnalyticsOptions<
   T extends StateNeededBySearchAnalyticsProvider,
 > {

--- a/packages/headless/src/features/commerce/search/search-actions.ts
+++ b/packages/headless/src/features/commerce/search/search-actions.ts
@@ -1,0 +1,72 @@
+import {CommerceSearchAction, SearchAction} from '../../analytics/analytics-utils';
+import {AsyncThunkSearchOptions, isErrorResponse} from '../../../api/search/search-api-client';
+import {buildSearchRequest} from '../../search/search-request';
+import {AsyncSearchThunkProcessor, StateNeededByExecuteSearch} from '../../search/search-actions-thunk-processor';
+import {addEntryInActionsHistory, ExecuteSearchThunkReturn} from '../../search/search-actions';
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import {
+  buildQuerySuggestRequest,
+  FetchQuerySuggestionsActionCreatorPayload,
+  FetchQuerySuggestionsThunkReturn, StateNeededByQuerySuggest
+} from '../../query-suggest/query-suggest-actions';
+import {requiredNonEmptyString} from '../../../utils/validate-payload';
+
+
+export const executeSearch = createAsyncThunk<
+  ExecuteSearchThunkReturn,
+  CommerceSearchAction,
+  AsyncThunkSearchOptions<StateNeededByExecuteSearch>
+>('commerce/search/executeSearch', async (searchAction: CommerceSearchAction, config) => {
+  const state = config.getState();
+  addEntryInActionsHistory(state);
+
+  const {analyticsClientMiddleware, preprocessRequest, logger} = config.extra;
+  const {description: eventDescription} = await searchAction.prepare({
+    getState: () => config.getState(),
+    analyticsClientMiddleware,
+    preprocessRequest,
+    logger,
+  });
+
+  const request = await buildSearchRequest(state, eventDescription);
+
+  // TODO(nico): Use commerce processor with commerce client
+  const processor = new AsyncSearchThunkProcessor<
+    ReturnType<typeof config.rejectWithValue>
+  >({...config, analyticsAction: searchAction});
+
+  const fetched = await processor.fetchFromAPI(request, {origin: 'mainSearch'});
+
+  return await processor.process(fetched);
+});
+
+export const fetchQuerySuggestions = createAsyncThunk<
+  FetchQuerySuggestionsThunkReturn,
+  FetchQuerySuggestionsActionCreatorPayload,
+  AsyncThunkSearchOptions<StateNeededByQuerySuggest>
+>(
+  'commerce/querySuggest/fetch',
+
+  async (
+    payload: {id: string},
+    {getState, rejectWithValue, extra: {apiClient, validatePayload}}
+  ) => {
+    validatePayload(payload, {
+      id: requiredNonEmptyString,
+    });
+    const id = payload.id;
+    const request = await buildQuerySuggestRequest(id, getState());
+    // TODO(nico): Use commerce service client with passthrough request
+    const response = await apiClient.querySuggest(request);
+
+    if (isErrorResponse(response)) {
+      return rejectWithValue(response.error);
+    }
+
+    return {
+      id,
+      q: request.q,
+      ...response.success,
+    };
+  }
+);

--- a/packages/headless/src/features/commerce/search/search-slice.ts
+++ b/packages/headless/src/features/commerce/search/search-slice.ts
@@ -1,0 +1,10 @@
+import {createReducer} from '../../../ssr.index';
+import {getCommerceSearchInitialState} from './search-state';
+
+export const searchReducer = createReducer(
+  getCommerceSearchInitialState(),
+
+  (builder) => {
+    builder
+  }
+);

--- a/packages/headless/src/features/commerce/search/search-state.ts
+++ b/packages/headless/src/features/commerce/search/search-state.ts
@@ -1,0 +1,19 @@
+import {CommerceAPIErrorStatusResponse} from '../../../api/commerce/commerce-api-error-response';
+import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
+import {AnyFacetResponse} from '../../facets/generic/interfaces/generic-facet-response';
+
+export interface CommerceSearchState {
+  error: CommerceAPIErrorStatusResponse | null;
+  isLoading: boolean;
+  responseId: string;
+  products: ProductRecommendation[];
+  facets: AnyFacetResponse[];
+}
+
+export const getCommerceSearchInitialState = (): CommerceSearchState => ({
+  error: null,
+  isLoading: false,
+  responseId: '',
+  products: [],
+  facets: [],
+});

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -293,7 +293,7 @@ const buildFetchFacetValuesRequest = async (
   return mappedRequest;
 };
 
-const addEntryInActionsHistory = (state: StateNeededByExecuteSearch) => {
+export const addEntryInActionsHistory = (state: StateNeededByExecuteSearch) => {
   if (state.configuration.analytics.enabled) {
     historyStore.addElement({
       name: 'Query',


### PR DESCRIPTION
🔔 This PR will **NOT** be merged. Some parts may be reused in work done as part of CAPI-243.

--- 

The goal of this POC was to figure out the work needed to support the Search solution type in the headless commerce sub-package.

This PR:
- Creates search & search box controllers
- Creates a core sort controller from the current product listing sort controller, and then implements it for both search and product listings. I've created 2 different controllers, but we might want to have a single controller that knows about both Search and Listings. TBD
- Copies over search actions

I've also added two integration tests that show:
- The reuse of a controller that **does not** need to be adapted for search (the context controller)
- The use of a controller that **does** need to be adapted for search (sort controller)

Furthermore, contrary to the search and insight engines which expose search methods directly on the Engine, I've chosen to expose search methods through a controller. This fits better with the structure of having the commerce engine support three solutions types (search, listings, recs). ❗ **I'm also open to exposing these search methods directly on the engines, I just haven't found any reason to do so yet!** ❗

Finally, this PR makes it evident that we need a query suggest route on the API to fully support search as a solution type in commerce headless.

[CAPI-223]

[CAPI-223]: https://coveord.atlassian.net/browse/CAPI-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAPI-243]: https://coveord.atlassian.net/browse/CAPI-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ