### PR TITLE
chore: reuse existing workflow for setup in daily quantic

### DIFF
--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Check Out Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-        with:
-          node-version-file: '.nvmrc'
       - name: Create cache file
         run: |
           mkdir check-SHA
@@ -42,7 +39,9 @@ jobs:
               run_id: context.runId
             })
       - name: Setup
-        uses: ./.github/actions/build
+        uses: ./.github/actions/setup
+      - name: Setup SFDX
+        uses: ./.github/actions/setup-sfdx
       - name: Create package version
         working-directory: ./packages/quantic
         run: |


### PR DESCRIPTION
Setup do 99% of the job (node install with cache, build).
Tiny lil thing missing is sfdx