### PR TITLE
chore: ensure we write the server key in the right directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
           SFDX_AUTH_JWT_USERNAME: ${{ secrets.SFDX_AUTH_JWT_USERNAME }}
           SFDX_AUTH_JWT_KEY_FILE: server.key
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ./packages/quantic
       - name: Notify Docs
         run: npm run notify:docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
           SFDX_AUTH_JWT_USERNAME: ${{ secrets.SFDX_AUTH_JWT_USERNAME }}
           SFDX_AUTH_JWT_KEY_FILE: server.key
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\
+        working-directory: ./packages/quantic
       - name: Notify Docs
         run: npm run notify:docs


### PR DESCRIPTION
 The last CD action fail because it doesn't found the server key, as it tries to read it from packages/quantic/server.key
 
 When checking the other place in the code where it works, this makes sense:
 https://github.com/coveo/ui-kit/blob/7bf6c83a69bd37d80dd829bb3314f66e59fe94eb/.github/workflows/create-quantic-package.yml#L45-L50
 In this working piece of code, we use the working-directory instruction to put the key where it should be.
 
 [KIT-3025](https://coveord.atlassian.net/browse/KIT-3025)

[KIT-3025]: https://coveord.atlassian.net/browse/KIT-3025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ