### PR TITLE
feat(headless): forbid next analytics on defunct engines

### DIFF
--- a/packages/headless/src/app/product-listing-engine/product-listing-engine-configuration.ts
+++ b/packages/headless/src/app/product-listing-engine/product-listing-engine-configuration.ts
@@ -1,7 +1,13 @@
-import {Schema} from '@coveo/bueno';
+import {
+  BooleanValue,
+  RecordValue,
+  Schema,
+  SchemaDefinition,
+  StringValue,
+} from '@coveo/bueno';
+import {requiredNonEmptyString} from '../../utils/validate-payload';
 import {
   EngineConfiguration,
-  engineConfigurationDefinitions,
   getSampleEngineConfiguration,
 } from '../engine-configuration';
 
@@ -10,6 +16,42 @@ import {
  */
 export interface ProductListingEngineConfiguration
   extends EngineConfiguration {}
+
+const engineConfigurationDefinitions: SchemaDefinition<EngineConfiguration> = {
+  organizationId: requiredNonEmptyString,
+  accessToken: requiredNonEmptyString,
+  platformUrl: new StringValue({
+    required: false,
+    emptyAllowed: false,
+  }),
+  name: new StringValue({
+    required: false,
+    emptyAllowed: false,
+  }),
+  analytics: new RecordValue({
+    options: {
+      required: false,
+    },
+    values: {
+      enabled: new BooleanValue({
+        required: false,
+      }),
+      originContext: new StringValue({
+        required: false,
+      }),
+      originLevel2: new StringValue({
+        required: false,
+      }),
+      originLevel3: new StringValue({
+        required: false,
+      }),
+      analyticsMode: new StringValue<'legacy'>({
+        constrainTo: ['legacy'],
+        required: false,
+      }),
+    },
+  }),
+};
 
 export const productListingEngineConfigurationSchema =
   new Schema<ProductListingEngineConfiguration>({

--- a/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine-configuration.ts
+++ b/packages/headless/src/app/product-recommendation-engine/product-recommendation-engine-configuration.ts
@@ -1,8 +1,16 @@
-import {Schema} from '@coveo/bueno';
-import {nonEmptyString} from '../../utils/validate-payload';
+import {
+  BooleanValue,
+  RecordValue,
+  Schema,
+  SchemaDefinition,
+  StringValue,
+} from '@coveo/bueno';
+import {
+  nonEmptyString,
+  requiredNonEmptyString,
+} from '../../utils/validate-payload';
 import {
   EngineConfiguration,
-  engineConfigurationDefinitions,
   getSampleEngineConfiguration,
 } from '../engine-configuration';
 
@@ -37,13 +45,50 @@ export interface ProductRecommendationEngineConfiguration
   timezone?: string;
 }
 
-export const productRecommendationEngineConfigurationSchema =
-  new Schema<ProductRecommendationEngineConfiguration>({
-    ...engineConfigurationDefinitions,
+const engineConfigurationDefinitions: SchemaDefinition<ProductRecommendationEngineConfiguration> =
+  {
+    organizationId: requiredNonEmptyString,
+    accessToken: requiredNonEmptyString,
+    platformUrl: new StringValue({
+      required: false,
+      emptyAllowed: false,
+    }),
+    name: new StringValue({
+      required: false,
+      emptyAllowed: false,
+    }),
+    analytics: new RecordValue({
+      options: {
+        required: false,
+      },
+      values: {
+        enabled: new BooleanValue({
+          required: false,
+        }),
+        originContext: new StringValue({
+          required: false,
+        }),
+        originLevel2: new StringValue({
+          required: false,
+        }),
+        originLevel3: new StringValue({
+          required: false,
+        }),
+        analyticsMode: new StringValue<'legacy'>({
+          constrainTo: ['legacy'],
+          required: false,
+        }),
+      },
+    }),
     searchHub: nonEmptyString,
     locale: nonEmptyString,
     timezone: nonEmptyString,
-  });
+  };
+
+export const productRecommendationEngineConfigurationSchema =
+  new Schema<ProductRecommendationEngineConfiguration>(
+    engineConfigurationDefinitions
+  );
 
 /**
  * Creates a sample product recommendation engine configuration.


### PR DESCRIPTION
Because the engines are defunct, I acted a bit lazy and decided to copy-paste the schema definitions.

https://coveord.atlassian.net/browse/KIT-2990