### PR TITLE
chore: add release internal in each package using it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@actions/github": "6.0.0",
         "@commitlint/config-conventional": "17.8.1",
         "@commitlint/lint": "17.8.1",
+        "@coveo/release": "1.0.0",
         "@cspell/dict-fr-fr": "2.2.2",
         "@cspell/eslint-plugin": "7.3.9",
         "@octokit/rest": "20.0.2",
@@ -3084,9 +3085,9 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "18.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.4.1.tgz",
-      "integrity": "sha512-o/plBiPJQgbSq/4ipDpsq4HCmURjBAEjr1EO/p2falr3VhwV0WGXTvb8NlihgI8xtSyO6lHvtycrE535GMLQbA==",
+      "version": "18.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.4.2.tgz",
+      "integrity": "sha512-CKmzXdF9XwZJoVijAqpUlV9qzZOkyiYni4KuSCtTZVAAVudi9H84cJ4FqZxSwEP9G21vmoJiNrW8G042AsduVg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -7819,9 +7820,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@octokit/app": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.1.tgz",
-      "integrity": "sha512-4opdXcWBVhzd6FOxlaxDKXXqi9Vz2hsDSWQGNo49HbYFAX11UqMpksMjEdfvHy0x19Pse8Nvn+R6inNb/V398w==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+      "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
       "dependencies": {
         "@octokit/auth-app": "^6.0.0",
         "@octokit/auth-unauthenticated": "^5.0.0",
@@ -7829,7 +7830,7 @@
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-rest": "^9.0.0",
         "@octokit/types": "^12.0.0",
-        "@octokit/webhooks": "^12.0.1"
+        "@octokit/webhooks": "^12.0.4"
       },
       "engines": {
         "node": ">= 18"
@@ -8069,9 +8070,9 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.4.tgz",
-      "integrity": "sha512-e8dSb9ypW1Q2I+qkOPzs3A9f4/EGpSZSI45wWBfXiqcvpoxSywVcZajZRhFwAutKI+/NNoeKxsxMwCx73oQyWw==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.5.tgz",
+      "integrity": "sha512-LMEdsMV8TTMjMTqVoqMzV95XTbv0ZsWxCxQtjAunQOCdwoDH4BVF/Ke5JMSZEVCWGI2kzxnUNbFnK/MxwV7NjA==",
       "dependencies": {
         "@octokit/types": "^12.3.0"
       },
@@ -8165,9 +8166,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.3.tgz",
-      "integrity": "sha512-8iG+/yza7hwz1RrQ7i7uGpK2/tuItZxZq1aTmeg2TNp2xTUB8F8lZF/FcZvyyAxT8tpDMF74TjFGCDACkf1kAQ==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.4.tgz",
+      "integrity": "sha512-dopyfA1suemLwlJsiEBKEW7hnVrxvk2xzXHkUkx68vl74ie9JzdizW6FUU0gVi3Bq3AVrIXS1Yt4vCF4KV5pqA==",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/webhooks-methods": "^4.0.0",
@@ -8304,20 +8305,20 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.3.7.tgz",
-      "integrity": "sha512-Ou8eDlF+yh2rzXeCTpMPYJ2fuqsusNOhmpYPYNQJQ2h6PvaF30kPomflgRILems+EBBuggRtcT+I+1YH4o/q6w==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.3.10.tgz",
+      "integrity": "sha512-bIx0t5s9ewH1PlcEcuQUD+UnVrCjPGAfjhVR5Gew565X60nE+GTIHRn70nMv9G4he/amBF+Z+vf5t8SNZEWMwg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-clean": "11.3.7",
-        "@react-native-community/cli-config": "11.3.7",
-        "@react-native-community/cli-debugger-ui": "11.3.7",
-        "@react-native-community/cli-doctor": "11.3.7",
-        "@react-native-community/cli-hermes": "11.3.7",
-        "@react-native-community/cli-plugin-metro": "11.3.7",
-        "@react-native-community/cli-server-api": "11.3.7",
-        "@react-native-community/cli-tools": "11.3.7",
-        "@react-native-community/cli-types": "11.3.7",
+        "@react-native-community/cli-clean": "11.3.10",
+        "@react-native-community/cli-config": "11.3.10",
+        "@react-native-community/cli-debugger-ui": "11.3.10",
+        "@react-native-community/cli-doctor": "11.3.10",
+        "@react-native-community/cli-hermes": "11.3.10",
+        "@react-native-community/cli-plugin-metro": "11.3.10",
+        "@react-native-community/cli-server-api": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
+        "@react-native-community/cli-types": "11.3.10",
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "execa": "^5.0.0",
@@ -8335,12 +8336,12 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-11.3.7.tgz",
-      "integrity": "sha512-twtsv54ohcRyWVzPXL3F9VHGb4Qhn3slqqRs3wEuRzjR7cTmV2TIO2b1VhaqF4HlCgNd+cGuirvLtK2JJyaxMg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-11.3.10.tgz",
+      "integrity": "sha512-g6QjW+DSqoWRHzmIQW3AH22k1AnynWuOdy2YPwYEGgPddTeXZtJphIpEVwDOiC0L4mZv2VmiX33/cGNUwO0cIA==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "prompts": "^2.4.0"
@@ -8454,12 +8455,12 @@
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-11.3.7.tgz",
-      "integrity": "sha512-FDBLku9xskS+bx0YFJFLCmUJhEZ4/MMSC9qPYOGBollWYdgE7k/TWI0IeYFmMALAnbCdKQAYP5N29N55Tad8lg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-11.3.10.tgz",
+      "integrity": "sha512-YYu14nm1JYLS6mDRBz78+zDdSFudLBFpPkhkOoj4LuBhNForQBIqFFHzQbd9/gcguJxfW3vlYSnudfaUI7oGLg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^4.3.0",
@@ -8573,24 +8574,24 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-11.3.7.tgz",
-      "integrity": "sha512-aVmKuPKHZENR8SrflkMurZqeyLwbKieHdOvaZCh1Nn/0UC5CxWcyST2DB2XQboZwsvr3/WXKJkSUO+SZ1J9qTQ==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-11.3.10.tgz",
+      "integrity": "sha512-kyitGV3RsjlXIioq9lsuawha2GUBPCTAyXV6EBlm3qlyF3dMniB3twEvz+fIOid/e1ZeucH3Tzy5G3qcP8yWoA==",
       "peer": true,
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-11.3.7.tgz",
-      "integrity": "sha512-YEHUqWISOHnsl5+NM14KHelKh68Sr5/HeEZvvNdIcvcKtZic3FU7Xd1WcbNdo3gCq5JvzGFfufx02Tabh5zmrg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-11.3.10.tgz",
+      "integrity": "sha512-DpMsfCWKZ15L9nFK/SyDvpl5v6MjV+arMHMC1i8kR+DOmf2xWmp/pgMywKk0/u50yGB9GwxBHt3i/S/IMK5Ylg==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-config": "11.3.7",
-        "@react-native-community/cli-platform-android": "11.3.7",
-        "@react-native-community/cli-platform-ios": "11.3.7",
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-config": "11.3.10",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-platform-ios": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "envinfo": "^7.7.2",
@@ -8745,25 +8746,25 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-11.3.7.tgz",
-      "integrity": "sha512-chkKd8n/xeZkinRvtH6QcYA8rjNOKU3S3Lw/3Psxgx+hAYV0Gyk95qJHTalx7iu+PwjOOqqvCkJo5jCkYLkoqw==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-11.3.10.tgz",
+      "integrity": "sha512-vqINuzAlcHS9ImNwJtT43N7kfBQ7ro9A8O1Gpc5TQ0A8V36yGG8eoCHeauayklVVgMZpZL6f6mcoLLr9IOgBZQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-platform-android": "11.3.7",
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-11.3.7.tgz",
-      "integrity": "sha512-WGtXI/Rm178UQb8bu1TAeFC/RJvYGnbHpULXvE20GkmeJ1HIrMjkagyk6kkY3Ej25JAP2R878gv+TJ/XiRhaEg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-11.3.10.tgz",
+      "integrity": "sha512-RGu9KuDIXnrcNkacSHj5ETTQtp/D/835L6veE2jMigO21p//gnKAjw3AVLCysGr8YXYfThF8OSOALrwNc94puQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "glob": "^7.1.3",
@@ -8920,12 +8921,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.3.7.tgz",
-      "integrity": "sha512-Z/8rseBput49EldX7MogvN6zJlWzZ/4M97s2P+zjS09ZoBU7I0eOKLi0N9wx+95FNBvGQQ/0P62bB9UaFQH2jw==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.3.10.tgz",
+      "integrity": "sha512-JjduMrBM567/j4Hvjsff77dGSLMA0+p9rr0nShlgnKPcc+0J4TDy0hgWpUceM7OG00AdDjpetAPupz0kkAh4cQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-xml-parser": "^4.0.12",
@@ -9083,13 +9084,13 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.3.7.tgz",
-      "integrity": "sha512-0WhgoBVGF1f9jXcuagQmtxpwpfP+2LbLZH4qMyo6OtYLWLG13n2uRep+8tdGzfNzl1bIuUTeE9yZSAdnf9LfYQ==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.3.10.tgz",
+      "integrity": "sha512-ZYAc5Hc+QVqJgj1XFbpKnIPbSJ9xKcBnfQrRhR+jFyt2DWx85u4bbzY1GSVc/USs0UbSUXv4dqPbnmOJz52EYQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "11.3.7",
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-server-api": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "metro": "0.76.8",
@@ -9209,13 +9210,13 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-11.3.7.tgz",
-      "integrity": "sha512-yoFyGdvR3HxCnU6i9vFqKmmSqFzCbnFSnJ29a+5dppgPRetN+d//O8ard/YHqHzToFnXutAFf2neONn23qcJAg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-11.3.10.tgz",
+      "integrity": "sha512-WEwHWIpqx3gA6Da+lrmq8+z78E1XbxxjBlvHAXevhjJj42N4SO417eZiiUVrFzEFVVJSUee9n9aRa0kUR+0/2w==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "11.3.7",
-        "@react-native-community/cli-tools": "11.3.7",
+        "@react-native-community/cli-debugger-ui": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
@@ -9302,9 +9303,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-11.3.7.tgz",
-      "integrity": "sha512-peyhP4TV6Ps1hk+MBHTFaIR1eI3u+OfGBvr5r0wPwo3FAJvldRinMgcB/TcCcOBXVORu7ba1XYjkubPeYcqAyA==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-11.3.10.tgz",
+      "integrity": "sha512-4kCuCwVcGagSrNg9vxMNVhynwpByuC/J5UnKGEet3HuqmoDhQW15m18fJXiehA8J+u9WBvHduefy9nZxO0C06Q==",
       "peer": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
@@ -9340,9 +9341,9 @@
       }
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "11.3.7",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-11.3.7.tgz",
-      "integrity": "sha512-OhSr/TiDQkXjL5YOs8+hvGSB+HltLn5ZI0+A3DCiMsjUgTTsYh+Z63OtyMpNjrdCEFcg0MpfdU2uxstCS6Dc5g==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-11.3.10.tgz",
+      "integrity": "sha512-0FHK/JE7bTn0x1y8Lk5m3RISDHIBQqWLltO2Mf7YQ6cAeKs8iNOJOeKaHJEY+ohjsOyCziw+XSC4cY57dQrwNA==",
       "peer": true,
       "dependencies": {
         "joi": "^17.2.1"
@@ -15794,9 +15795,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -16874,9 +16875,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "funding": [
         {
           "type": "opencollective",
@@ -20522,6 +20523,12 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
       "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -20957,14 +20964,14 @@
       }
     },
     "node_modules/deprecated-react-native-prop-types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-4.1.0.tgz",
-      "integrity": "sha512-WfepZHmRbbdTvhcolb8aOKEvQdcmTMn5tKLbqbXmkBvjFjRVWAYqsXk/DBsV8TZxws8SdGHLuHaJrHSQUPRdfw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-4.2.3.tgz",
+      "integrity": "sha512-2rLTiMKidIFFYpIVM69UnQKngLqQfL6I11Ch8wGSBftS18FUXda+o2we2950X+1dmbgps28niI3qwyH4eX3Z1g==",
       "peer": true,
       "dependencies": {
-        "@react-native/normalize-colors": "*",
-        "invariant": "*",
-        "prop-types": "*"
+        "@react-native/normalize-colors": "<0.73.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1"
       }
     },
     "node_modules/deprecation": {
@@ -21537,9 +21544,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.582",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
-      "integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA=="
+      "version": "1.4.585",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.585.tgz",
+      "integrity": "sha512-B4yBlX0azdA3rVMxpYwLQfDpdwOgcnLCkpvSOd68iFmeedo+WYjaBJS3/W58LVD8CB2nf+o7C4K9xz1l09RkWg=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -27049,9 +27056,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "engines": {
         "node": ">= 4"
       }
@@ -31364,12 +31371,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-zfA+5SuwYN2VWqN1/5HZaDzQKLJHaBVMZIIM+wuYjdptkaQsqzDdqjqf+lZZJUuJq1aanHiY8LhH8LmH+qBYJA==",
       "dev": true,
       "dependencies": {
-        "jsonify": "^0.0.1"
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -31379,6 +31392,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -32544,18 +32563,6 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -32566,12 +32573,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "node_modules/lodash.invokemap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
-      "integrity": "sha512-CfkycNtMqgUlfjfdh2BhKO/ZXrP8ePOX5lEU/g0R3ItJcnuxWDwokMGKx1hWcfOikmyOVx6X9IwWnDGlgKl61w==",
-      "dev": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -32644,12 +32645,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
-    "node_modules/lodash.pullall": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.pullall/-/lodash.pullall-4.2.0.tgz",
-      "integrity": "sha512-VhqxBKH0ZxPpLhiu68YD1KnHmbhQJQctcipvmFnqIBDYzcIHzf3Zpu0tpeOKtR4x76p9yohc506eGdOjTmyIBg==",
-      "dev": true
-    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
@@ -32677,12 +32672,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
-    },
-    "node_modules/lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-      "dev": true
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
@@ -39668,15 +39657,15 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-native": {
-      "version": "0.72.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.6.tgz",
-      "integrity": "sha512-RafPY2gM7mcrFySS8TL8x+TIO3q7oAlHpzEmC7Im6pmXni6n1AuufGaVh0Narbr1daxstw7yW7T9BKW5dpVc2A==",
+      "version": "0.72.7",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.7.tgz",
+      "integrity": "sha512-dqVFojOO9rOvyFbbM3/v9/GJR355OSuBhEY4NQlMIRc2w0Xch5MT/2uPoq3+OvJ+5h7a8LFAco3fucSffG0FbA==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.2.1",
-        "@react-native-community/cli": "11.3.7",
-        "@react-native-community/cli-platform-android": "11.3.7",
-        "@react-native-community/cli-platform-ios": "11.3.7",
+        "@react-native-community/cli": "11.3.10",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-platform-ios": "11.3.10",
         "@react-native/assets-registry": "^0.72.0",
         "@react-native/codegen": "^0.72.7",
         "@react-native/gradle-plugin": "^0.72.11",
@@ -39686,7 +39675,7 @@
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "base64-js": "^1.1.2",
-        "deprecated-react-native-prop-types": "4.1.0",
+        "deprecated-react-native-prop-types": "^4.2.3",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.5",
         "invariant": "^2.2.4",
@@ -46081,24 +46070,20 @@
       }
     },
     "node_modules/webpack-bundle-analyzer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.9.1.tgz",
-      "integrity": "sha512-jnd6EoYrf9yMxCyYDPj8eutJvtjQNp8PHmni/e/ulydHBWhT5J3menXt3HEkScsu9YqMAcG4CfFjs3rj5pVU1w==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "0.5.7",
         "acorn": "^8.0.4",
         "acorn-walk": "^8.0.0",
         "commander": "^7.2.0",
+        "debounce": "^1.2.1",
         "escape-string-regexp": "^4.0.0",
         "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
         "is-plain-object": "^5.0.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.escape": "^4.0.1",
-        "lodash.flatten": "^4.4.0",
-        "lodash.invokemap": "^4.6.0",
-        "lodash.pullall": "^4.2.0",
-        "lodash.uniqby": "^4.7.0",
         "opener": "^1.5.2",
         "picocolors": "^1.0.0",
         "sirv": "^2.0.3",
@@ -47642,6 +47627,7 @@
       "devDependencies": {
         "@babel/core": "7.23.3",
         "@coveo/headless": "2.39.0",
+        "@coveo/release": "1.0.0",
         "@fullhuman/postcss-purgecss": "5.0.0",
         "@rollup/plugin-alias": "5.0.1",
         "@rollup/plugin-replace": "5.0.5",
@@ -50518,6 +50504,7 @@
         "@stencil/core": "4.6.0"
       },
       "devDependencies": {
+        "@coveo/release": "1.0.0",
         "cypress": "13.5.0",
         "cypress-repeat": "2.3.4"
       }
@@ -50530,6 +50517,7 @@
       },
       "devDependencies": {
         "@coveo/headless": "2.39.0",
+        "@coveo/release": "1.0.0",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-replace": "^5.0.0",
@@ -50687,6 +50675,7 @@
       "version": "1.11.3",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@coveo/release": "1.0.0",
         "jest": "29.7.0",
         "rimraf": "5.0.5",
         "ts-jest": "29.1.1",
@@ -51759,6 +51748,7 @@
       "version": "0.45.3",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@coveo/release": "1.0.0",
         "jest": "29.7.0",
         "ts-jest": "29.1.1"
       }
@@ -52844,6 +52834,7 @@
         "undici": "5.27.2"
       },
       "devDependencies": {
+        "@coveo/release": "1.0.0",
         "@microsoft/api-extractor": "7.38.3",
         "@microsoft/api-extractor-model": "7.28.2",
         "@microsoft/tsdoc": "0.14.2",
@@ -52869,6 +52860,7 @@
         "@coveo/headless": "2.39.0"
       },
       "devDependencies": {
+        "@coveo/release": "1.0.0",
         "@testing-library/react": "14.0.0",
         "@types/jest": "29.5.8",
         "@types/react": "18.2.21",
@@ -55031,6 +55023,7 @@
       },
       "devDependencies": {
         "@ckeditor/jsdoc-plugins": "39.2.1",
+        "@coveo/release": "1.0.0",
         "@lwc/compiler": "3.8.0",
         "@lwc/eslint-plugin-lwc": "1.6.4",
         "@octokit/graphql": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@actions/core": "1.10.1",
     "@actions/github": "6.0.0",
+    "@coveo/release": "1.0.0",
     "@commitlint/config-conventional": "17.8.1",
     "@commitlint/lint": "17.8.1",
     "@cspell/dict-fr-fr": "2.2.2",

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -38,6 +38,7 @@
     "@stencil/core": "4.6.0"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "cypress": "13.5.0",
     "cypress-repeat": "2.3.4"
   }

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -33,6 +33,7 @@
     "@coveo/atomic": "2.49.0"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "@coveo/headless": "2.39.0",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.3",
+    "@coveo/release": "1.0.0",
     "@coveo/headless": "2.39.0",
     "@fullhuman/postcss-purgecss": "5.0.0",
     "@rollup/plugin-alias": "5.0.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/coveo/ui-kit/packages/auth#readme",
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "rimraf": "5.0.5",
     "vite": "4.5.0",
     "jest": "29.7.0",

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -32,6 +32,7 @@
     "promote:npm:latest": "node ../../scripts/deploy/update-npm-tag.mjs latest"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "jest": "29.7.0",
     "ts-jest": "29.1.1"
   }

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -38,6 +38,7 @@
     "@coveo/headless": "2.39.0"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "@testing-library/react": "14.0.0",
     "@types/jest": "29.5.8",
     "@types/react": "18.2.21",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -68,6 +68,7 @@
     "undici": "5.27.2"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "@microsoft/api-extractor": "7.38.3",
     "@microsoft/api-extractor-model": "7.28.2",
     "@microsoft/tsdoc": "0.14.2",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -52,6 +52,7 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
+    "@coveo/release": "1.0.0",
     "@ckeditor/jsdoc-plugins": "39.2.1",
     "@lwc/compiler": "3.8.0",
     "@lwc/eslint-plugin-lwc": "1.6.4",


### PR DESCRIPTION
I think since #3399 , NPM was able to reify the package-lock way more narrowly, breaking some of our misuse/implicit dependency links.
This makes those implicit links explicit.