### PR TITLE
fix: disable relay when headless analytics are disabled

### DIFF
--- a/packages/headless/src/api/analytics/analytics-relay-client.test.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.test.ts
@@ -31,11 +31,22 @@ describe('#getRelayInstanceFromState', () => {
     const relay = getRelayInstanceFromState(state);
 
     expect(mockedCreateRelay).toHaveBeenCalledWith({
+      mode: 'emit',
       url: state.configuration.analytics.nextApiBaseUrl,
       token: state.configuration.accessToken,
       trackingId: state.configuration.analytics.trackingId,
       source: expect.arrayContaining(['baguette']),
     });
     expect(mockedCreateRelay).toHaveReturnedWith(relay);
+  });
+
+  it('when headless analytics are disabled, relay is disabled', () => {
+    const state = createMockState();
+    state.configuration.analytics.enabled = false;
+
+    getRelayInstanceFromState(state);
+    expect(mockedCreateRelay).toHaveBeenCalledWith(
+      expect.objectContaining({mode: 'disabled'})
+    );
   });
 });

--- a/packages/headless/src/api/analytics/analytics-relay-client.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.ts
@@ -10,8 +10,9 @@ export const getRelayInstanceFromState = createSelector(
     state.configuration.analytics,
   (state: StateNeededBySearchAnalyticsProvider) =>
     getAnalyticsSource(state.configuration.analytics),
-  (token, {trackingId, nextApiBaseUrl}, source) =>
+  (token, {trackingId, nextApiBaseUrl, enabled}, source) =>
     createRelay({
+      mode: enabled ? 'emit' : 'disabled',
       url: nextApiBaseUrl,
       token,
       trackingId,


### PR DESCRIPTION
When headless analytics are disabled, relay events were still being fired.
The PR adjusts relay's initialization to set the correct mode based on how headless is configured.