### PR TITLE
chore: use @coveo/headless/ssr in generic SSR samples

### DIFF
--- a/packages/samples/headless-ssr/app-router/src/app/generic/page.tsx
+++ b/packages/samples/headless-ssr/app-router/src/app/generic/page.tsx
@@ -1,6 +1,6 @@
 import SearchPage from '@/common/components/generic/search-page';
 import {fetchStaticState} from '@/common/lib/generic/engine';
-import {buildSSRSearchParameterSerializer} from '@coveo/headless-react/ssr';
+import {buildSSRSearchParameterSerializer} from '@coveo/headless/ssr';
 
 /**
  * This file defines a Search component that uses the Coveo Headless library to manage its state.

--- a/packages/samples/headless-ssr/pages-router/src/pages/generic/index.tsx
+++ b/packages/samples/headless-ssr/pages-router/src/pages/generic/index.tsx
@@ -1,6 +1,6 @@
 import SearchPage from '@/common/components/generic/search-page';
 import {SearchStaticState, fetchStaticState} from '@/common/lib/generic/engine';
-import {buildSSRSearchParameterSerializer} from '@coveo/headless-react/ssr';
+import {buildSSRSearchParameterSerializer} from '@coveo/headless/ssr';
 
 export async function getServerSideProps(context: {
   query: {[key: string]: string | string[] | undefined};


### PR DESCRIPTION
import the util from the proper package for framework agnostic samples

https://coveord.atlassian.net/browse/KIT-3099