### PR TITLE
fix(commerce): bugfix missing recs request configuration

### DIFF
--- a/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.test.ts
+++ b/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.test.ts
@@ -1,5 +1,3 @@
-import {configuration} from '../../../app/common-reducers';
-import {contextReducer} from '../../../features/commerce/context/context-slice';
 import {fetchRecommendations} from '../../../features/commerce/recommendations/recommendations-actions';
 import {recommendationsReducer} from '../../../features/commerce/recommendations/recommendations-slice';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
@@ -28,8 +26,6 @@ describe('headless recommendations', () => {
   it('adds the correct reducers to engine', () => {
     expect(engine.addReducers).toHaveBeenCalledWith({
       recommendations: recommendationsReducer,
-      commerceContext: contextReducer,
-      configuration,
     });
   });
 

--- a/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.ts
+++ b/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.ts
@@ -5,8 +5,6 @@ import {
   CommerceEngine,
   CommerceEngineState,
 } from '../../../app/commerce-engine/commerce-engine';
-import {configuration} from '../../../app/common-reducers';
-import {contextReducer as commerceContext} from '../../../features/commerce/context/context-slice';
 import {recommendationsOptionsSchema} from '../../../features/commerce/recommendations/recommendations';
 import {
   fetchRecommendations,
@@ -95,6 +93,6 @@ export function buildRecommendations(
 function loadBaseRecommendationsReducers(
   engine: CommerceEngine
 ): engine is CommerceEngine {
-  engine.addReducers({recommendations, commerceContext, configuration});
+  engine.addReducers({recommendations});
   return true;
 }

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -69,10 +69,9 @@ export const buildBaseCommerceAPIRequest = async (
 export const buildCommerceAPIRequest = async (
   state: StateNeededByQueryCommerceAPI
 ): Promise<CommerceAPIRequest> => {
-  const facets = getFacets(state);
   return {
-    ...buildBaseCommerceAPIRequest(state),
-    facets,
+    ...(await buildBaseCommerceAPIRequest(state)),
+    facets: getFacets(state),
     ...(state.commerceSort && {
       sort: getSort(state.commerceSort.appliedSort),
     }),


### PR DESCRIPTION
[CAPI-724](https://coveord.atlassian.net/jira/software/c/projects/CAPI/boards/1103?assignee=6168b023c5388b006911910a&selectedIssue=CAPI-724)

The real bug wasn't the missing configuration it was forgetting to await a promise of config. Recommendations controller now works as expected.

[CAPI-724]: https://coveord.atlassian.net/browse/CAPI-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ