### PR TITLE
fix(headless): limit memory usage and property comparison for history manager

### DIFF
--- a/packages/headless/src/app/undoable.test.ts
+++ b/packages/headless/src/app/undoable.test.ts
@@ -87,5 +87,36 @@ describe('undoable', () => {
         future: [],
       });
     });
+
+    it('supports a maximum of 10 past history entries', () => {
+      const mockUndoableReducer = undoable({
+        reducer,
+        actionTypes: {
+          redo: redo().type,
+          undo: undo().type,
+          snapshot: snapshot().type,
+        },
+      });
+      const initialOverflow = 50;
+
+      const initialState = {
+        past: Array.from(
+          {length: initialOverflow},
+          (_, i) => `entry-overflow-${i}`
+        ),
+        present: 'present-before-snapshot',
+        future: [],
+      };
+      const newState = mockUndoableReducer(
+        initialState,
+        snapshot('present-after-snapshot')
+      );
+      expect(newState.past.length).toBe(10);
+      expect(newState.past[newState.past.length - 1]).toBe(
+        'present-before-snapshot'
+      );
+      expect(newState.past[0]).toBe(`entry-overflow-${initialOverflow - 9}`);
+      expect(newState.present).toBe('present-after-snapshot');
+    });
   });
 });

--- a/packages/headless/src/app/undoable.ts
+++ b/packages/headless/src/app/undoable.ts
@@ -1,5 +1,7 @@
 import {Reducer, AnyAction} from '@reduxjs/toolkit';
 
+const MAX_PAST_HISTORY_ENTRY_COUNT = 10;
+
 export const makeHistory = <State>(state?: State): StateWithHistory<State> => ({
   past: [],
   present: state,
@@ -71,7 +73,7 @@ const updateHistory = <State>(options: {
   }
 
   return {
-    past: [...past, present],
+    past: [...past, present].slice(-MAX_PAST_HISTORY_ENTRY_COUNT),
     present: newPresent,
     future: [],
   };

--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -73,6 +73,21 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
 
   return {
     ...controller,
+    // TODO: https://coveord.atlassian.net/browse/KIT-2969:
+    // Should be able to get rid of this local optimization following history management change
+    subscribe(listener: () => void) {
+      listener();
+      let previous = JSON.stringify(getState().history.present);
+      const strictListener = () => {
+        const current = JSON.stringify(getState().history.present);
+        const hasChanged = previous !== current;
+        if (hasChanged) {
+          previous = current;
+          listener();
+        }
+      };
+      return engine.subscribe(() => strictListener());
+    },
     get state() {
       return getState().history;
     },

--- a/packages/headless/src/features/history/history-slice.test.ts
+++ b/packages/headless/src/features/history/history-slice.test.ts
@@ -106,7 +106,6 @@ describe('history slice', () => {
         defaultFilters: {aq: '', cq: '', lq: '', dq: ''},
       },
       querySet: {foo: 'bar', hello: 'world'},
-      instantResults: {},
       sortCriteria: 'date descending',
       pipeline: 'my-pipeline',
       searchHub: 'my-search-hub',

--- a/packages/headless/src/features/history/history-slice.ts
+++ b/packages/headless/src/features/history/history-slice.ts
@@ -20,6 +20,9 @@ import {TabSetState} from '../tab-set/tab-set-state';
 import {snapshot, redo, undo} from './history-actions';
 import {getHistoryInitialState, HistoryState} from './history-state';
 
+// TODO: https://coveord.atlassian.net/browse/KIT-2969:
+// Should be able to remove most of the code in this file following changes history management change
+
 export const historyReducer = createReducer(
   getHistoryInitialState(),
   (builder) => {

--- a/packages/headless/src/features/history/history-state.ts
+++ b/packages/headless/src/features/history/history-state.ts
@@ -10,7 +10,6 @@ import {getFacetOrderInitialState} from '../facets/facet-order/facet-order-state
 import {getFacetSetInitialState} from '../facets/facet-set/facet-set-state';
 import {getDateFacetSetInitialState} from '../facets/range-facets/date-facet-set/date-facet-set-state';
 import {getNumericFacetSetInitialState} from '../facets/range-facets/numeric-facet-set/numeric-facet-set-state';
-import {getInstantResultsInitialState} from '../instant-results/instant-results-state';
 import {getPaginationInitialState} from '../pagination/pagination-state';
 import {getPipelineInitialState} from '../pipeline/pipeline-state';
 import {getQuerySetInitialState} from '../query-set/query-set-state';
@@ -47,7 +46,6 @@ export function extractHistory(state: Partial<HistoryState>): HistoryState {
       state.advancedSearchQueries || getAdvancedSearchQueriesInitialState(),
     staticFilterSet: state.staticFilterSet || getStaticFilterSetInitialState(),
     querySet: state.querySet || getQuerySetInitialState(),
-    instantResults: state.instantResults || getInstantResultsInitialState(),
     sortCriteria: state.sortCriteria || getSortCriteriaInitialState(),
     pipeline: state.pipeline || getPipelineInitialState(),
     searchHub: state.searchHub || getSearchHubInitialState(),

--- a/packages/headless/src/state/search-app-state.ts
+++ b/packages/headless/src/state/search-app-state.ts
@@ -54,7 +54,6 @@ export type SearchParametersState = FacetSection &
   ContextSection &
   DictionaryFieldContextSection &
   QuerySetSection &
-  InstantResultSection &
   PipelineSection &
   SearchHubSection &
   DebugSection;
@@ -78,4 +77,5 @@ export type SearchAppState = SearchParametersState &
   RecentResultsSection &
   RecentQueriesSection &
   ExcerptLengthSection &
-  GeneratedAnswerSection;
+  GeneratedAnswerSection &
+  InstantResultSection;


### PR DESCRIPTION
As discussed on slack, this is a performance fix related to history management in Headless.

* Remove instant result from history management. It is completely un-necessary to keep it in memory to restore history on navigation. This change on it's own would probably fix (most) of the problem for the original maintenance ticket.

* Limit the amount of data kept in memory for `past` history entry, by limiting it to 10 entry. This change on it's own would probably fix (most) of the problem for the original maintenance ticket.

* Do a local optimization in history-manager controller to only compare `current-snapshot` vs `previous-snapshot` with a JSON.stringify compare. This override the "base controller" generic comparison function, which does a full JSON.stringify compare on all properties of it's local state (ie: would stringify and compare all `past` entries). This change is not strictly necessary to fix the original ticket.

* Mark future improvements for v3 as TODO (as explained on slack, those changes would be breaking in current minor version). JIRA which explains the future improvement we can do in v3: https://coveord.atlassian.net/browse/KIT-2969


https://coveord.atlassian.net/browse/KIT-2970