### PR TITLE
chore: use side-repo for deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
       #     DEBUG: ${{ inputs.debug && '*' || '' }}
       - name: Call ui-kit-cd
         run: node ./scripts/deploy/trigger-ui-kit-cd.mjs
+        env:
+          GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
   promote-prod:
     needs: release
     environment: 'Production'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,20 +49,10 @@ jobs:
       #   env:
       #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #     DEBUG: ${{ inputs.debug && '*' || '' }}
-  start-deployment:
-    needs: release
-    runs-on: [coveo, linux, x64, ec2]
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          ref: 'release/v2'
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-ztsd
-      - uses: ./.github/actions/setup
-      - name: Start deployment pipeline
-        run: node ./scripts/deploy/execute-deployment-pipeline.mjs
+      - name: Call ui-kit-cd
+        run: node ./scripts/deploy/trigger-ui-kit-cd.mjs
   promote-prod:
-    needs: start-deployment
+    needs: release
     environment: 'Production'
     runs-on: 'ubuntu-latest'
     env:

--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -1,5 +1,3 @@
-import {context} from '@actions/github';
-import {resolve} from "node:path";
 import {execSync} from 'node:child_process';
 import {parse} from 'semver';
 import atomicHostedPageJson from '../../packages/atomic-hosted-page/package.json' assert {type: 'json'};
@@ -23,7 +21,6 @@ const atomic = getVersionComposants(atomicJson.version);
 const atomicReact = getVersionComposants(atomicReactJson.version);
 const atomicHostedPage = getVersionComposants(atomicHostedPageJson.version);
 console.log(execSync(`
-docker run -v ${resolve('.')}:/home/jenkins -a stderr -a stdout 458176070654.dkr.ecr.us-east-2.amazonaws.com/jenkins/deployment_package:stable
   deployment-package package create --with-deploy \
     --resolve HEADLESS_MAJOR_VERSION=${headless.major} \
     --resolve HEADLESS_MINOR_VERSION=${headless.minor} \
@@ -37,5 +34,5 @@ docker run -v ${resolve('.')}:/home/jenkins -a stderr -a stdout 458176070654.dkr
     --resolve ATOMIC_HOSTED_PAGE_MAJOR_VERSION=${atomicHostedPage.major} \
     --resolve ATOMIC_HOSTED_PAGE_MINOR_VERSION=${atomicHostedPage.minor} \
     --resolve ATOMIC_HOSTED_PAGE_PATCH_VERSION=${atomicHostedPage.patch} \
-    --resolve GITHUB_RUN_ID=${context.runId} \
+    --resolve GITHUB_RUN_ID=${process.env.RUN_ID} \
     --changeset ${releaseCommit}`.replaceAll(/\s+/g, ' ').trim()).toString());

--- a/scripts/deploy/trigger-ui-kit-cd.mjs
+++ b/scripts/deploy/trigger-ui-kit-cd.mjs
@@ -1,0 +1,12 @@
+import {context, getOctokit} from '@actions/github';
+
+const octokit = getOctokit(process.env.GH_TOKEN);
+
+await octokit.rest.repos.createDispatchEvent({
+  event_type: 'deploy',
+  client_payload: {
+    run_Id: context.runId,
+  },
+  owner: 'coveo-platform',
+  repo: 'ui-kit-cd',
+});


### PR DESCRIPTION
For various reason, we can't call deployment-pipeline from github.com/coveo anymore.
So let's do it from github.com/coveo-platform/ui-kit-cd
This is very crude, but it (should?) work.