### PR TITLE
feat(Commerce Atomic): add product price component

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -6325,7 +6325,7 @@ declare namespace LocalJSX {
         /**
           * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
          */
-        "currency": string;
+        "currency"?: string;
     }
     interface AtomicProductTemplate {
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1570,6 +1570,16 @@ export namespace Components {
          */
         "hrefTemplate"?: string;
     }
+    /**
+     * The `atomic-product-number` component renders the value of a number product field.
+     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
+     */
+    interface AtomicProductNumber {
+        /**
+          * The field that the component should use. The component will try to find this field in the `Product.additionalFields` object unless it finds it in the `Product` object first.
+         */
+        "field": string;
+    }
     interface AtomicProductPrice {
         /**
           * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
@@ -3834,6 +3844,16 @@ declare global {
         prototype: HTMLAtomicProductLinkElement;
         new (): HTMLAtomicProductLinkElement;
     };
+    /**
+     * The `atomic-product-number` component renders the value of a number product field.
+     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
+     */
+    interface HTMLAtomicProductNumberElement extends Components.AtomicProductNumber, HTMLStencilElement {
+    }
+    var HTMLAtomicProductNumberElement: {
+        prototype: HTMLAtomicProductNumberElement;
+        new (): HTMLAtomicProductNumberElement;
+    };
     interface HTMLAtomicProductPriceElement extends Components.AtomicProductPrice, HTMLStencilElement {
     }
     var HTMLAtomicProductPriceElement: {
@@ -4766,6 +4786,7 @@ declare global {
         "atomic-product": HTMLAtomicProductElement;
         "atomic-product-description": HTMLAtomicProductDescriptionElement;
         "atomic-product-link": HTMLAtomicProductLinkElement;
+        "atomic-product-number": HTMLAtomicProductNumberElement;
         "atomic-product-price": HTMLAtomicProductPriceElement;
         "atomic-product-template": HTMLAtomicProductTemplateElement;
         "atomic-product-text": HTMLAtomicProductTextElement;
@@ -6290,6 +6311,16 @@ declare namespace LocalJSX {
          */
         "hrefTemplate"?: string;
     }
+    /**
+     * The `atomic-product-number` component renders the value of a number product field.
+     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
+     */
+    interface AtomicProductNumber {
+        /**
+          * The field that the component should use. The component will try to find this field in the `Product.additionalFields` object unless it finds it in the `Product` object first.
+         */
+        "field": string;
+    }
     interface AtomicProductPrice {
         /**
           * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
@@ -7666,6 +7697,7 @@ declare namespace LocalJSX {
         "atomic-product": AtomicProduct;
         "atomic-product-description": AtomicProductDescription;
         "atomic-product-link": AtomicProductLink;
+        "atomic-product-number": AtomicProductNumber;
         "atomic-product-price": AtomicProductPrice;
         "atomic-product-template": AtomicProductTemplate;
         "atomic-product-text": AtomicProductText;
@@ -7983,6 +8015,11 @@ declare module "@stencil/core" {
             "atomic-product": LocalJSX.AtomicProduct & JSXBase.HTMLAttributes<HTMLAtomicProductElement>;
             "atomic-product-description": LocalJSX.AtomicProductDescription & JSXBase.HTMLAttributes<HTMLAtomicProductDescriptionElement>;
             "atomic-product-link": LocalJSX.AtomicProductLink & JSXBase.HTMLAttributes<HTMLAtomicProductLinkElement>;
+            /**
+             * The `atomic-product-number` component renders the value of a number product field.
+             * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
+             */
+            "atomic-product-number": LocalJSX.AtomicProductNumber & JSXBase.HTMLAttributes<HTMLAtomicProductNumberElement>;
             "atomic-product-price": LocalJSX.AtomicProductPrice & JSXBase.HTMLAttributes<HTMLAtomicProductPriceElement>;
             "atomic-product-template": LocalJSX.AtomicProductTemplate & JSXBase.HTMLAttributes<HTMLAtomicProductTemplateElement>;
             "atomic-product-text": LocalJSX.AtomicProductText & JSXBase.HTMLAttributes<HTMLAtomicProductTextElement>;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1570,6 +1570,12 @@ export namespace Components {
          */
         "hrefTemplate"?: string;
     }
+    interface AtomicProductPrice {
+        /**
+          * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+         */
+        "currency": string;
+    }
     interface AtomicProductTemplate {
         /**
           * A function that must return true on products for the product template to apply. Set programmatically before initialization, not via attribute.  For example, the following targets a template and sets a condition to make it apply only to products whose `ec_name` contains `singapore`: `document.querySelector('#target-template').conditions = [(product) => /singapore/i.test(product.ec_name)];`
@@ -3828,6 +3834,12 @@ declare global {
         prototype: HTMLAtomicProductLinkElement;
         new (): HTMLAtomicProductLinkElement;
     };
+    interface HTMLAtomicProductPriceElement extends Components.AtomicProductPrice, HTMLStencilElement {
+    }
+    var HTMLAtomicProductPriceElement: {
+        prototype: HTMLAtomicProductPriceElement;
+        new (): HTMLAtomicProductPriceElement;
+    };
     interface HTMLAtomicProductTemplateElement extends Components.AtomicProductTemplate, HTMLStencilElement {
     }
     var HTMLAtomicProductTemplateElement: {
@@ -4754,6 +4766,7 @@ declare global {
         "atomic-product": HTMLAtomicProductElement;
         "atomic-product-description": HTMLAtomicProductDescriptionElement;
         "atomic-product-link": HTMLAtomicProductLinkElement;
+        "atomic-product-price": HTMLAtomicProductPriceElement;
         "atomic-product-template": HTMLAtomicProductTemplateElement;
         "atomic-product-text": HTMLAtomicProductTextElement;
         "atomic-query-error": HTMLAtomicQueryErrorElement;
@@ -6277,6 +6290,12 @@ declare namespace LocalJSX {
          */
         "hrefTemplate"?: string;
     }
+    interface AtomicProductPrice {
+        /**
+          * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+         */
+        "currency": string;
+    }
     interface AtomicProductTemplate {
         /**
           * A function that must return true on products for the product template to apply. Set programmatically before initialization, not via attribute.  For example, the following targets a template and sets a condition to make it apply only to products whose `ec_name` contains `singapore`: `document.querySelector('#target-template').conditions = [(product) => /singapore/i.test(product.ec_name)];`
@@ -7647,6 +7666,7 @@ declare namespace LocalJSX {
         "atomic-product": AtomicProduct;
         "atomic-product-description": AtomicProductDescription;
         "atomic-product-link": AtomicProductLink;
+        "atomic-product-price": AtomicProductPrice;
         "atomic-product-template": AtomicProductTemplate;
         "atomic-product-text": AtomicProductText;
         "atomic-query-error": AtomicQueryError;
@@ -7963,6 +7983,7 @@ declare module "@stencil/core" {
             "atomic-product": LocalJSX.AtomicProduct & JSXBase.HTMLAttributes<HTMLAtomicProductElement>;
             "atomic-product-description": LocalJSX.AtomicProductDescription & JSXBase.HTMLAttributes<HTMLAtomicProductDescriptionElement>;
             "atomic-product-link": LocalJSX.AtomicProductLink & JSXBase.HTMLAttributes<HTMLAtomicProductLinkElement>;
+            "atomic-product-price": LocalJSX.AtomicProductPrice & JSXBase.HTMLAttributes<HTMLAtomicProductPriceElement>;
             "atomic-product-template": LocalJSX.AtomicProductTemplate & JSXBase.HTMLAttributes<HTMLAtomicProductTemplateElement>;
             "atomic-product-text": LocalJSX.AtomicProductText & JSXBase.HTMLAttributes<HTMLAtomicProductTextElement>;
             /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1570,11 +1570,7 @@ export namespace Components {
          */
         "hrefTemplate"?: string;
     }
-    /**
-     * The `atomic-product-number` component renders the value of a number product field.
-     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
-     */
-    interface AtomicProductNumber {
+    interface AtomicProductNumericFieldValue {
         /**
           * The field that the component should use. The component will try to find this field in the `Product.additionalFields` object unless it finds it in the `Product` object first.
          */
@@ -1582,7 +1578,7 @@ export namespace Components {
     }
     interface AtomicProductPrice {
         /**
-          * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+          * The currency to use in currency formatting. Allowed values are the [ISO 4217 currency codes](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency), such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
          */
         "currency": string;
     }
@@ -3844,15 +3840,11 @@ declare global {
         prototype: HTMLAtomicProductLinkElement;
         new (): HTMLAtomicProductLinkElement;
     };
-    /**
-     * The `atomic-product-number` component renders the value of a number product field.
-     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
-     */
-    interface HTMLAtomicProductNumberElement extends Components.AtomicProductNumber, HTMLStencilElement {
+    interface HTMLAtomicProductNumericFieldValueElement extends Components.AtomicProductNumericFieldValue, HTMLStencilElement {
     }
-    var HTMLAtomicProductNumberElement: {
-        prototype: HTMLAtomicProductNumberElement;
-        new (): HTMLAtomicProductNumberElement;
+    var HTMLAtomicProductNumericFieldValueElement: {
+        prototype: HTMLAtomicProductNumericFieldValueElement;
+        new (): HTMLAtomicProductNumericFieldValueElement;
     };
     interface HTMLAtomicProductPriceElement extends Components.AtomicProductPrice, HTMLStencilElement {
     }
@@ -4786,7 +4778,7 @@ declare global {
         "atomic-product": HTMLAtomicProductElement;
         "atomic-product-description": HTMLAtomicProductDescriptionElement;
         "atomic-product-link": HTMLAtomicProductLinkElement;
-        "atomic-product-number": HTMLAtomicProductNumberElement;
+        "atomic-product-numeric-field-value": HTMLAtomicProductNumericFieldValueElement;
         "atomic-product-price": HTMLAtomicProductPriceElement;
         "atomic-product-template": HTMLAtomicProductTemplateElement;
         "atomic-product-text": HTMLAtomicProductTextElement;
@@ -6311,11 +6303,7 @@ declare namespace LocalJSX {
          */
         "hrefTemplate"?: string;
     }
-    /**
-     * The `atomic-product-number` component renders the value of a number product field.
-     * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
-     */
-    interface AtomicProductNumber {
+    interface AtomicProductNumericFieldValue {
         /**
           * The field that the component should use. The component will try to find this field in the `Product.additionalFields` object unless it finds it in the `Product` object first.
          */
@@ -6323,7 +6311,7 @@ declare namespace LocalJSX {
     }
     interface AtomicProductPrice {
         /**
-          * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+          * The currency to use in currency formatting. Allowed values are the [ISO 4217 currency codes](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency), such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
          */
         "currency"?: string;
     }
@@ -7697,7 +7685,7 @@ declare namespace LocalJSX {
         "atomic-product": AtomicProduct;
         "atomic-product-description": AtomicProductDescription;
         "atomic-product-link": AtomicProductLink;
-        "atomic-product-number": AtomicProductNumber;
+        "atomic-product-numeric-field-value": AtomicProductNumericFieldValue;
         "atomic-product-price": AtomicProductPrice;
         "atomic-product-template": AtomicProductTemplate;
         "atomic-product-text": AtomicProductText;
@@ -8015,11 +8003,7 @@ declare module "@stencil/core" {
             "atomic-product": LocalJSX.AtomicProduct & JSXBase.HTMLAttributes<HTMLAtomicProductElement>;
             "atomic-product-description": LocalJSX.AtomicProductDescription & JSXBase.HTMLAttributes<HTMLAtomicProductDescriptionElement>;
             "atomic-product-link": LocalJSX.AtomicProductLink & JSXBase.HTMLAttributes<HTMLAtomicProductLinkElement>;
-            /**
-             * The `atomic-product-number` component renders the value of a number product field.
-             * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
-             */
-            "atomic-product-number": LocalJSX.AtomicProductNumber & JSXBase.HTMLAttributes<HTMLAtomicProductNumberElement>;
+            "atomic-product-numeric-field-value": LocalJSX.AtomicProductNumericFieldValue & JSXBase.HTMLAttributes<HTMLAtomicProductNumericFieldValueElement>;
             "atomic-product-price": LocalJSX.AtomicProductPrice & JSXBase.HTMLAttributes<HTMLAtomicProductPriceElement>;
             "atomic-product-template": LocalJSX.AtomicProductTemplate & JSXBase.HTMLAttributes<HTMLAtomicProductTemplateElement>;
             "atomic-product-text": LocalJSX.AtomicProductText & JSXBase.HTMLAttributes<HTMLAtomicProductTextElement>;

--- a/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
+++ b/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
@@ -14,10 +14,10 @@ function defaultTemplate() {
   brandEl.setAttribute('field', 'ec_brand');
   brandEl.className = 'block text-neutral-dark';
 
-  const imgEl = document.createElement('atomic-result-image');
+  const imgEl = document.createElement('atomic-product-image');
   imgEl.setAttribute('field', 'ec_thumbnails');
 
-  const ratingEl = document.createElement('atomic-result-rating');
+  const ratingEl = document.createElement('atomic-product-rating');
   ratingEl.setAttribute('field', 'ec_rating');
 
   const priceEl = document.createElement('atomic-product-price');

--- a/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
+++ b/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
@@ -6,16 +6,33 @@ import {
 
 function defaultTemplate() {
   const content = document.createDocumentFragment();
+
   const linkEl = document.createElement('atomic-product-link');
-  const descEl = document.createElement('atomic-product-description');
-  const priceEl = document.createElement('atomic-product-price');
-  const imgEl = document.createElement('atomic-product-image');
+  linkEl.className = 'font-bold';
+
+  const brandEl = document.createElement('atomic-product-text');
+  brandEl.setAttribute('field', 'ec_brand');
+  brandEl.className = 'block text-neutral-dark';
+
+  const imgEl = document.createElement('atomic-result-image');
   imgEl.setAttribute('field', 'ec_thumbnails');
+
+  const ratingEl = document.createElement('atomic-result-rating');
+  ratingEl.setAttribute('field', 'ec_rating');
+
+  const priceEl = document.createElement('atomic-product-price');
   priceEl.setAttribute('currency', 'USD');
+  priceEl.className = 'text-2xl';
+
+  const descEl = document.createElement('atomic-product-description');
+
   content.appendChild(linkEl);
+  content.appendChild(brandEl);
   content.appendChild(imgEl);
-  content.appendChild(descEl);
+  content.appendChild(ratingEl);
   content.appendChild(priceEl);
+  content.appendChild(descEl);
+
   return {
     content,
     conditions: [],

--- a/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
+++ b/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
@@ -8,11 +8,14 @@ function defaultTemplate() {
   const content = document.createDocumentFragment();
   const linkEl = document.createElement('atomic-product-link');
   const descEl = document.createElement('atomic-product-description');
+  const priceEl = document.createElement('atomic-product-price');
   const imgEl = document.createElement('atomic-product-image');
   imgEl.setAttribute('field', 'ec_thumbnails');
+  priceEl.setAttribute('currency', 'USD');
   content.appendChild(linkEl);
   content.appendChild(imgEl);
   content.appendChild(descEl);
+  content.appendChild(priceEl);
   return {
     content,
     conditions: [],

--- a/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
+++ b/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
@@ -4,6 +4,7 @@ import {
   TemplateProviderProps,
 } from '../../common/template-provider/template-provider';
 
+// TODO: Add JSX support for default template
 function defaultTemplate() {
   const content = document.createDocumentFragment();
 

--- a/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
+++ b/packages/atomic/src/components/commerce/product-list/product-template-provider.ts
@@ -7,31 +7,18 @@ import {
 function defaultTemplate() {
   const content = document.createDocumentFragment();
 
-  const linkEl = document.createElement('atomic-product-link');
-  linkEl.className = 'font-bold';
+  const markup = `
+    <atomic-product-link class="font-bold"></atomic-product-link>
+    <atomic-product-text field="ec_brand" class="block text-neutral-dark"></atomic-product-text>
+    <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+    <atomic-product-rating field="ec_rating"></atomic-product-rating>
+    <atomic-product-price currency="USD" class="text-2xl"></atomic-product-price>
+    <atomic-product-description></atomic-product-description>
+  `;
 
-  const brandEl = document.createElement('atomic-product-text');
-  brandEl.setAttribute('field', 'ec_brand');
-  brandEl.className = 'block text-neutral-dark';
-
-  const imgEl = document.createElement('atomic-product-image');
-  imgEl.setAttribute('field', 'ec_thumbnails');
-
-  const ratingEl = document.createElement('atomic-product-rating');
-  ratingEl.setAttribute('field', 'ec_rating');
-
-  const priceEl = document.createElement('atomic-product-price');
-  priceEl.setAttribute('currency', 'USD');
-  priceEl.className = 'text-2xl';
-
-  const descEl = document.createElement('atomic-product-description');
-
-  content.appendChild(linkEl);
-  content.appendChild(brandEl);
-  content.appendChild(imgEl);
-  content.appendChild(ratingEl);
-  content.appendChild(priceEl);
-  content.appendChild(descEl);
+  const template = document.createElement('template');
+  template.innerHTML = markup.trim();
+  content.appendChild(template.content);
 
   return {
     content,

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-number/atomic-product-number.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-number/atomic-product-number.tsx
@@ -1,0 +1,90 @@
+import {Product, ProductTemplatesHelpers} from '@coveo/headless/commerce';
+import {Component, Prop, Element, State, Listen} from '@stencil/core';
+import {Bindings} from '../../../../components';
+import {InitializeBindings} from '../../../../utils/initialization-utils';
+import {
+  defaultNumberFormatter,
+  NumberFormatter,
+} from '../../../common/formats/format-common';
+import {ProductContext} from '../product-template-decorators';
+
+/**
+ * The `atomic-product-number` component renders the value of a number product field.
+ *
+ * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
+ */
+@Component({
+  tag: 'atomic-product-number',
+  shadow: false,
+})
+export class AtomicProductNumber {
+  @InitializeBindings() public bindings!: Bindings;
+  @ProductContext() private product!: Product;
+
+  @Element() host!: HTMLElement;
+
+  @State() public error!: Error;
+
+  /**
+   * The field that the component should use.
+   * The component will try to find this field in the `Product.additionalFields` object unless it finds it in the `Product` object first.
+   */
+  @Prop({reflect: true}) field!: string;
+
+  @State() formatter: NumberFormatter = defaultNumberFormatter;
+
+  @State() valueToDisplay: string | null = null;
+
+  @Listen('atomic/numberFormat')
+  public setFormat(event: CustomEvent<NumberFormatter>) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.formatter = event.detail;
+  }
+
+  private parseValue() {
+    const value = ProductTemplatesHelpers.getProductProperty(
+      this.product,
+      this.field
+    );
+    if (value === null) {
+      return null;
+    }
+    const valueAsNumber = parseFloat(`${value}`);
+    if (Number.isNaN(valueAsNumber)) {
+      this.error = new Error(
+        `Could not parse "${value}" from field "${this.field}" as a number.`
+      );
+      return null;
+    }
+    return valueAsNumber;
+  }
+
+  private formatValue(value: number) {
+    try {
+      return this.formatter(value, this.bindings.i18n.languages as string[]);
+    } catch (error) {
+      this.error = error as Error;
+      return value.toString();
+    }
+  }
+
+  private updateValueToDisplay() {
+    const value = this.parseValue();
+    if (value !== null) {
+      this.valueToDisplay = this.formatValue(value);
+    }
+  }
+
+  componentWillRender() {
+    this.updateValueToDisplay();
+  }
+
+  public render() {
+    if (this.valueToDisplay === null) {
+      this.host.remove();
+      return;
+    }
+    return this.valueToDisplay;
+  }
+}

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-numeric-field-value/atomic-product-numeric-field-value.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-numeric-field-value/atomic-product-numeric-field-value.tsx
@@ -9,12 +9,13 @@ import {
 import {ProductContext} from '../product-template-decorators';
 
 /**
- * The `atomic-product-number` component renders the value of a number product field.
+ * @internal
+ * The `atomic-product-numeric-field-value` component renders the value of a number product field.
  *
  * The number can be formatted by adding a `atomic-format-number`, `atomic-format-currency` or `atomic-format-unit` component into this component.
  */
 @Component({
-  tag: 'atomic-product-number',
+  tag: 'atomic-product-numeric-field-value',
   shadow: false,
 })
 export class AtomicProductNumber {

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -1,0 +1,61 @@
+import {Product} from '@coveo/headless/commerce';
+import {Component, h, Prop} from '@stencil/core';
+import {
+  InitializableComponent,
+  InitializeBindings,
+} from '../../../../utils/initialization-utils';
+import {CommerceBindings} from '../../atomic-commerce-interface/atomic-commerce-interface';
+import {ProductContext} from '../product-template-decorators';
+
+/**
+ * @internal
+ * The `atomic-product-price` component renders the price of a product.
+ */
+@Component({
+  tag: 'atomic-product-price',
+  shadow: false,
+})
+export class AtomicProductPrice
+  implements InitializableComponent<CommerceBindings>
+{
+  @InitializeBindings() public bindings!: CommerceBindings;
+  public error!: Error;
+
+  @ProductContext() private product!: Product;
+
+  /**
+   * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
+   * See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+   */
+  @Prop({reflect: true}) public currency!: string;
+
+  public render() {
+    const hasPromo =
+      this.product?.ec_promo_price !== undefined &&
+      this.product?.ec_price !== undefined &&
+      this.product?.ec_promo_price < this.product?.ec_price;
+
+    return (
+      <div>
+        <atomic-result-number
+          class="mx-1 font-bold"
+          field={hasPromo ? 'ec_promo_price' : 'ec_price'}
+        >
+          <atomic-format-currency
+            currency={this.currency}
+          ></atomic-format-currency>
+        </atomic-result-number>
+        {hasPromo && (
+          <atomic-result-number
+            class="mx-1 text-xl line-through"
+            field="ec_price"
+          >
+            <atomic-format-currency
+              currency={this.currency}
+            ></atomic-format-currency>
+          </atomic-result-number>
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -38,7 +38,7 @@ export class AtomicProductPrice
     return (
       <div>
         <atomic-result-number
-          class="mx-1 font-bold"
+          class={`mx-1 ${hasPromo && 'text-error'}`}
           field={hasPromo ? 'ec_promo_price' : 'ec_price'}
         >
           <atomic-format-currency

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -27,7 +27,7 @@ export class AtomicProductPrice
    * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
    * See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
    */
-  @Prop({reflect: true}) public currency!: string;
+  @Prop({reflect: true}) public currency: string = 'USD';
 
   public render() {
     const hasPromotionalPrice =

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -37,23 +37,23 @@ export class AtomicProductPrice
 
     return (
       <div>
-        <atomic-result-number
+        <atomic-product-number
           class={`mx-1 ${hasPromotionalPrice && 'text-error'}`}
           field={hasPromotionalPrice ? 'ec_promo_price' : 'ec_price'}
         >
           <atomic-format-currency
             currency={this.currency}
           ></atomic-format-currency>
-        </atomic-result-number>
+        </atomic-product-number>
         {hasPromotionalPrice && (
-          <atomic-result-number
+          <atomic-product-number
             class="mx-1 text-xl line-through"
             field="ec_price"
           >
             <atomic-format-currency
               currency={this.currency}
             ></atomic-format-currency>
-          </atomic-result-number>
+          </atomic-product-number>
         )}
       </div>
     );

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -36,23 +36,23 @@ export class AtomicProductPrice
 
     return (
       <div>
-        <atomic-product-number
+        <atomic-product-numeric-field-value
           class={`mx-1 ${hasPromotionalPrice && 'text-error'}`}
           field={hasPromotionalPrice ? 'ec_promo_price' : 'ec_price'}
         >
           <atomic-format-currency
             currency={this.currency}
           ></atomic-format-currency>
-        </atomic-product-number>
+        </atomic-product-numeric-field-value>
         {hasPromotionalPrice && (
-          <atomic-product-number
+          <atomic-product-numeric-field-value
             class="mx-1 text-xl line-through"
             field="ec_price"
           >
             <atomic-format-currency
               currency={this.currency}
             ></atomic-format-currency>
-          </atomic-product-number>
+          </atomic-product-numeric-field-value>
         )}
       </div>
     );

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -24,8 +24,7 @@ export class AtomicProductPrice
   @ProductContext() private product!: Product;
 
   /**
-   * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
-   * See the current [currency & funds code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency).
+   * The currency to use in currency formatting. Allowed values are the [ISO 4217 currency codes](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency), such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB.
    */
   @Prop({reflect: true}) public currency: string = 'USD';
 

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-price/atomic-product-price.tsx
@@ -30,7 +30,7 @@ export class AtomicProductPrice
   @Prop({reflect: true}) public currency!: string;
 
   public render() {
-    const hasPromo =
+    const hasPromotionalPrice =
       this.product?.ec_promo_price !== undefined &&
       this.product?.ec_price !== undefined &&
       this.product?.ec_promo_price < this.product?.ec_price;
@@ -38,14 +38,14 @@ export class AtomicProductPrice
     return (
       <div>
         <atomic-result-number
-          class={`mx-1 ${hasPromo && 'text-error'}`}
-          field={hasPromo ? 'ec_promo_price' : 'ec_price'}
+          class={`mx-1 ${hasPromotionalPrice && 'text-error'}`}
+          field={hasPromotionalPrice ? 'ec_promo_price' : 'ec_price'}
         >
           <atomic-format-currency
             currency={this.currency}
           ></atomic-format-currency>
         </atomic-result-number>
-        {hasPromo && (
+        {hasPromotionalPrice && (
           <atomic-result-number
             class="mx-1 text-xl line-through"
             field="ec_price"

--- a/packages/atomic/src/pages/examples/commerce-website/listing-pants.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-pants.html
@@ -16,8 +16,6 @@
         const commerceInterface = document.querySelector('atomic-commerce-interface');
 
         await commerceInterface.initialize(commerceEngineConfig);
-
-        commerceInterface.executeFirstSearch();
       })();
     </script>
   </head>

--- a/packages/atomic/src/pages/examples/commerce-website/listing-surf-accessories.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-surf-accessories.html
@@ -16,8 +16,6 @@
         const commerceInterface = document.querySelector('atomic-commerce-interface');
 
         await commerceInterface.initialize(commerceEngineConfig);
-
-        commerceInterface.executeFirstSearch();
       })();
     </script>
   </head>
@@ -30,37 +28,6 @@
           <atomic-commerce-query-summary></atomic-commerce-query-summary>
           <atomic-commerce-sort-dropdown></atomic-commerce-sort-dropdown>
           <atomic-commerce-product-list display="grid" density="compact" image-size="small">
-            <atomic-product-template>
-              <template>
-                <atomic-product-image
-                  class="thumbnail"
-                  field="ec_thumbnails"
-                  fallback="https://picsum.photos/350"
-                ></atomic-product-image>
-
-                <atomic-product-link class="font-bold"></atomic-product-link>
-
-                <atomic-field-condition class="brand text-neutral-dark" if-defined="ec_brand">
-                  <atomic-product-text field="ec_brand"></atomic-product-text>
-                </atomic-field-condition>
-
-                <atomic-field-condition class="field" if-defined="ec_rating">
-                  <atomic-result-rating field="ec_rating"></atomic-result-rating>
-                </atomic-field-condition>
-
-                <atomic-field-condition class="mt-4 text-2xl font-bold field" if-defined="ec_price">
-                  <atomic-result-number field="ec_price">
-                    <atomic-format-currency currency="CAD"></atomic-format-currency>
-                  </atomic-result-number>
-                </atomic-field-condition>
-                <atomic-product-description></atomic-product-description>
-                <atomic-result-fields-list>
-                  <atomic-field-condition must-match-ec_in_stock="true">
-                    <atomic-result-badge label="In stock"></atomic-result-badge>
-                  </atomic-field-condition>
-                </atomic-result-fields-list>
-              </template>
-            </atomic-product-template>
           </atomic-commerce-product-list>
           <atomic-commerce-load-more-products></atomic-commerce-load-more-products>
           <atomic-commerce-pager></atomic-commerce-pager>

--- a/packages/atomic/src/pages/examples/commerce-website/listing-towels.html
+++ b/packages/atomic/src/pages/examples/commerce-website/listing-towels.html
@@ -16,8 +16,6 @@
         const commerceInterface = document.querySelector('atomic-commerce-interface');
 
         await commerceInterface.initialize(commerceEngineConfig);
-
-        commerceInterface.executeFirstSearch();
       })();
     </script>
   </head>

--- a/packages/atomic/src/pages/examples/commerce-website/search.html
+++ b/packages/atomic/src/pages/examples/commerce-website/search.html
@@ -61,10 +61,8 @@
                     <atomic-result-rating field="ec_rating"></atomic-result-rating>
                   </atomic-field-condition>
 
-                  <atomic-field-condition class="mt-4 text-2xl font-bold field" if-defined="ec_price">
-                    <atomic-result-number field="ec_price">
-                      <atomic-format-currency currency="CAD"></atomic-format-currency>
-                    </atomic-result-number>
+                  <atomic-field-condition class="mt-4 text-2xl field" if-defined="ec_price">
+                    <atomic-product-price fallbackText="no price" currency="USD"></atomic-product-price>
                   </atomic-field-condition>
                   <atomic-product-description></atomic-product-description>
                   <atomic-result-fields-list>


### PR DESCRIPTION
This PR adds the product price template component. This component displays the value of ec_price, in the specified currency. Additionally, it displays the value of ec_promo_price when that value is lower.

<img width="1000" alt="image" src="https://github.com/coveo/ui-kit/assets/1728218/682cd999-7b50-41fd-b9da-c28541551cc3">
