### PR TITLE
refactor(ci): refactor quantic jobs into reusable workflow

### DIFF
--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -5,8 +5,6 @@ on:
         required: true
       SFDX_AUTH_JWT_KEY:
         required: true
-      GITHUB_TOKEN:
-        required: true
 jobs:
   e2e-quantic-setup:
     name: 'Setup e2e tests on Quantic'

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -1,0 +1,53 @@
+on:
+  workflow_call:
+    secrets:
+      SFDX_AUTH_CLIENT_ID:
+        required: true
+      SFDX_AUTH_JWT_KEY:
+        required: true
+      GITHUB_TOKEN:
+        required: true
+jobs:
+  e2e-quantic-setup:
+    name: 'Setup e2e tests on Quantic'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-sfdx
+      - uses: ./.github/actions/e2e-quantic-setup
+        with:
+          clientid: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+          jwtkey: ${{ secrets.SFDX_AUTH_JWT_KEY }}
+  e2e-quantic-test:
+    name: 'Run e2e tests on Quantic'
+    needs: e2e-quantic-setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        spec:
+          [
+            'cypress/e2e/default-1/**/*',
+            'cypress/e2e/default-2/**/*',
+            'cypress/e2e/facets-1/**/*',
+            'cypress/e2e/facets-2/**/*',
+          ]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/e2e-quantic
+      - uses: ./.github/actions/setup-sfdx
+        with:
+          spec: ${{ matrix.spec }}
+  e2e-quantic-cleanup:
+    if: cancelled() || failure() || success()
+    needs: e2e-quantic-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-sfdx
+      - run: npx --no-install ts-node packages/quantic/scripts/build/delete-org.ts
+        shell: bash

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   e2e-quantic-setup:
     name: 'Setup e2e tests on Quantic'
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-quantic
+        with:
           spec: ${{ matrix.spec }}
   e2e-quantic-cleanup:
     if: cancelled() || failure() || success()

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -35,8 +35,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-quantic
-      - uses: ./.github/actions/setup-sfdx
-        with:
           spec: ${{ matrix.spec }}
   e2e-quantic-cleanup:
     if: cancelled() || failure() || success()

--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -170,50 +170,12 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-headless-ssr-pages-prod
-  e2e-quantic-setup:
-    name: 'Setup e2e tests on Quantic'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
-      - uses: ./.github/actions/e2e-quantic-setup
-        with:
-          clientid: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
-          jwtkey: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-  e2e-quantic-test:
-    name: 'Run e2e tests on Quantic'
-    needs: e2e-quantic-setup
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        spec:
-          [
-            'cypress/e2e/default-1/**/*',
-            'cypress/e2e/default-2/**/*',
-            'cypress/e2e/facets-1/**/*',
-            'cypress/e2e/facets-2/**/*',
-          ]
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
-      - uses: ./.github/actions/e2e-quantic
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          spec: ${{ matrix.spec }}
-  e2e-quantic-cleanup:
-    if: cancelled() || failure() || success()
-    needs: e2e-quantic-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
-      - run: npx --no-install ts-node packages/quantic/scripts/build/delete-org.ts
-        shell: bash
+  e2e-quantic:
+    uses: ./.github/workflows/e2e-quantic.yml
+    secrets:
+      SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+      SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   prerelease:
     timeout-minutes: 40
     name: Pre-release

--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -175,7 +175,6 @@ jobs:
     secrets:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   prerelease:
     timeout-minutes: 40
     name: Pre-release

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -246,7 +246,11 @@ jobs:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
   required-jobs:
-    if: success()
+    if: always()
+    # if: |
+    #   always() &&
+    #   !contains(needs.*.result, 'failure') &&
+    #   !contains(needs.*.result, 'cancelled')
     needs:
       - 'build'
       - 'lint-check'
@@ -269,11 +273,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All required jobs have passed'
+      - run: echo "${{ toJSON(needs) }}"
   is-valid:
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    if: cancelled() || failure() || success()
     name: 'Confirm build is valid'
     needs:
       - 'required-jobs'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -224,7 +224,19 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-headless-ssr-pages-prod
+  should-e2e-quantic:
+    name: 'Should test Quantic?'
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      shouldRunQuantic: ${{ steps.shouldRunQuantic.outputs.shouldRunQuantic }}
+    steps:
+      - run: node ./scripts/ci/hasFileChanged.mjs shouldRunQuantic packages/quantic/**/* packages/headless/**/* package.json package-lock.json
+        id: shouldRunQuantic
   e2e-quantic:
+    name: 'Run Quantic E2E tests'
+    needs: should-e2e-quantic
+    if: ${{ needs.should-e2e-quantic.outputs.shouldRunQuantic == 'true' }}
     uses: ./.github/workflows/e2e-quantic.yml
     secrets:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -241,7 +241,6 @@ jobs:
     secrets:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   required-jobs:
     if: success()
     needs:

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -224,49 +224,12 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/e2e-headless-ssr-pages-prod
-  e2e-quantic-setup:
-    name: 'Setup e2e tests on Quantic'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
-      - uses: ./.github/actions/e2e-quantic-setup
-        with:
-          clientid: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
-          jwtkey: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-  e2e-quantic-test:
-    name: 'Run e2e tests on Quantic'
-    needs: e2e-quantic-setup
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        spec:
-          [
-            'cypress/e2e/default-1/**/*',
-            'cypress/e2e/default-2/**/*',
-            'cypress/e2e/facets-1/**/*',
-            'cypress/e2e/facets-2/**/*',
-          ]
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/e2e-quantic
-      - uses: ./.github/actions/setup-sfdx
-        with:
-          spec: ${{ matrix.spec }}
-  e2e-quantic-cleanup:
-    if: cancelled() || failure() || success()
-    needs: e2e-quantic-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
-      - run: npx --no-install ts-node packages/quantic/scripts/build/delete-org.ts
-        shell: bash
+  e2e-quantic:
+    uses: ./.github/workflows/e2e-quantic.yml
+    secrets:
+      SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+      SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   required-jobs:
     if: success()
     needs:
@@ -274,7 +237,7 @@ jobs:
       - 'lint-check'
       - 'unit-test'
       - 'e2e-atomic-test'
-      - 'e2e-quantic-test'
+      - 'e2e-quantic'
       - 'e2e-atomic-screenshots'
       - 'e2e-atomic-react-test'
       - 'e2e-atomic-react-nextjs-test'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -270,7 +270,10 @@ jobs:
     steps:
       - run: echo 'All required jobs have passed'
   is-valid:
-    if: cancelled() || failure() || success()
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     name: 'Confirm build is valid'
     needs:
       - 'required-jobs'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -231,6 +231,7 @@ jobs:
     outputs:
       shouldRunQuantic: ${{ steps.shouldRunQuantic.outputs.shouldRunQuantic }}
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - run: node ./scripts/ci/hasFileChanged.mjs shouldRunQuantic packages/quantic/**/* packages/headless/**/* package.json package-lock.json
         id: shouldRunQuantic
   e2e-quantic:

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -249,7 +249,7 @@ jobs:
     if: |
       ${{
         !cancelled () &&
-        !contains(needs.*.result, 'failure') &&
+        !contains(needs.*.result, 'failure')
       }}
     needs:
       - 'build'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -246,11 +246,11 @@ jobs:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
   required-jobs:
-    if: always()
-    # if: |
-    #   always() &&
-    #   !contains(needs.*.result, 'failure') &&
-    #   !contains(needs.*.result, 'cancelled')
+    if: |
+      ${{
+        !cancelled () &&
+        !contains(needs.*.result, 'failure') &&
+      }}
     needs:
       - 'build'
       - 'lint-check'
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All required jobs have passed'
-      - run: echo "${{ toJSON(needs) }}"
+      # - run: echo "${{ toJSON(needs) }}"
   is-valid:
     if: cancelled() || failure() || success()
     name: 'Confirm build is valid'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -273,9 +273,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All required jobs have passed'
-      # - run: echo "${{ toJSON(needs) }}"
   is-valid:
-    if: cancelled() || failure() || success()
+    if: |
+      ${{
+        !cancelled () &&
+        !contains(needs.*.result, 'failure')
+      }}
     name: 'Confirm build is valid'
     needs:
       - 'required-jobs'

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -232,6 +232,7 @@ jobs:
       shouldRunQuantic: ${{ steps.shouldRunQuantic.outputs.shouldRunQuantic }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: ./.github/actions/setup
       - run: node ./scripts/ci/hasFileChanged.mjs shouldRunQuantic packages/quantic/**/* packages/headless/**/* package.json package-lock.json
         id: shouldRunQuantic
   e2e-quantic:

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -232,6 +232,8 @@ jobs:
       shouldRunQuantic: ${{ steps.shouldRunQuantic.outputs.shouldRunQuantic }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
       - run: node ./scripts/ci/hasFileChanged.mjs shouldRunQuantic packages/quantic/**/* packages/headless/**/* package.json package-lock.json
         id: shouldRunQuantic

--- a/scripts/ci/hasFileChanged.mjs
+++ b/scripts/ci/hasFileChanged.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import {setOutput} from '@actions/core';
+import {context} from '@actions/github';
+import {minimatch} from 'minimatch';
+import {execSync} from 'node:child_process';
+
+function getBaseHeadSHAs() {
+  switch (context.eventName) {
+    case 'pull_request':
+      return {
+        base: context.payload.pull_request.base.sha,
+        head: context.payload.pull_request.head.sha,
+      };
+    case 'merge_group':
+      return {
+        base: context.payload.merge_group.base_sha,
+        head: context.payload.merge_group.head_sha,
+      };
+  }
+}
+
+function getChangedFiles(from, to) {
+  return execSync(`git diff --name-only ${from}..${to}`, {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+  });
+}
+
+function getPatterns() {
+  return process.argv.slice(3);
+}
+
+function checkPatterns(files, patterns) {
+  for (const pattern of patterns) {
+    for (const file of files.split(/$/gm)) {
+      if (minimatch(file, pattern)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function getOutputName() {
+  return process.argv[2];
+}
+
+const {base, head} = getBaseHeadSHAs();
+const files = getChangedFiles(base, head);
+const patterns = getPatterns();
+const hasFileChanged = checkPatterns(files, patterns);
+const outputName = getOutputName();
+setOutput(outputName, hasFileChanged);


### PR DESCRIPTION
- Refactor Quantic CI into a reusable workflow
- Skip Quantic on `pull_request` and `merge_group` if no changes on headless, quantic, or the pjson has been detected