### PR TITLE
fix(atomic): fix query suggestions mismatch on searchbox disabled + manual input clear

### DIFF
--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -511,6 +511,7 @@ export class AtomicSearchBox {
     this.searchBox.updateText(value);
 
     if (this.isSearchDisabledForEndUser(value)) {
+      this.clearSuggestions();
       return;
     }
     this.isExpanded = true;


### PR DESCRIPTION
As described in the JIRA, the previous fix was partial: When the end user clears the input "manually" (by erasing the content with backspace) to go back under `minimumQueryLength`, then types again, there was a query suggestion mismatch that would appear briefly.

Proposed fix is to always `clearSuggestions()` on input if search box is disabled.

https://coveord.atlassian.net/browse/KIT-3020