### PR TITLE
feat(headless): removed the triggeredBy from the insight analytics actions for logCreateArticle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54628,9 +54628,9 @@
       }
     },
     "packages/headless/node_modules/coveo.analytics": {
-      "version": "2.28.23",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.28.23.tgz",
-      "integrity": "sha512-+DBUQlde++a5cpoGXLyfaZp7RpKya/41nKbfK58al7M0eAaiymMhBAC1dk1/0ajxj3fjp4pr3m0Dh0M34CSF0Q==",
+      "version": "2.28.24",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.28.24.tgz",
+      "integrity": "sha512-XTzlA9QY69jkNLyO/JBAv68IL/ss3AqZcGEjKDojOlBp0srWMtWe0wJf69W4/6pD8VZmw8JedQYBQ3/DRX6EWw==",
       "dependencies": {
         "@types/uuid": "^9.0.0",
         "cross-fetch": "^3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53196,7 +53196,7 @@
         "@reduxjs/toolkit": "1.9.7",
         "@types/redux-mock-store": "1.0.6",
         "abab": "2.0.6",
-        "coveo.analytics": "2.28.23",
+        "coveo.analytics": "2.28.24",
         "dayjs": "1.11.10",
         "exponential-backoff": "3.1.0",
         "fast-equals": "5.0.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -56,7 +56,7 @@
     "@reduxjs/toolkit": "1.9.7",
     "@types/redux-mock-store": "1.0.6",
     "abab": "2.0.6",
-    "coveo.analytics": "2.28.23",
+    "coveo.analytics": "2.28.24",
     "dayjs": "1.11.10",
     "exponential-backoff": "3.1.0",
     "fast-equals": "5.0.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -68,8 +68,8 @@
     "undici": "5.28.2"
   },
   "devDependencies": {
-    "@coveo/release": "1.0.0",
     "@coveo/relay-event-types": "6.28.2",
+    "@coveo/release": "1.0.0",
     "@microsoft/api-extractor": "7.38.5",
     "@microsoft/api-extractor-model": "7.28.3",
     "@microsoft/tsdoc": "0.14.2",

--- a/packages/headless/src/features/analytics/insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/analytics/insight-analytics-actions.test.ts
@@ -22,7 +22,6 @@ const exampleCaseNumber = '5678';
 const exampleOriginLevel2 = 'exampleOriginLevel2';
 const exampleCreateArticleMetadata = {
   articleType: 'Knowledge__kav',
-  triggeredBy: 'CreateArticleButton',
 };
 
 jest.mock('coveo.analytics', () => {

--- a/packages/headless/src/features/analytics/insight-analytics-actions.ts
+++ b/packages/headless/src/features/analytics/insight-analytics-actions.ts
@@ -7,7 +7,6 @@ import {InsightAction, makeInsightAnalyticsAction} from './analytics-utils';
 
 export interface CreateArticleMetadata {
   articleType: string;
-  triggeredBy: string;
 }
 
 export const logInsightInterfaceLoad = (): InsightAction =>
@@ -33,7 +32,6 @@ export const logInsightCreateArticle = (
     (client, state) => {
       validatePayload(createArticleMetadata, {
         articleType: requiredNonEmptyString,
-        triggeredBy: requiredNonEmptyString,
       });
       return client.logCreateArticle(
         createArticleMetadata,


### PR DESCRIPTION
[SFINT-5327](https://coveord.atlassian.net/browse/SFINT-5327)

**IN THIS PR:**

- Removed the triggeredBy from the insight analytics actions as it is no longer needed/ deemed useful
- updated coveo.analytics.js to 2.28.24


[SFINT-5328]: https://coveord.atlassian.net/browse/SFINT-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SFINT-5327]: https://coveord.atlassian.net/browse/SFINT-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ