### PR TITLE
chore(IPX+IP): remove filters top title

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.tsx
@@ -108,9 +108,6 @@ export class AtomicInsightRefineModal
   private renderHeader() {
     return (
       <div class="w-full flex justify-between mb-3">
-        <h2 class="text-2xl font-bold truncate">
-          {this.bindings.i18n.t('filters')}
-        </h2>
         {this.breadcrumbManagerState.hasBreadcrumbs && (
           <Button
             onClick={() => this.breadcrumbManager.deselectAll()}

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.tsx
@@ -84,9 +84,6 @@ export class AtomicIPXRefineModal implements InitializableComponent {
   private renderHeader() {
     return (
       <div class="w-full flex justify-between mb-3">
-        <h2 class="text-2xl font-bold truncate">
-          {this.bindings.i18n.t('filters')}
-        </h2>
         {this.breadcrumbManagerState.hasBreadcrumbs && (
           <Button
             onClick={() => this.breadcrumbManager.deselectAll()}


### PR DESCRIPTION
Remove double filters title in IPX and Insight since we don't have sorts for IPX and SPs

|   | Before | After |
| ------------- | ------------- | ------------- |
| IPX  | <img width="521" alt="image" src="https://github.com/coveo/ui-kit/assets/64476861/962cb9e0-6c10-4abc-98f1-98e04603fe33">l  | <img width="522" alt="image" src="https://github.com/coveo/ui-kit/assets/64476861/8a1e7fe8-d74b-4e98-bcbe-96f89fe17e43">  |
| Insight  | <img width="528" alt="image" src="https://github.com/coveo/ui-kit/assets/64476861/dc5dcc73-90a5-434d-8011-ec668effb6e0">  | <img width="573" alt="image" src="https://github.com/coveo/ui-kit/assets/64476861/8466382f-0f07-4c01-8e0d-5ff96dbe57a0">  |