### PR TITLE
feat(headless): expose cartAction method

### DIFF
--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -97,7 +97,7 @@ export interface Cart extends Controller {
   /**
    * Emits an `ec.cartAction` analytics event.
    *
-   * @param transaction - The object with the id and the total revenue from the transaction, including taxes, shipping, and discounts.
+   * @param payload - The payload for the cart action event. Note that `quantity` should be the amount added or removed rather than the final quantity in the cart.
    */
   cartAction(payload: CartActionPayload): void;
 


### PR DESCRIPTION
**Context**
The cart controller's `updateItem` currently does two things: a) it updates the state of the cart in headless, and b) logs a cart analytics event. The second behavior makes the `cartAction` event an exception. Whereas all other events are uncoupled (i.e. `productClick`, `productView` and `purchase`), the `cartAction` is coupled.

This design has created some challenges:
1. Conforama wants to use GTM to track events. Coupling meant that it would not be possible to opt-out of headless's behavior, and would result in duplicate cart events being sent by headless and GTM.
2. When Barca Sports initializes the cart controller, it calls [updateItem](https://github.com/coveo/barca-sports/blob/DEV/Components/Cart/cart-controller.ts#L27) to synchronize the state. This emits a burst of `cartAction` events if the cart is populated, even if the user did not add anything to the cart. Initializing the controller using `initialState.items` avoids the issue, but it's easy for an implementer to make this mistake. Worth noting there's a [TODO to expose batch helpers](https://github.com/coveo/ui-kit/blob/master/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts#L156) which might have prevented the issue if it doesn't send analytics events. More on this later.
3. From a documentation perspective, coupling the `cartAction` means it will always be different. The docs will explain how to opt-in to sending click, view and purchase, but we'll need a disclaimer explaining that cart events are handled and it is not possible to opt-out.

**Approach**
The PR decouples the analytics event from the state change, providing separate methods for each.

**Open questions**
- The `quantity` in `cartAction` expects a diff rather than an absolute number. A concern is this could become a recurring point of confusion, where a controller exposes two different approaches to `quantity`.
- Could it be helpful if `updateItem` used a diff api too? Setting quantity to `-1` decreases the amount by one, stopping at 0? Methods like `setItem` or a batch `setItems` would provide an absolute API?

CAPI-809