### PR TITLE
fix(quantic): improved the Quantic Printable URI to support opening links inside salesforce

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/defaultResult.json
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/defaultResult.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "printableUri": "https://coveo.com/",
+    "raw": {
+      "parents": ""
+    }
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/knowledgeArticleResult.json
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/knowledgeArticleResult.json
@@ -1,0 +1,10 @@
+{
+  "result": {
+    "printableUri": "https://coveo.com/",
+    "raw": {
+      "sfid": "1234",
+      "sfkavid": "1234",
+      "parents": ""
+    }
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/salesforceResult.json
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/data/salesforceResult.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "printableUri": "https://coveo.com/",
+    "raw": {
+      "sfid": "123",
+      "parents": ""
+    }
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/quanticResultPrintableUri.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/quanticResultPrintableUri.test.js
@@ -98,10 +98,10 @@ describe('c-quantic-result-printable-uri', () => {
           });
           await flushPromises();
 
-          const LinkKnowledgeArticle = element.shadowRoot.querySelector(
+          const linkKnowledgeArticle = element.shadowRoot.querySelector(
             selectors.link
           );
-          LinkKnowledgeArticle.click();
+          linkKnowledgeArticle.click();
 
           const {pageReference} = getNavigateCalledWith();
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/quanticResultPrintableUri.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/__tests__/quanticResultPrintableUri.test.js
@@ -1,0 +1,149 @@
+// @ts-ignore
+import {
+  // @ts-ignore
+  getNavigateCalledWith, // @ts-ignore
+  getGenerateUrlCalledWith,
+} from 'lightning/navigation';
+// @ts-ignore
+import {createElement} from 'lwc';
+import QuanticResultPrintableUri from '../quanticResultPrintableUri';
+// @ts-ignore
+import mockDefaultResult from './data/defaultResult.json';
+// @ts-ignore
+import mockKnowledgeArticleResult from './data/knowledgeArticleResult.json';
+// @ts-ignore
+import mockSalesforceResult from './data/salesforceResult.json';
+
+const selectors = {
+  link: '[data-test="link"]',
+};
+
+function createTestComponent(options) {
+  const element = createElement('c-quantic-result-printable-uri', {
+    is: QuanticResultPrintableUri,
+  });
+
+  for (const [key, value] of Object.entries(options)) {
+    element[key] = value;
+  }
+
+  document.body.appendChild(element);
+  return element;
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('c-quantic-result-printable-uri', () => {
+  function cleanup() {
+    // The jsdom instance is shared across test cases in a single file so reset the DOM
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  }
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.Bueno = {
+      isString: jest
+        .fn()
+        .mockImplementation(
+          (value) => Object.prototype.toString.call(value) === '[object String]'
+        ),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('when displaying the url', () => {
+    describe('when the result is of type Salesforce', () => {
+      it('should call the navigation mixin to get the Salesforce record URL', async () => {
+        createTestComponent({
+          ...mockSalesforceResult,
+        });
+        await flushPromises();
+
+        const {pageReference} = getGenerateUrlCalledWith();
+
+        expect(pageReference.attributes.recordId).toBe(
+          mockSalesforceResult.result.raw.sfid
+        );
+      });
+
+      it('should open the result link in a Salesforce subtab', async () => {
+        const element = createTestComponent({
+          ...mockSalesforceResult,
+        });
+        await flushPromises();
+
+        const linkSalesforce = element.shadowRoot.querySelector(selectors.link);
+        linkSalesforce.click();
+
+        const {pageReference} = getNavigateCalledWith();
+
+        expect(pageReference.attributes.recordId).toBe(
+          mockSalesforceResult.result.raw.sfid
+        );
+      });
+
+      describe('when the result is a knowledge article', () => {
+        it('should open the result link in a Salesforce console subtab', async () => {
+          const element = createTestComponent({
+            ...mockKnowledgeArticleResult,
+          });
+          await flushPromises();
+
+          const LinkKnowledgeArticle = element.shadowRoot.querySelector(
+            selectors.link
+          );
+          LinkKnowledgeArticle.click();
+
+          const {pageReference} = getNavigateCalledWith();
+
+          expect(pageReference.attributes.recordId).toBe(
+            mockKnowledgeArticleResult.result.raw.sfkavid
+          );
+        });
+      });
+    });
+
+    describe('when the result is not of type Salesforce', () => {
+      it('should open the result link in a browser tab', async () => {
+        const element = createTestComponent({
+          ...mockDefaultResult,
+        });
+        await flushPromises();
+
+        const link = element.shadowRoot.querySelector(selectors.link);
+
+        expect(link.getAttribute('href')).toEqual(
+          mockDefaultResult.result.printableUri
+        );
+        expect(link.getAttribute('target')).toEqual('_self');
+      });
+    });
+
+    describe('with a custom value for the target property', () => {
+      it('should open the result link based on the value of the target property', async () => {
+        const customTarget = '_blank';
+        const element = createTestComponent({
+          ...mockDefaultResult,
+          target: customTarget,
+        });
+        await flushPromises();
+
+        const link = element.shadowRoot.querySelector(selectors.link);
+
+        expect(link.getAttribute('href')).toEqual(
+          mockDefaultResult.result.printableUri
+        );
+        expect(link.getAttribute('target')).toEqual(customTarget);
+      });
+    });
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -15,7 +15,7 @@
           <lightning-icon class="slds-m-horizontal_xx-small result-parenturi__separator slds-current-color" icon-name="utility:chevronright" size="xx-small"></lightning-icon>
         </div>
       </template>
-      <template lwc:if={shouldDisplayLink}>
+      <template lwc:if={shouldDisplayPrintableUriLink}>
         <a class="slds-truncate" href={hrefValue} aria-label={ariaLabelValue} target={target} onclick={handleClick} tabindex="0" role="link" data-test="link">
           <c-quantic-result-text result={result} field="printableUri"></c-quantic-result-text>
         </a>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.html
@@ -15,6 +15,11 @@
           <lightning-icon class="slds-m-horizontal_xx-small result-parenturi__separator slds-current-color" icon-name="utility:chevronright" size="xx-small"></lightning-icon>
         </div>
       </template>
+      <template lwc:if={shouldDisplayLink}>
+        <a class="slds-truncate" href={hrefValue} aria-label={ariaLabelValue} target={target} onclick={handleClick} tabindex="0" role="link" data-test="link">
+          <c-quantic-result-text result={result} field="printableUri"></c-quantic-result-text>
+        </a>
+      </template>
     </template>
   </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
@@ -49,6 +49,8 @@ export default class QuanticResultPrintableUri extends NavigationMixin(
   error;
   /** @type {string} */
   salesforceRecordUrl;
+  /** @type {object} */
+  targetPageRef;
 
   labels = {
     navigateToRecord,
@@ -57,13 +59,14 @@ export default class QuanticResultPrintableUri extends NavigationMixin(
 
   connectedCallback() {
     if (this.isSalesforceLink) {
-      this[NavigationMixin.GenerateUrl]({
+      this.targetPageRef = {
         type: 'standard__recordPage',
         attributes: {
           recordId: this.recordIdAttribute,
           actionName: 'view',
         },
-      }).then((url) => {
+      };
+      this[NavigationMixin.GenerateUrl](this.targetPageRef).then((url) => {
         this.salesforceRecordUrl = url;
       });
     }
@@ -80,14 +83,7 @@ export default class QuanticResultPrintableUri extends NavigationMixin(
 
   navigateToSalesforceRecord(event) {
     event.stopPropagation();
-    const targetPageRef = {
-      type: 'standard__recordPage',
-      attributes: {
-        recordId: this.recordIdAttribute,
-        actionName: 'view',
-      },
-    };
-    this[NavigationMixin.Navigate](targetPageRef);
+    this[NavigationMixin.Navigate](this.targetPageRef);
   }
 
   handleClick(event) {
@@ -124,7 +120,7 @@ export default class QuanticResultPrintableUri extends NavigationMixin(
     ];
   }
 
-  get shouldDisplayLink() {
+  get shouldDisplayPrintableUriLink() {
     return this.allParents.length === 0;
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultPrintableUri/quanticResultPrintableUri.js
@@ -1,4 +1,7 @@
+import navigateToRecord from '@salesforce/label/c.quantic_NavigateToRecord';
+import opensInBrowserTab from '@salesforce/label/c.quantic_OpensInBrowserTab';
 import {parseXML} from 'c/quanticUtils';
+import {NavigationMixin} from 'lightning/navigation';
 import {LightningElement, api} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
@@ -9,7 +12,9 @@ import {LightningElement, api} from 'lwc';
  * @example
  * <c-quantic-result-printable-uri result={result} max-number-of-parts="3"></c-quantic-result-printable-uri>
  */
-export default class QuanticResultPrintableUri extends LightningElement {
+export default class QuanticResultPrintableUri extends NavigationMixin(
+  LightningElement
+) {
   /**
    * The [result item](https://docs.coveo.com/en/headless/latest/reference/search/controllers/result-list/#result).
    * @api
@@ -42,6 +47,27 @@ export default class QuanticResultPrintableUri extends LightningElement {
   isExpanded = false;
   /** @type {string} */
   error;
+  /** @type {string} */
+  salesforceRecordUrl;
+
+  labels = {
+    navigateToRecord,
+    opensInBrowserTab,
+  };
+
+  connectedCallback() {
+    if (this.isSalesforceLink) {
+      this[NavigationMixin.GenerateUrl]({
+        type: 'standard__recordPage',
+        attributes: {
+          recordId: this.recordIdAttribute,
+          actionName: 'view',
+        },
+      }).then((url) => {
+        this.salesforceRecordUrl = url;
+      });
+    }
+  }
 
   renderedCallback() {
     if (this.maxNumberOfParts < this.MIN_MAX_NUMBER_OF_PARTS) {
@@ -50,6 +76,29 @@ export default class QuanticResultPrintableUri extends LightningElement {
       );
       this.error = `${this.template.host.localName} Error`;
     }
+  }
+
+  navigateToSalesforceRecord(event) {
+    event.stopPropagation();
+    const targetPageRef = {
+      type: 'standard__recordPage',
+      attributes: {
+        recordId: this.recordIdAttribute,
+        actionName: 'view',
+      },
+    };
+    this[NavigationMixin.Navigate](targetPageRef);
+  }
+
+  handleClick(event) {
+    if (this.isSalesforceLink) {
+      event.preventDefault();
+      this.navigateToSalesforceRecord(event);
+    }
+  }
+
+  expandParents() {
+    this.isExpanded = true;
   }
 
   get allParents() {
@@ -75,7 +124,39 @@ export default class QuanticResultPrintableUri extends LightningElement {
     ];
   }
 
-  expandParents() {
-    this.isExpanded = true;
+  get shouldDisplayLink() {
+    return this.allParents.length === 0;
+  }
+
+  get hrefValue() {
+    if (this.isSalesforceLink) {
+      return this.salesforceRecordUrl;
+    }
+    return this.result.printableUri;
+  }
+
+  /**
+   * Returns the aria label value for the link.
+   */
+  get ariaLabelValue() {
+    if (this.isSalesforceLink) {
+      return this.labels.navigateToRecord;
+    }
+    return this.labels.opensInBrowserTab;
+  }
+
+  get recordIdAttribute() {
+    // Knowledge article uses the knowledge article version id to navigate.
+    if (this.result?.raw?.sfkbid && this.result?.raw?.sfkavid) {
+      return this.result.raw.sfkavid;
+    }
+    return this.result.raw.sfid;
+  }
+
+  /**
+   * Checks if the Result type is Salesforce.
+   */
+  get isSalesforceLink() {
+    return !!this.result?.raw?.sfid;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultText/quanticResultText.js
@@ -79,7 +79,9 @@ export default class QuanticResultText extends LightningElement {
    */
   get fieldValue() {
     // @ts-ignore
-    return this.field ? this.result?.raw[this.field] : undefined;
+    return this.field
+      ? this.result?.raw[this.field] ?? this.result?.[this.field]
+      : undefined;
   }
 
   /**


### PR DESCRIPTION
[SFINT-5353](https://coveord.atlassian.net/browse/SFINT-5353)


- Added the missing logic in the Quantic Printable URI that displays the printable URI of a result when its parents are not found.
- Added the logic that supports opening the result in Salesforce when the result is a Salesforce record.

#### Demo:

https://github.com/coveo/ui-kit/assets/86681870/a4af8331-f133-406d-81d7-4cd39ebfcd97



[SFINT-5353]: https://coveord.atlassian.net/browse/SFINT-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ