### PR TITLE
chore(codeowners): co-own the pjson of quantic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,7 @@
 
 # Owners of the Quantic package
 /packages/quantic/ @coveo/salesforce-integration
+/packages/quantic/package.json @coveo/salesforce-integration @coveo/search
 
 # Owners of the Atomic Insight components
 /packages/atomic/src/components/insight @coveo/service-core


### PR DESCRIPTION
This should allow us to merge and renovate updates without 2 teams' approval but only DXUI.