### PR TITLE
fix(commerce): fix commerce search facet selectors and facet order

### DIFF
--- a/packages/headless/src/controllers/commerce/facets/core/date/headless-commerce-date-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/facets/core/date/headless-commerce-date-facet.test.ts
@@ -1,6 +1,5 @@
 import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
-import {fetchProductListing} from '../../../../../features/commerce/product-listing/product-listing-actions';
 import {
   toggleExcludeDateFacetValue,
   toggleSelectDateFacetValue,
@@ -12,6 +11,7 @@ import {buildMockCommerceDateFacetResponse} from '../../../../../test/mock-comme
 import {buildMockCommerceFacetSlice} from '../../../../../test/mock-commerce-facet-slice';
 import {buildMockCommerceDateFacetValue} from '../../../../../test/mock-commerce-facet-value';
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
+import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
 import {
   CommerceDateFacet,
   CommerceDateFacetOptions,
@@ -45,7 +45,7 @@ describe('CommerceDateFacet', () => {
   beforeEach(() => {
     options = {
       facetId,
-      fetchResultsActionCreator: fetchProductListing,
+      ...commonOptions,
     };
 
     state = buildMockCommerceState();

--- a/packages/headless/src/controllers/commerce/facets/core/headless-core-commerce-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/facets/core/headless-core-commerce-facet.test.ts
@@ -21,6 +21,7 @@ import {buildMockCommerceFacetSlice} from '../../../../test/mock-commerce-facet-
 import {buildMockCommerceRegularFacetValue} from '../../../../test/mock-commerce-facet-value';
 import {buildMockCommerceState} from '../../../../test/mock-commerce-state';
 import {FacetValueState} from '../../../core/facets/facet/headless-core-facet';
+import {commonOptions} from '../../product-listing/facets/headless-product-listing-facet-options';
 import {
   buildCoreCommerceFacet,
   CoreCommerceFacet,
@@ -66,9 +67,9 @@ describe('CoreCommerceFacet', () => {
   beforeEach(() => {
     options = {
       facetId,
-      fetchResultsActionCreator,
       toggleExcludeActionCreator,
       toggleSelectActionCreator,
+      ...commonOptions,
     };
 
     state = buildMockCommerceState();

--- a/packages/headless/src/controllers/commerce/facets/core/headless-core-commerce-facet.ts
+++ b/packages/headless/src/controllers/commerce/facets/core/headless-core-commerce-facet.ts
@@ -3,12 +3,9 @@ import {
   AsyncThunkAction,
 } from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {
-  commerceFacetResponseSelector,
-  isCommerceFacetLoadingResponseSelector,
-} from '../../../../features/commerce/facets/facet-set/facet-set-selector';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {
+  AnyFacetResponse,
   AnyFacetValueResponse,
   DateFacetValue,
   FacetType,
@@ -74,6 +71,11 @@ export interface CoreCommerceFacetOptions {
   >;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fetchResultsActionCreator: () => AsyncThunkAction<unknown, void, any>;
+  facetResponseSelector: (
+    state: CommerceEngine['state'],
+    facetId: string
+  ) => AnyFacetResponse | undefined;
+  isFacetLoadingResponseSelector: (state: CommerceEngine['state']) => boolean;
 }
 
 export type CommerceFacetOptions = Omit<
@@ -81,6 +83,8 @@ export type CommerceFacetOptions = Omit<
   | 'fetchResultsActionCreator'
   | 'toggleSelectActionCreator'
   | 'toggleExcludeActionCreator'
+  | 'facetResponseSelector'
+  | 'isFacetLoadingResponseSelector'
 >;
 
 export type CoreCommerceFacet<
@@ -176,9 +180,9 @@ export function buildCoreCommerceFacet<
 
   const getRequest = () => engine.state.commerceFacetSet[facetId].request;
   const getResponse = () =>
-    commerceFacetResponseSelector(engine.state, facetId)!;
+    props.options.facetResponseSelector(engine.state, facetId)!;
   const getIsLoading = () =>
-    isCommerceFacetLoadingResponseSelector(engine.state);
+    props.options.isFacetLoadingResponseSelector(engine.state);
 
   const getNumberOfActiveValues = () => {
     return getRequest().values.filter((v) => v.state !== 'idle').length;

--- a/packages/headless/src/controllers/commerce/facets/core/numeric/headless-commerce-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/facets/core/numeric/headless-commerce-numeric-facet.test.ts
@@ -1,6 +1,5 @@
 import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
-import {fetchProductListing} from '../../../../../features/commerce/product-listing/product-listing-actions';
 import {
   toggleExcludeNumericFacetValue,
   toggleSelectNumericFacetValue,
@@ -12,6 +11,7 @@ import {buildMockCommerceNumericFacetResponse} from '../../../../../test/mock-co
 import {buildMockCommerceFacetSlice} from '../../../../../test/mock-commerce-facet-slice';
 import {buildMockCommerceNumericFacetValue} from '../../../../../test/mock-commerce-facet-value';
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
+import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
 import {
   CommerceNumericFacet,
   CommerceNumericFacetOptions,
@@ -45,7 +45,7 @@ describe('CommerceNumericFacet', () => {
   beforeEach(() => {
     options = {
       facetId,
-      fetchResultsActionCreator: fetchProductListing,
+      ...commonOptions,
     };
 
     state = buildMockCommerceState();

--- a/packages/headless/src/controllers/commerce/facets/core/regular/headless-commerce-regular-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/facets/core/regular/headless-commerce-regular-facet.test.ts
@@ -1,5 +1,4 @@
 import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
-import {fetchProductListing} from '../../../../../features/commerce/product-listing/product-listing-actions';
 import {
   toggleExcludeFacetValue,
   toggleSelectFacetValue,
@@ -11,6 +10,7 @@ import {buildMockCommerceRegularFacetResponse} from '../../../../../test/mock-co
 import {buildMockCommerceFacetSlice} from '../../../../../test/mock-commerce-facet-slice';
 import {buildMockCommerceRegularFacetValue} from '../../../../../test/mock-commerce-facet-value';
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
+import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
 import {
   CommerceRegularFacet,
   CommerceRegularFacetOptions,
@@ -41,7 +41,7 @@ describe('CommerceRegularFacet', () => {
   beforeEach(() => {
     options = {
       facetId,
-      fetchResultsActionCreator: fetchProductListing,
+      ...commonOptions,
     };
 
     state = buildMockCommerceState();

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-date-facet.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-date-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
   CommerceDateFacet,
@@ -7,6 +6,7 @@ import {
 } from '../../facets/core/date/headless-commerce-date-facet';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {loadProductListingReducer} from '../utils/load-product-listing-reducers';
+import {commonOptions} from './headless-product-listing-facet-options';
 
 export function buildProductListingDateFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildProductListingDateFacet(
 
   return buildCommerceDateFacet(engine, {
     ...options,
-    fetchResultsActionCreator: fetchProductListing,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
@@ -1,0 +1,35 @@
+import {isFacetResponse} from '../../../../features/commerce/facets/facet-set/facet-set-selector';
+import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
+import {
+  CommerceFacetSetSection,
+  ProductListingV2Section,
+} from '../../../../state/state-sections';
+import {CoreCommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
+
+const facetResponseSelector = (
+  state: ProductListingV2Section & CommerceFacetSetSection,
+  facetId: string
+) => {
+  const response = state.productListing.facets.find(
+    (response) => response.facetId === facetId
+  );
+  if (isFacetResponse(state, response)) {
+    return response;
+  }
+
+  return undefined;
+};
+
+const isFacetLoadingResponseSelector = (state: ProductListingV2Section) =>
+  state.productListing.isLoading;
+
+export const commonOptions: Pick<
+  CoreCommerceFacetOptions,
+  | 'fetchResultsActionCreator'
+  | 'facetResponseSelector'
+  | 'isFacetLoadingResponseSelector'
+> = {
+  fetchResultsActionCreator: fetchProductListing,
+  facetResponseSelector,
+  isFacetLoadingResponseSelector,
+};

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-numeric-facet.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-numeric-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {
@@ -7,6 +6,7 @@ import {
   buildCommerceNumericFacet,
 } from '../../facets/core/numeric/headless-commerce-numeric-facet';
 import {loadProductListingReducer} from '../utils/load-product-listing-reducers';
+import {commonOptions} from './headless-product-listing-facet-options';
 
 export function buildProductListingNumericFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildProductListingNumericFacet(
 
   return buildCommerceNumericFacet(engine, {
     ...options,
-    fetchResultsActionCreator: fetchProductListing,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-regular-facet.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-regular-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {
@@ -7,6 +6,7 @@ import {
   buildCommerceRegularFacet,
 } from '../../facets/core/regular/headless-commerce-regular-facet';
 import {loadProductListingReducer} from '../utils/load-product-listing-reducers';
+import {commonOptions} from './headless-product-listing-facet-options';
 
 export function buildProductListingRegularFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildProductListingRegularFacet(
 
   return buildCommerceRegularFacet(engine, {
     ...options,
-    fetchResultsActionCreator: fetchProductListing,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-date-facet.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-date-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
   CommerceDateFacet,
@@ -7,6 +6,7 @@ import {
 } from '../../facets/core/date/headless-commerce-date-facet';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {loadSearchReducer} from '../utils/load-search-reducers';
+import {commonOptions} from './headless-search-facet-options';
 
 export function buildSearchDateFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildSearchDateFacet(
 
   return buildCommerceDateFacet(engine, {
     ...options,
-    fetchResultsActionCreator: executeSearch,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
@@ -1,0 +1,35 @@
+import {isFacetResponse} from '../../../../features/commerce/facets/facet-set/facet-set-selector';
+import {executeSearch} from '../../../../features/commerce/search/search-actions';
+import {
+  CommerceFacetSetSection,
+  CommerceSearchSection,
+} from '../../../../state/state-sections';
+import {CoreCommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
+
+const facetResponseSelector = (
+  state: CommerceSearchSection & CommerceFacetSetSection,
+  facetId: string
+) => {
+  const response = state.commerceSearch.facets.find(
+    (response) => response.facetId === facetId
+  );
+  if (isFacetResponse(state, response)) {
+    return response;
+  }
+
+  return undefined;
+};
+
+const isFacetLoadingResponseSelector = (state: CommerceSearchSection) =>
+  state.commerceSearch.isLoading;
+
+export const commonOptions: Pick<
+  CoreCommerceFacetOptions,
+  | 'fetchResultsActionCreator'
+  | 'facetResponseSelector'
+  | 'isFacetLoadingResponseSelector'
+> = {
+  fetchResultsActionCreator: executeSearch,
+  facetResponseSelector,
+  isFacetLoadingResponseSelector,
+};

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-numeric-facet.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-numeric-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {
@@ -7,6 +6,7 @@ import {
   buildCommerceNumericFacet,
 } from '../../facets/core/numeric/headless-commerce-numeric-facet';
 import {loadSearchReducer} from '../utils/load-search-reducers';
+import {commonOptions} from './headless-search-facet-options';
 
 export function buildSearchNumericFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildSearchNumericFacet(
 
   return buildCommerceNumericFacet(engine, {
     ...options,
-    fetchResultsActionCreator: executeSearch,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-regular-facet.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-regular-facet.ts
@@ -1,5 +1,4 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {CommerceFacetOptions} from '../../facets/core/headless-core-commerce-facet';
 import {
@@ -7,6 +6,7 @@ import {
   buildCommerceRegularFacet,
 } from '../../facets/core/regular/headless-commerce-regular-facet';
 import {loadSearchReducer} from '../utils/load-search-reducers';
+import {commonOptions} from './headless-search-facet-options';
 
 export function buildSearchRegularFacet(
   engine: CommerceEngine,
@@ -18,6 +18,6 @@ export function buildSearchRegularFacet(
 
   return buildCommerceRegularFacet(engine, {
     ...options,
-    fetchResultsActionCreator: executeSearch,
+    ...commonOptions,
   });
 }

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
@@ -1,58 +1,9 @@
-import {
-  CommerceFacetSetSection,
-  CommerceSearchSection,
-  ProductListingV2Section,
-} from '../../../../state/state-sections';
+import {CommerceFacetSetSection} from '../../../../state/state-sections';
 import {AnyFacetResponse} from './interfaces/response';
 
-function isFacetResponse(
+export function isFacetResponse(
   state: CommerceFacetSetSection,
   response: AnyFacetResponse | undefined
 ): response is AnyFacetResponse {
   return !!response && response.facetId in state.commerceFacetSet;
 }
-
-function baseCommerceFacetResponseSelector(
-  state: ProductListingV2Section | CommerceSearchSection,
-  facetId: string
-) {
-  const findById = (response: {facetId: string}) =>
-    response.facetId === facetId;
-
-  if ('productListing' in state) {
-    return state.productListing.facets.find(findById);
-  }
-
-  if ('commerceSearch' in state) {
-    return state.commerceSearch.facets.find(findById);
-  }
-
-  return undefined;
-}
-
-export const commerceFacetResponseSelector = (
-  state: (ProductListingV2Section | CommerceSearchSection) &
-    CommerceFacetSetSection,
-  facetId: string
-) => {
-  const response = baseCommerceFacetResponseSelector(state, facetId);
-  if (isFacetResponse(state, response)) {
-    return response;
-  }
-
-  return undefined;
-};
-
-export const isCommerceFacetLoadingResponseSelector = (
-  state: ProductListingV2Section | CommerceSearchSection
-) => {
-  if ('productListing' in state) {
-    return state.productListing.isLoading;
-  }
-
-  if ('commerceSearch' in state) {
-    return state.commerceSearch.isLoading;
-  }
-
-  return undefined;
-};

--- a/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-order/facet-order-slice.test.ts
@@ -1,7 +1,13 @@
 import {AnyAction} from '@reduxjs/toolkit';
+import {buildMockCommerceRegularFacetResponse} from '../../../test/mock-commerce-facet-response';
+import {buildMockCommerceRegularFacetValue} from '../../../test/mock-commerce-facet-value';
+import {buildSearchResponse} from '../../../test/mock-commerce-search';
 import {buildMockFacetResponse} from '../../../test/mock-facet-response';
+import {buildFetchProductListingV2Response} from '../../../test/mock-product-listing-v2';
 import {buildMockSearch} from '../../../test/mock-search';
 import {buildMockSearchResponse} from '../../../test/mock-search-response';
+import {fetchProductListing} from '../../commerce/product-listing/product-listing-actions';
+import {executeSearch as executeCommerceSearch} from '../../commerce/search/search-actions';
 import {change} from '../../history/history-actions';
 import {getHistoryInitialState} from '../../history/history-state';
 import {executeSearch} from '../../search/search-actions';
@@ -59,5 +65,38 @@ describe('facet-order slice', () => {
     const facetIds = ['facetA', 'facetB'];
     dispatchMockHistoryChange(facetIds);
     expect(state).toEqual(facetIds);
+  });
+
+  describe.each([
+    {
+      actionName: '#fetchProductListing.fulfilled',
+      action: fetchProductListing.fulfilled,
+      responseBuilder: buildFetchProductListingV2Response,
+    },
+    {
+      actionName: '#executeCommerceSearch.fulfilled',
+      action: executeCommerceSearch.fulfilled,
+      responseBuilder: buildSearchResponse,
+    },
+  ])('$actionName', ({action, responseBuilder}) => {
+    function buildQueryAction(facetIds: string[]) {
+      const facetValue = buildMockCommerceRegularFacetValue({
+        value: 'some-value',
+      });
+      const response = responseBuilder();
+      response.response.facets = facetIds.map((facetId) =>
+        buildMockCommerceRegularFacetResponse({
+          facetId,
+          values: [facetValue],
+        })
+      );
+
+      return action(response, '');
+    }
+    it('saves the facet order when a query is successful', () => {
+      const facetIds = ['facetA', 'facetB'];
+      dispatchMock(buildQueryAction(facetIds));
+      expect(state).toEqual(facetIds);
+    });
   });
 });

--- a/packages/headless/src/features/facets/facet-order/facet-order-slice.ts
+++ b/packages/headless/src/features/facets/facet-order/facet-order-slice.ts
@@ -1,23 +1,25 @@
-import {createReducer} from '@reduxjs/toolkit';
+import {AnyAction, createReducer} from '@reduxjs/toolkit';
 import {fetchProductListing} from '../../commerce/product-listing/product-listing-actions';
+import {executeSearch as executeCommerceSearch} from '../../commerce/search/search-actions';
 import {change} from '../../history/history-actions';
 import {executeSearch} from '../../search/search-actions';
-import {getFacetOrderInitialState} from './facet-order-state';
+import {FacetOrderState, getFacetOrderInitialState} from './facet-order-state';
 
 export const facetOrderReducer = createReducer(
   getFacetOrderInitialState(),
   (builder) => {
     builder
-      .addCase(executeSearch.fulfilled, (_, action) => {
-        return action.payload.response.facets.map((facet) => facet.facetId);
-      })
-      .addCase(fetchProductListing.fulfilled, (_, action) => {
-        const generateFacetId = (facet: {facetId?: string; field: string}) =>
-          facet.facetId ?? facet.field;
-        return action.payload.response.facets.map(generateFacetId);
-      })
+      .addCase(executeSearch.fulfilled, handleQueryFulfilled)
+      .addCase(fetchProductListing.fulfilled, handleQueryFulfilled)
+      .addCase(executeCommerceSearch.fulfilled, handleQueryFulfilled)
       .addCase(change.fulfilled, (state, action) => {
         return action.payload?.facetOrder ?? state;
       });
   }
 );
+
+function handleQueryFulfilled(_: FacetOrderState, action: AnyAction) {
+  return action.payload.response.facets.map(
+    (facet: {facetId: string}) => facet.facetId
+  );
+}


### PR DESCRIPTION
This PR contains two fixes:
- Upon search query response, we set the facet order
- In the core facet controller, we use a solution-type specific selector. This fixes a bug where we'd always check the `productListing` state for facets, even when trying to select facet values. By doing so, the core facet controller is now fully solution-type agnostic.
 
[CAPI-393]