### PR TITLE
fix(quantic): fixed couple issues with generated answer and the expandable search box components

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -417,7 +417,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   get rephraseButtonsCssClass() {
     return `slds-var-m-top_small slds-grid flex-one ${
-      this.multilineFooter ? '' : 'generated-answer__rephrase--buttons'
+      this.multilineFooter ? '' : 'slds-grid_align-end'
     }`;
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -415,6 +415,12 @@ export default class QuanticGeneratedAnswer extends LightningElement {
       .filter((field) => field.length > 0);
   }
 
+  get rephraseButtonsCssClass() {
+    return `slds-var-m-top_small slds-grid flex-one ${
+      this.multilineFooter ? '' : 'generated-answer__rephrase--buttons'
+    }`;
+  }
+
   /**
    * Sets the component in the initialization error state.
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
@@ -2,6 +2,7 @@
 
 .generated-answer__header-actions {
   align-items: center;
+  flex-wrap: wrap-reverse;
 }
 
 .generated-answer__answer {
@@ -27,6 +28,16 @@
   display: inline-block;
   animation: cursor-blink 1.5s steps(2, start) infinite;
   vertical-align: baseline;
+}
+
+.generated-answer__rephrase--buttons,
+.generated-answer__toggle--button,
+.generated-answer__actions {
+  justify-content: flex-end;
+}
+
+.flex-one{
+  flex: 1;
 }
 
 @keyframes cursor-blink {

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
@@ -30,13 +30,7 @@
   vertical-align: baseline;
 }
 
-.generated-answer__rephrase--buttons,
-.generated-answer__toggle--button,
-.generated-answer__actions {
-  justify-content: flex-end;
-}
-
-.flex-one{
+.flex-one {
   flex: 1;
 }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
@@ -8,7 +8,7 @@
         >
         <div class="generated-answer__header-actions slds-grid">
           <template lwc:if={shouldDisplayActions}>
-            <div class="slds-grid flex-one generated-answer__actions">
+            <div class="slds-grid flex-one slds-grid_align-end">
               <c-quantic-feedback
                 state={feedbackState}
                 onlike={handleLike}
@@ -30,7 +30,7 @@
               ></c-quantic-generated-answer-copy-to-clipboard>
             </div>
           </template>
-          <div class="slds-grid flex-one generated-answer__toggle--button">
+          <div class="slds-grid flex-one slds-grid_align-end">
             <c-quantic-generated-answer-toggle
             is-generated-answer-visible={isVisible}
           ></c-quantic-generated-answer-toggle>

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
@@ -8,29 +8,33 @@
         >
         <div class="generated-answer__header-actions slds-grid">
           <template lwc:if={shouldDisplayActions}>
-            <c-quantic-feedback
-              state={feedbackState}
-              onlike={handleLike}
-              ondislike={handleDislike}
-              like-icon-name="utility:like"
-              like-label={labels.thisAnswerWasHelpful}
-              dislike-icon-name="utility:dislike"
-              dislike-label={labels.thisAnswerWasNotHelpful}
-              size="xx-small"
-              question=""
-              hide-explain-why-button
-              hide-labels
-              data-cy="generated-answer__feedback"
-            ></c-quantic-feedback>
-            <c-quantic-generated-answer-copy-to-clipboard
-              data-cy="generated-answer__copy-to-clipboard"
-              answer={answer}
-              class="slds-var-m-horizontal_xx-small"
-            ></c-quantic-generated-answer-copy-to-clipboard>
+            <div class="slds-grid flex-one generated-answer__actions">
+              <c-quantic-feedback
+                state={feedbackState}
+                onlike={handleLike}
+                ondislike={handleDislike}
+                like-icon-name="utility:like"
+                like-label={labels.thisAnswerWasHelpful}
+                dislike-icon-name="utility:dislike"
+                dislike-label={labels.thisAnswerWasNotHelpful}
+                size="xx-small"
+                question=""
+                hide-explain-why-button
+                hide-labels
+                data-cy="generated-answer__feedback"
+              ></c-quantic-feedback>
+              <c-quantic-generated-answer-copy-to-clipboard
+                data-cy="generated-answer__copy-to-clipboard"
+                answer={answer}
+                class="slds-var-m-horizontal_xx-small"
+              ></c-quantic-generated-answer-copy-to-clipboard>
+            </div>
           </template>
-          <c-quantic-generated-answer-toggle
+          <div class="slds-grid flex-one generated-answer__toggle--button">
+            <c-quantic-generated-answer-toggle
             is-generated-answer-visible={isVisible}
           ></c-quantic-generated-answer-toggle>
+          </div>
         </div>
       </div>
       <template lwc:if={isVisible}>
@@ -43,7 +47,7 @@
           </div>
           <div data-cy="generated-answer__footer" class={generatedAnswerFooterCssClass}>
             <template lwc:if={hasCitations}>
-              <div class="slds-var-m-top_small">
+              <div class="slds-var-m-top_small flex-one">
                 <c-quantic-source-citations
                   engine-id={engineId}
                   data-cy="generated-answer__citations"
@@ -53,7 +57,7 @@
               </div>
             </template>
             <template lwc:if={shouldDisplayActions}>
-              <div class="slds-var-m-top_small">
+              <div class={rephraseButtonsCssClass}>
                 <c-quantic-generated-answer-rephrase-buttons
                   data-cy="generated-answer__rephrase-buttons"
                   value={responseFormat}

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerRephraseButtons/quanticGeneratedAnswerRephraseButtons.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerRephraseButtons/quanticGeneratedAnswerRephraseButtons.html
@@ -5,7 +5,7 @@
     >{labels.rephrase}</span
   >
   <div
-    class="rephrase-buttons__content slds-grid slds-m-top_xx-small"
+    class="rephrase-buttons__content slds-grid slds-m-top_xx-small slds-wrap"
     data-cy="rephrase-buttons__content"
   >
     <template for:each={rephraseOptions} for:item="option">

--- a/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticModal/quanticModal.css
@@ -48,7 +48,7 @@
 }
 
 .part-screen {
-  z-index: 3;
+  z-index: 40;
   height: 100%;
   width: 100%;
   position: absolute;


### PR DESCRIPTION
[SFINT-5371](https://coveord.atlassian.net/browse/SFINT-5371)

### Issue 1

 The expandable search box was having a z index greater than the refine modal.

#### Before

![image (1) (1)](https://github.com/coveo/ui-kit/assets/86681870/8689da79-8945-47a2-ba51-b791fe60cd4e)


#### After 

https://github.com/coveo/ui-kit/assets/86681870/0ba1ad86-e240-44f5-a1ea-533a2e886a59


### Issue 2: 

The Quantic Generated Answer component was not very response when being in a narrow space like the Hosted Insight Panel when it's placed in a narrow space of the Salesforce Service Console.

#### Before: 

![image (3)](https://github.com/coveo/ui-kit/assets/86681870/f82302a8-6df8-47d7-982b-0fb1d68420a2)

![image (2)](https://github.com/coveo/ui-kit/assets/86681870/c773cf37-2879-4745-9f1e-3f4db57cbaab)

#### After

I discussed with the UX team and we aggreed on the following solution, in narrow screens  we keep the toggle button in one line and the feedback and copy to clipboard button in a second line:



https://github.com/coveo/ui-kit/assets/86681870/ea922b35-8628-488e-b0af-a436dcf09db4



https://github.com/coveo/ui-kit/assets/86681870/f1e11e2f-807b-4465-b71b-89d43ed60228









[SFINT-5371]: https://coveord.atlassian.net/browse/SFINT-5371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ