### PR TITLE
docs(atomic): add link to headless search engine

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -2191,7 +2191,7 @@ export namespace Components {
          */
         "fieldsToInclude": string[] | string;
         /**
-          * Returns the unique, organization-specific endpoint(s)
+          * Returns the unique, organization-specific endpoint(s).
           * @param organizationId
           * @param env
          */
@@ -2209,7 +2209,7 @@ export namespace Components {
          */
         "initialize": (options: InitializationOptions) => Promise<void>;
         /**
-          * Initializes the connection with an already preconfigured headless search engine, as opposed to the `initialize` method which will internally create a new search engine instance. This bypasses the properties set on the component, such as analytics, searchHub, pipeline, language, timezone & logLevel.
+          * Initializes the connection with an already preconfigured [headless search engine](https://docs.coveo.com/en/headless/latest/reference/search/), as opposed to the `initialize` method, which will internally create a new search engine instance. This bypasses the properties set on the component, such as analytics, searchHub, pipeline, language, timezone & logLevel.
          */
         "initializeWithSearchEngine": (engine: SearchEngine) => Promise<void>;
         /**

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -307,7 +307,7 @@ export class AtomicSearchInterface
   }
 
   /**
-   * Initializes the connection with an already preconfigured headless search engine, as opposed to the `initialize` method which will internally create a new search engine instance.
+   * Initializes the connection with an already preconfigured [headless search engine](https://docs.coveo.com/en/headless/latest/reference/search/), as opposed to the `initialize` method, which will internally create a new search engine instance.
    * This bypasses the properties set on the component, such as analytics, searchHub, pipeline, language, timezone & logLevel.
    */
   @Method() public initializeWithSearchEngine(engine: SearchEngine) {
@@ -367,7 +367,7 @@ export class AtomicSearchInterface
   }
 
   /**
-   * Returns the unique, organization-specific endpoint(s)
+   * Returns the unique, organization-specific endpoint(s).
    * @param {string} organizationId
    * @param {'prod'|'hipaa'|'staging'|'dev'} [env=Prod]
    */


### PR DESCRIPTION
The `initializeWithSearchEngine` method of the `atomic-search-interface` component mentions that it needs a preconfigured Headless search engine, but it doesn’t link to the Headless search engine reference documentation. Adding a link will hopefully deflect some support questions.

Also added a missing period to the description of the `getOrganizationEndpoints` method.