### PR TITLE
fix(headless): update extendedResults on all fulfilled searches

### DIFF
--- a/packages/headless/src/features/search/search-slice.test.ts
+++ b/packages/headless/src/features/search/search-slice.test.ts
@@ -226,6 +226,27 @@ describe('search-slice', () => {
 
       expect(finalState.questionAnswer).toEqual(originalQuestionAnswers);
     });
+
+    it('when a fetchMoreResults fulfilled is received, it updates the #extendedResults', () => {
+      state.extendedResults = {
+        generativeQuestionAnsweringId: 'an_initial_id',
+      };
+      const response = buildMockSearchResponse({results: [newResult]});
+      const expected = {
+        generativeQuestionAnsweringId: 'a_new_id',
+      };
+      response.extendedResults = expected;
+      const search = buildMockSearch({
+        response,
+      });
+
+      const finalState = searchReducer(
+        state,
+        fetchMoreResults.fulfilled(search, '')
+      );
+
+      expect(finalState.extendedResults).toBe(expected);
+    });
   });
 
   describe('handles rejected searches correctly', () => {

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -37,6 +37,7 @@ function handleFulfilledSearch(
   state.queryExecuted = action.payload.queryExecuted;
   state.duration = action.payload.duration;
   state.isLoading = false;
+  state.extendedResults = action.payload.response.extendedResults;
 }
 
 function handleFulfilledNewSearch(
@@ -47,7 +48,6 @@ function handleFulfilledNewSearch(
   state.results = action.payload.response.results;
   state.searchResponseId = action.payload.response.searchUid;
   state.questionAnswer = action.payload.response.questionAnswer;
-  state.extendedResults = action.payload.response.extendedResults;
 }
 
 function handlePendingSearch(


### PR DESCRIPTION
## The Issue ##
Fetching more results using the pager or the resultsPerPage component returns a new `generativeQuestionAnsweringId` but no new stream is initiated.

## The Fix ##
Update the redux state with the new `generativeQuestionAnsweringId` causing a new stream to be triggered.