### PR TITLE
fix(atomic): fix search disabled check for query suggestion

### DIFF
--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -559,6 +559,7 @@ describe('Search Box Test Suites', () => {
     const testQuery = 'test';
     const numOfSuggestions = 2;
     const minimumQueryLength = testQuery.length;
+
     beforeEach(() => {
       new TestFixture()
         .with(setSuggestions(numOfSuggestions))
@@ -571,38 +572,57 @@ describe('Search Box Test Suites', () => {
     });
 
     it('should be accessible', () => {
-      CommonAssertions.assertAccessibility(searchBoxComponent);
+      CommonAssertions.assertAccessibilityWithoutIt(searchBoxComponent);
     });
 
     it('search button is enabled when a query with minimum length is input', () => {
-      typeSearchInput(testQuery.slice(0, minimumQueryLength - 1)); // enter query less than min len
+      SearchBoxSelectors.inputBox()
+        .clear()
+        .type(testQuery.slice(0, minimumQueryLength - 1));
+
+      cy.wait(500);
+
       SearchBoxSelectors.submitButton().should('be.disabled');
       SearchBoxAssertions.assertNoSuggestionGenerated();
 
-      typeSearchInput(testQuery.slice(minimumQueryLength - 1)); // enter rest of the query
-      SearchBoxSelectors.submitButton().should('not.be.disabled');
+      SearchBoxSelectors.inputBox().type(
+        testQuery.slice(minimumQueryLength - 1)
+      );
 
-      typeSearchInput('{downarrow}'.repeat(numOfSuggestions));
-      SearchBoxAssertions.assertHasSuggestionsCount(numOfSuggestions);
-      SearchBoxAssertions.assertSuggestionIsSelected(numOfSuggestions);
+      cy.wait(500);
+
+      SearchBoxSelectors.submitButton().should('not.be.disabled');
+      SearchBoxAssertions.assertHasSuggestionsCountWithoutIt(numOfSuggestions);
+
+      SearchBoxSelectors.inputBox().type(
+        '{downarrow}'.repeat(numOfSuggestions)
+      );
+
+      SearchBoxAssertions.assertSuggestionIsSelectedWithoutIt(
+        numOfSuggestions - 1
+      );
     });
 
     it('search button is disabled when query is deleted', () => {
-      typeSearchInput(testQuery);
+      SearchBoxSelectors.inputBox().type(testQuery);
+
       SearchBoxSelectors.submitButton().should('not.be.disabled');
 
-      typeSearchInput('{backspace}'.repeat(minimumQueryLength), '');
+      SearchBoxSelectors.inputBox().type(
+        '{backspace}'.repeat(minimumQueryLength)
+      );
       SearchBoxSelectors.submitButton().should('be.disabled');
     });
 
     it('clear button should appear or disappear depending on the content of the input', () => {
-      typeSearchInput(testQuery);
+      SearchBoxSelectors.inputBox().type(testQuery);
+
       SearchBoxSelectors.clearButton().should('exist');
-      typeSearchInput(
-        Array.from({length: testQuery.length})
-          .map(() => '{backspace}')
-          .join('')
+
+      SearchBoxSelectors.inputBox().type(
+        '{backspace}'.repeat(testQuery.length)
       );
+
       SearchBoxSelectors.clearButton().should('not.exist');
     });
   });

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -863,7 +863,11 @@ export class AtomicSearchBox {
     );
   }
 
-  private isSearchDisabledForEndUser(queryValue: string) {
+  private isSearchDisabledForEndUser(queryValue?: string) {
+    if (isNullOrUndefined(queryValue)) {
+      return this.disableSearch;
+    }
+
     if (queryValue.trim().length < this.minimumQueryLength) {
       return true;
     }


### PR DESCRIPTION
* In atomic-search-box, remove `@State() private isSearchDisabled` and instead add a `isSearchDisabledForEndUser` function which returns true if either the `disableSearch` prop is set to true, or if the content of the input is not long enough.
* Modify some tests in cypress regarding this.

The reason to have a function to check this is because it's possible that `disableSearch` prop is controlled by implementer for other reasons than the content of the input. 

So it makes sense to have the "disabled because of the generic prop" to be decoupled from the "disabled because of the length of the input", and not conflate them with one another.

Hopefully with the name of the function, it makes it clearer why/when the input actually get disabled for the end user, and that using the prop directly to derive the state of the input, or control if query suggestions should be requested or not is clearer.


https://coveord.atlassian.net/browse/KIT-3020