### PR TITLE
refactor(analytics): allow search events to go through a new clean path

### DIFF
--- a/packages/headless/src/app/analytics-middleware.test.ts
+++ b/packages/headless/src/app/analytics-middleware.test.ts
@@ -2,9 +2,9 @@ import {logSearchboxSubmit} from '../features/query/query-analytics-actions';
 import {
   executeSearch,
   ExecuteSearchThunkReturn,
-} from '../features/search/search-actions';
+} from '../features/search/legacy/search-actions';
 import {buildMockSearchAppEngine} from '../test/mock-engine';
-import {buildMockSearch} from '../test/mock-search';
+import {buildMockLegacySearch} from '../test/mock-search';
 
 describe('analytics middleware', () => {
   beforeEach(() => {
@@ -22,7 +22,8 @@ describe('analytics middleware', () => {
 
   it('correctly pass through a search action with no analytics payload', () => {
     const e = buildMockSearchAppEngine();
-    const {analyticsAction, ...mockSearchWithoutAnalytics} = buildMockSearch();
+    const {analyticsAction, ...mockSearchWithoutAnalytics} =
+      buildMockLegacySearch();
 
     const action = executeSearch.fulfilled(
       mockSearchWithoutAnalytics as ExecuteSearchThunkReturn,
@@ -35,7 +36,7 @@ describe('analytics middleware', () => {
 
   it('correctly pass through a search action with an analytics payload', () => {
     const e = buildMockSearchAppEngine();
-    const mockSearch = buildMockSearch();
+    const mockSearch = buildMockLegacySearch();
 
     const action = executeSearch.fulfilled(
       mockSearch,
@@ -48,7 +49,7 @@ describe('analytics middleware', () => {
 
   it('correctly queue log analytics after search action', () => {
     const e = buildMockSearchAppEngine();
-    const mockSearch = buildMockSearch();
+    const mockSearch = buildMockLegacySearch();
 
     const action = executeSearch.fulfilled(
       mockSearch,
@@ -62,7 +63,7 @@ describe('analytics middleware', () => {
 
   it('correctly remove analytics payload from action', () => {
     const e = buildMockSearchAppEngine();
-    const mockSearch = buildMockSearch();
+    const mockSearch = buildMockLegacySearch();
 
     const action = executeSearch.fulfilled(
       mockSearch,

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -146,7 +146,7 @@ export function buildSearchEngine(options: SearchEngineOptions): SearchEngine {
         return;
       }
 
-      const action = executeSearch(analyticsEvent);
+      const action = executeSearch({legacy: analyticsEvent});
       engine.dispatch(action);
     },
 

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -138,7 +138,7 @@ export function buildBreadcrumbManager(
         dispatch(
           updateFreezeCurrentValues({facetId, freezeCurrentValues: false})
         );
-        dispatch(executeSearch(analyticsAction));
+        dispatch(executeSearch({legacy: analyticsAction}));
       },
       executeToggleExclude: ({facetId, selection}) => {
         const analyticsAction = logFacetBreadcrumb({
@@ -149,7 +149,7 @@ export function buildBreadcrumbManager(
         dispatch(
           updateFreezeCurrentValues({facetId, freezeCurrentValues: false})
         );
-        dispatch(executeSearch(analyticsAction));
+        dispatch(executeSearch({legacy: analyticsAction}));
       },
       facetValuesSelector: facetResponseActiveValuesSelector,
     };
@@ -165,11 +165,11 @@ export function buildBreadcrumbManager(
       facetSet: getState().numericFacetSet,
       executeToggleSelect: (payload) => {
         dispatch(toggleSelectNumericFacetValue(payload));
-        dispatch(executeSearch(logNumericFacetBreadcrumb(payload)));
+        dispatch(executeSearch({legacy: logNumericFacetBreadcrumb(payload)}));
       },
       executeToggleExclude: (payload) => {
         dispatch(toggleExcludeNumericFacetValue(payload));
-        dispatch(executeSearch(logNumericFacetBreadcrumb(payload)));
+        dispatch(executeSearch({legacy: logNumericFacetBreadcrumb(payload)}));
       },
       facetValuesSelector: numericFacetActiveValuesSelector,
     };
@@ -183,11 +183,11 @@ export function buildBreadcrumbManager(
         facetSet: getState().dateFacetSet,
         executeToggleSelect: (payload) => {
           dispatch(toggleSelectDateFacetValue(payload));
-          dispatch(executeSearch(logDateFacetBreadcrumb(payload)));
+          dispatch(executeSearch({legacy: logDateFacetBreadcrumb(payload)}));
         },
         executeToggleExclude: (payload) => {
           dispatch(toggleExcludeDateFacetValue(payload));
-          dispatch(executeSearch(logDateFacetBreadcrumb(payload)));
+          dispatch(executeSearch({legacy: logDateFacetBreadcrumb(payload)}));
         },
         facetValuesSelector: dateFacetActiveValuesSelector,
       };
@@ -213,14 +213,14 @@ export function buildBreadcrumbManager(
       deselect: () => {
         dispatch(deselectAllCategoryFacetValues(facetId));
         dispatch(
-          executeSearch(
-            logCategoryFacetBreadcrumb({
+          executeSearch({
+            legacy: logCategoryFacetBreadcrumb({
               categoryFacetPath: path.map(
                 (categoryFacetValue) => categoryFacetValue.value
               ),
               categoryFacetId: facetId,
-            })
-          )
+            }),
+          })
         );
       },
     };
@@ -260,7 +260,7 @@ export function buildBreadcrumbManager(
         } else if (value.state === 'excluded') {
           dispatch(toggleExcludeStaticFilterValue({id, value}));
         }
-        dispatch(executeSearch(analytics));
+        dispatch(executeSearch({legacy: analytics}));
       },
     };
   };
@@ -304,7 +304,7 @@ export function buildBreadcrumbManager(
             selection,
           })
         );
-        dispatch(executeSearch(analyticsAction));
+        dispatch(executeSearch({legacy: analyticsAction}));
       },
     };
   };
@@ -337,7 +337,7 @@ export function buildBreadcrumbManager(
 
     deselectAll: () => {
       controller.deselectAll();
-      dispatch(executeSearch(logClearBreadcrumbs()));
+      dispatch(executeSearch({legacy: logClearBreadcrumbs()}));
     },
   };
 }

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.test.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.test.ts
@@ -68,6 +68,7 @@ describe('headless CoreSearchBox', () => {
       options,
       executeSearchActionCreator: executeSearch,
       fetchQuerySuggestionsActionCreator: fetchQuerySuggestions,
+      isNextAnalyticsReady: true,
     };
 
     initState();

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
@@ -21,7 +21,10 @@ import {querySuggestReducer as querySuggest} from '../../../features/query-sugge
 import {QuerySuggestState} from '../../../features/query-suggest/query-suggest-state';
 import {logSearchboxSubmit} from '../../../features/query/query-analytics-actions';
 import {queryReducer as query} from '../../../features/query/query-slice';
-import {prepareForSearchWithQuery} from '../../../features/search/search-actions';
+import {
+  TransitiveSearchAction,
+  prepareForSearchWithQuery,
+} from '../../../features/search/search-actions';
 import {searchReducer as search} from '../../../features/search/search-slice';
 import {
   ConfigurationSection,
@@ -50,12 +53,22 @@ import {
 
 export type {SearchBoxOptions, SuggestionHighlightingOptions, Delimiters};
 
-export interface SearchBoxProps {
-  /**
-   * The `SearchBox` controller options.
-   */
-  options?: SearchBoxOptions;
+export type SearchBoxProps = SearchBoxPropsBase &
+  (NextSearchBoxProps | LegacySearchBoxProps);
 
+interface NextSearchBoxProps {
+  /**
+   * The action creator for the `executeSearch` thunk action.
+   */
+  executeSearchActionCreator: (
+    arg: TransitiveSearchAction
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => AsyncThunkAction<any, TransitiveSearchAction, any>;
+
+  isNextAnalyticsReady: true;
+}
+
+interface LegacySearchBoxProps {
   /**
    * The action creator for the `executeSearch` thunk action.
    */
@@ -64,6 +77,28 @@ export interface SearchBoxProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => AsyncThunkAction<any, SearchAction, any>;
 
+  isNextAnalyticsReady: false;
+}
+
+interface SearchBoxPropsBase {
+  /**
+   * The `SearchBox` controller options.
+   */
+  options?: SearchBoxOptions;
+
+  /**
+   * The action creator for the `executeSearch` thunk action.
+   */
+  executeSearchActionCreator:
+    | ((
+        arg: TransitiveSearchAction
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ) => AsyncThunkAction<any, TransitiveSearchAction, any>)
+    | ((
+        arg: SearchAction
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ) => AsyncThunkAction<any, SearchAction, any>);
+
   /**
    * The action creator for the `fetchQuerySuggestions` thunk action.
    */
@@ -71,6 +106,8 @@ export interface SearchBoxProps {
     arg: FetchQuerySuggestionsActionCreatorPayload
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => AsyncThunkAction<any, FetchQuerySuggestionsActionCreatorPayload, any>;
+  //Indicate if the executeSearchActionCreator can use the new analytics logic.
+  isNextAnalyticsReady: boolean;
 }
 
 /**
@@ -191,7 +228,7 @@ export function buildCoreSearchBox(
 
   const getValue = () => engine.state.querySet[options.id];
 
-  const performSearch = async (analytics: SearchAction) => {
+  const performSearch = async (analytics: TransitiveSearchAction) => {
     const {enableQuerySyntax, clearFilters} = options;
 
     dispatch(
@@ -201,8 +238,11 @@ export function buildCoreSearchBox(
         clearFilters,
       })
     );
-
-    await dispatch(props.executeSearchActionCreator(analytics));
+    if (props.isNextAnalyticsReady) {
+      dispatch(props.executeSearchActionCreator(analytics));
+    } else {
+      dispatch(props.executeSearchActionCreator(analytics.legacy));
+    }
   };
 
   return {
@@ -226,15 +266,15 @@ export function buildCoreSearchBox(
 
     selectSuggestion(value: string) {
       dispatch(selectQuerySuggestion({id, expression: value}));
-      performSearch(logQuerySuggestionClick({id, suggestion: value})).then(
-        () => {
-          dispatch(clearQuerySuggest({id}));
-        }
-      );
+      performSearch({
+        legacy: logQuerySuggestionClick({id, suggestion: value}),
+      }).then(() => {
+        dispatch(clearQuerySuggest({id}));
+      });
     },
 
     submit(analytics: SearchAction | InsightAction = logSearchboxSubmit()) {
-      performSearch(analytics);
+      performSearch({legacy: analytics});
       dispatch(clearQuerySuggest({id}));
     },
 

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -33,7 +33,7 @@ export function buildDidYouMean(engine: SearchEngine): DidYouMean {
 
     applyCorrection() {
       controller.applyCorrection();
-      dispatch(executeSearch(logDidYouMeanClick()));
+      dispatch(executeSearch({legacy: logDidYouMeanClick()}));
     },
   };
 }

--- a/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
@@ -46,13 +46,15 @@ export function buildAutomaticFacet(
     toggleSelect(selection: FacetValue) {
       dispatch(toggleSelectAutomaticFacetValue({field, selection}));
       dispatch(
-        executeSearch(getAnalyticsActionForToggleFacetSelect(field, selection))
+        executeSearch({
+          legacy: getAnalyticsActionForToggleFacetSelect(field, selection),
+        })
       );
     },
 
     deselectAll() {
       dispatch(deselectAllAutomaticFacetValues(field));
-      dispatch(executeSearch(logFacetClearAll(field)));
+      dispatch(executeSearch({legacy: logFacetClearAll(field)}));
     },
 
     get state() {

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
@@ -51,7 +51,9 @@ export function buildCategoryFacetSearch(
       coreFacetSearch.select(value);
       dispatch(updateFacetOptions());
       dispatch(
-        executeSearch(logFacetSelect({facetId, facetValue: value.rawValue}))
+        executeSearch({
+          legacy: logFacetSelect({facetId, facetValue: value.rawValue}),
+        })
       );
     },
 

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -94,29 +94,31 @@ export function buildCategoryFacet(
         getFacetId(),
         selection
       );
-      dispatch(executeSearch(analyticsAction));
+      dispatch(executeSearch({legacy: analyticsAction}));
     },
 
     deselectAll() {
       coreController.deselectAll();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
 
     sortBy(criterion: CategoryFacetSortCriterion) {
       coreController.sortBy(criterion);
       dispatch(
-        executeSearch(logFacetUpdateSort({facetId: getFacetId(), criterion}))
+        executeSearch({
+          legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
+        })
       );
     },
 
     showMoreValues() {
       coreController.showMoreValues();
-      dispatch(fetchFacetValues(logFacetShowMore(getFacetId())));
+      dispatch(fetchFacetValues({legacy: logFacetShowMore(getFacetId())}));
     },
 
     showLessValues() {
       coreController.showLessValues();
-      dispatch(fetchFacetValues(logFacetShowLess(getFacetId())));
+      dispatch(fetchFacetValues({legacy: logFacetShowLess(getFacetId())}));
     },
 
     get state() {

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -109,17 +109,23 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
       select: (value) => {
         dispatch(updateFacetOptions());
         dispatch(
-          executeSearch(
-            logFacetSelect({facetId: getFacetId(), facetValue: value.rawValue})
-          )
+          executeSearch({
+            legacy: logFacetSelect({
+              facetId: getFacetId(),
+              facetValue: value.rawValue,
+            }),
+          })
         );
       },
       exclude: (value) => {
         dispatch(updateFacetOptions());
         dispatch(
-          executeSearch(
-            logFacetExclude({facetId: getFacetId(), facetValue: value.rawValue})
-          )
+          executeSearch({
+            legacy: logFacetExclude({
+              facetId: getFacetId(),
+              facetValue: value.rawValue,
+            }),
+          })
         );
       },
       isForFieldSuggestions: false,
@@ -137,30 +143,38 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
     toggleSelect(selection) {
       coreController.toggleSelect(selection);
       dispatch(
-        executeSearch(
-          getAnalyticsActionForToggleFacetSelect(getFacetId(), selection)
-        )
+        executeSearch({
+          legacy: getAnalyticsActionForToggleFacetSelect(
+            getFacetId(),
+            selection
+          ),
+        })
       );
     },
 
     toggleExclude(selection) {
       coreController.toggleExclude(selection);
       dispatch(
-        executeSearch(
-          getAnalyticsActionForToggleFacetExclude(getFacetId(), selection)
-        )
+        executeSearch({
+          legacy: getAnalyticsActionForToggleFacetExclude(
+            getFacetId(),
+            selection
+          ),
+        })
       );
     },
 
     deselectAll() {
       coreController.deselectAll();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
 
     sortBy(criterion: FacetSortCriterion) {
       coreController.sortBy(criterion);
       dispatch(
-        executeSearch(logFacetUpdateSort({facetId: getFacetId(), criterion}))
+        executeSearch({
+          legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
+        })
       );
     },
 
@@ -170,12 +184,12 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
 
     showMoreValues() {
       coreController.showMoreValues();
-      dispatch(fetchFacetValues(logFacetShowMore(getFacetId())));
+      dispatch(fetchFacetValues({legacy: logFacetShowMore(getFacetId())}));
     },
 
     showLessValues() {
       coreController.showLessValues();
-      dispatch(fetchFacetValues(logFacetShowLess(getFacetId())));
+      dispatch(fetchFacetValues({legacy: logFacetShowLess(getFacetId())}));
     },
 
     get state() {

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -53,31 +53,39 @@ export function buildDateFacet(
 
     deselectAll() {
       coreController.deselectAll();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
 
     sortBy(criterion: RangeFacetSortCriterion) {
       coreController.sortBy(criterion);
       dispatch(
-        executeSearch(logFacetUpdateSort({facetId: getFacetId(), criterion}))
+        executeSearch({
+          legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
+        })
       );
     },
 
     toggleSelect: (selection: DateFacetValue) => {
       coreController.toggleSelect(selection);
       dispatch(
-        executeSearch(
-          getAnalyticsActionForToggleRangeFacetSelect(getFacetId(), selection)
-        )
+        executeSearch({
+          legacy: getAnalyticsActionForToggleRangeFacetSelect(
+            getFacetId(),
+            selection
+          ),
+        })
       );
     },
 
     toggleExclude: (selection: DateFacetValue) => {
       coreController.toggleExclude(selection);
       dispatch(
-        executeSearch(
-          getAnalyticsActionForToggleRangeFacetExclude(getFacetId(), selection)
-        )
+        executeSearch({
+          legacy: getAnalyticsActionForToggleRangeFacetExclude(
+            getFacetId(),
+            selection
+          ),
+        })
       );
     },
 

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
@@ -54,18 +54,18 @@ export function buildDateFilter(
     ...coreController,
     clear: () => {
       coreController.clear();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
     setRange: (range) => {
       const success = coreController.setRange(range);
       if (success) {
         dispatch(
-          executeSearch(
-            logFacetSelect({
+          executeSearch({
+            legacy: logFacetSelect({
               facetId: getFacetId(),
               facetValue: `${range.start}..${range.end}`,
-            })
-          )
+            }),
+          })
         );
       }
       return success;

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -62,22 +62,27 @@ export function buildNumericFacet(
 
     deselectAll() {
       coreController.deselectAll();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
 
     sortBy(criterion: RangeFacetSortCriterion) {
       coreController.sortBy(criterion);
       dispatch(
-        executeSearch(logFacetUpdateSort({facetId: getFacetId(), criterion}))
+        executeSearch({
+          legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
+        })
       );
     },
 
     toggleSelect: (selection: NumericFacetValue) => {
       coreController.toggleSelect(selection);
       dispatch(
-        executeSearch(
-          getAnalyticsActionForToggleRangeFacetSelect(getFacetId(), selection)
-        )
+        executeSearch({
+          legacy: getAnalyticsActionForToggleRangeFacetSelect(
+            getFacetId(),
+            selection
+          ),
+        })
       );
     },
 

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
@@ -54,18 +54,18 @@ export function buildNumericFilter(
     ...coreController,
     clear: () => {
       coreController.clear();
-      dispatch(executeSearch(logFacetClearAll(getFacetId())));
+      dispatch(executeSearch({legacy: logFacetClearAll(getFacetId())}));
     },
     setRange: (range) => {
       const success = coreController.setRange(range);
       if (success) {
         dispatch(
-          executeSearch(
-            logFacetSelect({
+          executeSearch({
+            legacy: logFacetSelect({
               facetId: getFacetId(),
               facetValue: `${range.start}..${range.end}`,
-            })
-          )
+            }),
+          })
         );
       }
       return success;

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -180,13 +180,17 @@ export function buildFieldSuggestions(
     select: (value) => {
       engine.dispatch(updateFacetOptions());
       engine.dispatch(
-        executeSearch(logFacetSelect({facetId, facetValue: value.rawValue}))
+        executeSearch({
+          legacy: logFacetSelect({facetId, facetValue: value.rawValue}),
+        })
       );
     },
     exclude: (value) => {
       engine.dispatch(updateFacetOptions());
       engine.dispatch(
-        executeSearch(logFacetExclude({facetId, facetValue: value.rawValue}))
+        executeSearch({
+          legacy: logFacetExclude({facetId, facetValue: value.rawValue}),
+        })
       );
     },
     isForFieldSuggestions: true,

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -211,7 +211,7 @@ export function buildGeneratedAnswer(
     },
 
     retry() {
-      dispatch(executeSearch(logRetryGeneratedAnswer()));
+      dispatch(executeSearch({legacy: logRetryGeneratedAnswer()}));
     },
 
     like() {
@@ -252,7 +252,9 @@ export function buildGeneratedAnswer(
 
     rephrase(responseFormat: GeneratedResponseFormat) {
       dispatch(updateResponseFormat(responseFormat));
-      dispatch(executeSearch(logRephraseGeneratedAnswer(responseFormat)));
+      dispatch(
+        executeSearch({legacy: logRephraseGeneratedAnswer(responseFormat)})
+      );
     },
 
     show() {

--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -79,7 +79,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
         return;
       }
       await dispatch(back());
-      dispatch(executeSearch(logNavigateBackward()));
+      dispatch(executeSearch({legacy: logNavigateBackward()}));
     },
 
     async forward() {
@@ -87,7 +87,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
         return;
       }
       await dispatch(forward());
-      dispatch(executeSearch(logNavigateForward()));
+      dispatch(executeSearch({legacy: logNavigateForward()}));
     },
 
     async backOnNoResults() {
@@ -95,7 +95,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
         return;
       }
       await dispatch(back());
-      dispatch(executeSearch(logNoResultsBack()));
+      dispatch(executeSearch({legacy: logNoResultsBack()}));
     },
   };
 }

--- a/packages/headless/src/controllers/insight/search-box/headless-insight-search-box.ts
+++ b/packages/headless/src/controllers/insight/search-box/headless-insight-search-box.ts
@@ -45,6 +45,7 @@ export function buildSearchBox(
     ...props,
     executeSearchActionCreator: executeSearch,
     fetchQuerySuggestionsActionCreator: fetchQuerySuggestions,
+    isNextAnalyticsReady: false,
   });
 
   return {

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -39,17 +39,17 @@ export function buildPager(
 
     selectPage(page: number) {
       pager.selectPage(page);
-      dispatch(fetchPage(logPageNumber()));
+      dispatch(fetchPage({legacy: logPageNumber()}));
     },
 
     nextPage() {
       pager.nextPage();
-      dispatch(fetchPage(logPageNext()));
+      dispatch(fetchPage({legacy: logPageNext()}));
     },
 
     previousPage() {
       pager.previousPage();
-      dispatch(fetchPage(logPagePrevious()));
+      dispatch(fetchPage({legacy: logPagePrevious()}));
     },
   };
 }

--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
@@ -200,7 +200,7 @@ export function buildRecentQueriesList(
           clearFilters: registrationOptions.clearFilters,
         })
       );
-      dispatch(executeSearch(logRecentQueryClick()));
+      dispatch(executeSearch({legacy: logRecentQueryClick()}));
     },
   };
 }

--- a/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
+++ b/packages/headless/src/controllers/results-per-page/headless-results-per-page.ts
@@ -52,7 +52,7 @@ export function buildResultsPerPage(
 
     set(num: number) {
       coreController.set(num);
-      dispatch(fetchPage(logPagerResize()));
+      dispatch(fetchPage({legacy: logPagerResize()}));
     },
   };
 }

--- a/packages/headless/src/controllers/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/search-box/headless-search-box.ts
@@ -81,6 +81,7 @@ export function buildSearchBox(
     ...props,
     executeSearchActionCreator: executeSearch,
     fetchQuerySuggestionsActionCreator: fetchQuerySuggestions,
+    isNextAnalyticsReady: true,
   });
 
   return {

--- a/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/search-parameter-manager/headless-search-parameter-manager.ts
@@ -58,7 +58,9 @@ export function buildSearchParameterManager(
       }
 
       controller.synchronize(parameters);
-      dispatch(executeSearch(logParametersChange(oldParams, newParams)));
+      dispatch(
+        executeSearch({legacy: logParametersChange(oldParams, newParams)})
+      );
     },
 
     get state() {

--- a/packages/headless/src/controllers/sort/headless-sort.ts
+++ b/packages/headless/src/controllers/sort/headless-sort.ts
@@ -22,7 +22,7 @@ export type {Sort, SortProps, SortState, SortInitialState};
 export function buildSort(engine: SearchEngine, props: SortProps = {}): Sort {
   const {dispatch} = engine;
   const sort = buildCoreSort(engine, props);
-  const search = () => dispatch(executeSearch(logResultsSort()));
+  const search = () => dispatch(executeSearch({legacy: logResultsSort()}));
 
   return {
     ...sort,

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.ts
@@ -169,7 +169,7 @@ export function buildStaticFilter(
       const analytics = getAnalyticsActionForToggledValue(id, value);
 
       dispatch(toggleSelectStaticFilterValue({id, value}));
-      dispatch(executeSearch(analytics));
+      dispatch(executeSearch({legacy: analytics}));
     },
 
     toggleSingleSelect(value: StaticFilterValue) {
@@ -180,14 +180,14 @@ export function buildStaticFilter(
       }
 
       dispatch(toggleSelectStaticFilterValue({id, value}));
-      dispatch(executeSearch(analytics));
+      dispatch(executeSearch({legacy: analytics}));
     },
 
     toggleExclude(value: StaticFilterValue) {
       const analytics = getAnalyticsActionForToggledValue(id, value);
 
       dispatch(toggleExcludeStaticFilterValue({id, value}));
-      dispatch(executeSearch(analytics));
+      dispatch(executeSearch({legacy: analytics}));
     },
 
     toggleSingleExclude(value: StaticFilterValue) {
@@ -198,14 +198,14 @@ export function buildStaticFilter(
       }
 
       dispatch(toggleExcludeStaticFilterValue({id, value}));
-      dispatch(executeSearch(analytics));
+      dispatch(executeSearch({legacy: analytics}));
     },
 
     deselectAll() {
       const analytics = logStaticFilterClearAll({staticFilterId: id});
 
       dispatch(deselectAllStaticFilterValues(id));
-      dispatch(executeSearch(analytics));
+      dispatch(executeSearch({legacy: analytics}));
     },
 
     isValueSelected(value: StaticFilterValue) {

--- a/packages/headless/src/controllers/tab/headless-tab.ts
+++ b/packages/headless/src/controllers/tab/headless-tab.ts
@@ -22,7 +22,7 @@ export type {Tab, TabProps, TabState, TabInitialState, TabOptions};
 export function buildTab(engine: SearchEngine, props: TabProps): Tab {
   const {dispatch} = engine;
   const tab = buildCoreTab(engine, props);
-  const search = () => dispatch(executeSearch(logInterfaceChange()));
+  const search = () => dispatch(executeSearch({legacy: logInterfaceChange()}));
 
   return {
     ...tab,

--- a/packages/headless/src/controllers/triggers/headless-query-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-query-trigger.ts
@@ -78,11 +78,11 @@ export function buildQueryTrigger(engine: SearchEngine): QueryTrigger {
       dispatch(updateIgnoreQueryTrigger(modification()));
       dispatch(updateQuery({q: originalQuery()}));
       dispatch(
-        executeSearch(
-          logUndoTriggerQuery({
+        executeSearch({
+          legacy: logUndoTriggerQuery({
             undoneQuery: modification(),
-          })
-        )
+          }),
+        })
       );
     },
   };

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -91,7 +91,6 @@ export function makeBasicNewSearchAnalyticsAction(
   return {
     ...new SearchAnalyticsProvider(getState).getBaseMetadata(),
     actionCause,
-    type: actionCause,
   };
 }
 

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -84,6 +84,17 @@ export type AnalyticsAsyncThunk<
     ConfigurationSection = StateNeededBySearchAnalyticsProvider,
 > = AsyncThunk<void, void, AsyncThunkAnalyticsOptions<StateNeeded>>;
 
+export function makeBasicNewSearchAnalyticsAction(
+  actionCause: string,
+  getState: () => StateNeededBySearchAnalyticsProvider
+) {
+  return {
+    ...new SearchAnalyticsProvider(getState).getBaseMetadata(),
+    actionCause,
+    type: actionCause,
+  };
+}
+
 export interface PreparedAnalyticsAction<
   StateNeeded extends
     ConfigurationSection = StateNeededBySearchAnalyticsProvider,

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -91,6 +91,7 @@ export function makeBasicNewSearchAnalyticsAction(
   return {
     ...new SearchAnalyticsProvider(getState).getBaseMetadata(),
     actionCause,
+    type: actionCause,
   };
 }
 

--- a/packages/headless/src/features/analytics/search-action-cause.ts
+++ b/packages/headless/src/features/analytics/search-action-cause.ts
@@ -1,0 +1,315 @@
+export enum SearchPageEvents {
+  /**
+   * Identifies the search event that gets logged when the initial query is performed as a result of loading a search interface.
+   */
+  interfaceLoad = 'interfaceLoad',
+  /**
+   * Identifies the search event that gets logged when a new tab is selected in the search interface.
+   */
+  interfaceChange = 'interfaceChange',
+  /**
+   * Identifies the search event that gets logged when `enableAutoCorrection: true` and the query is automatically corrected.
+   */
+  didyoumeanAutomatic = 'didyoumeanAutomatic',
+  /**
+   * Identifies the search event that gets logged when the query suggestion with the corrected term is selected and successfully updates the query.
+   */
+  didyoumeanClick = 'didyoumeanClick',
+  /**
+   * Identifies the search event that gets logged when a sorting method is selected.
+   */
+  resultsSort = 'resultsSort',
+  /**
+   * Identifies the search event that gets logged when a submit button is selected on a search box.
+   */
+  searchboxSubmit = 'searchboxSubmit',
+  /**
+   * Identifies the search event that gets logged when a clear button is selected on a search box.
+   */
+  searchboxClear = 'searchboxClear',
+  /**
+   * The search-as-you-type event that gets logged when a query is automatically generated, and results are displayed while a user is entering text in the search box before they voluntarily submit the query.
+   */
+  searchboxAsYouType = 'searchboxAsYouType',
+  /**
+   * The event that gets logged when a breadcrumb facet is selected and the query is updated.
+   */
+  breadcrumbFacet = 'breadcrumbFacet',
+  /**
+   * Identifies the search event that gets logged when the event to clear the current breadcrumbs is triggered.
+   */
+  breadcrumbResetAll = 'breadcrumbResetAll',
+  /**
+   * Identifies the click event that gets logged when the Quick View element is selected and a Quick View modal of the document is displayed.
+   */
+  documentQuickview = 'documentQuickview',
+  /**
+   * Identifies the click event that gets logged when a user clicks on a search result to open an item.
+   */
+  documentOpen = 'documentOpen',
+  /**
+   * Identifies the search event that gets logged when a user clicks a query suggestion based on the usage analytics recorded queries.
+   */
+  omniboxAnalytics = 'omniboxAnalytics',
+  /**
+   * Identifies the search event that gets logged when a suggested search query is selected from a standalone searchbox.
+   */
+  omniboxFromLink = 'omniboxFromLink',
+  /**
+   * Identifies the search event that gets logged when the search page loads with a query, such as when a user clicks a link pointing to a search results page with a query or enters a query in a standalone search box that points to a search page.
+   */
+  searchFromLink = 'searchFromLink',
+  /**
+   * Identifies the custom event that gets logged when a user action triggers a notification set in the effective query pipeline on the search page.
+   */
+  triggerNotify = 'notify',
+  /**
+   * Identifies the custom event that gets logged when a user action executes a JavaScript function set in the effective query pipeline on the search page.
+   */
+  triggerExecute = 'execute',
+  /**
+   * Identifies the custom event that gets logged when a user action triggers a new query set in the effective query pipeline on the search page.
+   */
+  triggerQuery = 'query',
+  /**
+   * Identifies the custom event that gets logged when a user undoes a query set in the effective query pipeline on the search page.
+   */
+  undoTriggerQuery = 'undoQuery',
+  /**
+   * Identifies the custom event that gets logged when a user action redirects them to a URL set in the effective query pipeline on the search page.
+   */
+  triggerRedirect = 'redirect',
+  /**
+   * Identifies the custom event that gets logged when the Results per page component is selected.
+   */
+  pagerResize = 'pagerResize',
+  /**
+   * Identifies the custom event that gets logged when a page number is selected and more items are loaded.
+   */
+  pagerNumber = 'pagerNumber',
+  /**
+   * Identifies the custom event that gets logged when the Next Page link is selected and more items are loaded.
+   */
+  pagerNext = 'pagerNext',
+  /**
+   * Identifies the custom event that gets logged when the Previous Page link is selected and more items are loaded.
+   */
+  pagerPrevious = 'pagerPrevious',
+  /**
+   * Identifies the custom event that gets logged when the user scrolls to the bottom of the item page and more results are loaded.
+   */
+  pagerScrolling = 'pagerScrolling',
+  /**
+   * Identifies the search event that gets logged when the clearing all selected values of a static filter.
+   */
+  staticFilterClearAll = 'staticFilterClearAll',
+  /**
+   * Identifies the search event that gets logged when a static filter check box is selected and the query is updated.
+   */
+  staticFilterSelect = 'staticFilterSelect',
+  /**
+   * Identifies the search event that gets logged when a static filter check box is deselected and the query is updated.
+   */
+  staticFilterDeselect = 'staticFilterDeselect',
+  /**
+   * Identifies the search event that gets logged when the Clear Facet button is selected.
+   */
+  facetClearAll = 'facetClearAll',
+  /**
+   * Identifies the custom event that gets logged when a query is being typed into the facet search box.
+   */
+  facetSearch = 'facetSearch',
+  /**
+   * Identifies the search event that gets logged when a facet check box is selected and the query is updated.
+   */
+  facetSelect = 'facetSelect',
+  /**
+   * Identifies the search event that gets logged when all filters on a facet are selected.
+   */
+  facetSelectAll = 'facetSelectAll',
+  /**
+   * Identifies the search event that gets logged when a facet check box is deselected and the query is updated.
+   */
+  facetDeselect = 'facetDeselect',
+  /**
+   * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing the facet value.
+   */
+  facetExclude = 'facetExclude',
+  /**
+   * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing the facet value.
+   */
+  facetUnexclude = 'facetUnexclude',
+  /**
+   * Identifies the search event that gets logged when the sort criteria on a facet is updated.
+   */
+  facetUpdateSort = 'facetUpdateSort',
+  /**
+   * The custom event that gets logged when an end-user expands a facet to see additional values.
+   */
+  facetShowMore = 'showMoreFacetResults',
+  /**
+   * The custom event that gets logged when an end-user collapses a facet to see less values.
+   */
+  facetShowLess = 'showLessFacetResults',
+  /**
+   * Identifies the custom event that gets logged when a user query encounters an error during execution.
+   */
+  //eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  queryError = 'query',
+  /**
+   * Identifies the search and custom event that gets logged when a user clicks the Go Back link after an error page.
+   */
+  queryErrorBack = 'errorBack',
+  /**
+   * Identifies the search and custom event that gets logged when a user clears the query box after an error page.
+   */
+  queryErrorClear = 'errorClearQuery',
+  /**
+   * Identifies the search and custom event that gets logged when a user clicks the Retry link after an error page.
+   */
+  queryErrorRetry = 'errorRetry',
+  /**
+   * Identifies the custom event that gets logged when a user performs a query that returns recommendations in the Recommendations panel.
+   */
+  recommendation = 'recommendation',
+  /**
+   * Identifies the search event that gets logged when a user action (that is not a query) reloads the Recommendations panel with new recommendations.
+   */
+  recommendationInterfaceLoad = 'recommendationInterfaceLoad',
+  /**
+   * Identifies the click event that gets logged when a user clicks a recommendation in the Recommendations panel.
+   */
+  recommendationOpen = 'recommendationOpen',
+  /**
+   * Identifies the custom event that gets logged when a user identifies a smart snippet answer as relevant.
+   */
+  likeSmartSnippet = 'likeSmartSnippet',
+  /**
+   * Identifies the custom event that gets logged when a user identifies a smart snippet answer as irrelevant.
+   */
+  dislikeSmartSnippet = 'dislikeSmartSnippet',
+  /**
+   * Identifies the custom event that gets logged when a user expand a smart snippet answer.
+   */
+  expandSmartSnippet = 'expandSmartSnippet',
+  /**
+   * Identifies the custom event that gets logged when a user collapse a smart snippet answer.
+   */
+  collapseSmartSnippet = 'collapseSmartSnippet',
+  /**
+   * Identifies the custom event that gets logged when a user open a smart snippet explanation modal for feedback.
+   */
+  openSmartSnippetFeedbackModal = 'openSmartSnippetFeedbackModal',
+  /**
+   * Identifies the custom event that gets logged when a user close a smart snippet explanation modal for feedback.
+   */
+  closeSmartSnippetFeedbackModal = 'closeSmartSnippetFeedbackModal',
+  /**
+   * Identifies the custom event that gets logged when a user sends an explanation for a smart snippet irrelevant answer.
+   */
+  sendSmartSnippetReason = 'sendSmartSnippetReason',
+  /**
+   * Identifies the custom event that gets logged when a snippet suggestion for a related question is expanded.
+   */
+  expandSmartSnippetSuggestion = 'expandSmartSnippetSuggestion',
+  /**
+   * Identifies the custom event that gets logged when a snippet suggestion for a related question is collapsed.
+   */
+  collapseSmartSnippetSuggestion = 'collapseSmartSnippetSuggestion',
+  /**
+   * Identifies the custom event that gets logged when the user presses "show more" on a snippet suggestion for a related question.
+   *
+   * @deprecated
+   */
+  showMoreSmartSnippetSuggestion = 'showMoreSmartSnippetSuggestion',
+  /**
+   * Identifies the custom event that gets logged when the user presses "show less" on a snippet suggestion for a related question.
+   *
+   * @deprecated
+   */
+  showLessSmartSnippetSuggestion = 'showLessSmartSnippetSuggestion',
+  /**
+   * Identifies the custom event that gets logged when a user clicks on the source of an answer in a smart snippet.
+   */
+  openSmartSnippetSource = 'openSmartSnippetSource',
+  /**
+   * Identifies the custom event that gets logged when a user clicks on the source of a snippet suggestion for a related question.
+   */
+  openSmartSnippetSuggestionSource = 'openSmartSnippetSuggestionSource',
+  /**
+   * Identifies the custom event that gets logged when a user clicks on a link in the answer of a smart snippet.
+   */
+  openSmartSnippetInlineLink = 'openSmartSnippetInlineLink',
+  /**
+   * Identifies the custom event that gets logged when a user clicks on a link in the snippet suggestion for a related question.
+   */
+  openSmartSnippetSuggestionInlineLink = 'openSmartSnippetSuggestionInlineLink',
+  /**
+   * Identifies the search event that gets logged when a recent queries list item gets clicked.
+   */
+  recentQueryClick = 'recentQueriesClick',
+  /**
+   * Identifies the custom event that gets logged when a recent queries list gets cleared.
+   */
+  clearRecentQueries = 'clearRecentQueries',
+  /**
+   * Identifies the custom event that gets logged when a recently clicked results list item gets clicked.
+   */
+  recentResultClick = 'recentResultClick',
+  /**
+   * Identifies the custom event that gets logged when a recently clicked results list gets cleared.
+   */
+  clearRecentResults = 'clearRecentResults',
+  /**
+   * Identifies the search event that gets logged when a user clicks the Cancel last action link when no results are returned following their last action.
+   */
+  noResultsBack = 'noResultsBack',
+  /**
+   * Identifies the click event that gets logged when a user clicks the Show More link under a search result that support the folding component.
+   */
+  showMoreFoldedResults = 'showMoreFoldedResults',
+  /**
+   * Identifies the custom event that gets logged when a user clicks the Show Less link under a search result that support the folding component.
+   */
+  showLessFoldedResults = 'showLessFoldedResults',
+  /**
+   * Identifies the click event that gets logged when a user clicks the Copy To Clipboard result action.
+   */
+  copyToClipboard = 'copyToClipboard',
+  /**
+   * Identifies the click event that gets logged when a user clicks the Send As Email result action.
+   */
+  caseSendEmail = 'Case.SendEmail',
+  /**
+   * Identifies the click event that gets logged when a user clicks the Post To Feed result action.
+   */
+  feedItemTextPost = 'FeedItem.TextPost',
+  /**
+   * Identifies the click event that gets logged when a user clicks the Attach To Case result action.
+   */
+  caseAttach = 'caseAttach',
+  /**
+   * Identifies the custom event that gets logged when a user clicks the Detach From Case result action.
+   */
+  caseDetach = 'caseDetach',
+  /**
+   * Identifies the cause of a search request being retried in order to regenerate an answer stream that failed.
+   */
+  retryGeneratedAnswer = 'retryGeneratedAnswer',
+  /**
+   * Identifies the custom event that gets logged when a user identifies a generated answer as relevant.
+   */
+  likeGeneratedAnswer = 'likeGeneratedAnswer',
+  /**
+   * Identifies the custom event that gets logged when a user identifies a generated answer as irrelevant.
+   */
+  dislikeGeneratedAnswer = 'dislikeGeneratedAnswer',
+  /**
+   * Identifies the custom event that gets logged when a user opens a generated answer citation.
+   */
+  openGeneratedAnswerSource = 'openGeneratedAnswerSource',
+  /**
+   * Identified the custom event that gets logged when a generated answer stream is completed.
+   */
+  generatedAnswerStreamEnd = 'generatedAnswerStreamEnd',
+}

--- a/packages/headless/src/features/did-you-mean/did-you-mean-slice.test.ts
+++ b/packages/headless/src/features/did-you-mean/did-you-mean-slice.test.ts
@@ -58,7 +58,7 @@ describe('did you mean slice', () => {
         }),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(
@@ -74,7 +74,7 @@ describe('did you mean slice', () => {
         }),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(
@@ -91,7 +91,7 @@ describe('did you mean slice', () => {
         }),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(didYouMeanReducer(state, searchAction).originalQuery).toBe('');

--- a/packages/headless/src/features/facet-options/facet-options-slice.test.ts
+++ b/packages/headless/src/features/facet-options/facet-options-slice.test.ts
@@ -47,7 +47,7 @@ describe('facet options slice', () => {
     const search = buildMockSearch();
     state = facetOptionsReducer(
       state,
-      executeSearch.fulfilled(search, '', logSearchEvent({evt: ''}))
+      executeSearch.fulfilled(search, '', {legacy: logSearchEvent({evt: ''})})
     );
 
     expect(state.freezeFacetOrder).toBe(false);
@@ -58,11 +58,9 @@ describe('facet options slice', () => {
 
     state = facetOptionsReducer(
       state,
-      executeSearch.rejected(
-        {message: '', name: ''},
-        '',
-        logSearchEvent({evt: ''})
-      )
+      executeSearch.rejected({message: '', name: ''}, '', {
+        legacy: logSearchEvent({evt: ''}),
+      })
     );
 
     expect(state.freezeFacetOrder).toBe(false);

--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
@@ -42,7 +42,9 @@ describe('automatic-facet-set slice', () => {
         facets,
       };
 
-      return executeSearch.fulfilled(search, '', logSearchEvent({evt: 'foo'}));
+      return executeSearch.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      });
     }
 
     it('registers facets', () => {

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -765,7 +765,9 @@ describe('category facet slice', () => {
       const search = buildMockSearch();
       search.response.facets = facets;
 
-      return executeSearch.fulfilled(search, '', logSearchEvent({evt: 'foo'}));
+      return executeSearch.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      });
     }
 
     it('when an invalid path is requested, it sets the request #currentValues to an empty array', () => {
@@ -830,11 +832,9 @@ describe('category facet slice', () => {
       const search = buildMockSearch();
       search.response.facets = facets;
 
-      return fetchFacetValues.fulfilled(
-        search,
-        '',
-        logSearchEvent({evt: 'foo'})
-      );
+      return fetchFacetValues.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      });
     }
 
     it('when an valid path is requested, it does not adjust the #currentValues of the request', () => {

--- a/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
@@ -26,7 +26,7 @@ describe('facet-order slice', () => {
           }),
         }),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
   }

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.test.ts
@@ -93,11 +93,9 @@ describe('FacetSearch slice', () => {
 
   it('#executeFacetSearch.fulfilled calls #handleFacetSearchSetClear', () => {
     jest.spyOn(FacetSearchReducerHelpers, 'handleFacetSearchSetClear');
-    const action = executeSearch.fulfilled(
-      {} as ExecuteSearchThunkReturn,
-      '',
-      null as never
-    );
+    const action = executeSearch.fulfilled({} as ExecuteSearchThunkReturn, '', {
+      legacy: null as never,
+    });
     facetSearchSetReducer(state, action);
 
     expect(

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.test.ts
@@ -95,11 +95,9 @@ describe('FacetSearch slice', () => {
 
   it('#executeFacetSearch.fulfilled calls #handleFacetSearchSetClear', () => {
     jest.spyOn(FacetSearchReducerHelpers, 'handleFacetSearchSetClear');
-    const action = executeSearch.fulfilled(
-      {} as ExecuteSearchThunkReturn,
-      '',
-      null as never
-    );
+    const action = executeSearch.fulfilled({} as ExecuteSearchThunkReturn, '', {
+      legacy: null as never,
+    });
     facetSearchSetReducer(state, action);
 
     expect(

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -587,7 +587,9 @@ describe('facet-set slice', () => {
       const search = buildMockSearch();
       search.response.facets = facets;
 
-      return executeSearch.fulfilled(search, '', logSearchEvent({evt: 'foo'}));
+      return executeSearch.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      });
     }
 
     testFulfilledSearchRequest(buildExecuteSearchAction);
@@ -598,11 +600,9 @@ describe('facet-set slice', () => {
       const search = buildMockSearch();
       search.response.facets = facets;
 
-      return fetchFacetValues.fulfilled(
-        search,
-        '',
-        logSearchEvent({evt: 'foo'})
-      );
+      return fetchFacetValues.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      });
     }
 
     testFulfilledSearchRequest(buildFetchFacetValuesAction);

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-set-slice.test.ts
@@ -163,7 +163,9 @@ describe('date-facet-set slice', () => {
     const search = buildMockSearch();
     dateFacetSetReducer(
       state,
-      executeSearch.fulfilled(search, '', logSearchEvent({evt: 'foo'}))
+      executeSearch.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      })
     );
 
     expect(

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice.test.ts
@@ -180,7 +180,9 @@ describe('numeric-facet-set slice', () => {
     const search = buildMockSearch();
     numericFacetSetReducer(
       state,
-      executeSearch.fulfilled(search, '', logSearchEvent({evt: 'foo'}))
+      executeSearch.fulfilled(search, '', {
+        legacy: logSearchEvent({evt: 'foo'}),
+      })
     );
 
     expect(

--- a/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions-loader.ts
@@ -7,7 +7,7 @@ import {
   FetchQuerySuggestionsActionCreatorPayload,
   FetchQuerySuggestionsThunkReturn,
 } from '../query-suggest/query-suggest-actions';
-import {ExecuteSearchThunkReturn} from '../search/search-actions';
+import {ExecuteSearchThunkReturn} from '../search/legacy/search-actions';
 import {
   executeSearch,
   fetchFacetValues,
@@ -31,7 +31,7 @@ export interface InsightSearchActionCreators {
    * const {executeSearch} = loadInsightSearchActions(engine);
    * ```
    *
-   * engine.dispatch(executeSearch(interfaceLoad()));
+   * engine.dispatch(executeSearch({legacy: interfaceLoad()}))
    * @param analyticsSearchAction  - The analytics action to log after a successful query. See `loadSearchAnalyticsActions` for possible values.
    * @returns A dispatchable action.
    */

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -43,7 +43,7 @@ import {
 } from '../query-suggest/query-suggest-actions';
 import {updateQuery} from '../query/query-actions';
 import {getQueryInitialState} from '../query/query-state';
-import {ExecuteSearchThunkReturn} from '../search/search-actions';
+import {ExecuteSearchThunkReturn} from '../search/legacy/search-actions';
 import {
   MappedSearchRequest,
   mapSearchResponse,

--- a/packages/headless/src/features/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/pagination/pagination-slice.test.ts
@@ -172,7 +172,9 @@ describe('pagination slice', () => {
   it('executeSearch.fulfilled updates totalCountFiltered to the response value', () => {
     const search = buildMockSearch();
     search.response.totalCountFiltered = 100;
-    const action = executeSearch.fulfilled(search, '', logSearchboxSubmit());
+    const action = executeSearch.fulfilled(search, '', {
+      legacy: logSearchboxSubmit(),
+    });
 
     const finalState = paginationReducer(state, action);
     expect(finalState.totalCountFiltered).toBe(

--- a/packages/headless/src/features/query-set/query-set-slice.test.ts
+++ b/packages/headless/src/features/query-set/query-set-slice.test.ts
@@ -97,7 +97,7 @@ describe('querySet slice', () => {
     const searchState = buildMockSearch({queryExecuted: 'world'});
     const nextState = querySetReducer(
       state,
-      executeSearch.fulfilled(searchState, '', logSearchboxSubmit())
+      executeSearch.fulfilled(searchState, '', {legacy: logSearchboxSubmit()})
     );
     expect(nextState).toEqual(expectedQuerySet);
   });

--- a/packages/headless/src/features/question-answering/question-answering-slice.test.ts
+++ b/packages/headless/src/features/question-answering/question-answering-slice.test.ts
@@ -187,7 +187,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: firstSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 
@@ -204,7 +204,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: secondSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 
@@ -218,7 +218,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: firstSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 
@@ -236,7 +236,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: secondSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 
@@ -254,7 +254,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: firstSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 
@@ -285,7 +285,7 @@ describe('question answering slice', () => {
       executeSearch.fulfilled(
         buildMockSearch({response: secondSearchResponse}),
         '',
-        null as never
+        {legacy: null as never}
       )
     );
 

--- a/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-slice.test.ts
@@ -77,7 +77,7 @@ describe('recent-queries-slice', () => {
         ),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(recentQueriesReducer(state, searchAction).queries).toEqual(
@@ -99,7 +99,7 @@ describe('recent-queries-slice', () => {
         ),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(recentQueriesReducer(state, searchAction).queries).toEqual([
@@ -117,7 +117,7 @@ describe('recent-queries-slice', () => {
         response: buildMockSearchResponse(withResult()),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(recentQueriesReducer(state, searchAction).queries).toEqual([
@@ -140,7 +140,7 @@ describe('recent-queries-slice', () => {
           response: buildMockSearchResponse(withResult()),
         }),
         '',
-        logSearchEvent({evt: 'foo'})
+        {legacy: logSearchEvent({evt: 'foo'})}
       );
 
       expect(recentQueriesReducer(state, searchAction).queries).toEqual(
@@ -157,7 +157,7 @@ describe('recent-queries-slice', () => {
         response: buildMockSearchResponse({}),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(recentQueriesReducer(state, searchAction).queries).toEqual([]);
@@ -172,7 +172,7 @@ describe('recent-queries-slice', () => {
           response: buildMockSearchResponse(withResult()),
         }),
         '',
-        logSearchEvent({evt: 'foo'})
+        {legacy: logSearchEvent({evt: 'foo'})}
       );
 
       expect(recentQueriesReducer(state, searchAction).queries.length).toEqual(
@@ -190,7 +190,7 @@ describe('recent-queries-slice', () => {
         response: buildMockSearchResponse(withResult()),
       }),
       '',
-      logSearchEvent({evt: 'foo'})
+      {legacy: logSearchEvent({evt: 'foo'})}
     );
 
     expect(recentQueriesReducer(state, searchAction).queries).toEqual([

--- a/packages/headless/src/features/result-preview/result-preview-slice.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-slice.test.ts
@@ -1,6 +1,6 @@
 import {buildMockResult} from '../../test';
 import {buildMockResultPreviewRequest} from '../../test/mock-result-preview-request-builder';
-import {buildMockSearch} from '../../test/mock-search';
+import {buildMockLegacySearch, buildMockSearch} from '../../test/mock-search';
 import {buildMockSearchResponse} from '../../test/mock-search-response';
 import {logInterfaceLoad} from '../analytics/analytics-actions';
 import {executeSearch} from '../insight-search/insight-search-actions';
@@ -44,7 +44,7 @@ describe('ResultPreview', () => {
       state.isLoading = true;
       state.uniqueId = 'uniqueId';
       const action = executeSearch.fulfilled(
-        buildMockSearch(),
+        buildMockLegacySearch(),
         '',
         logInterfaceLoad()
       );
@@ -57,7 +57,7 @@ describe('ResultPreview', () => {
     it('updates #resultsWithPreview property with the new results', () => {
       state.resultsWithPreview = ['foo', 'bar'];
 
-      const search = buildMockSearch({
+      const search = buildMockLegacySearch({
         response: buildMockSearchResponse({
           results: [
             buildMockResult({hasHtmlVersion: true, uniqueId: 'first'}),
@@ -115,7 +115,9 @@ describe('ResultPreview', () => {
       state.contentURL = 'url';
       state.isLoading = true;
       state.uniqueId = 'uniqueId';
-      const action = fetchPage.fulfilled(buildMockSearch(), '', logPageNext());
+      const action = fetchPage.fulfilled(buildMockSearch(), '', {
+        legacy: logPageNext(),
+      });
 
       const finalState = resultPreviewReducer(state, action);
 

--- a/packages/headless/src/features/search/legacy/search-actions-thunk-processor.test.ts
+++ b/packages/headless/src/features/search/legacy/search-actions-thunk-processor.test.ts
@@ -1,12 +1,12 @@
 import {Logger} from 'pino';
-import {SearchAPIClient} from '../../api/search/search-api-client';
-import {buildMockResult} from '../../test';
-import {buildMockSearchRequest} from '../../test/mock-search-request';
-import {buildMockSearchResponse} from '../../test/mock-search-response';
-import {buildMockSearchState} from '../../test/mock-search-state';
-import {getConfigurationInitialState} from '../configuration/configuration-state';
-import {updateQuery} from '../query/query-actions';
-import {logSearchboxSubmit} from '../query/query-analytics-actions';
+import {SearchAPIClient} from '../../../api/search/search-api-client';
+import {buildMockResult} from '../../../test';
+import {buildMockSearchRequest} from '../../../test/mock-search-request';
+import {buildMockSearchResponse} from '../../../test/mock-search-response';
+import {buildMockSearchState} from '../../../test/mock-search-state';
+import {getConfigurationInitialState} from '../../configuration/configuration-state';
+import {updateQuery} from '../../query/query-actions';
+import {logSearchboxSubmit} from '../../query/query-analytics-actions';
 import {ExecuteSearchThunkReturn} from './search-actions';
 import {
   AsyncSearchThunkProcessor,

--- a/packages/headless/src/features/search/legacy/search-actions.test.ts
+++ b/packages/headless/src/features/search/legacy/search-actions.test.ts
@@ -1,6 +1,7 @@
-import {buildMockSearchAppEngine, MockSearchEngine} from '../../test';
-import {createMockState} from '../../test/mock-state';
-import {logSearchboxSubmit} from '../query/query-analytics-actions';
+import {buildMockSearchAppEngine, MockSearchEngine} from '../../../test';
+import {createMockState} from '../../../test/mock-state';
+import {logSearchboxSubmit} from '../../query/query-analytics-actions';
+import {buildSearchRequest} from '../search-request';
 import {
   executeSearch,
   fetchInstantResults,
@@ -9,7 +10,6 @@ import {
   fetchPage,
   fetchMoreResults,
 } from './search-actions';
-import {buildSearchRequest} from './search-request';
 
 describe('search actions', () => {
   let e: MockSearchEngine;

--- a/packages/headless/src/features/search/search-actions-loader.ts
+++ b/packages/headless/src/features/search/search-actions-loader.ts
@@ -21,7 +21,7 @@ import {
   fetchFacetValues,
   fetchPage,
   fetchInstantResults,
-} from './search-actions';
+} from './legacy/search-actions';
 
 /**
  * The search action creators.
@@ -36,7 +36,7 @@ export interface SearchActionCreators {
    * const {logInterfaceLoad} = loadSearchAnalyticsActions(engine);
    * const {executeSearch} = loadSearchActions(engine);
    *
-   * engine.dispatch(executeSearch(interfaceLoad()));
+   * engine.dispatch(executeSearch({legacy: interfaceLoad()}))
    * ```
    *
    * @param analyticsSearchAction - The analytics action to log after a successful query. See `loadSearchAnalyticsActions` for possible values.

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -339,6 +339,7 @@ const buildSearchAction = (
   action: SearchAction,
   state: StateNeededByExecuteSearch
 ) => ({
-  ...action.getEventExtraPayload(state),
+  customData: action.getEventExtraPayload(state),
   actionCause: action.actionCause,
+  type: action.actionCause,
 });

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -33,6 +33,7 @@ import {
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/search-and-folding-request';
 import {
   legacyExecuteSearch,
+  legacyFetchInstantResults,
   legacyFetchMoreResults,
   legacyFetchPage,
 } from './legacy/search-actions';
@@ -229,6 +230,10 @@ export const fetchInstantResults = createAsyncThunk<
 >(
   'search/fetchInstantResults',
   async (payload: FetchInstantResultsActionCreatorPayload, config) => {
+    const state = config.getState();
+    if (state.configuration.analytics.analyticsMode === 'legacy') {
+      return legacyFetchInstantResults(payload, config);
+    }
     validatePayload(payload, {
       id: requiredNonEmptyString,
       q: requiredNonEmptyString,
@@ -239,7 +244,6 @@ export const fetchInstantResults = createAsyncThunk<
       cacheTimeout: new NumberValue(),
     });
     const {q, maxResultsPerQuery} = payload;
-    const state = config.getState();
     const analyticsAction = makeBasicNewSearchAnalyticsAction(
       SearchPageEvents.searchboxAsYouType,
       config.getState

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -53,21 +53,32 @@ export interface SearchAction<
   getEventExtraPayload: (state: State) => Payload;
 }
 
+type SingleOrArray<T> = T | T[];
+
 export const buildSearchAction = <
   State extends StateNeededByExecuteSearch = StateNeededByExecuteSearch,
   Payload extends Object = {},
 >(
   actionCause: string,
-  getEventExtraPayload: ((
-    state: StateNeededByExecuteSearch,
-    payload: Partial<Payload>
-  ) => void)[]
+  getEventExtraPayload: SingleOrArray<
+    ({
+      state,
+      payload,
+    }: {
+      state: StateNeededByExecuteSearch;
+      payload: Partial<Payload>;
+    }) => void
+  >
 ) => {
+  const getEventExtraPayloadFunctionArray = Array.isArray(getEventExtraPayload)
+    ? getEventExtraPayload
+    : [getEventExtraPayload];
   const combinedGetEventExtraPayload = (state: State) => {
     const payload = {};
-    for (const payloadTransformer of getEventExtraPayload) {
-      payloadTransformer(state, payload);
+    for (const payloadTransformer of getEventExtraPayloadFunctionArray) {
+      payloadTransformer({state, payload});
     }
+    return payload;
   };
   return {
     actionCause,

--- a/packages/headless/src/features/search/search-slice.test.ts
+++ b/packages/headless/src/features/search/search-slice.test.ts
@@ -62,11 +62,9 @@ describe('search-slice', () => {
         queryExecuted: 'foo',
       });
 
-      const action = executeSearch.fulfilled(
-        searchState,
-        '',
-        logSearchboxSubmit()
-      );
+      const action = executeSearch.fulfilled(searchState, '', {
+        legacy: logSearchboxSubmit(),
+      });
       const finalState = searchReducer(state, action);
 
       expect(finalState.response).toEqual(response);
@@ -107,7 +105,9 @@ describe('search-slice', () => {
         searchResponseId: 'a_new_id',
       });
 
-      const action = fetchPage.fulfilled(searchState, '', logPageNext());
+      const action = fetchPage.fulfilled(searchState, '', {
+        legacy: logPageNext(),
+      });
       const finalState = searchReducer(state, action);
 
       expect(finalState.response).toEqual(response);
@@ -135,7 +135,7 @@ describe('search-slice', () => {
             response: buildMockSearchResponse({results: [newResult]}),
           }),
           '',
-          logSearchboxSubmit()
+          {legacy: logSearchboxSubmit()}
         )
       );
 
@@ -152,7 +152,7 @@ describe('search-slice', () => {
 
       const finalState = searchReducer(
         state,
-        executeSearch.fulfilled(search, '', logSearchboxSubmit())
+        executeSearch.fulfilled(search, '', {legacy: logSearchboxSubmit()})
       );
 
       expect(finalState.searchResponseId).toBe('a_new_id');
@@ -174,7 +174,7 @@ describe('search-slice', () => {
 
       const finalState = searchReducer(
         state,
-        executeSearch.fulfilled(search, '', logSearchboxSubmit())
+        executeSearch.fulfilled(search, '', {legacy: logSearchboxSubmit()})
       );
 
       expect(finalState.questionAnswer).toEqual(response.questionAnswer);
@@ -337,11 +337,9 @@ describe('search-slice', () => {
     });
 
     it('when a executeSearch fulfilled is received', () => {
-      const action = executeSearch.fulfilled(
-        searchState,
-        '',
-        logSearchboxSubmit()
-      );
+      const action = executeSearch.fulfilled(searchState, '', {
+        legacy: logSearchboxSubmit(),
+      });
       const finalState = searchReducer(state, action);
       expect(finalState.error).toBeNull();
     });
@@ -353,7 +351,9 @@ describe('search-slice', () => {
     });
 
     it('when a fetchPage fulfilled is received', () => {
-      const action = fetchPage.fulfilled(searchState, '', logPageNext());
+      const action = fetchPage.fulfilled(searchState, '', {
+        legacy: logPageNext(),
+      });
       const finalState = searchReducer(state, action);
       expect(finalState.error).toBeNull();
     });
@@ -376,7 +376,7 @@ describe('search-slice', () => {
     });
 
     it('on a executeSearch error', async () => {
-      await e.dispatch(executeSearch(logSearchboxSubmit()));
+      await e.dispatch(executeSearch({legacy: logSearchboxSubmit()}));
       expect(e.actions).toContainEqual(
         expect.objectContaining({
           type: 'search/queryError/pending',
@@ -394,7 +394,7 @@ describe('search-slice', () => {
     });
 
     it('on a fetchPage error', async () => {
-      await e.dispatch(fetchPage(logPageNext()));
+      await e.dispatch(fetchPage({legacy: logPageNext()}));
       expect(e.actions).toContainEqual(
         expect.objectContaining({
           type: 'search/queryError/pending',
@@ -404,7 +404,9 @@ describe('search-slice', () => {
   });
 
   it('set the isloading state to true during executeSearch.pending', () => {
-    const pendingAction = executeSearch.pending('asd', logSearchboxSubmit());
+    const pendingAction = executeSearch.pending('asd', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = searchReducer(state, pendingAction);
     expect(finalState.isLoading).toBe(true);
   });
@@ -416,13 +418,15 @@ describe('search-slice', () => {
   });
 
   it('set the isloading state to true during fetchPage.pending', () => {
-    const pendingAction = fetchPage.pending('asd', logPageNext());
+    const pendingAction = fetchPage.pending('asd', {legacy: logPageNext()});
     const finalState = searchReducer(state, pendingAction);
     expect(finalState.isLoading).toBe(true);
   });
 
   it('update the requestId during executeSearch.pending', () => {
-    const pendingAction = executeSearch.pending('asd', logSearchboxSubmit());
+    const pendingAction = executeSearch.pending('asd', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = searchReducer(state, pendingAction);
     expect(finalState.requestId).toBe(pendingAction.meta.requestId);
   });
@@ -434,7 +438,7 @@ describe('search-slice', () => {
   });
 
   it('update the requestId during fetchPage.pending', () => {
-    const pendingAction = fetchPage.pending('asd', logPageNext());
+    const pendingAction = fetchPage.pending('asd', {legacy: logPageNext()});
     const finalState = searchReducer(state, pendingAction);
     expect(finalState.requestId).toBe(pendingAction.meta.requestId);
   });
@@ -462,7 +466,7 @@ describe('search-slice', () => {
         return Promise.resolve(response);
       });
 
-      await e.dispatch(executeSearch(logSearchboxSubmit()));
+      await e.dispatch(executeSearch({legacy: logSearchboxSubmit()}));
       expect(e.actions).toContainEqual({
         type: applyDidYouMeanCorrection.type,
         payload: 'foo',
@@ -506,7 +510,7 @@ describe('search-slice', () => {
           .fn()
           .mockImplementationOnce(fetched)
           .mockImplementationOnce(retried);
-        await e.dispatch(executeSearch(mockLogSubmit()));
+        await e.dispatch(executeSearch({legacy: mockLogSubmit()}));
       });
 
       it('should log the original query to the executeSearch analytics action', () => {
@@ -532,7 +536,7 @@ describe('search-slice', () => {
           }),
         })
       );
-      await e.dispatch(executeSearch(logSearchboxSubmit()));
+      await e.dispatch(executeSearch({legacy: logSearchboxSubmit()}));
       expect(e.actions).not.toContainEqual({
         type: applyDidYouMeanCorrection.type,
         payload: 'foo',
@@ -548,7 +552,7 @@ describe('search-slice', () => {
           }),
         })
       );
-      await e.dispatch(executeSearch(logSearchboxSubmit()));
+      await e.dispatch(executeSearch({legacy: logSearchboxSubmit()}));
       expect(e.actions).not.toContainEqual({
         type: applyDidYouMeanCorrection.type,
       });
@@ -563,11 +567,9 @@ describe('search-slice', () => {
       const initialState = buildMockSearch({
         response,
       });
-      const action = fetchFacetValues.fulfilled(
-        initialState,
-        '',
-        logFacetShowMore('')
-      );
+      const action = fetchFacetValues.fulfilled(initialState, '', {
+        legacy: logFacetShowMore(''),
+      });
 
       const finalState = searchReducer(state, action);
       expect(finalState.response.facets).toEqual(response.facets);
@@ -581,11 +583,9 @@ describe('search-slice', () => {
         response,
         searchResponseId: 'test',
       });
-      const action = fetchFacetValues.fulfilled(
-        initialState,
-        '',
-        logFacetShowMore('')
-      );
+      const action = fetchFacetValues.fulfilled(initialState, '', {
+        legacy: logFacetShowMore(''),
+      });
 
       const finalState = searchReducer(state, action);
       expect(finalState.response.searchUid).toEqual(response.searchUid);

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -4,7 +4,7 @@ import {
   fetchFacetValues,
   fetchMoreResults,
   fetchPage,
-} from './search-actions';
+} from './legacy/search-actions';
 import {
   emptyQuestionAnswer,
   getSearchInitialState,

--- a/packages/headless/src/features/triggers/triggers-slice.test.ts
+++ b/packages/headless/src/features/triggers/triggers-slice.test.ts
@@ -23,11 +23,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.redirectTo).toEqual('');
@@ -47,11 +45,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.redirectTo).toEqual('');
@@ -69,11 +65,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.redirectTo).toEqual('https://www.coveo.com');
@@ -92,11 +86,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.query).toEqual('');
@@ -115,11 +107,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.executions).toEqual([]);
@@ -140,11 +130,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.executions).toEqual([
@@ -168,11 +156,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.notifications).toEqual([]);
@@ -188,11 +174,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.notifications).toEqual(['Hello world']);
@@ -235,11 +219,9 @@ describe('trigger slice', () => {
       response,
     });
 
-    const action = executeSearch.fulfilled(
-      searchState,
-      '',
-      logSearchboxSubmit()
-    );
+    const action = executeSearch.fulfilled(searchState, '', {
+      legacy: logSearchboxSubmit(),
+    });
     const finalState = triggerReducer(state, action);
 
     expect(finalState.redirectTo).toEqual(expectedRedirections[0]);

--- a/packages/headless/src/test/mock-search.ts
+++ b/packages/headless/src/test/mock-search.ts
@@ -1,4 +1,6 @@
+import {SearchPageEvents} from '../features/analytics/search-action-cause';
 import {logSearchboxSubmit} from '../features/query/query-analytics-actions';
+import {ExecuteSearchThunkReturn as LegacyExecuteSearchThunkReturn} from '../features/search/legacy/search-actions';
 import {ExecuteSearchThunkReturn} from '../features/search/search-actions';
 import {SearchState} from '../features/search/search-state';
 import {buildMockSearchResponse} from './mock-search-response';
@@ -6,6 +8,23 @@ import {buildMockSearchResponse} from './mock-search-response';
 export function buildMockSearch(
   config: Partial<SearchState> = {}
 ): ExecuteSearchThunkReturn {
+  return {
+    response: buildMockSearchResponse(),
+    duration: 0,
+    queryExecuted: '',
+    error: null,
+    automaticallyCorrected: false,
+    originalQuery: '',
+    analyticsAction: {
+      actionCause: SearchPageEvents.searchboxSubmit,
+    },
+    ...config,
+  };
+}
+
+export function buildMockLegacySearch(
+  config: Partial<SearchState> = {}
+): LegacyExecuteSearchThunkReturn {
   return {
     response: buildMockSearchResponse(),
     duration: 0,


### PR DESCRIPTION
Review guide:
 - everything in `packages/headless/src/features/search/`
 - Where I sparkled a few comments