### PR TITLE
chore: add ztsd to coveo-hosted-runner for cache consistency

### DIFF
--- a/.github/actions/setup-ztsd/action.yml
+++ b/.github/actions/setup-ztsd/action.yml
@@ -1,0 +1,9 @@
+name: 'Setup ZTSD'
+description: Setup ZTSD in Self-Hosted Runner for Cache Consistency with GitHub-Hosted Runner
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        sudo apt update
+        sudo apt install zstd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: 'release/v2'
+      - uses: ./.github/actions/setup-ztsd
       - uses: ./.github/actions/setup
       - name: Start deployment pipeline
         run: node ./scripts/deploy/execute-deployment-pipeline.mjs


### PR DESCRIPTION
Short-story, in a Coveo-Hosted-Runner:
 - Without ZTSD: https://github.com/coveo/cross-cache-testing/actions/runs/8257881251/job/22589275437 
![image](https://github.com/coveo/ui-kit/assets/12366410/cc4f2777-f34d-4d41-bc8f-0700a60d015c)
 - With ZTSD: https://github.com/coveo/cross-cache-testing/actions/runs/8258103042/job/22590308607
![image](https://github.com/coveo/ui-kit/assets/12366410/a8325cf6-0b98-4b2d-a56f-23c6acafdfd9)

TL;DR: Can't hit a Cache made in GitHub if ZTSD is not there.

Long-story:
- `ubuntu-latest` from GitHub includes `ztsd`
- Coveo images does not include ztsd
- This generates a queryParam version. If the version of the cache doesn't match, the cache ain't used.
https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheHttpClient.ts#L78-L101
- As demonstrated in coveo/cross-cache-testing, the versions are not the same if ztsd is not installed (see the unredacted log in the links)
- This is because the compression method is determined here for save
https://github.com/actions/toolkit/blob/main/packages/cache/src/cache.ts#L174
and there for restore
https://github.com/actions/toolkit/blob/main/packages/cache/src/cache.ts#L90
- And here's the method
https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts#L99-L110
Essentially, if possible, it uses ztsd, if not possible it fallsback onto gzip.

So what was going on is that ztsd was used on GitHub-Runner, but not on Coveo-Runner, causing a cache miss

 