### PR TITLE
fix(commerce): use 0-based indexing for search box

### DIFF
--- a/packages/headless/src/controllers/commerce/search-box/headless-search-box.test.ts
+++ b/packages/headless/src/controllers/commerce/search-box/headless-search-box.test.ts
@@ -273,7 +273,7 @@ describe('headless search box', () => {
     });
 
     it('updates the page to the first one', () => {
-      expect(engine.actions).toContainEqual(selectPage(1));
+      expect(engine.actions).toContainEqual(selectPage(0));
     });
 
     it('dispatches #executeSearch', () => {

--- a/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
@@ -114,7 +114,7 @@ export function buildSearchBox(
 
     dispatch(updateFacetAutoSelection({allow: true}));
     dispatch(updateQuery({query: getValue()}));
-    dispatch(selectPage(1));
+    dispatch(selectPage(0));
     dispatch(executeSearch());
   };
 


### PR DESCRIPTION
because we use 0-based indexing for pagination, when performing a search, we should reset the pagination to the 0th page, not the 1st page.

[CAPI-355]

[CAPI-355]: https://coveord.atlassian.net/browse/CAPI-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ