### PR TITLE
feat(headless): expose relay on the engine

### DIFF
--- a/packages/headless/config/api-extractor/base.json
+++ b/packages/headless/config/api-extractor/base.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "mainEntryPointFilePath": "",
-  "bundledPackages": ["redux", "@reduxjs/toolkit"],
+  "bundledPackages": ["redux", "@reduxjs/toolkit", "@coveo/relay"],
   "apiReport": {
     "enabled": false
   },

--- a/packages/headless/src/api/analytics/analytics-relay-client.test.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.test.ts
@@ -1,8 +1,10 @@
 import {createRelay} from '@coveo/relay';
 import {createMockState} from '../../test/mock-state';
 import {getRelayInstanceFromState} from './analytics-relay-client';
+import {getAnalyticsSource} from './analytics-selectors';
 
 jest.mock('@coveo/relay');
+jest.mock('./analytics-selectors');
 
 describe('#getRelayInstanceFromState', () => {
   const mockedCreateRelay = jest.mocked(createRelay).mockImplementation(() => ({
@@ -14,6 +16,10 @@ describe('#getRelayInstanceFromState', () => {
     updateConfig: jest.fn(),
     version: 'test',
   }));
+
+  beforeEach(() => {
+    jest.mocked(getAnalyticsSource).mockReturnValue(['baguette']);
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -28,7 +34,7 @@ describe('#getRelayInstanceFromState', () => {
       url: state.configuration.analytics.nextApiBaseUrl,
       token: state.configuration.accessToken,
       trackingId: state.configuration.analytics.trackingId,
-      source: expect.arrayContaining([]),
+      source: expect.arrayContaining(['baguette']),
     });
     expect(mockedCreateRelay).toHaveReturnedWith(relay);
   });

--- a/packages/headless/src/api/analytics/analytics-relay-client.test.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.test.ts
@@ -2,6 +2,8 @@ import {createRelay} from '@coveo/relay';
 import {createMockState} from '../../test/mock-state';
 import {getRelayInstanceFromState} from './analytics-relay-client';
 
+jest.mock('@coveo/relay');
+
 describe('#getRelayInstanceFromState', () => {
   const mockedCreateRelay = jest.mocked(createRelay).mockImplementation(() => ({
     emit: jest.fn(),

--- a/packages/headless/src/api/analytics/analytics-relay-client.test.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.test.ts
@@ -1,0 +1,33 @@
+import {createRelay} from '@coveo/relay';
+import {createMockState} from '../../test/mock-state';
+import {getRelayInstanceFromState} from './analytics-relay-client';
+
+describe('#getRelayInstanceFromState', () => {
+  const mockedCreateRelay = jest.mocked(createRelay).mockImplementation(() => ({
+    emit: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
+    clearStorage: jest.fn(),
+    getMeta: jest.fn(),
+    updateConfig: jest.fn(),
+    version: 'test',
+  }));
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a Relay client properly and returns it', () => {
+    const state = createMockState();
+
+    const relay = getRelayInstanceFromState(state);
+
+    expect(mockedCreateRelay).toHaveBeenCalledWith({
+      url: state.configuration.analytics.nextApiBaseUrl,
+      token: state.configuration.accessToken,
+      trackingId: state.configuration.analytics.trackingId,
+      source: expect.arrayContaining([]),
+    });
+    expect(mockedCreateRelay).toHaveReturnedWith(relay);
+  });
+});

--- a/packages/headless/src/api/analytics/analytics-relay-client.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.ts
@@ -1,0 +1,20 @@
+import {createRelay} from '@coveo/relay';
+import {createSelector} from '@reduxjs/toolkit';
+import {getAnalyticsSource} from './analytics-selectors';
+import {StateNeededBySearchAnalyticsProvider} from './search-analytics';
+
+export const getRelayInstanceFromState = createSelector(
+  (state: StateNeededBySearchAnalyticsProvider) =>
+    state.configuration.accessToken,
+  (state: StateNeededBySearchAnalyticsProvider) =>
+    state.configuration.analytics,
+  (state: StateNeededBySearchAnalyticsProvider) =>
+    getAnalyticsSource(state.configuration.analytics),
+  (token, {trackingId, nextApiBaseUrl}, source) =>
+    createRelay({
+      url: nextApiBaseUrl,
+      token,
+      trackingId,
+      source: source,
+    })
+);

--- a/packages/headless/src/api/analytics/analytics-selectors.test.ts
+++ b/packages/headless/src/api/analytics/analytics-selectors.test.ts
@@ -1,0 +1,23 @@
+import {createMockState} from '../../test/mock-state';
+import {VERSION} from '../../utils/version';
+import {getAnalyticsSource} from './search-analytics';
+
+describe('#getAnalyticsSources', () => {
+  it('without a source, returns an array only with `@coveo/headless`', () => {
+    const state = createMockState();
+    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
+      `@coveo/headless@${VERSION}`,
+    ]);
+  });
+
+  it('with a source, returns an array with `@coveo/headless` and the serialized framework-version pair', () => {
+    const state = createMockState();
+    state.configuration.analytics.source = {
+      '@coveo/atomic': '1.2.3',
+    };
+    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
+      `@coveo/headless@${VERSION}`,
+      '@coveo/atomic@1.2.3',
+    ]);
+  });
+});

--- a/packages/headless/src/api/analytics/analytics-selectors.test.ts
+++ b/packages/headless/src/api/analytics/analytics-selectors.test.ts
@@ -1,6 +1,6 @@
 import {createMockState} from '../../test/mock-state';
 import {VERSION} from '../../utils/version';
-import {getAnalyticsSource} from './search-analytics';
+import {getAnalyticsSource} from './analytics-selectors';
 
 describe('#getAnalyticsSources', () => {
   it('without a source, returns an array only with `@coveo/headless`', () => {

--- a/packages/headless/src/api/analytics/analytics-selectors.ts
+++ b/packages/headless/src/api/analytics/analytics-selectors.ts
@@ -1,0 +1,14 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {AnalyticsState} from '../../features/configuration/configuration-state';
+import {VERSION} from '../../utils/version';
+
+export const getAnalyticsSource = createSelector(
+  (state: AnalyticsState) => state.source,
+  (source) =>
+    [`@coveo/headless@${VERSION}`].concat(
+      Object.entries(source).map(
+        ([frameworkName, frameworkVersion]) =>
+          `${frameworkName}@${frameworkVersion}`
+      )
+    )
+);

--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -1,4 +1,3 @@
-import {createRelay} from '@coveo/relay';
 import {CoveoAnalyticsClient} from 'coveo.analytics';
 import pino from 'pino';
 import {DateFacetValue} from '../../controllers/product-listing/range-facet/date-facet/headless-product-listing-date-facet';
@@ -21,12 +20,9 @@ import {buildMockQuerySuggestSet} from '../../test/mock-query-suggest-slice';
 import {buildMockResult} from '../../test/mock-result';
 import {buildMockSearchState} from '../../test/mock-search-state';
 import {createMockState} from '../../test/mock-state';
-import {VERSION} from '../../utils/version';
 import {QuerySuggestCompletion} from '../search/query-suggest/query-suggest-response';
 import {
-  configureAnalytics,
   configureLegacyAnalytics,
-  getAnalyticsSource,
   getPageID,
   SearchAnalyticsProvider,
   StateNeededBySearchAnalyticsProvider,
@@ -475,53 +471,5 @@ describe('#configureLegacyAnalytics', () => {
         ...metadata,
       });
     });
-  });
-});
-
-describe('#configureAnalytics', () => {
-  const mockedCreateRelay = jest.mocked(createRelay).mockImplementation(() => ({
-    emit: jest.fn() as unknown as ReturnType<typeof createRelay>['emit'],
-    on: jest.fn(),
-    off: jest.fn(),
-    clearStorage: jest.fn(),
-    getMeta: jest.fn(),
-    updateConfig: jest.fn(),
-    version: 'test',
-  }));
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('creates a Relay client properly and returns the emit function', () => {
-    const state = createMockState();
-    const emit = configureAnalytics(state);
-    expect(mockedCreateRelay).toHaveBeenCalledWith({
-      url: state.configuration.analytics.nextApiBaseUrl,
-      token: state.configuration.accessToken,
-      trackingId: state.configuration.analytics.trackingId,
-      source: expect.arrayContaining([]),
-    });
-    expect(emit).toBe(mockedCreateRelay.mock.results[0].value.emit);
-  });
-});
-
-describe('#getAnalyticsSources', () => {
-  it('without a source, returns an array only with `@coveo/headless`', () => {
-    const state = createMockState();
-    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
-      `@coveo/headless@${VERSION}`,
-    ]);
-  });
-
-  it('with a source, returns an array with `@coveo/headless` and the serialized framework-version pair', () => {
-    const state = createMockState();
-    state.configuration.analytics.source = {
-      '@coveo/atomic': '1.2.3',
-    };
-    expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
-      `@coveo/headless@${VERSION}`,
-      '@coveo/atomic@1.2.3',
-    ]);
   });
 });

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -1,4 +1,3 @@
-import {createRelay} from '@coveo/relay';
 import {
   CoveoSearchPageClient,
   SearchPageClientProvider,
@@ -6,7 +5,6 @@ import {
 } from 'coveo.analytics';
 import {SearchEventRequest} from 'coveo.analytics/dist/definitions/events';
 import {Logger} from 'pino';
-import {AnalyticsState} from '../../features/configuration/configuration-state';
 import {
   buildFacetStateMetadata,
   getStateNeededForFacetMetadata,
@@ -22,7 +20,6 @@ import {getSortCriteriaInitialState} from '../../features/sort-criteria/sort-cri
 import {StaticFilterValueMetadata} from '../../features/static-filter-set/static-filter-set-actions';
 import {SearchAppState} from '../../state/search-app-state';
 import {ConfigurationSection} from '../../state/state-sections';
-import {VERSION} from '../../utils/version';
 import {PreprocessRequest} from '../preprocess-request';
 import {BaseAnalyticsProvider} from './base-analytics';
 import {
@@ -296,20 +293,6 @@ interface LegacyConfigureAnalyticsOptions {
   getState(): StateNeededBySearchAnalyticsProvider;
 }
 
-export const configureAnalytics = (
-  state: StateNeededBySearchAnalyticsProvider
-) => {
-  const token = state.configuration.accessToken;
-  const trackingId = state.configuration.analytics.trackingId;
-  const {emit} = createRelay({
-    url: state.configuration.analytics.nextApiBaseUrl,
-    token,
-    trackingId,
-    source: getAnalyticsSource(state.configuration.analytics),
-  });
-  return emit;
-};
-
 //TODO: KIT-2859
 export const configureLegacyAnalytics = ({
   logger,
@@ -365,13 +348,4 @@ export const getPageID = () => {
   }
 
   return lastPageView.value!;
-};
-
-export const getAnalyticsSource = (state: AnalyticsState) => {
-  return [`@coveo/headless@${VERSION}`].concat(
-    Object.entries(state.source).map(
-      ([frameworkName, frameworkVersion]) =>
-        `${frameworkName}@${frameworkVersion}`
-    )
-  );
 };

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -267,7 +267,7 @@ describe('engine', () => {
     expect(engine.relay).toBeDefined();
   });
 
-  it('should return the same instance of Relay if the state has not changed', () => {
+  it('should return the exact same instance of Relay if the state has not changed between two calls to engine.relay', () => {
     const engine = initEngine();
     expect(engine.relay).toBe(engine.relay);
   });

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@reduxjs/toolkit';
 import {getOrganizationEndpoints} from '../api/platform-client';
 import * as Store from '../app/store';
+import {updateAnalyticsConfiguration} from '../features/configuration/configuration-actions';
 import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments';
 import {configuration} from './common-reducers';
 import {buildEngine, CoreEngine, EngineOptions} from './engine';
@@ -28,6 +29,7 @@ describe('engine', () => {
   function initEngine() {
     const thunkArguments = buildMockThunkExtraArguments();
     engine = buildEngine(options, thunkArguments);
+    return engine;
   }
 
   beforeEach(() => {
@@ -258,5 +260,24 @@ describe('engine', () => {
         });
       });
     });
+  });
+
+  it('should exposes a Relay instance', () => {
+    const engine = initEngine();
+    expect(engine.relay).toBeDefined();
+  });
+
+  it('should return the same instance of Relay if the state has not changed', () => {
+    const engine = initEngine();
+    expect(engine.relay).toBe(engine.relay);
+  });
+
+  it('should return a new instance of Relay if the state has changed', () => {
+    const engine = initEngine();
+    const oldRelay = engine.relay;
+    engine.dispatch(
+      updateAnalyticsConfiguration({trackingId: 'newTrackingId'})
+    );
+    expect(engine.relay).not.toBe(oldRelay);
   });
 });

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -1,4 +1,5 @@
 import {isNullOrUndefined, isUndefined} from '@coveo/bueno';
+import {type Relay} from '@coveo/relay';
 import {
   AnyAction,
   Dispatch,
@@ -10,6 +11,7 @@ import {
   Reducer,
 } from '@reduxjs/toolkit';
 import {Logger} from 'pino';
+import {getRelayInstanceFromState} from '../api/analytics/analytics-relay-client';
 import {
   disableAnalytics,
   enableAnalytics,
@@ -67,6 +69,10 @@ export interface CoreEngine<
    * The complete headless state tree.
    */
   state: State & CoreState;
+  /**
+   * The Relay instance used by Headless.
+   */
+  relay: Relay;
   /**
    * The redux store.
    */
@@ -263,6 +269,10 @@ function buildCoreEngine<
 
     get state() {
       return store.getState();
+    },
+
+    get relay() {
+      return getRelayInstanceFromState(this.state);
     },
 
     logger,

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -3,6 +3,7 @@ import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
 polyfillCryptoNode();
 // 3rd Party Libraries
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 // Main App
 export type {

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -2,6 +2,7 @@ import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
 
 polyfillCryptoNode();
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 export type {
   CommerceEngine,

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -26,6 +26,7 @@ import {
   DocumentIdentifier,
 } from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents';
 import {Logger} from 'pino';
+import {getRelayInstanceFromState} from '../../api/analytics/analytics-relay-client';
 import {
   CaseAssistAnalyticsProvider,
   configureCaseAssistAnalytics,
@@ -49,7 +50,6 @@ import {
 } from '../../api/analytics/product-listing-analytics';
 import {StateNeededByProductRecommendationsAnalyticsProvider} from '../../api/analytics/product-recommendations-analytics';
 import {
-  configureAnalytics,
   configureLegacyAnalytics,
   SearchAnalyticsProvider,
   StateNeededBySearchAnalyticsProvider,
@@ -509,7 +509,7 @@ const internalMakeAnalyticsAction = <
           );
         }
       });
-      const emitEvent = configureAnalytics(state);
+      const {emit} = getRelayInstanceFromState(state);
       loggers.push(async (state: LegacyStateNeeded & StateNeeded) => {
         if (
           shouldSendNextEvent(state) &&
@@ -517,7 +517,7 @@ const internalMakeAnalyticsAction = <
           analyticsPayloadBuilder
         ) {
           const payload = analyticsPayloadBuilder(state);
-          await logNextEvent(emitEvent, analyticsType, payload);
+          await logNextEvent(emit, analyticsType, payload);
         }
       });
       return analyticsAction;

--- a/packages/headless/src/features/configuration/analytics-params.ts
+++ b/packages/headless/src/features/configuration/analytics-params.ts
@@ -1,9 +1,7 @@
 import {EventDescription} from 'coveo.analytics';
+import {getAnalyticsSource} from '../../api/analytics/analytics-selectors';
 import {getVisitorID} from '../../api/analytics/coveo-analytics-utils';
-import {
-  getAnalyticsSource,
-  getPageID,
-} from '../../api/analytics/search-analytics';
+import {getPageID} from '../../api/analytics/search-analytics';
 import {AnalyticsParam} from '../../api/search/search-api-params';
 import {AnalyticsState} from './configuration-state';
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -18,6 +18,7 @@ polyfillCryptoNode();
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 export {createAction, createAsyncThunk, createReducer} from '@reduxjs/toolkit';
 export type {AnalyticsClientSendEventHook} from 'coveo.analytics';
+export type {Relay} from '@coveo/relay';
 
 // Main App
 export type {

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -4,6 +4,7 @@ import * as HighlightUtils from './utils/highlight';
 polyfillCryptoNode();
 // 3rd Party Libraries
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 // Main App
 export type {

--- a/packages/headless/src/product-listing.index.ts
+++ b/packages/headless/src/product-listing.index.ts
@@ -2,6 +2,7 @@ import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
 
 polyfillCryptoNode();
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 export type {
   ProductListingEngine,

--- a/packages/headless/src/product-recommendation.index.ts
+++ b/packages/headless/src/product-recommendation.index.ts
@@ -3,6 +3,7 @@ import {polyfillCryptoNode} from './api/analytics/analytics-crypto-polyfill';
 polyfillCryptoNode();
 
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 export type {
   ProductRecommendationEngine,

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -5,6 +5,7 @@ export {HighlightUtils};
 
 polyfillCryptoNode();
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
+export type {Relay} from '@coveo/relay';
 
 export type {
   RecommendationEngine,

--- a/packages/headless/src/ssr.index.ts
+++ b/packages/headless/src/ssr.index.ts
@@ -6,6 +6,7 @@ polyfillCryptoNode();
 export type {Unsubscribe, Middleware} from '@reduxjs/toolkit';
 export {createAction, createAsyncThunk, createReducer} from '@reduxjs/toolkit';
 export type {AnalyticsClientSendEventHook} from 'coveo.analytics';
+export type {Relay} from '@coveo/relay';
 
 // Main App
 export type {

--- a/packages/headless/src/test/mock-engine-v2.ts
+++ b/packages/headless/src/test/mock-engine-v2.ts
@@ -1,3 +1,4 @@
+import {Relay} from '@coveo/relay';
 import pino, {Logger} from 'pino';
 import {CaseAssistEngine} from '../app/case-assist-engine/case-assist-engine';
 import {CommerceEngine} from '../app/commerce-engine/commerce-engine';
@@ -32,12 +33,27 @@ function mockLogger(logger: Logger): MockedLogger {
   });
 }
 
+type MockedRelay = Relay & Pick<Relay, 'emit'>;
+
+function mockRelay(): MockedRelay {
+  return {
+    clearStorage: jest.fn(),
+    emit: jest.fn(),
+    getMeta: jest.fn(),
+    off: jest.fn(),
+    on: jest.fn(),
+    updateConfig: jest.fn(),
+    version: 'test',
+  };
+}
+
 type MockedCoreEngine<
   State extends StateFromEngine<CoreEngine> = StateFromEngine<CoreEngine>,
 > = CoreEngine & {
   state: State;
   logger: MockedLogger;
-} & SpyEverything<Omit<CoreEngine, 'logger' | 'state'>>;
+  relay: MockedRelay;
+} & SpyEverything<Omit<CoreEngine, 'logger' | 'state' | 'relay'>>;
 
 export function buildMockCoreEngine<State extends StateFromEngine<CoreEngine>>(
   initialState: State
@@ -50,6 +66,7 @@ export function buildMockCoreEngine<State extends StateFromEngine<CoreEngine>>(
     disableAnalytics: jest.fn(),
     enableAnalytics: jest.fn(),
     logger: mockLogger(pino({level: 'silent'})),
+    relay: mockRelay(),
     store: {
       dispatch: jest.fn(),
       getState: jest.fn(),

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -249,7 +249,7 @@ function buildMockCoreEngine<T extends AppState>(
       return isAsyncAction<ThunkArg>(action) ? action : undefined;
     },
     get relay(): Relay {
-      throw 'Use mock-engine-v2 instead.';
+      return null as unknown as Relay;
     },
     logger,
     addReducers: jest.fn(),

--- a/packages/headless/src/test/mock-engine.ts
+++ b/packages/headless/src/test/mock-engine.ts
@@ -1,3 +1,4 @@
+import {Relay} from '@coveo/relay';
 import {
   AnyAction,
   ThunkDispatch,
@@ -246,6 +247,9 @@ function buildMockCoreEngine<T extends AppState>(
     findAsyncAction<ThunkArg>(actionCreator: AsyncActionCreator<ThunkArg>) {
       const action = this.actions.find((a) => a.type === actionCreator.type);
       return isAsyncAction<ThunkArg>(action) ? action : undefined;
+    },
+    get relay(): Relay {
+      throw 'Use mock-engine-v2 instead.';
     },
     logger,
     addReducers: jest.fn(),


### PR DESCRIPTION
- Refactor the configureAnalytics & getAnalyticsSource
  - Make them into memoized selectors to shave off some computing
- Exposes Relay onto the engine.

KIT-3018