### PR TITLE
feat(headless): removed the triggeredBy from the insight analytics actions for logCreateArticle

### DIFF
--- a/packages/headless/src/features/analytics/insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/analytics/insight-analytics-actions.test.ts
@@ -22,7 +22,6 @@ const exampleCaseNumber = '5678';
 const exampleOriginLevel2 = 'exampleOriginLevel2';
 const exampleCreateArticleMetadata = {
   articleType: 'Knowledge__kav',
-  triggeredBy: 'CreateArticleButton',
 };
 
 jest.mock('coveo.analytics', () => {

--- a/packages/headless/src/features/analytics/insight-analytics-actions.ts
+++ b/packages/headless/src/features/analytics/insight-analytics-actions.ts
@@ -7,7 +7,6 @@ import {InsightAction, makeInsightAnalyticsAction} from './analytics-utils';
 
 export interface CreateArticleMetadata {
   articleType: string;
-  triggeredBy: string;
 }
 
 export const logInsightInterfaceLoad = (): InsightAction =>
@@ -33,7 +32,6 @@ export const logInsightCreateArticle = (
     (client, state) => {
       validatePayload(createArticleMetadata, {
         articleType: requiredNonEmptyString,
-        triggeredBy: requiredNonEmptyString,
       });
       return client.logCreateArticle(
         createArticleMetadata,


### PR DESCRIPTION
[SFINT-5327](https://coveord.atlassian.net/browse/SFINT-5327)

**IN THIS PR:**

- Removed the triggeredBy from the insight analytics actions as it is no longer needed/ deemed useful

NOTE: Before merging this PR, we have to wait for:

- This [PR](https://github.com/coveo/coveo.analytics.js/pull/448) to be merged
- Coveo.analytics.js to be released (next version after 2.16.0)
- Coveo.analytics.js to be updated in the UI-KIT 

[SFINT-5328]: https://coveord.atlassian.net/browse/SFINT-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SFINT-5327]: https://coveord.atlassian.net/browse/SFINT-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ