### PR TITLE
feat(commerce): expose did you mean as sub-controller

### DIFF
--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -211,8 +211,7 @@ export {getOrganizationEndpoints} from './api/platform-client';
 export type {
   DidYouMean,
   DidYouMeanState,
-} from './controllers/commerce/did-you-mean/headless-did-you-mean';
-export {buildDidYouMean} from './controllers/commerce/did-you-mean/headless-did-you-mean';
+} from './controllers/commerce/search/did-you-mean/headless-did-you-mean';
 export {ProductTemplatesHelpers} from './features/commerce/product-templates/product-templates-helpers';
 
 export type {

--- a/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.test.ts
+++ b/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.test.ts
@@ -3,6 +3,7 @@ import {
   MockedCommerceEngine,
   buildMockCommerceEngine,
 } from '../../../../test/mock-engine-v2';
+import * as DidYouMean from '../../search/did-you-mean/headless-did-you-mean';
 import * as CoreBreadcrumbManager from '../breadcrumb-manager/headless-core-breadcrumb-manager';
 import * as CoreFacetGenerator from '../facets/generator/headless-commerce-facet-generator';
 import * as CorePagination from '../pagination/headless-core-commerce-pagination';
@@ -10,16 +11,18 @@ import * as CoreInteractiveProduct from '../product-list/headless-core-interacti
 import * as CoreSort from '../sort/headless-core-commerce-sort';
 import {
   BaseSolutionTypeSubControllers,
-  buildBaseSolutionTypeControllers,
-  buildSolutionTypeSubControllers,
+  buildBaseSubControllers,
+  buildSearchAndListingsSubControllers,
+  buildSearchSubControllers,
   SearchAndListingSubControllers,
+  SearchSubControllers,
 } from './headless-sub-controller';
 
-describe('sub controllers', () => {
+describe('sub-controllers', () => {
   let engine: MockedCommerceEngine;
   const mockResponseIdSelector = jest.fn();
-  const mockfetchProductsActionCreator = jest.fn();
-  const mockfetchMoreProductsActionCreator = jest.fn();
+  const mockFetchProductsActionCreator = jest.fn();
+  const mockFetchMoreProductsActionCreator = jest.fn();
   const mockFacetResponseSelector = jest.fn();
   const mockIsFacetLoadingResponseSelector = jest.fn();
 
@@ -31,79 +34,56 @@ describe('sub controllers', () => {
     jest.clearAllMocks();
   });
 
-  it.each([
-    {
-      name: 'buildSolutionTypeSubControllers',
-      subControllersBuilder: buildSolutionTypeSubControllers,
-    },
-    {
-      name: 'buildBaseSolutionTypeControllers',
-      subControllersBuilder: buildBaseSolutionTypeControllers,
-    },
-  ])(
-    '#interactiveProduct builds interactive result controller',
-    ({
-      subControllersBuilder,
-    }: {
-      subControllersBuilder:
-        | typeof buildSolutionTypeSubControllers
-        | typeof buildBaseSolutionTypeControllers;
-    }) => {
-      const subControllers = subControllersBuilder(engine, {
-        responseIdSelector: mockResponseIdSelector,
-        fetchProductsActionCreator: mockfetchProductsActionCreator,
-        fetchMoreProductsActionCreator: mockfetchMoreProductsActionCreator,
-        facetResponseSelector: mockFacetResponseSelector,
-        isFacetLoadingResponseSelector: mockIsFacetLoadingResponseSelector,
-      });
-      const buildCoreInteractiveProductMock = jest.spyOn(
-        CoreInteractiveProduct,
-        'buildCoreInteractiveProduct'
-      );
-
-      const props = {
-        options: {
-          product: {
-            productId: '1',
-            name: 'Product name',
-            price: 17.99,
-          },
-          position: 1,
-        },
-      };
-
-      const interactiveProduct = subControllers.interactiveProduct({
-        ...props,
-      });
-
-      expect(interactiveProduct).toEqual(
-        buildCoreInteractiveProductMock.mock.results[0].value
-      );
-    }
-  );
-
-  describe('#buildSolutionTypeSubControllers', () => {
-    let subControllers: SearchAndListingSubControllers;
+  describe('#buildSearchSubControllers', () => {
+    let subControllers: SearchSubControllers;
 
     beforeEach(() => {
-      subControllers = buildSolutionTypeSubControllers(engine, {
+      subControllers = buildSearchSubControllers(engine, {
         responseIdSelector: mockResponseIdSelector,
-        fetchProductsActionCreator: mockfetchProductsActionCreator,
-        fetchMoreProductsActionCreator: mockfetchMoreProductsActionCreator,
+        fetchProductsActionCreator: mockFetchProductsActionCreator,
+        fetchMoreProductsActionCreator: mockFetchMoreProductsActionCreator,
         facetResponseSelector: mockFacetResponseSelector,
         isFacetLoadingResponseSelector: mockIsFacetLoadingResponseSelector,
       });
     });
 
-    it('#pagination builds pagination controller', () => {
-      const buildCorePaginationMock = jest.spyOn(
-        CorePagination,
-        'buildCorePagination'
-      );
+    it('exposes base sub-controllers', () => {
+      expect(subControllers).toHaveProperty('pagination');
+      expect(subControllers).toHaveProperty('interactiveProduct');
+    });
 
-      const pagination = subControllers.pagination();
+    it('exposes search and listing sub-controllers', () => {
+      expect(subControllers).toHaveProperty('sort');
+      expect(subControllers).toHaveProperty('facetGenerator');
+      expect(subControllers).toHaveProperty('breadcrumbManager');
+    });
 
-      expect(pagination).toEqual(buildCorePaginationMock.mock.results[0].value);
+    it('#didYouMean builds did you mean controller', () => {
+      const buildDidYouMean = jest.spyOn(DidYouMean, 'buildDidYouMean');
+
+      const didYouMean = subControllers.didYouMean();
+
+      expect(didYouMean).toEqual(buildDidYouMean.mock.results[0].value);
+      expect(buildDidYouMean).toHaveBeenCalledWith(engine);
+    });
+  });
+
+  describe('#buildSearchAndListingsSubControllers', () => {
+    let subControllers: SearchAndListingSubControllers;
+
+    beforeEach(() => {
+      subControllers = buildSearchAndListingsSubControllers(engine, {
+        responseIdSelector: mockResponseIdSelector,
+        fetchProductsActionCreator: mockFetchProductsActionCreator,
+        fetchMoreProductsActionCreator: mockFetchMoreProductsActionCreator,
+        facetResponseSelector: mockFacetResponseSelector,
+        isFacetLoadingResponseSelector: mockIsFacetLoadingResponseSelector,
+      });
+    });
+
+    it('exposes base sub-controllers', () => {
+      expect(subControllers).toHaveProperty('pagination');
+      expect(subControllers).toHaveProperty('interactiveProduct');
     });
 
     it('#sort builds sort controller', () => {
@@ -141,16 +121,46 @@ describe('sub controllers', () => {
     });
   });
 
-  describe('#buildRecommendationsSubControllers', () => {
+  describe('#buildBaseSubControllers', () => {
     const slotId = 'recommendations-slot-id';
     let subControllers: BaseSolutionTypeSubControllers;
 
     beforeEach(() => {
-      subControllers = buildBaseSolutionTypeControllers(engine, {
+      subControllers = buildBaseSubControllers(engine, {
         slotId,
         responseIdSelector: mockResponseIdSelector,
-        fetchProductsActionCreator: mockfetchProductsActionCreator,
-        fetchMoreProductsActionCreator: mockfetchMoreProductsActionCreator,
+        fetchProductsActionCreator: mockFetchProductsActionCreator,
+        fetchMoreProductsActionCreator: mockFetchMoreProductsActionCreator,
+      });
+    });
+
+    it('#interactiveProduct builds interactive product controller', () => {
+      const buildCoreInteractiveProductMock = jest.spyOn(
+        CoreInteractiveProduct,
+        'buildCoreInteractiveProduct'
+      );
+
+      const props = {
+        options: {
+          product: {
+            productId: '1',
+            name: 'Product name',
+            price: 17.99,
+          },
+          position: 1,
+        },
+      };
+
+      const interactiveProduct = subControllers.interactiveProduct({
+        ...props,
+      });
+
+      expect(interactiveProduct).toEqual(
+        buildCoreInteractiveProductMock.mock.results[0].value
+      );
+      expect(buildCoreInteractiveProductMock).toHaveBeenCalledWith(engine, {
+        ...props,
+        responseIdSelector: mockResponseIdSelector,
       });
     });
 
@@ -164,8 +174,8 @@ describe('sub controllers', () => {
 
       expect(pagination).toEqual(buildCorePaginationMock.mock.results[0].value);
       expect(buildCorePaginationMock).toHaveBeenCalledWith(engine, {
-        fetchProductsActionCreator: mockfetchProductsActionCreator,
-        fetchMoreProductsActionCreator: mockfetchMoreProductsActionCreator,
+        fetchProductsActionCreator: mockFetchProductsActionCreator,
+        fetchMoreProductsActionCreator: mockFetchMoreProductsActionCreator,
         options: {
           slotId,
         },

--- a/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.ts
+++ b/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.ts
@@ -5,6 +5,10 @@ import {
 import {stateKey} from '../../../../app/state-key';
 import {AnyFacetResponse} from '../../../../features/commerce/facets/facet-set/interfaces/response';
 import {
+  buildDidYouMean,
+  DidYouMean,
+} from '../../search/did-you-mean/headless-did-you-mean';
+import {
   BreadcrumbManager,
   buildCoreBreadcrumbManager,
 } from '../breadcrumb-manager/headless-core-breadcrumb-manager';
@@ -45,6 +49,10 @@ export interface SearchAndListingSubControllers
   breadcrumbManager: () => BreadcrumbManager;
 }
 
+export interface SearchSubControllers extends SearchAndListingSubControllers {
+  didYouMean: () => DidYouMean;
+}
+
 interface BaseSubControllerProps {
   responseIdSelector: (state: CommerceEngineState) => string;
   fetchProductsActionCreator: FetchProductsActionCreator;
@@ -63,7 +71,19 @@ export interface SearchAndListingSubControllerProps
   ) => boolean;
 }
 
-export function buildSolutionTypeSubControllers(
+export function buildSearchSubControllers(
+  engine: CommerceEngine,
+  subControllerProps: SearchAndListingSubControllerProps
+): SearchSubControllers {
+  return {
+    ...buildSearchAndListingsSubControllers(engine, subControllerProps),
+    didYouMean() {
+      return buildDidYouMean(engine);
+    },
+  };
+}
+
+export function buildSearchAndListingsSubControllers(
   engine: CommerceEngine,
   subControllerProps: SearchAndListingSubControllerProps
 ): SearchAndListingSubControllers {
@@ -73,7 +93,7 @@ export function buildSolutionTypeSubControllers(
     isFacetLoadingResponseSelector,
   } = subControllerProps;
   return {
-    ...buildBaseSolutionTypeControllers(engine, subControllerProps),
+    ...buildBaseSubControllers(engine, subControllerProps),
     sort(props?: SortProps) {
       return buildCoreSort(engine, {
         ...props,
@@ -106,7 +126,7 @@ export function buildSolutionTypeSubControllers(
   };
 }
 
-export function buildBaseSolutionTypeControllers(
+export function buildBaseSubControllers(
   engine: CommerceEngine,
   subControllerProps: BaseSubControllerProps
 ): BaseSolutionTypeSubControllers {

--- a/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.test.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.test.ts
@@ -1,15 +1,19 @@
 import {configuration} from '../../../app/common-reducers';
 import {contextReducer} from '../../../features/commerce/context/context-slice';
-import {fetchProductListing} from '../../../features/commerce/product-listing/product-listing-actions';
+import * as ProductListingActions from '../../../features/commerce/product-listing/product-listing-actions';
+import {responseIdSelector} from '../../../features/commerce/product-listing/product-listing-selectors';
 import {productListingV2Reducer} from '../../../features/commerce/product-listing/product-listing-slice';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
   MockedCommerceEngine,
   buildMockCommerceEngine,
 } from '../../../test/mock-engine-v2';
+import * as SubControllers from '../core/sub-controller/headless-sub-controller';
+import {
+  facetResponseSelector,
+  isFacetLoadingResponseSelector,
+} from './facets/headless-product-listing-facet-options';
 import {buildProductListing, ProductListing} from './headless-product-listing';
-
-jest.mock('../../../features/commerce/product-listing/product-listing-actions');
 
 describe('headless product-listing', () => {
   let productListing: ProductListing;
@@ -18,6 +22,27 @@ describe('headless product-listing', () => {
   beforeEach(() => {
     engine = buildMockCommerceEngine(buildMockCommerceState());
     productListing = buildProductListing(engine);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses sub-controllers', () => {
+    const buildSearchAndListingsSubControllers = jest.spyOn(
+      SubControllers,
+      'buildSearchAndListingsSubControllers'
+    );
+
+    buildProductListing(engine);
+
+    expect(buildSearchAndListingsSubControllers).toHaveBeenCalledWith(engine, {
+      responseIdSelector,
+      fetchProductsActionCreator: ProductListingActions.fetchProductListing,
+      fetchMoreProductsActionCreator: ProductListingActions.fetchMoreProducts,
+      facetResponseSelector,
+      isFacetLoadingResponseSelector,
+    });
   });
 
   it('adds the correct reducers to engine', () => {
@@ -29,7 +54,13 @@ describe('headless product-listing', () => {
   });
 
   it('refresh dispatches #fetchProductListing', () => {
+    const fetchProductListing = jest.spyOn(
+      ProductListingActions,
+      'fetchProductListing'
+    );
+
     productListing.refresh();
+
     expect(fetchProductListing).toHaveBeenCalled();
   });
 });

--- a/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/headless-product-listing.ts
@@ -16,7 +16,7 @@ import {
   Controller,
 } from '../../controller/headless-controller';
 import {
-  buildSolutionTypeSubControllers,
+  buildSearchAndListingsSubControllers,
   SearchAndListingSubControllers,
 } from '../core/sub-controller/headless-sub-controller';
 import {
@@ -62,7 +62,7 @@ export function buildProductListing(engine: CommerceEngine): ProductListing {
   const controller = buildController(engine);
   const {dispatch} = engine;
   const getState = () => engine[stateKey];
-  const subControllers = buildSolutionTypeSubControllers(engine, {
+  const subControllers = buildSearchAndListingsSubControllers(engine, {
     responseIdSelector,
     fetchProductsActionCreator: fetchProductListing,
     fetchMoreProductsActionCreator: fetchMoreProducts,

--- a/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.ts
+++ b/packages/headless/src/controllers/commerce/recommendations/headless-recommendations.ts
@@ -21,7 +21,7 @@ import {
 } from '../../controller/headless-controller';
 import {
   BaseSolutionTypeSubControllers,
-  buildBaseSolutionTypeControllers,
+  buildBaseSubControllers,
 } from '../core/sub-controller/headless-sub-controller';
 
 /**
@@ -96,7 +96,7 @@ export function buildRecommendations(
     (state: CommerceEngineState) => state.recommendations[slotId]!,
     (recommendations) => recommendations
   );
-  const subControllers = buildBaseSolutionTypeControllers(engine, {
+  const subControllers = buildBaseSubControllers(engine, {
     slotId,
     responseIdSelector: (state) => state.recommendations[slotId]!.responseId,
     fetchProductsActionCreator: () => fetchRecommendations({slotId}),

--- a/packages/headless/src/controllers/commerce/search/did-you-mean/headless-did-you-mean.test.ts
+++ b/packages/headless/src/controllers/commerce/search/did-you-mean/headless-did-you-mean.test.ts
@@ -1,10 +1,10 @@
-import {stateKey} from '../../../app/state-key';
-import {didYouMeanReducer} from '../../../features/commerce/did-you-mean/did-you-mean-slice';
-import {buildMockCommerceState} from '../../../test/mock-commerce-state';
+import {stateKey} from '../../../../app/state-key';
+import {didYouMeanReducer} from '../../../../features/commerce/did-you-mean/did-you-mean-slice';
+import {buildMockCommerceState} from '../../../../test/mock-commerce-state';
 import {
   buildMockCommerceEngine,
   MockedCommerceEngine,
-} from '../../../test/mock-engine-v2';
+} from '../../../../test/mock-engine-v2';
 import {buildDidYouMean, DidYouMean} from './headless-did-you-mean';
 
 describe('did you mean', () => {

--- a/packages/headless/src/controllers/commerce/search/did-you-mean/headless-did-you-mean.ts
+++ b/packages/headless/src/controllers/commerce/search/did-you-mean/headless-did-you-mean.ts
@@ -1,18 +1,18 @@
 import {
   QueryCorrection,
   WordCorrection,
-} from '../../../api/search/search/query-corrections';
-import {CommerceEngine} from '../../../app/commerce-engine/commerce-engine';
-import {stateKey} from '../../../app/state-key';
-import {didYouMeanReducer as didYouMean} from '../../../features/commerce/did-you-mean/did-you-mean-slice';
-import {hasQueryCorrectionSelector} from '../../../features/did-you-mean/did-you-mean-selectors';
-import {CommerceDidYouMeanSection} from '../../../state/state-sections';
-import {loadReducerError} from '../../../utils/errors';
+} from '../../../../api/search/search/query-corrections';
+import {CommerceEngine} from '../../../../app/commerce-engine/commerce-engine';
+import {stateKey} from '../../../../app/state-key';
+import {didYouMeanReducer as didYouMean} from '../../../../features/commerce/did-you-mean/did-you-mean-slice';
+import {hasQueryCorrectionSelector} from '../../../../features/did-you-mean/did-you-mean-selectors';
+import {CommerceDidYouMeanSection} from '../../../../state/state-sections';
+import {loadReducerError} from '../../../../utils/errors';
 import {
   buildController,
   Controller,
-} from '../../controller/headless-controller';
-import {DidYouMeanState} from '../../did-you-mean/headless-did-you-mean';
+} from '../../../controller/headless-controller';
+import {DidYouMeanState} from '../../../did-you-mean/headless-did-you-mean';
 
 export type {QueryCorrection, WordCorrection, DidYouMeanState};
 

--- a/packages/headless/src/controllers/commerce/search/headless-search.test.ts
+++ b/packages/headless/src/controllers/commerce/search/headless-search.test.ts
@@ -1,16 +1,20 @@
 import {configuration} from '../../../app/common-reducers';
 import {contextReducer as commerceContext} from '../../../features/commerce/context/context-slice';
 import {queryReducer as commerceQuery} from '../../../features/commerce/query/query-slice';
-import {executeSearch} from '../../../features/commerce/search/search-actions';
+import * as SearchActions from '../../../features/commerce/search/search-actions';
+import {responseIdSelector} from '../../../features/commerce/search/search-selectors';
 import {commerceSearchReducer as commerceSearch} from '../../../features/commerce/search/search-slice';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
   MockedCommerceEngine,
   buildMockCommerceEngine,
 } from '../../../test/mock-engine-v2';
+import * as SubControllers from '../core/sub-controller/headless-sub-controller';
+import {
+  facetResponseSelector,
+  isFacetLoadingResponseSelector,
+} from './facets/headless-search-facet-options';
 import {buildSearch, Search} from './headless-search';
-
-jest.mock('../../../features/commerce/search/search-actions');
 
 describe('headless search', () => {
   let search: Search;
@@ -19,6 +23,10 @@ describe('headless search', () => {
   beforeEach(() => {
     engine = buildMockCommerceEngine(buildMockCommerceState());
     search = buildSearch(engine);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('adds the correct reducers to engine', () => {
@@ -30,10 +38,30 @@ describe('headless search', () => {
     });
   });
 
+  it('uses sub-controllers', () => {
+    const buildSearchSubControllers = jest.spyOn(
+      SubControllers,
+      'buildSearchSubControllers'
+    );
+
+    buildSearch(engine);
+
+    expect(buildSearchSubControllers).toHaveBeenCalledWith(engine, {
+      responseIdSelector,
+      fetchProductsActionCreator: SearchActions.executeSearch,
+      fetchMoreProductsActionCreator: SearchActions.fetchMoreProducts,
+      facetResponseSelector,
+      isFacetLoadingResponseSelector,
+    });
+  });
+
   // eslint-disable-next-line @cspell/spellchecker
   // TODO CAPI-244: Handle analytics
   it('executeFirstSearch dispatches #executeSearch', () => {
+    const executeSearch = jest.spyOn(SearchActions, 'executeSearch');
+
     search.executeFirstSearch();
+
     expect(executeSearch).toHaveBeenCalled();
   });
 });

--- a/packages/headless/src/controllers/commerce/search/headless-search.ts
+++ b/packages/headless/src/controllers/commerce/search/headless-search.ts
@@ -18,15 +18,15 @@ import {
   Controller,
 } from '../../controller/headless-controller';
 import {
-  buildSolutionTypeSubControllers,
-  SearchAndListingSubControllers,
+  buildSearchSubControllers,
+  SearchSubControllers,
 } from '../core/sub-controller/headless-sub-controller';
 import {
   facetResponseSelector,
   isFacetLoadingResponseSelector,
 } from './facets/headless-search-facet-options';
 
-export interface Search extends Controller, SearchAndListingSubControllers {
+export interface Search extends Controller, SearchSubControllers {
   /**
    * Executes the first search.
    */
@@ -53,7 +53,7 @@ export function buildSearch(engine: CommerceEngine): Search {
   const controller = buildController(engine);
   const {dispatch} = engine;
   const getState = () => engine[stateKey];
-  const subControllers = buildSolutionTypeSubControllers(engine, {
+  const subControllers = buildSearchSubControllers(engine, {
     responseIdSelector,
     fetchProductsActionCreator: executeSearch,
     fetchMoreProductsActionCreator: fetchMoreProducts,


### PR DESCRIPTION
Follow-up to https://github.com/coveo/ui-kit/pull/3859

I also:
- Added tests for sub-controllers
- Tested that listing & search controllers use sub-controllers
- Nested the `did-you-mean` folder for the controller under `search`