### PR TITLE
feat(commerce): remove unused controller state exports

### DIFF
--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -39,14 +39,12 @@ export type {
   ContextProps,
   Context,
   ContextState,
-  ContextControllerState,
 } from './controllers/commerce/context/headless-context';
 export {buildContext} from './controllers/commerce/context/headless-context';
 
 export type {
   ProductListing,
   ProductListingState,
-  ProductListingControllerState,
 } from './controllers/commerce/product-listing/headless-product-listing';
 export {buildProductListing} from './controllers/commerce/product-listing/headless-product-listing';
 

--- a/packages/headless/src/controllers/commerce/context/headless-context.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.ts
@@ -95,8 +95,6 @@ export interface ContextState {
   view: View;
 }
 
-export type ContextControllerState = Context['state'];
-
 /**
  * Creates a `Context` controller instance.
  *

--- a/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
@@ -38,8 +38,6 @@ export interface ProductListingState {
   responseId: string;
 }
 
-export type ProductListingControllerState = ProductListing['state'];
-
 /**
  * Creates a `ProductListing` controller instance.
  *


### PR DESCRIPTION
These exports are unneeded and unused. Let's remove them.

See discussion from which this change stems from: https://github.com/coveo/ui-kit/pull/3734#discussion_r1537951235

[CAPI-761]

[CAPI-761]: https://coveord.atlassian.net/browse/CAPI-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ