### PR TITLE
fix(headless): remove un-necessary client side events for new query correction

### DIFF
--- a/packages/headless/src/features/search/legacy/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/search/legacy/search-actions-thunk-processor.ts
@@ -243,7 +243,6 @@ export class AsyncSearchThunkProcessor<RejectionType> {
   ): ExecuteSearchThunkReturn {
     const successResponse = this.getSuccessResponse(originalFetchedResponse)!;
     const {correctedQuery, originalQuery} = successResponse.queryCorrection!;
-    this.logOriginalAnalyticsQueryBeforeAutoCorrection(originalFetchedResponse);
 
     this.onUpdateQueryForCorrection(correctedQuery);
 


### PR DESCRIPTION
After testing against Barca sport, this client side UA event is ultimately un-necessary. 

We just need one to be logged (returned from this function):

```
analyticsAction: logDidYouMeanAutomatic(),
```

Importantly, `logDidYouMeanAutomatic` will log `q={corrected query}`, which is what ML will learn against, and not the typo.

https://coveord.atlassian.net/browse/KIT-2965