### PR TITLE
chore: handle empty message

### DIFF
--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -63,8 +63,10 @@ process.chdir(process.env.INIT_CWD);
   const commit = await commitChanges(commitMessage, octokit);
 
   // Add the tags locally...
-  for (const tag of packagesReleased.split('\n')) {
-    await gitTag(tag, commit);
+  if (packagesReleased) {
+    for (const tag of packagesReleased.split('\n')) {
+      await gitTag(tag, commit);
+    }
   }
 
   // And push them


### PR DESCRIPTION
`''.split('\n')` returns `['']` and not `[]`. Oops.