### PR TITLE
fix(genQA): show no title in citation when we have empty title

### DIFF
--- a/packages/atomic/cypress/e2e/generated-answer.cypress.ts
+++ b/packages/atomic/cypress/e2e/generated-answer.cypress.ts
@@ -52,6 +52,23 @@ const testCitationsPayload = {
   finishReason: 'COMPLETED',
 };
 
+const testCitationWithEmptyTitle = {
+  id: 'some-id-123',
+  title: '',
+  uri: 'https://www.coveo.com',
+  permanentid: 'some-permanent-id-123',
+  clickUri: 'https://www.coveo.com/en',
+  text: 'This is the snippet given to the generative model.',
+};
+
+const testCitationsWithEmptyTitlePayload = {
+  payloadType: 'genqa.citationsType',
+  payload: JSON.stringify({
+    citations: [testCitationWithEmptyTitle],
+  }),
+  finishReason: 'COMPLETED',
+};
+
 describe('Generated Answer Test Suites', () => {
   describe('Generated Answer', () => {
     function setupGeneratedAnswer(streamId?: string, props: TagProps = {}) {
@@ -400,6 +417,23 @@ describe('Generated Answer Test Suites', () => {
           it('should log an openGeneratedAnswerSource click event', () => {
             GeneratedAnswerAssertions.assertLogOpenGeneratedAnswerSource();
           });
+        });
+      });
+
+      describe('When a citation event is received with empty title', () => {
+        const streamId = crypto.randomUUID();
+
+        beforeEach(() => {
+          mockStreamResponse(streamId, testCitationsWithEmptyTitlePayload);
+          setupGeneratedAnswer(streamId);
+          cy.wait(getStreamInterceptAlias(streamId));
+        });
+
+        it('should display the citation with no title label', () => {
+          GeneratedAnswerSelectors.citationCard().should(
+            'contain.text',
+            'No title'
+          );
         });
       });
 

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
@@ -162,6 +162,15 @@ export class GeneratedAnswerCommon {
     }, 2000);
   }
 
+  private getCitation(citation: GeneratedAnswerCitation) {
+    const {title} = citation;
+    const {i18n} = this.props.getBindings();
+
+    return title.trim() !== ''
+      ? citation
+      : {...citation, title: i18n.t('no-title')};
+  }
+
   private renderCitations() {
     return this.props
       .getGeneratedAnswerState()
@@ -174,7 +183,7 @@ export class GeneratedAnswerCommon {
         return (
           <li key={citation.id} class="max-w-full">
             <atomic-citation
-              citation={citation}
+              citation={this.getCitation(citation)}
               index={index}
               sendHoverEndEvent={(citationHoverTimeMs: number) => {
                 this.props


### PR DESCRIPTION
[SVCC-3635](https://coveord.atlassian.net/browse/SVCC-3635)

Show `No title` when citation have empty title.

Before:
![image](https://github.com/coveo/ui-kit/assets/119955059/a1ef8d65-0077-4477-88af-928d764bb83d)

After:
![Screenshot 2024-04-30 at 10 36 57 AM](https://github.com/coveo/ui-kit/assets/119955059/76314877-ebd6-47fd-9aa4-395086bbbad8)


[SVCC-3635]: https://coveord.atlassian.net/browse/SVCC-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ