### PR TITLE
chore: disable quantic release, split production targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,22 +40,13 @@ jobs:
           RELEASER_INSTALLATION_ID: ${{ secrets.RELEASER_INSTALLATION_ID }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-      #   with:
-      #     registry-url: 'https://npm.pkg.github.com'
-      #     node-version-file: '.nvmrc'
-      # - name: Publish to GitHub Packages
-      #   run: npm run release:phase5
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     DEBUG: ${{ inputs.debug && '*' || '' }}
       - name: Call ui-kit-cd
         run: node ./scripts/deploy/trigger-ui-kit-cd.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
-  promote-prod:
+  npm-prod:
     needs: release
-    environment: 'Production'
+    environment: 'NPM Production'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: read
@@ -67,20 +58,55 @@ jobs:
         with:
           ref: 'release/v2'
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/setup-sfdx
       - name: Promote NPM package to production
         run: npm run promote:npm:latest
-      - name: Promote SFDX package to production
-        run: |
-          echo "${{ secrets.SFDX_AUTH_PACKAGE_JWT_KEY }}" > server.key
-          npx --no-install nx run quantic:"promote:sfdx:ci"
-          rm server.key
-        env:
-          SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
-          SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
-          SFDX_AUTH_JWT_USERNAME: ${{ secrets.SFDX_AUTH_JWT_USERNAME }}
-          SFDX_AUTH_JWT_KEY_FILE: server.key
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: ./packages/quantic
+  docs-prod:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: 'Docs Production'
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: 'release/v2'
+      - uses: ./.github/actions/setup
       - name: Notify Docs
         run: npm run notify:docs
+  # quantic-prod:
+  #   needs: release
+  #   runs-on: ubuntu-latest
+  #   environment: 'Quantic Production'
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #   steps:
+  #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+  #       with:
+  #         ref: 'release/v2'
+  #     - uses: ./.github/actions/setup
+  #     - uses: ./.github/actions/setup-sfdx
+  #     - name: Promote SFDX package to production
+  #       run: |
+  #         echo "${{ secrets.SFDX_AUTH_PACKAGE_JWT_KEY }}" > server.key
+  #         npx --no-install nx run quantic:"promote:sfdx:ci"
+  #         rm server.key
+  #       env:
+  #         SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+  #         SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
+  #         SFDX_AUTH_JWT_USERNAME: ${{ secrets.SFDX_AUTH_JWT_USERNAME }}
+  #         SFDX_AUTH_JWT_KEY_FILE: server.key
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       working-directory: ./packages/quantic
+  # github-prod:
+  #   needs: release
+  #   runs-on: ubuntu-latest
+  #   environment: 'GitHub Production'
+  #   steps:
+  #     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+  #       with:
+  #         registry-url: 'https://npm.pkg.github.com'
+  #         node-version-file: '.nvmrc'
+  #     - name: Publish to GitHub Packages
+  #       run: npm run release:phase5
+  #       env:
+  #         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         DEBUG: ${{ inputs.debug && '*' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Notify Docs
         run: npm run notify:docs
+  # TODO: KIT-3072, uncomment
   # quantic-prod:
   #   needs: release
   #   runs-on: ubuntu-latest

--- a/scripts/deploy/approve-production-release.mjs
+++ b/scripts/deploy/approve-production-release.mjs
@@ -12,17 +12,31 @@ const authSecrets = {
   installationId: process.env.RELEASER_INSTALLATION_ID,
 };
 
+const productionEnvironments = [
+  'NPM Production',
+  'Docs Production',
+  // TODO KIT-3072: uncomment
+  // 'Quantic Production',
+  // TODO KIT-3074: uncomment
+  // 'GitHub Production',
+];
+
 const octokit = new Octokit({
   authStrategy: createAppAuth,
   auth: authSecrets,
 });
-await octokit.request(
-  `POST /repos/coveo/ui-kit/actions/runs/${process.argv[2]}/deployment_protection_rule`,
-  {
-    state: 'approved',
-    environment_name: 'Production',
-    headers: {
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-  }
+
+await Promise.allSettled(
+  productionEnvironments.map((environment_name) =>
+    octokit.request(
+      `POST /repos/coveo/ui-kit/actions/runs/${process.argv[2]}/deployment_protection_rule`,
+      {
+        state: 'approved',
+        environment_name,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    )
+  )
 );


### PR DESCRIPTION
Currently, we're doing the following operation sequentially:
1. Move the latest tag of our npm package to the beta tag we created earlier
2. Promote the SFDX package in production
3. Notify the doc website to do their release

All those operations can and should occur in parallel:
- We want to promote NPM into production as soon as it's available in production through our CDN
- We want our documentation to be updated when we release new versions in production, even if it's only in the CDN (if the NPM promotion were to fail let's say)
- Quantic package does not depend on the two other operations

This PR does that by splitting the three tasks into separate jobs, controlled by different GitHub Environments. Those Environments are just a split of Production into 3, with a separation of concern applied to all.

By that account. GitHub package releases, while currently disabled should follow NPM logic as well, and so I moved the disabled part of the script into its own, commented, job.