### PR TITLE
docs(headless): added deprecation note to documentUriHash

### DIFF
--- a/packages/headless/src/api/search/search/product-recommendation.ts
+++ b/packages/headless/src/api/search/search/product-recommendation.ts
@@ -4,7 +4,9 @@ export interface ProductRecommendation {
    */
   documentUri: string;
   /**
-   * Document UriHash in the index. Useful for analytics.
+   * Document UriHash in the index.
+   *
+   * **Note:** This parameter is deprecated. Use the `permanentid` to identify items in the index.
    */
   documentUriHash: string;
   /**


### PR DESCRIPTION
The `documentUriHash` parameter is deprecated and we were asked by the data platform team to add a note to that effect.