### PR TITLE
feat(headless/commerce): set currency type as currency code iso4217 instead of string

### DIFF
--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -164,9 +164,8 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
     return isCurrentQuantityGreater ? 'add' : 'remove';
   }
 
-  // @todo LENS-1589: currently, the currency attribute is a string. However, the type should be CurrencyCodeISO4217
   function getCurrency(): CurrencyCodeISO4217 {
-    return engine.state.commerceContext.currency as CurrencyCodeISO4217;
+    return engine.state.commerceContext.currency;
   }
 
   function isEqual(

--- a/packages/headless/src/controllers/commerce/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.test.ts
@@ -4,6 +4,7 @@ import {
   setView,
 } from '../../../features/commerce/context/context-actions';
 import {contextReducer} from '../../../features/commerce/context/context-slice';
+import {CommerceContextState} from '../../../features/commerce/context/context-state';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
   MockedCommerceEngine,
@@ -14,7 +15,7 @@ import {buildContext, Context} from './headless-context';
 jest.mock('../../../features/commerce/context/context-actions');
 
 describe('headless commerce context', () => {
-  const options = {
+  const options: CommerceContextState = {
     trackingId: 'some-tracking-id',
     language: 'en',
     country: 'us',
@@ -70,9 +71,9 @@ describe('headless commerce context', () => {
   });
 
   it('setCurrency dispatches #setContext', () => {
-    context.setCurrency('new-currency');
+    context.setCurrency('CAD');
     expect(setContext).toHaveBeenCalledWith(
-      expect.objectContaining({currency: 'new-currency'})
+      expect.objectContaining({currency: 'CAD'})
     );
   });
 

--- a/packages/headless/src/controllers/commerce/context/headless-context.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.ts
@@ -1,3 +1,4 @@
+import {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
 import {
   setContext,
@@ -17,7 +18,7 @@ export interface ContextOptions {
   trackingId: string;
   language: string;
   country: string;
-  currency: string;
+  currency: CurrencyCodeISO4217;
   user?: User;
   view: View;
 }
@@ -73,7 +74,7 @@ export interface Context extends Controller {
    * Sets the currency.
    * @param currency - The new currency.
    */
-  setCurrency(currency: string): void;
+  setCurrency(currency: CurrencyCodeISO4217): void;
 
   /**
    * Sets the user.
@@ -97,7 +98,7 @@ export interface ContextState {
   trackingId: string;
   language: string;
   country: string;
-  currency: string;
+  currency: CurrencyCodeISO4217;
   user?: User;
   view: View;
 }
@@ -166,7 +167,7 @@ export function buildContext(
         })
       ),
 
-    setCurrency: (currency: string) =>
+    setCurrency: (currency: CurrencyCodeISO4217) =>
       dispatch(
         setContext({
           ...getState().commerceContext,

--- a/packages/headless/src/features/commerce/context/context-actions.ts
+++ b/packages/headless/src/features/commerce/context/context-actions.ts
@@ -1,4 +1,5 @@
 import {SchemaValidationError, isNullOrUndefined} from '@coveo/bueno';
+import {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {createAction} from '@reduxjs/toolkit';
 import {
   UserParams,
@@ -18,7 +19,7 @@ export interface SetContextPayload {
   trackingId: string;
   language: string;
   country: string;
-  currency: string;
+  currency: CurrencyCodeISO4217;
   user?: UserParams;
   view: ViewParams;
 }

--- a/packages/headless/src/features/commerce/context/context-state.ts
+++ b/packages/headless/src/features/commerce/context/context-state.ts
@@ -1,3 +1,4 @@
+import {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {
   UserParams,
   ViewParams,
@@ -7,7 +8,7 @@ export interface CommerceContextState {
   trackingId: string;
   language: string;
   country: string;
-  currency: string;
+  currency: CurrencyCodeISO4217;
   user?: UserParams;
   view: ViewParams;
 }
@@ -16,7 +17,7 @@ export const getContextInitialState = (): CommerceContextState => ({
   trackingId: '',
   language: '',
   country: '',
-  currency: '',
+  currency: '' as CurrencyCodeISO4217,
   view: {
     url: '',
   },

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -1,9 +1,15 @@
-import {RecordValue, Schema} from '@coveo/bueno';
+import {RecordValue, Schema, StringValue} from '@coveo/bueno';
+import {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {
   nonEmptyString,
   nonRequiredEmptyAllowedString,
   requiredNonEmptyString,
 } from '../../../utils/validate-payload';
+
+export const currencyDefinition = new StringValue<CurrencyCodeISO4217>({
+  required: true,
+  emptyAllowed: false,
+});
 
 export const viewDefinition = {
   url: requiredNonEmptyString,
@@ -21,7 +27,7 @@ export const contextDefinition = {
   trackingId: requiredNonEmptyString,
   language: requiredNonEmptyString,
   country: requiredNonEmptyString,
-  currency: requiredNonEmptyString,
+  currency: currencyDefinition,
   user: new RecordValue({
     values: {
       ...userDefinition,

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -6,9 +6,12 @@ import {
   requiredNonEmptyString,
 } from '../../../utils/validate-payload';
 
+const currencies = Intl.supportedValuesOf('currency') as CurrencyCodeISO4217[];
+
 const currencyDefinition = new StringValue<CurrencyCodeISO4217>({
   required: true,
   emptyAllowed: false,
+  constrainTo: currencies,
 });
 
 export const viewDefinition = {

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -6,7 +6,7 @@ import {
   requiredNonEmptyString,
 } from '../../../utils/validate-payload';
 
-export const currencyDefinition = new StringValue<CurrencyCodeISO4217>({
+const currencyDefinition = new StringValue<CurrencyCodeISO4217>({
   required: true,
   emptyAllowed: false,
 });

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -41,7 +41,7 @@ describe.skip('commerce', () => {
         trackingId: 'barca',
         language: 'en-gb',
         country: 'gb',
-        currency: 'gbp',
+        currency: 'GBP',
         view: {
           url: 'https://sports-dev.barca.group/browse/promotions/surf-with-us-this-year',
         },

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "isolatedModules": true,
     "declaration": false,
-    "lib": ["DOM", "ES2019"],
+    "lib": ["DOM", "ES2019", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Jira: https://coveord.atlassian.net/browse/LENS-1589

This branch is to change the type of the currency set in the commerce state (context-state). It was a `string`, it's now switch to `CurrencyCodeISO4217`. 

By doing this, the value set by the user for the commerce context will be type-checked differently (illustrate by the demo below):

https://github.com/coveo/ui-kit/assets/58052881/472fbfd2-b1c6-415e-9107-2076b997d592
