### PR TITLE
fix(atomic): separator should not be consider for ARIA

### DIFF
--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -84,9 +84,15 @@ export function assertAccessibilityWithoutIt<T extends HTMLElement>(
   const axeOptions = {rules, retries: 3};
 
   if (typeof component === 'string') {
+    cy.get(component).then((el) => {
+      cy.log(el.html());
+      cy.log(el[0]?.shadowRoot?.innerHTML ?? '');
+    });
     cy.checkA11y(component, axeOptions, logAxeIssues);
   } else if (typeof component === 'function') {
     component().then(([el]) => {
+      cy.log(el.outerHTML);
+      cy.log(el?.shadowRoot?.innerHTML ?? '');
       cy.checkA11y(el, axeOptions, logAxeIssues);
     });
   } else {

--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -84,15 +84,9 @@ export function assertAccessibilityWithoutIt<T extends HTMLElement>(
   const axeOptions = {rules, retries: 3};
 
   if (typeof component === 'string') {
-    cy.get(component).then((el) => {
-      cy.log(el.html());
-      cy.log(el[0]?.shadowRoot?.innerHTML ?? '');
-    });
     cy.checkA11y(component, axeOptions, logAxeIssues);
   } else if (typeof component === 'function') {
     component().then(([el]) => {
-      cy.log(el.outerHTML);
-      cy.log(el?.shadowRoot?.innerHTML ?? '');
       cy.checkA11y(el, axeOptions, logAxeIssues);
     });
   } else {

--- a/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet-depends-on/facet-depends-on.cypress.ts
@@ -115,7 +115,6 @@ describe('Facet DependsOn Test Suites', () => {
 
     describe('when deselecting a parent facet', () => {
       beforeEach(() => {
-        cy.window().then((window) => (window.location.href = 'about:blank'));
         new TestFixture()
           .with(addThreeLevelDependantFacet())
           .withHash(hashToDisplayFacets(true, true))
@@ -134,7 +133,7 @@ describe('Facet DependsOn Test Suites', () => {
 
         it('should not have a duplicate history state', () => {
           cy.go('back');
-          cy.location('href').should('eq', 'about:blank');
+          cy.location('pathname').should('eq', '/');
         });
       });
     });

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
@@ -70,6 +70,7 @@ describe('Result MultiValueText Component', () => {
       new TestFixture()
         .with(addMultiValueText({field: 'thisfielddoesnotexist'}))
         .init();
+
       CommonAssertions.assertConsoleErrorWithoutIt(false);
     });
 
@@ -93,7 +94,8 @@ describe('Result MultiValueText Component', () => {
         .with(addFieldValueInResponse(field, originalValues.slice(0, 2)))
         .withFieldCaptions(field, values)
         .withTranslation({'n-more': '{{value}} more'})
-        .init();
+        .init()
+        .waitForComponentHydration(resultMultiValueTextComponent);
 
       assertShouldRenderValues(localizedValues.slice(0, 1));
       assertDisplaysXMoreLabel(1);
@@ -113,7 +115,8 @@ describe('Result MultiValueText Component', () => {
         .with(addFieldValueInResponse(field, originalValues))
         .withFieldCaptions(field, values)
         .withTranslation({'n-more': '{{value}} more'})
-        .init();
+        .init()
+        .waitForComponentHydration(resultMultiValueTextComponent);
 
       assertShouldRenderValues(localizedValues);
       assertDoesNotDisplayXMoreLabel();
@@ -142,7 +145,8 @@ describe('Result MultiValueText Component', () => {
         .with(addFieldValueInResponse(field, originalValues))
         .withFieldCaptions(field, values)
         .withTranslation({'n-more': '{{value}} more'})
-        .init();
+        .init()
+        .waitForComponentHydration(resultMultiValueTextComponent);
 
       assertShouldRenderValues([
         localizedValues[0],
@@ -184,7 +188,8 @@ describe('Result MultiValueText Component', () => {
               ];
             });
         })
-        .init();
+        .init()
+        .waitForComponentHydration(resultMultiValueTextComponent);
 
       assertShouldRenderValues([
         localizedValues[1],

--- a/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-components/result-multi-value-text.cypress.ts
@@ -16,7 +16,8 @@ import {
   assertShouldRenderValues,
 } from './result-multi-value-text-assertions';
 import {
-  resultMultiValueTextComponent, // ResultMultiValueTextSelectors,
+  resultMultiValueTextComponent,
+  ResultMultiValueTextSelectors,
 } from './result-multi-value-text-selectors';
 
 export interface MultiValueTextProps {
@@ -96,10 +97,9 @@ describe('Result MultiValueText Component', () => {
 
       assertShouldRenderValues(localizedValues.slice(0, 1));
       assertDisplaysXMoreLabel(1);
-      // TODO KIT-3105
-      // CommonAssertions.assertAccessibilityWithoutIt(
-      //   ResultMultiValueTextSelectors.firstInResult
-      // );
+      CommonAssertions.assertAccessibilityWithoutIt(
+        ResultMultiValueTextSelectors.firstInResult
+      );
     });
 
     it('when the field is an array of 3 values and max-values-to-display is 3, it should not truncate', () => {
@@ -117,10 +117,9 @@ describe('Result MultiValueText Component', () => {
 
       assertShouldRenderValues(localizedValues);
       assertDoesNotDisplayXMoreLabel();
-      // TODO KIT-3105
-      // CommonAssertions.assertAccessibilityWithoutIt(
-      //   ResultMultiValueTextSelectors.firstInResult
-      // );
+      CommonAssertions.assertAccessibilityWithoutIt(
+        ResultMultiValueTextSelectors.firstInResult
+      );
     });
 
     it('when there is a slot it should replace the correct values', () => {

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -205,9 +205,7 @@ export class TestFixture {
   }
 
   public init() {
-    !this.redirected &&
-      cy.visit('chrome://dino/') &&
-      cy.visit(buildTestUrl(this.hash));
+    !this.redirected && cy.visit('/') && cy.visit(buildTestUrl(this.hash));
     cy.injectAxe();
     setupIntercept();
     spyConsole();

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -205,7 +205,9 @@ export class TestFixture {
   }
 
   public init() {
-    !this.redirected && cy.visit(buildTestUrl(this.hash));
+    !this.redirected &&
+      cy.visit('about:blank') &&
+      cy.visit(buildTestUrl(this.hash));
     cy.injectAxe();
     setupIntercept();
     spyConsole();
@@ -283,6 +285,11 @@ export class TestFixture {
     this.aliases.forEach((alias) => alias(this));
 
     return this;
+  }
+  public waitForComponentHydration(componentTag: string) {
+    cy.document()
+      .find(componentTag, {timeout: 10e3, includeShadowDom: true})
+      .should('have.class', 'hydrated');
   }
 }
 

--- a/packages/atomic/cypress/fixtures/test-fixture.ts
+++ b/packages/atomic/cypress/fixtures/test-fixture.ts
@@ -206,7 +206,7 @@ export class TestFixture {
 
   public init() {
     !this.redirected &&
-      cy.visit('about:blank') &&
+      cy.visit('chrome://dino/') &&
       cy.visit(buildTestUrl(this.hash));
     cy.injectAxe();
     setupIntercept();

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
@@ -142,6 +142,7 @@ export class AtomicResultMultiText {
   private renderSeparator(beforeValue: string, afterValue: string) {
     return (
       <li
+        aria-hidden="true"
         role="separator"
         part="result-multi-value-text-separator"
         key={`${beforeValue}~${afterValue}`}

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-multi-value-text/atomic-result-multi-value-text.tsx
@@ -143,7 +143,6 @@ export class AtomicResultMultiText {
     return (
       <li
         aria-hidden="true"
-        role="separator"
         part="result-multi-value-text-separator"
         key={`${beforeValue}~${afterValue}`}
         class="separator"


### PR DESCRIPTION
Spec: https://w3c.github.io/aria/#list

## Issue

The important bit is this:
<img width="444" alt="image" src="https://github.com/coveo/ui-kit/assets/12366410/1b6c4893-37cd-4034-ba89-e4afc0933268">

Essentially, anything but a role=listitem is forbidden under a `role=list`. `ol` is defacto a list, always (afaik). So `role=separator` is a nogo.

Example here: https://louis-bompart.github.io/automatic-octo-spoon/index.html

## Solution

The obvious: remove the faulty role.

Editorial choice: I don't think the separator has any value whatsoever for a screen reader, so I elected to use `aria-hidden` to make it 'disappear' for all intent and purposes from the standpoint of a screen reader or accessibility tools.

## Tests:

This PR includes flakiness proofing on the accessibility test of this component (the method could be reused on as needed).

### Wait for component to be hydrated

The flakiness of the test was reproducable on the client-side, and was indeed a 'false green'. This was caused by axe core running _before_ the component was hydrated, and on the component element nonetheless. So yeah: cool cucumber, testing no DOM is ARIA compliant :slowclap:

This add a protection on that regard: Do wait for the component to be hydrated before doing anything else.

The wait for hydration is used 'as needed' on the green path (i.e when the component actually tries to render something)

### Properly reset between retries.
Fun stuff: If you are on foo.com/acme.html and navigate to foo.com/acme.html#, you're not doing a DOM unload/load.
Essentially, it's the same stuff with cy.visit. I noted a pollution of components in-between tests, which would skew the result, I reckon.
To fix that, I added a `cy.visit('/')` (last choice: `about:blank` tries to goto `localhost:3333/about:blank` in the CI, and `chrome://dino` redirect to `https://chrome://dino`, which is very disappointing.)