### PR TITLE
feat(commerce): create breadcrumbs

### DIFF
--- a/packages/headless/src/controllers/commerce/core/common.ts
+++ b/packages/headless/src/controllers/commerce/core/common.ts
@@ -1,0 +1,8 @@
+import {AsyncThunkAction} from '@reduxjs/toolkit';
+import {AsyncThunkOptions} from '../../../app/async-thunk-options';
+
+export type FetchResultsActionCreator = () => AsyncThunkAction<
+  unknown,
+  void,
+  AsyncThunkOptions<unknown>
+>;

--- a/packages/headless/src/controllers/commerce/core/facets/breadcrumb-manager/headless-core-breadcrumb-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/breadcrumb-manager/headless-core-breadcrumb-generator.ts
@@ -1,0 +1,124 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {createFacetFactory} from '../common';
+import {
+  CommerceFacetOptions,
+  DateFacetValue,
+  NumericFacetValue,
+  RegularFacetValue
+} from '../headless-core-commerce-facet';
+import {
+  AnyFacetValueResponse,
+  BaseFacetValue
+} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {buildController} from '../../../../controller/headless-controller';
+import {FetchResultsActionCreator} from '../../common';
+import {CommerceEngine, CommerceEngineState} from '../../../../../app/commerce-engine/commerce-engine';
+import {
+  BreadcrumbValue,
+  CoreBreadcrumbManager,
+  DeselectableValue
+} from '../../../../breadcrumb-manager/headless-breadcrumb-manager';
+import {deselectAllBreadcrumbs} from '../../../../../features/breadcrumb/breadcrumb-actions';
+
+/**
+ * Represents a generic breadcrumb type.
+ *
+ * This can be a `FacetBreadcrumb`, `NumericFacetBreadcrumb`, `DateFacetBreadcrumb`, or `CategoryFacetBreadcrumb`.
+ */
+export interface Breadcrumb<T extends BaseFacetValue> {
+  /**
+   * The ID of the underlying facet.
+   */
+  facetId: string;
+  /**
+   * The field on which the underlying facet is configured.
+   */
+  field: string;
+  /**
+   * The list of facet values currently selected.
+   */
+  values: BreadcrumbValue<T>[];
+}
+
+export type CommerceBreadcrumbBuilder<
+  FacetValue extends AnyFacetValueResponse,
+  // We should restrict this to only options for breadcrumbs
+> = (engine: CommerceEngine, options: CommerceFacetOptions) => Breadcrumb<FacetValue>;
+
+export interface CoreBreadcrumbManagerProps {
+  options: CoreBreadcrumbManagerOptions;
+}
+
+interface CoreBreadcrumbManagerOptions {
+  buildRegularFacet: CommerceBreadcrumbBuilder<RegularFacetValue>;
+  buildNumericFacet: CommerceBreadcrumbBuilder<NumericFacetValue>;
+  buildDateFacet: CommerceBreadcrumbBuilder<DateFacetValue>;
+  fetchResultsActionCreator: FetchResultsActionCreator;
+}
+
+interface BreadcrumbManagerState {
+  /**
+   * The list of facet breadcrumbs.
+   */
+  facetBreadcrumbs: Breadcrumb<AnyFacetValueResponse>[]; // or Breadcrumb<RegularFacetValue> | Breadcrumb<NumericFacetValue> | Breadcrumb<DateFacetValue>
+
+  /**
+   * Returns `true` if there are any available breadcrumbs (i.e., if there are any active facet values), and `false` if not.
+   */
+  hasBreadcrumbs: boolean;
+}
+
+export type BreadcrumbManager = Omit<CoreBreadcrumbManager, 'state'> & {
+  /**
+   * The state of the `BreadcrumbManager` controller.
+   */
+  state: BreadcrumbManagerState;
+}
+
+export function buildCoreBreadcrumbManager(
+  engine: CommerceEngine,
+  props: CoreBreadcrumbManagerProps
+): BreadcrumbManager {
+  // TODO(nico): Declare reducers usage
+  const controller = buildController(engine);
+  const {dispatch} = engine;
+
+  const commerceFacetSelector = createSelector(
+    (state: CommerceEngineState) => state.facetOrder,
+    (facetOrder): BreadcrumbManagerState => {
+
+      const breadcrumbs = facetOrder.map(createFacet) ?? [];
+      return {
+        facetBreadcrumbs: breadcrumbs,
+        hasBreadcrumbs: breadcrumbs.length > 0
+      };
+    }
+  );
+
+  const builders = {
+    numericalRange: (facetId: string) => props.options.buildNumericFacet(engine, {facetId}),
+    dateRange: (facetId: string) => props.options.buildDateFacet(engine, {facetId}),
+    // TODO return options.buildCategoryFacet(engine, {facetId});
+    hierarchical: (facetId: string) => props.options.buildRegularFacet(engine, {facetId}),
+    regular: (facetId: string) => props.options.buildRegularFacet(engine, {facetId})
+  };
+
+  const createFacet = createFacetFactory<Breadcrumb<AnyFacetValueResponse>>(
+    (facetId) => engine.state.commerceFacetSet[facetId].request.type, builders);
+
+  return {
+    ...controller,
+
+    deselectAll: () => {
+      dispatch(deselectAllBreadcrumbs());
+    },
+
+    deselectBreadcrumb(value: DeselectableValue) {
+      value.deselect();
+    },
+
+    get state() {
+      return commerceFacetSelector(engine.state);
+    },
+  };
+}

--- a/packages/headless/src/controllers/commerce/core/facets/common.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/common.ts
@@ -1,0 +1,14 @@
+interface FacetBuilders<T> {
+  numericalRange: (facetId: string) => T
+  dateRange: (facetId: string) => T
+  hierarchical: (facetId: string) => T
+  regular: (facetId: string) => T
+}
+export const createFacetFactory = <T> (getType: (facetId: string) => string, builders: FacetBuilders<T>) => (facetId: string) => {
+  const type = getType(facetId)
+  if (type in builders) {
+    return builders[type as keyof FacetBuilders<any>](facetId);
+  }
+
+  return builders.regular(facetId);
+};

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
@@ -24,6 +24,7 @@ import {
 import {NumericFacet} from '../numeric/headless-commerce-numeric-facet';
 import {RegularFacet} from '../regular/headless-commerce-regular-facet';
 import {SearchableFacetOptions} from '../searchable/headless-commerce-searchable-facet';
+import {createFacetFactory} from '../common';
 
 /**
  * The `FacetGenerator` headless controller creates commerce facet controllers from the Commerce API search or
@@ -96,20 +97,13 @@ export function buildFacetGenerator(
     (facetOrder) => ({facets: facetOrder.map(createFacet) ?? []})
   );
 
-  const createFacet = (facetId: string) => {
-    const {type} = engine.state.commerceFacetSet[facetId].request;
-
-    switch (type) {
-      case 'numericalRange':
-        return options.buildNumericFacet(engine, {facetId});
-      case 'dateRange':
-        return options.buildDateFacet(engine, {facetId});
-      case 'hierarchical': // TODO return options.buildCategoryFacet(engine, {facetId});
-      case 'regular':
-      default:
-        return options.buildRegularFacet(engine, {facetId});
-    }
-  };
+  const createFacet = createFacetFactory<CoreCommerceFacet<AnyFacetValueRequest, AnyFacetValueResponse>>((facetId) => engine.state.commerceFacetSet[facetId].request.type, {
+    numericalRange: (facetId: string) => options.buildNumericFacet(engine, {facetId}),
+    dateRange: (facetId: string) => options.buildDateFacet(engine, {facetId}),
+    // TODO return options.buildCategoryFacet(engine, {facetId});
+    hierarchical: (facetId: string) => options.buildRegularFacet(engine, {facetId}),
+    regular: (facetId: string) => options.buildRegularFacet(engine, {facetId})
+  });
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/commerce/core/facets/headless-core-commerce-facet.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/headless-core-commerce-facet.ts
@@ -1,10 +1,5 @@
-import {
-  ActionCreatorWithPreparedPayload,
-  AsyncThunkAction,
-} from '@reduxjs/toolkit';
-import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
+import {ActionCreatorWithPreparedPayload} from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
-import {ThunkExtraArguments} from '../../../../app/thunk-extra-arguments';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {AnyCommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {
@@ -31,6 +26,7 @@ import {
 } from '../../../core/facets/facet/headless-core-facet';
 import {DateRangeRequest} from '../../../core/facets/range-facet/date-facet/headless-core-date-facet';
 import {NumericRangeRequest} from '../../../core/facets/range-facet/numeric-facet/headless-core-numeric-facet';
+import {FetchResultsActionCreator} from '../common';
 
 export type {
   FacetType,
@@ -72,11 +68,7 @@ export interface CoreCommerceFacetOptions {
     never,
     never
   >;
-  fetchResultsActionCreator: () => AsyncThunkAction<
-    unknown,
-    void,
-    AsyncThunkOptions<unknown, ThunkExtraArguments>
-  >;
+  fetchResultsActionCreator: FetchResultsActionCreator;
   facetResponseSelector: (
     state: CommerceEngine['state'],
     facetId: string

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -1,4 +1,3 @@
-import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
 import {
   nextPage,
@@ -11,6 +10,7 @@ import {
   Controller,
   buildController,
 } from '../../../controller/headless-controller';
+import {FetchResultsActionCreator} from '../common';
 
 /**
  * The `Pagination` controller is responsible for navigating between pages of results in a commerce interface.
@@ -49,8 +49,7 @@ export interface PaginationState {
 export type PaginationControllerState = Pagination['state'];
 
 export interface CorePaginationProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchResultsActionCreator: () => AsyncThunkAction<unknown, void, any>;
+  fetchResultsActionCreator: FetchResultsActionCreator;
 }
 
 /**

--- a/packages/headless/src/controllers/commerce/core/parameter-manager/headless-core-parameter-manager.ts
+++ b/packages/headless/src/controllers/commerce/core/parameter-manager/headless-core-parameter-manager.ts
@@ -1,5 +1,5 @@
 import {RecordValue, Schema, SchemaDefinition} from '@coveo/bueno';
-import {AnyAction, AsyncThunkAction} from '@reduxjs/toolkit';
+import {AnyAction} from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
 import {Parameters} from '../../../../features/commerce/search-parameters/search-parameter-actions';
 import {deepEqualAnyOrder} from '../../../../utils/compare-utils';
@@ -8,6 +8,7 @@ import {
   buildController,
   Controller,
 } from '../../../controller/headless-controller';
+import {FetchResultsActionCreator} from '../common';
 
 export interface ParameterManagerProps<T extends Parameters> {
   /**
@@ -36,8 +37,7 @@ export interface CoreParameterManagerProps<T extends Parameters>
   /**
    * The action to dispatch to fetch more results.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchResultsActionCreator: () => AsyncThunkAction<unknown, void, any>;
+  fetchResultsActionCreator: FetchResultsActionCreator;
 
   /**
    * Enriches the parameters with the active parameters.

--- a/packages/headless/src/controllers/commerce/core/sort/headless-core-commerce-sort.ts
+++ b/packages/headless/src/controllers/commerce/core/sort/headless-core-commerce-sort.ts
@@ -1,5 +1,4 @@
 import {Schema} from '@coveo/bueno';
-import {AsyncThunkAction} from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
 import {
   buildFieldsSortCriterion,
@@ -21,6 +20,7 @@ import {
   buildController,
   Controller,
 } from '../../../controller/headless-controller';
+import {FetchResultsActionCreator} from '../common';
 
 export type {SortByRelevance, SortByFields, SortByFieldsFields, SortCriterion};
 export {
@@ -38,8 +38,7 @@ export interface SortProps {
 }
 
 export interface CoreSortProps extends SortProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchResultsActionCreator: () => AsyncThunkAction<unknown, void, any>;
+  fetchResultsActionCreator: FetchResultsActionCreator;
 }
 
 export interface SortInitialState {


### PR DESCRIPTION
Similarly to the facet generator, a breadcrumb controller produces multiple controllers that allow for facet selection. This PR is an attempt at reflecting that.

[CAPI-95]