### PR TITLE
fix(refine-modal): Sort facets values based on their DOM position

### DIFF
--- a/packages/atomic/cypress/e2e/refine-toggle-actions.ts
+++ b/packages/atomic/cypress/e2e/refine-toggle-actions.ts
@@ -156,3 +156,23 @@ export const addRefineToggleRangeVariations =
 
     env.withElement(manager).withElement(refineToggle);
   };
+
+export const addRefineToggleWithDependsOnFacetAndNumerical =
+  (props: TagProps = {}) =>
+  (env: TestFixture) => {
+    const manager = generateComponentHTML(facetManagerComponent);
+    const refineToggle = generateComponentHTML(refineToggleComponent, props);
+
+    manager.append(generateComponentHTML(facetComponent, {field: facetField}));
+    manager.append(
+      generateComponentHTML(numericFacetComponent, {
+        field: colorFacetField,
+        'depends-on': facetField,
+      })
+    );
+    manager.append(
+      generateComponentHTML(numericFacetComponent, {field: numericFacetField})
+    );
+
+    env.withElement(manager).withElement(refineToggle);
+  };

--- a/packages/atomic/cypress/e2e/refine-toggle.cypress.ts
+++ b/packages/atomic/cypress/e2e/refine-toggle.cypress.ts
@@ -237,7 +237,7 @@ describe('Refine Toggle Test Suites', () => {
     });
   });
 
-  describe.skip('when the modal is opened with both facets type', () => {
+  describe('when the modal is opened with both facets type', () => {
     const collapseFacetsAfter = 4;
     const staticFacetAmount = 1;
     const automaticFacetAmount = 1;
@@ -309,7 +309,7 @@ describe('Refine Toggle Test Suites', () => {
     });
   });
 
-  describe.skip('when the modal is opened with range facet variations', () => {
+  describe('when the modal is opened with range facet variations', () => {
     beforeEach(() => {
       new TestFixture()
         .with(addRefineToggleRangeVariations())

--- a/packages/atomic/cypress/e2e/refine-toggle.cypress.ts
+++ b/packages/atomic/cypress/e2e/refine-toggle.cypress.ts
@@ -20,6 +20,7 @@ import {
   addFacetManagerWithBothTypesOfFacets,
   addRefineToggleRangeVariations,
   addRefineToggleWithAutomaticFacets,
+  addRefineToggleWithDependsOnFacetAndNumerical,
   addRefineToggleWithStaticFacets,
   addRefineToggleWithStaticFacetsAndNoManager,
   addRefineToggleWithoutFacets,
@@ -337,6 +338,21 @@ describe('Refine Toggle Test Suites', () => {
       RefineModalSelectors.facets()
         .find(numericFacetComponent)
         .should('have.length', 3);
+    });
+  });
+
+  describe('when the modal is opened with a `depends-on` facet', () => {
+    beforeEach(() => {
+      new TestFixture()
+        .with(addRefineToggleWithDependsOnFacetAndNumerical())
+        .withMobileViewport()
+        .init();
+      cy.wait(1000);
+      RefineToggleSelectors.buttonOpen().should('be.visible').click();
+    });
+
+    it('should render each facets only once', () => {
+      RefineModalSelectors.facets().children().should('have.length', 3);
     });
   });
 });

--- a/packages/atomic/src/components/common/facets/facet-common.tsx
+++ b/packages/atomic/src/components/common/facets/facet-common.tsx
@@ -313,6 +313,39 @@ export function getAutomaticFacetGenerator(
   );
 }
 
+/**
+ * Triage elements by their parents.
+ * @param facets Facet Elements
+ * @param parents Elements that may contains the facets
+ * @returns an array in the same order as the parents, containing the facets that are contained by the corresponding parent.
+ * The last element of the array contains the facets that are not contained by any of the parents.
+ */
+export function triageFacetByParents(
+  facets: BaseFacetElement[],
+  ...parents: (HTMLElement | null)[]
+) {
+  const sortedFacets: BaseFacetElement[][] = new Array(parents.length + 1)
+    .fill(null)
+    .map(() => []);
+  facets: for (const facet of facets) {
+    parents: for (
+      let parentIndex = 0;
+      parentIndex < parents.length;
+      parentIndex++
+    ) {
+      const parent = parents[parentIndex];
+      if (parent === null) {
+        continue parents;
+      } else if (parent.contains(facet)) {
+        sortedFacets[parentIndex].push(facet);
+        continue facets;
+      }
+    }
+    sortedFacets[parents.length].push(facet);
+  }
+  return sortedFacets;
+}
+
 export function sortFacetsUsingManager(
   facets: BaseFacetElement[],
   facetManager: FacetManager

--- a/packages/atomic/src/components/common/facets/facet-common.tsx
+++ b/packages/atomic/src/components/common/facets/facet-common.tsx
@@ -313,6 +313,21 @@ export function getAutomaticFacetGenerator(
   );
 }
 
+const get2DMatrix = (xSize: number, ySize: number = 0) =>
+  new Array(xSize).fill(null).map(() => new Array(ySize));
+
+function findIndiceOfParent(
+  facet: BaseFacetElement,
+  parents: (HTMLElement | null)[]
+) {
+  for (let i = 0; i < parents.length; i++) {
+    if (parents[i]?.contains(facet)) {
+      return i;
+    }
+  }
+  return parents.length;
+}
+
 /**
  * Triage elements by their parents.
  * @param facets Facet Elements
@@ -320,28 +335,14 @@ export function getAutomaticFacetGenerator(
  * @returns an array in the same order as the parents, containing the facets that are contained by the corresponding parent.
  * The last element of the array contains the facets that are not contained by any of the parents.
  */
-export function triageFacetByParents(
+export function triageFacetsByParents(
   facets: BaseFacetElement[],
   ...parents: (HTMLElement | null)[]
 ) {
-  const sortedFacets: BaseFacetElement[][] = new Array(parents.length + 1)
-    .fill(null)
-    .map(() => []);
-  facets: for (const facet of facets) {
-    parents: for (
-      let parentIndex = 0;
-      parentIndex < parents.length;
-      parentIndex++
-    ) {
-      const parent = parents[parentIndex];
-      if (parent === null) {
-        continue parents;
-      } else if (parent.contains(facet)) {
-        sortedFacets[parentIndex].push(facet);
-        continue facets;
-      }
-    }
-    sortedFacets[parents.length].push(facet);
+  const sortedFacets: BaseFacetElement[][] = get2DMatrix(parents.length + 1);
+  for (const facet of facets) {
+    const indice = findIndiceOfParent(facet, parents);
+    sortedFacets[indice].push(facet);
   }
   return sortedFacets;
 }

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -35,7 +35,7 @@ import {Button} from '../../common/button';
 import {
   BaseFacetElement,
   sortFacetVisibility,
-  triageFacetByParents,
+  triageFacetsByParents,
   collapseFacetsAfter,
 } from '../../common/facets/facet-common';
 import {isRefineModalFacet} from '../../common/interface/store';
@@ -145,7 +145,7 @@ export class AtomicRefineModal implements InitializableComponent {
       atomicSearchInterface,
       'horizontal-facets'
     );
-    const triagedFacets = triageFacetByParents(
+    const triagedFacets = triageFacetsByParents(
       facets,
       horizontalFacetsSection,
       facetsSection

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -29,6 +29,7 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
+import {sortByDocumentPosition} from '../../../utils/utils';
 import {findSection} from '../../common/atomic-layout-section/sections';
 import {Button} from '../../common/button';
 import {
@@ -151,11 +152,7 @@ export class AtomicRefineModal implements InitializableComponent {
     );
     const [horizontalFacetsSectionFacets, facetsSectionFacets, orphanedFacets] =
       triagedFacets.map((facetsArray) =>
-        facetsArray.sort((a, b) =>
-          a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING
-            ? -1
-            : 1
-        )
+        facetsArray.sort(sortByDocumentPosition)
       );
     const sortedFacets = [
       ...facetsSectionFacets,

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -29,11 +29,12 @@ import {
   InitializableComponent,
   InitializeBindings,
 } from '../../../utils/initialization-utils';
+import {findSection} from '../../common/atomic-layout-section/sections';
 import {Button} from '../../common/button';
 import {
   BaseFacetElement,
   sortFacetVisibility,
-  sortFacetsUsingManager,
+  triageFacetByParents,
   collapseFacetsAfter,
 } from '../../common/facets/facet-common';
 import {isRefineModalFacet} from '../../common/interface/store';
@@ -137,8 +138,30 @@ export class AtomicRefineModal implements InitializableComponent {
     this.addFacetColumnStyling(divSlot);
 
     const facets = this.bindings.store.getFacetElements() as BaseFacetElement[];
-
-    const sortedFacets = sortFacetsUsingManager(facets, this.facetManager);
+    const atomicSearchInterface = this.host.closest('atomic-search-interface')!;
+    const facetsSection = findSection(atomicSearchInterface, 'facets');
+    const horizontalFacetsSection = findSection(
+      atomicSearchInterface,
+      'horizontal-facets'
+    );
+    const triagedFacets = triageFacetByParents(
+      facets,
+      horizontalFacetsSection,
+      facetsSection
+    );
+    const [horizontalFacetsSectionFacets, facetsSectionFacets, orphanedFacets] =
+      triagedFacets.map((facetsArray) =>
+        facetsArray.sort((a, b) =>
+          a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING
+            ? -1
+            : 1
+        )
+      );
+    const sortedFacets = [
+      ...facetsSectionFacets,
+      ...horizontalFacetsSectionFacets,
+      ...orphanedFacets,
+    ];
 
     const {visibleFacets, invisibleFacets} = sortFacetVisibility(
       sortedFacets,
@@ -166,27 +189,16 @@ export class AtomicRefineModal implements InitializableComponent {
   }
 
   private cloneFacets(facets: BaseFacetElement[]): BaseFacetElement[] {
-    const allFacetTags = Array.from(
-      new Set(facets.map((el) => el.tagName.toLowerCase()))
-    );
-
-    const allFacetsInOrderInDOM = allFacetTags.length
-      ? this.bindings.interfaceElement.querySelectorAll(allFacetTags.join(','))
-      : [];
-
-    const clones: BaseFacetElement[] = [];
-    allFacetsInOrderInDOM.forEach((facetElement, index) => {
-      const clone = facetElement.cloneNode(true) as BaseFacetElement;
-      clone.classList.remove(popoverClass);
-      clone.setAttribute(isRefineModalFacet, '');
+    return facets.map((facet, i) => {
+      facet.classList.remove(popoverClass);
+      facet.setAttribute(isRefineModalFacet, '');
+      const clone = facet.cloneNode(true) as BaseFacetElement;
       clone.isCollapsed =
         this.collapseFacetsAfter === -1
           ? false
-          : index + 1 > this.collapseFacetsAfter;
-      clones.push(clone);
+          : i + 1 > this.collapseFacetsAfter;
+      return clone;
     });
-
-    return clones;
   }
 
   private makeAutomaticFacetGenerator() {

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -145,6 +145,9 @@ export function closest(
   return closest(element.parentElement, selector);
 }
 
+export const sortByDocumentPosition = (a: Node, b: Node): 1 | -1 =>
+  a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+
 export function sanitizeStyle(style: string) {
   const purifiedOuterHTML = sanitize(`<style>${style}</style>`, {
     ALLOWED_TAGS: ['style'],


### PR DESCRIPTION
> [!WARNING]
> This PR uses esoteric JavaScript APIs.
>Caffeine consumption/injection is advised before attempting a review.


## What went wrong?
During #3572, we changed the clone node algorithm:
https://github.com/coveo/ui-kit/blob/12140a1d91ec018a1bae05a94d87b42d70378452/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx#L168-L190

This algorithm fails as it queries the DOM again for the facet, but only considering the tags of the components, and not taking into account the prefiltering that happened before in the execution stack:
https://github.com/coveo/ui-kit/blob/12140a1d91ec018a1bae05a94d87b42d70378452/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx#L143-L149

This causes facets to be duplicated when some facets are invisible, such as when a  `depends-on` condition is unmet.

> [!NOTE]
> Decision 1: Revert the clone algorithm to the previous one.


## What really caused the issue of #3572?
This line:
https://github.com/coveo/ui-kit/blob/12140a1d91ec018a1bae05a94d87b42d70378452/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx#L141
We sort facets using a facet manager, regardless of if the facets were originally managed, which leads to issue when some facets (or all) are not managed.

This leads of course to

> [!NOTE]
> Decision 2: the refine modal must not use a `FacetManager`

## Proposed solution


This is where the _fun_ begins. The gig is to 'sort facets' in the same order as they appear to the user.
Let's assume the HTML DOM tree does represent the order in which the information will be displayed.
We can then use [`compareDocumentPosition`](https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition) to figure out if an Element precedes or follows another Element.
This should solve all our problems (said no one ever)

> [!NOTE]
> Decision 3: We'll use the DOM tree as the source of truth for facet order.

However, we know that most of the time facets are put in `atomic-section`, which morphs where DOM goes, so we have to make some opinionated decisions:

> [!NOTE]
> Decision 4: Facets first criterion of sorting is "Which section is your parent". The priority order is as such:
> 1. `facets` section
> 2. `horizontal-facet` section
> 3. all the other facets
>
> Decision 3 criterion is still relevant as the second sort criterion

To reduce the complexity of the algorithm to use to sort all facets mixed up together, I decided to first split them up into the 3 categories defined in Decision 3, and then sort them out in each of their set.