### PR TITLE
docs(atomic): create poor man's version of barca sport in local setup for atomic

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
     "Artemiidae",
     "attachtocase",
     "azerty",
+    "barcasportsmcy",
     "bazz",
     "behaviour",
     "bloup",

--- a/packages/atomic/src/pages/examples/commerce-website/cart.html
+++ b/packages/atomic/src/pages/examples/commerce-website/cart.html
@@ -37,7 +37,7 @@
     </script>
   </head>
   <body>
-    <h1>HOMEPAGE</h1>
+    <h1>Cart</h1>
     <main>
       <section>
         <article id="mostPurchased" style="border-bottom: 1px solid black; padding-bottom: 50px">

--- a/packages/atomic/src/pages/examples/commerce-website/cart.html
+++ b/packages/atomic/src/pages/examples/commerce-website/cart.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Cart</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {
+        setupEngine,
+        setupRecommendationsMostPurchased,
+        setupRecommendationsMostViewed,
+        renderProducts,
+      } from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic-commerce-recommendation component
+       */
+
+      const recommendationsMostPurchased = setupRecommendationsMostPurchased(engine);
+      recommendationsMostPurchased.subscribe(() => {
+        renderProducts('#mostPurchased', 'MOST PURCHASED', recommendationsMostPurchased.state.products);
+      });
+
+      const recommendationsMostViewed = setupRecommendationsMostViewed(engine);
+      recommendationsMostViewed.subscribe(() => {
+        renderProducts('#mostViewed', 'MOST VIEWED', recommendationsMostViewed.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>HOMEPAGE</h1>
+    <main>
+      <section>
+        <article id="mostPurchased" style="border-bottom: 1px solid black; padding-bottom: 50px">
+          REPLACE ME; THIS SHOULD BE A RECOMMENDATION CAROUSEL FOR MOST POPULAR BOUGHT
+        </article>
+      </section>
+      <section>
+        <article id="mostViewed">REPLACE ME; THIS SHOULD BE A RECOMMENDATION CAROUSEL FOR MOST POPULAR VIEWED</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/examples/commerce-website/commerce-nav.mjs
+++ b/packages/atomic/src/pages/examples/commerce-website/commerce-nav.mjs
@@ -44,6 +44,13 @@ const makeLinks = () => {
     .join('');
 };
 
+const escapeHTML = (html) => {
+  var text = document.createTextNode(html);
+  var p = document.createElement('p');
+  p.appendChild(text);
+  return p.innerHTML;
+};
+
 const searchBox = () => {
   const searchBox = document.createElement('input');
   searchBox.type = 'search';
@@ -52,7 +59,7 @@ const searchBox = () => {
   searchBox.onkeydown = (e) => {
     if (e.key === 'Enter') {
       if (window.location.href.indexOf(navContent['Search'].href) === -1) {
-        window.location.href = 'search.html#q=' + searchBox.value;
+        window.location.href = 'search.html#q=' + escapeHTML(searchBox.value);
       } else {
         window.location.hash = `#q=${searchBox.value}`;
         window.location.reload();

--- a/packages/atomic/src/pages/examples/commerce-website/commerce-nav.mjs
+++ b/packages/atomic/src/pages/examples/commerce-website/commerce-nav.mjs
@@ -1,0 +1,78 @@
+const barcaRoot = 'https://sports-dev.barca.group';
+export const navContent = {
+  Homepage: {href: 'homepage.html', label: 'Homepage', barcaUrl: barcaRoot},
+  Pants: {
+    href: 'listing-pants.html',
+    label: 'Pants',
+    barcaUrl: `${barcaRoot}/browse/promotions/clothing/pants`,
+  },
+  'Surf accessories': {
+    href: 'listing-surf-accessories.html',
+    label: 'Surf accessories',
+    barcaUrl: `${barcaRoot}/browse/promotions/surf-with-us-this-year`,
+  },
+  Towels: {
+    href: 'listing-towels.html',
+    label: 'Towels',
+    barcaUrl: `${barcaRoot}/browse/promotions/accessories/towels`,
+  },
+  Cart: {href: 'cart.html', label: 'Cart', barcaUrl: `${barcaRoot}/cart`},
+  Search: {
+    href: 'search.html',
+    label: 'Search',
+    barcaUrl: `${barcaRoot}/commerce-search`,
+  },
+};
+
+export const getParamValue = (param) => {
+  return document.location.hash
+    .substring(1)
+    .split('&')
+    .reduce(function (res, item) {
+      var parts = item.split('=');
+      res[parts[0]] = parts[1];
+      return res;
+    }, {})[param];
+};
+
+const makeLinks = () => {
+  return Object.values(navContent)
+    .map(
+      (nav) =>
+        `<a href="${nav.href}" style="margin-right: 10px; color: var(--atomic-neutral-dark); text-decoration: none;">${nav.label}</a>`
+    )
+    .join('');
+};
+
+const searchBox = () => {
+  const searchBox = document.createElement('input');
+  searchBox.type = 'search';
+  searchBox.placeholder = 'Atomic search box';
+  searchBox.value = getParamValue('q') || '';
+  searchBox.onkeydown = (e) => {
+    if (e.key === 'Enter') {
+      if (window.location.href.indexOf(navContent['Search'].href) === -1) {
+        window.location.href = 'search.html#q=' + searchBox.value;
+      } else {
+        window.location.hash = `#q=${searchBox.value}`;
+        window.location.reload();
+      }
+    }
+  };
+  return searchBox;
+};
+
+const nav = document.createElement('nav');
+nav.style.borderTop = '1px solid var(--atomic-neutral-dark)';
+nav.style.marginBottom = '2em';
+
+nav.innerHTML = `
+            <p style="margin-bottom: 0; margin-left: 0;">Commerce website nav menu:</p>
+            <ul style="display: inline-block; font-size: var(--atomic-text-lg); padding-left: 0;">
+              ${makeLinks()}
+            </ul>
+        `;
+
+nav.appendChild(searchBox());
+
+document.body.querySelector('header').insertAdjacentElement('beforeend', nav);

--- a/packages/atomic/src/pages/examples/commerce-website/engine.mjs
+++ b/packages/atomic/src/pages/examples/commerce-website/engine.mjs
@@ -1,0 +1,99 @@
+import {getParamValue, navContent} from './commerce-nav.mjs';
+import {
+  buildCommerceEngine,
+  getOrganizationEndpoints,
+  buildRecommendations,
+  buildContext,
+  buildProductListing,
+  buildCart,
+  buildSearch,
+  buildSearchBox,
+} from '/build/headless/commerce/headless.esm.js';
+
+export const setupEngine = async () => {
+  const engine = buildCommerceEngine({
+    configuration: {
+      accessToken: 'xxc481d5de-16cb-4290-bd78-45345319d94c',
+      organizationId: 'barcasportsmcy01fvu',
+      organizationEndpoints: await getOrganizationEndpoints(
+        'barcasportsmcy01fvu',
+        'dev'
+      ),
+      analytics: {
+        trackingId: 'sports',
+      },
+    },
+  });
+
+  buildContext(engine, {
+    options: {
+      view: {
+        url: navContent[document.title].barcaUrl,
+        referrer: document.referrer,
+      },
+      language: 'en',
+      country: 'US',
+      currency: 'USD',
+    },
+  });
+  return engine;
+};
+
+export const setupRecommendationsMostPurchased = (engine) => {
+  const recommendationsMostPurchased = buildRecommendations(engine, {
+    options: {
+      slotId: '573ae88e-37ae-456f-a949-829164ad7a84',
+    },
+  });
+  recommendationsMostPurchased.refresh();
+  return recommendationsMostPurchased;
+};
+
+export const setupRecommendationsMostViewed = (engine) => {
+  const recommendationsMostViewed = buildRecommendations(engine, {
+    options: {
+      slotId: 'e098ca76-e7de-4488-b818-c87fbce35542',
+    },
+  });
+  recommendationsMostViewed.refresh();
+  return recommendationsMostViewed;
+};
+
+export const setupProductListing = (engine) => {
+  const productListing = buildProductListing(engine);
+  productListing.refresh();
+  return productListing;
+};
+
+export const setupCart = (engine) => {
+  const cart = buildCart(engine);
+  return cart;
+};
+
+export const setupSearch = (engine) => {
+  const search = buildSearch(engine);
+  const searchBox = buildSearchBox(engine);
+  searchBox.updateText(getParamValue('q'));
+  searchBox.submit();
+  return search;
+};
+
+export const renderProducts = (elem, title, products) => {
+  if (!products.length) {
+    document.querySelector(elem).innerHTML = 'No products found.';
+    return;
+  }
+  document.querySelector(elem).innerHTML =
+    `<h2>${title}</h2>` +
+    products
+      .map((product) => {
+        return `<span><a href='${product.clickUri}'><img width="100px" src='${product.ec_images[0]}'>${product.ec_name}</a></span>`;
+      })
+      .join('');
+
+  return products
+    .map((product) => {
+      return `<div>${product.name}</div>`;
+    })
+    .join('');
+};

--- a/packages/atomic/src/pages/examples/commerce-website/homepage.html
+++ b/packages/atomic/src/pages/examples/commerce-website/homepage.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Homepage</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {
+        setupEngine,
+        setupRecommendationsMostPurchased,
+        setupRecommendationsMostViewed,
+        renderProducts,
+      } from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic recommendations
+       */
+
+      const recommendationsMostPurchased = setupRecommendationsMostPurchased(engine);
+      recommendationsMostPurchased.subscribe(() => {
+        renderProducts('#mostPurchased', 'MOST PURCHASED', recommendationsMostPurchased.state.products);
+      });
+
+      const recommendationsMostViewed = setupRecommendationsMostViewed(engine);
+      recommendationsMostViewed.subscribe(() => {
+        renderProducts('#mostViewed', 'MOST VIEWED', recommendationsMostViewed.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>HOMEPAGE</h1>
+    <main>
+      <section>
+        <article id="mostPurchased" style="border-bottom: 1px solid black; padding-bottom: 50px">
+          REPLACE ME; THIS SHOULD BE A RECOMMENDATION CAROUSEL FOR MOST POPULAR BOUGHT
+        </article>
+      </section>
+      <section>
+        <article id="mostViewed">REPLACE ME; THIS SHOULD BE A RECOMMENDATION CAROUSEL FOR MOST POPULAR VIEWED</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/examples/commerce-website/listing-pants.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-pants.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Pants</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {setupEngine, setupProductListing, renderProducts} from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic commerce listing page
+       */
+      const listing = setupProductListing(engine);
+      listing.subscribe(() => {
+        renderProducts('#productList', 'Pants', listing.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>Product listing page</h1>
+    <main>
+      <section>
+        <article id="productList">REPLACE ME; THIS SHOULD BE THE PRODUCT LISTING PAGE</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/examples/commerce-website/listing-surf-accessories.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-surf-accessories.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Surf accessories</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {setupEngine, setupProductListing, renderProducts} from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic commerce listing page
+       */
+      const listing = setupProductListing(engine);
+      listing.subscribe(() => {
+        renderProducts('#productList', 'Surf accessories', listing.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>Product listing page</h1>
+    <main>
+      <section>
+        <article id="productList">REPLACE ME; THIS SHOULD BE THE PRODUCT LISTING PAGE</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/examples/commerce-website/listing-towels.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-towels.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Towels</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {setupEngine, setupProductListing, renderProducts} from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic commerce listing page
+       */
+      const listing = setupProductListing(engine);
+      listing.subscribe(() => {
+        renderProducts('#productList', 'Towels ', listing.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>Product listing page</h1>
+    <main>
+      <section>
+        <article id="productList">REPLACE ME; THIS SHOULD BE THE PRODUCT LISTING PAGE</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/examples/commerce-website/search.html
+++ b/packages/atomic/src/pages/examples/commerce-website/search.html
@@ -26,7 +26,7 @@
     </script>
   </head>
   <body>
-    <h1>Product listing page</h1>
+    <h1>Search page</h1>
     <main>
       <section>
         <article id="productList">REPLACE ME; THIS SHOULD BE THE SEARCH PAGE</article>

--- a/packages/atomic/src/pages/examples/commerce-website/search.html
+++ b/packages/atomic/src/pages/examples/commerce-website/search.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Search</title>
+
+    <script type="module" src="/build/atomic.esm.js"></script>
+    <script nomodule src="/build/atomic.js"></script>
+    <link rel="stylesheet" href="/themes/coveo.css" />
+    <script type="module">
+      import {setupEngine, setupSearch, renderProducts} from './engine.mjs';
+
+      const engine = await setupEngine();
+
+      /*
+       * The following code section should be replaced by actual atomic commerce search page
+       */
+      const search = setupSearch(engine);
+      search.subscribe(() => {
+        renderProducts('#productList', 'Search', search.state.products);
+      });
+      /**
+       * End of section to be replaced
+       */
+    </script>
+  </head>
+  <body>
+    <h1>Product listing page</h1>
+    <main>
+      <section>
+        <article id="productList">REPLACE ME; THIS SHOULD BE THE SEARCH PAGE</article>
+      </section>
+    </main>
+
+    <script src="../../header.js" type="text/javascript"></script>
+    <script src="commerce-nav.mjs" type="module"></script>
+  </body>
+</html>

--- a/packages/atomic/src/pages/header.js
+++ b/packages/atomic/src/pages/header.js
@@ -21,6 +21,7 @@ const links = [
   },
   {href: '/examples/ipx.html', label: 'IPX'},
   {href: '/examples/genqa.html', label: 'Gen Q&A'},
+  {href: '/examples/commerce-website/homepage.html', label: 'Commerce Website'},
 ];
 
 const header = document.createElement('header');

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -164,3 +164,5 @@ export type {
 } from './controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager';
 export {buildProductListingBreadcrumbManager} from './controllers/commerce/product-listing/breadcrumb-manager/headless-product-listing-breadcrumb-manager';
 export {buildSearchBreadcrumbManager} from './controllers/commerce/search/breadcrumb-manager/headless-search-breadcrumb-manager';
+
+export {getOrganizationEndpoints} from './api/platform-client';


### PR DESCRIPTION
Lots of ugly throwaway/temporary code.

Goal is to have a setup to "fill in the blank" with atomic components in the following weeks.

* Homepage, with 2 recommendations strategy
* 3 listing page
* One search page
* One cart with 2 recommendations strategy

This should allow us to test properly navigation between pages, and how the state will be kept from one page to another in a non SPA scenario

https://coveord.atlassian.net/browse/KIT-3045