### PR TITLE
feat(atomic): add rga disclaimer

### DIFF
--- a/packages/atomic/cypress/e2e/generated-answer-assertions.ts
+++ b/packages/atomic/cypress/e2e/generated-answer-assertions.ts
@@ -105,3 +105,11 @@ export function assertAnswerCopiedToClipboard(answer: string) {
     });
   });
 }
+
+export function assertDisclaimer(isDisplayed: boolean) {
+  it(`${should(isDisplayed)} show the disclaimer`, () => {
+    GeneratedAnswerSelectors.disclaimer().should(
+      isDisplayed ? 'exist' : 'not.exist'
+    );
+  });
+}

--- a/packages/atomic/cypress/e2e/generated-answer-selectors.ts
+++ b/packages/atomic/cypress/e2e/generated-answer-selectors.ts
@@ -34,6 +34,8 @@ export const GeneratedAnswerSelectors = {
       .parent(),
   copyButton: () =>
     GeneratedAnswerSelectors.shadow().find('[part="copy-button"]'),
+  disclaimer: () =>
+    GeneratedAnswerSelectors.shadow().find('[slot="disclaimer"]'),
 };
 
 export const feedbackModalSelectors = {

--- a/packages/atomic/cypress/e2e/generated-answer.cypress.ts
+++ b/packages/atomic/cypress/e2e/generated-answer.cypress.ts
@@ -200,6 +200,7 @@ describe('Generated Answer Test Suites', () => {
         GeneratedAnswerAssertions.assertCopyButtonVisibility(false);
         GeneratedAnswerAssertions.assertLocalStorageData({isVisible: false});
         GeneratedAnswerAssertions.assertLogHideGeneratedAnswer();
+        GeneratedAnswerAssertions.assertDisclaimer(false);
 
         describe('when component is re-activated', () => {
           beforeEach(() => {
@@ -213,6 +214,7 @@ describe('Generated Answer Test Suites', () => {
           GeneratedAnswerAssertions.assertCopyButtonVisibility(true);
           GeneratedAnswerAssertions.assertLocalStorageData({isVisible: true});
           GeneratedAnswerAssertions.assertLogShowGeneratedAnswer();
+          GeneratedAnswerAssertions.assertDisclaimer(true);
         });
       });
 
@@ -253,6 +255,10 @@ describe('Generated Answer Test Suites', () => {
               'exist'
             )
           );
+        });
+
+        it('should display the disclaimer', () => {
+          GeneratedAnswerSelectors.disclaimer().should('exist');
         });
 
         describe('when like button is clicked', () => {

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
@@ -312,6 +312,19 @@ export class GeneratedAnswerCommon {
             )}
           </GeneratedContentContainer>
         ) : null}
+
+        {!this.hasRetryableError &&
+          this.isAnswerVisible &&
+          !this.props.getGeneratedAnswerState()?.isStreaming && (
+            <div
+              part="generated-answer-footer"
+              class="flex justify-end mt-6 text-neutral-dark text-xs"
+            >
+              <slot name="disclaimer" slot="disclaimer">
+                {this.props.getBindings().i18n.t('generated-answer-disclaimer')}
+              </slot>
+            </div>
+          )}
       </div>
     );
   }

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -46,7 +46,8 @@
   container-type: inline-size;
 }
 
-.footer {
+.footer,
+[part='generated-answer-footer'] {
   @apply flex;
 
   .source-citations {

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -7371,5 +7371,32 @@
     "zh": "无法复制答案",
     "zh-CN": "无法复制答案",
     "zh-TW": "無法複製答案"
+  },
+  "generated-answer-disclaimer": {
+    "en": "Generated content may contain errors. Verify important information.",
+    "fr": "Le contenu généré peut contenir des erreurs. Vérifiez les informations importantes.",
+    "cs": "Generovaný obsah může obsahovat chyby. Ověřte důležité informace.",
+    "da": "Genereret indhold kan indeholde fejl. Bekræft vigtig information.",
+    "de": "Generierte Inhalte können Fehler enthalten. Überprüfen Sie wichtige Informationen.",
+    "el": "Το παραγμένο περιεχόμενο μπορεί να περιέχει σφάλματα. Επιβεβαιώστε σημαντικές πληροφορίες.",
+    "es": "El contenido generado puede contener errores. Verifique información importante.",
+    "fi": "Tuotettu sisältö voi sisältää virheitä. Varmista tärkeät tiedot.",
+    "hu": "Az előállított tartalom hibákat tartalmazhat. Ellenőrizze a fontos információkat.",
+    "id": "Konten yang dihasilkan mungkin mengandung kesalahan. Verifikasi informasi penting.",
+    "it": "Il contenuto generato può contenere errori. Verifica le informazioni importanti.",
+    "ja": "生成されたコンテンツにはエラーが含まれている可能性があります。重要な情報を確認してください。",
+    "ko": "생성된 콘텐츠에는 오류가 포함될 수 있습니다. 중요한 정보를 확인하세요.",
+    "nl": "Gegenereerde inhoud kan fouten bevatten. Verifieer belangrijke informatie.",
+    "no": "Generert innhold kan inneholde feil. Verifiser viktig informasjon.",
+    "pl": "Wygenerowane treści mogą zawierać błędy. Zweryfikuj ważne informacje.",
+    "pt": "O conteúdo gerado pode conter erros. Verifique as informações importantes.",
+    "pt-BR": "O conteúdo gerado pode conter erros. Verifique as informações importantes.",
+    "ru": "Сгенерированный контент может содержать ошибки. Проверьте важную информацию.",
+    "sv": "Genererat innehåll kan innehålla fel. Verifiera viktig information.",
+    "th": "เนื้อหาที่สร้างขึ้นอาจมีข้อผิดพลาด ตรวจสอบข้อมูลที่สำคัญ",
+    "tr": "Oluşturulan içerik hatalar içerebilir. Önemli bilgileri doğrulayın.",
+    "zh": "生成的內容可能包含錯誤。驗證重要信息。",
+    "zh-CN": "生成的内容可能包含错误。验证重要信息。",
+    "zh-TW": "生成的內容可能包含錯誤。驗證重要資訊。"
   }
 }


### PR DESCRIPTION
[SVCC-3573](https://coveord.atlassian.net/browse/SVCC-3573)

Add Legal disclaimer to the RGA component:

- disclaimer displayed when the response is finished, but can be edited (slot) and removed.
- default text is: `Generated content may contain errors. Verify important information.`

<img width="915" alt="Screenshot 2024-03-29 at 2 57 52 PM" src="https://github.com/coveo/ui-kit/assets/119955059/1e9552c1-6f61-4fba-b0ef-19a4406d07f9">

Mobile Layout:

<img width="568" alt="Screenshot 2024-03-29 at 4 03 55 PM" src="https://github.com/coveo/ui-kit/assets/119955059/6023a8eb-53eb-45c3-ad6e-d193bc4ac5b0">

XS mobiel Layout:

<img width="280" alt="Screenshot 2024-03-29 at 2 59 03 PM" src="https://github.com/coveo/ui-kit/assets/119955059/7751dcc6-22fa-47be-8be6-3deb3d5f0c3d">


https://github.com/coveo/ui-kit/assets/119955059/43e655a0-6500-4c3d-ade7-1b555832d3ed



[SVCC-3573]: https://coveord.atlassian.net/browse/SVCC-3573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ