### PR TITLE
feat(interactive-result): allow sending ecproduct click event

### DIFF
--- a/packages/headless/src/controllers/commerce/result-list/headless-interactive-result.test.ts
+++ b/packages/headless/src/controllers/commerce/result-list/headless-interactive-result.test.ts
@@ -1,5 +1,6 @@
 import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
 import {configuration} from '../../../app/common-reducers';
+import {productClick} from '../../../features/commerce/interactive-result/interactive-result-actions';
 import {pushRecentResult} from '../../../features/product-listing/product-listing-recent-results';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
@@ -13,6 +14,9 @@ import {
 } from './headless-interactive-result';
 
 jest.mock('../../../features/product-listing/product-listing-recent-results');
+jest.mock(
+  '../../../features/commerce/interactive-result/interactive-result-actions'
+);
 
 describe('InteractiveResult', () => {
   let engine: MockedCommerceEngine;
@@ -32,6 +36,7 @@ describe('InteractiveResult', () => {
   }
 
   beforeEach(() => {
+    jest.clearAllMocks();
     engine = buildMockCommerceEngine(buildMockCommerceState());
     initializeInteractiveResult();
     jest.useFakeTimers();
@@ -46,24 +51,30 @@ describe('InteractiveResult', () => {
   });
 
   describe('#select', () => {
-    it('dispatches #pushRecentResult', async () => {
+    it('dispatches #pushRecentResult', () => {
       interactiveResult.select();
       jest.runAllTimers();
       expect(pushRecentResult).toHaveBeenCalled();
     });
 
-    // eslint-disable-next-line @cspell/spellchecker
-    // TODO LENS-1500
-    /*it('dispatches ec.productClick', () => {
+    it('dispatches ec.productClick', () => {
+      const mockedProductClick = jest.mocked(productClick);
       interactiveResult.select();
-      ...
-    });*/
+      jest.runAllTimers();
+      expect(mockedProductClick).toHaveBeenCalledTimes(1);
+    });
 
-    // eslint-disable-next-line @cspell/spellchecker
-    // TODO LENS-1500
-    /*it('does not dispatch ec.productClick when product was opened', () => {
+    it('does not dispatch ec.productClick when product was opened', () => {
+      const mockedProductClick = jest.mocked(productClick);
+      // open the product
       interactiveResult.select();
-      ...
-    });*/
+      jest.runAllTimers();
+
+      // Second click
+      interactiveResult.select();
+      jest.runAllTimers();
+
+      expect(mockedProductClick).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/headless/src/controllers/commerce/result-list/headless-interactive-result.ts
+++ b/packages/headless/src/controllers/commerce/result-list/headless-interactive-result.ts
@@ -1,5 +1,6 @@
 import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
+import {productClick} from '../../../features/commerce/interactive-result/interactive-result-actions';
 import {pushRecentResult} from '../../../features/product-listing/product-listing-recent-results';
 import {
   buildInteractiveResultCore,
@@ -46,8 +47,7 @@ export function buildInteractiveResult(
       return;
     }
     wasOpened = true;
-    // eslint-disable-next-line @cspell/spellchecker
-    // TODO LENS-1500: Trigger ec.productClick event
+    engine.dispatch(productClick(props.options.result));
   };
 
   const action = () => {

--- a/packages/headless/src/features/commerce/interactive-result/interactive-result-actions.ts
+++ b/packages/headless/src/features/commerce/interactive-result/interactive-result-actions.ts
@@ -1,0 +1,19 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+import {AsyncThunkCommerceOptions} from '../../../api/commerce/commerce-api-client';
+import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
+import {CommerceEngineState} from '../../../app/commerce-engine/commerce-engine';
+import {getECProductClickPayload} from './interactive-result-selectors';
+
+export const productClick = createAsyncThunk<
+  void,
+  ProductRecommendation,
+  AsyncThunkCommerceOptions<CommerceEngineState>
+>(
+  'commerce/interactiveResult/productClick',
+  async (product: ProductRecommendation, {extra, getState}) => {
+    const payload = getECProductClickPayload(product, getState());
+    const {relay} = extra;
+
+    relay.emit('ec.productClick', payload);
+  }
+);

--- a/packages/headless/src/features/commerce/interactive-result/interactive-result-selectors.ts
+++ b/packages/headless/src/features/commerce/interactive-result/interactive-result-selectors.ts
@@ -1,0 +1,58 @@
+import {Ec, Product} from '@coveo/relay-event-types';
+import {createSelector} from '@reduxjs/toolkit';
+import {ProductRecommendation} from '../../../api/search/search/product-recommendation';
+import {CommerceEngineState} from '../../../app/commerce-engine/commerce-engine';
+import {getCurrency} from '../context/context-selector';
+import {ProductListingV2State} from '../product-listing/product-listing-state';
+import {CommerceSearchState} from '../search/search-state';
+
+export const getECProductClickPayload = (
+  product: ProductRecommendation,
+  state: CommerceEngineState
+): Ec.ProductClick => ({
+  product: formatProduct(product),
+  responseId: getResponseId({...state.productListing, ...state.commerceSearch}),
+  currency: getCurrency(state.commerceContext),
+  position: getPosition(product, state),
+});
+
+const formatProduct = (product: ProductRecommendation): Product => ({
+  productId: product.permanentid,
+  name: product.ec_name ?? '',
+  price: product.ec_price ?? 0,
+});
+
+const getPosition = (
+  product: ProductRecommendation,
+  state: CommerceEngineState
+) => {
+  const listingProducts = getListingProducts(state.productListing);
+  const searchProducts = getSearchProducts(state.commerceSearch);
+  const selectedProducts = listingProducts.some(
+    (lProduct) => lProduct.permanentid === product.permanentid
+  )
+    ? listingProducts
+    : searchProducts;
+
+  return (
+    selectedProducts.findIndex((p) => p.permanentid === product.permanentid) + 1
+  );
+};
+
+const getResponseId = createSelector(
+  (productListingState: ProductListingV2State) =>
+    productListingState.responseId,
+  (searchState: CommerceSearchState) => searchState.responseId,
+  (listingResponseId, searchResponseId) =>
+    listingResponseId ? listingResponseId : searchResponseId
+);
+
+const getListingProducts = createSelector(
+  (productListingState: ProductListingV2State) => productListingState.products,
+  (listingProducts) => listingProducts
+);
+
+const getSearchProducts = createSelector(
+  (searchState: CommerceSearchState) => searchState.products,
+  (searchProducts) => searchProducts
+);


### PR DESCRIPTION
[LENS-1595](https://coveord.atlassian.net/browse/LENS-1595)

Draft solution: dispatch an action to send the productClick event. The main challenge is to make sure we are getting the right information based on the solution type. 

Current solution is to check if the `responseId` and `products` are defined in the `productListing` state. If that's the case, we get these parameters from that state. Otherwise, we get them from the `commerSearch` state.

[LENS-1595]: https://coveord.atlassian.net/browse/LENS-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ