### PR TITLE
chore: refactor: duplicate search-and-folding-request

### DIFF
--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -11,6 +11,7 @@ import {
   QuerySection,
 } from '../../state/state-sections';
 import {validatePayload} from '../../utils/validate-payload';
+import {buildSearchAndFoldingLoadCollectionRequest as legacyBuildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/legacy/search-and-folding-request';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/search-and-folding-request';
 import {ResultWithFolding} from './folding-slice';
 import {CollectionId} from './folding-state';
@@ -79,7 +80,9 @@ export const loadCollection = createAsyncThunk<
   ) => {
     const state = getState();
     const sharedWithSearchRequest =
-      await buildSearchAndFoldingLoadCollectionRequest(state);
+      state.configuration.analytics.analyticsMode === 'legacy'
+        ? await legacyBuildSearchAndFoldingLoadCollectionRequest(state)
+        : await buildSearchAndFoldingLoadCollectionRequest(state);
 
     const response = await apiClient.search(
       {

--- a/packages/headless/src/features/search-and-folding/legacy/search-and-folding-request.test.ts
+++ b/packages/headless/src/features/search-and-folding/legacy/search-and-folding-request.test.ts
@@ -1,0 +1,140 @@
+import {SearchAppState} from '../../../state/search-app-state';
+import {createMockState} from '../../../test/mock-state';
+import {buildMockTabSlice} from '../../../test/mock-tab-state';
+import {buildSearchAndFoldingLoadCollectionRequest} from './search-and-folding-request';
+
+describe('buildSearchAndFoldingLoadCollectionRequest', () => {
+  describe('#aq', () => {
+    it(`when there is an aq in state,
+    the expression is included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.aq = 'a';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.aq).toBe('a');
+    });
+
+    it(`when the aq is an empty string,
+    the aq is not included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.aq = '';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.aq).toBe(undefined);
+    });
+  });
+
+  describe('#cq', () => {
+    it(`when there is a cq in state,
+    the expression is included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.cq = 'a';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.cq).toBe('a');
+    });
+
+    it(`when there is an active tab,
+    the tab expression is not included in the cq`, async () => {
+      const state = createMockState();
+      state.tabSet = {a: buildMockTabSlice({expression: 'a', isActive: true})};
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.cq).toBe(undefined);
+    });
+  });
+
+  describe('#lq', () => {
+    it(`when there is an lq in state,
+    the expression is included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.lq = 'a';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.lq).toBe('a');
+    });
+
+    it(`when the lq is an empty string,
+    the lq is not included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.lq = '';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.lq).toBe(undefined);
+    });
+  });
+
+  describe('#dq', () => {
+    it(`when there is a dq in state,
+    the expression is included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.dq = 'a';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.dq).toBe('a');
+    });
+
+    it(`when the dq is an empty string,
+    the dq is not included in the request`, async () => {
+      const state = createMockState();
+      state.advancedSearchQueries.dq = '';
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.dq).toBe(undefined);
+    });
+  });
+
+  describe('#excerptLength', () => {
+    it(`when there is an excerpt length in state,
+    the parameter is included in the request`, async () => {
+      const state = createMockState();
+      state.excerptLength = {length: 1234};
+
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.excerptLength).toBe(1234);
+    });
+
+    it('when there is no excerptLength in the state, the parameter is not included in the request', async () => {
+      const state = createMockState();
+      state.excerptLength.length = undefined;
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.excerptLength).toBe(undefined);
+    });
+  });
+
+  describe('when analytics are enabled', () => {
+    let state: SearchAppState;
+    beforeEach(() => {
+      state = createMockState();
+      state.configuration.analytics.enabled = true;
+    });
+
+    it('#visitorId is included in the request', async () => {
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.visitorId).toBeDefined();
+    });
+
+    it('#actionsHistory is included in the request', async () => {
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.actionsHistory).toBeDefined();
+    });
+  });
+
+  describe('when analytics are disabled', () => {
+    let state: SearchAppState;
+    beforeEach(() => {
+      state = createMockState();
+      state.configuration.analytics.enabled = false;
+    });
+
+    it('#visitorId is not included in the request', async () => {
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.visitorId).toBeUndefined();
+    });
+
+    it('#actionsHistory is not included in the request', async () => {
+      const request = await buildSearchAndFoldingLoadCollectionRequest(state);
+      expect(request.actionsHistory).toBeUndefined();
+    });
+  });
+});

--- a/packages/headless/src/features/search-and-folding/legacy/search-and-folding-request.ts
+++ b/packages/headless/src/features/search-and-folding/legacy/search-and-folding-request.ts
@@ -1,0 +1,81 @@
+import {isNullOrUndefined} from '@coveo/bueno';
+import {EventDescription} from 'coveo.analytics';
+import {
+  getVisitorID,
+  historyStore,
+} from '../../../api/analytics/coveo-analytics-utils';
+import {SearchRequest} from '../../../api/search/search/search-request';
+import {SearchAppState} from '../../../state/search-app-state';
+import {ConfigurationSection} from '../../../state/state-sections';
+import {fromAnalyticsStateToAnalyticsParams} from '../../configuration/analytics-params';
+
+type StateNeededByExecuteSearchAndFolding = ConfigurationSection &
+  Partial<SearchAppState>;
+
+export const buildSearchAndFoldingLoadCollectionRequest = async (
+  state: StateNeededByExecuteSearchAndFolding,
+  eventDescription?: EventDescription
+): Promise<SearchRequest> => {
+  return {
+    accessToken: state.configuration.accessToken,
+    organizationId: state.configuration.organizationId,
+    url: state.configuration.search.apiBaseUrl,
+    locale: state.configuration.search.locale,
+    debug: state.debug,
+    tab: state.configuration.analytics.originLevel2,
+    referrer: state.configuration.analytics.originLevel3,
+    timezone: state.configuration.search.timezone,
+    ...(state.configuration.analytics.enabled && {
+      visitorId: await getVisitorID(state.configuration.analytics),
+      actionsHistory: historyStore.getHistory(),
+    }),
+    ...(state.advancedSearchQueries?.aq && {
+      aq: state.advancedSearchQueries.aq,
+    }),
+    ...(state.advancedSearchQueries?.cq && {
+      cq: state.advancedSearchQueries.cq,
+    }),
+    ...(state.advancedSearchQueries?.lq && {
+      lq: state.advancedSearchQueries.lq,
+    }),
+    ...(state.advancedSearchQueries?.dq && {
+      dq: state.advancedSearchQueries.dq,
+    }),
+    ...(state.context && {
+      context: state.context.contextValues,
+    }),
+    ...(state.fields &&
+      !state.fields.fetchAllFields && {
+        fieldsToInclude: state.fields.fieldsToInclude,
+      }),
+    ...(state.dictionaryFieldContext && {
+      dictionaryFieldContext: state.dictionaryFieldContext.contextValues,
+    }),
+    ...(state.pipeline && {
+      pipeline: state.pipeline,
+    }),
+    ...(state.query && {
+      q: state.query.q,
+      enableQuerySyntax: state.query.enableQuerySyntax,
+    }),
+    ...(state.searchHub && {
+      searchHub: state.searchHub,
+    }),
+    ...(state.sortCriteria && {
+      sortCriteria: state.sortCriteria,
+    }),
+    ...(state.configuration.analytics.enabled &&
+      (await fromAnalyticsStateToAnalyticsParams(
+        state.configuration.analytics,
+        eventDescription
+      ))),
+    ...(state.excerptLength &&
+      !isNullOrUndefined(state.excerptLength.length) && {
+        excerptLength: state.excerptLength.length,
+      }),
+    ...(state.configuration.search.authenticationProviders.length && {
+      authentication:
+        state.configuration.search.authenticationProviders.join(','),
+    }),
+  };
+};

--- a/packages/headless/src/features/search/legacy/search-actions.ts
+++ b/packages/headless/src/features/search/legacy/search-actions.ts
@@ -30,7 +30,7 @@ import {
   updateQuery,
   UpdateQueryActionCreatorPayload,
 } from '../../query/query-actions';
-import {buildSearchAndFoldingLoadCollectionRequest} from '../../search-and-folding/search-and-folding-request';
+import {buildSearchAndFoldingLoadCollectionRequest} from '../../search-and-folding/legacy/search-and-folding-request';
 import {logFetchMoreResults} from '../search-analytics-actions';
 import {MappedSearchRequest, mapSearchRequest} from '../search-mappings';
 import {buildSearchRequest} from '../search-request';

--- a/packages/headless/src/features/search/search-request.ts
+++ b/packages/headless/src/features/search/search-request.ts
@@ -9,6 +9,7 @@ import {getFacetRequests} from '../facets/generic/interfaces/generic-facet-reque
 import {AnyFacetValue} from '../facets/generic/interfaces/generic-facet-response';
 import {RangeFacetSetState} from '../facets/range-facets/generic/interfaces/range-facet';
 import {maximumNumberOfResultsFromIndex} from '../pagination/pagination-constants';
+import {buildSearchAndFoldingLoadCollectionRequest as legacyBuildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/legacy/search-and-folding-request';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/search-and-folding-request';
 import {mapSearchRequest} from './search-mappings';
 
@@ -23,7 +24,15 @@ export const buildSearchRequest = async (
   const facets = getFacets(state);
   const automaticFacets = getAutomaticFacets(state);
   const sharedWithFoldingRequest =
-    await buildSearchAndFoldingLoadCollectionRequest(state, eventDescription);
+    state.configuration.analytics.analyticsMode === 'legacy'
+      ? await legacyBuildSearchAndFoldingLoadCollectionRequest(
+          state,
+          eventDescription
+        )
+      : await buildSearchAndFoldingLoadCollectionRequest(
+          state,
+          eventDescription
+        );
 
   // Corner case:
   // If the number of results requested would go over the index limit (maximumNumberOfResultsFromIndex)


### PR DESCRIPTION
Duplicate `packages/headless/src/features/search-and-folding/legacy/search-and-folding-request.ts` to allow more straightforward modification in the 'nextAnalytics' behaviour.

https://coveord.atlassian.net/browse/KIT-3024