### PR TITLE
fix(quantic): fixed issue with the Quantic Search Box Input

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -185,7 +185,7 @@ describe('c-quantic-search-box-input', () => {
     });
   });
 
-  describe('when suggestions are found', () => {
+  describe('when the suggestions list is not empty', () => {
     it('should display the suggestions in the suggestions list', async () => {
       const element = createTestComponent({
         ...defaultOptions,
@@ -203,6 +203,21 @@ describe('c-quantic-search-box-input', () => {
       expect(suggestionsListItems).not.toBeNull();
 
       expect(suggestionsListItems.length).toEqual(mockSuggestions.length);
+    });
+  });
+
+  describe('when the suggestions list is empty', () => {
+    it('should not display the quanticSearchBoxSuggestionsList component', async () => {
+      const element = createTestComponent({
+        ...defaultOptions,
+        suggestions: [],
+      });
+      await flushPromises();
+
+      const suggestionsList = element.shadowRoot.querySelector(
+        selectors.searchBoxSuggestionsList
+      );
+      expect(suggestionsList).toBeNull();
     });
   });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -26,8 +26,8 @@ const defaultOptions = {
 };
 
 const selectors = {
-  searchBoxInput: '.searchbox__input',
-  searchBoxTextArea: '.searchbox__container textarea',
+  searchBoxInput: '[data-cy="search-box-input"]',
+  searchBoxTextArea: '[data-cy="search-box-textarea"]',
   searchBoxSubmitBtn: '.searchbox__submit-button',
   searchBoxClearIcon: '.searchbox__clear-button',
   searchBoxSuggestionsList: 'c-quantic-search-box-suggestions-list',
@@ -93,7 +93,7 @@ describe('c-quantic-search-box-input', () => {
       } search box properly`, async () => {
         const element = createTestComponent({
           ...defaultOptions,
-          textarea: true,
+          textarea: textareaValue,
         });
         await flushPromises();
 
@@ -170,7 +170,9 @@ describe('c-quantic-search-box-input', () => {
           await flushPromises();
 
           const input = element.shadowRoot.querySelector(
-            selectors.searchBoxInput
+            textareaValue
+              ? selectors.searchBoxTextArea
+              : selectors.searchBoxInput
           );
 
           expect(input.placeholder).toEqual(customPlaceholder);
@@ -225,7 +227,9 @@ describe('c-quantic-search-box-input', () => {
           await flushPromises();
 
           const input = element.shadowRoot.querySelector(
-            selectors.searchBoxInput
+            textareaValue
+              ? selectors.searchBoxTextArea
+              : selectors.searchBoxInput
           );
           expect(input).not.toBeNull();
 
@@ -286,7 +290,9 @@ describe('c-quantic-search-box-input', () => {
           element.inputValue = mockInputValue;
 
           const input = element.shadowRoot.querySelector(
-            selectors.searchBoxInput
+            textareaValue
+              ? selectors.searchBoxTextArea
+              : selectors.searchBoxInput
           );
           expect(input).not.toBeNull();
 
@@ -334,7 +340,9 @@ describe('c-quantic-search-box-input', () => {
             await flushPromises();
 
             const input = element.shadowRoot.querySelector(
-              selectors.searchBoxInput
+              textareaValue
+                ? selectors.searchBoxTextArea
+                : selectors.searchBoxInput
             );
             expect(input).not.toBeNull();
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -88,53 +88,30 @@ describe('c-quantic-search-box-input', () => {
 
   [true, false].forEach((textareaValue) => {
     describe(`when the textarea property is set to ${textareaValue}`, () => {
-      if (textareaValue) {
-        it('should display the expandable search box properly', async () => {
-          const element = createTestComponent({
-            ...defaultOptions,
-            textarea: true,
-          });
-          await flushPromises();
-
-          const submitButton = element.shadowRoot.querySelector(
-            selectors.searchBoxSubmitBtn
-          );
-          const clearIcon = element.shadowRoot.querySelector(
-            selectors.searchBoxClearIcon
-          );
-          const textarea = element.shadowRoot.querySelector(
-            selectors.searchBoxTextArea
-          );
-
-          expect(textarea).not.toBeNull();
-          expect(textarea.placeholder).toEqual(defaultOptions.placeholder);
-          expect(submitButton).not.toBeNull();
-          expect(clearIcon).toBeNull();
+      it(`should display the ${
+        textareaValue ? 'expandable' : 'default'
+      } search box properly`, async () => {
+        const element = createTestComponent({
+          ...defaultOptions,
+          textarea: true,
         });
-      } else {
-        it('should display the default search box properly', async () => {
-          const element = createTestComponent({
-            ...defaultOptions,
-            textarea: textareaValue,
-          });
-          await flushPromises();
+        await flushPromises();
 
-          const input = element.shadowRoot.querySelector(
-            selectors.searchBoxInput
-          );
-          const submitButton = element.shadowRoot.querySelector(
-            selectors.searchBoxSubmitBtn
-          );
-          const clearIcon = element.shadowRoot.querySelector(
-            selectors.searchBoxClearIcon
-          );
+        const submitButton = element.shadowRoot.querySelector(
+          selectors.searchBoxSubmitBtn
+        );
+        const clearIcon = element.shadowRoot.querySelector(
+          selectors.searchBoxClearIcon
+        );
+        const input = element.shadowRoot.querySelector(
+          textareaValue ? selectors.searchBoxTextArea : selectors.searchBoxInput
+        );
 
-          expect(input).not.toBeNull();
-          expect(input.placeholder).toEqual(defaultOptions.placeholder);
-          expect(submitButton).not.toBeNull();
-          expect(clearIcon).toBeNull();
-        });
-      }
+        expect(input).not.toBeNull();
+        expect(input.placeholder).toEqual(defaultOptions.placeholder);
+        expect(submitButton).not.toBeNull();
+        expect(clearIcon).toBeNull();
+      });
 
       describe('when the withoutSubmitButton is set to false', () => {
         it('should display the submit button correctly to the right only', async () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -86,249 +86,289 @@ describe('c-quantic-search-box-input', () => {
     jest.clearAllMocks();
   });
 
-  describe('when the textarea property is set to false', () => {
-    it('should display the search input properly', async () => {
-      const element = createTestComponent();
-      await flushPromises();
+  [true, false].forEach((textareaValue) => {
+    describe(`when the textarea property is set to ${textareaValue}`, () => {
+      if (textareaValue) {
+        it('should display the expandable search box properly', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            textarea: true,
+          });
+          await flushPromises();
 
-      const input = element.shadowRoot.querySelector(selectors.searchBoxInput);
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.searchBoxSubmitBtn
-      );
-      const clearIcon = element.shadowRoot.querySelector(
-        selectors.searchBoxClearIcon
-      );
+          const submitButton = element.shadowRoot.querySelector(
+            selectors.searchBoxSubmitBtn
+          );
+          const clearIcon = element.shadowRoot.querySelector(
+            selectors.searchBoxClearIcon
+          );
+          const textarea = element.shadowRoot.querySelector(
+            selectors.searchBoxTextArea
+          );
 
-      expect(input).not.toBeNull();
-      expect(input.placeholder).toEqual(defaultOptions.placeholder);
-      expect(submitButton).not.toBeNull();
-      expect(clearIcon).toBeNull();
-    });
-  });
-
-  describe('when the textarea property is set to true', () => {
-    it('should display the search textarea properly', async () => {
-      const element = createTestComponent({...defaultOptions, textarea: true});
-      await flushPromises();
-
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.searchBoxSubmitBtn
-      );
-      const clearIcon = element.shadowRoot.querySelector(
-        selectors.searchBoxClearIcon
-      );
-      const textarea = element.shadowRoot.querySelector(
-        selectors.searchBoxTextArea
-      );
-
-      expect(textarea).not.toBeNull();
-      expect(textarea.placeholder).toEqual(defaultOptions.placeholder);
-      expect(submitButton).not.toBeNull();
-      expect(clearIcon).toBeNull();
-    });
-  });
-
-  describe('when the withoutSubmitButton is set to false', () => {
-    it('should display the submit button correctly to the right only', async () => {
-      const element = createTestComponent({
-        ...defaultOptions,
-        withoutSubmitButton: false,
-      });
-      await flushPromises();
-
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.searchBoxSubmitBtn
-      );
-
-      const searchIcon = element.shadowRoot.querySelector(
-        selectors.searchBoxSearchIcon
-      );
-
-      expect(submitButton).not.toBeNull();
-      expect(searchIcon).toBeNull();
-    });
-  });
-
-  describe('when the withoutSubmitButton is set to true', () => {
-    it('should not display the submit button to the right of the searchbox', async () => {
-      const element = createTestComponent({
-        ...defaultOptions,
-        withoutSubmitButton: true,
-      });
-      await flushPromises();
-
-      const searchIcon = element.shadowRoot.querySelector(
-        selectors.searchBoxSearchIcon
-      );
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.searchBoxSubmitBtn
-      );
-
-      expect(submitButton).toBeNull();
-      expect(searchIcon).not.toBeNull();
-      expect(searchIcon.classList.contains('slds-input__icon_left')).toBe(true);
-    });
-  });
-
-  describe('when the placeholder property receives a custom placeholder value', () => {
-    it('should display the custom value as the searchbox placeholder', async () => {
-      const customPlaceholder = 'Custom placeholder';
-      const element = createTestComponent({
-        ...defaultOptions,
-        placeholder: customPlaceholder,
-      });
-      await flushPromises();
-
-      const input = element.shadowRoot.querySelector(selectors.searchBoxInput);
-
-      expect(input.placeholder).toEqual(customPlaceholder);
-    });
-  });
-
-  describe('when the suggestions list is not empty', () => {
-    it('should display the suggestions in the suggestions list', async () => {
-      const element = createTestComponent({
-        ...defaultOptions,
-        suggestions: mockSuggestions,
-      });
-      await flushPromises();
-
-      const suggestionsList = element.shadowRoot.querySelector(
-        selectors.searchBoxSuggestionsList
-      );
-      expect(suggestionsList).not.toBeNull();
-
-      const suggestionsListItems =
-        suggestionsList.shadowRoot.querySelectorAll('li');
-      expect(suggestionsListItems).not.toBeNull();
-
-      expect(suggestionsListItems.length).toEqual(mockSuggestions.length);
-    });
-  });
-
-  describe('when the suggestions list is empty', () => {
-    it('should not display the quanticSearchBoxSuggestionsList component', async () => {
-      const element = createTestComponent({
-        ...defaultOptions,
-        suggestions: [],
-      });
-      await flushPromises();
-
-      const suggestionsList = element.shadowRoot.querySelector(
-        selectors.searchBoxSuggestionsList
-      );
-      expect(suggestionsList).toBeNull();
-    });
-  });
-
-  describe('when focusing on the input', () => {
-    it('should dispatch a #quantic__showsuggestions custom event', async () => {
-      const element = createTestComponent();
-      setupEventListeners(element);
-      await flushPromises();
-
-      const input = element.shadowRoot.querySelector(selectors.searchBoxInput);
-      expect(input).not.toBeNull();
-
-      await input.focus();
-
-      expect(functionsMocks.exampleShowSuggestions).toHaveBeenCalledTimes(1);
-    });
-
-    describe('when selecting a suggestion from the suggestions list', () => {
-      it('should dispatch a #quantic__selectsuggestion event with the selected suggestion as payload', async () => {
-        const element = createTestComponent({
-          ...defaultOptions,
-          suggestions: mockSuggestions,
+          expect(textarea).not.toBeNull();
+          expect(textarea.placeholder).toEqual(defaultOptions.placeholder);
+          expect(submitButton).not.toBeNull();
+          expect(clearIcon).toBeNull();
         });
-        setupEventListeners(element);
-        await flushPromises();
+      } else {
+        it('should display the default search box properly', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            textarea: textareaValue,
+          });
+          await flushPromises();
 
-        const suggestionsList = element.shadowRoot.querySelector(
-          selectors.searchBoxSuggestionsList
-        );
-        expect(suggestionsList).not.toBeNull();
+          const input = element.shadowRoot.querySelector(
+            selectors.searchBoxInput
+          );
+          const submitButton = element.shadowRoot.querySelector(
+            selectors.searchBoxSubmitBtn
+          );
+          const clearIcon = element.shadowRoot.querySelector(
+            selectors.searchBoxClearIcon
+          );
 
-        const firstSuggestion =
-          suggestionsList.shadowRoot.querySelectorAll('li')[0];
-        expect(firstSuggestion).not.toBeNull();
+          expect(input).not.toBeNull();
+          expect(input.placeholder).toEqual(defaultOptions.placeholder);
+          expect(submitButton).not.toBeNull();
+          expect(clearIcon).toBeNull();
+        });
+      }
 
-        firstSuggestion.click();
+      describe('when the withoutSubmitButton is set to false', () => {
+        it('should display the submit button correctly to the right only', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            withoutSubmitButton: false,
+            textarea: textareaValue,
+          });
+          await flushPromises();
 
-        expect(functionsMocks.exampleSelectSuggestion).toHaveBeenCalledTimes(1);
+          const submitButton = element.shadowRoot.querySelector(
+            selectors.searchBoxSubmitBtn
+          );
 
-        const eventData =
-          functionsMocks.exampleSelectSuggestion.mock.calls[0][0] &&
-          functionsMocks.exampleSelectSuggestion.mock.calls[0][0];
-        const expectedFirstSuggestionSelected = mockSuggestions[0].rawValue;
+          const searchIcon = element.shadowRoot.querySelector(
+            selectors.searchBoxSearchIcon
+          );
 
-        // @ts-ignore
-        expect(eventData.detail.selectedSuggestion).toEqual(
-          expectedFirstSuggestionSelected
-        );
+          expect(submitButton).not.toBeNull();
+          expect(searchIcon).toBeNull();
+        });
       });
-    });
-  });
 
-  describe('when typing something in the input', () => {
-    it('should dispatch a #quantic__inputvaluechange custom event with the input value as payload', async () => {
-      const element = createTestComponent();
-      setupEventListeners(element);
-      await flushPromises();
+      describe('when the withoutSubmitButton is set to true', () => {
+        it('should not display the submit button to the right of the searchbox', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            withoutSubmitButton: true,
+            textarea: textareaValue,
+          });
+          await flushPromises();
 
-      element.inputValue = mockInputValue;
+          const searchIcon = element.shadowRoot.querySelector(
+            selectors.searchBoxSearchIcon
+          );
+          const submitButton = element.shadowRoot.querySelector(
+            selectors.searchBoxSubmitBtn
+          );
 
-      const input = element.shadowRoot.querySelector(selectors.searchBoxInput);
-      expect(input).not.toBeNull();
-
-      input.dispatchEvent(new KeyboardEvent('keyup', {key: 'a'}));
-      expect(
-        functionsMocks.exampleHandleInputValueChange
-      ).toHaveBeenCalledTimes(1);
-
-      // @ts-ignore
-      const eventData =
-        functionsMocks.exampleHandleInputValueChange.mock.calls[0][0];
-      // @ts-ignore
-      expect(eventData.detail.newInputValue).toEqual(mockInputValue);
-    });
-
-    describe('when clicking on the submit button', () => {
-      it('should dispatch a #quantic__submitsearch custom event', async () => {
-        const element = createTestComponent();
-        setupEventListeners(element);
-        await flushPromises();
-
-        const submitButton = element.shadowRoot.querySelector(
-          selectors.searchBoxSubmitBtn
-        );
-        expect(submitButton).not.toBeNull();
-
-        submitButton.click();
-
-        expect(functionsMocks.exampleHandleSubmitSearch).toHaveBeenCalledTimes(
-          1
-        );
+          expect(submitButton).toBeNull();
+          expect(searchIcon).not.toBeNull();
+          expect(searchIcon.classList.contains('slds-input__icon_left')).toBe(
+            true
+          );
+        });
       });
-    });
 
-    describe('when pressing the ENTER key', () => {
-      it('should dispatch a #quantic__submitsearch custom event', async () => {
-        const element = createTestComponent();
-        setupEventListeners(element);
-        await flushPromises();
+      describe('when the placeholder property receives a custom placeholder value', () => {
+        it('should display the custom value as the searchbox placeholder', async () => {
+          const customPlaceholder = 'Custom placeholder';
+          const element = createTestComponent({
+            ...defaultOptions,
+            placeholder: customPlaceholder,
+            textarea: textareaValue,
+          });
+          await flushPromises();
 
-        const input = element.shadowRoot.querySelector(
-          selectors.searchBoxInput
-        );
-        expect(input).not.toBeNull();
+          const input = element.shadowRoot.querySelector(
+            selectors.searchBoxInput
+          );
 
-        await input.focus();
-        input.dispatchEvent(new KeyboardEvent('keyup', {key: 'Enter'}));
+          expect(input.placeholder).toEqual(customPlaceholder);
+        });
+      });
 
-        expect(functionsMocks.exampleHandleSubmitSearch).toHaveBeenCalledTimes(
-          1
-        );
+      describe('when the suggestions list is not empty', () => {
+        it('should display the suggestions in the suggestions list', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            suggestions: mockSuggestions,
+            textarea: textareaValue,
+          });
+          await flushPromises();
+
+          const suggestionsList = element.shadowRoot.querySelector(
+            selectors.searchBoxSuggestionsList
+          );
+          expect(suggestionsList).not.toBeNull();
+
+          const suggestionsListItems =
+            suggestionsList.shadowRoot.querySelectorAll('li');
+          expect(suggestionsListItems).not.toBeNull();
+
+          expect(suggestionsListItems.length).toEqual(mockSuggestions.length);
+        });
+      });
+
+      describe('when the suggestions list is empty', () => {
+        it('should not display the quanticSearchBoxSuggestionsList component', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            suggestions: [],
+            textarea: textareaValue,
+          });
+          await flushPromises();
+
+          const suggestionsList = element.shadowRoot.querySelector(
+            selectors.searchBoxSuggestionsList
+          );
+          expect(suggestionsList).toBeNull();
+        });
+      });
+
+      describe('when focusing on the input', () => {
+        it('should dispatch a #quantic__showsuggestions custom event', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            textarea: textareaValue,
+          });
+          setupEventListeners(element);
+          await flushPromises();
+
+          const input = element.shadowRoot.querySelector(
+            selectors.searchBoxInput
+          );
+          expect(input).not.toBeNull();
+
+          await input.focus();
+
+          expect(functionsMocks.exampleShowSuggestions).toHaveBeenCalledTimes(
+            1
+          );
+        });
+
+        describe('when selecting a suggestion from the suggestions list', () => {
+          it('should dispatch a #quantic__selectsuggestion event with the selected suggestion as payload', async () => {
+            const element = createTestComponent({
+              ...defaultOptions,
+              suggestions: mockSuggestions,
+              textarea: textareaValue,
+            });
+            setupEventListeners(element);
+            await flushPromises();
+
+            const suggestionsList = element.shadowRoot.querySelector(
+              selectors.searchBoxSuggestionsList
+            );
+            expect(suggestionsList).not.toBeNull();
+
+            const firstSuggestion =
+              suggestionsList.shadowRoot.querySelectorAll('li')[0];
+            expect(firstSuggestion).not.toBeNull();
+
+            firstSuggestion.click();
+
+            expect(
+              functionsMocks.exampleSelectSuggestion
+            ).toHaveBeenCalledTimes(1);
+
+            const eventData =
+              functionsMocks.exampleSelectSuggestion.mock.calls[0][0] &&
+              functionsMocks.exampleSelectSuggestion.mock.calls[0][0];
+            const expectedFirstSuggestionSelected = mockSuggestions[0].rawValue;
+
+            // @ts-ignore
+            expect(eventData.detail.selectedSuggestion).toEqual(
+              expectedFirstSuggestionSelected
+            );
+          });
+        });
+      });
+
+      describe('when typing something in the input', () => {
+        it('should dispatch a #quantic__inputvaluechange custom event with the input value as payload', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            textarea: textareaValue,
+          });
+          setupEventListeners(element);
+          await flushPromises();
+
+          element.inputValue = mockInputValue;
+
+          const input = element.shadowRoot.querySelector(
+            selectors.searchBoxInput
+          );
+          expect(input).not.toBeNull();
+
+          input.dispatchEvent(new KeyboardEvent('keyup', {key: 'a'}));
+          expect(
+            functionsMocks.exampleHandleInputValueChange
+          ).toHaveBeenCalledTimes(1);
+
+          // @ts-ignore
+          const eventData =
+            functionsMocks.exampleHandleInputValueChange.mock.calls[0][0];
+          // @ts-ignore
+          expect(eventData.detail.newInputValue).toEqual(mockInputValue);
+        });
+
+        describe('when clicking on the submit button', () => {
+          it('should dispatch a #quantic__submitsearch custom event', async () => {
+            const element = createTestComponent({
+              ...defaultOptions,
+              textarea: textareaValue,
+            });
+            setupEventListeners(element);
+            await flushPromises();
+
+            const submitButton = element.shadowRoot.querySelector(
+              selectors.searchBoxSubmitBtn
+            );
+            expect(submitButton).not.toBeNull();
+
+            submitButton.click();
+
+            expect(
+              functionsMocks.exampleHandleSubmitSearch
+            ).toHaveBeenCalledTimes(1);
+          });
+        });
+
+        describe('when pressing the ENTER key', () => {
+          it('should dispatch a #quantic__submitsearch custom event', async () => {
+            const element = createTestComponent({
+              ...defaultOptions,
+              textarea: textareaValue,
+            });
+            setupEventListeners(element);
+            await flushPromises();
+
+            const input = element.shadowRoot.querySelector(
+              selectors.searchBoxInput
+            );
+            expect(input).not.toBeNull();
+
+            await input.focus();
+            input.dispatchEvent(new KeyboardEvent('keyup', {key: 'Enter'}));
+
+            expect(
+              functionsMocks.exampleHandleSubmitSearch
+            ).toHaveBeenCalledTimes(1);
+          });
+        });
       });
     });
   });

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -334,6 +334,10 @@ export default class QuanticSearchBoxInput extends LightningElement {
     return this.template.querySelector('.slds-combobox');
   }
 
+  get hasSuggestions() {
+    return this.suggestions?.length;
+  }
+
   render() {
     return this?.textarea ? expandableSearchBoxInput : defaultSearchBoxInput;
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/defaultSearchBoxInput.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/defaultSearchBoxInput.html
@@ -68,11 +68,13 @@
               </button>
             </template>
           </div>
-          <c-quantic-search-box-suggestions-list
-            suggestions={suggestions}
-            onhighlightchange={handleHighlightChange}
-            onsuggestionselected={handleSuggestionSelection}
-          ></c-quantic-search-box-suggestions-list>
+          <template if:true={hasSuggestions}>
+            <c-quantic-search-box-suggestions-list
+              suggestions={suggestions}
+              onhighlightchange={handleHighlightChange}
+              onsuggestionselected={handleSuggestionSelection}
+            ></c-quantic-search-box-suggestions-list>
+          </template>
         </div>
       </div>
     </div>

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.html
@@ -78,11 +78,13 @@
               </template>
             </div>
           </div>
-          <c-quantic-search-box-suggestions-list
-            suggestions={suggestions}
-            onhighlightchange={handleHighlightChange}
-            onsuggestionselected={handleSuggestionSelection}
-          ></c-quantic-search-box-suggestions-list>
+          <template if:true={hasSuggestions}>
+            <c-quantic-search-box-suggestions-list
+              suggestions={suggestions}
+              onhighlightchange={handleHighlightChange}
+              onsuggestionselected={handleSuggestionSelection}
+            ></c-quantic-search-box-suggestions-list>
+          </template>
         </div>
       </div>
     </div>


### PR DESCRIPTION
[SFINT-5374](https://coveord.atlassian.net/browse/SFINT-5374)


#### Work made in this PR:

- Issue fixed.
- New test added to make sure this bug will not happen again.
- Test improved to execute the whole tests for both the default search box and the standalone searchbox.

#### The issue

The issue appears after executing the following actions:

- Enter a query in the search box, for example: “abc“.
- Click the down arrow key.
- Click the del key to delete the last character in the search box.
- The query transforms to a whole other word.

https://github.com/coveo/ui-kit/assets/86681870/1464d98a-1716-40ac-9441-92225f069856

#### The solution

The issue was occurring because the clicking the Down arrow key was triggering the selection of the first suggestion of the suggestions list, however at the moment of the click on the Down Arrow the suggestions list was empty causing this unexpected behaviour.

To fix this I added a condition that displays the suggestions list only when it's not empty.

That was the original behaviour in the Quantic Search Box component, but we have missed that in the last refactoring.



https://github.com/coveo/ui-kit/assets/86681870/deaafe03-0b7c-4c2b-8e12-7dfcc8e4cfdb





[SFINT-5374]: https://coveord.atlassian.net/browse/SFINT-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ