### PR TITLE
chore: add missing registry-url

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
       with:
+        registry-url: 'https://registry.npmjs.org'
         node-version-file: '.nvmrc'
     - name: Ensure Nx cache can be shared between different CI environments # Source: https://nx.dev/recipes/troubleshooting/unknown-local-cache
       run: echo "NX_REJECT_UNKNOWN_LOCAL_CACHE=0" >> $GITHUB_ENV


### PR DESCRIPTION
We need `registry-url` to be able to publish on NPM.
No impact for other use case.