### PR TITLE
chore: support 'empty' release

### DIFF
--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -17,7 +17,7 @@ import {
 import {createAppAuth} from '@octokit/auth-app';
 import {spawnSync} from 'child_process';
 import {randomUUID} from 'crypto';
-import {readFileSync} from 'fs';
+import {accessSync, constants, existsSync, readFileSync} from 'fs';
 import {Octokit} from 'octokit';
 import {dedent} from 'ts-dedent';
 import {
@@ -40,9 +40,11 @@ process.chdir(process.env.INIT_CWD);
   });
 
   // Find all packages that have been released in this release.
-  const packagesReleased = readFileSync('.git-message', {
-    encoding: 'utf-8',
-  }).trim();
+  const packagesReleased = existsSync('.git-message')
+    ? readFileSync('.git-message', {
+        encoding: 'utf-8',
+      }).trim()
+    : '';
 
   // Compile git commit message
   const commitMessage = dedent`


### PR DESCRIPTION
This allows for the first phase of the release.yml, `release` to work without any packages changes.
It skips git tag publishing but do the rest as usual.