### PR TITLE
fix: default on empty str for query when restoring search params

### DIFF
--- a/packages/headless/src/features/commerce/query/query-slice.test.ts
+++ b/packages/headless/src/features/commerce/query/query-slice.test.ts
@@ -44,5 +44,9 @@ describe('query slice', () => {
         query: 'new query',
       });
     });
+
+    it('default to empty string if no query in payload', () => {
+      expect(queryReducer(state, restoreSearchParameters({})).query).toBe('');
+    });
   });
 });

--- a/packages/headless/src/features/commerce/query/query-slice.ts
+++ b/packages/headless/src/features/commerce/query/query-slice.ts
@@ -13,7 +13,7 @@ export const queryReducer = createReducer(
         ...action.payload,
       }))
       .addCase(restoreSearchParameters, (state, action) => {
-        state.query = action.payload.q;
+        state.query = action.payload.q ?? '';
       });
   }
 );

--- a/packages/headless/src/features/commerce/query/query-state.ts
+++ b/packages/headless/src/features/commerce/query/query-state.ts
@@ -1,5 +1,5 @@
 export interface CommerceQueryState {
-  query?: string;
+  query: string;
 }
 
 export const getCommerceQueryInitialState: () => CommerceQueryState = () => ({


### PR DESCRIPTION
CAPI doesn't like empty/missing query.

https://coveord.atlassian.net/browse/KIT-3161