### PR TITLE
feat(headless): add isAnswerGenerated to the state

### DIFF
--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -181,21 +181,15 @@ export const streamAnswer = createAsyncThunk<
           )
         );
         break;
-      case 'genqa.endOfStreamType':
+      case 'genqa.endOfStreamType': {
+        const isAnswerGenerated = (
+          JSON.parse(payload) as GeneratedAnswerEndOfStreamPayload
+        ).answerGenerated;
         dispatch(setIsStreaming(false));
-        dispatch(
-          setIsAnswerGenerated(
-            (JSON.parse(payload) as GeneratedAnswerEndOfStreamPayload)
-              .answerGenerated
-          )
-        );
-        dispatch(
-          logGeneratedAnswerStreamEnd(
-            (JSON.parse(payload) as GeneratedAnswerEndOfStreamPayload)
-              .answerGenerated
-          )
-        );
+        dispatch(setIsAnswerGenerated(isAnswerGenerated));
+        dispatch(logGeneratedAnswerStreamEnd(isAnswerGenerated));
         break;
+      }
       default:
         if (state.debug) {
           extra.logger.warn(`Unknown payloadType: "${payloadType}"`);

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -143,6 +143,11 @@ export const registerFieldsToIncludeInCitations = createAction(
   (payload: string[]) => validatePayload<string[]>(payload, nonEmptyStringArray)
 );
 
+export const setIsAnswerGenerated = createAction(
+  'generatedAnswer/setIsAnswerGenerated',
+  (payload: boolean) => validatePayload(payload, booleanValue)
+);
+
 interface StreamAnswerArgs {
   setAbortControllerRef: (ref: AbortController) => void;
 }
@@ -178,6 +183,12 @@ export const streamAnswer = createAsyncThunk<
         break;
       case 'genqa.endOfStreamType':
         dispatch(setIsStreaming(false));
+        dispatch(
+          setIsAnswerGenerated(
+            (JSON.parse(payload) as GeneratedAnswerEndOfStreamPayload)
+              .answerGenerated
+          )
+        );
         dispatch(
           logGeneratedAnswerStreamEnd(
             (JSON.parse(payload) as GeneratedAnswerEndOfStreamPayload)

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -15,6 +15,7 @@ import {
   closeGeneratedAnswerFeedbackModal,
   sendGeneratedAnswerFeedback,
   registerFieldsToIncludeInCitations,
+  setIsAnswerGenerated,
 } from './generated-answer-actions';
 import {generatedAnswerReducer} from './generated-answer-slice';
 import {getGeneratedAnswerInitialState} from './generated-answer-state';
@@ -383,6 +384,26 @@ describe('generated answer slice', () => {
       );
 
       expect(finalState.isVisible).toEqual(false);
+    });
+  });
+
+  describe('#setIsAnswerGenerated', () => {
+    it('should set isAnswerGenerated to true when given true', () => {
+      const finalState = generatedAnswerReducer(
+        {...baseState, isAnswerGenerated: false},
+        setIsAnswerGenerated(true)
+      );
+
+      expect(finalState.isAnswerGenerated).toEqual(true);
+    });
+
+    it('should set isAnswerGenerated to false when given false', () => {
+      const finalState = generatedAnswerReducer(
+        {...baseState, isAnswerGenerated: true},
+        setIsAnswerGenerated(false)
+      );
+
+      expect(finalState.isAnswerGenerated).toEqual(false);
     });
   });
 });

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -16,6 +16,7 @@ import {
   sendGeneratedAnswerFeedback,
   registerFieldsToIncludeInCitations,
   setId,
+  setIsAnswerGenerated,
 } from './generated-answer-actions';
 import {getGeneratedAnswerInitialState} from './generated-answer-state';
 
@@ -93,5 +94,8 @@ export const generatedAnswerReducer = createReducer(
         state.fieldsToIncludeInCitations = [
           ...new Set(state.fieldsToIncludeInCitations.concat(action.payload)),
         ];
+      })
+      .addCase(setIsAnswerGenerated, (state, {payload}) => {
+        state.isAnswerGenerated = payload;
       })
 );

--- a/packages/headless/src/features/generated-answer/generated-answer-state.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-state.ts
@@ -55,6 +55,10 @@ export interface GeneratedAnswerState {
    * A list of indexed fields to include in the citations returned with the generated answer.
    */
   fieldsToIncludeInCitations: string[];
+  /**
+   * Determines if the answer is generated.
+   */
+  isAnswerGenerated: boolean;
 }
 
 export function getGeneratedAnswerInitialState(): GeneratedAnswerState {
@@ -72,5 +76,6 @@ export function getGeneratedAnswerInitialState(): GeneratedAnswerState {
     feedbackModalOpen: false,
     feedbackSubmitted: false,
     fieldsToIncludeInCitations: [],
+    isAnswerGenerated: false,
   };
 }


### PR DESCRIPTION
[SVCC-3597](https://coveord.atlassian.net/browse/SVCC-3597)

Add `isAnswerGenerated` to GenerateAnswerState, to be able to check if the answer was properly generated.

`isAnswerGenerated` is set to `true` when an answer is properly generated.
`isAnswerGenerated` is set to `false` when “sorry message” is returned.

<img width="946" alt="Screenshot 2024-03-21 at 8 22 20 PM" src="https://github.com/coveo/ui-kit/assets/119955059/f14f95ae-f5da-4fcb-950e-2932d52c2718">


[SVCC-3597]: https://coveord.atlassian.net/browse/SVCC-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ