### PR TITLE
fix(commerce): replace barrel import with proper import

### DIFF
--- a/packages/headless/src/features/product-listing/product-listing-recent-results.ts
+++ b/packages/headless/src/features/product-listing/product-listing-recent-results.ts
@@ -1,4 +1,4 @@
-import {createAction} from '../..';
+import {createAction} from '@reduxjs/toolkit';
 import {validateProductRecommendationPayload} from '../analytics/analytics-utils';
 import {ProductRecommendation} from './../../api/search/search/product-recommendation';
 


### PR DESCRIPTION
As part of CAPI-496, we compared bundle sizes for different changes we wanted to make to headless and spotted issues with imports in the commerce package.

Running dependency cruiser to map a graph of dependencies in the `packages/headless` folder showed that `index.ts` was being included ([full dependencies.svg file here](https://github.com/coveo/test-headless-tree-shaking/blob/main/bundler-comparison/dependencies.svg)):
```shell
npx depcruise --no-config \
  --exclude "^node_modules" \
  --output-type dot \
  src/commerce.index.ts > dependencies.out && dot dependencies.out -T svg -o dependencies.svg
```
![image](https://github.com/coveo/ui-kit/assets/8978908/fa02b1e4-3367-4dc5-a509-f956e910200b)

We then found the source of the issue was `product-listing-recent-results` with:
```shell
npx depcruise --no-config \
  --exclude "^node_modules" \
  --output-type dot \
  --ts-config tsconfig.json \
  --do-not-follow "^src/index.ts" \
  --focus "^src/index.ts" \
  src/commerce.index.ts > dependencies.out && dot dependencies.out -T svg -o dependencies.svg
```
![image](https://github.com/coveo/ui-kit/assets/8978908/5104100d-bd52-4329-a213-46cb2070b705)

This PR replace the `index.ts` barrel import with the proper redux import.

