### PR TITLE
refactor(headless): remove analytics search events duplication

### DIFF
--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -287,7 +287,7 @@ describe('search analytics', () => {
       state.facetSet[facetId] = buildMockFacetSlice({});
 
       expect(
-        new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
+        new SearchAnalyticsProvider(() => state).getFacetUpdateSortMetadata(
           facetId,
           criteria
         )
@@ -316,7 +316,7 @@ describe('search analytics', () => {
       expect(
         new SearchAnalyticsProvider(
           () => state
-        ).getRangeFacetBreadcrumbMetadata(facetId, facetValue)
+        ).getRangeBreadcrumbFacetMetadata(facetId, facetValue)
       ).toEqual({
         coveoHeadlessVersion: 'Test version',
         facetField: state.facetSet[facetId].request.field,
@@ -385,7 +385,7 @@ describe('search analytics', () => {
       expect(
         new SearchAnalyticsProvider(
           () => state
-        ).getCategoryFacetBreadcrumbMetadata(categoryFacetId, categoryFacetPath)
+        ).getCategoryBreadcrumbFacetMetadata(categoryFacetId, categoryFacetPath)
       ).toEqual({
         coveoHeadlessVersion: 'Test version',
         categoryFacetField:

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -125,7 +125,7 @@ export class SearchAnalyticsProvider
     };
   }
 
-  public getFacetSortMetadata(
+  public getFacetUpdateSortMetadata(
     facetId: string,
     criteria: FacetSortCriterion | RangeFacetSortCriterion
   ) {
@@ -140,7 +140,7 @@ export class SearchAnalyticsProvider
     };
   }
 
-  public getRangeFacetBreadcrumbMetadata(
+  public getRangeBreadcrumbFacetMetadata(
     facetId: string,
     facetValue: DateFacetValue | NumericFacetValue
   ) {
@@ -199,7 +199,7 @@ export class SearchAnalyticsProvider
     };
   }
 
-  public getCategoryFacetBreadcrumbMetadata(
+  public getCategoryBreadcrumbFacetMetadata(
     categoryFacetId: string,
     categoryFacetPath: string[]
   ) {

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -13,7 +13,10 @@ import {
   toggleSelectFacetValue,
   updateFreezeCurrentValues,
 } from '../../features/facets/facet-set/facet-set-actions';
-import {logFacetBreadcrumb} from '../../features/facets/facet-set/facet-set-analytics-actions';
+import {
+  breadcrumbFacet,
+  logFacetBreadcrumb,
+} from '../../features/facets/facet-set/facet-set-analytics-actions';
 import {facetResponseActiveValuesSelector} from '../../features/facets/facet-set/facet-set-selectors';
 import {facetSetReducer as facetSet} from '../../features/facets/facet-set/facet-set-slice';
 import {FacetSlice} from '../../features/facets/facet-set/facet-set-state';
@@ -142,14 +145,7 @@ export function buildBreadcrumbManager(
               facetId: facetId,
               facetValue: selection.value,
             }),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  facetId,
-                  selection.value
-                ),
-            },
+            next: breadcrumbFacet(facetId, selection.value),
           })
         );
       },
@@ -164,14 +160,7 @@ export function buildBreadcrumbManager(
               facetId: facetId,
               facetValue: selection.value,
             }),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  facetId,
-                  selection.value
-                ),
-            },
+            next: breadcrumbFacet(facetId, selection.value),
           })
         );
       },
@@ -396,14 +385,7 @@ export function buildBreadcrumbManager(
               facetId: field,
               facetValue: selection.value,
             }),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  field,
-                  selection.value
-                ),
-            },
+            next: breadcrumbFacet(field, selection.value),
           })
         );
       },

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -1,11 +1,12 @@
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {configuration} from '../../app/common-reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {toggleSelectAutomaticFacetValue} from '../../features/facets/automatic-facet-set/automatic-facet-set-actions';
 import {AutomaticFacetResponse} from '../../features/facets/automatic-facet-set/interfaces/response';
 import {deselectAllCategoryFacetValues} from '../../features/facets/category-facet-set/category-facet-set-actions';
-import {logCategoryFacetBreadcrumb} from '../../features/facets/category-facet-set/category-facet-set-analytics-actions';
+import {
+  categoryBreadcrumbFacet,
+  logCategoryFacetBreadcrumb,
+} from '../../features/facets/category-facet-set/category-facet-set-analytics-actions';
 import {categoryFacetResponseSelectedValuesSelector} from '../../features/facets/category-facet-set/category-facet-set-selectors';
 import {categoryFacetSetReducer as categoryFacetSet} from '../../features/facets/category-facet-set/category-facet-set-slice';
 import {
@@ -263,16 +264,10 @@ export function buildBreadcrumbManager(
               ),
               categoryFacetId: facetId,
             }),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(
-                  () => state
-                ).getCategoryFacetBreadcrumbMetadata(
-                  facetId,
-                  path.map((categoryFacetValue) => categoryFacetValue.value)
-                ),
-            },
+            next: categoryBreadcrumbFacet(
+              facetId,
+              path.map((v) => v.value)
+            ),
           })
         );
       },

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -51,6 +51,7 @@ import {executeSearch} from '../../features/search/search-actions';
 import {searchReducer as search} from '../../features/search/search-slice';
 import {
   logStaticFilterDeselect,
+  staticFilterDeselect,
   toggleExcludeStaticFilterValue,
   toggleSelectStaticFilterValue,
 } from '../../features/static-filter-set/static-filter-set-actions';
@@ -302,17 +303,21 @@ export function buildBreadcrumbManager(
       value,
       deselect: () => {
         const {caption, expression} = value;
-        const analytics = logStaticFilterDeselect({
-          staticFilterId: id,
-          staticFilterValue: {caption, expression},
-        });
 
         if (value.state === 'selected') {
           dispatch(toggleSelectStaticFilterValue({id, value}));
         } else if (value.state === 'excluded') {
           dispatch(toggleExcludeStaticFilterValue({id, value}));
         }
-        dispatch(executeSearch({legacy: analytics}));
+        dispatch(
+          executeSearch({
+            legacy: logStaticFilterDeselect({
+              staticFilterId: id,
+              staticFilterValue: {caption, expression},
+            }),
+            next: staticFilterDeselect(id, {caption, expression}),
+          })
+        );
       },
     };
   };

--- a/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/breadcrumb-manager/headless-breadcrumb-manager.ts
@@ -21,12 +21,18 @@ import {facetResponseActiveValuesSelector} from '../../features/facets/facet-set
 import {facetSetReducer as facetSet} from '../../features/facets/facet-set/facet-set-slice';
 import {FacetSlice} from '../../features/facets/facet-set/facet-set-state';
 import {FacetValue} from '../../features/facets/facet-set/interfaces/response';
-import {logClearBreadcrumbs} from '../../features/facets/generic/facet-generic-analytics-actions';
+import {
+  breadcrumbResetAll,
+  logClearBreadcrumbs,
+} from '../../features/facets/generic/facet-generic-analytics-actions';
 import {
   toggleExcludeDateFacetValue,
   toggleSelectDateFacetValue,
 } from '../../features/facets/range-facets/date-facet-set/date-facet-actions';
-import {logDateFacetBreadcrumb} from '../../features/facets/range-facets/date-facet-set/date-facet-analytics-actions';
+import {
+  dateBreadcrumbFacet,
+  logDateFacetBreadcrumb,
+} from '../../features/facets/range-facets/date-facet-set/date-facet-analytics-actions';
 import {dateFacetActiveValuesSelector} from '../../features/facets/range-facets/date-facet-set/date-facet-selectors';
 import {dateFacetSetReducer as dateFacetSet} from '../../features/facets/range-facets/date-facet-set/date-facet-set-slice';
 import {DateFacetSlice} from '../../features/facets/range-facets/date-facet-set/date-facet-set-state';
@@ -34,7 +40,10 @@ import {
   toggleExcludeNumericFacetValue,
   toggleSelectNumericFacetValue,
 } from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
-import {logNumericFacetBreadcrumb} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions';
+import {
+  logNumericFacetBreadcrumb,
+  numericBreadcrumbFacet,
+} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions';
 import {numericFacetActiveValuesSelector} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-selectors';
 import {numericFacetSetReducer as numericFacetSet} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice';
 import {NumericFacetSlice} from '../../features/facets/range-facets/numeric-facet-set/numeric-facet-set-state';
@@ -181,16 +190,7 @@ export function buildBreadcrumbManager(
         dispatch(
           executeSearch({
             legacy: logNumericFacetBreadcrumb(payload),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(
-                  () => state
-                ).getRangeFacetBreadcrumbMetadata(
-                  payload.facetId,
-                  payload.selection
-                ),
-            },
+            next: numericBreadcrumbFacet(payload.facetId, payload.selection),
           })
         );
       },
@@ -199,16 +199,7 @@ export function buildBreadcrumbManager(
         dispatch(
           executeSearch({
             legacy: logNumericFacetBreadcrumb(payload),
-            next: {
-              actionCause: SearchPageEvents.breadcrumbFacet,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(
-                  () => state
-                ).getRangeFacetBreadcrumbMetadata(
-                  payload.facetId,
-                  payload.selection
-                ),
-            },
+            next: numericBreadcrumbFacet(payload.facetId, payload.selection),
           })
         );
       },
@@ -227,16 +218,7 @@ export function buildBreadcrumbManager(
           dispatch(
             executeSearch({
               legacy: logDateFacetBreadcrumb(payload),
-              next: {
-                actionCause: SearchPageEvents.breadcrumbFacet,
-                getEventExtraPayload: (state) =>
-                  new SearchAnalyticsProvider(
-                    () => state
-                  ).getRangeFacetBreadcrumbMetadata(
-                    payload.facetId,
-                    payload.selection
-                  ),
-              },
+              next: dateBreadcrumbFacet(payload.facetId, payload.selection),
             })
           );
         },
@@ -245,16 +227,7 @@ export function buildBreadcrumbManager(
           dispatch(
             executeSearch({
               legacy: logDateFacetBreadcrumb(payload),
-              next: {
-                actionCause: SearchPageEvents.breadcrumbFacet,
-                getEventExtraPayload: (state) =>
-                  new SearchAnalyticsProvider(
-                    () => state
-                  ).getRangeFacetBreadcrumbMetadata(
-                    payload.facetId,
-                    payload.selection
-                  ),
-              },
+              next: dateBreadcrumbFacet(payload.facetId, payload.selection),
             })
           );
         },
@@ -423,11 +396,7 @@ export function buildBreadcrumbManager(
       dispatch(
         executeSearch({
           legacy: logClearBreadcrumbs(),
-          next: {
-            actionCause: SearchPageEvents.breadcrumbResetAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: breadcrumbResetAll(),
         })
       );
     },

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../features/query-suggest/query-suggest-actions';
 import {
   logQuerySuggestionClick,
-  querySuggestionClick,
+  omniboxAnalytics,
 } from '../../../features/query-suggest/query-suggest-analytics-actions';
 import {querySuggestReducer as querySuggest} from '../../../features/query-suggest/query-suggest-slice';
 import {QuerySuggestState} from '../../../features/query-suggest/query-suggest-state';
@@ -271,7 +271,7 @@ export function buildCoreSearchBox(
       dispatch(selectQuerySuggestion({id, expression: value}));
       performSearch({
         legacy: logQuerySuggestionClick({id, suggestion: value}),
-        next: querySuggestionClick(id, value),
+        next: omniboxAnalytics(id, value),
       }).then(() => {
         dispatch(clearQuerySuggest({id}));
       });

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
@@ -1,12 +1,10 @@
 import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {CoreEngine} from '../../..';
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {configuration} from '../../../app/common-reducers';
 import {
   InsightAction,
   LegacySearchAction,
 } from '../../../features/analytics/analytics-utils';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {
   registerQuerySetQuery,
   updateQuerySetQuery,
@@ -18,7 +16,10 @@ import {
   registerQuerySuggest,
   selectQuerySuggestion,
 } from '../../../features/query-suggest/query-suggest-actions';
-import {logQuerySuggestionClick} from '../../../features/query-suggest/query-suggest-analytics-actions';
+import {
+  logQuerySuggestionClick,
+  querySuggestionClick,
+} from '../../../features/query-suggest/query-suggest-analytics-actions';
 import {querySuggestReducer as querySuggest} from '../../../features/query-suggest/query-suggest-slice';
 import {QuerySuggestState} from '../../../features/query-suggest/query-suggest-state';
 import {logSearchboxSubmit} from '../../../features/query/query-analytics-actions';
@@ -270,13 +271,7 @@ export function buildCoreSearchBox(
       dispatch(selectQuerySuggestion({id, expression: value}));
       performSearch({
         legacy: logQuerySuggestionClick({id, suggestion: value}),
-        next: {
-          actionCause: SearchPageEvents.omniboxAnalytics,
-          getEventExtraPayload: (state) =>
-            new SearchAnalyticsProvider(
-              () => state
-            ).getOmniboxAnalyticsMetadata(id, value),
-        },
+        next: querySuggestionClick(id, value),
       }).then(() => {
         dispatch(clearQuerySuggest({id}));
       });

--- a/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/did-you-mean/headless-did-you-mean.ts
@@ -1,11 +1,12 @@
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   QueryCorrection,
   WordCorrection,
 } from '../../api/search/search/query-corrections';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
-import {logDidYouMeanClick} from '../../features/did-you-mean/did-you-mean-analytics-actions';
+import {
+  didYouMeanClick,
+  logDidYouMeanClick,
+} from '../../features/did-you-mean/did-you-mean-analytics-actions';
 import {executeSearch} from '../../features/search/search-actions';
 import {
   buildCoreDidYouMean,
@@ -38,11 +39,7 @@ export function buildDidYouMean(engine: SearchEngine): DidYouMean {
       dispatch(
         executeSearch({
           legacy: logDidYouMeanClick(),
-          next: {
-            actionCause: SearchPageEvents.didyoumeanClick,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: didYouMeanClick(),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet/headless-automatic-facet.ts
@@ -1,11 +1,12 @@
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {
   deselectAllAutomaticFacetValues,
   toggleSelectAutomaticFacetValue,
 } from '../../../features/facets/automatic-facet-set/automatic-facet-set-actions';
-import {logFacetClearAll} from '../../../features/facets/facet-set/facet-set-analytics-actions';
+import {
+  facetClearAll,
+  logFacetClearAll,
+} from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {
   getLegacyAnalyticsActionForToggleFacetSelect,
   getAnalyticsActionForToggleFacetSelect,
@@ -66,13 +67,7 @@ export function buildAutomaticFacet(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(field),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                field
-              ),
-          },
+          next: facetClearAll(field),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet-search.ts
@@ -1,11 +1,12 @@
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {CoreEngine} from '../../../app/engine';
 import {SearchThunkExtraArguments} from '../../../app/search-thunk-extra-arguments';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 import {registerCategoryFacetSearch} from '../../../features/facets/facet-search-set/category/category-facet-search-actions';
 import {defaultFacetSearchOptions} from '../../../features/facets/facet-search-set/facet-search-reducer-helpers';
-import {logFacetSelect} from '../../../features/facets/facet-set/facet-set-analytics-actions';
+import {
+  facetSelect,
+  logFacetSelect,
+} from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {executeSearch} from '../../../features/search/search-actions';
 import {
   CategoryFacetSearchSection,
@@ -55,14 +56,7 @@ export function buildCategoryFacetSearch(
       dispatch(
         executeSearch({
           legacy: logFacetSelect({facetId, facetValue: value.rawValue}),
-          next: {
-            actionCause: SearchPageEvents.facetSelect,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                facetId,
-                value.rawValue
-              ),
-          },
+          next: facetSelect(facetId, value.rawValue),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
+++ b/packages/headless/src/controllers/facets/category-facet/headless-category-facet.ts
@@ -1,7 +1,5 @@
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {configuration} from '../../../app/common-reducers';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {categoryFacetSetReducer as categoryFacetSet} from '../../../features/facets/category-facet-set/category-facet-set-slice';
 import {CategoryFacetSortCriterion} from '../../../features/facets/category-facet-set/interfaces/request';
 import {CategoryFacetValue} from '../../../features/facets/category-facet-set/interfaces/response';
@@ -13,6 +11,10 @@ import {
   logFacetClearAll,
   logFacetDeselect,
   logFacetSelect,
+  facetUpdateSort,
+  facetClearAll,
+  facetDeselect,
+  facetSelect,
 } from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {
   SearchAction,
@@ -106,13 +108,7 @@ export function buildCategoryFacet(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -122,14 +118,7 @@ export function buildCategoryFacet(
       dispatch(
         executeSearch({
           legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
-          next: {
-            actionCause: SearchPageEvents.facetUpdateSort,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
-                getFacetId(),
-                criterion
-              ),
-          },
+          next: facetUpdateSort(getFacetId(), criterion),
         })
       );
     },
@@ -188,14 +177,7 @@ function getToggleSelectAnalyticsAction(
   selection: CategoryFacetValue
 ): SearchAction {
   const isSelected = selection.state === 'selected';
-  return {
-    actionCause: isSelected
-      ? SearchPageEvents.facetDeselect
-      : SearchPageEvents.facetSelect,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetMetadata(
-        facetId,
-        selection.value
-      ),
-  };
+  return isSelected
+    ? facetDeselect(facetId, selection.value)
+    : facetSelect(facetId, selection.value);
 }

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -1,9 +1,7 @@
 import {CoreEngine} from '../../..';
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {configuration} from '../../../app/common-reducers';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {SearchThunkExtraArguments} from '../../../app/search-thunk-extra-arguments';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 import {FacetValueState} from '../../../features/facets/facet-api/value';
 import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
@@ -14,6 +12,10 @@ import {
   logFacetShowLess,
   logFacetSelect,
   logFacetExclude,
+  facetSelect,
+  facetUpdateSort,
+  facetClearAll,
+  facetExclude,
 } from '../../../features/facets/facet-set/facet-set-analytics-actions';
 import {facetSetReducer as facetSet} from '../../../features/facets/facet-set/facet-set-slice';
 import {
@@ -118,14 +120,7 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
               facetId: getFacetId(),
               facetValue: value.rawValue,
             }),
-            next: {
-              actionCause: SearchPageEvents.facetSelect,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  getFacetId(),
-                  value.rawValue
-                ),
-            },
+            next: facetSelect(getFacetId(), value.rawValue),
           })
         );
       },
@@ -137,14 +132,7 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
               facetId: getFacetId(),
               facetValue: value.rawValue,
             }),
-            next: {
-              actionCause: SearchPageEvents.facetExclude,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  getFacetId(),
-                  value.rawValue
-                ),
-            },
+            next: facetExclude(getFacetId(), value.rawValue),
           })
         );
       },
@@ -194,13 +182,7 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -210,14 +192,7 @@ export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
       dispatch(
         executeSearch({
           legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
-          next: {
-            actionCause: SearchPageEvents.facetUpdateSort,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
-                getFacetId(),
-                criterion
-              ),
-          },
+          next: facetUpdateSort(getFacetId(), criterion),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-facet.ts
@@ -1,7 +1,7 @@
-import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../../features/analytics/search-action-cause';
 import {
+  facetClearAll,
+  facetUpdateSort,
   logFacetClearAll,
   logFacetUpdateSort,
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
@@ -59,13 +59,7 @@ export function buildDateFacet(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -75,14 +69,7 @@ export function buildDateFacet(
       dispatch(
         executeSearch({
           legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
-          next: {
-            actionCause: SearchPageEvents.facetUpdateSort,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
-                getFacetId(),
-                criterion
-              ),
-          },
+          next: facetUpdateSort(getFacetId(), criterion),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/date-facet/headless-date-filter.ts
@@ -1,8 +1,8 @@
-import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
 import {configuration} from '../../../../app/common-reducers';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../../features/analytics/search-action-cause';
 import {
+  facetClearAll,
+  facetSelect,
   logFacetClearAll,
   logFacetSelect,
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
@@ -59,13 +59,7 @@ export function buildDateFilter(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -78,14 +72,7 @@ export function buildDateFilter(
               facetId: getFacetId(),
               facetValue: `${range.start}..${range.end}`,
             }),
-            next: {
-              actionCause: SearchPageEvents.facetSelect,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  getFacetId(),
-                  `${range.start}..${range.end}`
-                ),
-            },
+            next: facetSelect(getFacetId(), `${range.start}..${range.end}`),
           })
         );
       }

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-facet.ts
@@ -1,8 +1,8 @@
-import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
 import {configuration} from '../../../../app/common-reducers';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../../features/analytics/search-action-cause';
 import {
+  facetClearAll,
+  facetUpdateSort,
   logFacetClearAll,
   logFacetUpdateSort,
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
@@ -70,13 +70,7 @@ export function buildNumericFacet(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -86,14 +80,7 @@ export function buildNumericFacet(
       dispatch(
         executeSearch({
           legacy: logFacetUpdateSort({facetId: getFacetId(), criterion}),
-          next: {
-            actionCause: SearchPageEvents.facetUpdateSort,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
-                getFacetId(),
-                criterion
-              ),
-          },
+          next: facetUpdateSort(getFacetId(), criterion),
         })
       );
     },

--- a/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
+++ b/packages/headless/src/controllers/facets/range-facet/numeric-facet/headless-numeric-filter.ts
@@ -1,8 +1,8 @@
-import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
 import {configuration} from '../../../../app/common-reducers';
 import {SearchEngine} from '../../../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../../../features/analytics/search-action-cause';
 import {
+  facetClearAll,
+  facetSelect,
   logFacetClearAll,
   logFacetSelect,
 } from '../../../../features/facets/facet-set/facet-set-analytics-actions';
@@ -59,13 +59,7 @@ export function buildNumericFilter(
       dispatch(
         executeSearch({
           legacy: logFacetClearAll(getFacetId()),
-          next: {
-            actionCause: SearchPageEvents.facetClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-                getFacetId()
-              ),
-          },
+          next: facetClearAll(getFacetId()),
         })
       );
     },
@@ -78,14 +72,7 @@ export function buildNumericFilter(
               facetId: getFacetId(),
               facetValue: `${range.start}..${range.end}`,
             }),
-            next: {
-              actionCause: SearchPageEvents.facetSelect,
-              getEventExtraPayload: (state) =>
-                new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                  getFacetId(),
-                  `${range.start}..${range.end}`
-                ),
-            },
+            next: facetSelect(getFacetId(), `${range.start}..${range.end}`),
           })
         );
       }

--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -1,13 +1,13 @@
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {configuration} from '../../../app/common-reducers';
 import {CoreEngine} from '../../../app/engine';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {SearchThunkExtraArguments} from '../../../app/search-thunk-extra-arguments';
-import {SearchPageEvents} from '../../../features/analytics/search-action-cause';
 import {updateFacetOptions} from '../../../features/facet-options/facet-options-actions';
 import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {registerFacet} from '../../../features/facets/facet-set/facet-set-actions';
 import {
+  facetExclude,
+  facetSelect,
   logFacetExclude,
   logFacetSelect,
 } from '../../../features/facets/facet-set/facet-set-analytics-actions';
@@ -184,14 +184,7 @@ export function buildFieldSuggestions(
       engine.dispatch(
         executeSearch({
           legacy: logFacetSelect({facetId, facetValue: value.rawValue}),
-          next: {
-            actionCause: SearchPageEvents.facetSelect,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                facetId,
-                value.rawValue
-              ),
-          },
+          next: facetSelect(facetId, value.rawValue),
         })
       );
     },
@@ -200,14 +193,7 @@ export function buildFieldSuggestions(
       engine.dispatch(
         executeSearch({
           legacy: logFacetExclude({facetId, facetValue: value.rawValue}),
-          next: {
-            actionCause: SearchPageEvents.facetExclude,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getFacetMetadata(
-                facetId,
-                value.rawValue
-              ),
-          },
+          next: facetExclude(facetId, value.rawValue),
         })
       );
     },

--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -1,15 +1,16 @@
 import {isNullOrUndefined} from '@coveo/bueno';
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {configuration} from '../../app/common-reducers';
 import {SearchEngine} from '../../app/search-engine/search-engine';
 import {StateWithHistory} from '../../app/undoable';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {facetOrderReducer as facetOrder} from '../../features/facets/facet-order/facet-order-slice';
 import {back, forward} from '../../features/history/history-actions';
 import {
   logNavigateBackward,
   logNavigateForward,
   logNoResultsBack,
+  navigateBackward,
+  navigateForward,
+  noResultsBack,
 } from '../../features/history/history-analytics-actions';
 import {history} from '../../features/history/history-slice';
 import {HistoryState} from '../../features/history/history-state';
@@ -84,11 +85,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
       dispatch(
         executeSearch({
           legacy: logNavigateBackward(),
-          next: {
-            actionCause: SearchPageEvents.historyBackward,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: navigateBackward(),
         })
       );
     },
@@ -101,11 +98,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
       dispatch(
         executeSearch({
           legacy: logNavigateForward(),
-          next: {
-            actionCause: SearchPageEvents.historyForward,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: navigateForward(),
         })
       );
     },
@@ -118,11 +111,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
       dispatch(
         executeSearch({
           legacy: logNoResultsBack(),
-          next: {
-            actionCause: SearchPageEvents.noResultsBack,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: noResultsBack(),
         })
       );
     },

--- a/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
+++ b/packages/headless/src/controllers/recent-queries-list/headless-recent-queries-list.ts
@@ -1,7 +1,5 @@
 import {ArrayValue, BooleanValue, NumberValue, Schema} from '@coveo/bueno';
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {
   clearRecentQueries,
   registerRecentQueries,
@@ -9,6 +7,7 @@ import {
 import {
   logClearRecentQueries,
   logRecentQueryClick,
+  recentQueryClick,
 } from '../../features/recent-queries/recent-queries-analytics-actions';
 import {recentQueriesReducer as recentQueries} from '../../features/recent-queries/recent-queries-slice';
 import {
@@ -205,11 +204,7 @@ export function buildRecentQueriesList(
       dispatch(
         executeSearch({
           legacy: logRecentQueryClick(),
-          next: {
-            actionCause: SearchPageEvents.recentQueryClick,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-          },
+          next: recentQueryClick(),
         })
       );
     },

--- a/packages/headless/src/controllers/sort/headless-sort.ts
+++ b/packages/headless/src/controllers/sort/headless-sort.ts
@@ -1,9 +1,10 @@
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {executeSearch} from '../../features/search/search-actions';
 import {SortCriterion} from '../../features/sort-criteria/criteria';
-import {logResultsSort} from '../../features/sort-criteria/sort-criteria-analytics-actions';
+import {
+  logResultsSort,
+  resultsSort,
+} from '../../features/sort-criteria/sort-criteria-analytics-actions';
 import {
   buildCoreSort,
   Sort,
@@ -28,11 +29,7 @@ export function buildSort(engine: SearchEngine, props: SortProps = {}): Sort {
     dispatch(
       executeSearch({
         legacy: logResultsSort(),
-        next: {
-          actionCause: SearchPageEvents.resultsSort,
-          getEventExtraPayload: (state) =>
-            new SearchAnalyticsProvider(() => state).getResultSortMetadata(),
-        },
+        next: resultsSort(),
       })
     );
 

--- a/packages/headless/src/controllers/static-filter/headless-static-filter.ts
+++ b/packages/headless/src/controllers/static-filter/headless-static-filter.ts
@@ -1,7 +1,5 @@
 import {Schema} from '@coveo/bueno';
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {
   SearchAction,
   executeSearch,
@@ -12,6 +10,9 @@ import {
   logStaticFilterDeselect,
   logStaticFilterSelect,
   registerStaticFilter,
+  staticFilterClearAll,
+  staticFilterDeselect,
+  staticFilterSelect,
   toggleExcludeStaticFilterValue,
   toggleSelectStaticFilterValue,
 } from '../../features/static-filter-set/static-filter-set-actions';
@@ -223,13 +224,7 @@ export function buildStaticFilter(
       dispatch(
         executeSearch({
           legacy: logStaticFilterClearAll({staticFilterId: id}),
-          next: {
-            actionCause: SearchPageEvents.staticFilterClearAll,
-            getEventExtraPayload: (state) =>
-              new SearchAnalyticsProvider(
-                () => state
-              ).getStaticFilterClearAllMetadata(id),
-          },
+          next: staticFilterClearAll(id),
         })
       );
     },
@@ -282,14 +277,7 @@ function getAnalyticsActionForToggledValue(
 ): SearchAction {
   const isSelected = value.state === 'selected';
 
-  return {
-    actionCause: isSelected
-      ? SearchPageEvents.staticFilterDeselect
-      : SearchPageEvents.staticFilterSelect,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getStaticFilterToggleMetadata(
-        id,
-        value
-      ),
-  };
+  return isSelected
+    ? staticFilterSelect(id, value)
+    : staticFilterDeselect(id, value);
 }

--- a/packages/headless/src/controllers/tab/headless-tab.ts
+++ b/packages/headless/src/controllers/tab/headless-tab.ts
@@ -1,7 +1,8 @@
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {logInterfaceChange} from '../../features/analytics/analytics-actions';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
+import {
+  interfaceChange,
+  logInterfaceChange,
+} from '../../features/analytics/analytics-actions';
 import {executeSearch} from '../../features/search/search-actions';
 import {
   buildCoreTab,
@@ -28,13 +29,7 @@ export function buildTab(engine: SearchEngine, props: TabProps): Tab {
     dispatch(
       executeSearch({
         legacy: logInterfaceChange(),
-        next: {
-          actionCause: SearchPageEvents.interfaceChange,
-          getEventExtraPayload: (state) =>
-            new SearchAnalyticsProvider(
-              () => state
-            ).getInterfaceChangeMetadata(),
-        },
+        next: interfaceChange(),
       })
     );
 

--- a/packages/headless/src/controllers/triggers/headless-query-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-query-trigger.ts
@@ -1,10 +1,11 @@
-import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchEngine} from '../../app/search-engine/search-engine';
-import {SearchPageEvents} from '../../features/analytics/search-action-cause';
 import {updateQuery} from '../../features/query/query-actions';
 import {queryReducer as query} from '../../features/query/query-slice';
 import {executeSearch} from '../../features/search/search-actions';
-import {logUndoTriggerQuery} from '../../features/triggers/trigger-analytics-actions';
+import {
+  logUndoTriggerQuery,
+  undoTriggerQuery,
+} from '../../features/triggers/trigger-analytics-actions';
 import {updateIgnoreQueryTrigger} from '../../features/triggers/triggers-actions';
 import {triggerReducer as triggers} from '../../features/triggers/triggers-slice';
 import {TriggerSection, QuerySection} from '../../state/state-sections';
@@ -84,13 +85,7 @@ export function buildQueryTrigger(engine: SearchEngine): QueryTrigger {
           legacy: logUndoTriggerQuery({
             undoneQuery: modification(),
           }),
-          next: {
-            actionCause: SearchPageEvents.undoTriggerQuery,
-            getEventExtraPayload: () =>
-              new SearchAnalyticsProvider(getState).getUndoTriggerQueryMetadata(
-                modification()
-              ),
-          },
+          next: undoTriggerQuery(modification()),
         })
       );
     },

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -1,4 +1,4 @@
-import {SearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchPageEvents as LegacySearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
 import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {Result} from '../../api/search/search/result';
 import {
@@ -17,10 +17,11 @@ import {
   LegacySearchAction,
   validateResultPayload,
 } from './analytics-utils';
+import {SearchPageEvents} from './search-action-cause';
 
 export interface SearchEventPayload {
   /** The identifier of the search action (e.g., `interfaceLoad`). */
-  evt: SearchPageEvents | string;
+  evt: LegacySearchPageEvents | string;
   /** The event metadata. */
   meta?: Record<string, unknown>;
 }
@@ -29,7 +30,7 @@ export interface ClickEventPayload {
   /**
    * The identifier of the click action.
    */
-  evt: SearchPageEvents | string;
+  evt: LegacySearchPageEvents | string;
   /**
    * The result associated with the click event.
    */
@@ -44,7 +45,7 @@ export interface CustomEventPayload {
   /**
    * The event cause identifier of the custom action
    */
-  evt: SearchPageEvents | string;
+  evt: LegacySearchPageEvents | string;
   /**
    * The event type identifier of the custom action
    */
@@ -76,7 +77,7 @@ export const logSearchEvent = (
   makeAnalyticsAction('analytics/generic/search', (client) => {
     validateEvent(p);
     const {evt, meta} = p;
-    return client.makeSearchEvent(evt as SearchPageEvents, meta);
+    return client.makeSearchEvent(evt as LegacySearchPageEvents, meta);
   });
 
 export interface LogClickEventActionCreatorPayload {
@@ -104,7 +105,7 @@ export const logClickEvent = (
     validateEvent(p);
 
     return client.makeClickEvent(
-      p.evt as SearchPageEvents,
+      p.evt as LegacySearchPageEvents,
       partialDocumentInformation(p.result, state),
       documentIdentifier(p.result),
       p.meta

--- a/packages/headless/src/features/analytics/analytics-actions.ts
+++ b/packages/headless/src/features/analytics/analytics-actions.ts
@@ -1,4 +1,5 @@
 import {SearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {Result} from '../../api/search/search/result';
 import {
   validatePayload,
@@ -6,6 +7,7 @@ import {
   nonEmptyString,
 } from '../../utils/validate-payload';
 import {OmniboxSuggestionMetadata} from '../query-suggest/query-suggest-analytics-actions';
+import {SearchAction} from '../search/search-actions';
 import {
   ClickAction,
   CustomAction,
@@ -159,3 +161,40 @@ export const logOmniboxFromLink = (
   makeAnalyticsAction('analytics/interface/omniboxFromLink', (client) =>
     client.makeOmniboxFromLink(metadata)
   );
+
+// --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
+export const interfaceLoad = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.interfaceLoad,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};
+
+export const interfaceChange = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.interfaceChange,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getInterfaceChangeMetadata(),
+  };
+};
+
+export const searchFromLink = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.searchFromLink,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};
+
+export const omniboxFromLink = (
+  metadata: OmniboxSuggestionMetadata
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.omniboxFromLink,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getOmniboxFromLinkMetadata(
+        metadata
+      ),
+  };
+};

--- a/packages/headless/src/features/did-you-mean/did-you-mean-analytics-actions.ts
+++ b/packages/headless/src/features/did-you-mean/did-you-mean-analytics-actions.ts
@@ -1,7 +1,10 @@
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 
 //TODO: KIT-2859
 export const logDidYouMeanClick = (): LegacySearchAction =>
@@ -13,3 +16,11 @@ export const logDidYouMeanAutomatic = (): LegacySearchAction =>
   makeAnalyticsAction('analytics/didyoumean/automatic', (client) =>
     client.makeDidYouMeanAutomatic()
   );
+
+export const didYouMeanClick = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.didyoumeanClick,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
@@ -71,6 +71,6 @@ export const categoryBreadcrumbFacet = (
     getEventExtraPayload: (state) =>
       new SearchAnalyticsProvider(
         () => state
-      ).getCategoryFacetBreadcrumbMetadata(id, path),
+      ).getCategoryBreadcrumbFacetMetadata(id, path),
   };
 };

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-analytics-actions.ts
@@ -1,5 +1,6 @@
 import {ArrayValue} from '@coveo/bueno';
 import type {CategoryFacetMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {SearchAppState} from '../../../state/search-app-state';
 import {
   requiredNonEmptyString,
@@ -9,6 +10,8 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../../analytics/analytics-utils';
+import {SearchPageEvents} from '../../analytics/search-action-cause';
+import {SearchAction} from '../../search/search-actions';
 import {facetIdDefinition} from '../generic/facet-actions-validation';
 
 export interface LogCategoryFacetBreadcrumbActionCreatorPayload {
@@ -58,3 +61,16 @@ export const logCategoryFacetBreadcrumb = (
 
     return client.makeBreadcrumbFacet(getCategoryFacetMetadata(state, payload));
   });
+
+export const categoryBreadcrumbFacet = (
+  id: string,
+  path: string[]
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.breadcrumbFacet,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(
+        () => state
+      ).getCategoryFacetBreadcrumbMetadata(id, path),
+  };
+};

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -201,7 +201,7 @@ export const facetUpdateSort = (
   return {
     actionCause: SearchPageEvents.facetUpdateSort,
     getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
+      new SearchAnalyticsProvider(() => state).getFacetUpdateSortMetadata(
         id,
         criterion
       ),

--- a/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-analytics-actions.ts
@@ -1,4 +1,5 @@
 import {Value} from '@coveo/bueno';
+import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {
   validatePayload,
   requiredNonEmptyString,
@@ -7,6 +8,8 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../../analytics/analytics-utils';
+import {SearchPageEvents} from '../../analytics/search-action-cause';
+import {SearchAction} from '../../search/search-actions';
 import {facetIdDefinition} from '../generic/facet-actions-validation';
 import {RangeFacetSortCriterion} from '../range-facets/generic/interfaces/request';
 import {
@@ -189,3 +192,58 @@ export const logFacetBreadcrumb = (
 
     return client.makeBreadcrumbFacet(metadata);
   });
+
+// --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
+export const facetUpdateSort = (
+  id: string,
+  criterion: FacetSortCriterion | RangeFacetSortCriterion
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.facetUpdateSort,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
+        id,
+        criterion
+      ),
+  };
+};
+
+export const facetClearAll = (id: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.facetClearAll,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(id),
+  };
+};
+
+export const facetSelect = (id: string, value: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.facetSelect,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetMetadata(id, value),
+  };
+};
+
+export const facetExclude = (id: string, value: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.facetExclude,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetMetadata(id, value),
+  };
+};
+
+export const facetDeselect = (id: string, value: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.facetDeselect,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetMetadata(id, value),
+  };
+};
+
+export const breadcrumbFacet = (id: string, value: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.breadcrumbFacet,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getFacetMetadata(id, value),
+  };
+};

--- a/packages/headless/src/features/facets/facet-set/facet-set-utils.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-utils.ts
@@ -1,7 +1,8 @@
-import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
-import {SearchPageEvents} from '../../analytics/search-action-cause';
 import {SearchAction} from '../../search/search-actions';
 import {
+  facetDeselect,
+  facetExclude,
+  facetSelect,
   logFacetDeselect,
   logFacetExclude,
   logFacetSelect,
@@ -35,16 +36,9 @@ export const getAnalyticsActionForToggleFacetSelect = (
   facetId: string,
   selection: FacetValue
 ): SearchAction => {
-  return {
-    actionCause: isFacetValueSelected(selection)
-      ? SearchPageEvents.facetDeselect
-      : SearchPageEvents.facetSelect,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetMetadata(
-        facetId,
-        selection.value
-      ),
-  };
+  return isFacetValueSelected(selection)
+    ? facetDeselect(facetId, selection.value)
+    : facetSelect(facetId, selection.value);
 };
 
 export const getLegacyAnalyticsActionForToggleFacetExclude = (
@@ -65,14 +59,7 @@ export const getAnalyticsActionForToggleFacetExclude = (
   facetId: string,
   selection: FacetValue
 ): SearchAction => {
-  return {
-    actionCause: isFacetValueExcluded(selection)
-      ? SearchPageEvents.facetUnexclude
-      : SearchPageEvents.facetExclude,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetMetadata(
-        facetId,
-        selection.value
-      ),
-  };
+  return isFacetValueExcluded(selection)
+    ? facetDeselect(facetId, selection.value)
+    : facetExclude(facetId, selection.value);
 };

--- a/packages/headless/src/features/facets/generic/facet-generic-analytics-actions.ts
+++ b/packages/headless/src/features/facets/generic/facet-generic-analytics-actions.ts
@@ -1,10 +1,21 @@
+import {SearchAnalyticsProvider} from '../../../api/analytics/search-analytics';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../../analytics/analytics-utils';
+import {SearchPageEvents} from '../../analytics/search-action-cause';
+import {SearchAction} from '../../search/search-actions';
 
 //TODO: KIT-2859
 export const logClearBreadcrumbs = (): LegacySearchAction =>
   makeAnalyticsAction('analytics/facet/deselectAllBreadcrumbs', (client) => {
     return client.makeBreadcrumbResetAll();
   });
+
+export const breadcrumbResetAll = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.breadcrumbResetAll,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-analytics-actions.ts
@@ -3,7 +3,11 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../../../analytics/analytics-utils';
-import {getRangeFacetMetadata} from '../generic/range-facet-analytics-actions';
+import {SearchAction} from '../../../search/search-actions';
+import {
+  getRangeFacetMetadata,
+  rangeBreadcrumbFacet,
+} from '../generic/range-facet-analytics-actions';
 import {rangeFacetSelectionPayloadDefinition} from '../generic/range-facet-validate-payload';
 import {DateFacetValue} from './interfaces/response';
 
@@ -32,3 +36,10 @@ export const logDateFacetBreadcrumb = (
 
     return client.makeBreadcrumbFacet(metadata);
   });
+
+export const dateBreadcrumbFacet = (
+  id: string,
+  value: DateFacetValue
+): SearchAction => {
+  return rangeBreadcrumbFacet(id, value);
+};

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
@@ -31,7 +31,7 @@ export const rangeBreadcrumbFacet = (
   return {
     actionCause: SearchPageEvents.breadcrumbFacet,
     getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getRangeFacetBreadcrumbMetadata(
+      new SearchAnalyticsProvider(() => state).getRangeBreadcrumbFacetMetadata(
         id,
         value
       ),

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-analytics-actions.ts
@@ -1,5 +1,10 @@
 import type {FacetRangeMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
 import {SearchAppState} from '../../../../state/search-app-state';
+import {SearchPageEvents} from '../../../analytics/search-action-cause';
+import {SearchAction} from '../../../search/search-actions';
+import {DateFacetValue} from '../date-facet-set/interfaces/response';
+import {NumericFacetValue} from '../numeric-facet-set/interfaces/response';
 import {RangeFacetSelectionPayload} from './range-facet-validate-payload';
 
 export const getRangeFacetMetadata = (
@@ -16,5 +21,19 @@ export const getRangeFacetMetadata = (
     facetRangeEndInclusive: selection.endInclusive,
     facetRangeEnd: `${selection.end}`,
     facetRangeStart: `${selection.start}`,
+  };
+};
+
+export const rangeBreadcrumbFacet = (
+  id: string,
+  value: DateFacetValue | NumericFacetValue
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.breadcrumbFacet,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getRangeFacetBreadcrumbMetadata(
+        id,
+        value
+      ),
   };
 };

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-utils.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-utils.ts
@@ -1,7 +1,8 @@
-import {SearchAnalyticsProvider} from '../../../../api/analytics/search-analytics';
-import {SearchPageEvents} from '../../../analytics/search-action-cause';
 import {SearchAction} from '../../../search/search-actions';
 import {
+  facetDeselect,
+  facetExclude,
+  facetSelect,
   logFacetDeselect,
   logFacetExclude,
   logFacetSelect,
@@ -33,16 +34,10 @@ export const getAnalyticsActionForToggleFacetSelect = (
   facetId: string,
   selection: RangeFacetValue
 ): SearchAction => {
-  return {
-    actionCause: isRangeFacetValueSelected(selection)
-      ? SearchPageEvents.facetSelect
-      : SearchPageEvents.facetDeselect,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetMetadata(
-        facetId,
-        `${selection.start}..${selection.end}`
-      ),
-  };
+  const facetValue = `${selection.start}..${selection.end}`;
+  return isRangeFacetValueSelected(selection)
+    ? facetDeselect(facetId, facetValue)
+    : facetSelect(facetId, facetValue);
 };
 
 export const getLegacyAnalyticsActionForToggleRangeFacetExclude = (
@@ -61,14 +56,8 @@ export const getAnalyticsActionForToggleRangeFacetExclude = (
   facetId: string,
   selection: RangeFacetValue
 ): SearchAction => {
-  return {
-    actionCause: isRangeFacetValueExcluded(selection)
-      ? SearchPageEvents.facetUnexclude
-      : SearchPageEvents.facetExclude,
-    getEventExtraPayload: (state) =>
-      new SearchAnalyticsProvider(() => state).getFacetMetadata(
-        facetId,
-        `${selection.start}..${selection.end}`
-      ),
-  };
+  const facetValue = `${selection.start}..${selection.end}`;
+  return isRangeFacetValueExcluded(selection)
+    ? facetDeselect(facetId, facetValue)
+    : facetExclude(facetId, facetValue);
 };

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions.ts
@@ -3,7 +3,11 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../../../analytics/analytics-utils';
-import {getRangeFacetMetadata} from '../generic/range-facet-analytics-actions';
+import {SearchAction} from '../../../search/search-actions';
+import {
+  getRangeFacetMetadata,
+  rangeBreadcrumbFacet,
+} from '../generic/range-facet-analytics-actions';
 import {rangeFacetSelectionPayloadDefinition} from '../generic/range-facet-validate-payload';
 import {NumericFacetValue} from './interfaces/response';
 
@@ -32,3 +36,10 @@ export const logNumericFacetBreadcrumb = (
 
     return client.makeBreadcrumbFacet(metadata);
   });
+
+export const numericBreadcrumbFacet = (
+  id: string,
+  value: NumericFacetValue
+): SearchAction => {
+  return rangeBreadcrumbFacet(id, value);
+};

--- a/packages/headless/src/features/history/history-analytics-actions.ts
+++ b/packages/headless/src/features/history/history-analytics-actions.ts
@@ -1,21 +1,26 @@
-import {SearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchPageEvents as LegacySearchPageEvents} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 
 //TODO: KIT-2859
 export const logNavigateForward = (): LegacySearchAction =>
   makeAnalyticsAction(
     'history/analytics/forward',
-    (client) => client.makeSearchEvent('historyForward' as SearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
+    (client) =>
+      client.makeSearchEvent('historyForward' as LegacySearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
   );
 
 //TODO: KIT-2859
 export const logNavigateBackward = (): LegacySearchAction =>
   makeAnalyticsAction(
     'history/analytics/backward',
-    (client) => client.makeSearchEvent('historyBackward' as SearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
+    (client) =>
+      client.makeSearchEvent('historyBackward' as LegacySearchPageEvents) // TODO: Need to create this event natively in coveo.analytics to remove cast
   );
 
 //TODO: KIT-2859
@@ -23,3 +28,28 @@ export const logNoResultsBack = (): LegacySearchAction =>
   makeAnalyticsAction('history/analytics/noresultsback', (client) =>
     client.makeNoResultsBack()
   );
+
+// --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
+export const navigateForward = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.historyForward,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};
+
+export const navigateBackward = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.historyBackward,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};
+
+export const noResultsBack = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.noResultsBack,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -1,9 +1,12 @@
 import type {OmniboxSuggestionsMetadata} from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {SearchAppState} from '../../state/search-app-state';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 
 export interface LogQuerySuggestionClickActionCreatorPayload {
   /**
@@ -25,6 +28,20 @@ export const logQuerySuggestionClick = (
     const metadata = buildOmniboxSuggestionMetadata(state, payload);
     return client.makeOmniboxAnalytics(metadata);
   });
+
+export const querySuggestionClick = (
+  id: string,
+  suggestion: string
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.omniboxAnalytics,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getOmniboxAnalyticsMetadata(
+        id,
+        suggestion
+      ),
+  };
+};
 
 export type OmniboxSuggestionMetadata = OmniboxSuggestionsMetadata;
 

--- a/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
+++ b/packages/headless/src/features/query-suggest/query-suggest-analytics-actions.ts
@@ -29,7 +29,7 @@ export const logQuerySuggestionClick = (
     return client.makeOmniboxAnalytics(metadata);
   });
 
-export const querySuggestionClick = (
+export const omniboxAnalytics = (
   id: string,
   suggestion: string
 ): SearchAction => {

--- a/packages/headless/src/features/recent-queries/recent-queries-analytics-actions.ts
+++ b/packages/headless/src/features/recent-queries/recent-queries-analytics-actions.ts
@@ -1,8 +1,11 @@
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   makeAnalyticsAction,
   CustomAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 
 export const logClearRecentQueries = (): CustomAction =>
   makeAnalyticsAction('analytics/recentQueries/clear', (client) => {
@@ -14,3 +17,11 @@ export const logRecentQueryClick = (): LegacySearchAction =>
   makeAnalyticsAction('analytics/recentQueries/click', (client) => {
     return client.makeRecentQueryClick();
   });
+
+export const recentQueryClick = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.recentQueryClick,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getBaseMetadata(),
+  };
+};

--- a/packages/headless/src/features/sort-criteria/sort-criteria-analytics-actions.ts
+++ b/packages/headless/src/features/sort-criteria/sort-criteria-analytics-actions.ts
@@ -1,7 +1,10 @@
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 import {getSortCriteriaInitialState} from './sort-criteria-state';
 
 //TODO: KIT-2859
@@ -11,3 +14,11 @@ export const logResultsSort = (): LegacySearchAction =>
       resultsSortBy: state.sortCriteria || getSortCriteriaInitialState(),
     })
   );
+
+export const resultsSort = (): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.resultsSort,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getResultSortMetadata(),
+  };
+};

--- a/packages/headless/src/features/static-filter-set/static-filter-set-actions.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-actions.ts
@@ -1,9 +1,12 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {validatePayload} from '../../utils/validate-payload';
 import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 import {
   staticFilterIdSchema,
   staticFilterValueSchema,
@@ -132,3 +135,42 @@ export const logStaticFilterClearAll = (
   makeAnalyticsAction('analytics/staticFilter/clearAll', (client) =>
     client.makeStaticFilterClearAll(metadata)
   );
+
+// --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
+export const staticFilterSelect = (
+  id: string,
+  value: StaticFilterValueMetadata
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.staticFilterSelect,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getStaticFilterToggleMetadata(
+        id,
+        value
+      ),
+  };
+};
+
+export const staticFilterDeselect = (
+  id: string,
+  value: StaticFilterValueMetadata
+): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.staticFilterDeselect,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getStaticFilterToggleMetadata(
+        id,
+        value
+      ),
+  };
+};
+
+export const staticFilterClearAll = (id: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.staticFilterClearAll,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getStaticFilterClearAllMetadata(
+        id
+      ),
+  };
+};

--- a/packages/headless/src/features/triggers/trigger-analytics-actions.ts
+++ b/packages/headless/src/features/triggers/trigger-analytics-actions.ts
@@ -1,4 +1,5 @@
 import {RecordValue} from '@coveo/bueno';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics';
 import {
   requiredEmptyAllowedString,
   validatePayload,
@@ -7,6 +8,8 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils';
+import {SearchPageEvents} from '../analytics/search-action-cause';
+import {SearchAction} from '../search/search-actions';
 
 export interface LogUndoTriggerQueryActionCreatorPayload {
   /**
@@ -59,9 +62,6 @@ export const logTriggerRedirect = (): LegacySearchAction =>
     return null;
   });
 
-/**
- * Log trigger execute
- */
 export const logTriggerExecute = (): LegacySearchAction =>
   makeAnalyticsAction('analytics/trigger/execute', (client, state) => {
     if (!state.triggers?.executions.length) {
@@ -71,3 +71,14 @@ export const logTriggerExecute = (): LegacySearchAction =>
       executions: state.triggers.executions,
     });
   });
+
+// --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
+export const undoTriggerQuery = (undoneQuery: string): SearchAction => {
+  return {
+    actionCause: SearchPageEvents.undoTriggerQuery,
+    getEventExtraPayload: (state) =>
+      new SearchAnalyticsProvider(() => state).getUndoTriggerQueryMetadata(
+        undoneQuery
+      ),
+  };
+};

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -1,4 +1,3 @@
-import {SearchAnalyticsProvider} from '../api/analytics/search-analytics';
 import {PlatformClient, PlatformClientCallError} from '../api/platform-client';
 import {
   buildSearchEngine,
@@ -19,13 +18,15 @@ import {
   omniboxFromLink,
   searchFromLink,
 } from '../features/analytics/analytics-actions';
-import {SearchPageEvents} from '../features/analytics/search-action-cause';
 import {
   didYouMeanClick,
   logDidYouMeanClick,
 } from '../features/did-you-mean/did-you-mean-analytics-actions';
 import {registerCategoryFacet} from '../features/facets/category-facet-set/category-facet-set-actions';
-import {logCategoryFacetBreadcrumb} from '../features/facets/category-facet-set/category-facet-set-analytics-actions';
+import {
+  categoryBreadcrumbFacet,
+  logCategoryFacetBreadcrumb,
+} from '../features/facets/category-facet-set/category-facet-set-analytics-actions';
 import {categoryFacetSetReducer} from '../features/facets/category-facet-set/category-facet-set-slice';
 import {
   breadcrumbFacet,
@@ -70,7 +71,10 @@ import {
 } from '../features/history/history-analytics-actions';
 import {fetchQuerySuggestions} from '../features/query-suggest/query-suggest-actions';
 import {OmniboxSuggestionMetadata} from '../features/query-suggest/query-suggest-analytics-actions';
-import {logRecentQueryClick} from '../features/recent-queries/recent-queries-analytics-actions';
+import {
+  logRecentQueryClick,
+  recentQueryClick,
+} from '../features/recent-queries/recent-queries-analytics-actions';
 import {executeSearch} from '../features/search/search-actions';
 import {
   logResultsSort,
@@ -85,7 +89,10 @@ import {
   staticFilterDeselect,
   staticFilterSelect,
 } from '../features/static-filter-set/static-filter-set-actions';
-import {logUndoTriggerQuery} from '../features/triggers/trigger-analytics-actions';
+import {
+  logUndoTriggerQuery,
+  undoTriggerQuery,
+} from '../features/triggers/trigger-analytics-actions';
 
 const nextSearchEngine = buildSearchEngine({
   configuration: {
@@ -513,13 +520,7 @@ describe('Analytics Search Migration', () => {
       legacy: logUndoTriggerQuery({
         undoneQuery: ANY_QUERY,
       }),
-      next: {
-        actionCause: SearchPageEvents.undoTriggerQuery,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getUndoTriggerQueryMetadata(
-            ANY_QUERY
-          ),
-      },
+      next: undoTriggerQuery(ANY_QUERY),
     });
 
     legacySearchEngine.dispatch(action);
@@ -553,16 +554,7 @@ describe('Analytics Search Migration', () => {
         categoryFacetId: ANY_FACET_ID,
         categoryFacetPath: ANY_CATEGORY_FACET_PATH,
       }),
-      next: {
-        actionCause: SearchPageEvents.breadcrumbFacet,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getCategoryFacetBreadcrumbMetadata(
-            ANY_FACET_ID,
-            ANY_CATEGORY_FACET_PATH
-          ),
-      },
+      next: categoryBreadcrumbFacet(ANY_FACET_ID, ANY_CATEGORY_FACET_PATH),
     });
 
     legacySearchEngine.dispatch(action);
@@ -575,11 +567,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/recentQueries/click', async () => {
     const action = executeSearch({
       legacy: logRecentQueryClick(),
-      next: {
-        actionCause: SearchPageEvents.recentQueryClick,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: recentQueryClick(),
     });
 
     legacySearchEngine.dispatch(action);

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -10,10 +10,14 @@ import {
   buildCoreSearchBox,
 } from '../controllers/core/search-box/headless-core-search-box';
 import {
+  interfaceChange,
+  interfaceLoad,
   logInterfaceChange,
   logInterfaceLoad,
   logOmniboxFromLink,
   logSearchFromLink,
+  omniboxFromLink,
+  searchFromLink,
 } from '../features/analytics/analytics-actions';
 import {SearchPageEvents} from '../features/analytics/search-action-cause';
 import {logDidYouMeanClick} from '../features/did-you-mean/did-you-mean-analytics-actions';
@@ -148,11 +152,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/interface/load', async () => {
     const action = executeSearch({
       legacy: logInterfaceLoad(),
-      next: {
-        actionCause: SearchPageEvents.interfaceLoad,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: interfaceLoad(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -634,11 +634,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/interface/change', async () => {
     const action = executeSearch({
       legacy: logInterfaceChange(),
-      next: {
-        actionCause: SearchPageEvents.interfaceChange,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getInterfaceChangeMetadata(),
-      },
+      next: interfaceChange(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -651,11 +647,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/interface/searchFromLink', async () => {
     const action = executeSearch({
       legacy: logSearchFromLink(),
-      next: {
-        actionCause: SearchPageEvents.searchFromLink,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: searchFromLink(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -676,13 +668,7 @@ describe('Analytics Search Migration', () => {
 
     const action = executeSearch({
       legacy: logOmniboxFromLink(metadata),
-      next: {
-        actionCause: SearchPageEvents.omniboxFromLink,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getOmniboxFromLinkMetadata(
-            metadata
-          ),
-      },
+      next: omniboxFromLink(metadata),
     });
 
     legacySearchEngine.dispatch(action);

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -20,7 +20,10 @@ import {
   searchFromLink,
 } from '../features/analytics/analytics-actions';
 import {SearchPageEvents} from '../features/analytics/search-action-cause';
-import {logDidYouMeanClick} from '../features/did-you-mean/did-you-mean-analytics-actions';
+import {
+  didYouMeanClick,
+  logDidYouMeanClick,
+} from '../features/did-you-mean/did-you-mean-analytics-actions';
 import {registerCategoryFacet} from '../features/facets/category-facet-set/category-facet-set-actions';
 import {logCategoryFacetBreadcrumb} from '../features/facets/category-facet-set/category-facet-set-analytics-actions';
 import {categoryFacetSetReducer} from '../features/facets/category-facet-set/category-facet-set-slice';
@@ -39,25 +42,40 @@ import {
   logFacetUpdateSort,
 } from '../features/facets/facet-set/facet-set-analytics-actions';
 import {FacetSortCriterion} from '../features/facets/facet-set/interfaces/request';
-import {logClearBreadcrumbs} from '../features/facets/generic/facet-generic-analytics-actions';
+import {
+  breadcrumbResetAll,
+  logClearBreadcrumbs,
+} from '../features/facets/generic/facet-generic-analytics-actions';
 import {registerDateFacet} from '../features/facets/range-facets/date-facet-set/date-facet-actions';
-import {logDateFacetBreadcrumb} from '../features/facets/range-facets/date-facet-set/date-facet-analytics-actions';
+import {
+  dateBreadcrumbFacet,
+  logDateFacetBreadcrumb,
+} from '../features/facets/range-facets/date-facet-set/date-facet-analytics-actions';
 import {dateFacetSetReducer} from '../features/facets/range-facets/date-facet-set/date-facet-set-slice';
 import {DateFacetValue} from '../features/facets/range-facets/date-facet-set/interfaces/response';
 import {NumericFacetValue} from '../features/facets/range-facets/numeric-facet-set/interfaces/response';
 import {registerNumericFacet} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
-import {logNumericFacetBreadcrumb} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions';
+import {
+  logNumericFacetBreadcrumb,
+  numericBreadcrumbFacet,
+} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-analytics-actions';
 import {numericFacetSetReducer} from '../features/facets/range-facets/numeric-facet-set/numeric-facet-set-slice';
 import {
   logNavigateBackward,
   logNavigateForward,
   logNoResultsBack,
+  navigateBackward,
+  navigateForward,
+  noResultsBack,
 } from '../features/history/history-analytics-actions';
 import {fetchQuerySuggestions} from '../features/query-suggest/query-suggest-actions';
 import {OmniboxSuggestionMetadata} from '../features/query-suggest/query-suggest-analytics-actions';
 import {logRecentQueryClick} from '../features/recent-queries/recent-queries-analytics-actions';
 import {executeSearch} from '../features/search/search-actions';
-import {logResultsSort} from '../features/sort-criteria/sort-criteria-analytics-actions';
+import {
+  logResultsSort,
+  resultsSort,
+} from '../features/sort-criteria/sort-criteria-analytics-actions';
 import {
   StaticFilterValueMetadata,
   logStaticFilterClearAll,
@@ -181,11 +199,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/didyoumean/click', async () => {
     const action = executeSearch({
       legacy: logDidYouMeanClick(),
-      next: {
-        actionCause: SearchPageEvents.didyoumeanClick,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: didYouMeanClick(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -213,11 +227,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/facet/deselectAllBreadcrumbs', async () => {
     const action = executeSearch({
       legacy: logClearBreadcrumbs(),
-      next: {
-        actionCause: SearchPageEvents.breadcrumbResetAll,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: breadcrumbResetAll(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -262,11 +272,7 @@ describe('Analytics Search Migration', () => {
   it('history/analytics/forward', async () => {
     const action = executeSearch({
       legacy: logNavigateForward(),
-      next: {
-        actionCause: SearchPageEvents.historyForward,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: navigateForward(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -295,11 +301,7 @@ describe('Analytics Search Migration', () => {
   it('history/analytics/backward', async () => {
     const action = executeSearch({
       legacy: logNavigateBackward(),
-      next: {
-        actionCause: SearchPageEvents.historyBackward,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: navigateBackward(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -325,11 +327,7 @@ describe('Analytics Search Migration', () => {
   it('history/analytics/noresultsback', async () => {
     const action = executeSearch({
       legacy: logNoResultsBack(),
-      next: {
-        actionCause: SearchPageEvents.noResultsBack,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getBaseMetadata(),
-      },
+      next: noResultsBack(),
     });
 
     legacySearchEngine.dispatch(action);
@@ -365,16 +363,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         selection: ANY_RANGE_FACET_BREADCRUMB_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.breadcrumbFacet,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getRangeFacetBreadcrumbMetadata(
-            ANY_FACET_ID,
-            ANY_RANGE_FACET_BREADCRUMB_VALUE
-          ),
-      },
+      next: dateBreadcrumbFacet(ANY_FACET_ID, ANY_RANGE_FACET_BREADCRUMB_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -411,16 +400,10 @@ describe('Analytics Search Migration', () => {
         selection:
           ANY_RANGE_FACET_BREADCRUMB_VALUE as unknown as NumericFacetValue,
       }),
-      next: {
-        actionCause: SearchPageEvents.breadcrumbFacet,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getRangeFacetBreadcrumbMetadata(
-            ANY_FACET_ID,
-            ANY_RANGE_FACET_BREADCRUMB_VALUE
-          ),
-      },
+      next: numericBreadcrumbFacet(
+        ANY_FACET_ID,
+        ANY_RANGE_FACET_BREADCRUMB_VALUE as unknown as NumericFacetValue
+      ),
     });
 
     legacySearchEngine.dispatch(action);
@@ -433,11 +416,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/sort/results', async () => {
     const action = executeSearch({
       legacy: logResultsSort(),
-      next: {
-        actionCause: SearchPageEvents.resultsSort,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getResultSortMetadata(),
-      },
+      next: resultsSort(),
     });
 
     legacySearchEngine.dispatch(action);

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -81,6 +81,9 @@ import {
   logStaticFilterClearAll,
   logStaticFilterDeselect,
   logStaticFilterSelect,
+  staticFilterClearAll,
+  staticFilterDeselect,
+  staticFilterSelect,
 } from '../features/static-filter-set/static-filter-set-actions';
 import {logUndoTriggerQuery} from '../features/triggers/trigger-analytics-actions';
 
@@ -464,16 +467,7 @@ describe('Analytics Search Migration', () => {
         staticFilterId: ANY_STATIC_FILTER_ID,
         staticFilterValue: ANY_STATIC_FILTER_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.staticFilterSelect,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getStaticFilterToggleMetadata(
-            ANY_STATIC_FILTER_ID,
-            ANY_STATIC_FILTER_VALUE
-          ),
-      },
+      next: staticFilterSelect(ANY_STATIC_FILTER_ID, ANY_STATIC_FILTER_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -489,16 +483,7 @@ describe('Analytics Search Migration', () => {
         staticFilterId: ANY_STATIC_FILTER_ID,
         staticFilterValue: ANY_STATIC_FILTER_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.staticFilterDeselect,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getStaticFilterToggleMetadata(
-            ANY_STATIC_FILTER_ID,
-            ANY_STATIC_FILTER_VALUE
-          ),
-      },
+      next: staticFilterDeselect(ANY_STATIC_FILTER_ID, ANY_STATIC_FILTER_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -513,13 +498,7 @@ describe('Analytics Search Migration', () => {
       legacy: logStaticFilterClearAll({
         staticFilterId: ANY_STATIC_FILTER_ID,
       }),
-      next: {
-        actionCause: SearchPageEvents.staticFilterClearAll,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(
-            () => state
-          ).getStaticFilterClearAllMetadata(ANY_STATIC_FILTER_ID),
-      },
+      next: staticFilterClearAll(ANY_STATIC_FILTER_ID),
     });
 
     legacySearchEngine.dispatch(action);

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -21,6 +21,12 @@ import {registerCategoryFacet} from '../features/facets/category-facet-set/categ
 import {logCategoryFacetBreadcrumb} from '../features/facets/category-facet-set/category-facet-set-analytics-actions';
 import {categoryFacetSetReducer} from '../features/facets/category-facet-set/category-facet-set-slice';
 import {
+  breadcrumbFacet,
+  facetClearAll,
+  facetDeselect,
+  facetExclude,
+  facetSelect,
+  facetUpdateSort,
   logFacetBreadcrumb,
   logFacetClearAll,
   logFacetDeselect,
@@ -162,14 +168,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         facetValue: ANY_FACET_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.facetSelect,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetMetadata(
-            ANY_FACET_ID,
-            ANY_FACET_VALUE
-          ),
-      },
+      next: facetSelect(ANY_FACET_ID, ANY_FACET_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -202,14 +201,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         facetValue: ANY_FACET_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.facetDeselect,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetMetadata(
-            ANY_FACET_ID,
-            ANY_FACET_VALUE
-          ),
-      },
+      next: facetDeselect(ANY_FACET_ID, ANY_FACET_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -241,14 +233,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         facetValue: ANY_FACET_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.facetExclude,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetMetadata(
-            ANY_FACET_ID,
-            ANY_FACET_VALUE
-          ),
-      },
+      next: facetExclude(ANY_FACET_ID, ANY_FACET_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -264,14 +249,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         criterion: ANY_CRITERION,
       }),
-      next: {
-        actionCause: SearchPageEvents.facetUpdateSort,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetSortMetadata(
-            ANY_FACET_ID,
-            ANY_CRITERION
-          ),
-      },
+      next: facetUpdateSort(ANY_FACET_ID, ANY_CRITERION),
     });
 
     legacySearchEngine.dispatch(action);
@@ -304,14 +282,7 @@ describe('Analytics Search Migration', () => {
         facetId: ANY_FACET_ID,
         facetValue: ANY_FACET_VALUE,
       }),
-      next: {
-        actionCause: SearchPageEvents.breadcrumbFacet,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetMetadata(
-            ANY_FACET_ID,
-            ANY_FACET_VALUE
-          ),
-      },
+      next: breadcrumbFacet(ANY_FACET_ID, ANY_FACET_VALUE),
     });
 
     legacySearchEngine.dispatch(action);
@@ -341,13 +312,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/facet/reset', async () => {
     const action = executeSearch({
       legacy: logFacetClearAll(ANY_FACET_ID),
-      next: {
-        actionCause: SearchPageEvents.facetClearAll,
-        getEventExtraPayload: (state) =>
-          new SearchAnalyticsProvider(() => state).getFacetClearAllMetadata(
-            ANY_FACET_ID
-          ),
-      },
+      next: facetClearAll(ANY_FACET_ID),
     });
 
     legacySearchEngine.dispatch(action);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2920

Now, no controller is using the provider directly, it is through a function. This is better for readability and also for future changes and implementations. Even for the other use cases, this could get useful.