### PR TITLE
feat: crash engine initialization for analyticsMode=next iif no trackingId

### DIFF
--- a/packages/atomic/src/pages/index.html
+++ b/packages/atomic/src/pages/index.html
@@ -18,6 +18,9 @@
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
         organizationEndpoints: await searchInterface.getOrganizationEndpoints('searchuisamples'),
+        analytics: {
+          analyticsMode: 'next',
+        },
       });
 
       // Trigger a first search

--- a/packages/headless/src/app/__snapshots__/engine.test.ts.snap
+++ b/packages/headless/src/app/__snapshots__/engine.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`engine should throw an error if trackingId is not set in the analytics configuration and analyticsMode is next 1`] = `"analytics.trackingId is required when analytics.analyticsMode="next""`;

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -184,6 +184,11 @@ describe('engine', () => {
     );
   });
 
+  it('should throw an error if trackingId is not set in the analytics configuration and analyticsMode is next', () => {
+    options.configuration.analytics = {analyticsMode: 'next'};
+    expect(() => initEngine()).toThrowErrorMatchingSnapshot();
+  });
+
   describe('with preloaded state', () => {
     const testAction = createAction('increment');
     const testReducer = createReducer(0, (builder) =>

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -206,6 +206,12 @@ function getUpdateAnalyticsConfigurationPayload(
     };
   }
 
+  if (payloadWithURL.analyticsMode === 'next' && !payload.trackingId) {
+    throw new InvalidEngineConfiguration(
+      'analytics.trackingId is required when analytics.analyticsMode="next"'
+    );
+  }
+
   return payloadWithURL;
 }
 
@@ -404,4 +410,11 @@ function shouldWarnAboutMismatchBetweenOrganizationIDAndOrganizationEndpoints(
 
   const match = matchCoveoOrganizationEndpointUrlAnyOrganization(platform);
   return match && match.organizationId !== configuration.organizationId;
+}
+
+class InvalidEngineConfiguration extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidEngineConfiguration';
+  }
 }


### PR DESCRIPTION
Why a crash? Because it's best to stop the devs right in their track if they f-up.
Can't make it more apparent than 'nothing on your page' and some red stuff in your console ;)

https://coveord.atlassian.net/browse/KIT-3137