### PR TITLE
fix(atomic): update initializeBindings utility function for commerce custom components

### DIFF
--- a/packages/atomic/src/index.ts
+++ b/packages/atomic/src/index.ts
@@ -1,5 +1,4 @@
-import {Bindings} from './components/search/atomic-search-interface/atomic-search-interface';
-import {initializeBindings as genericInitializeBindings} from './utils/initialization-utils';
+export {initializeBindings} from './utils/initialization-utils';
 
 export {Bindings} from './components/search/atomic-search-interface/atomic-search-interface';
 
@@ -12,9 +11,6 @@ export {MissingInterfaceParentError} from './utils/initialization-utils';
 
 export {PopoverChildFacet} from './components/search/facets/atomic-popover/popover-type';
 
-export function initializeBindings(element: Element) {
-  return genericInitializeBindings<Bindings>(element);
-}
 export {resultContext} from './components/search/result-template-components/result-template-decorators';
 export {productContext} from './components/commerce/product-template-components/product-template-decorators';
 export {

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -35,9 +35,9 @@ const initializableElements = [
  * @param event Element on which to dispatch the event, which must be the child of a configured "atomic-search-interface" or "atomic-external" element.
  * @returns A promise that resolves on initialization of the parent "atomic-search-interface" or "atomic-external" element, and rejects when it's not the case.
  */
-export function initializeBindings<SpecificBindings extends AnyBindings>(
-  element: Element
-) {
+export function initializeBindings<
+  SpecificBindings extends AnyBindings = Bindings,
+>(element: Element) {
   return new Promise<SpecificBindings>((resolve, reject) => {
     const event = buildCustomEvent<InitializeEventHandler>(
       initializeEventName,

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -32,8 +32,8 @@ const initializableElements = [
 
 /**
  * Retrieves `Bindings` or `CommerceBindings` on a configured parent interface.
- * @param event Element on which to dispatch the event, which must be the child of a configured atomic container element.
- * @returns A promise that resolves on initialization of the parent container element, and rejects when it's not the case.
+ * @param event - The element on which to dispatch the event, which must be the child of a configured Atomic container element.
+ * @returns A promise that resolves upon initialization of the parent container element, and rejects otherwise.
  */
 export function initializeBindings<
   SpecificBindings extends AnyBindings = Bindings,

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -31,9 +31,9 @@ const initializableElements = [
 ];
 
 /**
- * Retrieves `Bindings` on a configured parent search interface.
- * @param event Element on which to dispatch the event, which must be the child of a configured "atomic-search-interface" or "atomic-external" element.
- * @returns A promise that resolves on initialization of the parent "atomic-search-interface" or "atomic-external" element, and rejects when it's not the case.
+ * Retrieves `Bindings` or `CommerceBindings` on a configured parent interface.
+ * @param event Element on which to dispatch the event, which must be the child of a configured atomic container element.
+ * @returns A promise that resolves on initialization of the parent container element, and rejects when it's not the case.
  */
 export function initializeBindings<
   SpecificBindings extends AnyBindings = Bindings,


### PR DESCRIPTION
Custom components were previously only possible with classic `Bindings` (ie: headless search engine). We need to make it possible with `CommerceBindings` (headless commerce engine)

Modify the exported function to instead expose the fact that it is generic under the hood.
Make it so that it defaults on `Bindings` (search engine use case) for backward compatibility.

https://coveord.atlassian.net/browse/KIT-3156