### PR TITLE
fix(commerce): forward country to commerce api

### DIFF
--- a/packages/headless/src/api/commerce/commerce-api-client.test.ts
+++ b/packages/headless/src/api/commerce/commerce-api-client.test.ts
@@ -37,6 +37,7 @@ describe('commerce api client', () => {
     url: platformUrl,
     trackingId: trackingId,
     language: req.language ?? '',
+    country: req.country ?? '',
     currency: req.currency ?? '',
     clientId: req.clientId ?? '',
     context: req.context ?? {

--- a/packages/headless/src/api/commerce/commerce-api-params.ts
+++ b/packages/headless/src/api/commerce/commerce-api-params.ts
@@ -9,6 +9,10 @@ export interface LanguageParam {
   language: string;
 }
 
+export interface CountryParam {
+  country: string;
+}
+
 export interface CurrencyParam {
   currency: string;
 }

--- a/packages/headless/src/api/commerce/common/request.ts
+++ b/packages/headless/src/api/commerce/common/request.ts
@@ -9,11 +9,13 @@ import {
   PageParam,
   SortParam,
   TrackingIdParam,
+  CountryParam,
 } from '../commerce-api-params';
 
 export type CommerceAPIRequest = BaseParam &
   TrackingIdParam &
   LanguageParam &
+  CountryParam &
   CurrencyParam &
   ClientIdParam &
   ContextParam &
@@ -34,6 +36,7 @@ const prepareRequestParams = (req: CommerceAPIRequest) => {
     clientId,
     context,
     language,
+    country,
     currency,
     page,
     facets,
@@ -44,6 +47,7 @@ const prepareRequestParams = (req: CommerceAPIRequest) => {
     clientId,
     context,
     language,
+    country,
     currency,
     page,
     facets,

--- a/packages/headless/src/controllers/commerce/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.test.ts
@@ -13,6 +13,7 @@ describe('headless commerce context', () => {
   const options = {
     trackingId: 'some-tracking-id',
     language: 'en',
+    country: 'ca',
     currency: 'USD',
     clientId: 'some-client-id',
     view: {
@@ -69,6 +70,11 @@ describe('headless commerce context', () => {
   it('setLanguage dispatches #setContext', () => {
     context.setLanguage('new-language');
     expectContainActionWithPayload(setContext, {language: 'new-language'});
+  });
+
+  it('setCountry dispatches #setContext', () => {
+    context.setCountry('new-country');
+    expectContainActionWithPayload(setContext, {country: 'new-country'});
   });
 
   it('setCurrency dispatches #setContext', () => {

--- a/packages/headless/src/controllers/commerce/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.test.ts
@@ -13,7 +13,7 @@ describe('headless commerce context', () => {
   const options = {
     trackingId: 'some-tracking-id',
     language: 'en',
-    country: 'ca',
+    country: 'us',
     currency: 'USD',
     clientId: 'some-client-id',
     view: {

--- a/packages/headless/src/controllers/commerce/context/headless-context.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.ts
@@ -16,6 +16,7 @@ import {
 export interface ContextOptions {
   trackingId: string;
   language: string;
+  country: string;
   currency: string;
   clientId: string;
   user?: User;
@@ -63,6 +64,12 @@ export interface Context extends Controller {
   setLanguage(language: string): void;
 
   /**
+   * Sets the country.
+   * @param country - The new country.
+   */
+  setCountry(country: string): void;
+
+  /**
    * Sets the currency.
    * @param currency - The new currency.
    */
@@ -95,6 +102,7 @@ export interface Context extends Controller {
 export interface ContextState {
   trackingId: string;
   language: string;
+  country: string;
   currency: string;
   clientId: string;
   user?: User;
@@ -154,6 +162,14 @@ export function buildContext(
         setContext({
           ...getState().commerceContext,
           language,
+        })
+      ),
+
+    setCountry: (country: string) =>
+      dispatch(
+        setContext({
+          ...getState().commerceContext,
+          country,
         })
       ),
 

--- a/packages/headless/src/features/commerce/context/context-actions.ts
+++ b/packages/headless/src/features/commerce/context/context-actions.ts
@@ -17,6 +17,7 @@ import {
 export interface SetContextPayload {
   trackingId: string;
   language: string;
+  country: string;
   currency: string;
   clientId: string;
   user?: UserParams;

--- a/packages/headless/src/features/commerce/context/context-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/context-slice.test.ts
@@ -20,8 +20,9 @@ describe('context-slice', () => {
         state,
         setContext({
           trackingId: 'some-tracking-id',
-          currency: 'CAD',
           language: 'fr',
+          country: 'ca',
+          currency: 'CAD',
           clientId: 'some-client-id',
           view: {
             url: 'https://example.org',
@@ -30,8 +31,9 @@ describe('context-slice', () => {
       )
     ).toEqual({
       trackingId: 'some-tracking-id',
-      currency: 'CAD',
       language: 'fr',
+      country: 'ca',
+      currency: 'CAD',
       clientId: 'some-client-id',
       view: {
         url: 'https://example.org',

--- a/packages/headless/src/features/commerce/context/context-state.ts
+++ b/packages/headless/src/features/commerce/context/context-state.ts
@@ -6,6 +6,7 @@ import {
 export interface CommerceContextState {
   trackingId: string;
   language: string;
+  country: string;
   currency: string;
   clientId: string;
   user?: UserParams;
@@ -15,6 +16,7 @@ export interface CommerceContextState {
 export const getContextInitialState = (): CommerceContextState => ({
   trackingId: '',
   language: '',
+  country: '',
   currency: '',
   clientId: '',
   view: {

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -18,6 +18,7 @@ export const userDefinition = {
 export const contextDefinition = {
   trackingId: requiredNonEmptyString,
   language: requiredNonEmptyString,
+  country: requiredNonEmptyString,
   currency: requiredNonEmptyString,
   clientId: requiredNonEmptyString,
   user: new RecordValue({

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -39,7 +39,7 @@ describe.skip('commerce', () => {
       options: {
         trackingId: 'barca',
         language: 'en-gb',
-        country: 'ca',
+        country: 'gb',
         currency: 'gbp',
         clientId: '41915baa-621c-4408-b9c0-6e59b3cde129',
         view: {

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -39,6 +39,7 @@ describe.skip('commerce', () => {
       options: {
         trackingId: 'barca',
         language: 'en-gb',
+        country: 'ca',
         currency: 'gbp',
         clientId: '41915baa-621c-4408-b9c0-6e59b3cde129',
         view: {


### PR DESCRIPTION
The commerce api now exposes a required `country` body parameter. This PR exposes methods to set it through the context controller, and builds commerce api requests using it.

[CAPI-348]

[CAPI-348]: https://coveord.atlassian.net/browse/CAPI-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ