### PR TITLE
docs(quantic): use parseString asynchronously

### DIFF
--- a/packages/quantic/docs/template/lwc-json/publish.js
+++ b/packages/quantic/docs/template/lwc-json/publish.js
@@ -99,11 +99,14 @@ function getMetadata(element) {
   const filePath = `${element.meta.path}/${element.meta.filename}-meta.xml`;
 
   const xmlData = fs.readFileSync(filePath, 'utf8');
-  return parseString(xmlData, {explicitArray: false}, function (err, result) {
-    if (err) {
-      throw err;
-    }
-    return result;
+  return new Promise((resolve, reject) => {
+    parseString(xmlData, {explicitArray: false}, function (err, result) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
   });
 }
 
@@ -124,7 +127,7 @@ const categoryMap = {
   recommendation: 'Recommendation',
 };
 
-function parseClass(element, parentNode, childNodes) {
+async function parseClass(element, parentNode, childNodes) {
   if (!parentNode.components) {
     parentNode.components = {};
     Object.keys(categoryMap).forEach(
@@ -132,7 +135,8 @@ function parseClass(element, parentNode, childNodes) {
     );
   }
 
-  element.xmlMeta = getMetadata(element).LightningComponentBundle;
+  const metadata = await getMetadata(element);
+  element.xmlMeta = metadata.LightningComponentBundle;
 
   const thisClass = {
     name: element.name,
@@ -185,36 +189,38 @@ function parseClass(element, parentNode, childNodes) {
   graft(thisClass, childNodes, element.longname);
 }
 
-function graft(parentNode, childNodes, parentLongname) {
-  childNodes
-    .filter(function (element) {
-      return element.memberof === parentLongname;
-    })
-    .forEach(function (element, _index) {
-      switch (element.kind) {
-        case 'function':
-          return parseFunction(element, parentNode);
-        case 'member':
-          return parseMember(element, parentNode);
-        case 'class':
-          return parseClass(element, parentNode, childNodes);
-        default:
-          return;
-      }
-    });
+async function graft(parentNode, childNodes, parentLongname) {
+  const elements = childNodes.filter(function (element) {
+    return element.memberof === parentLongname;
+  });
+
+  const promises = elements.map(function (element, _index) {
+    switch (element.kind) {
+      case 'function':
+        return parseFunction(element, parentNode);
+      case 'member':
+        return parseMember(element, parentNode);
+      case 'class':
+        return parseClass(element, parentNode, childNodes);
+      default:
+        return Promise.resolve();
+    }
+  });
+
+  await Promise.all(promises);
 }
 
 /**
  * @param {TAFFY} data
  * @param {object} opts
  */
-exports.publish = function (data, opts) {
+exports.publish = async function (data, opts) {
   let root = {};
 
   data({undocumented: true}).remove();
   const docs = data().get();
 
-  graft(root, docs);
+  await graft(root, docs);
 
   if (opts.destination === 'console') {
     console.log(dump(root));


### PR DESCRIPTION
I noticed that the xmlMeta values came out as null in the latest quantic-docs.json
 
<img width="432" alt="Screenshot 2024-04-19 at 12 20 43 PM" src="https://github.com/coveo/ui-kit/assets/39384459/322f53b2-8610-45db-84e0-e17984de3065">

It seems to be due to `parseString` which requires to be run async. When I do that, the JSON looks good again:

<img width="432" alt="Screenshot 2024-04-19 at 12 24 21 PM" src="https://github.com/coveo/ui-kit/assets/39384459/9139cebb-d3ec-4a1f-99cb-20e2471b66d4">


