### PR TITLE
chore(ci): deploy patch&minor at the right place

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -9,7 +9,7 @@
       "sequential": ["dev", "stg", "prd"]
     },
     "team_jenkins": "searchuibuilds",
-    "start_environment_automatically": true,
+    "start_environment_automatically": false,
     "notifications": {
       "slack_channels": ["#searchuibuilds"]
     }

--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -23,16 +23,16 @@ const atomicHostedPage = getVersionComposants(atomicHostedPageJson.version);
 console.log(execSync(`
   deployment-package package create --with-deploy \
     --resolve HEADLESS_MAJOR_VERSION=${headless.major} \
-    --resolve HEADLESS_MINOR_VERSION=${headless.minor} \
-    --resolve HEADLESS_PATCH_VERSION=${headless.patch} \
+    --resolve HEADLESS_MINOR_VERSION=${headless.major}.${headless.minor} \
+    --resolve HEADLESS_PATCH_VERSION=${headless.major}.${headless.minor}.${headless.patch} \
     --resolve ATOMIC_MAJOR_VERSION=${atomic.major} \
-    --resolve ATOMIC_MINOR_VERSION=${atomic.minor} \
-    --resolve ATOMIC_PATCH_VERSION=${atomic.patch} \
+    --resolve ATOMIC_MINOR_VERSION=${atomic.major}.${atomic.minor} \
+    --resolve ATOMIC_PATCH_VERSION=${atomic.major}.${atomic.minor}.${atomic.patch} \
     --resolve ATOMIC_REACT_MAJOR_VERSION=${atomicReact.major} \
-    --resolve ATOMIC_REACT_MINOR_VERSION=${atomicReact.minor} \
-    --resolve ATOMIC_REACT_PATCH_VERSION=${atomicReact.patch} \
+    --resolve ATOMIC_REACT_MINOR_VERSION=${atomicReact.major}.${atomicReact.minor} \
+    --resolve ATOMIC_REACT_PATCH_VERSION=${atomicReact.major}.${atomicReact.minor}.${atomicReact.patch} \
     --resolve ATOMIC_HOSTED_PAGE_MAJOR_VERSION=${atomicHostedPage.major} \
-    --resolve ATOMIC_HOSTED_PAGE_MINOR_VERSION=${atomicHostedPage.minor} \
-    --resolve ATOMIC_HOSTED_PAGE_PATCH_VERSION=${atomicHostedPage.patch} \
+    --resolve ATOMIC_HOSTED_PAGE_MINOR_VERSION=${atomicHostedPage.major}.${atomicHostedPage.minor} \
+    --resolve ATOMIC_HOSTED_PAGE_PATCH_VERSION=${atomicHostedPage.major}.${atomicHostedPage.minor}.${atomicHostedPage.patch} \
     --resolve GITHUB_RUN_ID=${process.env.RUN_ID} \
     --changeset ${releaseCommit}`.replaceAll(/\s+/g, ' ').trim()).toString());


### PR DESCRIPTION
We had an incident where, for version v.X.Y.Z, we deployed `/vX/`, `/vY/` and `/vZ/` to our CDN instead of `/vX/`, `/vX.Y/` and `/vX.Y.Z/`.
faeba9fecf72f55da2151fd7ec977e0e652ae8d0 fixes that, and b0a208d0d219561c3bb8d4c583d79daf6720cecd ensure deployment to a given environment can start only after manual approval.
We want the latter to verify our fix is working.

https://coveord.atlassian.net/browse/CDX-1535