### PR TITLE
chore: enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
   release:
     environment: 'Release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:

--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -37,7 +37,7 @@ if (!name || !version) {
 }
 if (!(await isPublished(name, version))) {
   const tagToPublish = isPrerelease ? 'alpha' : 'beta';
-  await npmPublish('.', {tag: tagToPublish});
+  await npmPublish('.', {tag: tagToPublish, provenance: !isPrerelease});
   await retry(
     async () => {
       if (!(await isPublished(name, version, tagToPublish))) {


### PR DESCRIPTION
Should allow to have a ✅ on NPM.
Might become a requirement to comply with CSEC.