### PR TITLE
fix(quantic): adjust citation tooltip width in specific situations inside Salesforce

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.css
@@ -41,7 +41,7 @@
 
 .citation__tooltip-text {
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticStatefulButton/quanticStatefulButton.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticStatefulButton/quanticStatefulButton.html
@@ -12,7 +12,7 @@
       </template>
     </button>
     <template lwc:if={tooltip}>
-      <c-quantic-tooltip target={template.host}>
+      <c-quantic-tooltip>
         <div slot="content">{tooltip}</div>
       </c-quantic-tooltip>
     </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticTooltip/quanticTooltip.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTooltip/quanticTooltip.js
@@ -1,6 +1,8 @@
 import {getAbsoluteWidth, getAbsoluteHeight} from 'c/quanticUtils';
 import {LightningElement, api} from 'lwc';
 
+const targetWidthToTooltipWidthRatio = 1.2;
+
 /**
  * The `QuanticTooltip` displays a tooltip containing a small amount of text that can be displayed when hovering over certain elements.
  * This component should be used inside a container with a CSS position attribute set to the value `relative`
@@ -55,8 +57,15 @@ export default class QuanticTooltip extends LightningElement {
 
   updateTooltipMaxWidth() {
     const windowWidth = window.innerWidth;
+    const targetWidth = getAbsoluteWidth(this.target);
+
+    const adaptedWidth =
+      targetWidth > 0
+        ? Math.min(windowWidth, targetWidth * targetWidthToTooltipWidthRatio)
+        : windowWidth;
+
     const styles = this.template.host?.style;
-    styles.setProperty('--adapted-max-width', `${windowWidth}px`);
+    styles.setProperty('--adapted-max-width', `${adaptedWidth}px`);
   }
 
   updateTooltipVerticalPosition = () => {


### PR DESCRIPTION
[SFINT-5350](https://coveord.atlassian.net/browse/SFINT-5350)


### The issue:
In some specific situations is Salesforce, like in the Hosted Insight Panel for example, the citations tooltip were being cropped because they were displayed inside a Salesforce container that had some stying rules that hide any thing that overflows the container:

<img width="1300" alt="Issue" src="https://github.com/coveo/ui-kit/assets/86681870/ebeb87fb-591c-471f-87fe-01b1b0e6a1f8">


### The solution

In order to avoid such situations, I added a new logic to the Quantic Tooltip component that limits the width of the tooltip relatively to the width of its target.
This way the tooltip will never be too big to be cropped.

Additionally, since we reduced the width, I alsso made the tooltip of the citations display the first 6 lines of the descriptions instead of 4 and this keep always approximately  displaying the same amount  of information. In other words I reduced the width of the citation tooltip but increased its height.

<img width="1728" alt="Screenshot 2024-01-23 at 6 43 51 AM" src="https://github.com/coveo/ui-kit/assets/86681870/afb46a78-aa3b-4373-b67c-7f1fc956a418">



[SFINT-5350]: https://coveord.atlassian.net/browse/SFINT-5350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ