### PR TITLE
feat(commerce): use slotId for Commerce recommendations requests

### DIFF
--- a/packages/headless/src/api/commerce/commerce-api-client.test.ts
+++ b/packages/headless/src/api/commerce/commerce-api-client.test.ts
@@ -53,7 +53,7 @@ describe('commerce api client', () => {
     req: Partial<CommerceRecommendationsRequest> = {}
   ): Promise<CommerceRecommendationsRequest> => {
     return {
-      id: 'slotId',
+      slotId: 'slotId',
       accessToken: accessToken,
       organizationId: organizationId,
       url: platformUrl,

--- a/packages/headless/src/api/commerce/commerce-api-params.ts
+++ b/packages/headless/src/api/commerce/commerce-api-params.ts
@@ -94,5 +94,5 @@ export interface IgnorePathsParam {
 }
 
 export interface SlotIdParam {
-  id: string;
+  slotId: string;
 }

--- a/packages/headless/src/api/commerce/recommendations/recommendations-request.ts
+++ b/packages/headless/src/api/commerce/recommendations/recommendations-request.ts
@@ -16,10 +16,18 @@ export const buildRecommendationsRequest = (
 const prepareRecommendationsRequestParams = (
   req: CommerceRecommendationsRequest
 ) => {
-  const {id, trackingId, clientId, context, language, country, currency, page} =
-    req;
+  const {
+    slotId,
+    trackingId,
+    clientId,
+    context,
+    language,
+    country,
+    currency,
+    page,
+  } = req;
   return {
-    id,
+    slotId,
     trackingId,
     clientId,
     context,

--- a/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
+++ b/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
@@ -24,7 +24,7 @@ const buildRecommendationCommerceAPIRequest = async (
   const commerceAPIRequest = await buildBaseCommerceAPIRequest(state);
   return {
     ...commerceAPIRequest,
-    id: slotId,
+    slotId,
   };
 };
 


### PR DESCRIPTION
[CAPI-754](https://coveord.atlassian.net/jira/software/c/projects/CAPI/boards/1103?selectedIssue=CAPI-754)

Commerce API recommendations will be replacing `id` with `slotId` for slot identifier. This prepares for this change.

[CAPI-754]: https://coveord.atlassian.net/browse/CAPI-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ