### PR TITLE
test(core-pager): rework with new practices

### DIFF
--- a/packages/headless/src/test/mock-engine-v2.ts
+++ b/packages/headless/src/test/mock-engine-v2.ts
@@ -1,0 +1,132 @@
+import pino, {Logger} from 'pino';
+import type {CoreEngine} from '../app/engine';
+import type {CaseAssistEngine} from '../case-assist.index';
+import type {CommerceEngine} from '../commerce.index';
+import type {SearchEngine} from '../index';
+import type {InsightEngine} from '../insight.index';
+import type {ProductListingEngine} from '../product-listing.index';
+import type {ProductRecommendationEngine} from '../product-recommendation.index';
+import type {RecommendationEngine} from '../recommendation.index';
+
+type SpyEverything<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? jest.Mock<R, A>
+    : T[K] extends object
+      ? SpyEverything<T[K]>
+      : T[K];
+};
+
+type SpiedLoggerProps = SpyEverything<
+  Pick<Logger, 'debug' | 'info' | 'warn' | 'error' | 'fatal'>
+>;
+
+type MockedLogger = Logger & SpiedLoggerProps;
+
+function mockLogger(logger: Logger): MockedLogger {
+  return Object.assign<Logger, SpiedLoggerProps>(logger, {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+  });
+}
+
+type MockedCoreEngine<
+  State extends StateFromEngine<CoreEngine> = StateFromEngine<CoreEngine>,
+> = CoreEngine & {
+  state: State;
+  logger: MockedLogger;
+} & SpyEverything<Omit<CoreEngine, 'logger' | 'state'>>;
+
+export function buildMockCoreEngine<State extends StateFromEngine<CoreEngine>>(
+  initialState: State
+): MockedCoreEngine<State> {
+  const state: State = initialState;
+  return {
+    state,
+    dispatch: jest.fn(),
+    addReducers: jest.fn(),
+    disableAnalytics: jest.fn(),
+    enableAnalytics: jest.fn(),
+    logger: mockLogger(pino({level: 'silent'})),
+    store: {
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+      replaceReducer: jest.fn(),
+      subscribe: jest.fn(),
+      [Symbol.observable]: jest.fn(),
+    },
+    subscribe: jest.fn(),
+  };
+}
+
+export type MockedSearchEngine = SearchEngine &
+  MockedCoreEngine<StateFromEngine<SearchEngine>> &
+  SpyEverything<
+    Pick<
+      SearchEngine,
+      | 'executeFirstSearch'
+      | 'executeFirstSearchAfterStandaloneSearchBoxRedirect'
+    >
+  >;
+
+type StateFromEngine<TEngine extends CoreEngine> = TEngine['state'];
+
+export function buildMockSearchEngine(
+  initialState: StateFromEngine<SearchEngine>
+): MockedSearchEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+    executeFirstSearch: jest.fn(),
+    executeFirstSearchAfterStandaloneSearchBoxRedirect: jest.fn(),
+  };
+}
+
+export function buildMockCaseAssistEngine<
+  State extends StateFromEngine<CaseAssistEngine>,
+>(initialState: State): CaseAssistEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+  };
+}
+
+export function buildMockCommerceEngine<
+  State extends StateFromEngine<CommerceEngine>,
+>(initialState: State): CommerceEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+  };
+}
+
+export function buildMockInsightEngine<
+  State extends StateFromEngine<InsightEngine>,
+>(initialState: State): InsightEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+    executeFirstSearch: jest.fn(),
+  };
+}
+export function buildMockProductListingEngine<
+  State extends StateFromEngine<ProductListingEngine>,
+>(initialState: State): ProductListingEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+  };
+}
+
+export function buildMockProductRecommendationEngine<
+  State extends StateFromEngine<ProductRecommendationEngine>,
+>(initialState: State): ProductRecommendationEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+  };
+}
+
+export function buildMockRecommendationEngine<
+  State extends StateFromEngine<RecommendationEngine>,
+>(initialState: State): RecommendationEngine {
+  return {
+    ...buildMockCoreEngine(initialState),
+  };
+}

--- a/packages/headless/src/tsconfig.build.json
+++ b/packages/headless/src/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["node", "jest"]
   },
   "exclude": ["./**/*.test.ts"]
 }

--- a/packages/headless/src/tsconfig.build.json
+++ b/packages/headless/src/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "isolatedModules": true,
-    "types": ["node", "jest"]
+    "isolatedModules": true
   },
   "exclude": ["./**/*.test.ts"]
 }

--- a/packages/headless/src/tsconfig.test.json
+++ b/packages/headless/src/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  },
+  "include": ["./**/*.test.ts"]
+}


### PR DESCRIPTION
This is an example PR for how I think we may want to modify our tests to try to 'fit' with some Redux good practices (and adapt some others to our specificity).

My first attempt was to try to use integration testing with our controllers, but was not able to. The main reasons are that it's cumbersome/inadequate to test all reducers using the actions triggered by a controller, and vice-versa.

So I went the opposite route, where I isolated everything

I reason that we can test everything that does consume an engine in isolation, and we mostly do actually.
The only piece that hasn't been black boxed like this is the controllers, and essentially this is what this PR do with the pager controller.

KIT-2954