### PR TITLE
[CAPI-87] feat(headless): allow skipping facet registration

### DIFF
--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.test.ts
@@ -113,6 +113,16 @@ describe('facet', () => {
     expect(() => initFacet()).toThrow('Check the options of buildFacet');
   });
 
+  it('skips registering the facet if explicitly told to', () => {
+    engine = buildMockSearchAppEngine({state});
+    facet = buildCoreFacet(engine, {
+      options,
+      registerFacet: false,
+    });
+    const action = engine.actions.find((a) => a.type === registerFacet.type);
+    expect(action).toBeUndefined();
+  });
+
   it('#state.facetId exposes the facet id', () => {
     expect(facet.state.facetId).toBe(facetId);
   });

--- a/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
+++ b/packages/headless/src/controllers/core/facets/facet/headless-core-facet.ts
@@ -63,6 +63,13 @@ export interface CoreFacetProps {
    * The options for the core `Facet` controller.
    * */
   options: FacetOptions;
+
+  /**
+   * Whether the facet should be registered.
+   *
+   * @defaultValue `true`
+   */
+  registerFacet?: boolean;
 }
 
 /**
@@ -376,7 +383,9 @@ export function buildCoreFacet(
     return initialNumberOfValues < currentValues.length && hasIdleValues;
   };
 
-  dispatch(registerFacet(registrationOptions));
+  if (props.registerFacet !== false) {
+    dispatch(registerFacet(registrationOptions));
+  }
 
   return {
     ...controller,


### PR DESCRIPTION
To support generating facets, we must be able to register facets **outside** of the core facet controller.

Here's an example use case which depends on the mechanism proposed in this PR (https://github.com/coveo/ui-kit/pull/3389):
https://github.com/coveo/ui-kit/blob/5080e7855478c96321ccd33bf5061b1556fc96c1/packages/headless/src/controllers/commerce/facets/headless-facet-generator.ts#L34-L67

Without conditionally registering the facet, the facet generator's state seems to continuously `dispatch` the `registerFacet` action. Only by extracting the registration outside of the core facet, we are able to register facets properly.

[CAPI-87]