### PR TITLE
chore: ensure command stands on a singleline

### DIFF
--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -37,4 +37,4 @@ docker run -a stderr -a stdout 458176070654.dkr.ecr.us-east-2.amazonaws.com/jenk
     --resolve ATOMIC_HOSTED_PAGE_MINOR_VERSION=${atomicHostedPage.minor} \
     --resolve ATOMIC_HOSTED_PAGE_PATCH_VERSION=${atomicHostedPage.patch} \
     --resolve GITHUB_RUN_ID=${context.runId} \
-    --changeset ${releaseCommit}`);
+    --changeset ${releaseCommit}`.replaceAll(/\s+/g, ' ').trim());


### PR DESCRIPTION
Each line was interpreted independently of the other. Oops.

This concat the script, and ensures we have a single whitespace every time 