### PR TITLE
chore(headless): refactor Type into BaseFacetRequest

### DIFF
--- a/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/category-facet-set/interfaces/request.ts
@@ -2,7 +2,6 @@ import {
   BaseFacetRequest,
   CurrentValues,
   Delimitable,
-  Type,
   SortCriteria,
   BaseFacetValueRequest,
 } from '../../facet-api/request';
@@ -23,10 +22,9 @@ export interface CategoryFacetValueRequest
 }
 
 export interface CategoryFacetRequest
-  extends BaseFacetRequest,
+  extends BaseFacetRequest<'hierarchical'>,
     CurrentValues<CategoryFacetValueRequest>,
     Delimitable,
-    Type<'hierarchical'>,
     SortCriteria<CategoryFacetSortCriterion> {
   /** @defaultValue `5` */
   numberOfValues: number;

--- a/packages/headless/src/features/facets/facet-api/request.ts
+++ b/packages/headless/src/features/facets/facet-api/request.ts
@@ -1,7 +1,7 @@
 import {FacetSortOrder} from '../facet-set/interfaces/request';
 import {FacetValueState} from './value';
 
-export interface BaseFacetRequest {
+export interface BaseFacetRequest<TFacetType extends FacetType> {
   /**
    * A unique identifier for the controller.
    * By default, a unique random identifier is generated.
@@ -40,6 +40,12 @@ export interface BaseFacetRequest {
    * @defaultValue `atLeastOneValue`
    */
   resultsMustMatch: FacetResultsMustMatch;
+  /**
+   * The kind of values to request for the facet.
+   *
+   * @default `specific`
+   */
+  type: TFacetType;
 }
 
 export interface BaseFacetValueRequest {
@@ -77,15 +83,9 @@ export interface Expandable {
   isFieldExpanded: boolean;
 }
 
-export interface Type<T extends FacetType> {
-  type: T;
-}
+export type FacetType = 'specific' | 'hierarchical' | RangeFacetType;
 
-export type FacetType =
-  | 'specific'
-  | 'dateRange'
-  | 'numericalRange'
-  | 'hierarchical';
+export type RangeFacetType = 'dateRange' | 'numericalRange';
 
 export interface SortCriteria<
   T extends

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-request-options.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-request-options.ts
@@ -1,5 +1,5 @@
 import {FacetSearchRequestOptions} from '../../../api/search/facet-search/base/base-facet-search-request';
 import {BaseFacetRequest} from '../facet-api/request';
 
-export type FacetSearchOptions = Pick<BaseFacetRequest, 'facetId'> &
+export type FacetSearchOptions = Pick<BaseFacetRequest<'specific'>, 'facetId'> &
   Partial<FacetSearchRequestOptions>;

--- a/packages/headless/src/features/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/facet-set/interfaces/request.ts
@@ -2,7 +2,6 @@ import {
   BaseFacetRequest,
   CurrentValues,
   Freezable,
-  Type,
   SortCriteria,
   BaseFacetValueRequest,
   Expandable,
@@ -33,11 +32,10 @@ export interface FacetValueRequest extends BaseFacetValueRequest {
 }
 
 export interface FacetRequest
-  extends BaseFacetRequest,
+  extends BaseFacetRequest<'specific'>,
     CurrentValues<FacetValueRequest>,
     Expandable,
     Freezable,
-    Type<'specific'>,
     AllowedValues,
     CustomSort,
     SortCriteria<

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/interfaces/request.ts
@@ -1,4 +1,4 @@
-import {CurrentValues, Type} from '../../../facet-api/request';
+import {CurrentValues} from '../../../facet-api/request';
 import {FacetValueState} from '../../../facet-api/value';
 import {AnyFacetRequest} from '../../../generic/interfaces/generic-facet-request';
 import {BaseRangeFacetRequest} from '../../generic/interfaces/request';
@@ -35,6 +35,5 @@ export function isDateFacetRequest(
 }
 
 export interface DateFacetRequest
-  extends BaseRangeFacetRequest,
-    CurrentValues<DateRangeRequest>,
-    Type<'dateRange'> {}
+  extends BaseRangeFacetRequest<'dateRange'>,
+    CurrentValues<DateRangeRequest> {}

--- a/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/interfaces/request.ts
@@ -3,6 +3,7 @@ import {
   SortCriteria,
   BaseFacetValueRequest,
   RangeAlgorithm,
+  RangeFacetType,
 } from '../../../facet-api/request';
 
 export const rangeFacetSortCriteria: RangeFacetSortCriterion[] = [
@@ -40,8 +41,8 @@ export interface RangeRequest<T extends string | number>
   endInclusive: boolean;
 }
 
-export interface BaseRangeFacetRequest
-  extends BaseFacetRequest,
+export interface BaseRangeFacetRequest<TFacetType extends RangeFacetType>
+  extends BaseFacetRequest<TFacetType>,
     AutomaticRanges<boolean>,
     SortCriteria<RangeFacetSortCriterion>,
     RangeAlgorithm<RangeFacetRangeAlgorithm> {

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/interfaces/request.ts
@@ -1,4 +1,4 @@
-import {CurrentValues, Type} from '../../../facet-api/request';
+import {CurrentValues} from '../../../facet-api/request';
 import {FacetValueState} from '../../../facet-api/value';
 import {BaseRangeFacetRequest} from '../../generic/interfaces/request';
 
@@ -28,6 +28,5 @@ export interface NumericRangeRequest {
 }
 
 export interface NumericFacetRequest
-  extends BaseRangeFacetRequest,
-    CurrentValues<NumericRangeRequest>,
-    Type<'numericalRange'> {}
+  extends BaseRangeFacetRequest<'numericalRange'>,
+    CurrentValues<NumericRangeRequest> {}


### PR DESCRIPTION
I noticed that every interfaces that extends `Type` also extends BaseFacetRequest (make sense).
I think that refactoring `Type` into `BaseFacetRequest` is a good thing to do because it makes the latter more representative of what is sent to the SearchAPI: i.e. If I want to describe what's sent to describe a facet, regardless of its type, I think BaseFacetRequest is the one to use. It was missing the `type` field, now it doesn't.

Trade-off tho, there was a single place where we decided to extract FacetId from the BaseFacetRequest, I'm assuming to DRY the JSDOC associated with this field.
To solve that there were no pretty solutions I think, here's a few I explored;
 - Extract FieldId into another interface: It recreates the same issue I'm trying to solve here, and is tedious :x:
 - Duplicate: Meh, not a fan, especially because the uses is mostly around documentation, we're very likely to forget I reckon, :x:
 - Set a default value to TFacetType: I think that setting 'specific' by default would have been a source of error, so I chose not to :x:
 - Use a specific facetType, even if that's wrong: That's what I chose, because it isolate the problem in a corner 😂 