### PR TITLE
feat(commerce): require context on engine initialization

### DIFF
--- a/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
@@ -1,5 +1,7 @@
-import {Schema} from '@coveo/bueno';
+import {RecordValue, Schema} from '@coveo/bueno';
 import {getOrganizationEndpoints} from '../../api/platform-client';
+import {ContextOptions} from '../../controllers/commerce/context/headless-context';
+import {contextDefinition} from '../../features/commerce/context/context-validation';
 import {
   EngineConfiguration,
   engineConfigurationDefinitions,
@@ -10,11 +12,17 @@ import {
  *
  * @internal WORK IN PROGRESS. DO NOT USE IN ACTUAL IMPLEMENTATIONS.
  */
-export interface CommerceEngineConfiguration extends EngineConfiguration {}
+export interface CommerceEngineConfiguration extends EngineConfiguration {
+  context: ContextOptions;
+}
 
 export const commerceEngineConfigurationSchema =
   new Schema<CommerceEngineConfiguration>({
     ...engineConfigurationDefinitions,
+    context: new RecordValue({
+      options: {required: true},
+      values: contextDefinition,
+    }),
   });
 
 export function getSampleCommerceEngineConfiguration(): CommerceEngineConfiguration {
@@ -25,5 +33,13 @@ export function getSampleCommerceEngineConfiguration(): CommerceEngineConfigurat
     organizationEndpoints: getOrganizationEndpoints(
       'fashioncoveodemocomgzh7iep8'
     ),
+    context: {
+      language: 'en',
+      country: 'CA',
+      currency: 'CAD',
+      view: {
+        url: 'https://www.example.com',
+      },
+    },
   };
 }

--- a/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
@@ -22,8 +22,12 @@ describe('buildCommerceEngine', () => {
     initEngine();
   });
 
-  it('works', () => {
+  it('initializes', () => {
     expect(initEngine).not.toThrow();
     expect(engine.state).toBeTruthy();
+  });
+
+  it('sets the context', () => {
+    expect(engine.state.commerceContext).toEqual(options.configuration.context);
   });
 });

--- a/packages/headless/src/app/commerce-engine/commerce-engine.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ts
@@ -3,6 +3,7 @@ import {Logger} from 'pino';
 import {CommerceAPIClient} from '../../api/commerce/commerce-api-client';
 import {NoopPreprocessRequest} from '../../api/preprocess-request';
 import {cartReducer} from '../../features/commerce/context/cart/cart-slice';
+import {setContext} from '../../features/commerce/context/context-actions';
 import {contextReducer} from '../../features/commerce/context/context-slice';
 import {commerceFacetSetReducer} from '../../features/commerce/facets/facet-set/facet-set-slice';
 import {paginationReducer} from '../../features/commerce/pagination/pagination-slice';
@@ -99,6 +100,8 @@ export function buildCommerceEngine(
   };
 
   const engine = buildEngine(augmentedOptions, thunkArguments);
+
+  engine.dispatch(setContext(options.configuration.context));
 
   return {
     ...engine,

--- a/packages/headless/src/controllers/commerce/context/headless-context.test.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.test.ts
@@ -44,8 +44,16 @@ describe('headless commerce context', () => {
     });
   });
 
-  it('dispatches #setContext on load', () => {
+  it('when context is provided, dispatches #setContext on load', () => {
     expect(setContext).toHaveBeenCalled();
+  });
+
+  it('when context is not provided, does not dispatch #setContext on load', () => {
+    jest.resetAllMocks();
+
+    context = buildContext(engine);
+
+    expect(setContext).not.toHaveBeenCalled();
   });
 
   it('setLanguage dispatches #setContext', () => {

--- a/packages/headless/src/controllers/commerce/context/headless-context.ts
+++ b/packages/headless/src/controllers/commerce/context/headless-context.ts
@@ -44,7 +44,7 @@ export interface ContextProps {
   /**
    * The initial options that should be applied to this `Context` controller.
    */
-  options: ContextOptions;
+  options?: ContextOptions;
 }
 
 /**
@@ -104,7 +104,7 @@ export interface ContextState {
  */
 export function buildContext(
   engine: CommerceEngine,
-  props: ContextProps
+  props: ContextProps = {}
 ): Context {
   if (!loadBaseContextReducers(engine)) {
     throw loadReducerError;
@@ -114,17 +114,10 @@ export function buildContext(
   const {dispatch} = engine;
   const getState = () => engine.state;
 
-  const options = {
-    ...props.options,
-  };
-
-  validateOptions(engine, contextSchema, options, 'buildContext');
-
-  dispatch(
-    setContext({
-      ...options,
-    })
-  );
+  if (props.options) {
+    validateOptions(engine, contextSchema, props.options, 'buildContext');
+    dispatch(setContext(props.options));
+  }
 
   return {
     ...controller,

--- a/packages/headless/src/features/commerce/context/context-validation.ts
+++ b/packages/headless/src/features/commerce/context/context-validation.ts
@@ -31,15 +31,11 @@ export const contextDefinition = {
   country: requiredNonEmptyString,
   currency: currencyDefinition,
   user: new RecordValue({
-    values: {
-      ...userDefinition,
-    },
+    values: userDefinition,
   }),
   view: new RecordValue({
     options: {required: true},
-    values: {
-      ...viewDefinition,
-    },
+    values: viewDefinition,
   }),
 };
 

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -4,7 +4,6 @@ import {
   buildCommerceEngine,
 } from '../app/commerce-engine/commerce-engine';
 import {buildCart} from '../controllers/commerce/context/cart/headless-cart';
-import {buildContext} from '../controllers/commerce/context/headless-context';
 import {buildRelevanceSortCriterion} from '../controllers/commerce/core/sort/headless-core-commerce-sort';
 import {buildProductListingFacetGenerator} from '../controllers/commerce/product-listing/facets/headless-product-listing-facet-generator';
 import {ProductListing} from '../controllers/commerce/product-listing/headless-product-listing';
@@ -35,19 +34,16 @@ describe.skip('commerce', () => {
         analytics: {
           trackingId: 'barca',
         },
-      },
-      loggerOptions: {level: 'silent'},
-    });
-
-    buildContext(engine, {
-      options: {
-        language: 'en-gb',
-        country: 'gb',
-        currency: 'GBP',
-        view: {
-          url: 'https://sports-dev.barca.group/browse/promotions/surf-with-us-this-year',
+        context: {
+          language: 'en-gb',
+          country: 'gb',
+          currency: 'GBP',
+          view: {
+            url: 'https://sports-dev.barca.group/browse/promotions/surf-with-us-this-year',
+          },
         },
       },
+      loggerOptions: {level: 'silent'},
     });
 
     const cart = buildCart(engine);


### PR DESCRIPTION
Requiring the context on engine initialization means we can make the context non-required on the context controller.

[CAPI-560]

[CAPI-560]: https://coveord.atlassian.net/browse/CAPI-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ