### PR TITLE
chore: disable github-pkg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,15 @@ jobs:
           RELEASER_INSTALLATION_ID: ${{ secrets.RELEASER_INSTALLATION_ID }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-        with:
-          registry-url: 'https://npm.pkg.github.com'
-          node-version-file: '.nvmrc'
-      - name: Publish to GitHub Packages
-        run: npm run release:phase5
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: ${{ inputs.debug && '*' || '' }}
+      # - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+      #   with:
+      #     registry-url: 'https://npm.pkg.github.com'
+      #     node-version-file: '.nvmrc'
+      # - name: Publish to GitHub Packages
+      #   run: npm run release:phase5
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     DEBUG: ${{ inputs.debug && '*' || '' }}
   start-deployment:
     needs: release
     runs-on: [coveo, linux, x64, ec2]


### PR DESCRIPTION
Disabling this step for now, we reenable for future release.

In the latest [releases run](https://github.com/coveo/ui-kit/actions/runs/8254691568/job/22579419419) (and a few before), the release log are mangled for this specific action, for unknown reasons.
Manual runs on a 'full clone' of the repo is required/recommended but will likely take a good chunk of time.
We still want to release to the main channels (NPM/S3) in the meantime, so for now, we disable the GH PKG channel publishing