### PR TITLE
docs(headless): added RGA controller to doc-parser

### DIFF
--- a/packages/headless/doc-parser/use-cases/search.ts
+++ b/packages/headless/doc-parser/use-cases/search.ts
@@ -465,6 +465,10 @@ const controllers: ControllerConfiguration[] = [
     initializer: 'buildInteractiveCitation',
     samplePaths: {},
   },
+  {
+    initializer: 'buildGeneratedAnswer',
+    samplePaths: {},
+  },
 ];
 
 const actionLoaders: ActionLoaderConfiguration[] = [

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -34,7 +34,11 @@ import {GeneratedAnswerSection} from '../../state/state-sections';
 import {loadReducerError} from '../../utils/errors';
 import {Controller, buildController} from '../controller/headless-controller';
 
-export type {GeneratedAnswerState, GeneratedAnswerCitation};
+export type {
+  GeneratedAnswerCitation,
+  GeneratedResponseFormat,
+  GeneratedAnswerState,
+};
 
 export interface GeneratedAnswer extends Controller {
   /**
@@ -55,6 +59,7 @@ export interface GeneratedAnswer extends Controller {
   dislike(): void;
   /**
    * Re-executes the query to generate the answer in the specified format.
+   * @param responseFormat - The formatting options to apply to generated answers.
    */
   rephrase(responseFormat: GeneratedResponseFormat): void;
   /**
@@ -77,7 +82,7 @@ export interface GeneratedAnswer extends Controller {
   sendDetailedFeedback(details: string): void;
   /**
    * Logs a custom event indicating a cited source link was clicked.
-   * @param id The ID of the clicked citation.
+   * @param id - The ID of the clicked citation.
    */
   logCitationClick(id: string): void;
   /**
@@ -94,8 +99,8 @@ export interface GeneratedAnswer extends Controller {
   logCopyToClipboard(): void;
   /**
    * Logs a custom event indicating a cited source link was hovered.
-   * @param citationId The ID of the clicked citation.
-   * @param citationHoverTimeMs The number of milliseconds spent hovering over the citation.
+   * @param citationId - The ID of the clicked citation.
+   * @param citationHoverTimeMs - The number of milliseconds spent hovering over the citation.
    */
   logCitationHover(citationId: string, citationHoverTimeMs: number): void;
 }

--- a/packages/headless/src/controllers/index.ts
+++ b/packages/headless/src/controllers/index.ts
@@ -426,7 +426,9 @@ export {buildAutomaticFacetGenerator} from './facets/automatic-facet-generator/h
 export type {
   GeneratedAnswer,
   GeneratedAnswerState,
+  GeneratedAnswerProps,
   GeneratedAnswerCitation,
+  GeneratedResponseFormat,
 } from './generated-answer/headless-generated-answer';
 export {buildGeneratedAnswer} from './generated-answer/headless-generated-answer';
 


### PR DESCRIPTION
Apparently the buildGeneratedAnswer function was not included in the JSON the docs team uses to generate our reference documentation.

This should do it.