### PR TITLE
fix(atomic): fix insight search box width

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.pcss
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.pcss
@@ -2,7 +2,11 @@
 @import '../../common/search-box/search-box.pcss';
 
 [part='wrapper'] {
-  @apply max-w-[303px] top-6 left-6 z-10;
+  @apply z-10;
+}
+
+:host {
+  position: relative;
 }
 
 [part='input'] {


### PR DESCRIPTION
[SVCC-3415](https://coveord.atlassian.net/browse/SVCC-3415)

Fix atomic-insight-search-box width 
Before:
<img width="543" alt="Screenshot 2024-01-25 at 10 31 05 AM" src="https://github.com/coveo/ui-kit/assets/119955059/1b7dd848-4d2e-4d3d-b987-3fc25aa65992">

After:
<img width="555" alt="Screenshot 2024-01-25 at 3 56 03 PM" src="https://github.com/coveo/ui-kit/assets/119955059/3850da59-c801-4b98-adcd-bfae84c08266">
<img width="555" alt="Screenshot 2024-01-25 at 3 56 18 PM" src="https://github.com/coveo/ui-kit/assets/119955059/17dac69b-523d-413c-ac84-b0673dfda18f">

<img width="543" alt="Screenshot 2024-01-25 at 3 55 25 PM" src="https://github.com/coveo/ui-kit/assets/119955059/bce225dd-1661-4509-873c-68c1c87f8855">



[SVCC-3415]: https://coveord.atlassian.net/browse/SVCC-3415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ