### PR TITLE
fix(commerce-face-search-request-builder): set await to builder

### DIFF
--- a/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-request-builder.ts
@@ -22,7 +22,7 @@ export const buildCommerceFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = buildCommerceAPIRequest(state);
+  } = await buildCommerceAPIRequest(state);
 
   return {
     url,


### PR DESCRIPTION
To fix the build job :scream: . There was an `await` missing for the `buildCommerceAPIRequest` function