### PR TITLE
refactor(atomic): refactor atomic category facet into function components

### DIFF
--- a/packages/atomic/src/components/common/facets/category-facet/all-categories-button.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/all-categories-button.tsx
@@ -1,0 +1,31 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {i18n} from 'i18next';
+import LeftArrow from '../../../../images/arrow-left-rounded.svg';
+import {Button} from '../../button';
+
+interface CategoryFacetAllCategoryButtonProps {
+  i18n: i18n;
+  onClick(): void;
+}
+
+export const CategoryFacetAllCategoryButton: FunctionalComponent<
+  CategoryFacetAllCategoryButtonProps
+> = ({i18n, onClick}) => {
+  const allCategories = i18n.t('all-categories');
+  return (
+    <Button
+      style="text-neutral"
+      part="all-categories-button"
+      onClick={() => {
+        onClick();
+      }}
+    >
+      <atomic-icon
+        aria-hidden="true"
+        icon={LeftArrow}
+        part="back-arrow"
+      ></atomic-icon>
+      <span class="truncate">{allCategories}</span>
+    </Button>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/child-value-link.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/child-value-link.tsx
@@ -1,0 +1,18 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {
+  CategoryFacetValueLink,
+  CategoryFacetValueLinkProps,
+} from './value-link';
+
+interface CategoryFacetParentValueLinkProps
+  extends Omit<CategoryFacetValueLinkProps, 'isParent'> {}
+
+export const CategoryFacetChildValueLink: FunctionalComponent<
+  CategoryFacetParentValueLinkProps
+> = (props, children) => {
+  return (
+    <CategoryFacetValueLink {...props} isParent={false}>
+      {children}
+    </CategoryFacetValueLink>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/child-value-link.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/child-value-link.tsx
@@ -4,11 +4,11 @@ import {
   CategoryFacetValueLinkProps,
 } from './value-link';
 
-interface CategoryFacetParentValueLinkProps
+interface CategoryFacetChildValueLinkProps
   extends Omit<CategoryFacetValueLinkProps, 'isParent'> {}
 
 export const CategoryFacetChildValueLink: FunctionalComponent<
-  CategoryFacetParentValueLinkProps
+  CategoryFacetChildValueLinkProps
 > = (props, children) => {
   return (
     <CategoryFacetValueLink {...props} isParent={false}>

--- a/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.tsx
@@ -7,7 +7,7 @@ export const CategoryFacetChildrenAsTreeContainer: FunctionalComponent<
   CategoryFacetChildrenAsTreeContainerProps
 > = ({className}, children) => {
   return (
-    <ul part="values" class={className ? className : ''}>
+    <ul part="values" class={className ?? ''}>
       {children}
     </ul>
   );

--- a/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.tsx
@@ -1,0 +1,14 @@
+import {FunctionalComponent, h} from '@stencil/core';
+
+interface CategoryFacetChildrenAsTreeContainerProps {
+  className?: string;
+}
+export const CategoryFacetChildrenAsTreeContainer: FunctionalComponent<
+  CategoryFacetChildrenAsTreeContainerProps
+> = ({className}, children) => {
+  return (
+    <ul part="values" class={className ? className : ''}>
+      {children}
+    </ul>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
@@ -8,10 +8,7 @@ export const CategoryFacetParentAsTreeContainer: FunctionalComponent<
   CategoryFacetParentAsTreeContainerProps
 > = ({isTopLevel, className}, children) => {
   return (
-    <ul
-      class={className ? className : ''}
-      part={`${isTopLevel ? '' : 'sub-'}parents`}
-    >
+    <ul class={className ?? ''} part={`${isTopLevel ? '' : 'sub-'}parents`}>
       {children}
     </ul>
   );

--- a/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
@@ -1,0 +1,18 @@
+import {FunctionalComponent, h} from '@stencil/core';
+
+export interface CategoryFacetParentAsTreeContainerProps {
+  isRoot: boolean;
+  className?: string;
+}
+export const CategoryFacetParentAsTreeContainer: FunctionalComponent<
+  CategoryFacetParentAsTreeContainerProps
+> = ({isRoot, className}, children) => {
+  return (
+    <ul
+      class={className ? className : ''}
+      part={`${isRoot ? '' : 'sub-'}parents`}
+    >
+      {children}
+    </ul>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.tsx
@@ -1,16 +1,16 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
 export interface CategoryFacetParentAsTreeContainerProps {
-  isRoot: boolean;
+  isTopLevel: boolean;
   className?: string;
 }
 export const CategoryFacetParentAsTreeContainer: FunctionalComponent<
   CategoryFacetParentAsTreeContainerProps
-> = ({isRoot, className}, children) => {
+> = ({isTopLevel, className}, children) => {
   return (
     <ul
       class={className ? className : ''}
-      part={`${isRoot ? '' : 'sub-'}parents`}
+      part={`${isTopLevel ? '' : 'sub-'}parents`}
     >
       {children}
     </ul>

--- a/packages/atomic/src/components/common/facets/category-facet/parent-button.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-button.tsx
@@ -1,0 +1,40 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {i18n} from 'i18next';
+import LeftArrow from '../../../../images/arrow-left-rounded.svg';
+import {getFieldValueCaption} from '../../../../utils/field-utils';
+import {Button} from '../../button';
+
+interface CategoryFacetParentButtonProps {
+  i18n: i18n;
+  field: string;
+  facetValue: {value: string; numberOfResults: number};
+  onClick: () => void;
+}
+export const CategoryFacetParentButton: FunctionalComponent<
+  CategoryFacetParentButtonProps
+> = ({field, facetValue, i18n, onClick}) => {
+  const displayValue = getFieldValueCaption(field, facetValue.value, i18n);
+  const ariaLabel = i18n.t('facet-value', {
+    value: displayValue,
+    count: facetValue.numberOfResults,
+  });
+
+  return (
+    <Button
+      style="text-neutral"
+      part="parent-button"
+      ariaPressed="false"
+      onClick={() => {
+        onClick();
+      }}
+      ariaLabel={ariaLabel}
+    >
+      <atomic-icon
+        icon={LeftArrow}
+        part="back-arrow"
+        class="back-arrow"
+      ></atomic-icon>
+      <span class="truncate">{displayValue}</span>
+    </Button>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/parent-value-link.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-value-link.tsx
@@ -1,0 +1,18 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {
+  CategoryFacetValueLink,
+  CategoryFacetValueLinkProps,
+} from './value-link';
+
+interface CategoryFacetParentValueLinkProps
+  extends Omit<CategoryFacetValueLinkProps, 'isParent' | 'isSelected'> {}
+
+export const CategoryFacetParentValueLink: FunctionalComponent<
+  CategoryFacetParentValueLinkProps
+> = (props, children) => {
+  return (
+    <CategoryFacetValueLink {...props} isParent isSelected>
+      {children}
+    </CategoryFacetValueLink>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/search-results-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/search-results-container.tsx
@@ -1,0 +1,12 @@
+import {FunctionalComponent, h} from '@stencil/core';
+
+export const CategoryFacetSearchResultsContainer: FunctionalComponent = (
+  _,
+  children
+) => {
+  return (
+    <ul part="search-results" class="mt-3">
+      {children}
+    </ul>
+  );
+};

--- a/packages/atomic/src/components/common/facets/category-facet/search-value.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/search-value.tsx
@@ -1,12 +1,11 @@
-import {CategoryFacetSearchResult as HeadlessCategoryFacetSearchResult} from '@coveo/headless';
 import {FunctionalComponent, h} from '@stencil/core';
 import {i18n} from 'i18next';
 import {getFieldValueCaption} from '../../../../utils/field-utils';
-import {Button} from '../../../common/button';
-import {FacetValueLabelHighlight} from '../../../common/facets/facet-value-label-highlight/facet-value-label-highlight';
+import {Button} from '../../button';
+import {FacetValueLabelHighlight} from '../facet-value-label-highlight/facet-value-label-highlight';
 
-interface CategoryFacetSearchResultProps {
-  result: HeadlessCategoryFacetSearchResult;
+interface CategoryFacetSearchValueProps {
+  value: {count: number; path: string[]; displayValue: string};
   i18n: i18n;
   field: string;
   onClick(): void;
@@ -17,19 +16,19 @@ const SEPARATOR = '/';
 const ELLIPSIS = '...';
 const PATH_MAX_LENGTH = 3;
 
-export const CategoryFacetSearchResult: FunctionalComponent<
-  CategoryFacetSearchResultProps
-> = ({result, field, i18n, onClick, searchQuery}) => {
-  const count = result.count.toLocaleString(i18n.language);
+export const CategoryFacetSearchValue: FunctionalComponent<
+  CategoryFacetSearchValueProps
+> = ({value, field, i18n, onClick, searchQuery}) => {
+  const count = value.count.toLocaleString(i18n.language);
   const inLabel = i18n.t('in');
   const allCategories = i18n.t('all-categories');
-  const localizedPath = result.path.length
-    ? result.path.map((value) => getFieldValueCaption(field, value, i18n))
+  const localizedPath = value.path.length
+    ? value.path.map((value) => getFieldValueCaption(field, value, i18n))
     : [allCategories];
   const ariaLabel = i18n.t('under', {
     child: i18n.t('facet-value', {
-      numberOfResults: result.count,
-      value: result.displayValue,
+      numberOfResults: value.count,
+      value: value.displayValue,
     }),
     parent: localizedPath.join(', '),
   });
@@ -60,7 +59,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<
   }
 
   return (
-    <li key={result.displayValue}>
+    <li key={value.displayValue}>
       <Button
         style="text-neutral"
         part="search-result"
@@ -70,7 +69,7 @@ export const CategoryFacetSearchResult: FunctionalComponent<
       >
         <div class="w-full flex">
           <FacetValueLabelHighlight
-            displayValue={result.displayValue}
+            displayValue={value.displayValue}
             isSelected={false}
             searchQuery={searchQuery}
           ></FacetValueLabelHighlight>

--- a/packages/atomic/src/components/common/facets/category-facet/value-as-tree-container.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/value-as-tree-container.tsx
@@ -1,0 +1,8 @@
+import {FunctionalComponent, h} from '@stencil/core';
+
+export const CategoryFacetTreeValueContainer: FunctionalComponent = (
+  _,
+  children
+) => {
+  return <li class="contents">{children}</li>;
+};

--- a/packages/atomic/src/components/common/facets/category-facet/value-link.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/value-link.tsx
@@ -31,7 +31,19 @@ export const CategoryFacetValueLink: FunctionalComponent<
   },
   children
 ) => {
-  const partName = `${isParent ? 'active-parent' : ''} ${isLeafValue ? 'leaf-value' : 'node-value'}`;
+  const partNames = [];
+  if (isParent) {
+    partNames.push('active-parent');
+  } else {
+    partNames.push(`value-link${isSelected ? ' value-link-selected' : ''}`);
+  }
+
+  if (isLeafValue) {
+    partNames.push('leaf-value');
+  } else {
+    partNames.push('node-value');
+  }
+
   return (
     <FacetValueLink
       displayValue={displayValue}
@@ -42,7 +54,7 @@ export const CategoryFacetValueLink: FunctionalComponent<
         onClick();
       }}
       searchQuery={searchQuery}
-      part={partName}
+      part={partNames.join(' ')}
       class="contents"
       buttonRef={(btn) => setRef(btn)}
       subList={children}

--- a/packages/atomic/src/components/common/facets/category-facet/value-link.tsx
+++ b/packages/atomic/src/components/common/facets/category-facet/value-link.tsx
@@ -1,0 +1,56 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {i18n} from 'i18next';
+import {FacetValueLabelHighlight} from '../facet-value-label-highlight/facet-value-label-highlight';
+import {FacetValueLink} from '../facet-value-link/facet-value-link';
+
+export interface CategoryFacetValueLinkProps {
+  displayValue: string;
+  numberOfResults: number;
+  i18n: i18n;
+  onClick: () => void;
+  isParent: boolean;
+  isSelected: boolean;
+  searchQuery: string;
+  isLeafValue: boolean;
+  setRef: (el?: HTMLButtonElement) => void;
+}
+
+export const CategoryFacetValueLink: FunctionalComponent<
+  CategoryFacetValueLinkProps
+> = (
+  {
+    displayValue,
+    numberOfResults,
+    i18n,
+    onClick,
+    isParent,
+    isSelected,
+    searchQuery,
+    isLeafValue,
+    setRef,
+  },
+  children
+) => {
+  const partName = `${isParent ? 'active-parent' : ''} ${isLeafValue ? 'leaf-value' : 'node-value'}`;
+  return (
+    <FacetValueLink
+      displayValue={displayValue}
+      numberOfResults={numberOfResults}
+      isSelected={isSelected}
+      i18n={i18n}
+      onClick={() => {
+        onClick();
+      }}
+      searchQuery={searchQuery}
+      part={partName}
+      class="contents"
+      buttonRef={(btn) => setRef(btn)}
+      subList={children}
+    >
+      <FacetValueLabelHighlight
+        displayValue={displayValue}
+        isSelected={isSelected}
+      ></FacetValueLabelHighlight>
+    </FacetValueLink>
+  );
+};

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -395,7 +395,7 @@ export class AtomicCategoryFacet implements InitializableComponent {
               this.facet.deselectAll();
             }}
           />
-          <CategoryFacetParentAsTreeContainer isRoot={isRoot}>
+          <CategoryFacetParentAsTreeContainer isTopLevel={false}>
             {this.renderValuesTree(parents, false)}
           </CategoryFacetParentAsTreeContainer>
         </CategoryFacetTreeValueContainer>
@@ -416,7 +416,7 @@ export class AtomicCategoryFacet implements InitializableComponent {
               this.facet.toggleSelect(parentValue);
             }}
           />
-          <CategoryFacetParentAsTreeContainer isRoot={isRoot}>
+          <CategoryFacetParentAsTreeContainer isTopLevel={false}>
             {this.renderValuesTree(parents.slice(1), false)}
           </CategoryFacetParentAsTreeContainer>
         </CategoryFacetTreeValueContainer>
@@ -594,7 +594,7 @@ export class AtomicCategoryFacet implements InitializableComponent {
                 <FacetValuesGroup i18n={i18n} label={label}>
                   {this.hasParents ? (
                     <CategoryFacetParentAsTreeContainer
-                      isRoot={true}
+                      isTopLevel={true}
                       className="mt-3"
                     >
                       {this.renderValuesTree(parents, true)}

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -42,6 +42,7 @@ import {FacetInfo} from '../../../common/facets/facet-common-store';
 import {FacetContainer} from '../../../common/facets/facet-container/facet-container';
 import {FacetGuard} from '../../../common/facets/facet-guard';
 import {FacetHeader} from '../../../common/facets/facet-header/facet-header';
+import {FacetPlaceholder} from '../../../common/facets/facet-placeholder/facet-placeholder';
 import {announceFacetSearchResultsWithAriaLive} from '../../../common/facets/facet-search/facet-search-aria-live';
 import {FacetSearchInput} from '../../../common/facets/facet-search/facet-search-input';
 import {FacetSearchMatches} from '../../../common/facets/facet-search/facet-search-matches';
@@ -570,46 +571,53 @@ export class AtomicCategoryFacet implements InitializableComponent {
         hasError={hasError}
         hasResults={valuesAsTrees.length > 0}
       >
-        <FacetContainer>
-          {this.renderHeader()}
-          {!this.isCollapsed && [
-            this.renderSearchInput(),
-            shouldDisplaySearchResults(facetSearch) ? (
-              <Fragment>
-                {facetSearch.values.length ? (
-                  <FacetValuesGroup
-                    i18n={i18n}
-                    label={label}
-                    query={facetSearch.query}
-                  >
-                    {this.renderSearchResults()}
-                  </FacetValuesGroup>
-                ) : (
-                  <div class="mt-3"></div>
-                )}
-                {this.renderMatches()}
-              </Fragment>
-            ) : (
-              <Fragment>
-                <FacetValuesGroup i18n={i18n} label={label}>
-                  {this.hasParents ? (
-                    <CategoryFacetParentAsTreeContainer
-                      isTopLevel={true}
-                      className="mt-3"
+        {firstSearchExecuted ? (
+          <FacetContainer>
+            {this.renderHeader()}
+            {!this.isCollapsed && [
+              this.renderSearchInput(),
+              shouldDisplaySearchResults(facetSearch) ? (
+                <Fragment>
+                  {facetSearch.values.length ? (
+                    <FacetValuesGroup
+                      i18n={i18n}
+                      label={label}
+                      query={facetSearch.query}
                     >
-                      {this.renderValuesTree(parents, true)}
-                    </CategoryFacetParentAsTreeContainer>
+                      {this.renderSearchResults()}
+                    </FacetValuesGroup>
                   ) : (
-                    <CategoryFacetChildrenAsTreeContainer className="mt-3">
-                      {this.renderChildren()}
-                    </CategoryFacetChildrenAsTreeContainer>
+                    <div class="mt-3"></div>
                   )}
-                </FacetValuesGroup>
-                {this.renderShowMoreLess()}
-              </Fragment>
-            ),
-          ]}
-        </FacetContainer>
+                  {this.renderMatches()}
+                </Fragment>
+              ) : (
+                <Fragment>
+                  <FacetValuesGroup i18n={i18n} label={label}>
+                    {this.hasParents ? (
+                      <CategoryFacetParentAsTreeContainer
+                        isTopLevel={true}
+                        className="mt-3"
+                      >
+                        {this.renderValuesTree(parents, true)}
+                      </CategoryFacetParentAsTreeContainer>
+                    ) : (
+                      <CategoryFacetChildrenAsTreeContainer className="mt-3">
+                        {this.renderChildren()}
+                      </CategoryFacetChildrenAsTreeContainer>
+                    )}
+                  </FacetValuesGroup>
+                  {this.renderShowMoreLess()}
+                </Fragment>
+              ),
+            ]}
+          </FacetContainer>
+        ) : (
+          <FacetPlaceholder
+            isCollapsed={this.isCollapsed}
+            numberOfValues={this.numberOfValues}
+          />
+        )}
       </FacetGuard>
     );
   }

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -14,7 +14,6 @@ import {
   CategoryFacetValueRequest,
 } from '@coveo/headless';
 import {Component, h, State, Prop, Element, Fragment} from '@stencil/core';
-import LeftArrow from '../../../../images/arrow-left-rounded.svg';
 import {
   AriaLiveRegion,
   FocusTargetController,
@@ -29,12 +28,20 @@ import {
   InitializeBindings,
 } from '../../../../utils/initialization-utils';
 import {ArrayProp, MapProp} from '../../../../utils/props-utils';
-import {Button} from '../../../common/button';
+import {CategoryFacetAllCategoryButton} from '../../../common/facets/category-facet/all-categories-button';
+import {CategoryFacetChildValueLink} from '../../../common/facets/category-facet/child-value-link';
+import {CategoryFacetChildrenAsTreeContainer} from '../../../common/facets/category-facet/children-as-tree-container';
+import {CategoryFacetParentAsTreeContainer} from '../../../common/facets/category-facet/parent-as-tree-container';
+import {CategoryFacetParentButton} from '../../../common/facets/category-facet/parent-button';
+import {CategoryFacetParentValueLink} from '../../../common/facets/category-facet/parent-value-link';
+import {CategoryFacetSearchResultsContainer} from '../../../common/facets/category-facet/search-results-container';
+import {CategoryFacetSearchValue} from '../../../common/facets/category-facet/search-value';
+import {CategoryFacetTreeValueContainer} from '../../../common/facets/category-facet/value-as-tree-container';
 import {parseDependsOn} from '../../../common/facets/depends-on';
 import {FacetInfo} from '../../../common/facets/facet-common-store';
 import {FacetContainer} from '../../../common/facets/facet-container/facet-container';
+import {FacetGuard} from '../../../common/facets/facet-guard';
 import {FacetHeader} from '../../../common/facets/facet-header/facet-header';
-import {FacetPlaceholder} from '../../../common/facets/facet-placeholder/facet-placeholder';
 import {announceFacetSearchResultsWithAriaLive} from '../../../common/facets/facet-search/facet-search-aria-live';
 import {FacetSearchInput} from '../../../common/facets/facet-search/facet-search-input';
 import {FacetSearchMatches} from '../../../common/facets/facet-search/facet-search-matches';
@@ -43,13 +50,9 @@ import {
   shouldDisplaySearchResults,
 } from '../../../common/facets/facet-search/facet-search-utils';
 import {FacetShowMoreLess} from '../../../common/facets/facet-show-more-less/facet-show-more-less';
-import {FacetValueLabelHighlight} from '../../../common/facets/facet-value-label-highlight/facet-value-label-highlight';
-import {FacetValueLink} from '../../../common/facets/facet-value-link/facet-value-link';
 import {FacetValuesGroup} from '../../../common/facets/facet-values-group/facet-values-group';
-import {Hidden} from '../../../common/hidden';
 import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 import {initializePopover} from '../atomic-popover/popover-type';
-import {CategoryFacetSearchResult} from '../category-facet-search-result/category-facet-search-result';
 
 /**
  * A facet is a list of values for a certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
@@ -298,13 +301,15 @@ export class AtomicCategoryFacet implements InitializableComponent {
     prev: unknown,
     propName: keyof AtomicCategoryFacet
   ) {
-    if (propName === 'facetState' && prev && this.withSearch) {
+    if (
+      this.isCategoryFacetState(prev, propName) &&
+      this.isCategoryFacetState(next, propName)
+    ) {
       return shouldUpdateFacetSearchComponent(
-        (next as CategoryFacetState).facetSearch,
-        (prev as CategoryFacetState).facetSearch
+        next.facetSearch,
+        prev.facetSearch
       );
     }
-
     return true;
   }
 
@@ -375,59 +380,6 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
   }
 
-  private renderAllCategoriesButton() {
-    const allCategories = this.bindings.i18n.t('all-categories');
-    return (
-      <Button
-        style="text-neutral"
-        part="all-categories-button"
-        onClick={() => {
-          this.focusTargets.activeValueFocus.focusAfterSearch();
-          this.facet.deselectAll();
-        }}
-      >
-        <atomic-icon
-          aria-hidden="true"
-          icon={LeftArrow}
-          part="back-arrow"
-        ></atomic-icon>
-        <span class="truncate">{allCategories}</span>
-      </Button>
-    );
-  }
-
-  private renderParentButton(facetValue: CategoryFacetValue) {
-    const displayValue = getFieldValueCaption(
-      this.field,
-      facetValue.value,
-      this.bindings.i18n
-    );
-    const ariaLabel = this.bindings.i18n.t('facet-value', {
-      value: displayValue,
-      count: facetValue.numberOfResults,
-    });
-
-    return (
-      <Button
-        style="text-neutral"
-        part="parent-button"
-        ariaPressed="false"
-        onClick={() => {
-          this.focusTargets.activeValueFocus.focusAfterSearch();
-          this.facet.toggleSelect(facetValue);
-        }}
-        ariaLabel={ariaLabel}
-      >
-        <atomic-icon
-          icon={LeftArrow}
-          part="back-arrow"
-          class="back-arrow"
-        ></atomic-icon>
-        <span class="truncate">{displayValue}</span>
-      </Button>
-    );
-  }
-
   private renderValuesTree(parents: CategoryFacetValue[], isRoot: boolean) {
     if (!this.hasParents) {
       return this.renderChildren();
@@ -435,21 +387,39 @@ export class AtomicCategoryFacet implements InitializableComponent {
 
     if (isRoot) {
       return (
-        <li class="contents">
-          {this.renderAllCategoriesButton()}
-          <ul part="sub-parents">{this.renderValuesTree(parents, false)}</ul>
-        </li>
+        <CategoryFacetTreeValueContainer>
+          <CategoryFacetAllCategoryButton
+            i18n={this.bindings.i18n}
+            onClick={() => {
+              this.focusTargets.activeValueFocus.focusAfterSearch();
+              this.facet.deselectAll();
+            }}
+          />
+          <CategoryFacetParentAsTreeContainer isRoot={isRoot}>
+            {this.renderValuesTree(parents, false)}
+          </CategoryFacetParentAsTreeContainer>
+        </CategoryFacetTreeValueContainer>
       );
     }
 
     if (parents.length > 1) {
+      const parentValue = parents[0];
+
       return (
-        <li class="contents">
-          {this.renderParentButton(parents[0])}
-          <ul part="sub-parents">
+        <CategoryFacetTreeValueContainer>
+          <CategoryFacetParentButton
+            facetValue={parentValue}
+            field={this.field}
+            i18n={this.bindings.i18n}
+            onClick={() => {
+              this.focusTargets.activeValueFocus.focusAfterSearch();
+              this.facet.toggleSelect(parentValue);
+            }}
+          />
+          <CategoryFacetParentAsTreeContainer isRoot={isRoot}>
             {this.renderValuesTree(parents.slice(1), false)}
-          </ul>
-        </li>
+          </CategoryFacetParentAsTreeContainer>
+        </CategoryFacetTreeValueContainer>
       );
     }
 
@@ -461,26 +431,22 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
 
     return (
-      <FacetValueLink
+      <CategoryFacetParentValueLink
         displayValue={activeParentDisplayValue}
         numberOfResults={activeParent.numberOfResults}
-        isSelected={true}
         i18n={this.bindings.i18n}
+        isLeafValue={activeParent.isLeafValue}
         onClick={() => {
           this.focusTargets.activeValueFocus.focusAfterSearch();
-          this.facet.deselectAll();
+          this.facet.toggleSelect(activeParent);
         }}
         searchQuery={this.facetState.facetSearch.query}
-        part={`active-parent ${this.getIsLeafOrNodePart(activeParent)}`}
-        class="contents"
-        buttonRef={this.focusTargets.activeValueFocus.setTarget}
-        subList={<ul part="values">{this.renderChildren()}</ul>}
+        setRef={(el) => this.focusTargets.activeValueFocus.setTarget(el)}
       >
-        <FacetValueLabelHighlight
-          displayValue={activeParentDisplayValue}
-          isSelected={true}
-        ></FacetValueLabelHighlight>
-      </FacetValueLink>
+        <CategoryFacetChildrenAsTreeContainer>
+          {this.renderChildren()}
+        </CategoryFacetChildrenAsTreeContainer>
+      </CategoryFacetParentValueLink>
     );
   }
 
@@ -496,29 +462,24 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
     const isSelected = facetValue.state === 'selected';
     return (
-      <FacetValueLink
+      <CategoryFacetChildValueLink
         displayValue={displayValue}
-        numberOfResults={facetValue.numberOfResults}
-        isSelected={isSelected}
         i18n={this.bindings.i18n}
+        isLeafValue={facetValue.isLeafValue}
+        isSelected={isSelected}
+        numberOfResults={facetValue.numberOfResults}
         onClick={() => {
           this.focusTargets.activeValueFocus.focusAfterSearch();
           this.facet.toggleSelect(facetValue);
         }}
         searchQuery={this.facetState.facetSearch.query}
-        buttonRef={(element) => {
+        setRef={(element) => {
           isShowLessFocusTarget &&
             this.focusTargets.showLessFocus.setTarget(element);
           isShowMoreFocusTarget &&
             this.focusTargets.showMoreFocus.setTarget(element);
         }}
-        additionalPart={this.getIsLeafOrNodePart(facetValue)}
-      >
-        <FacetValueLabelHighlight
-          displayValue={displayValue}
-          isSelected={isSelected}
-        ></FacetValueLabelHighlight>
-      </FacetValueLink>
+      ></CategoryFacetChildValueLink>
     );
   }
 
@@ -532,16 +493,12 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
   }
 
-  private getIsLeafOrNodePart(value: CategoryFacetValue) {
-    return value.isLeafValue ? 'leaf-value' : 'node-value';
-  }
-
   private renderSearchResults() {
     return (
-      <ul part="search-results" class="mt-3">
+      <CategoryFacetSearchResultsContainer>
         {this.facetState.facetSearch.values.map((value) => (
-          <CategoryFacetSearchResult
-            result={value}
+          <CategoryFacetSearchValue
+            value={value}
             field={this.field}
             i18n={this.bindings.i18n}
             searchQuery={this.facetState.facetSearch.query}
@@ -549,9 +506,9 @@ export class AtomicCategoryFacet implements InitializableComponent {
               this.focusTargets.activeValueFocus.focusAfterSearch();
               this.facet.facetSearch.select(value);
             }}
-          ></CategoryFacetSearchResult>
+          ></CategoryFacetSearchValue>
         ))}
-      </ul>
+      </CategoryFacetSearchResultsContainer>
     );
   }
 
@@ -588,62 +545,72 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
   }
 
+  private isCategoryFacetState(
+    state: unknown,
+    propName: string
+  ): state is CategoryFacetState {
+    return (
+      propName === 'facetState' &&
+      typeof (state as CategoryFacetState)?.facetId === 'string'
+    );
+  }
+
   public render() {
-    if (this.searchStatusState.hasError || !this.facet.state.enabled) {
-      return <Hidden></Hidden>;
-    }
-
-    if (!this.searchStatusState.firstSearchExecuted) {
-      return (
-        <FacetPlaceholder
-          numberOfValues={this.numberOfValues}
-          isCollapsed={this.isCollapsed}
-        ></FacetPlaceholder>
-      );
-    }
-
-    if (!this.facetState.values.length && !this.facetState.parents.length) {
-      return <Hidden></Hidden>;
-    }
+    const {
+      bindings: {i18n},
+      label,
+      facetState: {facetSearch, enabled, valuesAsTrees, parents},
+      searchStatusState: {hasError, firstSearchExecuted},
+    } = this;
 
     return (
-      <FacetContainer>
-        {this.renderHeader()}
-        {!this.isCollapsed && [
-          this.renderSearchInput(),
-          shouldDisplaySearchResults(this.facetState.facetSearch) ? (
-            <Fragment>
-              {this.facetState.facetSearch.values.length ? (
-                <FacetValuesGroup
-                  i18n={this.bindings.i18n}
-                  label={this.label}
-                  query={this.facetState.facetSearch.query}
-                >
-                  {this.renderSearchResults()}
-                </FacetValuesGroup>
-              ) : (
-                <div class="mt-3"></div>
-              )}
-              {this.renderMatches()}
-            </Fragment>
-          ) : (
-            <Fragment>
-              <FacetValuesGroup i18n={this.bindings.i18n} label={this.label}>
-                {this.hasParents ? (
-                  <ul part="parents" class="mt-3">
-                    {this.renderValuesTree(this.facetState.parents, true)}
-                  </ul>
+      <FacetGuard
+        enabled={enabled}
+        firstSearchExecuted={firstSearchExecuted}
+        hasError={hasError}
+        hasResults={valuesAsTrees.length > 0}
+      >
+        <FacetContainer>
+          {this.renderHeader()}
+          {!this.isCollapsed && [
+            this.renderSearchInput(),
+            shouldDisplaySearchResults(facetSearch) ? (
+              <Fragment>
+                {facetSearch.values.length ? (
+                  <FacetValuesGroup
+                    i18n={i18n}
+                    label={label}
+                    query={facetSearch.query}
+                  >
+                    {this.renderSearchResults()}
+                  </FacetValuesGroup>
                 ) : (
-                  <ul part="values" class="mt-3">
-                    {this.renderChildren()}
-                  </ul>
+                  <div class="mt-3"></div>
                 )}
-              </FacetValuesGroup>
-              {this.renderShowMoreLess()}
-            </Fragment>
-          ),
-        ]}
-      </FacetContainer>
+                {this.renderMatches()}
+              </Fragment>
+            ) : (
+              <Fragment>
+                <FacetValuesGroup i18n={i18n} label={label}>
+                  {this.hasParents ? (
+                    <CategoryFacetParentAsTreeContainer
+                      isRoot={true}
+                      className="mt-3"
+                    >
+                      {this.renderValuesTree(parents, true)}
+                    </CategoryFacetParentAsTreeContainer>
+                  ) : (
+                    <CategoryFacetChildrenAsTreeContainer className="mt-3">
+                      {this.renderChildren()}
+                    </CategoryFacetChildrenAsTreeContainer>
+                  )}
+                </FacetValuesGroup>
+                {this.renderShowMoreLess()}
+              </Fragment>
+            ),
+          ]}
+        </FacetContainer>
+      </FacetGuard>
     );
   }
 }

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -438,7 +438,7 @@ export class AtomicCategoryFacet implements InitializableComponent {
         isLeafValue={activeParent.isLeafValue}
         onClick={() => {
           this.focusTargets.activeValueFocus.focusAfterSearch();
-          this.facet.toggleSelect(activeParent);
+          this.facet.deselectAll();
         }}
         searchQuery={this.facetState.facetSearch.query}
         setRef={(el) => this.focusTargets.activeValueFocus.setTarget(el)}


### PR DESCRIPTION
Simpler refactor than previous story/components:

* Category facet is currently exclusively used for the classic search use case. As such there is way less pollution from `@coveo/headless` in common files related to this one. It also benefits from the previous refactor for `facet-common`. The only one I had to modify was `category-facet/search-value`

* This PR focuses mostly on making sure there is no `"part"` attribute configured at the web component level, and instead extract them into lots of smaller functional components . If you refer to the design doc for  Atomic for commerce epic, one of the goal is to ensure styling consistency through `parts` attribute. So we want to make sure that atomic-commerce-category-facet re-use/output the exact same part name as classic search category facet.

https://coveord.atlassian.net/browse/KIT-3060