### PR TITLE
fix(hsp): use admin url

### DIFF
--- a/packages/atomic-hosted-page/src/components/utils/options-utils.ts
+++ b/packages/atomic-hosted-page/src/components/utils/options-utils.ts
@@ -49,4 +49,4 @@ export const validateOptions = (
 export const extractPlatformUrl = (options: InitializationOptions) =>
   options.platformUrl ||
   options.organizationEndpoints?.admin ||
-  `https://${options.organizationId}.org.coveo.com`;
+  `https://${options.organizationId}.admin.org.coveo.com`;


### PR DESCRIPTION
Using orgEndpoint
# `https://:orgId.org.coveo.com/rest/organizations/:orgId/hostedpages/:pageId`
![404](https://http.dog/404.jpg) 
# `https://:orgId.admin.org.coveo.com/rest/organizations/:orgId/hostedPages/:pageId`
![200](https://http.dog/200.jpg)

https://coveord.atlassian.net/browse/KIT-2996