### PR TITLE
feat(atomic): add part attribute for genQA component

### DIFF
--- a/packages/atomic/cypress/e2e/generated-answer-selectors.ts
+++ b/packages/atomic/cypress/e2e/generated-answer-selectors.ts
@@ -19,7 +19,7 @@ export const GeneratedAnswerSelectors = {
   citationTitle: () =>
     GeneratedAnswerSelectors.citation().find('.citation-title'),
   citationIndex: () =>
-    GeneratedAnswerSelectors.citation().find('.citation-index'),
+    GeneratedAnswerSelectors.citation().find('[part="citation-index"]'),
   citationCard: () =>
     GeneratedAnswerSelectors.shadow().find('[part="citation-popover"]'),
   loader: () => GeneratedAnswerSelectors.shadow().find('.typing-indicator'),

--- a/packages/atomic/src/components/common/generated-answer/atomic-citation/atomic-citation.pcss
+++ b/packages/atomic/src/components/common/generated-answer/atomic-citation/atomic-citation.pcss
@@ -8,11 +8,11 @@
 
   max-width: var(--max-citation-width);
   height: var(--height);
+}
 
-  .citation-index {
-    height: var(--index-height);
-    width: var(--index-height);
-  }
+[part='citation-index'] {
+  height: var(--index-height);
+  width: var(--index-height);
 }
 
 [part='citation-popover'] {

--- a/packages/atomic/src/components/common/generated-answer/atomic-citation/atomic-citation.tsx
+++ b/packages/atomic/src/components/common/generated-answer/atomic-citation/atomic-citation.tsx
@@ -158,7 +158,10 @@ export class AtomicCitation {
           onFocus={this.openPopover}
           onBlur={this.closePopover}
         >
-          <div class="citation-index rounded-full font-medium flex items-center text-bg-primary shrink-0">
+          <div
+            part="citation-index"
+            class="rounded-full font-medium flex items-center text-bg-primary shrink-0"
+          >
             <div class="mx-auto">{this.index + 1}</div>
           </div>
           <span class="citation-title truncate mx-1">

--- a/packages/atomic/src/components/common/generated-answer/rephrase-buttons.tsx
+++ b/packages/atomic/src/components/common/generated-answer/rephrase-buttons.tsx
@@ -73,7 +73,10 @@ export const RephraseButtons: FunctionalComponent<RephraseButtonProps> = (
               <div class="icon-container text-neutral-dark h-full mx-auto shrink-0 relative">
                 <atomic-icon icon={option.icon}></atomic-icon>
               </div>
-              <div part="rephrase-btn-label" class="hidden text-neutral-dark">
+              <div
+                part="rephrase-button-label"
+                class="hidden text-neutral-dark"
+              >
                 {i18n.t(option.titleKey)}
               </div>
             </Button>

--- a/packages/atomic/src/components/common/generated-answer/rephrase-buttons.tsx
+++ b/packages/atomic/src/components/common/generated-answer/rephrase-buttons.tsx
@@ -52,7 +52,7 @@ export const RephraseButtons: FunctionalComponent<RephraseButtonProps> = (
 ) => {
   const {i18n} = props;
   return (
-    <div class="rephrase-buttons shrink-0">
+    <div part="rephrase-buttons" class="shrink-0">
       <p part="rephrase-label" class="mb-2 text-neutral-dark shrink-0">
         {i18n.t('rephrase')}
       </p>
@@ -73,7 +73,7 @@ export const RephraseButtons: FunctionalComponent<RephraseButtonProps> = (
               <div class="icon-container text-neutral-dark h-full mx-auto shrink-0 relative">
                 <atomic-icon icon={option.icon}></atomic-icon>
               </div>
-              <div class="rephrase-btn-label hidden text-neutral-dark">
+              <div part="rephrase-btn-label" class="hidden text-neutral-dark">
                 {i18n.t(option.titleKey)}
               </div>
             </Button>

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -15,7 +15,7 @@
     @apply mr-0;
   }
 
-  .rephrase-buttons {
+  [part='rephrase-buttons'] {
     @apply ml-0;
   }
 
@@ -29,10 +29,8 @@
 }
 
 @define-mixin mobile-footer-xs-layout {
-  [part='rephrase-button'] {
-    .rephrase-btn-label {
-      @apply hidden;
-    }
+  [part='rephrase-btn-label'] {
+    @apply hidden;
   }
 }
 
@@ -52,7 +50,8 @@
   .source-citations {
     @apply mr-2;
   }
-  .rephrase-buttons {
+
+  [part='rephrase-buttons'] {
     @apply ml-auto;
   }
 

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -29,7 +29,7 @@
 }
 
 @define-mixin mobile-footer-xs-layout {
-  [part='rephrase-btn-label'] {
+  [part='rephrase-button-label'] {
     @apply hidden;
   }
 }

--- a/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
@@ -2,15 +2,15 @@
   padding: 0 8px;
   width: unset;
 
-  .rephrase-btn-label {
+  [part='rephrase-btn-label'] {
     @apply block ml-2;
   }
 
-  &:hover .rephrase-btn-label {
+  &:hover [part='rephrase-btn-label'] {
     @apply text-primary;
   }
 
-  &.active .rephrase-btn-label {
+  &.active [part='rephrase-btn-label'] {
     @apply text-white;
   }
 }
@@ -41,7 +41,7 @@
   &:hover,
   &.active {
     .icon-container,
-    .rephrase-btn-label {
+    [part='rephrase-btn-label'] {
       @apply text-inherit;
     }
   }
@@ -56,6 +56,6 @@
   }
 }
 
-.rephrase-buttons > div {
+[part='rephrase-buttons'] > div {
   border-color: var(--atomic-neutral);
 }

--- a/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
@@ -2,15 +2,15 @@
   padding: 0 8px;
   width: unset;
 
-  [part='rephrase-btn-label'] {
+  [part='rephrase-button-label'] {
     @apply block ml-2;
   }
 
-  &:hover [part='rephrase-btn-label'] {
+  &:hover [part='rephrase-button-label'] {
     @apply text-primary;
   }
 
-  &.active [part='rephrase-btn-label'] {
+  &.active [part='rephrase-button-label'] {
     @apply text-white;
   }
 }
@@ -41,7 +41,7 @@
   &:hover,
   &.active {
     .icon-container,
-    [part='rephrase-btn-label'] {
+    [part='rephrase-button-label'] {
       @apply text-inherit;
     }
   }

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -31,10 +31,13 @@ import {Bindings} from '../atomic-search-interface/atomic-search-interface';
  * @part generated-text - The text of the generated answer.
  * @part citations-label - The header of the citations list.
  * @part rephrase-label - The header of the rephrase options.
+ * @part rephrase-buttons - The container of the rephrase buttons section.
  * @part rephrase-button - The button for each of the rephrase options (step-by-step instructions, bulleted list, and summary).
+ * @part rephrase-button-label - The label of the rephrase button.
  *
  * @part citation - The link that allows the user to navigate to the item.
  * @part citation-popover - The pop-up that shows an item preview when the user hovers over the citation.
+ * @part citation-index - The content of the citation item.
  */
 @Component({
   tag: 'atomic-generated-answer',


### PR DESCRIPTION
[SVCC-3626](https://coveord.atlassian.net/browse/SVCC-3626)

Adding `part` attribute to some genQA components, regarding Xero feedback.

- The div containing the citation-index element
- The div containing the rephrase-buttons element
- The div containing the rephrase-btn-label element

[SVCC-3626]: https://coveord.atlassian.net/browse/SVCC-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ