### PR TITLE
fix: decode HTML content

### DIFF
--- a/packages/headless/src/api/search/encoding-finder.test.ts
+++ b/packages/headless/src/api/search/encoding-finder.test.ts
@@ -1,0 +1,22 @@
+import {findEncoding} from './encoding-finder';
+
+describe('#findEncoding', () => {
+  it('when the response has no content-type header, it returns UTF-8', () => {
+    const response = new Response('', {headers: {}});
+    expect(findEncoding(response)).toBe('UTF-8');
+  });
+
+  it('when the content-type header does not contain a charset, it returns UTF-8', () => {
+    const headers = {'content-type': 'text/html'};
+    const response = new Response('', {headers});
+
+    expect(findEncoding(response)).toBe('UTF-8');
+  });
+
+  it('when the content-type header has a charset, it returns the charset value', () => {
+    const headers = {'content-type': 'text/html; charset=UTF-16'};
+    const response = new Response('', {headers});
+
+    expect(findEncoding(response)).toBe('UTF-16');
+  });
+});

--- a/packages/headless/src/api/search/encoding-finder.ts
+++ b/packages/headless/src/api/search/encoding-finder.ts
@@ -1,0 +1,8 @@
+export function findEncoding(response: Response) {
+  const contentType = response.headers.get('content-type') || '';
+  const charset =
+    contentType.split(';').find((part) => part.indexOf('charset=') !== -1) ||
+    '';
+
+  return charset.split('=')[1] || 'UTF-8';
+}

--- a/packages/headless/src/api/search/html/html-api-client.ts
+++ b/packages/headless/src/api/search/html/html-api-client.ts
@@ -3,6 +3,7 @@ import {URLPath} from '../../../utils/url-utils';
 import {pickNonBaseParams, unwrapError} from '../../api-client-utils';
 import {PlatformClient} from '../../platform-client';
 import {PreprocessRequest, RequestMetadata} from '../../preprocess-request';
+import {findEncoding} from '../encoding-finder';
 import {SearchAPIErrorWithStatusCode} from '../search-api-error-response';
 import {baseSearchRequest} from '../search-api-params';
 import {HtmlRequest} from './html-request';
@@ -66,7 +67,10 @@ export const getHtml = async (
     throw response;
   }
 
-  const body = await response.text();
+  const encoding = findEncoding(response);
+  const buffer = await response.arrayBuffer();
+  const decoder = new TextDecoder(encoding);
+  const body = decoder.decode(buffer);
 
   if (isSuccessHtmlResponse(body)) {
     return {success: body};

--- a/packages/headless/src/api/search/search-api-client.test.ts
+++ b/packages/headless/src/api/search/search-api-client.test.ts
@@ -647,6 +647,29 @@ describe('search api client', () => {
     });
 
     describe('SearchAPIClient.html', () => {
+      function encodeUTF16(str: string) {
+        const buf = new ArrayBuffer(str.length * 2);
+        const bufView = new Uint16Array(buf);
+
+        for (let i = 0, strLen = str.length; i < strLen; i++) {
+          bufView[i] = str.charCodeAt(i);
+        }
+
+        return bufView;
+      }
+
+      it('when the response is UTF-16 encoded, it decodes the response correctly', async () => {
+        const payload = encodeUTF16('hello');
+        const headers = {'content-type': 'text/html; charset=UTF-16'};
+        const response = new Response(payload, {headers});
+        PlatformClient.call = () => Promise.resolve(response);
+
+        const req = await buildResultPreviewRequest(state, {uniqueId: '1'});
+        const res = await searchAPIClient.html(req);
+
+        expect(res.success).toBe('hello');
+      });
+
       it('when calling SearchAPIClient.html should call PlatformClient.call with the right options', async () => {
         const req = await buildResultPreviewRequest(state, {uniqueId: '1'});
         searchAPIClient.html(req);

--- a/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
+++ b/packages/headless/src/api/service/case-assist/case-assist-api-client.test.ts
@@ -1,3 +1,5 @@
+import {buildResultPreviewRequest} from '../../../features/result-preview/result-preview-request-builder';
+import {createMockState} from '../../../test';
 import {buildMockCaseAssistAPIClient} from '../../../test/mock-case-assist-api-client';
 import {PlatformClient} from '../../platform-client';
 import {CaseAssistAPIClient} from './case-assist-api-client';
@@ -268,6 +270,32 @@ describe('case assist api client', () => {
       expect(response).toMatchObject({
         success: expectedBody,
       });
+    });
+  });
+
+  describe('caseAssistAPIClient.html', () => {
+    function encodeUTF16(str: string) {
+      const buf = new ArrayBuffer(str.length * 2);
+      const bufView = new Uint16Array(buf);
+
+      for (let i = 0, strLen = str.length; i < strLen; i++) {
+        bufView[i] = str.charCodeAt(i);
+      }
+
+      return bufView;
+    }
+
+    it('when the response is UTF-16 encoded, it decodes the response correctly', async () => {
+      const state = createMockState();
+      const payload = encodeUTF16('hello');
+      const headers = {'content-type': 'text/html; charset=UTF-16'};
+      const response = new Response(payload, {headers});
+      PlatformClient.call = () => Promise.resolve(response);
+
+      const req = await buildResultPreviewRequest(state, {uniqueId: '1'});
+      const res = await client.html(req);
+
+      expect(res.success).toBe('hello');
     });
   });
 });


### PR DESCRIPTION
Revert most of #3134.
I don't re-add the dependencies because TextDecoder/Encoder is a common web feature.
Yes, there's the question of React Native:
 - I confirmed with @olamothe in October: we don't support React Native
 - The documentation agrees: No trace of React Native (except some Qubit stuff ;) )
 
So, if anyone wants to use React-Native comes up about this, our answer will be:
1. We don't support React Native
2. If you still want to try, our best advice is: to try to polyfill all the missing libraries.