### PR TITLE
feat(commerce): namespace pagination on a per-solution-type basis

### DIFF
--- a/packages/headless/src/controllers/commerce/core/common.ts
+++ b/packages/headless/src/controllers/commerce/core/common.ts
@@ -4,10 +4,11 @@ import {
   PrepareAction,
 } from '@reduxjs/toolkit';
 import {AsyncThunkOptions} from '../../../app/async-thunk-options';
+import {SolutionTypeActionCreatorPayload} from '../../../features/commerce/common/actions';
 
 export type FetchResultsActionCreator = () => AsyncThunkAction<
   unknown,
-  void,
+  SolutionTypeActionCreatorPayload,
   AsyncThunkOptions<unknown>
 >;
 

--- a/packages/headless/src/controllers/commerce/core/facets/searchable/headless-commerce-facet-search.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/searchable/headless-commerce-facet-search.ts
@@ -1,5 +1,6 @@
 import {SpecificFacetSearchResult} from '../../../../../api/search/facet-search/specific-facet-search/specific-facet-search-response';
 import {CommerceEngine} from '../../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../../features/commerce/common/actions';
 import {
   executeCommerceFacetSearch,
   executeCommerceFieldSuggest,
@@ -47,8 +48,16 @@ export function buildCommerceFacetSearch(
   const {showMoreResults, updateCaptions, ...restOfFacetSearch} =
     buildFacetSearch(engine, {
       ...props,
-      executeFacetSearchActionCreator: executeCommerceFacetSearch,
-      executeFieldSuggestActionCreator: executeCommerceFieldSuggest,
+      executeFacetSearchActionCreator: (facetId: string) =>
+        executeCommerceFacetSearch({
+          solutionTypeId: defaultSolutionTypeId,
+          facetId,
+        }),
+      executeFieldSuggestActionCreator: (facetId: string) =>
+        executeCommerceFieldSuggest({
+          solutionTypeId: defaultSolutionTypeId,
+          facetId,
+        }),
     });
 
   return {

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -1,6 +1,7 @@
 import {NumberValue, Schema} from '@coveo/bueno';
 import {createSelector} from '@reduxjs/toolkit';
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {
   nextPage,
   previousPage,
@@ -97,7 +98,12 @@ export function buildCorePagination(
   validateOptions(engine, optionsSchema, props.options, 'buildCorePagination');
 
   if (props.options?.pageSize) {
-    dispatch(setPageSize(props.options.pageSize));
+    dispatch(
+      setPageSize({
+        solutionTypeId: defaultSolutionTypeId,
+        pageSize: props.options.pageSize,
+      })
+    );
   }
 
   const paginationSelector = createSelector(
@@ -116,22 +122,27 @@ export function buildCorePagination(
     },
 
     selectPage(page: number) {
-      dispatch(selectPage(page));
+      dispatch(
+        selectPage({
+          solutionTypeId: defaultSolutionTypeId,
+          page,
+        })
+      );
       dispatch(props.fetchResultsActionCreator());
     },
 
     nextPage() {
-      dispatch(nextPage());
+      dispatch(nextPage({solutionTypeId: defaultSolutionTypeId}));
       dispatch(props.fetchResultsActionCreator());
     },
 
     previousPage() {
-      dispatch(previousPage());
+      dispatch(previousPage({solutionTypeId: defaultSolutionTypeId}));
       dispatch(props.fetchResultsActionCreator());
     },
 
     setPageSize(pageSize: number) {
-      dispatch(setPageSize(pageSize));
+      dispatch(setPageSize({solutionTypeId: defaultSolutionTypeId, pageSize}));
       dispatch(props.fetchResultsActionCreator());
     },
   };

--- a/packages/headless/src/controllers/commerce/product-listing/breadcrumb-manager/headless-product-listing-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/breadcrumb-manager/headless-product-listing-breadcrumb-manager.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -23,6 +24,7 @@ export function buildProductListingBreadcrumbManager(
 
   return buildCoreBreadcrumbManager(engine, {
     facetResponseSelector: facetResponseSelector,
-    fetchResultsActionCreator: fetchProductListing,
+    fetchResultsActionCreator: () =>
+      fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
@@ -1,3 +1,4 @@
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {isFacetResponse} from '../../../../features/commerce/facets/facet-set/facet-set-selector';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {
@@ -29,7 +30,8 @@ export const commonOptions: Pick<
   | 'facetResponseSelector'
   | 'isFacetLoadingResponseSelector'
 > = {
-  fetchResultsActionCreator: fetchProductListing,
+  fetchResultsActionCreator: () =>
+    fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
   facetResponseSelector,
   isFacetLoadingResponseSelector,
 };

--- a/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
@@ -2,6 +2,7 @@ import {CommerceAPIErrorStatusResponse} from '../../../api/commerce/commerce-api
 import {Product} from '../../../api/commerce/common/product';
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
 import {configuration} from '../../../app/common-reducers';
+import {defaultSolutionTypeId} from '../../../features/commerce/common/actions';
 import {contextReducer as commerceContext} from '../../../features/commerce/context/context-slice';
 import {fetchProductListing} from '../../../features/commerce/product-listing/product-listing-actions';
 import {responseIdSelector} from '../../../features/commerce/product-listing/product-listing-selectors';
@@ -54,7 +55,8 @@ export function buildProductListing(engine: CommerceEngine): ProductListing {
   const getState = () => engine.state;
   const subControllers = buildSolutionTypeSubControllers(engine, {
     responseIdSelector,
-    fetchResultsActionCreator: fetchProductListing,
+    fetchResultsActionCreator: () =>
+      fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
   });
 
   return {
@@ -72,7 +74,8 @@ export function buildProductListing(engine: CommerceEngine): ProductListing {
       };
     },
 
-    refresh: () => dispatch(fetchProductListing()),
+    refresh: () =>
+      dispatch(fetchProductListing({solutionTypeId: defaultSolutionTypeId})),
   };
 }
 

--- a/packages/headless/src/controllers/commerce/product-listing/pagination/headless-product-listing-pagination.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/pagination/headless-product-listing-pagination.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -25,6 +26,7 @@ export function buildProductListingPagination(
 
   return buildCorePagination(engine, {
     ...props,
-    fetchResultsActionCreator: fetchProductListing,
+    fetchResultsActionCreator: () =>
+      fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/commerce/product-listing/parameter-manager/headless-product-listing-parameter-manager.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/parameter-manager/headless-product-listing-parameter-manager.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {
   ProductListingParameters,
@@ -27,7 +28,8 @@ export function buildProductListingParameterManager(
     parametersDefinition: productListingParametersDefinition,
     activeParametersSelector,
     restoreActionCreator: restoreProductListingParameters,
-    fetchResultsActionCreator: fetchProductListing,
+    fetchResultsActionCreator: () =>
+      fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
     enrichParameters: () => ({}),
   });
 }

--- a/packages/headless/src/controllers/commerce/product-listing/sort/headless-product-listing-sort.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/sort/headless-product-listing-sort.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -25,6 +26,7 @@ export function buildProductListingSort(
 
   return buildCoreSort(engine, {
     ...props,
-    fetchResultsActionCreator: fetchProductListing,
+    fetchResultsActionCreator: () =>
+      fetchProductListing({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
@@ -1,6 +1,7 @@
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
 import {configuration} from '../../../app/common-reducers';
 import {deselectAllBreadcrumbs} from '../../../features/breadcrumb/breadcrumb-actions';
+import {defaultSolutionTypeId} from '../../../features/commerce/common/actions';
 import {selectPage} from '../../../features/commerce/pagination/pagination-actions';
 import {fetchQuerySuggestions} from '../../../features/commerce/query-suggest/query-suggest-actions';
 import {updateQuery} from '../../../features/commerce/query/query-actions';
@@ -114,8 +115,17 @@ export function buildSearchBox(
 
     dispatch(updateFacetAutoSelection({allow: true}));
     dispatch(updateQuery({query: getValue()}));
-    dispatch(selectPage(0));
-    dispatch(executeSearch());
+    dispatch(
+      selectPage({
+        solutionTypeId: defaultSolutionTypeId,
+        page: 0,
+      })
+    );
+    dispatch(
+      executeSearch({
+        solutionTypeId: defaultSolutionTypeId,
+      })
+    );
   };
 
   return {

--- a/packages/headless/src/controllers/commerce/search/breadcrumb-manager/headless-search-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/commerce/search/breadcrumb-manager/headless-search-breadcrumb-manager.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -23,6 +24,7 @@ export function buildSearchBreadcrumbManager(
 
   return buildCoreBreadcrumbManager(engine, {
     facetResponseSelector: facetResponseSelector,
-    fetchResultsActionCreator: executeSearch,
+    fetchResultsActionCreator: () =>
+      executeSearch({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
@@ -1,3 +1,4 @@
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {isFacetResponse} from '../../../../features/commerce/facets/facet-set/facet-set-selector';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {
@@ -29,7 +30,8 @@ export const commonOptions: Pick<
   | 'facetResponseSelector'
   | 'isFacetLoadingResponseSelector'
 > = {
-  fetchResultsActionCreator: executeSearch,
+  fetchResultsActionCreator: () =>
+    executeSearch({solutionTypeId: defaultSolutionTypeId}),
   facetResponseSelector,
   isFacetLoadingResponseSelector,
 };

--- a/packages/headless/src/controllers/commerce/search/headless-search.ts
+++ b/packages/headless/src/controllers/commerce/search/headless-search.ts
@@ -3,6 +3,7 @@ import {Product} from '../../../api/commerce/common/product';
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
 import {configuration} from '../../../app/common-reducers';
 import {LegacySearchAction} from '../../../features/analytics/analytics-utils';
+import {defaultSolutionTypeId} from '../../../features/commerce/common/actions';
 import {contextReducer as commerceContext} from '../../../features/commerce/context/context-slice';
 import {queryReducer as commerceQuery} from '../../../features/commerce/query/query-slice';
 import {executeSearch} from '../../../features/commerce/search/search-actions';
@@ -47,7 +48,8 @@ export function buildSearch(engine: CommerceEngine): Search {
   const getState = () => engine.state;
   const subControllers = buildSolutionTypeSubControllers(engine, {
     responseIdSelector,
-    fetchResultsActionCreator: executeSearch,
+    fetchResultsActionCreator: () =>
+      executeSearch({solutionTypeId: defaultSolutionTypeId}),
   });
 
   return {
@@ -67,7 +69,11 @@ export function buildSearch(engine: CommerceEngine): Search {
         return;
       }
 
-      dispatch(executeSearch());
+      dispatch(
+        executeSearch({
+          solutionTypeId: defaultSolutionTypeId,
+        })
+      );
     },
   };
 }

--- a/packages/headless/src/controllers/commerce/search/pagination/headless-search-pagination.ts
+++ b/packages/headless/src/controllers/commerce/search/pagination/headless-search-pagination.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -25,6 +26,7 @@ export function buildSearchPagination(
 
   return buildCorePagination(engine, {
     ...props,
-    fetchResultsActionCreator: executeSearch,
+    fetchResultsActionCreator: () =>
+      executeSearch({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/commerce/search/parameter-manager/headless-search-parameter-manager.ts
+++ b/packages/headless/src/controllers/commerce/search/parameter-manager/headless-search-parameter-manager.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {queryReducer as commerceQuery} from '../../../../features/commerce/query/query-slice';
 import {getCommerceQueryInitialState} from '../../../../features/commerce/query/query-state';
 import {
@@ -35,7 +36,8 @@ export function buildSearchParameterManager(
     activeParametersSelector,
     restoreActionCreator: restoreSearchParameters,
     parametersDefinition: searchParametersDefinition,
-    fetchResultsActionCreator: executeSearch,
+    fetchResultsActionCreator: () =>
+      executeSearch({solutionTypeId: defaultSolutionTypeId}),
     enrichParameters: (_state, activeParams) => ({
       q: getCommerceQueryInitialState().query!,
       ...activeParams,

--- a/packages/headless/src/controllers/commerce/search/sort/headless-search-sort.ts
+++ b/packages/headless/src/controllers/commerce/search/sort/headless-search-sort.ts
@@ -1,4 +1,5 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {defaultSolutionTypeId} from '../../../../features/commerce/common/actions';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {loadReducerError} from '../../../../utils/errors';
 import {
@@ -25,6 +26,7 @@ export function buildSearchSort(
 
   return buildCoreSort(engine, {
     ...props,
-    fetchResultsActionCreator: executeSearch,
+    fetchResultsActionCreator: () =>
+      executeSearch({solutionTypeId: defaultSolutionTypeId}),
   });
 }

--- a/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/facet-search.ts
@@ -28,14 +28,14 @@ export interface GenericFacetSearchProps<T extends FacetSearchState> {
     facetId: string
   ) => AsyncThunkAction<
     unknown,
-    string,
+    unknown,
     AsyncThunkOptions<unknown, ThunkExtraArguments>
   >;
   executeFieldSuggestActionCreator: (
     facetId: string
   ) => AsyncThunkAction<
     unknown,
-    string,
+    unknown,
     AsyncThunkOptions<unknown, ThunkExtraArguments>
   >;
 }

--- a/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
+++ b/packages/headless/src/controllers/core/facets/facet-search/specific/headless-facet-search.ts
@@ -25,14 +25,14 @@ export interface FacetSearchProps {
     facetId: string
   ) => AsyncThunkAction<
     unknown,
-    string,
+    unknown,
     AsyncThunkOptions<unknown, ThunkExtraArguments>
   >;
   executeFieldSuggestActionCreator: (
     facetId: string
   ) => AsyncThunkAction<
     unknown,
-    string,
+    unknown,
     AsyncThunkOptions<unknown, ThunkExtraArguments>
   >;
 }

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -1,3 +1,5 @@
+import {SchemaDefinition} from '@coveo/bueno';
+import {createAction} from '@reduxjs/toolkit';
 import {getVisitorID} from '../../../api/analytics/coveo-analytics-utils';
 import {SortParam} from '../../../api/commerce/commerce-api-params';
 import {
@@ -20,6 +22,10 @@ import {
   RecommendationsSection,
   VersionSection,
 } from '../../../state/state-sections';
+import {
+  requiredNonEmptyString,
+  validatePayload,
+} from '../../../utils/validate-payload';
 import {PreparableAnalyticsAction} from '../../analytics/analytics-utils';
 import {StateNeededByFetchProductListingV2} from '../product-listing/product-listing-actions';
 import {SortBy, SortCriterion} from '../sort/sort';
@@ -47,6 +53,7 @@ export interface QueryCommerceAPIThunkReturn {
 }
 
 export const buildBaseCommerceAPIRequest = async (
+  solutionTypeId: string,
   state: StateNeededByQueryCommerceAPI
 ): Promise<BaseCommerceAPIRequest> => {
   const {view, user, ...restOfContext} = state.commerceContext;
@@ -62,20 +69,21 @@ export const buildBaseCommerceAPIRequest = async (
       view,
       cart: state.cart.cartItems.map((id) => state.cart.cart[id]),
     },
-    ...(state.commercePagination && {
-      page: state.commercePagination.page,
-      ...(state.commercePagination.perPage && {
-        perPage: state.commercePagination.perPage,
+    ...(state.commercePagination?.[solutionTypeId] && {
+      page: state.commercePagination[solutionTypeId].page,
+      ...(state.commercePagination[solutionTypeId].perPage && {
+        perPage: state.commercePagination[solutionTypeId].perPage,
       }),
     }),
   };
 };
 
 export const buildCommerceAPIRequest = async (
+  solutionTypeId: string,
   state: StateNeededByQueryCommerceAPI
 ): Promise<CommerceAPIRequest> => {
   return {
-    ...(await buildBaseCommerceAPIRequest(state)),
+    ...(await buildBaseCommerceAPIRequest(solutionTypeId, state)),
     facets: getFacets(state),
     ...(state.commerceSort && {
       sort: getSort(state.commerceSort.appliedSort),
@@ -112,3 +120,26 @@ function getSort(appliedSort: SortCriterion): SortParam['sort'] | undefined {
     };
   }
 }
+
+export const defaultSolutionTypeId = 'default';
+
+export const solutionTypeDefinition = {
+  solutionTypeId: requiredNonEmptyString,
+};
+
+export interface SolutionTypePayload {
+  solutionTypeId: string;
+}
+
+export type SolutionTypeActionCreatorPayload = SolutionTypePayload;
+
+export const createSolutionTypeAction = <P>(
+  type: string,
+  definition?: SchemaDefinition<Required<P>>
+) =>
+  createAction(type, (payload: P & SolutionTypePayload) =>
+    validatePayload(payload, {
+      ...solutionTypeDefinition,
+      ...definition,
+    } as SchemaDefinition<Required<P & SolutionTypePayload>>)
+  );

--- a/packages/headless/src/features/commerce/common/state.ts
+++ b/packages/headless/src/features/commerce/common/state.ts
@@ -1,0 +1,9 @@
+export type SolutionTypeId = string;
+
+export type SlicedBySolutionType<Slice> = Record<SolutionTypeId, Slice>;
+
+export function getSlicedBySolutionTypeInitialState<
+  Slice,
+>(): SlicedBySolutionType<Slice> {
+  return {};
+}

--- a/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
@@ -7,6 +7,7 @@ import {SpecificFacetSearchResponse} from '../../../../api/search/facet-search/s
 import {AsyncThunkOptions} from '../../../../app/async-thunk-options';
 import {ClientThunkExtraArguments} from '../../../../app/thunk-extra-arguments';
 import {requiredNonEmptyString} from '../../../../utils/validate-payload';
+import {SolutionTypeActionCreatorPayload} from '../../common/actions';
 import {buildCommerceFacetSearchRequest} from './commerce-facet-search-request-builder';
 import {StateNeededForCommerceFacetSearch} from './commerce-facet-search-state';
 
@@ -15,7 +16,10 @@ type ExecuteCommerceFacetSearchThunkReturn = {
   response: CommerceAPIResponse<SpecificFacetSearchResponse>;
 };
 
-type ExecuteCommerceFacetSearchThunkArg = string;
+export type ExecuteCommerceFacetSearchThunkArg =
+  SolutionTypeActionCreatorPayload & {
+    facetId: string;
+  };
 
 type ExecuteCommerceFacetSearchThunkApiConfig = AsyncThunkOptions<
   StateNeededForCommerceFacetSearch,
@@ -30,10 +34,14 @@ const getExecuteFacetSearchThunkPayloadCreator =
     ExecuteCommerceFacetSearchThunkArg,
     ExecuteCommerceFacetSearchThunkApiConfig
   > =>
-  async (facetId: string, {getState, extra: {apiClient, validatePayload}}) => {
+  async (
+    {facetId, solutionTypeId},
+    {getState, extra: {apiClient, validatePayload}}
+  ) => {
     const state = getState();
     validatePayload(facetId, requiredNonEmptyString);
     const req = await buildCommerceFacetSearchRequest(
+      solutionTypeId,
       facetId,
       state,
       isFieldSuggestionsRequest
@@ -46,7 +54,7 @@ const getExecuteFacetSearchThunkPayloadCreator =
 
 export const executeCommerceFacetSearch = createAsyncThunk<
   ExecuteCommerceFacetSearchThunkReturn,
-  string,
+  ExecuteCommerceFacetSearchThunkArg,
   AsyncThunkOptions<
     StateNeededForCommerceFacetSearch,
     ClientThunkExtraArguments<CommerceFacetSearchAPIClient>
@@ -58,7 +66,7 @@ export const executeCommerceFacetSearch = createAsyncThunk<
 
 export const executeCommerceFieldSuggest = createAsyncThunk<
   ExecuteCommerceFacetSearchThunkReturn,
-  string,
+  ExecuteCommerceFacetSearchThunkArg,
   AsyncThunkOptions<
     StateNeededForCommerceFacetSearch,
     ClientThunkExtraArguments<CommerceFacetSearchAPIClient>

--- a/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-request-builder.ts
@@ -3,6 +3,7 @@ import {buildCommerceAPIRequest} from '../../common/actions';
 import {StateNeededForCommerceFacetSearch} from './commerce-facet-search-state';
 
 export const buildCommerceFacetSearchRequest = async (
+  solutionTypeId: string,
   facetId: string,
   state: StateNeededForCommerceFacetSearch,
   isFieldSuggestionsRequest: boolean
@@ -22,7 +23,7 @@ export const buildCommerceFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = await buildCommerceAPIRequest(state);
+  } = await buildCommerceAPIRequest(solutionTypeId, state);
 
   return {
     url,

--- a/packages/headless/src/features/commerce/pagination/pagination-actions.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-actions.ts
@@ -1,19 +1,32 @@
 import {NumberValue} from '@coveo/bueno';
-import {createAction} from '@reduxjs/toolkit';
-import {validatePayload} from '../../../utils/validate-payload';
+import {createSolutionTypeAction} from '../common/actions';
 
-const numberValue = new NumberValue({required: true, min: 0});
+const setPageSizeDefinition = {
+  pageSize: new NumberValue({required: true, min: 0}),
+};
 
-export const setPageSize = createAction(
+interface SetPageSizePayload {
+  pageSize: number;
+}
+
+export const setPageSize = createSolutionTypeAction<SetPageSizePayload>(
   'commerce/pagination/setPageSize',
-  (payload: number) => validatePayload(payload, numberValue)
+  setPageSizeDefinition
 );
 
-export const selectPage = createAction(
+const selectPageDefinition = {
+  page: new NumberValue({required: true, min: 0}),
+};
+
+export const selectPage = createSolutionTypeAction(
   'commerce/pagination/selectPage',
-  (payload: number) => validatePayload(payload, numberValue)
+  selectPageDefinition
 );
 
-export const nextPage = createAction('commerce/pagination/nextPage');
+export const nextPage = createSolutionTypeAction(
+  'commerce/pagination/nextPage'
+);
 
-export const previousPage = createAction('commerce/pagination/previousPage');
+export const previousPage = createSolutionTypeAction(
+  'commerce/pagination/previousPage'
+);

--- a/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
@@ -21,6 +21,7 @@ import {
 import {paginationReducer} from './pagination-slice';
 import {
   CommercePaginationState,
+  getCommercePaginationInitialSlice,
   getCommercePaginationInitialState,
 } from './pagination-state';
 
@@ -32,6 +33,7 @@ describe('pagination slice', () => {
     totalCount: 999,
     totalPages: 999,
   };
+  const solutionTypeId = 'solution-type-id';
 
   beforeEach(() => {
     state = getCommercePaginationInitialState();
@@ -48,57 +50,84 @@ describe('pagination slice', () => {
   });
 
   it('#selectPage does not update the current page if specified page is invalid', () => {
-    state.totalPages = 1;
+    state[solutionTypeId].totalPages = 1;
 
-    let finalState = paginationReducer(state, selectPage(1));
+    let finalState = paginationReducer(
+      state,
+      selectPage({
+        solutionTypeId,
+        page: 1,
+      })
+    );
 
     expect(finalState.page).toBe(0);
 
-    finalState = paginationReducer(state, selectPage(-1));
+    finalState = paginationReducer(
+      state,
+      selectPage({
+        solutionTypeId,
+        page: -1,
+      })
+    );
 
-    expect(finalState.page).toBe(0);
+    expect(finalState[solutionTypeId].page).toBe(0);
   });
 
   it('#selectPage updates the current page if valid', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, selectPage(1));
+    state[solutionTypeId].totalPages = 2;
+    const finalState = paginationReducer(
+      state,
+      selectPage({
+        solutionTypeId,
+        page: 1,
+      })
+    );
 
-    expect(finalState.page).toBe(1);
+    expect(finalState[solutionTypeId].page).toBe(1);
   });
 
   it('#nextPage does not update the current page if already on the last page', () => {
-    state.totalPages = 2;
-    state.page = 1;
-    const finalState = paginationReducer(state, nextPage());
+    state[solutionTypeId].totalPages = 2;
+    state[solutionTypeId].page = 1;
+    const finalState = paginationReducer(state, nextPage({solutionTypeId}));
 
-    expect(finalState.page).toBe(1);
+    expect(finalState[solutionTypeId].page).toBe(1);
   });
 
   it('#nextPage increments the current page if not already on last page', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, nextPage());
+    state[solutionTypeId].totalPages = 2;
+    const finalState = paginationReducer(state, nextPage({solutionTypeId}));
 
-    expect(finalState.page).toBe(1);
+    expect(finalState[solutionTypeId].page).toBe(1);
   });
 
   it('#previousPage does not update the current page if already on the first page', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, previousPage());
+    state[solutionTypeId].totalPages = 2;
+    const finalState = paginationReducer(state, previousPage({solutionTypeId}));
 
-    expect(finalState.page).toBe(0);
+    expect(finalState[solutionTypeId].page).toBe(0);
   });
 
   it('#previousPage decrements the current page if not already on first page', () => {
-    state.totalPages = 2;
-    state.page = 1;
-    const finalState = paginationReducer(state, previousPage());
+    state[solutionTypeId] = {
+      ...getCommercePaginationInitialSlice(),
+      totalPages: 2,
+      page: 1,
+    };
+    const finalState = paginationReducer(state, previousPage({solutionTypeId}));
 
-    expect(finalState.page).toBe(0);
+    expect(finalState[solutionTypeId].page).toBe(0);
   });
 
   it('#setPageSize sets the page size', () => {
     const pageSize = 17;
-    const finalState = paginationReducer(state, setPageSize(pageSize));
+    const finalState = paginationReducer(
+      state,
+      setPageSize({
+        solutionTypeId,
+        pageSize,
+      })
+    );
 
     expect(finalState.perPage).toBe(pageSize);
   });
@@ -109,7 +138,10 @@ describe('pagination slice', () => {
     });
 
     expect(
-      paginationReducer(state, fetchProductListing.fulfilled(response, ''))
+      paginationReducer(
+        state,
+        fetchProductListing.fulfilled(response, '', {solutionTypeId})
+      )
     ).toEqual(pagination);
   });
 
@@ -119,7 +151,10 @@ describe('pagination slice', () => {
     });
 
     expect(
-      paginationReducer(state, executeSearch.fulfilled(response, ''))
+      paginationReducer(
+        state,
+        executeSearch.fulfilled(response, '', {solutionTypeId})
+      )
     ).toEqual(pagination);
   });
 
@@ -158,8 +193,11 @@ describe('pagination slice', () => {
     },
   ])('$actionName', ({action}) => {
     it('resets pagination', () => {
-      state.page = 5;
-      state.perPage = 17;
+      state[solutionTypeId] = {
+        ...getCommercePaginationInitialSlice(),
+        page: 5,
+        perPage: 17,
+      };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const finalState = paginationReducer(state, action({} as any));

--- a/packages/headless/src/features/commerce/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-slice.ts
@@ -26,32 +26,67 @@ export const paginationReducer = createReducer(
   getCommercePaginationInitialState(),
   (builder) => {
     builder
-      .addCase(nextPage, (state) => {
-        if (state.page < state.totalPages - 1) {
-          ++state.page;
+      .addCase(nextPage, (state, action) => {
+        const slice = state[action.payload.solutionTypeId];
+
+        if (!slice) {
+          return;
+        }
+
+        if (slice.page < slice.totalPages - 1) {
+          ++slice.page;
         }
       })
-      .addCase(previousPage, (state) => {
-        if (state.page > 0) {
-          --state.page;
+      .addCase(previousPage, (state, action) => {
+        const slice = state[action.payload.solutionTypeId];
+
+        if (!slice) {
+          return;
+        }
+
+        if (slice.page > 0) {
+          --slice.page;
         }
       })
       .addCase(selectPage, (state, action) => {
-        if (action.payload >= 0 && action.payload < state.totalPages) {
-          state.page = action.payload;
+        const slice = state[action.payload.solutionTypeId];
+
+        if (!slice) {
+          return;
+        }
+
+        if (
+          action.payload.page >= 0 &&
+          action.payload.page < slice.totalPages
+        ) {
+          slice.page = action.payload.page;
         }
       })
       .addCase(setPageSize, (state, action) => {
-        state.perPage = action.payload;
+        const slice = state[action.payload.solutionTypeId];
+
+        if (!slice) {
+          return;
+        }
+
+        slice.perPage = action.payload.pageSize;
       })
-      .addCase(
-        fetchProductListing.fulfilled,
-        (_, action) => action.payload.response.pagination
-      )
-      .addCase(
-        executeSearch.fulfilled,
-        (_, action) => action.payload.response.pagination
-      )
+      .addCase(fetchProductListing.fulfilled, (state, action) => {
+        if (!state[action.meta.arg.solutionTypeId]) {
+          return;
+        }
+
+        state[action.meta.arg.solutionTypeId] =
+          action.payload.response.pagination;
+      })
+      .addCase(executeSearch.fulfilled, (state, action) => {
+        if (!state[action.meta.arg.solutionTypeId]) {
+          return;
+        }
+
+        state[action.meta.arg.solutionTypeId] =
+          action.payload.response.pagination;
+      })
       .addCase(deselectAllFacetValues, handlePaginationReset)
       .addCase(toggleSelectFacetValue, handlePaginationReset)
       .addCase(toggleExcludeFacetValue, handlePaginationReset)
@@ -64,6 +99,8 @@ export const paginationReducer = createReducer(
 );
 
 function handlePaginationReset(state: CommercePaginationState) {
-  state.page = 0;
-  state.perPage = undefined;
+  for (const solutionTypeId in state) {
+    state[solutionTypeId].page = 0;
+    state[solutionTypeId].perPage = undefined;
+  }
 }

--- a/packages/headless/src/features/commerce/pagination/pagination-state.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-state.ts
@@ -1,11 +1,21 @@
-export interface CommercePaginationState {
+import {
+  getSlicedBySolutionTypeInitialState,
+  SlicedBySolutionType,
+} from '../common/state';
+
+export interface PaginationSlice {
   page: number;
   perPage?: number;
   totalCount: number;
   totalPages: number;
 }
 
-export function getCommercePaginationInitialState(): CommercePaginationState {
+export type CommercePaginationState = SlicedBySolutionType<PaginationSlice>;
+
+export const getCommercePaginationInitialState =
+  getSlicedBySolutionTypeInitialState<PaginationSlice>;
+
+export function getCommercePaginationInitialSlice(): PaginationSlice {
   return {
     page: 0,
     totalCount: 0,

--- a/packages/headless/src/features/commerce/product-listing/product-listing-actions-loader.ts
+++ b/packages/headless/src/features/commerce/product-listing/product-listing-actions-loader.ts
@@ -1,5 +1,3 @@
-import {AsyncThunkAction} from '@reduxjs/toolkit';
-import {AsyncThunkCommerceOptions} from '../../../api/commerce/commerce-api-client';
 import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
 import {productListingV2Reducer as productListing} from '../../../features/commerce/product-listing/product-listing-slice';
 import {ProductListingV2Action} from '../../analytics/analytics-utils';
@@ -14,10 +12,6 @@ import {
   LogFacetSelectActionCreatorPayload,
   LogFacetUpdateSortActionCreatorPayload,
 } from '../../facets/facet-set/facet-set-product-listing-v2-analytics-actions';
-import {
-  QueryCommerceAPIThunkReturn,
-  StateNeededByQueryCommerceAPI,
-} from '../common/actions';
 import {fetchProductListing} from './product-listing-actions';
 
 /**
@@ -31,11 +25,7 @@ export interface ProductListingActionCreators {
    *
    * @returns A dispatchable action.
    */
-  fetchProductListing(): AsyncThunkAction<
-    QueryCommerceAPIThunkReturn,
-    void,
-    AsyncThunkCommerceOptions<StateNeededByQueryCommerceAPI>
-  >;
+  fetchProductListing: typeof fetchProductListing;
 }
 
 /**

--- a/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
@@ -18,6 +18,7 @@ import {logQueryError} from '../../search/search-analytics-actions';
 import {
   buildCommerceAPIRequest,
   QueryCommerceAPIThunkReturn,
+  SolutionTypeActionCreatorPayload,
   StateNeededByQueryCommerceAPI,
 } from '../common/actions';
 import {logProductListingV2Load} from './product-listing-analytics';
@@ -36,15 +37,15 @@ export type StateNeededByFetchProductListingV2 = ConfigurationSection &
 
 export const fetchProductListing = createAsyncThunk<
   QueryCommerceAPIThunkReturn,
-  void,
+  SolutionTypeActionCreatorPayload,
   AsyncThunkCommerceOptions<StateNeededByQueryCommerceAPI>
 >(
   'commerce/productListing/fetch',
-  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
+  async (action, {getState, dispatch, rejectWithValue, extra}) => {
     const state = getState();
     const {apiClient} = extra;
     const fetched = await apiClient.getProductListing(
-      await buildCommerceAPIRequest(state)
+      await buildCommerceAPIRequest(action.solutionTypeId, state)
     );
 
     if (isErrorResponse(fetched)) {

--- a/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
+++ b/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
@@ -20,7 +20,7 @@ const buildRecommendationCommerceAPIRequest = async (
   slotId: string,
   state: StateNeededByQueryCommerceAPI
 ): Promise<CommerceRecommendationsRequest> => {
-  const commerceAPIRequest = await buildCommerceAPIRequest(state);
+  const commerceAPIRequest = await buildCommerceAPIRequest(slotId, state);
   return {
     ...commerceAPIRequest,
     id: slotId,

--- a/packages/headless/src/features/commerce/search/search-actions.ts
+++ b/packages/headless/src/features/commerce/search/search-actions.ts
@@ -8,6 +8,7 @@ import {logQueryError} from '../../search/search-analytics-actions';
 import {
   buildCommerceAPIRequest,
   QueryCommerceAPIThunkReturn,
+  SolutionTypeActionCreatorPayload,
   StateNeededByQueryCommerceAPI,
 } from '../common/actions';
 import {logProductListingV2Load} from '../product-listing/product-listing-analytics';
@@ -17,15 +18,15 @@ export type StateNeededByExecuteSearch = StateNeededByQueryCommerceAPI &
 
 export const executeSearch = createAsyncThunk<
   QueryCommerceAPIThunkReturn,
-  void,
+  SolutionTypeActionCreatorPayload,
   AsyncThunkCommerceOptions<StateNeededByExecuteSearch>
 >(
   'commerce/search/executeSearch',
-  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
+  async (action, {getState, dispatch, rejectWithValue, extra}) => {
     const state = getState();
     const {apiClient} = extra;
     const fetched = await apiClient.search({
-      ...(await buildCommerceAPIRequest(state)),
+      ...(await buildCommerceAPIRequest(action.solutionTypeId, state)),
       query: state.commerceQuery?.query,
     });
 
@@ -35,6 +36,7 @@ export const executeSearch = createAsyncThunk<
     }
 
     return {
+      solutionTypeId: action.solutionTypeId,
       response: fetched.success,
       // eslint-disable-next-line @cspell/spellchecker
       // TODO CAPI-244: Use actual search analytics action

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
@@ -35,7 +35,7 @@ export const specificFacetSearchSetReducer = createReducer(
         handleFacetSearchUpdate(state, action.payload);
       })
       .addCase(executeCommerceFacetSearch.pending, (state, action) => {
-        const facetId = action.meta.arg;
+        const {facetId} = action.meta.arg;
         handleFacetSearchPending(state, facetId, action.meta.requestId);
       })
       .addCase(executeFacetSearch.pending, (state, action) => {
@@ -43,7 +43,7 @@ export const specificFacetSearchSetReducer = createReducer(
         handleFacetSearchPending(state, facetId, action.meta.requestId);
       })
       .addCase(executeCommerceFacetSearch.rejected, (state, action) => {
-        const facetId = action.meta.arg;
+        const {facetId} = action.meta.arg;
         handleFacetSearchRejected(state, facetId);
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {


### PR DESCRIPTION
To make the pagination solution-type specific, I introduce the concept of a `solutionTypeId` to access to pagination slice. We could also name this `sliceName`, `slice`, or `namespace`! Open to suggestions!

I also considered registering reducers on a **slice** instead of on the state section directly, but couldn't easily make it work, which is how I landed with the current approach. Registering reducers for a slice would allow us to leave the reducers relatively unchanged, apart from the fact that their state would be a slice's state, and not a state section. 
Here's pseudocode of how this would look like:
```ts
engine.addReducer({
  [solutionTypeId]: {
    ...currentSolutionTypeReducers,
    paginationReducer
  }
});

// then, we'd have to find a way to let actions be dispatched on a specific *slice*... something like this
engine.dispatch(action, solutionTypeId);
```

Keeping this as draft because I want feedback on the approach before continuing further.

[CAPI-719]

[CAPI-719]: https://coveord.atlassian.net/browse/CAPI-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ