### PR TITLE
feat(commerce): structure pagination slices by solution types

### DIFF
--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
@@ -3,6 +3,7 @@ import {
   nextPage,
   previousPage,
   setPageSize,
+  registerRecommendationsSlotPagination,
 } from '../../../../features/commerce/pagination/pagination-actions';
 import {paginationReducer as commercePagination} from '../../../../features/commerce/pagination/pagination-slice';
 import {buildMockCommerceState} from '../../../../test/mock-commerce-state';
@@ -22,6 +23,7 @@ describe('core pagination', () => {
   let engine: MockedCommerceEngine;
   let pagination: Pagination;
   const fetchResultsActionCreator = jest.fn();
+  const slotId = 'recommendations-slot-id';
 
   function initPagination(props: Partial<CorePaginationProps> = {}) {
     engine = buildMockCommerceEngine(buildMockCommerceState());
@@ -57,6 +59,46 @@ describe('core pagination', () => {
         options: {pageSize},
       });
       expect(setPageSize).toHaveBeenCalledWith({pageSize});
+    });
+
+    it('when slot id is provided, registers recommendation slot pagination', () => {
+      initPagination({slotId});
+      expect(registerRecommendationsSlotPagination).toHaveBeenCalledWith({
+        slotId,
+      });
+    });
+  });
+
+  describe('#state', () => {
+    it('when slot id is specified, reflects the recommendations slot state', () => {
+      initPagination({slotId: 'slot-id'});
+      engine.state.commercePagination.recommendations['slot-id'] = {
+        perPage: 111,
+        page: 111,
+        totalItems: 111,
+        totalPages: 111,
+      };
+      expect(pagination.state).toEqual({
+        pageSize: 111,
+        page: 111,
+        totalItems: 111,
+        totalPages: 111,
+      });
+    });
+
+    it('when slot id is not specified, reflects the principal state', () => {
+      engine.state.commercePagination.principal = {
+        perPage: 222,
+        page: 222,
+        totalItems: 222,
+        totalPages: 222,
+      };
+      expect(pagination.state).toEqual({
+        pageSize: 222,
+        page: 222,
+        totalItems: 222,
+        totalPages: 222,
+      });
     });
   });
 

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
@@ -56,7 +56,7 @@ describe('core pagination', () => {
       initPagination({
         options: {pageSize},
       });
-      expect(setPageSize).toHaveBeenCalledWith(pageSize);
+      expect(setPageSize).toHaveBeenCalledWith({pageSize});
     });
   });
 
@@ -66,7 +66,7 @@ describe('core pagination', () => {
     });
 
     it('dispatches #selectPage', () => {
-      expect(selectPage).toHaveBeenCalledWith(0);
+      expect(selectPage).toHaveBeenCalledWith({page: 0});
     });
 
     it('dispatches #fetchResultsActionCreator', () => {
@@ -109,7 +109,7 @@ describe('core pagination', () => {
     });
 
     it('dispatches #setPageSize', () => {
-      expect(setPageSize).toHaveBeenCalledWith(pageSize);
+      expect(setPageSize).toHaveBeenCalledWith({pageSize});
     });
 
     it('dispatches #fetchResultsActionCreator', () => {

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../../../../test/mock-engine-v2';
 import {
   buildCorePagination,
-  CorePaginationProps,
   Pagination,
+  PaginationOptions,
 } from './headless-core-commerce-pagination';
 
 jest.mock('../../../../features/commerce/pagination/pagination-actions');
@@ -25,12 +25,12 @@ describe('core pagination', () => {
   const fetchResultsActionCreator = jest.fn();
   const slotId = 'recommendations-slot-id';
 
-  function initPagination(props: Partial<CorePaginationProps> = {}) {
+  function initPagination(options: PaginationOptions = {}) {
     engine = buildMockCommerceEngine(buildMockCommerceState());
 
     pagination = buildCorePagination(engine, {
       fetchResultsActionCreator,
-      ...props,
+      options,
     });
   }
 
@@ -55,9 +55,7 @@ describe('core pagination', () => {
 
     it('sets page size when provided', () => {
       const pageSize = 11;
-      initPagination({
-        options: {pageSize},
-      });
+      initPagination({pageSize});
       expect(setPageSize).toHaveBeenCalledWith({pageSize});
     });
 
@@ -70,7 +68,7 @@ describe('core pagination', () => {
   });
 
   describe('#state', () => {
-    it('when slot id is specified, reflects the recommendations slot state', () => {
+    it('when slot id is specified, reflects the recommendations slot pagination state', () => {
       initPagination({slotId: 'slot-id'});
       engine.state.commercePagination.recommendations['slot-id'] = {
         perPage: 111,
@@ -86,7 +84,7 @@ describe('core pagination', () => {
       });
     });
 
-    it('when slot id is not specified, reflects the principal state', () => {
+    it('when slot id is not specified, reflects the principal pagination state', () => {
       engine.state.commercePagination.principal = {
         perPage: 222,
         page: 222,

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -1,9 +1,13 @@
 import {NumberValue, Schema} from '@coveo/bueno';
 import {createSelector} from '@reduxjs/toolkit';
-import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {
+  CommerceEngine,
+  CommerceEngineState,
+} from '../../../../app/commerce-engine/commerce-engine';
 import {
   nextPage,
   previousPage,
+  registerRecommendationsSlotPagination,
   selectPage,
   setPageSize,
 } from '../../../../features/commerce/pagination/pagination-actions';
@@ -111,10 +115,17 @@ export function buildCorePagination(
     );
   }
 
+  if (slotId) {
+    dispatch(registerRecommendationsSlotPagination({slotId}));
+  }
+
   const paginationSelector = createSelector(
-    (state) => state.commercePagination,
+    (state: CommerceEngineState) =>
+      slotId
+        ? state.commercePagination.recommendations[slotId]!
+        : state.commercePagination.principal,
     ({perPage, ...rest}) => ({
-      pageSize: perPage,
+      pageSize: perPage || 0,
       ...rest,
     })
   );

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -63,6 +63,10 @@ export interface PaginationOptions {
 
 export interface CorePaginationProps {
   fetchResultsActionCreator: FetchResultsActionCreator;
+  /**
+   * Recs slot id, or none for listings and search
+   */
+  slotId?: string;
   options?: PaginationOptions;
 }
 
@@ -96,8 +100,15 @@ export function buildCorePagination(
 
   validateOptions(engine, optionsSchema, props.options, 'buildCorePagination');
 
+  const slotId = props.slotId;
+
   if (props.options?.pageSize) {
-    dispatch(setPageSize(props.options.pageSize));
+    dispatch(
+      setPageSize({
+        slotId,
+        pageSize: props.options.pageSize,
+      })
+    );
   }
 
   const paginationSelector = createSelector(
@@ -116,22 +127,27 @@ export function buildCorePagination(
     },
 
     selectPage(page: number) {
-      dispatch(selectPage(page));
+      dispatch(
+        selectPage({
+          slotId,
+          page,
+        })
+      );
       dispatch(props.fetchResultsActionCreator());
     },
 
     nextPage() {
-      dispatch(nextPage());
+      dispatch(nextPage({slotId}));
       dispatch(props.fetchResultsActionCreator());
     },
 
     previousPage() {
-      dispatch(previousPage());
+      dispatch(previousPage({slotId}));
       dispatch(props.fetchResultsActionCreator());
     },
 
     setPageSize(pageSize: number) {
-      dispatch(setPageSize(pageSize));
+      dispatch(setPageSize({slotId, pageSize}));
       dispatch(props.fetchResultsActionCreator());
     },
   };

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -62,15 +62,15 @@ export interface PaginationState {
 }
 
 export interface PaginationOptions {
-  pageSize: number;
-}
-
-export interface CorePaginationProps {
-  fetchResultsActionCreator: FetchResultsActionCreator;
   /**
    * Recs slot id, or none for listings and search
    */
   slotId?: string;
+  pageSize?: number;
+}
+
+export interface CorePaginationProps {
+  fetchResultsActionCreator: FetchResultsActionCreator;
   options?: PaginationOptions;
 }
 
@@ -104,7 +104,7 @@ export function buildCorePagination(
 
   validateOptions(engine, optionsSchema, props.options, 'buildCorePagination');
 
-  const slotId = props.slotId;
+  const slotId = props.options?.slotId;
 
   if (props.options?.pageSize) {
     dispatch(

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -125,7 +125,7 @@ export function buildCorePagination(
         ? state.commercePagination.recommendations[slotId]!
         : state.commercePagination.principal,
     ({perPage, ...rest}) => ({
-      pageSize: perPage || 0,
+      pageSize: perPage ?? 0,
       ...rest,
     })
   );

--- a/packages/headless/src/controllers/commerce/search-box/headless-search-box.test.ts
+++ b/packages/headless/src/controllers/commerce/search-box/headless-search-box.test.ts
@@ -261,7 +261,7 @@ describe('headless search box', () => {
     });
 
     it('updates the page to the first one', () => {
-      expect(selectPage).toHaveBeenCalledWith(0);
+      expect(selectPage).toHaveBeenCalledWith({page: 0});
     });
 
     it('dispatches #executeSearch', () => {

--- a/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
+++ b/packages/headless/src/controllers/commerce/search-box/headless-search-box.ts
@@ -114,7 +114,11 @@ export function buildSearchBox(
 
     dispatch(updateFacetAutoSelection({allow: true}));
     dispatch(updateQuery({query: getValue()}));
-    dispatch(selectPage(0));
+    dispatch(
+      selectPage({
+        page: 0,
+      })
+    );
     dispatch(executeSearch());
   };
 

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -8,7 +8,10 @@ import {buildMockCommerceFacetSlice} from '../../../test/mock-commerce-facet-sli
 import {buildMockCommerceRegularFacetValue} from '../../../test/mock-commerce-facet-value';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {CommerceFacetSlice} from '../facets/facet-set/facet-set-state';
-import {getCommercePaginationInitialState} from '../pagination/pagination-state';
+import {
+  getCommercePaginationInitialSlice,
+  getCommercePaginationInitialState,
+} from '../pagination/pagination-state';
 import {SortBy, SortCriterion, SortDirection} from '../sort/sort';
 import {getCommerceSortInitialState} from '../sort/sort-state';
 import * as Actions from './actions';
@@ -87,17 +90,46 @@ describe('commerce common actions', () => {
 
       state.commercePagination = {
         ...getCommercePaginationInitialState(),
-        page: 1,
-        perPage: 10,
+        principal: {
+          ...getCommercePaginationInitialSlice(),
+          page: 1,
+          perPage: 10,
+        },
       };
 
       const expectedWithPagination: CommerceAPIRequest = {
         ...expected,
-        page: state.commercePagination.page,
-        perPage: state.commercePagination.perPage,
+        page: state.commercePagination.principal.page,
+        perPage: state.commercePagination.principal.perPage,
       };
 
       const request = await Actions.buildBaseCommerceAPIRequest(state);
+
+      expect(request).toEqual(expectedWithPagination);
+    });
+
+    it('given a slotId, returns expected base request with the effective pagination for that slot', async () => {
+      delete state.commerceSort;
+
+      const slotId = 'slot_id';
+      state.commercePagination = {
+        ...getCommercePaginationInitialState(),
+        recommendations: {
+          [slotId]: {
+            ...getCommercePaginationInitialSlice(),
+            page: 2,
+            perPage: 17,
+          },
+        },
+      };
+
+      const expectedWithPagination: CommerceAPIRequest = {
+        ...expected,
+        page: state.commercePagination.recommendations[slotId]!.page,
+        perPage: state.commercePagination.recommendations[slotId]!.perPage,
+      };
+
+      const request = await Actions.buildBaseCommerceAPIRequest(state, slotId);
 
       expect(request).toEqual(expectedWithPagination);
     });

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -53,7 +53,8 @@ export const buildCommerceAPIRequest = async (
 };
 
 export const buildBaseCommerceAPIRequest = async (
-  state: StateNeededByQueryCommerceAPI
+  state: StateNeededByQueryCommerceAPI,
+  slotId?: string
 ): Promise<BaseCommerceAPIRequest> => {
   const {view, user, ...restOfContext} = state.commerceContext;
   return {
@@ -74,13 +75,25 @@ export const buildBaseCommerceAPIRequest = async (
         };
       }),
     },
-    ...(state.commercePagination && {
-      page: state.commercePagination.page,
-      ...(state.commercePagination.perPage && {
-        perPage: state.commercePagination.perPage,
-      }),
-    }),
+    ...effectivePagination(state, slotId),
   };
+};
+
+const effectivePagination = (
+  state: StateNeededByQueryCommerceAPI,
+  slotId?: string
+) => {
+  const effectiveSlice = slotId
+    ? state.commercePagination?.recommendations[slotId]
+    : state.commercePagination?.principal;
+  return (
+    effectiveSlice && {
+      page: effectiveSlice!.page,
+      ...(effectiveSlice!.perPage && {
+        perPage: effectiveSlice!.perPage,
+      }),
+    }
+  );
 };
 
 function getFacets(state: StateNeededByFetchProductListingV2) {

--- a/packages/headless/src/features/commerce/pagination/pagination-actions.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-actions.ts
@@ -2,6 +2,7 @@ import {NumberValue} from '@coveo/bueno';
 import {createAction} from '@reduxjs/toolkit';
 import {
   nonRequiredEmptyAllowedString,
+  requiredNonEmptyString,
   validatePayload,
 } from '../../../utils/validate-payload';
 
@@ -50,4 +51,12 @@ export const nextPage = createAction(
 export const previousPage = createAction(
   'commerce/pagination/previousPage',
   (payload?: SlotIdPayload) => validatePayload(payload, slotIdDefinition)
+);
+
+export const registerRecommendationsSlotPagination = createAction(
+  'commerce/pagination/registerRecommendationsSlot',
+  (payload: Required<SlotIdPayload>) =>
+    validatePayload(payload, {
+      slotId: requiredNonEmptyString,
+    })
 );

--- a/packages/headless/src/features/commerce/pagination/pagination-actions.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-actions.ts
@@ -1,19 +1,53 @@
 import {NumberValue} from '@coveo/bueno';
 import {createAction} from '@reduxjs/toolkit';
-import {validatePayload} from '../../../utils/validate-payload';
+import {
+  nonRequiredEmptyAllowedString,
+  validatePayload,
+} from '../../../utils/validate-payload';
 
-const numberValue = new NumberValue({required: true, min: 0});
+export const slotIdDefinition = {
+  slotId: nonRequiredEmptyAllowedString,
+};
+
+interface SlotIdPayload {
+  slotId?: string;
+}
+
+const setPageSizeDefinition = {
+  ...slotIdDefinition,
+  pageSize: new NumberValue({required: true, min: 0}),
+};
+
+type SetPageSizePayload = SlotIdPayload & {
+  pageSize: number;
+};
 
 export const setPageSize = createAction(
   'commerce/pagination/setPageSize',
-  (payload: number) => validatePayload(payload, numberValue)
+  (payload: SetPageSizePayload) =>
+    validatePayload(payload, setPageSizeDefinition)
 );
+
+const selectPageDefinition = {
+  ...slotIdDefinition,
+  page: new NumberValue({required: true, min: 0}),
+};
+
+type SelectPagePayload = SlotIdPayload & {
+  page: number;
+};
 
 export const selectPage = createAction(
   'commerce/pagination/selectPage',
-  (payload: number) => validatePayload(payload, numberValue)
+  (payload: SelectPagePayload) => validatePayload(payload, selectPageDefinition)
 );
 
-export const nextPage = createAction('commerce/pagination/nextPage');
+export const nextPage = createAction(
+  'commerce/pagination/nextPage',
+  (payload?: SlotIdPayload) => validatePayload(payload, slotIdDefinition)
+);
 
-export const previousPage = createAction('commerce/pagination/previousPage');
+export const previousPage = createAction(
+  'commerce/pagination/previousPage',
+  (payload?: SlotIdPayload) => validatePayload(payload, slotIdDefinition)
+);

--- a/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
@@ -1,5 +1,6 @@
 import {buildSearchResponse} from '../../../test/mock-commerce-search';
 import {buildFetchProductListingV2Response} from '../../../test/mock-product-listing-v2';
+import {buildMockRecommendationsResponse} from '../../../test/mock-recommendations';
 import {
   deselectAllFacetValues,
   toggleExcludeFacetValue,
@@ -11,6 +12,7 @@ import {
 } from '../../facets/range-facets/numeric-facet-set/numeric-facet-actions';
 import {setContext, setUser, setView} from '../context/context-actions';
 import {fetchProductListing} from '../product-listing/product-listing-actions';
+import {fetchRecommendations} from '../recommendations/recommendations-actions';
 import {executeSearch} from '../search/search-actions';
 import {
   nextPage,
@@ -21,7 +23,9 @@ import {
 import {paginationReducer} from './pagination-slice';
 import {
   CommercePaginationState,
+  getCommercePaginationInitialSlice,
   getCommercePaginationInitialState,
+  PaginationSlice,
 } from './pagination-state';
 
 describe('pagination slice', () => {
@@ -32,6 +36,7 @@ describe('pagination slice', () => {
     totalItems: 999,
     totalPages: 999,
   };
+  const slotId = 'recommendations-slot-id';
 
   beforeEach(() => {
     state = getCommercePaginationInitialState();
@@ -40,86 +45,164 @@ describe('pagination slice', () => {
   it('initializes the state correctly', () => {
     const finalState = paginationReducer(undefined, {type: ''});
     expect(finalState).toEqual({
-      page: 0,
-      perPage: undefined,
-      totalItems: 0,
-      totalPages: 0,
+      recommendations: {},
+      principal: {
+        page: 0,
+        perPage: undefined,
+        totalItems: 0,
+        totalPages: 0,
+      },
     });
   });
 
-  it('#selectPage does not update the current page if specified page is invalid', () => {
-    state.totalPages = 1;
+  describe.each([
+    {
+      name: 'principal',
+      getSlice: (state: CommercePaginationState) => state.principal,
+      setSlice: (slice: PaginationSlice) => {
+        state.principal = slice;
+      },
+      slotParams: {},
+    },
+    {
+      name: 'recommendation slot',
+      getSlice: (state: CommercePaginationState) =>
+        state.recommendations[slotId],
+      setSlice: (slice: PaginationSlice) => {
+        state.recommendations[slotId] = slice;
+      },
+      slotParams: {
+        slotId,
+      },
+    },
+  ])(
+    '$name pagination',
+    ({
+      getSlice,
+      setSlice,
+      slotParams,
+    }: {
+      setSlice: (slice: PaginationSlice) => void;
+      getSlice: (state: CommercePaginationState) => PaginationSlice | undefined;
+      slotParams: {} | {slotId: string};
+    }) => {
+      beforeEach(() => {
+        setSlice(getCommercePaginationInitialSlice());
+      });
 
-    let finalState = paginationReducer(state, selectPage(1));
+      it('#selectPage does not update the current page if specified page is invalid', () => {
+        getSlice(state)!.totalPages = 1;
 
-    expect(finalState.page).toBe(0);
+        const intermediaryState = paginationReducer(
+          state,
+          selectPage({
+            ...slotParams,
+            page: 1,
+          })
+        );
 
-    finalState = paginationReducer(state, selectPage(-1));
+        expect(getSlice(intermediaryState)!.page).toBe(0);
 
-    expect(finalState.page).toBe(0);
-  });
+        const finalState = paginationReducer(
+          state,
+          selectPage({
+            ...slotParams,
+            page: -1,
+          })
+        );
 
-  it('#selectPage updates the current page if valid', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, selectPage(1));
+        expect(getSlice(finalState)!.page).toBe(0);
+      });
 
-    expect(finalState.page).toBe(1);
-  });
+      it('#selectPage updates the current page if valid', () => {
+        getSlice(state)!.totalPages = 2;
+        const finalState = paginationReducer(
+          state,
+          selectPage({
+            ...slotParams,
+            page: 1,
+          })
+        );
 
-  it('#nextPage does not update the current page if already on the last page', () => {
-    state.totalPages = 2;
-    state.page = 1;
-    const finalState = paginationReducer(state, nextPage());
+        expect(getSlice(finalState)!.page).toBe(1);
+      });
 
-    expect(finalState.page).toBe(1);
-  });
+      it('#nextPage does not update the current page if already on the last page', () => {
+        getSlice(state)!.totalPages = 2;
+        getSlice(state)!.page = 1;
+        const finalState = paginationReducer(state, nextPage(slotParams));
 
-  it('#nextPage increments the current page if not already on last page', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, nextPage());
+        expect(getSlice(finalState)!.page).toBe(1);
+      });
 
-    expect(finalState.page).toBe(1);
-  });
+      it('#nextPage increments the current page if not already on last page', () => {
+        getSlice(state)!.totalPages = 2;
+        const finalState = paginationReducer(state, nextPage(slotParams));
 
-  it('#previousPage does not update the current page if already on the first page', () => {
-    state.totalPages = 2;
-    const finalState = paginationReducer(state, previousPage());
+        expect(getSlice(finalState)!.page).toBe(1);
+      });
 
-    expect(finalState.page).toBe(0);
-  });
+      it('#previousPage does not update the current page if already on the first page', () => {
+        getSlice(state)!.totalPages = 2;
+        const finalState = paginationReducer(state, previousPage(slotParams));
 
-  it('#previousPage decrements the current page if not already on first page', () => {
-    state.totalPages = 2;
-    state.page = 1;
-    const finalState = paginationReducer(state, previousPage());
+        expect(getSlice(finalState)!.page).toBe(0);
+      });
 
-    expect(finalState.page).toBe(0);
-  });
+      it('#previousPage decrements the current page if not already on first page', () => {
+        getSlice(state)!.totalPages = 2;
+        getSlice(state)!.page = 1;
+        const finalState = paginationReducer(state, previousPage(slotParams));
 
-  it('#setPageSize sets the page size', () => {
-    const pageSize = 17;
-    const finalState = paginationReducer(state, setPageSize(pageSize));
+        expect(getSlice(finalState)!.page).toBe(0);
+      });
 
-    expect(finalState.perPage).toBe(pageSize);
-  });
+      it('#setPageSize sets the page size', () => {
+        const pageSize = 17;
+        const finalState = paginationReducer(
+          state,
+          setPageSize({
+            ...slotParams,
+            pageSize,
+          })
+        );
 
-  it('sets the pagination on #fetchProductListing.fulfilled', () => {
+        expect(getSlice(finalState)!.perPage).toBe(pageSize);
+      });
+    }
+  );
+
+  it('sets the principal pagination on #fetchProductListing.fulfilled', () => {
     const response = buildFetchProductListingV2Response({
       pagination,
     });
 
     expect(
       paginationReducer(state, fetchProductListing.fulfilled(response, ''))
+        .principal
     ).toEqual(pagination);
   });
 
-  it('sets the pagination on product #executeSearch.fulfilled', () => {
+  it('sets the principal pagination on #executeSearch.fulfilled', () => {
     const response = buildSearchResponse({
       pagination,
     });
 
     expect(
-      paginationReducer(state, executeSearch.fulfilled(response, ''))
+      paginationReducer(state, executeSearch.fulfilled(response, '')).principal
+    ).toEqual(pagination);
+  });
+
+  it('sets the recommendation slot pagination on #fetchRecommendations.fulfilled', () => {
+    const response = buildMockRecommendationsResponse({
+      pagination,
+    });
+
+    expect(
+      paginationReducer(
+        state,
+        fetchRecommendations.fulfilled(response, '', {slotId})
+      ).recommendations[slotId]
     ).toEqual(pagination);
   });
 
@@ -157,15 +240,15 @@ describe('pagination slice', () => {
       action: setUser,
     },
   ])('$actionName', ({action}) => {
-    it('resets pagination', () => {
-      state.page = 5;
-      state.perPage = 17;
+    it('resets principal pagination', () => {
+      state.principal.page = 5;
+      state.principal.perPage = 17;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const finalState = paginationReducer(state, action({} as any));
 
-      expect(finalState.page).toBe(0);
-      expect(finalState.perPage).toBe(undefined);
+      expect(finalState.principal.page).toBe(0);
+      expect(finalState.principal.perPage).toBe(undefined);
     });
   });
 });

--- a/packages/headless/src/features/commerce/pagination/pagination-slice.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-slice.ts
@@ -15,6 +15,7 @@ import {executeSearch} from '../search/search-actions';
 import {
   nextPage,
   previousPage,
+  registerRecommendationsSlotPagination,
   selectPage,
   setPageSize,
 } from './pagination-actions';
@@ -82,6 +83,15 @@ export const paginationReducer = createReducer(
       .addCase(fetchRecommendations.fulfilled, (state, action) => {
         state.recommendations[action.meta.arg.slotId] =
           action.payload.response.pagination;
+      })
+      .addCase(registerRecommendationsSlotPagination, (state, action) => {
+        const slotId = action.payload.slotId;
+
+        if (slotId in state) {
+          return;
+        }
+
+        state.recommendations[slotId] = getCommercePaginationInitialSlice();
       })
       .addCase(deselectAllFacetValues, handlePaginationReset)
       .addCase(toggleSelectFacetValue, handlePaginationReset)

--- a/packages/headless/src/features/commerce/pagination/pagination-state.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-state.ts
@@ -1,11 +1,23 @@
-export interface CommercePaginationState {
+export interface PaginationSlice {
   page: number;
   perPage?: number;
   totalItems: number;
   totalPages: number;
 }
 
+export interface CommercePaginationState {
+  principal: PaginationSlice;
+  recommendations: Record<string, PaginationSlice | undefined>;
+}
+
 export function getCommercePaginationInitialState(): CommercePaginationState {
+  return {
+    principal: getCommercePaginationInitialSlice(),
+    recommendations: {},
+  };
+}
+
+export function getCommercePaginationInitialSlice(): PaginationSlice {
   return {
     page: 0,
     totalItems: 0,

--- a/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
+++ b/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
@@ -21,7 +21,7 @@ const buildRecommendationCommerceAPIRequest = async (
   slotId: string,
   state: StateNeededByQueryCommerceAPI
 ): Promise<CommerceRecommendationsRequest> => {
-  const commerceAPIRequest = await buildBaseCommerceAPIRequest(state);
+  const commerceAPIRequest = await buildBaseCommerceAPIRequest(state, slotId);
   return {
     ...commerceAPIRequest,
     slotId,
@@ -54,7 +54,6 @@ export const fetchRecommendations = createAsyncThunk<
     }
 
     return {
-      slotId,
       response: fetched.success,
     };
   }


### PR DESCRIPTION
To understand changes this enables, see:
- https://github.com/coveo/ui-kit/pull/3854 where the pagination sub-controller is put to use
- https://github.com/coveo/ui-kit/pull/3855 where we expose the facet sub-controllers
- https://github.com/coveo/ui-kit/pull/3857 where we remove now replaced top-level controllers
- https://github.com/coveo/ui-kit/pull/3859 where we expose the breadcrumb manager sub-controller

To understand how we came to this solution, see:
- https://github.com/coveo/ui-kit/pull/3825 where we tried slicing the pagination as a `Record`
- https://github.com/coveo/ui-kit/pull/3800 where we added pagination and sort as sub-controllers

~And see https://github.com/coveo/ui-kit/compare/feat-capi-719-sliced-pagination-states...feat-capi-719-sliced-structured-pagination-states for the diff between this approach and the above PR~

[CAPI-719]

[CAPI-719]: https://coveord.atlassian.net/browse/CAPI-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ