### PR TITLE
test: change query in the E2E test

### DIFF
--- a/packages/atomic/cypress/e2e/search-box/standalone-search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/standalone-search-box.cypress.ts
@@ -68,7 +68,7 @@ describe('Standalone Search Box Test Suites', () => {
   });
 
   describe('when being redirected to an Atomic Search Interface after selecting a suggestion', () => {
-    const query = 'awards';
+    const query = 'how';
     beforeEach(() => {
       setupStandaloneSearchBox();
       SearchBoxSelectors.inputBox().type(query);


### PR DESCRIPTION
The E2E standalone search box test involves entering a keyword into the search box and anticipating a suggestion from the Search API. However, currently, there are no suggestions being provided for this particular keyword (“awards”).

To address this issue, I propose utilizing a query that is more likely to yield suggestions from the API.

KIT-2989