### PR TITLE
feat(headless/commerce): support continuous ranges on numeric facets

### DIFF
--- a/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
@@ -5,11 +5,11 @@ import {
 } from '../../../../app/commerce-engine/commerce-engine';
 import {deselectAllBreadcrumbs} from '../../../../features/breadcrumb/breadcrumb-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../features/commerce/facets/facet-set/facet-set-slice';
+import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/common';
 import {
   AnyFacetResponse,
   AnyFacetValueResponse,
   BaseFacetValue,
-  FacetType,
 } from '../../../../features/commerce/facets/facet-set/interfaces/response';
 import {toggleSelectCategoryFacetValue} from '../../../../features/facets/category-facet-set/category-facet-set-actions';
 import {facetOrderReducer as facetOrder} from '../../../../features/facets/facet-order/facet-order-slice';

--- a/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
@@ -50,6 +50,10 @@ export interface Breadcrumb<Value extends BaseFacetValue> {
    */
   facetId: string;
   /**
+   * The display name of the underlying facet.
+   */
+  facetDisplayName: string;
+  /**
    * The field on which the underlying facet is configured.
    */
   field: string;
@@ -142,6 +146,7 @@ export function buildCoreBreadcrumbManager(
 
   const createBreadcrumb = (facet: AnyFacetResponse) => ({
     facetId: facet.facetId,
+    facetDisplayName: facet.displayName,
     field: facet.field,
     type: facet.type,
     values: facet.values

--- a/packages/headless/src/controllers/commerce/core/facets/category/headless-commerce-category-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/category/headless-commerce-category-facet.test.ts
@@ -1,8 +1,4 @@
-import {
-  CategoryFacetValueRequest,
-  CommerceFacetRequest,
-} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
-import {CategoryFacetValue} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {CategoryFacetResponse} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
 import {
   toggleSelectCategoryFacetValue,
   updateCategoryFacetNumberOfValues,
@@ -45,7 +41,7 @@ describe('CategoryFacet', () => {
   }
 
   function setFacetState(
-    config: Partial<CommerceFacetRequest<CategoryFacetValueRequest>> = {},
+    config: Partial<CategoryFacetResponse> = {},
     moreValuesAvailable = false
   ) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
@@ -60,7 +56,7 @@ describe('CategoryFacet', () => {
         moreValuesAvailable,
         facetId,
         type: 'hierarchical',
-        values: (config.values as CategoryFacetValue[]) ?? [],
+        values: config.values ?? [],
       }),
     ];
     state.categoryFacetSearchSet[facetId] = buildMockCategoryFacetSearch();
@@ -132,7 +128,7 @@ describe('CategoryFacet', () => {
           values: [activeValue, buildMockCategoryFacetValue()],
         });
 
-        expect(facet.state.activeValue).toBe(activeValue);
+        expect(facet.state.activeValue).toEqual(activeValue);
       });
     });
 

--- a/packages/headless/src/controllers/commerce/core/facets/date/headless-commerce-date-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/date/headless-commerce-date-facet.test.ts
@@ -1,5 +1,5 @@
-import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
-import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
+import {DateFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
 import {
   toggleExcludeDateFacetValue,
   toggleSelectDateFacetValue,
@@ -15,7 +15,6 @@ import {
   MockedCommerceEngine,
 } from '../../../../../test/mock-engine-v2';
 import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
-import {DateRangeRequest} from '../headless-core-commerce-facet';
 import {
   DateFacet,
   DateFacetOptions,
@@ -41,9 +40,7 @@ describe('DateFacet', () => {
     facet = buildCommerceDateFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<DateRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<DateFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, type, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
@@ -1,5 +1,5 @@
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
-import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
 import {facetOrderReducer as facetOrder} from '../../../../../features/facets/facet-order/facet-order-slice';
 import {CommerceAppState} from '../../../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../../../test/mock-category-facet-search';

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
@@ -5,10 +5,8 @@ import {
 } from '../../../../../app/commerce-engine/commerce-engine';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {CommerceFacetSetState} from '../../../../../features/commerce/facets/facet-set/facet-set-state';
-import {
-  AnyFacetValueResponse,
-  FacetType,
-} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
+import {AnyFacetValueResponse} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
 import {facetOrderReducer as facetOrder} from '../../../../../features/facets/facet-order/facet-order-slice';
 import {AnyFacetValueRequest} from '../../../../../features/facets/generic/interfaces/generic-facet-request';
 import {

--- a/packages/headless/src/controllers/commerce/core/facets/headless-core-commerce-facet.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/headless-core-commerce-facet.ts
@@ -1,5 +1,6 @@
 import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../features/commerce/facets/facet-set/facet-set-slice';
+import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/common';
 import {
   AnyFacetRequest,
   CategoryFacetValueRequest,
@@ -9,7 +10,6 @@ import {
   AnyFacetValueResponse,
   CategoryFacetValue,
   DateFacetValue,
-  FacetType,
   NumericFacetValue,
   RegularFacetValue,
 } from '../../../../features/commerce/facets/facet-set/interfaces/response';

--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
@@ -131,7 +131,7 @@ describe('NumericFacet', () => {
 
       initFacet();
 
-      expect(facet.state.domain).toEqual(domain);
+      expect(facet.state.domain).toEqual({min: domain.min, max: domain.max});
     });
 
     it('does not include #domain if not present in the response state', () => {

--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
@@ -1,8 +1,10 @@
-import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
-import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
+import {NumericFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
+import {NumericFacetValue} from '../../../../../features/commerce/facets/facet-set/interfaces/response';
 import {
   toggleExcludeNumericFacetValue,
   toggleSelectNumericFacetValue,
+  updateNumericFacetValues,
 } from '../../../../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions';
 import {CommerceAppState} from '../../../../../state/commerce-app-state';
 import {buildMockCommerceFacetRequest} from '../../../../../test/mock-commerce-facet-request';
@@ -15,7 +17,6 @@ import {
   MockedCommerceEngine,
 } from '../../../../../test/mock-engine-v2';
 import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
-import {NumericRangeRequest} from '../headless-core-commerce-facet';
 import {
   NumericFacet,
   NumericFacetOptions,
@@ -26,11 +27,16 @@ jest.mock(
   '../../../../../features/facets/range-facets/numeric-facet-set/numeric-facet-actions'
 );
 
+jest.mock(
+  '../../../../../features/commerce/product-listing/product-listing-actions'
+);
+
 describe('NumericFacet', () => {
   const facetId: string = 'numeric_facet_id';
   const type: FacetType = 'numericalRange';
   const start = 0;
   const end = 100;
+  const fetchResultsActionCreator = jest.fn();
   let options: NumericFacetOptions;
   let state: CommerceAppState;
   let engine: MockedCommerceEngine;
@@ -41,9 +47,7 @@ describe('NumericFacet', () => {
     facet = buildCommerceNumericFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<NumericRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<NumericFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, type, ...config}),
     });
@@ -53,9 +57,12 @@ describe('NumericFacet', () => {
   }
 
   beforeEach(() => {
+    jest.resetAllMocks();
+
     options = {
       facetId,
       ...commonOptions,
+      fetchResultsActionCreator,
     };
 
     state = buildMockCommerceState();
@@ -91,6 +98,44 @@ describe('NumericFacet', () => {
         facetId,
         selection: facetValue,
       });
+    });
+  });
+
+  describe('#setRanges', () => {
+    let values: NumericFacetValue[];
+    beforeEach(() => {
+      values = [buildMockCommerceNumericFacetValue()];
+      facet.setRanges(values);
+    });
+    it('dispatches #updateNumericFacetValues with the correct payload', () => {
+      expect(updateNumericFacetValues).toHaveBeenCalledWith({
+        facetId,
+        values,
+      });
+    });
+
+    it('dispatches #fetchResultsActionCreator', () => {
+      expect(fetchResultsActionCreator).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#state', () => {
+    it('includes #domain if present in the response state', () => {
+      const domain = {increment: 1, max: 100, min: 0};
+      state.productListing.facets = [
+        buildMockCommerceNumericFacetResponse({
+          facetId,
+          domain,
+        }),
+      ];
+
+      initFacet();
+
+      expect(facet.state.domain).toEqual(domain);
+    });
+
+    it('does not include #domain if not present in the response state', () => {
+      expect(facet.state.domain).toBeUndefined();
     });
   });
 

--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
@@ -22,33 +22,23 @@ export type NumericFacetOptions = Omit<
 export type NumericFacetState = CoreCommerceFacetState<NumericFacetValue> & {
   /**
    * The domain of the numeric facet.
-   *
-   * This property is only defined when the facet consists of a single continuous range whose boundaries (i.e.,
-   * `start` and `end` properties) are meant to be updated by calling the `setRanges` method when the end user
-   * interacts with the range (e.g., by dragging a slider or by entering a value in an input field).
    */
-  domain?: NumericFacetRequestDomain;
+  domain?: NumericFacetDomain;
 };
 
-type NumericFacetRequestDomain = {
+type NumericFacetDomain = {
   /**
    * The minimum value that the continuous range can have.
    *
-   * No products will be returned if you set the `start` property of the range to a value lower than this.
+   * No products will be returned if the `start` property of a selected range is set to a value lower than this.
    */
   min: number;
   /**
    * The maximum value that the continuous range can have.
    *
-   * No products will be returned if you set the `end` property of the range to a value higher than this.
+   * No products will be returned if the `end` property of a selected range is set to a value higher than this.
    */
   max: number;
-  /**
-   * The value to add or subtract when incrementing or decrementing the range.
-   *
-   * This values comes from the facet configuration in the Coveo Merchandising Hub (CMH).
-   */
-  increment?: number;
 };
 
 /**
@@ -61,6 +51,7 @@ export type NumericFacet = CoreCommerceFacet<
 > & {
   /**
    * Replaces the current range values with the specified ones.
+   *
    * @param ranges - The new ranges to set.
    */
   setRanges: (ranges: NumericFacetValue[]) => void;
@@ -115,10 +106,14 @@ export function buildCommerceNumericFacet(
 
     get state() {
       const response = options.facetResponseSelector(engine.state, facetId);
-      if (response?.type === 'numericalRange') {
+      if (response?.type === 'numericalRange' && response.domain) {
+        const {min, max} = response.domain;
         return {
           ...coreController.state,
-          domain: response.domain,
+          domain: {
+            min,
+            max,
+          },
         };
       }
 

--- a/packages/headless/src/controllers/commerce/core/facets/regular/headless-commerce-regular-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/regular/headless-commerce-regular-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
+import {RegularFacetRequest} from '../../../../../features/commerce/facets/facet-set/interfaces/request';
 import {
   toggleExcludeFacetValue,
   toggleSelectFacetValue,
@@ -15,7 +15,6 @@ import {
 } from '../../../../../test/mock-engine-v2';
 import {buildMockFacetSearch} from '../../../../../test/mock-facet-search';
 import {commonOptions} from '../../../product-listing/facets/headless-product-listing-facet-options';
-import {FacetValueRequest} from '../headless-core-commerce-facet';
 import {
   RegularFacet,
   RegularFacetOptions,
@@ -39,9 +38,7 @@ describe('RegularFacet', () => {
     facet = buildCommerceRegularFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<FacetValueRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<RegularFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-category-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-category-facet.test.ts
@@ -1,7 +1,4 @@
-import {
-  CategoryFacetValueRequest,
-  CommerceFacetRequest,
-} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {CategoryFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -39,9 +36,7 @@ describe('ProductListingCategoryFacet', () => {
     facet = buildProductListingCategoryFacet(engine, options);
   }
 
-  function setFacetState(
-    config: Partial<CommerceFacetRequest<CategoryFacetValueRequest>> = {}
-  ) {
+  function setFacetState(config: Partial<CategoryFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-date-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-date-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {DateFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -12,10 +12,7 @@ import {
   buildMockCommerceEngine,
 } from '../../../../test/mock-engine-v2';
 import {DateFacet} from '../../core/facets/date/headless-commerce-date-facet';
-import {
-  CommerceFacetOptions,
-  DateRangeRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {buildProductListingDateFacet} from './headless-product-listing-date-facet';
 
 jest.mock(
@@ -36,9 +33,7 @@ describe('ProductListingDateFacet', () => {
     facet = buildProductListingDateFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<DateRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<DateFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-generator.test.ts
@@ -1,4 +1,4 @@
-import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/common';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../../test/mock-category-facet-search';

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-numeric-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {NumericFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -11,10 +11,7 @@ import {
   buildMockCommerceEngine,
   MockedCommerceEngine,
 } from '../../../../test/mock-engine-v2';
-import {
-  CommerceFacetOptions,
-  NumericRangeRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {NumericFacet} from '../../core/facets/numeric/headless-commerce-numeric-facet';
 import {buildProductListingNumericFacet} from './headless-product-listing-numeric-facet';
 
@@ -36,9 +33,7 @@ describe('ProductListingNumericFacet', () => {
     facet = buildProductListingNumericFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<NumericRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<NumericFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-regular-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-regular-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {RegularFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {fetchProductListing} from '../../../../features/commerce/product-listing/product-listing-actions';
 import {productListingV2Reducer as productListing} from '../../../../features/commerce/product-listing/product-listing-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -13,10 +13,7 @@ import {
 } from '../../../../test/mock-engine-v2';
 import {buildMockFacetSearch} from '../../../../test/mock-facet-search';
 import {buildMockFacetSearchResult} from '../../../../test/mock-facet-search-result';
-import {
-  CommerceFacetOptions,
-  FacetValueRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {RegularFacet} from '../../core/facets/regular/headless-commerce-regular-facet';
 import {buildProductListingRegularFacet} from './headless-product-listing-regular-facet';
 
@@ -39,9 +36,7 @@ describe('ProductListingRegularFacet', () => {
     facet = buildProductListingRegularFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<FacetValueRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<RegularFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-category-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-category-facet.test.ts
@@ -1,7 +1,4 @@
-import {
-  CategoryFacetValueRequest,
-  CommerceFacetRequest,
-} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {CategoryFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {commerceSearchReducer as commerceSearch} from '../../../../features/commerce/search/search-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -37,9 +34,7 @@ describe('SearchCategoryFacet', () => {
     facet = buildSearchCategoryFacet(engine, options);
   }
 
-  function setFacetState(
-    config: Partial<CommerceFacetRequest<CategoryFacetValueRequest>> = {}
-  ) {
+  function setFacetState(config: Partial<CategoryFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-date-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-date-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {DateFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {commerceSearchReducer as commerceSearch} from '../../../../features/commerce/search/search-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -12,10 +12,7 @@ import {
   MockedCommerceEngine,
 } from '../../../../test/mock-engine-v2';
 import {DateFacet} from '../../core/facets/date/headless-commerce-date-facet';
-import {
-  CommerceFacetOptions,
-  DateRangeRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {buildSearchDateFacet} from './headless-search-date-facet';
 
 jest.mock('../../../../features/commerce/search/search-actions');
@@ -34,9 +31,7 @@ describe('SearchDateFacet', () => {
     facet = buildSearchDateFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<DateRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<DateFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-generator.test.ts
@@ -1,4 +1,4 @@
-import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/response';
+import {FacetType} from '../../../../features/commerce/facets/facet-set/interfaces/common';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../../test/mock-category-facet-search';

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-numeric-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {NumericFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {commerceSearchReducer as commerceSearch} from '../../../../features/commerce/search/search-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -11,10 +11,7 @@ import {
   buildMockCommerceEngine,
   MockedCommerceEngine,
 } from '../../../../test/mock-engine-v2';
-import {
-  CommerceFacetOptions,
-  NumericRangeRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {NumericFacet} from '../../core/facets/numeric/headless-commerce-numeric-facet';
 import {buildSearchNumericFacet} from './headless-search-numeric-facet';
 
@@ -34,9 +31,7 @@ describe('SearchNumericFacet', () => {
     facet = buildSearchNumericFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<NumericRangeRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<NumericFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-regular-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-regular-facet.test.ts
@@ -1,4 +1,4 @@
-import {CommerceFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
+import {RegularFacetRequest} from '../../../../features/commerce/facets/facet-set/interfaces/request';
 import {executeSearch} from '../../../../features/commerce/search/search-actions';
 import {commerceSearchReducer as commerceSearch} from '../../../../features/commerce/search/search-slice';
 import {CommerceAppState} from '../../../../state/commerce-app-state';
@@ -13,10 +13,7 @@ import {
 } from '../../../../test/mock-engine-v2';
 import {buildMockFacetSearch} from '../../../../test/mock-facet-search';
 import {buildMockFacetSearchResult} from '../../../../test/mock-facet-search-result';
-import {
-  CommerceFacetOptions,
-  FacetValueRequest,
-} from '../../core/facets/headless-core-commerce-facet';
+import {CommerceFacetOptions} from '../../core/facets/headless-core-commerce-facet';
 import {RegularFacet} from '../../core/facets/regular/headless-commerce-regular-facet';
 import {buildSearchRegularFacet} from './headless-search-regular-facet';
 
@@ -37,9 +34,7 @@ describe('SearchRegularFacet', () => {
     facet = buildSearchRegularFacet(engine, options);
   }
 
-  function setFacetRequest(
-    config: Partial<CommerceFacetRequest<FacetValueRequest>> = {}
-  ) {
+  function setFacetRequest(config: Partial<RegularFacetRequest> = {}) {
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
       request: buildMockCommerceFacetRequest({facetId, ...config}),
     });

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -2,8 +2,7 @@ import {CategoryFacetSearchRequest} from '../../../../../api/commerce/facet-sear
 import {buildCommerceAPIRequest} from '../../../common/actions';
 import {
   AnyFacetRequest,
-  CategoryFacetValueRequest,
-  CommerceFacetRequest,
+  CategoryFacetRequest,
 } from '../../facet-set/interfaces/request';
 import {StateNeededForCategoryFacetSearch} from './commerce-category-facet-search-state';
 
@@ -53,12 +52,12 @@ export const buildCategoryFacetSearchRequest = async (
 
 function isCategoryFacetRequest(
   request: AnyFacetRequest
-): request is CommerceFacetRequest<CategoryFacetValueRequest> {
+): request is CategoryFacetRequest {
   return request.type === 'hierarchical';
 }
 
 const getPathToSelectedCategoryFacetItem = (
-  categoryFacet: CommerceFacetRequest<CategoryFacetValueRequest>
+  categoryFacet: CategoryFacetRequest
 ): string[] => {
   const path = [];
   let selectedValue = categoryFacet.values[0];

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -155,26 +155,6 @@ describe('commerceFacetSetReducer', () => {
               5
             );
           });
-
-          it('when the facet is a numeric facet with a continuous range, sets the #domain from the facet response', () => {
-            const facet = buildMockCommerceNumericFacetResponse({
-              facetId,
-              domain: {
-                min: 0,
-                max: 10,
-                increment: 1,
-              },
-            });
-
-            const action = buildQueryAction([facet]);
-            const finalState = commerceFacetSetReducer(state, action);
-
-            expect(finalState[facetId]?.request.domain).toEqual({
-              min: 0,
-              max: 10,
-              increment: 1,
-            });
-          });
         });
 
         it('when found facet is already registered in the state, does not update the facet #initialNumberOfResults in the state', () => {
@@ -290,34 +270,6 @@ describe('commerceFacetSetReducer', () => {
           expect(updatedState2[facetId]?.request.type).toEqual('dateRange');
         });
 
-        it('when found facet #type is "hierarchical", sets/updates #delimitingCharacter in state from response', () => {
-          const delimitingCharacter1 = '>';
-          const facetResponse1 = buildMockCategoryFacetResponse({
-            facetId,
-            delimitingCharacter: delimitingCharacter1,
-          });
-
-          const action1 = buildQueryAction([facetResponse1]);
-          const initialState = commerceFacetSetReducer(state, action1);
-
-          expect(initialState[facetId]?.request.delimitingCharacter).toEqual(
-            delimitingCharacter1
-          );
-
-          const delimitingCharacter2 = '|';
-          const facetResponse2 = buildMockCategoryFacetResponse({
-            facetId,
-            delimitingCharacter: delimitingCharacter2,
-          });
-
-          const action2 = buildQueryAction([facetResponse2]);
-          const updatedState = commerceFacetSetReducer(state, action2);
-
-          expect(updatedState[facetId]?.request.delimitingCharacter).toEqual(
-            delimitingCharacter2
-          );
-        });
-
         it('when found facet #type is "regular", sets/updates #values in state from response', () => {
           const facetValue1 = buildMockCommerceRegularFacetValue({
             value: 'TED',
@@ -358,44 +310,84 @@ describe('commerceFacetSetReducer', () => {
           ]);
         });
 
-        it('when found facet #type is "numericalRange", sets/updates #values in facet state from response', () => {
-          const facetValue1 = buildMockCommerceNumericFacetValue({
-            start: 0,
-            end: 5,
+        describe('when found facet #type is "numericalRange"', () => {
+          it('sets/updates #values in facet state from response', () => {
+            const facetValue1 = buildMockCommerceNumericFacetValue({
+              start: 0,
+              end: 5,
+            });
+            const facetResponse1 = buildMockCommerceNumericFacetResponse({
+              facetId,
+              values: [facetValue1],
+            });
+
+            const action1 = buildQueryAction([facetResponse1]);
+            const state1 = commerceFacetSetReducer(state, action1);
+
+            const expectedFacetValueRequests1 = convertToNumericRangeRequests([
+              facetValue1,
+            ]);
+            expect(state1[facetId]?.request.values).toEqual(
+              expectedFacetValueRequests1
+            );
+
+            const facetValue2 = buildMockCommerceNumericFacetValue({
+              start: 5,
+              end: 10,
+            });
+            const facetResponse2 = buildMockCommerceNumericFacetResponse({
+              facetId,
+              values: [facetValue2],
+            });
+
+            const action2 = buildQueryAction([facetResponse2]);
+            const state2 = commerceFacetSetReducer(state, action2);
+
+            const expectedFacetValueRequests2 = convertToNumericRangeRequests([
+              facetValue2,
+            ]);
+            expect(state2[facetId]?.request.values).toEqual(
+              expectedFacetValueRequests2
+            );
           });
-          const facetResponse1 = buildMockCommerceNumericFacetResponse({
-            facetId,
-            values: [facetValue1],
+
+          it('sets/updates #domain in the facet state from response', () => {
+            let facet = buildMockCommerceNumericFacetResponse({
+              facetId,
+              domain: {
+                min: 0,
+                max: 10,
+                increment: 1,
+              },
+            });
+
+            let action = buildQueryAction([facet]);
+            let finalState = commerceFacetSetReducer(state, action);
+
+            expect(finalState[facetId]?.request.domain).toEqual({
+              min: 0,
+              max: 10,
+              increment: 1,
+            });
+
+            facet = buildMockCommerceNumericFacetResponse({
+              facetId,
+              domain: {
+                min: 101,
+                max: 200,
+                increment: 5,
+              },
+            });
+
+            action = buildQueryAction([facet]);
+            finalState = commerceFacetSetReducer(state, action);
+
+            expect(finalState[facetId]?.request.domain).toEqual({
+              min: 101,
+              max: 200,
+              increment: 5,
+            });
           });
-
-          const action1 = buildQueryAction([facetResponse1]);
-          const state1 = commerceFacetSetReducer(state, action1);
-
-          const expectedFacetValueRequests1 = convertToNumericRangeRequests([
-            facetValue1,
-          ]);
-          expect(state1[facetId]?.request.values).toEqual(
-            expectedFacetValueRequests1
-          );
-
-          const facetValue2 = buildMockCommerceNumericFacetValue({
-            start: 5,
-            end: 10,
-          });
-          const facetResponse2 = buildMockCommerceNumericFacetResponse({
-            facetId,
-            values: [facetValue2],
-          });
-
-          const action2 = buildQueryAction([facetResponse2]);
-          const state2 = commerceFacetSetReducer(state, action2);
-
-          const expectedFacetValueRequests2 = convertToNumericRangeRequests([
-            facetValue2,
-          ]);
-          expect(state2[facetId]?.request.values).toEqual(
-            expectedFacetValueRequests2
-          );
         });
 
         it('when found facet #type is "dateRange", sets/updates #values in request from response', () => {
@@ -438,56 +430,86 @@ describe('commerceFacetSetReducer', () => {
           );
         });
 
-        it('when found facet #type is "hierarchical", sets/updates #values in state from response', () => {
-          const facetValue1 = buildMockCategoryFacetValue({
-            path: ['Food'],
-            value: 'Food',
-            children: [
-              buildMockCategoryFacetValue({
-                path: ['Food', 'Burgers'],
-                value: 'Burgers',
-              }),
-            ],
-          });
-          const facetResponse1 = buildMockCategoryFacetResponse({
-            facetId,
-            values: [facetValue1],
-          });
+        describe('when found facet #type is "hierarchical"', () => {
+          it('sets/updates #delimitingCharacter in state from response', () => {
+            const delimitingCharacter1 = '>';
+            const facetResponse1 = buildMockCategoryFacetResponse({
+              facetId,
+              delimitingCharacter: delimitingCharacter1,
+            });
 
-          const action1 = buildQueryAction([facetResponse1]);
-          const updatedState1 = commerceFacetSetReducer(state, action1);
+            const action1 = buildQueryAction([facetResponse1]);
+            const initialState = commerceFacetSetReducer(state, action1);
 
-          const expectedFacetValueRequests1 = [
-            convertCategoryFacetValueToRequest(facetValue1),
-          ];
-          expect(updatedState1[facetId]?.request.values).toEqual(
-            expectedFacetValueRequests1
-          );
+            expect(initialState[facetId]?.request.delimitingCharacter).toEqual(
+              delimitingCharacter1
+            );
 
-          const facetValue2 = buildMockCategoryFacetValue({
-            path: ['Beverages'],
-            value: 'Beverages',
-            children: [
-              buildMockCategoryFacetValue({
-                path: ['Beverages', 'Soft drinks'],
-                value: 'Soft drinks',
-              }),
-            ],
-          });
-          const facetResponse2 = buildMockCategoryFacetResponse({
-            facetId,
-            values: [facetValue2],
+            const delimitingCharacter2 = '|';
+            const facetResponse2 = buildMockCategoryFacetResponse({
+              facetId,
+              delimitingCharacter: delimitingCharacter2,
+            });
+
+            const action2 = buildQueryAction([facetResponse2]);
+            const updatedState = commerceFacetSetReducer(state, action2);
+
+            expect(updatedState[facetId]?.request.delimitingCharacter).toEqual(
+              delimitingCharacter2
+            );
           });
 
-          const action2 = buildQueryAction([facetResponse2]);
-          const updatedState2 = commerceFacetSetReducer(state, action2);
+          it('sets/updates #values in state from response', () => {
+            const facetValue1 = buildMockCategoryFacetValue({
+              path: ['Food'],
+              value: 'Food',
+              children: [
+                buildMockCategoryFacetValue({
+                  path: ['Food', 'Burgers'],
+                  value: 'Burgers',
+                }),
+              ],
+            });
+            const facetResponse1 = buildMockCategoryFacetResponse({
+              facetId,
+              values: [facetValue1],
+            });
 
-          const expectedFacetValueRequests2 = [
-            convertCategoryFacetValueToRequest(facetValue2),
-          ];
-          expect(updatedState2[facetId]?.request.values).toEqual(
-            expectedFacetValueRequests2
-          );
+            const action1 = buildQueryAction([facetResponse1]);
+            const updatedState1 = commerceFacetSetReducer(state, action1);
+
+            const expectedFacetValueRequests1 = [
+              convertCategoryFacetValueToRequest(facetValue1),
+            ];
+            expect(updatedState1[facetId]?.request.values).toEqual(
+              expectedFacetValueRequests1
+            );
+
+            const facetValue2 = buildMockCategoryFacetValue({
+              path: ['Beverages'],
+              value: 'Beverages',
+              children: [
+                buildMockCategoryFacetValue({
+                  path: ['Beverages', 'Soft drinks'],
+                  value: 'Soft drinks',
+                }),
+              ],
+            });
+            const facetResponse2 = buildMockCategoryFacetResponse({
+              facetId,
+              values: [facetValue2],
+            });
+
+            const action2 = buildQueryAction([facetResponse2]);
+            const updatedState2 = commerceFacetSetReducer(state, action2);
+
+            const expectedFacetValueRequests2 = [
+              convertCategoryFacetValueToRequest(facetValue2),
+            ];
+            expect(updatedState2[facetId]?.request.values).toEqual(
+              expectedFacetValueRequests2
+            );
+          });
         });
       });
 
@@ -984,7 +1006,7 @@ describe('commerceFacetSetReducer', () => {
                 domain: {
                   min: 0,
                   max: 5,
-                  increment: 1,
+                  increment: 0,
                 },
               }),
             });

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -494,15 +494,6 @@ function updateStateFromFacetResponse(
     state[facetId] = {request: {} as AnyFacetRequest};
     facetRequest = state[facetId].request;
     facetRequest.initialNumberOfValues = facetResponse.numberOfValues;
-    // eslint-disable-next-line @cspell/spellchecker
-    // TODO CAPI-817: When the API starts returning the correct domain, we'll set it on every response, not just the initial one.
-    if (facetResponse.type === 'numericalRange' && facetResponse.domain) {
-      facetRequest.domain = {
-        min: facetResponse.domain.min,
-        max: facetResponse.domain.max,
-        increment: facetResponse.domain.increment,
-      };
-    }
   } else {
     facetsToRemove.delete(facetId);
   }
@@ -520,6 +511,12 @@ function updateStateFromFacetResponse(
     ensureCategoryFacetRequest(facetRequest)
   ) {
     facetRequest.delimitingCharacter = facetResponse.delimitingCharacter;
+  } else if (facetResponse.type === 'numericalRange' && facetResponse.domain) {
+    facetRequest.domain = {
+      min: facetResponse.domain.min,
+      max: facetResponse.domain.max,
+      increment: facetResponse.domain.increment,
+    };
   }
 }
 
@@ -619,6 +616,8 @@ function buildCurrentValuesFromPath(path: string[], retrieveCount: number) {
   return [root];
 }
 
+// eslint-disable-next-line @cspell/spellchecker
+// TODO CAPI-850: Tthis is the best we can do for now to identify a continuous range. When the `interval` property gets added to the facet response, we'll use that instead.
 function isContinuousRangeRequest(request: NumericFacetRequest): boolean {
-  return !!request.domain;
+  return request.values.length === 1 && request.domain?.increment === 0;
 }

--- a/packages/headless/src/features/commerce/facets/facet-set/interfaces/common.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/interfaces/common.ts
@@ -1,0 +1,19 @@
+export type NumericFacetDomain = {
+  domain: NumericFacetDomainProperties;
+};
+
+type NumericFacetDomainProperties = {
+  min: number;
+  max: number;
+  increment: number;
+};
+
+export type CategoryFacetDelimitingCharacter = {
+  delimitingCharacter: string;
+};
+
+export type FacetType =
+  | 'regular'
+  | 'dateRange'
+  | 'numericalRange'
+  | 'hierarchical';

--- a/packages/headless/src/features/commerce/facets/facet-set/interfaces/request.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/interfaces/request.ts
@@ -7,7 +7,54 @@ import {
   FacetRequest,
   FacetValueRequest,
 } from '../../../../facets/facet-set/interfaces/request';
-import {FacetType} from './response';
+import {
+  CategoryFacetDelimitingCharacter,
+  FacetType,
+  NumericFacetDomain,
+} from './common';
+
+export type CategoryFacetRequest = BaseCommerceFacetRequest<
+  CategoryFacetValueRequest,
+  'hierarchical'
+> &
+  CategoryFacetDelimitingCharacter;
+
+export interface CategoryFacetValueRequest extends BaseFacetValueRequest {
+  children: CategoryFacetValueRequest[];
+  value: string;
+  retrieveCount?: number;
+}
+
+export type DateFacetRequest = BaseCommerceFacetRequest<
+  DateRangeRequest,
+  'dateRange'
+>;
+
+export type NumericFacetRequest = BaseCommerceFacetRequest<
+  NumericRangeRequest,
+  'numericalRange'
+> &
+  Partial<NumericFacetDomain>;
+
+export type RegularFacetRequest = BaseCommerceFacetRequest<
+  FacetValueRequest,
+  'regular'
+>;
+
+export type BaseCommerceFacetRequest<Value, Type extends FacetType> = Pick<
+  FacetRequest,
+  | 'facetId'
+  | 'field'
+  | 'numberOfValues'
+  | 'isFieldExpanded'
+  | 'preventAutoSelect'
+> & {
+  displayName: string;
+  type: Type;
+  values: Value[];
+  initialNumberOfValues: number;
+  numberOfValues?: number;
+};
 
 export type AnyFacetValueRequest =
   | FacetValueRequest
@@ -28,17 +75,18 @@ export type AnyFacetRequest = Pick<
   values: AnyFacetValueRequest[];
   initialNumberOfValues: number;
   numberOfValues?: number;
-  delimitingCharacter?: string;
+} & Partial<CategoryFacetDelimitingCharacter & NumericFacetDomain>;
+
+type MappedFacetRequest = {
+  [T in FacetType]: T extends 'numericalRange'
+    ? NumericFacetRequest
+    : T extends 'regular'
+      ? RegularFacetRequest
+      : T extends 'dateRange'
+        ? DateFacetRequest
+        : T extends 'hierarchical'
+          ? CategoryFacetRequest
+          : never;
 };
 
-export interface CategoryFacetValueRequest extends BaseFacetValueRequest {
-  children: CategoryFacetValueRequest[];
-  value: string;
-  retrieveCount?: number;
-}
-export type CommerceFacetRequest<T extends AnyFacetValueRequest> = Omit<
-  AnyFacetRequest,
-  'values'
-> & {
-  values: T[];
-};
+export type CommerceFacetRequest = MappedFacetRequest[FacetType];

--- a/packages/headless/src/features/commerce/facets/facet-set/interfaces/response.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/interfaces/response.ts
@@ -1,48 +1,39 @@
 import {FacetValueState} from '../../../../facets/facet-api/value';
+import {
+  CategoryFacetDelimitingCharacter,
+  FacetType,
+  NumericFacetDomain,
+} from './common';
 
-export interface BaseFacetResponse<Value, Type extends FacetType> {
-  facetId: string;
-  field: string;
-  displayName: string;
-  isFieldExpanded: boolean;
-  moreValuesAvailable: boolean;
-  fromAutoSelect: boolean;
-  values: Value[];
-  type: Type;
-  numberOfValues: number;
+export type CategoryFacetResponse = BaseFacetResponse<
+  CategoryFacetValue,
+  'hierarchical'
+> &
+  CategoryFacetDelimitingCharacter;
+
+export interface CategoryFacetValue extends BaseFacetValue {
+  value: string;
+  path: string[];
+  isLeafValue: boolean;
+  children: CategoryFacetValue[];
 }
+
+export type DateFacetResponse = BaseFacetResponse<DateFacetValue, 'dateRange'>;
+
+export type DateFacetValue = RangeFacetValue<string>;
+
+export type NumericFacetResponse = BaseFacetResponse<
+  NumericFacetValue,
+  'numericalRange'
+> &
+  Partial<NumericFacetDomain>;
+
+export type NumericFacetValue = RangeFacetValue<number>;
 
 export type RegularFacetResponse = BaseFacetResponse<
   RegularFacetValue,
   'regular'
 >;
-export type DateRangeFacetResponse = BaseFacetResponse<
-  DateFacetValue,
-  'dateRange'
->;
-export type NumericFacetResponse = BaseFacetResponse<
-  NumericFacetValue,
-  'numericalRange'
->;
-export type CategoryFacetResponse = BaseFacetResponse<
-  CategoryFacetValue,
-  'hierarchical'
-> & {
-  delimitingCharacter: string;
-};
-export type FacetType =
-  | 'regular'
-  | 'dateRange'
-  | 'numericalRange'
-  | 'hierarchical';
-
-export interface BaseFacetValue {
-  state: FacetValueState;
-  numberOfResults: number;
-  isAutoSelected: boolean;
-  isSuggested: boolean;
-  moreValuesAvailable: boolean;
-}
 
 export interface RegularFacetValue extends BaseFacetValue {
   value: string;
@@ -54,22 +45,45 @@ export interface RangeFacetValue<T> extends BaseFacetValue {
   endInclusive: boolean;
 }
 
-export type DateFacetValue = RangeFacetValue<string>;
-export type NumericFacetValue = RangeFacetValue<number>;
+export interface BaseFacetResponse<
+  Value extends BaseFacetValue,
+  Type extends FacetType,
+> {
+  facetId: string;
+  field: string;
+  displayName: string;
+  isFieldExpanded: boolean;
+  moreValuesAvailable: boolean;
+  fromAutoSelect: boolean;
+  values: Value[];
+  type: Type;
+  numberOfValues: number;
+}
+
+export interface BaseFacetValue {
+  state: FacetValueState;
+  numberOfResults: number;
+  isAutoSelected: boolean;
+  isSuggested: boolean;
+  moreValuesAvailable: boolean;
+}
+
 export type AnyFacetValueResponse =
   | RegularFacetValue
   | NumericFacetValue
   | DateFacetValue
   | CategoryFacetValue;
-export type AnyFacetResponse =
-  | RegularFacetResponse
-  | DateRangeFacetResponse
-  | NumericFacetResponse
-  | CategoryFacetResponse;
 
-export interface CategoryFacetValue extends BaseFacetValue {
-  value: string;
-  path: string[];
-  isLeafValue: boolean;
-  children: CategoryFacetValue[];
-}
+type MappedFacetResponse = {
+  [T in FacetType]: T extends 'numericalRange'
+    ? NumericFacetResponse
+    : T extends 'regular'
+      ? RegularFacetResponse
+      : T extends 'dateRange'
+        ? DateFacetResponse
+        : T extends 'hierarchical'
+          ? CategoryFacetResponse
+          : never;
+};
+
+export type AnyFacetResponse = MappedFacetResponse[FacetType];

--- a/packages/headless/src/test/mock-commerce-facet-response.ts
+++ b/packages/headless/src/test/mock-commerce-facet-response.ts
@@ -1,7 +1,7 @@
 import {
   RegularFacetResponse,
   NumericFacetResponse,
-  DateRangeFacetResponse,
+  DateFacetResponse,
   AnyFacetResponse,
   CategoryFacetResponse,
 } from '../features/commerce/facets/facet-set/interfaces/response';
@@ -44,8 +44,8 @@ export function buildMockCommerceNumericFacetResponse(
 }
 
 export function buildMockCommerceDateFacetResponse(
-  config: Partial<DateRangeFacetResponse> = {}
-): DateRangeFacetResponse {
+  config: Partial<DateFacetResponse> = {}
+): DateFacetResponse {
   return {
     ...getMockBaseCommerceFacetResponse(),
     type: 'dateRange',


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CAPI-720

Initially when we implemented commerce numeric facets, ranges had to be explicitly specified in the CMH configuration.

It is now also possible to configure numeric facets with automatic discrete ranges, or with a single continuous range in the CMH.

Every facet response now includes a `domain` property indicating the `min` and `max` range values that will return products when a set as a selected range's `start` and `end` values respectively.

The `domain` also includes an `increment` property that indicates the number of "steps" between each value. This will always be `0` if the range is continuous, or if there is no regularity between the discrete ranges (e.g., if the discrete ranges overlap or "jump" steps).

The `domain` property is not absolutely necessary for discrete ranges, although an implementer could leverage it to allow end users to "add" and select valid arbitrary numeric ranges in a facet (e.g., by entering valid start and end values in an input).

The `domain` is absolutely necessary to implement continuous facets (e.g., sliders), however.

In this pull request, I added support for the `domain` on the request and response types (and did some refactoring too...), as well as on the numeric facet controller state (I did not expose the `increment` property in the numeric facet controller state, as I don't see an immediate use for it, though). I also exposed a `setRanges` method on the numeric facet controller.

Corresponding PR in Barca Sports: https://github.com/coveo/barca-sports/pull/243