### PR TITLE
chore: run setup on gh runner first, remove dup build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
         with:
           ref: 'release/v2'
       - uses: ./.github/actions/setup
-      - name: Build
-        run: npm run build
       - name: Start deployment pipeline
         run: node ./scripts/deploy/execute-deployment-pipeline.mjs
   promote-prod:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-        with:
-          registry-url: 'https://registry.npmjs.org'
-          node-version-file: '.nvmrc'
-      - name: Install npm
-        run: npm i -g npm@10
-        shell: bash
-      - run: npm ci
-        shell: bash
+      - uses: ./.github/actions/setup
       - name: Release
         run: npm run release
         env:


### PR DESCRIPTION
By doing the following, we'll leverage the cache mechanism integrated into our setup action.
This will ensure that we have a cache built on the release stage, ready to be used in the `start-deployment` job.

Also, we don't need to build after setup.