### PR TITLE
chore: mount repo into docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: 'release/v2'
+          fetch-depth: 0
       - uses: ./.github/actions/setup-ztsd
       - uses: ./.github/actions/setup
       - name: Start deployment pipeline

--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -22,7 +22,7 @@ const atomic = getVersionComposants(atomicJson.version);
 const atomicReact = getVersionComposants(atomicReactJson.version);
 const atomicHostedPage = getVersionComposants(atomicHostedPageJson.version);
 execSync(`
-docker run -a stderr -a stdout 458176070654.dkr.ecr.us-east-2.amazonaws.com/jenkins/deployment_package:stable
+docker run -v ${resolve('.')}:/home/jenkins -a stderr -a stdout 458176070654.dkr.ecr.us-east-2.amazonaws.com/jenkins/deployment_package:stable
   deployment-package package create --with-deploy \
     --resolve HEADLESS_MAJOR_VERSION=${headless.major} \
     --resolve HEADLESS_MINOR_VERSION=${headless.minor} \


### PR DESCRIPTION
When running the deployment pipeline, we need the full history. This PR adds that
 - Do fetch-depth:0
 - Mount the repo into the docker