### PR TITLE
fix(atomic): use variable to set font-weight of strong and th elements in generated rich answers

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.pcss
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.pcss
@@ -36,6 +36,10 @@
     @apply leading-6;
   }
 
+  [part='answer-strong'] {
+    font-weight: var(--atomic-font-bold);
+  }
+
   [part='answer-ordered-list'] {
     @apply list-decimal ps-8 mb-2;
   }
@@ -85,6 +89,7 @@
       [part='answer-table-header'] {
         @apply p-4 text-left;
         background-color: var(--atomic-neutral);
+        font-weight: var(--atomic-font-bold);
         border-bottom: solid 2px var(--atomic-neutral-dim);
         border-left: solid 1px var(--atomic-neutral-dim);
       }


### PR DESCRIPTION
# [SVCC-3766](https://coveord.atlassian.net/browse/SVCC-3766)

In some cases, the bold text in rich generated answers could be too light or too heavy compared to other bold elements in the search interface.

This PR updates the styling of `strong` and `th` elements in generated rich answers to rely on the `--atomic-font-bold` variable and maintain a consistent look across the search interface.



[SVCC-3766]: https://coveord.atlassian.net/browse/SVCC-3766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ