### PR TITLE
fix: remove trackingId from commerce context

### DIFF
--- a/packages/headless/src/controllers/commerce/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.test.ts
@@ -16,7 +16,6 @@ jest.mock('../../../features/commerce/context/context-actions');
 
 describe('headless commerce context', () => {
   const options: CommerceContextState = {
-    trackingId: 'some-tracking-id',
     language: 'en',
     country: 'us',
     currency: 'USD',
@@ -47,13 +46,6 @@ describe('headless commerce context', () => {
 
   it('dispatches #setContext on load', () => {
     expect(setContext).toHaveBeenCalled();
-  });
-
-  it('setTrackingId dispatches #setContext', () => {
-    context.setTrackingId('new-tracking-id');
-    expect(setContext).toHaveBeenCalledWith(
-      expect.objectContaining({trackingId: 'new-tracking-id'})
-    );
   });
 
   it('setLanguage dispatches #setContext', () => {

--- a/packages/headless/src/controllers/commerce/context/headless-context.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.ts
@@ -15,7 +15,6 @@ import {
 } from '../../controller/headless-controller';
 
 export interface ContextOptions {
-  trackingId: string;
   language: string;
   country: string;
   currency: CurrencyCodeISO4217;
@@ -53,12 +52,6 @@ export interface ContextProps {
  */
 export interface Context extends Controller {
   /**
-   * Sets the tracking ID.
-   * @param trackingId - The new tracking ID.
-   */
-  setTrackingId(trackingId: string): void;
-
-  /**
    * Sets the language.
    * @param language - The new language.
    */
@@ -95,7 +88,6 @@ export interface Context extends Controller {
 }
 
 export interface ContextState {
-  trackingId: string;
   language: string;
   country: string;
   currency: CurrencyCodeISO4217;
@@ -142,14 +134,6 @@ export function buildContext(
     get state() {
       return getState().commerceContext;
     },
-
-    setTrackingId: (trackingId: string) =>
-      dispatch(
-        setContext({
-          ...getState().commerceContext,
-          trackingId,
-        })
-      ),
 
     setLanguage: (language: string) =>
       dispatch(

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -49,6 +49,7 @@ export const buildCommerceAPIRequest = async (
   return {
     accessToken: state.configuration.accessToken,
     url: state.configuration.platformUrl,
+    trackingId: state.configuration.analytics.trackingId,
     organizationId: state.configuration.organizationId,
     ...restOfContext,
     clientId: await getVisitorID(state.configuration.analytics),

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -49,8 +49,8 @@ export const buildCommerceAPIRequest = async (
   return {
     accessToken: state.configuration.accessToken,
     url: state.configuration.platformUrl,
-    trackingId: state.configuration.analytics.trackingId,
     organizationId: state.configuration.organizationId,
+    trackingId: state.configuration.analytics.trackingId,
     ...restOfContext,
     clientId: await getVisitorID(state.configuration.analytics),
     context: {

--- a/packages/headless/src/features/commerce/context/context-actions.ts
+++ b/packages/headless/src/features/commerce/context/context-actions.ts
@@ -16,7 +16,6 @@ import {
 } from './context-validation';
 
 export interface SetContextPayload {
-  trackingId: string;
   language: string;
   country: string;
   currency: CurrencyCodeISO4217;

--- a/packages/headless/src/features/commerce/context/context-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/context-slice.test.ts
@@ -19,7 +19,6 @@ describe('context-slice', () => {
       contextReducer(
         state,
         setContext({
-          trackingId: 'some-tracking-id',
           language: 'fr',
           country: 'ca',
           currency: 'CAD',
@@ -29,7 +28,6 @@ describe('context-slice', () => {
         })
       )
     ).toEqual({
-      trackingId: 'some-tracking-id',
       language: 'fr',
       country: 'ca',
       currency: 'CAD',

--- a/packages/headless/src/features/commerce/context/context-state.ts
+++ b/packages/headless/src/features/commerce/context/context-state.ts
@@ -5,7 +5,6 @@ import {
 } from '../../../api/commerce/commerce-api-params';
 
 export interface CommerceContextState {
-  trackingId: string;
   language: string;
   country: string;
   currency: CurrencyCodeISO4217;
@@ -14,7 +13,6 @@ export interface CommerceContextState {
 }
 
 export const getContextInitialState = (): CommerceContextState => ({
-  trackingId: '',
   language: '',
   country: '',
   currency: '' as CurrencyCodeISO4217,

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -27,7 +27,6 @@ export const userDefinition = {
 };
 
 export const contextDefinition = {
-  trackingId: requiredNonEmptyString,
   language: requiredNonEmptyString,
   country: requiredNonEmptyString,
   currency: currencyDefinition,

--- a/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
@@ -68,8 +68,8 @@ export const buildQuerySuggestRequest = async (
   return {
     accessToken: state.configuration.accessToken,
     url: state.configuration.platformUrl,
-    trackingId: state.configuration.analytics.trackingId,
     organizationId: state.configuration.organizationId,
+    trackingId: state.configuration.analytics.trackingId,
     query: state.querySet[id],
     ...restOfContext,
     clientId: await getVisitorID(state.configuration.analytics),

--- a/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
@@ -68,6 +68,7 @@ export const buildQuerySuggestRequest = async (
   return {
     accessToken: state.configuration.accessToken,
     url: state.configuration.platformUrl,
+    trackingId: state.configuration.analytics.trackingId,
     organizationId: state.configuration.organizationId,
     query: state.querySet[id],
     ...restOfContext,

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -32,13 +32,15 @@ describe.skip('commerce', () => {
         organizationEndpoints: {
           ...getOrganizationEndpoints(organizationId, 'dev'),
         },
+        analytics: {
+          trackingId: 'barca',
+        },
       },
       loggerOptions: {level: 'silent'},
     });
 
     buildContext(engine, {
       options: {
-        trackingId: 'barca',
         language: 'en-gb',
         country: 'gb',
         currency: 'GBP',


### PR DESCRIPTION
The commerce engine was storing `trackingId` under commerce context, but the value was already available under the `configuration` slice. This was creating two sources of truth for `trackingId` on the commerce engine. If `trackingId` was set on init of the engine, it would not be used.

This PR resolves the duplication and uses the value on the `configuration` slice.
We're making this breaking change now to get ahead of customer adoption.