### PR TITLE
chore(headless): remove undefined properties from request after it is built rather than using spread syntax in builder function

### DIFF
--- a/packages/headless/src/api/api-client-utils.test.ts
+++ b/packages/headless/src/api/api-client-utils.test.ts
@@ -1,0 +1,117 @@
+import {pickNonBaseParams} from './api-client-utils';
+import {BaseParam} from './platform-service-params';
+import {AuthenticationParam} from './search/search-api-params';
+
+interface TestParam {
+  a?: string;
+  b?: number;
+  c?: boolean;
+  d?: TestParam;
+  e?: TestParam[];
+}
+
+describe('api-client-utils', () => {
+  describe('#pickNonBaseParams', () => {
+    let params: BaseParam & AuthenticationParam & TestParam;
+    beforeEach(() => {
+      params = {
+        url: 'url',
+        accessToken: 'accessToken',
+        organizationId: 'organizationId',
+        authentication: 'authentication',
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      };
+    });
+    it('should return all defined properties', () => {
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+    });
+    it('should not return undefined top-level properties', () => {
+      params.a = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.b = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.c = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        d: {a: 'a', b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.d = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.e = undefined;
+      expect(pickNonBaseParams(params)).toEqual({});
+    });
+    it('should not return undefined nested properties', () => {
+      params.d!.a = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {b: 1, c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.d!.b = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {c: false},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+      params.d!.c = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {},
+        e: [{a: 'a', b: 1, c: false}],
+      });
+    });
+    it('should not return any undefined array object nested properties', () => {
+      params.e![0].a = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{b: 1, c: false}],
+      });
+      params.e![0].b = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{c: false}],
+      });
+      params.e![0].c = undefined;
+      expect(pickNonBaseParams(params)).toEqual({
+        a: 'a',
+        b: 1,
+        c: false,
+        d: {a: 'a', b: 1, c: false},
+        e: [{}],
+      });
+    });
+  });
+});

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -253,7 +253,7 @@ export const buildProductRecommendationsRequest = async (
         s.productRecommendations.skus.length > 0
           ? s.productRecommendations.skus
           : undefined,
-      brandFilter: undefined,
+      brandFilter: s.productRecommendations.filter.brand,
       categoryFilter: s.productRecommendations.filter.category,
     },
     actionsHistory: s.configuration.analytics.enabled
@@ -261,6 +261,6 @@ export const buildProductRecommendationsRequest = async (
       : [],
     context: s.context?.contextValues,
     dictionaryFieldContext: s.dictionaryFieldContext?.contextValues,
-    searchHub: undefined,
+    searchHub: s.searchHub,
   };
 };

--- a/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
+++ b/packages/headless/src/features/product-recommendations/product-recommendations-actions.ts
@@ -238,9 +238,9 @@ export const buildProductRecommendationsRequest = async (
     url: s.configuration.search.apiBaseUrl,
     locale: s.configuration.search.locale,
     timezone: s.configuration.search.timezone,
-    ...(s.configuration.analytics.enabled && {
-      visitorId: await getVisitorID(s.configuration.analytics),
-    }),
+    visitorId: s.configuration.analytics.enabled
+      ? await getVisitorID(s.configuration.analytics)
+      : undefined,
     recommendation: s.productRecommendations.id,
     numberOfResults: s.productRecommendations.maxNumberOfRecommendations,
     fieldsToInclude: [
@@ -248,28 +248,19 @@ export const buildProductRecommendationsRequest = async (
       ...(s.productRecommendations.additionalFields || []),
     ],
     mlParameters: {
-      ...(s.productRecommendations.skus &&
-        s.productRecommendations.skus.length > 0 && {
-          itemIds: s.productRecommendations.skus,
-        }),
-      ...(s.productRecommendations.filter.brand && {
-        brandFilter: s.productRecommendations.filter.brand,
-      }),
-      ...(s.productRecommendations.filter.category && {
-        categoryFilter: s.productRecommendations.filter.category,
-      }),
+      itemIds:
+        s.productRecommendations.skus &&
+        s.productRecommendations.skus.length > 0
+          ? s.productRecommendations.skus
+          : undefined,
+      brandFilter: undefined,
+      categoryFilter: s.productRecommendations.filter.category,
     },
     actionsHistory: s.configuration.analytics.enabled
       ? historyStore.getHistory()
       : [],
-    ...(s.context && {
-      context: s.context.contextValues,
-    }),
-    ...(s.dictionaryFieldContext && {
-      dictionaryFieldContext: s.dictionaryFieldContext.contextValues,
-    }),
-    ...(s.searchHub && {
-      searchHub: s.searchHub,
-    }),
+    context: s.context?.contextValues,
+    dictionaryFieldContext: s.dictionaryFieldContext?.contextValues,
+    searchHub: undefined,
   };
 };

--- a/packages/headless/src/features/search/search-request.ts
+++ b/packages/headless/src/features/search/search-request.ts
@@ -70,6 +70,8 @@ export const buildSearchRequest = async (
       facetOptions: {freezeFacetOrder: state.facetOptions.freezeFacetOrder},
     }),
     ...(state.folding?.enabled && {
+      // TODO KIT-3082 remove the comment below; it's only to demonstrate how the spread syntax can cause issues
+      // flutterField: state.folding.fields.collection,
       filterField: state.folding.fields.collection,
       childField: state.folding.fields.parent,
       parentField: state.folding.fields.child,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3082

I only eliminated the spread syntax from the `buildProductRecommendationsRequest` for now to show what I have in mind.

If you agree with the approach I'm proposing, I'll apply it to every build request function and convert this draft to an actual PR.