### PR TITLE
fix(commerce): forward required display name

### DIFF
--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
@@ -1,5 +1,6 @@
 import {
   CommerceFacetSetSection,
+  CommerceSearchSection,
   ProductListingV2Section,
 } from '../../../../state/state-sections';
 import {AnyFacetResponse} from './interfaces/response';
@@ -12,7 +13,7 @@ function isFacetResponse(
 }
 
 function baseCommerceFacetResponseSelector(
-  state: ProductListingV2Section,
+  state: ProductListingV2Section | CommerceSearchSection,
   facetId: string
 ) {
   const findById = (response: {facetId: string}) =>
@@ -22,11 +23,16 @@ function baseCommerceFacetResponseSelector(
     return state.productListing.facets.find(findById);
   }
 
+  if ('commerceSearch' in state) {
+    return state.commerceSearch.facets.find(findById);
+  }
+
   return undefined;
 }
 
 export const commerceFacetResponseSelector = (
-  state: ProductListingV2Section & CommerceFacetSetSection,
+  state: (ProductListingV2Section | CommerceSearchSection) &
+    CommerceFacetSetSection,
   facetId: string
 ) => {
   const response = baseCommerceFacetResponseSelector(state, facetId);
@@ -38,10 +44,14 @@ export const commerceFacetResponseSelector = (
 };
 
 export const isCommerceFacetLoadingResponseSelector = (
-  state: ProductListingV2Section
+  state: ProductListingV2Section | CommerceSearchSection
 ) => {
   if ('productListing' in state) {
     return state.productListing.isLoading;
+  }
+
+  if ('commerceSearch' in state) {
+    return state.commerceSearch.isLoading;
   }
 
   return undefined;

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -255,6 +255,7 @@ function updateStateFromFacetResponse(
   }
 
   facetRequest.facetId = facetId;
+  facetRequest.displayName = facetResponse.displayName;
   facetRequest.numberOfValues = facetResponse.values.length;
   facetRequest.field = facetResponse.field;
   facetRequest.type = facetResponse.type;

--- a/packages/headless/src/features/commerce/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/interfaces/request.ts
@@ -10,6 +10,7 @@ export type CommerceFacetRequest = Pick<
   | 'isFieldExpanded'
   | 'preventAutoSelect'
 > & {
+  displayName: string;
   type: FacetType;
   values: AnyFacetValueRequest[];
   initialNumberOfValues: number;

--- a/packages/headless/src/test/mock-commerce-facet-request.ts
+++ b/packages/headless/src/test/mock-commerce-facet-request.ts
@@ -5,6 +5,7 @@ export function buildMockCommerceFacetRequest(
 ): CommerceFacetRequest {
   return {
     facetId: '',
+    displayName: '',
     field: '',
     type: 'regular',
     numberOfValues: 8,


### PR DESCRIPTION
The display name is required on commerce query requests. This PR attaches it to them.

🎩 tested on barca as well: 
![image](https://github.com/coveo/ui-kit/assets/8978908/7285cb3c-bce5-4620-add9-08b35e152030)


[CAPI-355]

[CAPI-355]: https://coveord.atlassian.net/browse/CAPI-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ