### PR TITLE
fix(genqa): fix rephrase buttons for very small layout

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -26,6 +26,10 @@
       @apply mx-0;
     }
   }
+
+  [part='rephrase-button-label'] {
+    @apply block;
+  }
 }
 
 @define-mixin mobile-footer-xs-layout {

--- a/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/rephrase-buttons.pcss
@@ -3,7 +3,7 @@
   width: unset;
 
   [part='rephrase-button-label'] {
-    @apply block ml-2;
+    @apply ml-2;
   }
 
   &:hover [part='rephrase-button-label'] {


### PR DESCRIPTION
[SVCC-3659](https://coveord.atlassian.net/browse/SVCC-3659)

Fix rephrase buttons for small layout. The label should be hidden.

**Before:**

![Screenshot 2024-04-19 at 3 34 34 PM](https://github.com/coveo/ui-kit/assets/119955059/1ce0b993-37a6-4157-89e9-52572a907035)

**After:**

_very small layout_

![Screenshot 2024-04-19 at 3 38 15 PM](https://github.com/coveo/ui-kit/assets/119955059/527f997c-3d67-4581-8ffd-dbabb1a2038c)

_small layout:_

![Screenshot 2024-04-19 at 3 38 30 PM](https://github.com/coveo/ui-kit/assets/119955059/001ec3a5-d5b0-4c35-a458-1af2b6774987)


[SVCC-3659]: https://coveord.atlassian.net/browse/SVCC-3659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ