### PR TITLE
fix(atomic): answer generation component glitch

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
@@ -22,7 +22,6 @@ import {GeneratedContentContainer} from './generated-content-container';
 import {RephraseButtons} from './rephrase-buttons';
 import {RetryPrompt} from './retry-prompt';
 import {SourceCitations} from './source-citations';
-import {TypingLoader} from './typing-loader';
 
 interface GeneratedAnswerCommonOptions {
   host: HTMLElement;
@@ -47,7 +46,6 @@ export class GeneratedAnswerCommon {
 
   private contentClasses =
     'mt-0 mb-4 border border-neutral shadow-lg p-6 bg-background rounded-lg p-6 text-on-background';
-  private loadingClasses = 'my-3';
 
   constructor(private props: GeneratedAnswerCommonOptions) {
     this._data = this.readStoredData();
@@ -115,11 +113,9 @@ export class GeneratedAnswerCommon {
   }
 
   private get shouldBeHidden() {
-    const {isLoading, answer, citations} =
-      this.props.getGeneratedAnswerState() ?? {};
+    const {answer, citations} = this.props.getGeneratedAnswerState() ?? {};
     return (
-      !(isLoading || answer !== undefined || citations?.length) &&
-      !this.hasRetryableError
+      answer === undefined && !citations?.length && !this.hasRetryableError
     );
   }
 
@@ -330,21 +326,13 @@ export class GeneratedAnswerCommon {
   }
 
   public render() {
-    const {isLoading} = this.props.getGeneratedAnswerState() ?? {};
     if (this.shouldBeHidden) {
       return null;
     }
     return (
       <div>
-        <aside
-          class={`mx-auto ${
-            isLoading ? this.loadingClasses : this.contentClasses
-          }`}
-          part="container"
-        >
-          <article>
-            {isLoading ? <TypingLoader /> : this.renderContent()}
-          </article>
+        <aside class={`mx-auto ${this.contentClasses}`} part="container">
+          <article>{this.renderContent()}</article>
         </aside>
       </div>
     );


### PR DESCRIPTION
# Bug Fix

[SVCC-3357](https://coveord.atlassian.net/browse/SVCC-3357)

[Internal Coveo Documentation](https://docs.google.com/document/d/1gX-Kr0yP_Mqog4CT8OYZAbu25YQbkaewjMJw-LewGK0) about the issue and the proposed fix

## Description

### TLDR

In Atomic. Removal of the loading in the quantic generative answering component will prevent the UI from glitching

### The problem

In Atomic
When the generative answering functionalities are enabled, but the model is asked a question it cannot answer, the stream opens and closes very quickly. This cause a jarring movement in the UI.

### The fix

In Atomic
Removing the loading, letting the component appears only when the answer begins to stream will prevent the component from appearing and disappearing uselessly.  

**Before**
[simplescreenrecorder-2024-04-22_16.30.24.webm](https://github.com/coveo/ui-kit/assets/45688129/c61d2075-8390-414d-ac7f-1a554a8a3d9d)

**After**
[simplescreenrecorder-2024-04-22_16.31.55.webm](https://github.com/coveo/ui-kit/assets/45688129/2cc162b7-5fca-4ffc-92ec-a2091e165cd7)

![image](https://github.com/coveo/ui-kit/assets/45688129/06768e36-9195-4e8d-a877-29d152cac5cd)




[SVCC-3357]: https://coveord.atlassian.net/browse/SVCC-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ