### PR TITLE
feat(headless,atomic): migrate framework versions from customData to source w/ next analytics

### DIFF
--- a/packages/atomic/src/components/common/interface/analytics-config.ts
+++ b/packages/atomic/src/components/common/interface/analytics-config.ts
@@ -37,8 +37,15 @@ export function augmentAnalyticsConfigWithDocument(): AnalyticsConfiguration {
   };
 }
 
+const versionMatcher = /^(\d+\.\d+\.\d+)/;
+
 export function augmentAnalyticsConfigWithAtomicVersion(): Required<
-  Pick<AnalyticsConfiguration, 'frameworkVersions'>
+  Pick<AnalyticsConfiguration, 'source'>
 > {
-  return {frameworkVersions: {'@coveo/atomic': getAtomicEnvironment().version}};
+  return {
+    source: {
+      '@coveo/atomic':
+        versionMatcher.exec(getAtomicEnvironment().version)?.[0] || '0.0.0',
+    },
+  };
 }

--- a/packages/atomic/src/components/common/interface/analytics-config.ts
+++ b/packages/atomic/src/components/common/interface/analytics-config.ts
@@ -38,7 +38,7 @@ export function augmentAnalyticsConfigWithDocument(): AnalyticsConfiguration {
 }
 
 export function augmentAnalyticsConfigWithAtomicVersion(): Required<
-  Pick<AnalyticsConfiguration, 'atomicVersion'>
+  Pick<AnalyticsConfiguration, 'frameworkVersions'>
 > {
-  return {atomicVersion: getAtomicEnvironment().version};
+  return {frameworkVersions: {'@coveo/atomic': getAtomicEnvironment().version}};
 }

--- a/packages/atomic/src/components/common/interface/analytics-config.ts
+++ b/packages/atomic/src/components/common/interface/analytics-config.ts
@@ -36,3 +36,9 @@ export function augmentAnalyticsConfigWithDocument(): AnalyticsConfiguration {
     ...(document.referrer && {originLevel3: document.referrer}),
   };
 }
+
+export function augmentAnalyticsConfigWithAtomicVersion(): Required<
+  Pick<AnalyticsConfiguration, 'atomicVersion'>
+> {
+  return {atomicVersion: getAtomicEnvironment().version};
+}

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/analytics-config.ts
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/analytics-config.ts
@@ -7,6 +7,7 @@ import {
   augmentAnalyticsWithAtomicVersion,
   augmentWithExternalMiddleware,
   augmentAnalyticsConfigWithDocument,
+  augmentAnalyticsConfigWithAtomicVersion,
 } from '../../common/interface/analytics-config';
 
 export function getAnalyticsConfig(
@@ -22,6 +23,7 @@ export function getAnalyticsConfig(
     analyticsClientMiddleware,
     enabled,
     ...augmentAnalyticsConfigWithDocument(),
+    ...augmentAnalyticsConfigWithAtomicVersion(),
   };
 
   if (recsConfig.analytics) {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -3,8 +3,11 @@ import {
   getSampleSearchEngineConfiguration,
   SearchEngineConfiguration,
 } from '@coveo/headless';
+import {getAtomicEnvironment} from '../../../global/environment';
 import {getAnalyticsConfig} from './analytics-config';
 import {createAtomicStore} from './store';
+
+jest.mock('../../../global/environment');
 
 describe('analyticsConfig', () => {
   let config: SearchEngineConfiguration;
@@ -63,6 +66,7 @@ describe('analyticsConfig', () => {
         enabled: true,
         originContext: 'something',
         originLevel3: 'bar',
+        atomicVersion: '3.4.5',
       };
       const resultingConfig = getAnalyticsConfig(config, false, store);
       expect(resultingConfig.enabled).toBe(true);

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -10,6 +10,7 @@ describe('analyticsConfig', () => {
   let config: SearchEngineConfiguration;
   let store: ReturnType<typeof createAtomicStore>;
   const originalReferrer = document.referrer;
+  const {version: atomicVersion} = getAtomicEnvironment();
   const setReferrer = (value: string) => {
     Object.defineProperty(document, 'referrer', {value, configurable: true});
   };
@@ -25,6 +26,7 @@ describe('analyticsConfig', () => {
     };
     return config;
   };
+
 
   describe.each([
     {
@@ -52,6 +54,7 @@ describe('analyticsConfig', () => {
       const resultingConfig = getAnalyticsConfig(config, true, store);
       expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
       expect(resultingConfig.originLevel3).toBe('foo');
+      expect(resultingConfig.atomicVersion).toBe(atomicVersion);
     });
 
     it('merges provided engine analytics config', () => {
@@ -65,6 +68,7 @@ describe('analyticsConfig', () => {
       expect(resultingConfig.enabled).toBe(true);
       expect(resultingConfig.originContext).toBe('something');
       expect(resultingConfig.originLevel3).toBe('bar');
+      expect(resultingConfig.atomicVersion).toBe(atomicVersion);
     });
 
     it('use the existing analytic middleware if available', () => {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -3,7 +3,6 @@ import {
   getSampleSearchEngineConfiguration,
   SearchEngineConfiguration,
 } from '@coveo/headless';
-import {getAtomicEnvironment} from '../../../global/environment';
 import {getAnalyticsConfig} from './analytics-config';
 import {createAtomicStore} from './store';
 
@@ -13,7 +12,6 @@ describe('analyticsConfig', () => {
   let config: SearchEngineConfiguration;
   let store: ReturnType<typeof createAtomicStore>;
   const originalReferrer = document.referrer;
-  const {version: atomicVersion} = getAtomicEnvironment();
   const setReferrer = (value: string) => {
     Object.defineProperty(document, 'referrer', {value, configurable: true});
   };
@@ -56,9 +54,7 @@ describe('analyticsConfig', () => {
       const resultingConfig = getAnalyticsConfig(config, true, store);
       expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
       expect(resultingConfig.originLevel3).toBe('foo');
-      expect(resultingConfig.frameworkVersions?.['@coveo/atomic']).toBe(
-        atomicVersion
-      );
+      expect(resultingConfig.source?.['@coveo/atomic']).toBe('0.0.0');
     });
 
     it('merges provided engine analytics config', () => {
@@ -67,7 +63,7 @@ describe('analyticsConfig', () => {
         enabled: true,
         originContext: 'something',
         originLevel3: 'bar',
-        frameworkVersions: {
+        source: {
           '@coveo/atomic': '3.4.5',
         },
       };
@@ -75,9 +71,7 @@ describe('analyticsConfig', () => {
       expect(resultingConfig.enabled).toBe(true);
       expect(resultingConfig.originContext).toBe('something');
       expect(resultingConfig.originLevel3).toBe('bar');
-      expect(resultingConfig.frameworkVersions?.['@coveo/atomic']).toBe(
-        atomicVersion
-      );
+      expect(resultingConfig.source?.['@coveo/atomic']).toBe('0.0.0');
     });
 
     it('use the existing analytic middleware if available', () => {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -30,7 +30,6 @@ describe('analyticsConfig', () => {
     return config;
   };
 
-
   describe.each([
     {
       describeName:
@@ -57,7 +56,9 @@ describe('analyticsConfig', () => {
       const resultingConfig = getAnalyticsConfig(config, true, store);
       expect(resultingConfig.analyticsClientMiddleware).toBeDefined();
       expect(resultingConfig.originLevel3).toBe('foo');
-      expect(resultingConfig.atomicVersion).toBe(atomicVersion);
+      expect(resultingConfig.frameworkVersions?.['@coveo/atomic']).toBe(
+        atomicVersion
+      );
     });
 
     it('merges provided engine analytics config', () => {
@@ -66,13 +67,17 @@ describe('analyticsConfig', () => {
         enabled: true,
         originContext: 'something',
         originLevel3: 'bar',
-        atomicVersion: '3.4.5',
+        frameworkVersions: {
+          '@coveo/atomic': '3.4.5',
+        },
       };
       const resultingConfig = getAnalyticsConfig(config, false, store);
       expect(resultingConfig.enabled).toBe(true);
       expect(resultingConfig.originContext).toBe('something');
       expect(resultingConfig.originLevel3).toBe('bar');
-      expect(resultingConfig.atomicVersion).toBe(atomicVersion);
+      expect(resultingConfig.frameworkVersions?.['@coveo/atomic']).toBe(
+        atomicVersion
+      );
     });
 
     it('use the existing analytic middleware if available', () => {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.ts
@@ -7,6 +7,7 @@ import {
   augmentAnalyticsWithAtomicVersion,
   augmentWithExternalMiddleware,
   augmentAnalyticsConfigWithDocument,
+  augmentAnalyticsConfigWithAtomicVersion,
 } from '../../common/interface/analytics-config';
 import {createAtomicStore} from './store';
 
@@ -26,14 +27,23 @@ export function getAnalyticsConfig(
     ...augmentAnalyticsConfigWithDocument(),
   };
 
+  const immutableConfiguration: AnalyticsConfiguration = {
+    ...augmentAnalyticsConfigWithAtomicVersion(),
+  };
+
   if (searchEngineConfig.analytics) {
     return {
       ...defaultConfiguration,
       ...searchEngineConfig.analytics,
       analyticsClientMiddleware,
+      ...immutableConfiguration,
     };
   }
-  return defaultConfiguration;
+
+  return {
+    ...defaultConfiguration,
+    ...immutableConfiguration,
+  };
 }
 
 function augmentAnalytics(

--- a/packages/headless/src/api/analytics/base-analytics.test.ts
+++ b/packages/headless/src/api/analytics/base-analytics.test.ts
@@ -33,7 +33,21 @@ describe('base analytics provider', () => {
     configuration: getConfigurationInitialState(),
   };
 
-  it('when context is not provided, #getBaseMetadata returns an object with version', () => {
+  it('when analyticMode=next, #getBaseMetadata returns an object without coveoHeadlessVersion', () => {
+    const state: StateNeededByBaseAnalyticsProvider = {
+      ...baseState,
+      configuration: {
+        ...baseState.configuration,
+        analytics: buildMockAnalyticsState({analyticsMode: 'next'}),
+      },
+    };
+    const provider = new TestProvider(() => state);
+    expect(provider.getBaseMetadata()).not.toHaveProperty(
+      'coveoHeadlessVersion'
+    );
+  });
+
+  it('when analyticMode=legacy, #getBaseMetadata returns an object with coveoHeadlessVersion', () => {
     const provider = new TestProvider(() => baseState);
     expect(provider.getBaseMetadata()).toEqual({
       coveoHeadlessVersion: expect.any(String),

--- a/packages/headless/src/api/analytics/base-analytics.ts
+++ b/packages/headless/src/api/analytics/base-analytics.ts
@@ -42,14 +42,16 @@ export abstract class BaseAnalyticsProvider<
   }
 
   public getBaseMetadata() {
-    const {context} = this.state;
+    const {context, configuration} = this.state;
     const contextValues = context?.contextValues || {};
     const formattedObject: Record<string, string | string[]> = {};
     for (const [key, value] of Object.entries(contextValues)) {
       const formattedKey = `context_${key}`;
       formattedObject[formattedKey] = value;
     }
-    formattedObject['coveoHeadlessVersion'] = VERSION;
+    if (configuration.analytics.analyticsMode === 'legacy') {
+      formattedObject['coveoHeadlessVersion'] = VERSION;
+    }
     return formattedObject;
   }
 

--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -508,15 +508,17 @@ describe('#configureAnalytics', () => {
 });
 
 describe('#getAnalyticsSources', () => {
-  it('without atomicVersion, returns an array only with `@coveo/headless`', () => {
+  it('without a frameworkVersions, returns an array only with `@coveo/headless`', () => {
     const state = createMockState();
     expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
       `@coveo/headless@${VERSION}`,
     ]);
   });
-  it('with atomicVersion, returns an array only with `@coveo/headless`', () => {
+  it('with a frameworkVersions, returns an array only with `@coveo/headless`', () => {
     const state = createMockState();
-    state.configuration.analytics.atomicVersion = '1.2.3';
+    state.configuration.analytics.frameworkVersions = {
+      '@coveo/atomic': '1.2.3',
+    };
     expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
       `@coveo/headless@${VERSION}`,
       '@coveo/atomic@1.2.3',

--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -27,6 +27,7 @@ import {QuerySuggestCompletion} from '../search/query-suggest/query-suggest-resp
 import {
   configureAnalytics,
   configureLegacyAnalytics,
+  getAnalyticsSource,
   getPageID,
   SearchAnalyticsProvider,
   StateNeededBySearchAnalyticsProvider,
@@ -493,30 +494,32 @@ describe('#configureAnalytics', () => {
     jest.clearAllMocks();
   });
 
-  it('without atomicVersion, creates a Relay client without `@coveo/atomic` in its sources', () => {
+  it('creates a Relay client properly and returns the emit function', () => {
     const state = createMockState();
     const emit = configureAnalytics(state);
-
     expect(mockedCreateRelay).toHaveBeenCalledWith({
       url: state.configuration.analytics.nextApiBaseUrl,
       token: state.configuration.accessToken,
       trackingId: state.configuration.analytics.trackingId,
-      source: [`@coveo/headless@${VERSION}`],
+      source: expect.arrayContaining([]),
     });
     expect(emit).toBe(mockedCreateRelay.mock.results[0].value.emit);
   });
+});
 
-  it('with atomicVersion, creates a Relay client with `@coveo/atomic` in its sources', () => {
+describe('#getAnalyticsSources', () => {
+  it('without atomicVersion, returns an array only with `@coveo/headless`', () => {
+    const state = createMockState();
+    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
+      `@coveo/headless@${VERSION}`,
+    ]);
+  });
+  it('with atomicVersion, returns an array only with `@coveo/headless`', () => {
     const state = createMockState();
     state.configuration.analytics.atomicVersion = '1.2.3';
-    const emit = configureAnalytics(state);
-
-    expect(mockedCreateRelay).toHaveBeenCalledWith({
-      url: state.configuration.analytics.nextApiBaseUrl,
-      token: state.configuration.accessToken,
-      trackingId: state.configuration.analytics.trackingId,
-      source: [`@coveo/headless@${VERSION}`, '@coveo/atomic@1.2.3'],
-    });
-    expect(emit).toBe(mockedCreateRelay.mock.results[0].value.emit);
+    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
+      `@coveo/headless@${VERSION}`,
+      '@coveo/atomic@1.2.3',
+    ]);
   });
 });

--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -508,15 +508,16 @@ describe('#configureAnalytics', () => {
 });
 
 describe('#getAnalyticsSources', () => {
-  it('without a frameworkVersions, returns an array only with `@coveo/headless`', () => {
+  it('without a source, returns an array only with `@coveo/headless`', () => {
     const state = createMockState();
     expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
       `@coveo/headless@${VERSION}`,
     ]);
   });
-  it('with a frameworkVersions, returns an array only with `@coveo/headless`', () => {
+
+  it('with a source, returns an array with `@coveo/headless` and the serialized framework-version pair', () => {
     const state = createMockState();
-    state.configuration.analytics.frameworkVersions = {
+    state.configuration.analytics.source = {
       '@coveo/atomic': '1.2.3',
     };
     expect(getAnalyticsSource(state.configuration.analytics)).toEqual([

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -21,6 +21,7 @@ import {getSortCriteriaInitialState} from '../../features/sort-criteria/sort-cri
 import {StaticFilterValueMetadata} from '../../features/static-filter-set/static-filter-set-actions';
 import {SearchAppState} from '../../state/search-app-state';
 import {ConfigurationSection} from '../../state/state-sections';
+import {VERSION} from '../../utils/version';
 import {PreprocessRequest} from '../preprocess-request';
 import {BaseAnalyticsProvider} from './base-analytics';
 import {
@@ -299,14 +300,19 @@ export const configureAnalytics = (
 ) => {
   const token = state.configuration.accessToken;
   const trackingId = state.configuration.analytics.trackingId;
+  const atomicVersion = state.configuration.analytics.atomicVersion;
   const {emit} = createRelay({
     url: state.configuration.analytics.nextApiBaseUrl,
     token,
     trackingId,
+    source: [`@coveo/headless@${VERSION}`].concat(
+      atomicVersion ? [`@coveo/atomic@${atomicVersion}`] : []
+    ),
   });
   return emit;
 };
 
+//TODO: KIT-2859
 export const configureLegacyAnalytics = ({
   logger,
   getState,

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -368,8 +368,10 @@ export const getPageID = () => {
 };
 
 export const getAnalyticsSource = (state: AnalyticsState) => {
-  const atomicVersion = state.atomicVersion;
   return [`@coveo/headless@${VERSION}`].concat(
-    atomicVersion ? [`@coveo/atomic@${atomicVersion}`] : []
+    Object.entries(state.frameworkVersions).map(
+      ([frameworkName, frameworkVersion]) =>
+        `${frameworkName}@${frameworkVersion}`
+    )
   );
 };

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -369,7 +369,7 @@ export const getPageID = () => {
 
 export const getAnalyticsSource = (state: AnalyticsState) => {
   return [`@coveo/headless@${VERSION}`].concat(
-    Object.entries(state.frameworkVersions).map(
+    Object.entries(state.source).map(
       ([frameworkName, frameworkVersion]) =>
         `${frameworkName}@${frameworkVersion}`
     )

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -6,6 +6,7 @@ import {
 } from 'coveo.analytics';
 import {SearchEventRequest} from 'coveo.analytics/dist/definitions/events';
 import {Logger} from 'pino';
+import {AnalyticsState} from '../../features/configuration/configuration-state';
 import {
   buildFacetStateMetadata,
   getStateNeededForFacetMetadata,
@@ -300,14 +301,11 @@ export const configureAnalytics = (
 ) => {
   const token = state.configuration.accessToken;
   const trackingId = state.configuration.analytics.trackingId;
-  const atomicVersion = state.configuration.analytics.atomicVersion;
   const {emit} = createRelay({
     url: state.configuration.analytics.nextApiBaseUrl,
     token,
     trackingId,
-    source: [`@coveo/headless@${VERSION}`].concat(
-      atomicVersion ? [`@coveo/atomic@${atomicVersion}`] : []
-    ),
+    source: getAnalyticsSource(state.configuration.analytics),
   });
   return emit;
 };
@@ -367,4 +365,11 @@ export const getPageID = () => {
   }
 
   return lastPageView.value!;
+};
+
+export const getAnalyticsSource = (state: AnalyticsState) => {
+  const atomicVersion = state.atomicVersion;
+  return [`@coveo/headless@${VERSION}`].concat(
+    atomicVersion ? [`@coveo/atomic@${atomicVersion}`] : []
+  );
 };

--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -125,6 +125,7 @@ export interface AnalyticsParam {
     documentLocation?: string;
     trackingId?: string;
     capture?: boolean;
+    source?: string[];
   };
 }
 

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -163,10 +163,10 @@ export interface AnalyticsConfiguration {
    */
   analyticsMode?: 'legacy' | 'next';
   /**
-   * The version of `@coveo/atomic` used.
+   * Specifies the frameworks and version used around Headless (e.g. @coveo/atomic).
    * @internal
    */
-  frameworkVersions?: Partial<Record<CoveoFramework, string>>;
+  source?: Partial<Record<CoveoFramework, string>>;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -11,6 +11,7 @@ import {
 import {getOrganizationEndpoints} from '../api/platform-client';
 import {PreprocessRequest} from '../api/preprocess-request';
 import {requiredNonEmptyString} from '../utils/validate-payload';
+import {CoveoFramework} from '../utils/version';
 
 /**
  * The endpoints to use.
@@ -165,7 +166,7 @@ export interface AnalyticsConfiguration {
    * The version of `@coveo/atomic` used.
    * @internal
    */
-  atomicVersion?: string;
+  frameworkVersions?: Partial<Record<CoveoFramework, string>>;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -155,7 +155,17 @@ export interface AnalyticsConfiguration {
    * @internal
    */
   trackingId?: string;
+  /**
+   * Specifies the analytics mode to use.
+   * By default, `legacy`.
+   * @internal
+   */
   analyticsMode?: 'legacy' | 'next';
+  /**
+   * The version of `@coveo/atomic` used.
+   * @internal
+   */
+  atomicVersion?: string;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;

--- a/packages/headless/src/features/configuration/analytics-params.ts
+++ b/packages/headless/src/features/configuration/analytics-params.ts
@@ -1,6 +1,9 @@
 import {EventDescription} from 'coveo.analytics';
 import {getVisitorID} from '../../api/analytics/coveo-analytics-utils';
-import {getPageID} from '../../api/analytics/search-analytics';
+import {
+  getAnalyticsSource,
+  getPageID,
+} from '../../api/analytics/search-analytics';
 import {AnalyticsParam} from '../../api/search/search-api-params';
 import {AnalyticsState} from './configuration-state';
 
@@ -8,6 +11,7 @@ export const fromAnalyticsStateToAnalyticsParams = async (
   s: AnalyticsState,
   eventDescription?: EventDescription
 ): Promise<AnalyticsParam> => {
+  const isNextAnalytics = s.analyticsMode === 'next';
   return {
     analytics: {
       clientId: await getVisitorID(s),
@@ -22,8 +26,9 @@ export const fromAnalyticsStateToAnalyticsParams = async (
       ...(s.documentLocation && {documentLocation: s.documentLocation}),
       ...(s.deviceId && {deviceId: s.deviceId}),
       ...(getPageID() && {pageId: getPageID()}),
-      ...(s.analyticsMode && s.trackingId && {trackingId: s.trackingId}),
-      ...{capture: s.analyticsMode === 'next' ?? false},
+      ...(isNextAnalytics && s.trackingId && {trackingId: s.trackingId}),
+      ...{capture: isNextAnalytics},
+      ...(isNextAnalytics && {source: getAnalyticsSource(s)}),
     },
   };
 };

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -164,10 +164,10 @@ export interface UpdateAnalyticsConfigurationActionCreatorPayload {
    */
   analyticsMode?: 'legacy' | 'next';
   /**
-   * The version of `@coveo/atomic` used.
+   * Specifies the frameworks and version used around Headless (e.g. @coveo/atomic).
    * @internal
    */
-  frameworkVersions?: Partial<Record<CoveoFramework, string>>;
+  source?: Partial<Record<CoveoFramework, string>>;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;
@@ -192,7 +192,7 @@ const analyticsConfigurationSchema: SchemaDefinition<
     required: false,
     default: 'legacy',
   }),
-  frameworkVersions: new RecordValue({
+  source: new RecordValue({
     options: {required: false},
     values: COVEO_FRAMEWORK.reduce(
       (acc, framework) => {

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -148,8 +148,17 @@ export interface UpdateAnalyticsConfigurationActionCreatorPayload {
    * TBD
    */
   trackingId?: string;
-
+  /**
+   * Specifies the analytics mode to use.
+   * By default, `legacy`.
+   * @internal
+   */
   analyticsMode?: 'legacy' | 'next';
+  /**
+   * The version of `@coveo/atomic` used.
+   * @internal
+   */
+  atomicVersion?: string;
 }
 
 export type AnalyticsRuntimeEnvironment = IRuntimeEnvironment;
@@ -177,6 +186,10 @@ export const updateAnalyticsConfiguration = createAction(
         constrainTo: ['legacy', 'next'],
         required: false,
         default: 'legacy',
+      }),
+      atomicVersion: new StringValue({
+        regex: /^\d+\.\d+\.\d+$/,
+        required: false,
       }),
     });
   }

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -48,6 +48,7 @@ describe('configuration slice', () => {
       documentLocation: 'http://hello.world.com',
       trackingId: 'someTrackingId',
       analyticsMode: 'legacy',
+      frameworkVersions: {},
     },
   };
 
@@ -157,6 +158,7 @@ describe('configuration slice', () => {
           documentLocation: 'http://somewhere.com',
           trackingId: 'someTrackingId',
           analyticsMode: 'legacy',
+          frameworkVersions: {},
         },
       };
       expect(
@@ -195,6 +197,7 @@ describe('configuration slice', () => {
           documentLocation: 'http://somewhere.com',
           trackingId: 'someTrackingId',
           analyticsMode: 'legacy',
+          frameworkVersions: {},
         },
       };
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -48,7 +48,7 @@ describe('configuration slice', () => {
       documentLocation: 'http://hello.world.com',
       trackingId: 'someTrackingId',
       analyticsMode: 'legacy',
-      frameworkVersions: {},
+      source: {},
     },
   };
 
@@ -158,7 +158,7 @@ describe('configuration slice', () => {
           documentLocation: 'http://somewhere.com',
           trackingId: 'someTrackingId',
           analyticsMode: 'legacy',
-          frameworkVersions: {},
+          source: {},
         },
       };
       expect(
@@ -197,7 +197,7 @@ describe('configuration slice', () => {
           documentLocation: 'http://somewhere.com',
           trackingId: 'someTrackingId',
           analyticsMode: 'legacy',
-          frameworkVersions: {},
+          source: {},
         },
       };
 

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -116,8 +116,8 @@ export const configurationReducer = createReducer(
         if (!isNullOrUndefined(action.payload.analyticsMode)) {
           state.analytics.analyticsMode = action.payload.analyticsMode;
         }
-        if (!isNullOrUndefined(action.payload.frameworkVersions)) {
-          state.analytics.frameworkVersions = action.payload.frameworkVersions;
+        if (!isNullOrUndefined(action.payload.source)) {
+          state.analytics.source = action.payload.source;
         }
         const magicCookie = getMagicCookie();
         if (magicCookie) {

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -116,8 +116,8 @@ export const configurationReducer = createReducer(
         if (!isNullOrUndefined(action.payload.analyticsMode)) {
           state.analytics.analyticsMode = action.payload.analyticsMode;
         }
-        if (!isNullOrUndefined(action.payload.atomicVersion)) {
-          state.analytics.atomicVersion = action.payload.atomicVersion;
+        if (!isNullOrUndefined(action.payload.frameworkVersions)) {
+          state.analytics.frameworkVersions = action.payload.frameworkVersions;
         }
         const magicCookie = getMagicCookie();
         if (magicCookie) {

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -116,6 +116,9 @@ export const configurationReducer = createReducer(
         if (!isNullOrUndefined(action.payload.analyticsMode)) {
           state.analytics.analyticsMode = action.payload.analyticsMode;
         }
+        if (!isNullOrUndefined(action.payload.atomicVersion)) {
+          state.analytics.atomicVersion = action.payload.atomicVersion;
+        }
         const magicCookie = getMagicCookie();
         if (magicCookie) {
           state.analytics.analyticsMode = 'next';

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -127,8 +127,17 @@ export interface AnalyticsState {
    * @internal
    */
   trackingId: string;
-
+  /**
+   * Specifies the analytics mode to use.
+   * By default, `legacy`.
+   * @internal
+   */
   analyticsMode: 'legacy' | 'next';
+  /**
+   * The version of `@coveo/atomic` used.
+   * @internal
+   */
+  atomicVersion?: string;
 }
 
 export const searchAPIEndpoint = '/rest/search/v2';

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import {analyticsUrl, platformUrl} from '../../api/platform-client';
+import {CoveoFramework} from '../../utils/version';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -137,7 +138,7 @@ export interface AnalyticsState {
    * The version of `@coveo/atomic` used.
    * @internal
    */
-  atomicVersion?: string;
+  frameworkVersions: Partial<Record<CoveoFramework, string>>;
 }
 
 export const searchAPIEndpoint = '/rest/search/v2';
@@ -166,5 +167,6 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     documentLocation: '',
     trackingId: '',
     analyticsMode: 'legacy',
+    frameworkVersions: {},
   },
 });

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -135,10 +135,10 @@ export interface AnalyticsState {
    */
   analyticsMode: 'legacy' | 'next';
   /**
-   * The version of `@coveo/atomic` used.
+   * Specifies the frameworks and version used around Headless (e.g. @coveo/atomic)
    * @internal
    */
-  frameworkVersions: Partial<Record<CoveoFramework, string>>;
+  source: Partial<Record<CoveoFramework, string>>;
 }
 
 export const searchAPIEndpoint = '/rest/search/v2';
@@ -167,6 +167,6 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     documentLocation: '',
     trackingId: '',
     analyticsMode: 'legacy',
-    frameworkVersions: {},
+    source: {},
   },
 });

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -140,18 +140,25 @@ function extractAndExcludeProperties(
   } = call.mock.calls[callIndex][0] as {
     requestParams: {analytics?: Record<string, unknown>};
   };
-
-  return excludeProperties(analytics);
+  let result = analytics;
+  result = excludeProperties(result, excludedBaseProperties);
+  result.customData = excludeProperties(
+    result?.customData ?? {},
+    excludedCustomDataProperties
+  );
+  return result;
 }
 
 async function wait() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-function excludeProperties(obj: Record<string, unknown>) {
+function excludeProperties(
+  obj: Record<string, unknown> | object,
+  excludedKeys: string[]
+) {
   const result = {...obj};
-  excludedBaseProperties.forEach((prop: string) => delete result[prop]);
-
+  excludedKeys.forEach((prop: string) => delete result[prop]);
   return result;
 }
 
@@ -162,6 +169,8 @@ const excludedBaseProperties = [
   'trackingId',
   'source',
 ];
+
+const excludedCustomDataProperties = ['coveoHeadlessVersion'];
 
 const ANY_FACET_VALUE = 'any facet value';
 const ANY_FACET_ID = 'any facet id';

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -160,6 +160,7 @@ const excludedBaseProperties = [
   'capture',
   'clientTimestamp',
   'trackingId',
+  'source',
 ];
 
 const ANY_FACET_VALUE = 'any facet value';

--- a/packages/headless/src/test/mock-analytics-state.ts
+++ b/packages/headless/src/test/mock-analytics-state.ts
@@ -16,7 +16,7 @@ export function buildMockAnalyticsState(
     documentLocation: '',
     trackingId: '',
     analyticsMode: 'legacy',
-    frameworkVersions: {},
+    source: {},
     ...config,
   };
 }

--- a/packages/headless/src/test/mock-analytics-state.ts
+++ b/packages/headless/src/test/mock-analytics-state.ts
@@ -16,6 +16,7 @@ export function buildMockAnalyticsState(
     documentLocation: '',
     trackingId: '',
     analyticsMode: 'legacy',
+    frameworkVersions: {},
     ...config,
   };
 }

--- a/packages/headless/src/utils/validate-payload.ts
+++ b/packages/headless/src/utils/validate-payload.ts
@@ -35,6 +35,12 @@ export const nonEmptyStringArray = new ArrayValue({
   required: true,
 });
 
+export const optionalNonEmptyVersionString = new StringValue({
+  required: false,
+  emptyAllowed: false,
+  regex: /^\d+\.\d+\.\d+$/,
+});
+
 export const serializeSchemaValidationError = ({
   message,
   name,

--- a/packages/headless/src/utils/version.ts
+++ b/packages/headless/src/utils/version.ts
@@ -1,1 +1,5 @@
 export const VERSION = process.env.VERSION || 'Test version';
+
+export const COVEO_FRAMEWORK = ['@coveo/atomic', '@coveo/quantic'] as const;
+
+export type CoveoFramework = (typeof COVEO_FRAMEWORK)[number];


### PR DESCRIPTION
Context, the new schema defined a new place for Coveo frameworks to report their versions: https://github.com/coveo/analytics_schema/pull/292.

This PR:
 - Add a new config parameter in headless: `configuration.analytics.atomicVersion`. This will replace the analyticsMiddleware that atomic was using to set its version in the payloads.
 - When `analyticsMode=next`, set the Headless version & Atomic Version (if any) to:
    - The instantiation parameters of Relay
    - The analytics section of the request body of the call made to the Search API
 - When `analyticsMode=next`, do not set  `coveoHeadlessVersion` anymore in the customData. 
 
 
 KIT-2930