### PR TITLE
feat(headless-cart): allow both productid and SKU when updating a cart item with the cart controller

### DIFF
--- a/packages/headless/src/api/commerce/commerce-api-params.ts
+++ b/packages/headless/src/api/commerce/commerce-api-params.ts
@@ -57,7 +57,7 @@ export type UserParams = (UserIdRequired | EmailRequired | UserIdAndEmail) & {
 };
 
 export interface CartItemParam {
-  productId: string;
+  sku: string;
   quantity: number;
 }
 

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
@@ -21,19 +21,37 @@ describe('headless-cart-selectors', () => {
     jest.resetAllMocks();
     cartOptions = {
       cart: {
-        p3: {productId: 'p1', quantity: 1, name: 'product1', price: 25},
-        p2: {productId: 'p2', quantity: 2, name: 'product2', price: 50},
-        p1: {productId: 'p3', quantity: 3, name: 'product3', price: 100},
+        ['p1_1']: {
+          productId: 'p1',
+          sku: 'p1_1',
+          quantity: 1,
+          name: 'product1',
+          price: 25,
+        },
+        ['p1_2']: {
+          productId: 'p1',
+          sku: 'p1_2',
+          quantity: 2,
+          name: 'product2',
+          price: 50,
+        },
+        ['p1_3']: {
+          productId: 'p1',
+          sku: 'p1_3',
+          quantity: 3,
+          name: 'product3',
+          price: 100,
+        },
       },
-      cartItems: ['p1', 'p2', 'p3'],
+      cartItems: ['p1_1', 'p1_2', 'p1_3'],
     };
     initState(cartOptions);
   });
 
   describe('itemSelector', () => {
     it('should return the correct item from the cart', () => {
-      const selectedItem = itemSelector(cartState, 'p2');
-      expect(selectedItem).toEqual(cartOptions.cart.p2);
+      const selectedItem = itemSelector(cartState, 'p1_1');
+      expect(selectedItem).toEqual(cartOptions.cart['p1_1']);
     });
 
     it('should return undefined if the item is not found in the cart', () => {
@@ -45,12 +63,28 @@ describe('headless-cart-selectors', () => {
   describe('itemsSelector', () => {
     it('should return an array containing all items in the cart', () => {
       const selectedItems = itemsSelector(cartState);
-      expect(
-        selectedItems.sort((a, b) => (a.productId < b.productId ? -1 : 1))
-      ).toEqual([
-        {productId: 'p1', quantity: 1, name: 'product1', price: 25},
-        {productId: 'p2', quantity: 2, name: 'product2', price: 50},
-        {productId: 'p3', quantity: 3, name: 'product3', price: 100},
+      expect(selectedItems.sort((a, b) => (a.sku < b.sku ? -1 : 1))).toEqual([
+        {
+          productId: 'p1',
+          sku: 'p1_1',
+          quantity: 1,
+          name: 'product1',
+          price: 25,
+        },
+        {
+          productId: 'p1',
+          sku: 'p1_2',
+          quantity: 2,
+          name: 'product2',
+          price: 50,
+        },
+        {
+          productId: 'p1',
+          sku: 'p1_3',
+          quantity: 3,
+          name: 'product3',
+          price: 100,
+        },
       ]);
     });
   });

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
@@ -2,8 +2,8 @@ import {createSelector} from '@reduxjs/toolkit';
 import {itemsSelector} from '../../../../features/commerce/context/cart/cart-selector';
 import {CartState} from '../../../../features/commerce/context/cart/cart-state';
 
-export function itemSelector(cartState: CartState, productId: string) {
-  return cartState.cart[productId];
+export function itemSelector(cartState: CartState, sku: string) {
+  return cartState.cart[sku];
 }
 
 export const totalQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -42,13 +42,15 @@ describe('headless commerce cart', () => {
     initialState = {
       items: [
         {
-          productId: 'product-id-1',
+          productId: 'product-id',
+          sku: 'product-id-1',
           quantity: 2,
           name: 'product-name-1',
           price: 100,
         },
         {
-          productId: 'product-id-2',
+          productId: 'product-id',
+          sku: 'product-id-2',
           quantity: 4,
           name: 'product-name-2',
           price: 25,
@@ -131,7 +133,8 @@ describe('headless commerce cart', () => {
 
   describe('#updateItem', () => {
     const productWithoutQuantity = {
-      productId: 'product-id-1',
+      productId: 'product-id',
+      sku: 'product-id-1',
       name: 'product-name-1',
       price: 100,
     };

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -138,6 +138,7 @@ describe('headless commerce cart', () => {
       name: 'product-name-1',
       price: 100,
     };
+    const {sku, ...productWithoutQuantityAndSku} = productWithoutQuantity;
 
     const productWithQuantity = (quantity: number) => ({
       ...productWithoutQuantity,
@@ -161,7 +162,7 @@ describe('headless commerce cart', () => {
       quantity: number = 1
     ) => ({
       action,
-      product: productWithoutQuantity,
+      product: productWithoutQuantityAndSku,
       quantity,
       currency: 'USD',
     });

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -38,8 +38,8 @@ export interface CartItem {
   productId: string;
 
   /**
-   * The unique identifier of the product's variant.
-   * If the item is not a variant, set the same value as the productId.
+   * The stock keeping unit for the item being added to cart.
+   * Depending on how your catalog is structured, this may be the same value as the productId.
    */
   sku: string;
 

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -191,7 +191,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
     currentItem: CartItem,
     prevItem: CartItemWithMetadata | undefined
   ): Ec.CartAction {
-    const {quantity: currentQuantity, ...product} = currentItem;
+    const {quantity: currentQuantity, sku, ...product} = currentItem;
     const action = getCartAction(currentItem, prevItem);
     const quantity = !prevItem
       ? currentQuantity

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -38,6 +38,11 @@ export interface CartItem {
   productId: string;
 
   /**
+   * The unique identifier of the product variant.
+   */
+  sku: string;
+
+  /**
    * The human-readable name of the product.
    */
   name: string;
@@ -215,7 +220,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
     },
 
     updateItem(item: CartItem) {
-      const prevItem = itemSelector(getState(), item.productId);
+      const prevItem = itemSelector(getState(), item.sku);
       const doesNotNeedUpdate = !prevItem && item.quantity <= 0;
 
       if (doesNotNeedUpdate || isEqual(item, prevItem)) {

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -38,7 +38,8 @@ export interface CartItem {
   productId: string;
 
   /**
-   * The unique identifier of the product variant.
+   * The unique identifier of the product's variant.
+   * If the item is not a variant, set the same value as the productId.
    */
   sku: string;
 

--- a/packages/headless/src/features/commerce/context/cart/cart-selector.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-selector.ts
@@ -35,7 +35,7 @@ export const itemsSelector = createSelector(
 );
 
 const productQuantitySelector = createSelector(itemsSelector, (items) =>
-  items.map(({quantity, ...product}) => ({
+  items.map(({quantity, sku, ...product}) => ({
     quantity,
     product,
   }))

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
@@ -9,9 +9,10 @@ import {
 
 describe('cart-slice', () => {
   const someItem: CartItemWithMetadata = {
-    productId: 'product-id-1',
+    productId: 'product-id',
+    sku: 'product-id-1',
     quantity: 10,
-    name: 'product 2',
+    name: 'product 1',
     price: 50,
   };
   let state: CartState;
@@ -27,33 +28,32 @@ describe('cart-slice', () => {
 
   it('#setItems replaces current cart state with specified state', () => {
     const secondItem: CartItemWithMetadata = {
-      productId: 'product-id-2',
+      productId: 'product-id',
+      sku: 'product-id-2',
       quantity: 20,
       name: 'product 2',
       price: 100,
     };
     const updatedState = cartReducer(state, setItems([someItem, secondItem]));
-    expect(updatedState.cartItems).toEqual([
-      someItem.productId,
-      secondItem.productId,
-    ]);
+    expect(updatedState.cartItems).toEqual([someItem.sku, secondItem.sku]);
     expect(updatedState.cart).toEqual({
-      [someItem.productId]: someItem,
-      [secondItem.productId]: secondItem,
+      [someItem.sku]: someItem,
+      [secondItem.sku]: secondItem,
     });
   });
 
   it('#purchase.fulfilled replaces current cart state with empty state', async () => {
     const secondItem: CartItemWithMetadata = {
-      productId: 'product-id-2',
+      productId: 'product-id',
+      sku: 'product-id-2',
       quantity: 20,
       name: 'product 2',
       price: 100,
     };
-    state.cartItems = [someItem.productId, secondItem.productId];
+    state.cartItems = [someItem.sku, secondItem.sku];
     state.cart = {
-      [someItem.productId]: someItem,
-      [secondItem.productId]: secondItem,
+      [someItem.sku]: someItem,
+      [secondItem.sku]: secondItem,
     };
     const fakePurchaseAction = createAction(purchase.fulfilled.type);
     const updatedState = cartReducer(state, fakePurchaseAction());
@@ -64,9 +64,9 @@ describe('cart-slice', () => {
   describe('#updateItem', () => {
     it('adds new item to cart if item is not already in cart and specified quantity is positive', () => {
       const updatedState = cartReducer(state, updateItem(someItem));
-      expect(updatedState.cartItems).toEqual([someItem.productId]);
+      expect(updatedState.cartItems).toEqual([someItem.sku]);
       expect(updatedState.cart).toEqual({
-        [someItem.productId]: someItem,
+        [someItem.sku]: someItem,
       });
     });
 
@@ -82,9 +82,9 @@ describe('cart-slice', () => {
     it('removes existing item from cart if specified quantity is 0', () => {
       const updatedState = cartReducer(
         {
-          cartItems: [someItem.productId],
+          cartItems: [someItem.sku],
           cart: {
-            [someItem.productId]: someItem,
+            [someItem.sku]: someItem,
           },
         },
         updateItem({...someItem, quantity: 0})
@@ -96,9 +96,9 @@ describe('cart-slice', () => {
     it('updates existing item in cart if specified quantity is greater than 0', () => {
       const updatedState = cartReducer(
         {
-          cartItems: [someItem.productId],
+          cartItems: [someItem.sku],
           cart: {
-            [someItem.productId]: someItem,
+            [someItem.sku]: someItem,
           },
         },
         updateItem({
@@ -108,10 +108,11 @@ describe('cart-slice', () => {
           price: 25,
         })
       );
-      expect(updatedState.cartItems).toEqual([someItem.productId]);
+      expect(updatedState.cartItems).toEqual([someItem.sku]);
       expect(updatedState.cart).toEqual({
-        [someItem.productId]: {
+        [someItem.sku]: {
           productId: someItem.productId,
+          sku: someItem.sku,
           name: 'renamed product',
           quantity: 5,
           price: 25,

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.ts
@@ -14,10 +14,10 @@ export const cartReducer = createReducer(
       .addCase(setItems, (state, {payload}) => {
         const {cart, cartItems} = payload.reduce((acc, item) => {
           return {
-            cartItems: [...acc.cartItems, item.productId],
+            cartItems: [...acc.cartItems, item.sku],
             cart: {
               ...acc.cart,
-              [item.productId]: item,
+              [item.sku]: item,
             },
           } as CartState;
         }, getCartInitialState());
@@ -25,17 +25,17 @@ export const cartReducer = createReducer(
         setItemsInState(state, cartItems, cart);
       })
       .addCase(updateItem, (state, {payload}) => {
-        if (!(payload.productId in state.cart)) {
+        if (!(payload.sku in state.cart)) {
           createItemInCart(payload, state);
           return;
         }
 
         if (payload.quantity <= 0) {
-          deleteProductFromCart(payload.productId, state);
+          deleteProductFromCart(payload.sku, state);
           return;
         }
 
-        state.cart[payload.productId] = payload;
+        state.cart[payload.sku] = payload;
         return;
       })
       .addCase(purchase.fulfilled, (state) => {
@@ -59,11 +59,11 @@ function createItemInCart(item: CartItemWithMetadata, state: CartState) {
     return;
   }
 
-  state.cartItems = [...state.cartItems, item.productId];
-  state.cart[item.productId] = item;
+  state.cartItems = [...state.cartItems, item.sku];
+  state.cart[item.sku] = item;
 }
 
-function deleteProductFromCart(productId: string, state: CartState) {
-  state.cartItems = state.cartItems.filter((itemId) => itemId !== productId);
-  delete state.cart[productId];
+function deleteProductFromCart(sku: string, state: CartState) {
+  state.cartItems = state.cartItems.filter((itemId) => itemId !== sku);
+  delete state.cart[sku];
 }

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -2,7 +2,7 @@ import {CartItemParam} from '../../../../api/commerce/commerce-api-params';
 
 export interface CartItemWithMetadata extends CartItemParam {
   /**
-   * The product unique identifier of the cart item.
+   * The unique identifier of the product.
    */
   productId: string;
   /**

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -2,6 +2,10 @@ import {CartItemParam} from '../../../../api/commerce/commerce-api-params';
 
 export interface CartItemWithMetadata extends CartItemParam {
   /**
+   * The product unique identifier of the cart item.
+   */
+  productId: string;
+  /**
    * The name of the cart item.
    */
   name: string;

--- a/packages/headless/src/features/commerce/context/cart/cart-validation.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-validation.ts
@@ -10,6 +10,7 @@ import {requiredNonEmptyString} from '../../../../utils/validate-payload';
 
 export const updateItemPayloadDefinition = {
   productId: requiredNonEmptyString,
+  sku: requiredNonEmptyString,
   quantity: new NumberValue({
     required: true,
     min: 0,

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -53,12 +53,14 @@ describe.skip('commerce', () => {
     const cart = buildCart(engine);
     cart.updateItem({
       productId: 'p1',
+      sku: 'p1_1',
       quantity: 2,
       price: 100,
       name: 'Nice Shoes',
     });
     cart.updateItem({
-      productId: 'p2',
+      productId: 'p1',
+      sku: 'p1_2',
       quantity: 3,
       price: 200,
       name: 'Nicer Shoes',


### PR DESCRIPTION
[LENS-1761](https://coveord.atlassian.net/browse/LENS-1761)

It was noticed that the `productId` emitted with the cart events (`ec.cartAction` & `ec.purchase`) in Barca sports was actually the sku of the product. To guarantee the uniqueness of the cart item in the state and that we send the right information to EP, we decided to add the `sku` property to the `updateItem` action.

Demo of linking the solution to Barca sports

https://github.com/coveo/ui-kit/assets/58052881/524973b7-ab52-4072-9b38-ce955f96d174


[LENS-1761]: https://coveord.atlassian.net/browse/LENS-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ