### PR TITLE
test(headless): migrate more controllers tests for redux tool kit 2

### DIFF
--- a/packages/headless/src/controllers/core/breadcrumb-manager/headless-core-breadcrumb-manager.test.ts
+++ b/packages/headless/src/controllers/core/breadcrumb-manager/headless-core-breadcrumb-manager.test.ts
@@ -1,33 +1,34 @@
 import {deselectAllBreadcrumbs} from '../../../features/breadcrumb/breadcrumb-actions';
-import {SearchAppState} from '../../../state/search-app-state';
-import {MockSearchEngine} from '../../../test/mock-engine';
-import {buildMockSearchAppEngine} from '../../../test/mock-engine';
+import {
+  buildMockSearchEngine,
+  MockedSearchEngine,
+} from '../../../test/mock-engine-v2';
 import {createMockState} from '../../../test/mock-state';
 import {
   BreadcrumbManager,
   buildCoreBreadcrumbManager,
 } from './headless-core-breadcrumb-manager';
 
+jest.mock('../../../features/breadcrumb/breadcrumb-actions');
+
 describe('headless breadcrumb manager', () => {
-  let engine: MockSearchEngine;
-  let state: SearchAppState;
+  let engine: MockedSearchEngine;
   let breadcrumbManager: BreadcrumbManager;
 
   function initController() {
-    engine = buildMockSearchAppEngine();
-    engine.state = state;
+    engine = buildMockSearchEngine(createMockState());
     breadcrumbManager = buildCoreBreadcrumbManager(engine);
   }
 
   beforeEach(() => {
-    state = createMockState();
+    jest.resetAllMocks();
     initController();
   });
 
   describe('#deselectAll', () => {
     it('dispatches #deselectAllBreadcrumbs', () => {
       breadcrumbManager.deselectAll();
-      expect(engine.actions).toContainEqual(deselectAllBreadcrumbs());
+      expect(deselectAllBreadcrumbs).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/headless/src/controllers/core/context/headless-core-context.test.ts
+++ b/packages/headless/src/controllers/core/context/headless-core-context.test.ts
@@ -1,29 +1,27 @@
-import {Action} from '@reduxjs/toolkit';
 import {
-  setContext,
   addContext,
   removeContext,
+  setContext,
 } from '../../../features/context/context-actions';
 import {contextReducer} from '../../../features/context/context-slice';
 import {
-  buildMockSearchAppEngine,
-  MockSearchEngine,
-} from '../../../test/mock-engine';
+  buildMockSearchEngine,
+  MockedSearchEngine,
+} from '../../../test/mock-engine-v2';
+import {createMockState} from '../../../test/mock-state';
 import {buildCoreContext, Context} from './headless-core-context';
+
+jest.mock('../../../features/context/context-actions');
 
 describe('Context', () => {
   let context: Context;
-  let engine: MockSearchEngine;
+  let engine: MockedSearchEngine;
 
   beforeEach(() => {
-    engine = buildMockSearchAppEngine();
+    jest.resetAllMocks();
+    engine = buildMockSearchEngine(createMockState());
     context = buildCoreContext(engine);
   });
-
-  const expectContainAction = (action: Action) => {
-    const found = engine.actions.find((a) => a.type === action.type);
-    expect(engine.actions).toContainEqual(found);
-  };
 
   it('initializes properly', () => {
     expect(context.state.values).toEqual({});
@@ -37,23 +35,29 @@ describe('Context', () => {
 
   it('setContext dispatches #setContext', () => {
     context.set({foo: ['bar']});
-    expectContainAction(setContext);
+    expect(setContext).toHaveBeenCalledWith(
+      expect.objectContaining({foo: ['bar']})
+    );
   });
 
   it('initialize context with values dispatches #setContext', () => {
     buildCoreContext(engine, {
       initialState: {values: {foo: ['bar']}},
     });
-    expectContainAction(setContext);
+    expect(setContext).toHaveBeenCalledWith(
+      expect.objectContaining({foo: ['bar']})
+    );
   });
 
   it('addContext dispatches #addContext', () => {
     context.add('foo', ['bar']);
-    expectContainAction(addContext);
+    expect(addContext).toHaveBeenCalledWith(
+      expect.objectContaining({contextKey: 'foo', contextValue: ['bar']})
+    );
   });
 
   it('removeContext dispatches #removeContext', () => {
     context.remove('foo');
-    expectContainAction(removeContext);
+    expect(removeContext).toHaveBeenCalledWith('foo');
   });
 });

--- a/packages/headless/src/controllers/core/facet-manager/headless-core-facet-manager.test.ts
+++ b/packages/headless/src/controllers/core/facet-manager/headless-core-facet-manager.test.ts
@@ -1,8 +1,11 @@
 import {facetOptionsReducer as facetOptions} from '../../../features/facet-options/facet-options-slice';
 import {searchReducer as search} from '../../../features/search/search-slice';
-import {MockSearchEngine} from '../../../test/mock-engine';
-import {buildMockSearchAppEngine} from '../../../test/mock-engine';
+import {
+  buildMockSearchEngine,
+  MockedSearchEngine,
+} from '../../../test/mock-engine-v2';
 import {buildMockFacetResponse} from '../../../test/mock-facet-response';
+import {createMockState} from '../../../test/mock-state';
 import {
   buildCoreFacetManager,
   FacetManager,
@@ -10,11 +13,11 @@ import {
 } from './headless-core-facet-manager';
 
 describe('facet manager', () => {
-  let engine: MockSearchEngine;
+  let engine: MockedSearchEngine;
   let facetManager: FacetManager;
 
   beforeEach(() => {
-    engine = buildMockSearchAppEngine();
+    engine = buildMockSearchEngine(createMockState());
     facetManager = buildCoreFacetManager(engine);
   });
 

--- a/packages/headless/src/controllers/core/facets/_common/facet-id-determinor.test.ts
+++ b/packages/headless/src/controllers/core/facets/_common/facet-id-determinor.test.ts
@@ -1,14 +1,17 @@
-import {MockSearchEngine} from '../../../../test/mock-engine';
-import {buildMockSearchAppEngine} from '../../../../test/mock-engine';
+import {
+  buildMockSearchEngine,
+  MockedSearchEngine,
+} from '../../../../test/mock-engine-v2';
 import {buildMockFacetIdConfig} from '../../../../test/mock-facet-id-config';
+import {createMockState} from '../../../../test/mock-state';
 import {determineFacetId} from './facet-id-determinor';
 import * as FacetIdGenerator from './facet-id-generator';
 
 describe('#determineFacetId', () => {
-  let engine: MockSearchEngine;
+  let engine: MockedSearchEngine;
 
   beforeEach(() => {
-    engine = buildMockSearchAppEngine();
+    engine = buildMockSearchEngine(createMockState());
   });
 
   it('when a #facetId key is passed, it returns it', () => {

--- a/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
+++ b/packages/headless/src/controllers/core/facets/category-facet/headless-core-category-facet.test.ts
@@ -2,9 +2,9 @@ import {configuration} from '../../../../app/common-reducers';
 import {updateFacetOptions} from '../../../../features/facet-options/facet-options-actions';
 import {facetOptionsReducer as facetOptions} from '../../../../features/facet-options/facet-options-slice';
 import {
+  deselectAllCategoryFacetValues,
   registerCategoryFacet,
   toggleSelectCategoryFacetValue,
-  deselectAllCategoryFacetValues,
   updateCategoryFacetNumberOfValues,
   updateCategoryFacetSortCriterion,
 } from '../../../../features/facets/category-facet-set/category-facet-set-actions';
@@ -26,8 +26,10 @@ import {buildMockCategoryFacetResponse} from '../../../../test/mock-category-fac
 import {buildMockCategoryFacetSearch} from '../../../../test/mock-category-facet-search';
 import {buildMockCategoryFacetSlice} from '../../../../test/mock-category-facet-slice';
 import {buildMockCategoryFacetValue} from '../../../../test/mock-category-facet-value';
-import {MockSearchEngine} from '../../../../test/mock-engine';
-import {buildMockSearchAppEngine} from '../../../../test/mock-engine';
+import {
+  buildMockSearchEngine,
+  MockedSearchEngine,
+} from '../../../../test/mock-engine-v2';
 import {createMockState} from '../../../../test/mock-state';
 import * as FacetIdDeterminor from '../_common/facet-id-determinor';
 import {
@@ -41,6 +43,12 @@ jest.mock(
   '../../../../features/facets/category-facet-set/category-facet-utils'
 );
 
+jest.mock(
+  '../../../../features/facets/category-facet-set/category-facet-set-actions'
+);
+
+jest.mock('../../../../features/facet-options/facet-options-actions');
+
 const {
   findActiveValueAncestry: actualFindActiveValueAncestry,
   partitionIntoParentsAndValues: actualPartitionIntoParentsAndValues,
@@ -52,7 +60,7 @@ describe('category facet', () => {
   const facetId = '1';
   let options: CategoryFacetOptions;
   let state: SearchAppState;
-  let engine: MockSearchEngine;
+  let engine: MockedSearchEngine;
   let categoryFacet: CoreCategoryFacet;
   const findActiveValueAncestryMock = jest.mocked(findActiveValueAncestry);
   const partitionIntoParentsAndValuesMock = jest.mocked(
@@ -60,7 +68,7 @@ describe('category facet', () => {
   );
 
   function initCategoryFacet() {
-    engine = buildMockSearchAppEngine({state});
+    engine = buildMockSearchEngine(state);
     categoryFacet = buildCoreCategoryFacet(engine, {options});
   }
 
@@ -112,12 +120,13 @@ describe('category facet', () => {
   });
 
   it('registers a category facet with the passed options and default optional parameters', () => {
-    const action = registerCategoryFacet({
-      ...defaultCategoryFacetOptions,
-      ...options,
-      facetId,
-    });
-    expect(engine.actions).toContainEqual(action);
+    expect(registerCategoryFacet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...defaultCategoryFacetOptions,
+        ...options,
+        facetId,
+      })
+    );
   });
 
   it('when an option is invalid, it throws', () => {
@@ -301,12 +310,13 @@ describe('category facet', () => {
       const selection = buildMockCategoryFacetValue({value: 'A'});
       categoryFacet.toggleSelect(selection);
 
-      const action = toggleSelectCategoryFacetValue({
-        facetId,
-        selection,
-        retrieveCount: defaultCategoryFacetOptions.numberOfValues,
-      });
-      expect(engine.actions).toContainEqual(action);
+      expect(toggleSelectCategoryFacetValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          facetId,
+          selection,
+          retrieveCount: defaultCategoryFacetOptions.numberOfValues,
+        })
+      );
     });
 
     it('if the numberOfValues is set it dispatches #toggleCategoryFacetValue with the correct retrieveCount', () => {
@@ -315,19 +325,20 @@ describe('category facet', () => {
       const selection = buildMockCategoryFacetValue({value: 'A'});
       categoryFacet.toggleSelect(selection);
 
-      const action = toggleSelectCategoryFacetValue({
-        facetId,
-        selection,
-        retrieveCount: 10,
-      });
-      expect(engine.actions).toContainEqual(action);
+      expect(toggleSelectCategoryFacetValue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          facetId,
+          selection,
+          retrieveCount: 10,
+        })
+      );
     });
 
-    it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
+    it('dispatches #updateFacetOptions', () => {
       const selection = buildMockCategoryFacetValue({value: 'A'});
       categoryFacet.toggleSelect(selection);
 
-      expect(engine.actions).toContainEqual(updateFacetOptions());
+      expect(updateFacetOptions).toHaveBeenCalled();
     });
   });
 
@@ -335,13 +346,11 @@ describe('category facet', () => {
     beforeEach(() => categoryFacet.deselectAll());
 
     it('dispatches #deselectAllCategoryFacetValues', () => {
-      expect(engine.actions).toContainEqual(
-        deselectAllCategoryFacetValues(facetId)
-      );
+      expect(deselectAllCategoryFacetValues).toHaveBeenCalledWith(facetId);
     });
 
-    it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
-      expect(engine.actions).toContainEqual(updateFacetOptions());
+    it('dispatches #updateFacetOptions', () => {
+      expect(updateFacetOptions).toHaveBeenCalled();
     });
   });
 
@@ -466,12 +475,10 @@ describe('category facet', () => {
   describe('#showMoreValues', () => {
     it('with no values, it dispatches #updateCategoryFacetNumberOfResults with the correct number of values', () => {
       categoryFacet.showMoreValues();
-
-      const action = updateCategoryFacetNumberOfValues({
+      expect(updateCategoryFacetNumberOfValues).toHaveBeenCalledWith({
         facetId,
         numberOfValues: defaultCategoryFacetOptions.numberOfValues,
       });
-      expect(engine.actions).toContainEqual(action);
     });
 
     it('with a value, it dispatches #updateCategoryFacetNumberOfResults with the correct number of values', () => {
@@ -481,18 +488,16 @@ describe('category facet', () => {
 
       initCategoryFacet();
 
-      const action = updateCategoryFacetNumberOfValues({
+      categoryFacet.showMoreValues();
+      expect(updateCategoryFacetNumberOfValues).toHaveBeenCalledWith({
         facetId,
         numberOfValues: 6,
       });
-      categoryFacet.showMoreValues();
-      expect(engine.actions).toContainEqual(action);
     });
 
     it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
       categoryFacet.showMoreValues();
-
-      expect(engine.actions).toContainEqual(updateFacetOptions());
+      expect(updateFacetOptions).toHaveBeenCalled();
     });
   });
 
@@ -500,15 +505,14 @@ describe('category facet', () => {
     beforeEach(() => categoryFacet.showLessValues());
 
     it('dispatches #updateCategoryFacetNumberOfResults with the correct numberOfValues', () => {
-      const action = updateCategoryFacetNumberOfValues({
+      expect(updateCategoryFacetNumberOfValues).toHaveBeenCalledWith({
         facetId,
         numberOfValues: 5,
       });
-      expect(engine.actions).toContainEqual(action);
     });
 
     it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
-      expect(engine.actions).toContainEqual(updateFacetOptions());
+      expect(updateFacetOptions).toHaveBeenCalled();
     });
   });
 
@@ -516,17 +520,15 @@ describe('category facet', () => {
     it('dispatches #toggleCategoryFacetValue with the passed selection', () => {
       const sortCriterion: CategoryFacetSortCriterion = 'alphanumeric';
       categoryFacet.sortBy(sortCriterion);
-      const action = updateCategoryFacetSortCriterion({
+      expect(updateCategoryFacetSortCriterion).toHaveBeenCalledWith({
         facetId,
         criterion: sortCriterion,
       });
-      expect(engine.actions).toContainEqual(action);
     });
 
     it('dispatches #updateFacetOptions with #freezeFacetOrder true', () => {
       categoryFacet.sortBy('alphanumeric');
-
-      expect(engine.actions).toContainEqual(updateFacetOptions());
+      expect(updateFacetOptions).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Migrating some more controller tests for Redux toolkit 2 support.

https://coveord.atlassian.net/browse/KIT-2955