### PR TITLE
fix(atomic): icons in textarea search box are not centered

### DIFF
--- a/packages/atomic/src/components/common/search-box/text-area-clear-button.tsx
+++ b/packages/atomic/src/components/common/search-box/text-area-clear-button.tsx
@@ -16,7 +16,7 @@ export const TextAreaClearButton: FunctionalComponent<Props> = ({
 }) => (
   <div
     part="clear-button-wrapper"
-    class="py-2 flex items-start justify-center ml-2"
+    class="py-2 flex items-start justify-center items-center ml-2"
   >
     <Button
       style="text-transparent"

--- a/packages/atomic/src/components/common/search-box/text-area-submit-button.tsx
+++ b/packages/atomic/src/components/common/search-box/text-area-submit-button.tsx
@@ -14,7 +14,7 @@ export const TextAreaSubmitButton: FunctionalComponent<Props> = ({
 }) => (
   <div
     part="submit-button-wrapper"
-    class="py-2 flex items-start justify-center mr-2"
+    class="py-2 flex items-start justify-center items-center mr-2"
   >
     <Button
       style="text-primary"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2938


## Before
<img width="661" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/ed06914c-207b-4ed5-a6c5-ba64d0d80dcd">


## After

<img width="1197" alt="image" src="https://github.com/coveo/ui-kit/assets/78121423/01bace60-3f4e-4985-a5e9-59200a5d0c52">
