### PR TITLE
fix(quantic): fixed issue of copy to clipboard button not being  displayed

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerCopyToClipboard/quanticGeneratedAnswerCopyToClipboard.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerCopyToClipboard/quanticGeneratedAnswerCopyToClipboard.html
@@ -1,13 +1,11 @@
 <template>
-  <template lwc:if={showCopyToClipboard}>
-    <c-quantic-stateful-button
-      selected={isSelected}
-      tooltip={tooltip}
-      icon-name="utility:copy"
-      onselect={handleCopyToClipboard}
-      without-borders
-      selected-state-color="#2e844a"
-      icon-size="xx-small"
-    ></c-quantic-stateful-button>
-  </template>
+  <c-quantic-stateful-button
+    selected={isSelected}
+    tooltip={tooltip}
+    icon-name="utility:copy"
+    onselect={handleCopyToClipboard}
+    without-borders
+    selected-state-color="#2e844a"
+    icon-size="xx-small"
+  ></c-quantic-stateful-button>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerCopyToClipboard/quanticGeneratedAnswerCopyToClipboard.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerCopyToClipboard/quanticGeneratedAnswerCopyToClipboard.js
@@ -22,10 +22,6 @@ export default class QuanticGeneratedAnswerCopyToClipboard extends LightningElem
   isSelected = false;
   tooltip = this.labels.copy;
 
-  get showCopyToClipboard() {
-    return !!navigator?.clipboard?.writeText;
-  }
-
   dispatchCopyToClipboardEvent(option) {
     this.dispatchEvent(
       new CustomEvent('quantic__generatedanswercopy', {


### PR DESCRIPTION
[SFINT-5364](https://coveord.atlassian.net/browse/SFINT-5364)

Removed the logic that was making the issue of making the copy to clipboard button not appear in the generated answer component.

`navigator.clipboard.writeText()` is not supported yet in Salesforce service console, that's what was causing the issue.
 but the thing is that in Quantic, we have a fallback method that does the copy to clip board job without relying on `navigator.clipboard` so we don't really need this logic.

This condition has been initially added by the SVCC team cause they had this problem in Atomic, but in our side it's not needed cause we have a fallback method allowing us to copy to clipboard properly.

[SFINT-5364]: https://coveord.atlassian.net/browse/SFINT-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ