### PR TITLE
chore: adapt angular scripts for npm run-script

### DIFF
--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -7,6 +7,7 @@
     "build": "nx build",
     "build:bundles": "ng build",
     "build:assets": "ncp ../atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp ../atomic/dist/atomic/lang projects/atomic-angular/dist/lang",
+    "release:phase1": "node ./scripts/bump.mjs",
     "release:phase2": "npm run publish:npm",
     "release:phase5": "npm run publish:npm",
     "publish:npm": "node ./scripts/publish-npm.mjs"

--- a/packages/atomic-angular/project.json
+++ b/packages/atomic-angular/project.json
@@ -18,13 +18,6 @@
     "build": {
       "dependsOn": ["cached:build"],
       "executor": "nx:noop"
-    },
-    "release:phase1": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "npm run-script -w=@coveo/release bump",
-        "cwd": "packages/atomic-angular/projects/atomic-angular"
-      }
     }
   }
 }

--- a/packages/atomic-angular/scripts/bump.mjs
+++ b/packages/atomic-angular/scripts/bump.mjs
@@ -1,0 +1,4 @@
+import {resolve} from 'node:path';
+
+process.env.INIT_CWD = resolve('./projects/atomic-angular');
+await import('@coveo/release/bump-package.mjs');

--- a/packages/atomic-angular/scripts/publish-npm.mjs
+++ b/packages/atomic-angular/scripts/publish-npm.mjs
@@ -1,2 +1,4 @@
-process.chdir('./projects/atomic-angular/dist');
+import {resolve} from 'node:path';
+
+process.env.INIT_CWD = resolve('./projects/atomic-angular/dist');
 await import('@coveo/release/npm-publish-package.mjs');


### PR DESCRIPTION
- Remove NX quirk, it doesn't play nice with angular
- Replace with script in the same vein as later phases
- Adapt scripts to use process.env.INIT_CWD for compat.