### PR TITLE
feat(headless): getGeneratedAnswerMetadata method added to the InsightAnalytics provider

### DIFF
--- a/packages/headless/src/api/analytics/insight-analytics.test.ts
+++ b/packages/headless/src/api/analytics/insight-analytics.test.ts
@@ -1,6 +1,7 @@
 import {CoveoAnalyticsClient} from 'coveo.analytics';
 import pino from 'pino';
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state';
+import {getGeneratedAnswerInitialState} from '../../features/generated-answer/generated-answer-state';
 import {buildMockFacetRequest} from '../../test/mock-facet-request';
 import {buildMockFacetResponse} from '../../test/mock-facet-response';
 import {buildMockFacetSlice} from '../../test/mock-facet-slice';
@@ -140,6 +141,15 @@ describe('insight analytics', () => {
       expect(new InsightAnalyticsProvider(() => state).getSearchUID()).toEqual(
         'another_id'
       );
+    });
+
+    it('should properly return the generated answer metadata from the state', () => {
+      const state = getBaseState();
+      state.generatedAnswer = getGeneratedAnswerInitialState();
+      state.generatedAnswer.isVisible = false;
+      expect(
+        new InsightAnalyticsProvider(() => state).getGeneratedAnswerMetadata()
+      ).toEqual({showGeneratedAnswer: false});
     });
   });
 });

--- a/packages/headless/src/api/analytics/insight-analytics.ts
+++ b/packages/headless/src/api/analytics/insight-analytics.ts
@@ -72,6 +72,15 @@ export class InsightAnalyticsProvider
     return buildFacetStateMetadata(getStateNeededForFacetMetadata(this.state));
   }
 
+  public getGeneratedAnswerMetadata() {
+    const state = this.getState();
+    const formattedObject: Record<string, string | boolean> = {};
+    if (state.generatedAnswer?.isVisible !== undefined) {
+      formattedObject['showGeneratedAnswer'] = state.generatedAnswer.isVisible;
+    }
+    return formattedObject;
+  }
+
   private get queryText() {
     return this.state.query?.q || getQueryInitialState().q;
   }


### PR DESCRIPTION
[SFINT-5248](https://coveord.atlassian.net/browse/SFINT-5248)