### PR TITLE
spike(commerce): demonstrate controller-compatible routes usage

### DIFF
--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -82,6 +82,12 @@ export interface CoreEngine<
    */
   addReducers(reducers: ReducersMapObject): void;
   /**
+   * Removes the specified reducers from the store.
+   *
+   * @param reducers - An object containing the reducers to remove from the engine.
+   */
+  removeReducers(reducers: ReducersMapObject): void;
+  /**
    * Enable analytics tracking
    */
   enableAnalytics(): void;
@@ -247,6 +253,10 @@ function buildCoreEngine<
 
       reducerManager.add(reducers);
       store.replaceReducer(reducerManager.combinedReducer);
+    },
+
+    removeReducers(reducers: ReducersMapObject) {
+      // TODO(nico): Implement
     },
 
     dispatch: store.dispatch,

--- a/packages/headless/src/app/reducer-manager.ts
+++ b/packages/headless/src/app/reducer-manager.ts
@@ -10,6 +10,7 @@ import {fromEntries} from '../utils/utils';
 export interface ReducerManager {
   combinedReducer: Reducer;
   add(newReducers: ReducersMapObject): void;
+  remove(oldReducers: ReducersMapObject): void;
   containsAll(newReducers: ReducersMapObject): boolean;
   addCrossReducer(reducer: Reducer): void;
 }
@@ -54,6 +55,12 @@ export function createReducerManager(
       Object.keys(newReducers)
         .filter((key) => !(key in reducers))
         .forEach((key) => (reducers[key] = newReducers[key]));
+    },
+
+    remove(oldReducers: ReducersMapObject) {
+      Object.keys(oldReducers)
+        .filter((key) => key in reducers)
+        .forEach((key) => (reducers[key] = <Reducer>(() => {})));
     },
 
     addCrossReducer(reducer: Reducer) {

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -132,3 +132,6 @@ export {buildCoreUrlManager} from './controllers/commerce/core/url-manager/headl
 
 export {buildSearchUrlManager} from './controllers/commerce/search/url-manager/headless-search-url-manager';
 export {buildProductListingUrlManager} from './controllers/commerce/product-listing/url-manager/headless-product-listing-url-manager';
+
+export type {CommerceRoute} from './routes/commerce';
+export {buildProductListingRoute, buildSearchRoute, buildProductRoute} from './routes/commerce'

--- a/packages/headless/src/routes/commerce.ts
+++ b/packages/headless/src/routes/commerce.ts
@@ -1,0 +1,86 @@
+import {CommerceEngine} from '../app/commerce-engine/commerce-engine';
+import {randomID} from '../utils/utils';
+import {CommerceRoutableState} from '../state/commerce-app-state';
+
+export interface RouteProps {
+  id?: string;
+  url?: string;
+}
+
+interface CoreRouteProps extends RouteProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  refreshState?: any;
+  id: string;
+}
+
+// This makes current controllers compatible with routes, since a route is a special kind of engine from the
+// controller's perspective
+export interface CommerceRoute extends CommerceEngine {
+  id: string;
+  navigate: () => void;
+  deregister: () => void;
+}
+
+function buildCoreRoute(
+  engine: CommerceEngine,
+  props: CoreRouteProps): CommerceRoute {
+  const deregister = engine.registerRoute(props.id)
+  return {
+    ...engine,
+    id: props.id,
+    navigate: props?.refreshState || (() => {}),
+    deregister,
+    // Overriding the engine state to reflect the route's state. This makes controllers automatically
+    // compatible with routes!
+    // We'll also need to override the engine's dispatch method to dispatch the action to the route's state
+    get state() {
+      return {
+        commerceContext: engine.state.commerceContext,
+        ...engine.state[props.id] as CommerceRoutableState
+      }
+    }
+  }
+}
+
+export function buildProductListingRoute(engine: CommerceEngine, props?: RouteProps) {
+  const id = props?.id || randomID('plp');
+  return buildCoreRoute(engine, {
+    ...props,
+    id,
+    refreshState: () => {}, // TODO(nico): Refresh state of routes through action
+    // Should we offer controllers built by default?
+  });
+}
+
+export function buildSearchRoute(engine: CommerceEngine, props?: RouteProps) {
+  const id = props?.id || randomID('search');
+  return buildCoreRoute(engine, {
+    ...props,
+    id,
+    refreshState: () => {}
+  });
+}
+
+export function buildProductRoute(engine: CommerceEngine, props?: RouteProps) {
+  const id = props?.id || randomID('pdp');
+  return buildCoreRoute(engine, {
+    ...props,
+    id
+  });
+}
+
+export function buildCartRoute(engine: CommerceEngine, props?: RouteProps) {
+  const id = props?.id || randomID('cart');
+  return buildCoreRoute(engine, {
+    ...props,
+    id
+  });
+}
+
+export function buildCustomRoute(engine: CommerceEngine, props?: RouteProps) {
+  const id = props?.id || randomID('custom');
+  return buildCoreRoute(engine, {
+    ...props,
+    id
+  });
+}

--- a/packages/headless/src/state/commerce-app-state.ts
+++ b/packages/headless/src/state/commerce-app-state.ts
@@ -19,16 +19,17 @@ import {
 export type CommerceSearchParametersState = CommerceQuerySection;
 export type CommerceProductListingParametersState = {};
 
-export type CommerceAppState = ConfigurationSection &
-  ProductListingV2Section &
+export type CommerceRoutableState = ProductListingV2Section &
   CommerceSearchSection &
   CommerceQuerySection &
   FacetOrderSection &
   CommerceFacetSetSection &
   CommercePaginationSection &
   CommerceSortSection &
-  CommerceContextSection &
   CartSection &
   QuerySuggestionSection &
-  QuerySetSection &
+  QuerySetSection;
+
+export type CommerceAppState = ConfigurationSection &
+  CommerceContextSection &
   VersionSection;


### PR DESCRIPTION
The central idea to this approach is that I'm extending the engine type to create a route type. This makes current controllers immediately route-compatible. This also means slices don't need to be route-aware.

Routes are registered at runtime, when we inject the necessary reducers for it.

[CAPI-496]

[CAPI-496]: https://coveord.atlassian.net/browse/CAPI-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ