### PR TITLE
docs(quantic): new information added to better document result templates components dealing with fields

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultDate/quanticResultDate.js
@@ -6,6 +6,7 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticResultDate` component displays a given result date field value.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <template if:true={result.raw.date}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultField/quanticResultField.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultField/quanticResultField.js
@@ -14,6 +14,7 @@ import stringTemplate from './stringTemplate.html';
 
 /**
  * The `QuanticResultField` component properly displays a given result field according to its type.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <template if:true={result.raw.source}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultHighlightedTextField/quanticResultHighlightedTextField.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultHighlightedTextField/quanticResultHighlightedTextField.js
@@ -11,6 +11,7 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticResultHighlightedTextField` component displays a given result field value and supports text highlighting for the following fields: `title`, `excerpt`, `printable URI`, `first sentences` and `summary`.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <c-quantic-result-highlighted-text-field engine-id={engineId} result={result} field="title"></c-quantic-result-highlighted-text-field>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultMultiValueText/quanticResultMultiValueText.js
@@ -7,6 +7,7 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticResultMultiValueText` component displays a given result multi-value field value.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <template if:true={result.raw.language}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultNumber/quanticResultNumber.js
@@ -6,6 +6,7 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticResultNumber` component displays a given result number field value.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <template if:true={result.raw.ytlikecount}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -5,6 +5,7 @@ import {LightningElement, api} from 'lwc';
 
 /**
  * The `QuanticResultText` component displays a given result field value.
+ * Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript).
  * @category Result Template
  * @example
  * <template if:true={result.raw.source}>
@@ -27,6 +28,7 @@ export default class QuanticResultText extends LightningElement {
   @api label;
   /**
    * The field whose values you want to display.
+   *
    * @api
    * @type {string}
    */


### PR DESCRIPTION

[SFINT-4910](https://coveord.atlassian.net/browse/SFINT-4910)

The following new information has been added to the Quantic result templates component dealing with fields:
```
Make sure the field specified in this component is also included in the field array for the relevant template. See the this example: [Quantic usage](https://docs.coveo.com/en/quantic/latest/usage/#javascript)
```