### PR TITLE
feat(headless): in development, rebuild modules with source maps 

### DIFF
--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -87,15 +87,23 @@ const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${outDir}/headless.esm.js`;
+  const config = {
+    entryPoints: [entryPoint],
+    outfile,
+    format: 'esm',
+  };
 
-  return buildBrowserConfig(
-    {
-      entryPoints: [entryPoint],
-      outfile,
-      format: 'esm',
-    },
-    outDir
-  );
+  return devMode
+    ? buildBrowserConfig(
+        {
+          ...config,
+          watch: devMode,
+          minify: false,
+          sourcemap: true,
+        },
+        outDir
+      )
+    : buildBrowserConfig(config, outDir);
 });
 
 const browserUmd = Object.entries(useCaseEntries).map((entry) => {

--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -87,23 +87,23 @@ const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('dist/browser', useCase);
   const outfile = `${outDir}/headless.esm.js`;
-  const config = {
+
+  let config = {
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
   };
 
-  return devMode
-    ? buildBrowserConfig(
-        {
-          ...config,
-          watch: devMode,
-          minify: false,
-          sourcemap: true,
-        },
-        outDir
-      )
-    : buildBrowserConfig(config, outDir);
+  if (devMode) {
+    config = {
+      ...config,
+      watch: true,
+      minify: false,
+      sourcemap: true,
+    };
+  }
+
+  return buildBrowserConfig(config, outDir);
 });
 
 const browserUmd = Object.entries(useCaseEntries).map((entry) => {


### PR DESCRIPTION
## [CAPI-646]

### Proposed changes

Build ui-kit, with the immediate use case of Headless, in dev on file change for hot reloading when debugging with Barca Sports. Also, remove minification and add source maps to allow debugging alongside an implementation.

Companion PR in Barca Sports [#192](https://github.com/coveo/barca-sports/pull/192)

Hot reloading example
https://github.com/coveo/ui-kit/assets/15649627/825480c4-79c2-45b6-b9c6-e97fd8309e5c

Debugging with source maps example
Uploading Screen Recording 2024-03-08 at 18.03.23.mov…

### How to test

Link with Barca sports, using `yarn link` and add console.logs into the the running headless code. Changes should be reflected in the browser.

### Checklist:

- [x] Service tested locally
 


[CAPI-646]: https://coveord.atlassian.net/browse/CAPI-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ