### PR TITLE
feat(commerce): capi 851 commerce context cart should sent product id instead of SKU

### DIFF
--- a/packages/headless/src/api/commerce/commerce-api-params.ts
+++ b/packages/headless/src/api/commerce/commerce-api-params.ts
@@ -62,7 +62,13 @@ export type UserParams = (UserIdRequired | EmailRequired | UserIdAndEmail) & {
 };
 
 export interface CartItemParam {
-  sku: string;
+  /**
+   * The unique identifier of the product.
+   */
+  productId: string;
+  /**
+   * The quantity of the product in the cart.
+   */
   quantity: number;
 }
 

--- a/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
@@ -54,7 +54,6 @@ export function getSampleCommerceEngineConfiguration(): CommerceEngineConfigurat
           quantity: 1,
           price: 100,
           productId: 'sample-product-id',
-          sku: 'sample-sku',
         },
       ],
     },

--- a/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
@@ -1,3 +1,4 @@
+import {createCartKey} from '../../controllers/commerce/context/cart/headless-cart';
 import {stateKey} from '../state-key';
 import {
   buildCommerceEngine,
@@ -38,14 +39,12 @@ describe('buildCommerceEngine', () => {
     const items = [
       {
         productId: 'product-id',
-        sku: 'product-id-1',
         quantity: 2,
         name: 'product-name-1',
         price: 100,
       },
       {
         productId: 'product-id',
-        sku: 'product-id-2',
         quantity: 4,
         name: 'product-name-2',
         price: 25,
@@ -57,12 +56,12 @@ describe('buildCommerceEngine', () => {
     initEngine();
 
     expect(engine[stateKey].cart.cartItems).toEqual(
-      items.map((item) => item.sku)
+      items.map((item) => createCartKey(item))
     );
 
     expect(engine[stateKey].cart.cart).toEqual({
-      [items[0].sku]: items[0],
-      [items[1].sku]: items[1],
+      [createCartKey(items[0])]: items[0],
+      [createCartKey(items[1])]: items[1],
     });
   });
 });

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
@@ -46,15 +46,9 @@ describe('headless-cart-selectors', () => {
     const item3Key = createCartKey(item3);
     cartOptions = {
       cart: {
-        [item1Key]: {
-          [item1.price]: item1,
-        },
-        [item2Key]: {
-          [item2.price]: item2,
-        },
-        [item3Key]: {
-          [item3.price]: item3,
-        },
+        [item1Key]: item1,
+        [item2Key]: item2,
+        [item3Key]: item3,
       },
       cartItems: [item1Key, item2Key, item3Key],
     };
@@ -64,7 +58,7 @@ describe('headless-cart-selectors', () => {
   describe('itemSelector', () => {
     it('should return the correct item from the cart', () => {
       const selectedItem = itemSelector(cartState, item1);
-      expect(selectedItem).toEqual(cartOptions.cart[item1Key][item1.price]);
+      expect(selectedItem).toEqual(cartOptions.cart[item1Key]);
     });
 
     it('should return undefined if the item is not found in the cart', () => {

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
@@ -3,6 +3,8 @@ import {
   CartState,
   getCartInitialState,
 } from '../../../../features/commerce/context/cart/cart-state';
+import {CartItemWithMetadata} from '../../../../features/commerce/context/cart/cart-state';
+import {createCartKey} from './headless-cart';
 import {
   itemSelector,
   totalQuantitySelector,
@@ -17,45 +19,56 @@ describe('headless-cart-selectors', () => {
     cartState = preloadedState;
   }
 
+  const item1: CartItemWithMetadata = {
+    productId: 'p1',
+    name: 'product1',
+    price: 25,
+    quantity: 1,
+  };
+  const item1Key = createCartKey(item1);
+  const item2: CartItemWithMetadata = {
+    productId: 'p1',
+    name: 'product2',
+    price: 50,
+    quantity: 2,
+  };
+  const item2Key = createCartKey(item2);
+  const item3: CartItemWithMetadata = {
+    productId: 'p1',
+    name: 'product3',
+    price: 100,
+    quantity: 3,
+  };
+
   beforeEach(() => {
     jest.resetAllMocks();
+
+    const item3Key = createCartKey(item3);
     cartOptions = {
       cart: {
-        ['p1_1']: {
-          productId: 'p1',
-          sku: 'p1_1',
-          quantity: 1,
-          name: 'product1',
-          price: 25,
-        },
-        ['p1_2']: {
-          productId: 'p1',
-          sku: 'p1_2',
-          quantity: 2,
-          name: 'product2',
-          price: 50,
-        },
-        ['p1_3']: {
-          productId: 'p1',
-          sku: 'p1_3',
-          quantity: 3,
-          name: 'product3',
-          price: 100,
-        },
+        [item1Key]: item1,
+        [item2Key]: item2,
+        [item3Key]: item3,
       },
-      cartItems: ['p1_1', 'p1_2', 'p1_3'],
+      cartItems: [item1Key, item2Key, item3Key],
     };
     initState(cartOptions);
   });
 
   describe('itemSelector', () => {
     it('should return the correct item from the cart', () => {
-      const selectedItem = itemSelector(cartState, 'p1_1');
-      expect(selectedItem).toEqual(cartOptions.cart['p1_1']);
+      const selectedItem = itemSelector(cartState, item1);
+      expect(selectedItem).toEqual(cartOptions.cart[item1Key]);
     });
 
     it('should return undefined if the item is not found in the cart', () => {
-      const selectedItem = itemSelector(cartState, 'p0');
+      const item4: CartItemWithMetadata = {
+        productId: 'p1',
+        name: 'product3',
+        price: 10000,
+        quantity: 3,
+      };
+      const selectedItem = itemSelector(cartState, item4);
       expect(selectedItem).toBeUndefined();
     });
   });
@@ -63,24 +76,21 @@ describe('headless-cart-selectors', () => {
   describe('itemsSelector', () => {
     it('should return an array containing all items in the cart', () => {
       const selectedItems = itemsSelector(cartState);
-      expect(selectedItems.sort((a, b) => (a.sku < b.sku ? -1 : 1))).toEqual([
+      expect(selectedItems.sort((a, b) => (a.name < b.name ? -1 : 1))).toEqual([
         {
           productId: 'p1',
-          sku: 'p1_1',
           quantity: 1,
           name: 'product1',
           price: 25,
         },
         {
           productId: 'p1',
-          sku: 'p1_2',
           quantity: 2,
           name: 'product2',
           price: 50,
         },
         {
           productId: 'p1',
-          sku: 'p1_3',
           quantity: 3,
           name: 'product3',
           price: 100,

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
@@ -39,11 +39,11 @@ describe('headless-cart-selectors', () => {
     price: 100,
     quantity: 3,
   };
+  const item3Key = createCartKey(item3);
 
   beforeEach(() => {
     jest.resetAllMocks();
 
-    const item3Key = createCartKey(item3);
     cartOptions = {
       cart: {
         [item1Key]: item1,

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.test.ts
@@ -46,9 +46,15 @@ describe('headless-cart-selectors', () => {
     const item3Key = createCartKey(item3);
     cartOptions = {
       cart: {
-        [item1Key]: item1,
-        [item2Key]: item2,
-        [item3Key]: item3,
+        [item1Key]: {
+          [item1.price]: item1,
+        },
+        [item2Key]: {
+          [item2.price]: item2,
+        },
+        [item3Key]: {
+          [item3.price]: item3,
+        },
       },
       cartItems: [item1Key, item2Key, item3Key],
     };
@@ -58,7 +64,7 @@ describe('headless-cart-selectors', () => {
   describe('itemSelector', () => {
     it('should return the correct item from the cart', () => {
       const selectedItem = itemSelector(cartState, item1);
-      expect(selectedItem).toEqual(cartOptions.cart[item1Key]);
+      expect(selectedItem).toEqual(cartOptions.cart[item1Key][item1.price]);
     });
 
     it('should return undefined if the item is not found in the cart', () => {

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
@@ -1,9 +1,10 @@
 import {createSelector} from '@reduxjs/toolkit';
 import {itemsSelector} from '../../../../features/commerce/context/cart/cart-selector';
 import {CartState} from '../../../../features/commerce/context/cart/cart-state';
+import {CartItem, createCartKey} from './headless-cart';
 
-export function itemSelector(cartState: CartState, sku: string) {
-  return cartState.cart[sku];
+export function itemSelector(cartState: CartState, item: CartItem) {
+  return cartState.cart[createCartKey(item)];
 }
 
 export const totalQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
@@ -3,10 +3,8 @@ import {itemsSelector} from '../../../../features/commerce/context/cart/cart-sel
 import {CartState} from '../../../../features/commerce/context/cart/cart-state';
 import {CartItem, createCartKey} from './headless-cart';
 
-export function itemSelector(cartState: CartState, cartItem: CartItem) {
-  return Object.entries(cartState.cart[createCartKey(cartItem)])
-    .filter(([_, item]) => item.price === cartItem.price)
-    .map(([_, item]) => item)[0];
+export function itemSelector(cartState: CartState, item: CartItem) {
+  return cartState.cart[createCartKey(item)];
 }
 
 export const totalQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart-selectors.ts
@@ -3,8 +3,10 @@ import {itemsSelector} from '../../../../features/commerce/context/cart/cart-sel
 import {CartState} from '../../../../features/commerce/context/cart/cart-state';
 import {CartItem, createCartKey} from './headless-cart';
 
-export function itemSelector(cartState: CartState, item: CartItem) {
-  return cartState.cart[createCartKey(item)];
+export function itemSelector(cartState: CartState, cartItem: CartItem) {
+  return Object.entries(cartState.cart[createCartKey(cartItem)])
+    .filter(([_, item]) => item.price === cartItem.price)
+    .map(([_, item]) => item)[0];
 }
 
 export const totalQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -175,17 +175,17 @@ describe('headless commerce cart', () => {
     };
 
     it('will not dispatch an action or emit an event if the item = cartItem', () => {
-      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
       cart.updateItemQuantity(productWithQuantity(3));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
-      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(0);
+      expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
     });
 
     it('will not dispatch an action or emit an event if item does not exist in cart and item.quantity <= 0', () => {
-      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
@@ -193,38 +193,38 @@ describe('headless commerce cart', () => {
       cart.updateItemQuantity(productWithQuantity(0));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
-      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(0);
+      expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
     });
 
     it('dispatches #updateItemQuantity when the item != cartItem', () => {
-      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
+      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches #updateItemQuantity when the item does not exist in the cart state and item.quantity > 0', () => {
-      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
+      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches #updateItemQuantity but does not emit #ec.cartAction when the item.quantity = cartItem.quantity but item != cartItem', () => {
-      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue({...productWithQuantity(3), name: 'bap'});
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
+      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
     });
 

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -43,14 +43,12 @@ describe('headless commerce cart', () => {
       items: [
         {
           productId: 'product-id',
-          sku: 'product-id-1',
           quantity: 2,
           name: 'product-name-1',
           price: 100,
         },
         {
           productId: 'product-id',
-          sku: 'product-id-2',
           quantity: 4,
           name: 'product-name-2',
           price: 25,
@@ -102,7 +100,7 @@ describe('headless commerce cart', () => {
 
     const item = initialState.items![0];
 
-    expect(updateItemSpy).toHaveBeenCalledWith({
+    expect(updateItemSpy).toHaveBeenCalledWith(item, {
       ...item,
       quantity: 0,
     });
@@ -134,11 +132,9 @@ describe('headless commerce cart', () => {
   describe('#updateItem', () => {
     const productWithoutQuantity = {
       productId: 'product-id',
-      sku: 'product-id-1',
       name: 'product-name-1',
       price: 100,
     };
-    const {sku, ...productWithoutQuantityAndSku} = productWithoutQuantity;
 
     const productWithQuantity = (quantity: number) => ({
       ...productWithoutQuantity,
@@ -162,7 +158,7 @@ describe('headless commerce cart', () => {
       quantity: number = 1
     ) => ({
       action,
-      product: productWithoutQuantityAndSku,
+      product: productWithoutQuantity,
       quantity,
       currency: 'USD',
     });
@@ -182,7 +178,7 @@ describe('headless commerce cart', () => {
       const mockedUpdateItem = jest.mocked(updateItem);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
-      cart.updateItem(productWithQuantity(3));
+      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
       expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
@@ -194,7 +190,7 @@ describe('headless commerce cart', () => {
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(0));
+      cart.updateItem(productWithQuantity(0), productWithQuantity(0));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
       expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
@@ -204,7 +200,7 @@ describe('headless commerce cart', () => {
       const mockedUpdateItem = jest.mocked(updateItem);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
-      cart.updateItem(productWithQuantity(3));
+      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
@@ -215,7 +211,7 @@ describe('headless commerce cart', () => {
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(3));
+      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
@@ -226,7 +222,7 @@ describe('headless commerce cart', () => {
         .mocked(itemSelector)
         .mockReturnValue({...productWithQuantity(3), name: 'bap'});
 
-      cart.updateItem(productWithQuantity(3));
+      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
@@ -237,7 +233,7 @@ describe('headless commerce cart', () => {
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(3));
+      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
 
       expectCartAction('add', 3);
     });
@@ -245,7 +241,7 @@ describe('headless commerce cart', () => {
     it('emits #ec.cartAction with "add" action and correct payload if item exists in cart and new quantity > current', () => {
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
-      cart.updateItem(productWithQuantity(5));
+      cart.updateItem(productWithQuantity(5), productWithQuantity(5));
 
       expectCartAction('add', 4);
     });
@@ -253,7 +249,7 @@ describe('headless commerce cart', () => {
     it('emits #ec.cartAction with "remove" action and correct payload if item exists in cart and new quantity < current', () => {
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
-      cart.updateItem(productWithQuantity(1));
+      cart.updateItem(productWithQuantity(1), productWithQuantity(1));
 
       expectCartAction('remove', 2);
     });

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -1,7 +1,7 @@
 import {
   purchase,
   setItems,
-  updateItem,
+  updateItemQuantity,
 } from '../../../../features/commerce/context/cart/cart-actions';
 import {itemsSelector} from '../../../../features/commerce/context/cart/cart-selector';
 import {cartReducer} from '../../../../features/commerce/context/cart/cart-slice';
@@ -92,15 +92,15 @@ describe('headless commerce cart', () => {
     });
   });
 
-  it('#empty calls #updateItem with quantity of 0 for each item in the cart', () => {
-    const updateItemSpy = jest.spyOn(cart, 'updateItem');
+  it('#empty calls #updateItemQuantity with quantity of 0 for each item in the cart', () => {
+    const updateItemQuantitySpy = jest.spyOn(cart, 'updateItemQuantity');
     jest.mocked(itemsSelector).mockReturnValue(initialState.items!);
 
     cart.empty();
 
     const item = initialState.items![0];
 
-    expect(updateItemSpy).toHaveBeenCalledWith(item, {
+    expect(updateItemQuantitySpy).toHaveBeenCalledWith({
       ...item,
       quantity: 0,
     });
@@ -129,7 +129,7 @@ describe('headless commerce cart', () => {
     });
   });
 
-  describe('#updateItem', () => {
+  describe('#updateItemQuantity', () => {
     const productWithoutQuantity = {
       productId: 'product-id',
       name: 'product-name-1',
@@ -175,54 +175,54 @@ describe('headless commerce cart', () => {
     };
 
     it('will not dispatch an action or emit an event if the item = cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItem);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
-      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
+      cart.updateItemQuantity(productWithQuantity(3));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
       expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
     });
 
     it('will not dispatch an action or emit an event if item does not exist in cart and item.quantity <= 0', () => {
-      const mockedUpdateItem = jest.mocked(updateItem);
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(0), productWithQuantity(0));
+      cart.updateItemQuantity(productWithQuantity(0));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
       expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
     });
 
-    it('dispatches #updateItem when the item != cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItem);
+    it('dispatches #updateItemQuantity when the item != cartItem', () => {
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
-      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
+      cart.updateItemQuantity(productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
 
-    it('dispatches #updateItem when the item does not exist in the cart state and item.quantity > 0', () => {
-      const mockedUpdateItem = jest.mocked(updateItem);
+    it('dispatches #updateItemQuantity when the item does not exist in the cart state and item.quantity > 0', () => {
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
+      cart.updateItemQuantity(productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
     });
 
-    it('dispatches #updateItem but does not emit #ec.cartAction when the item.quantity = cartItem.quantity but item != cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItem);
+    it('dispatches #updateItemQuantity but does not emit #ec.cartAction when the item.quantity = cartItem.quantity but item != cartItem', () => {
+      const mockedUpdateItem = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue({...productWithQuantity(3), name: 'bap'});
 
-      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
+      cart.updateItemQuantity(productWithQuantity(3));
 
       expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
@@ -233,7 +233,7 @@ describe('headless commerce cart', () => {
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
-      cart.updateItem(productWithQuantity(3), productWithQuantity(3));
+      cart.updateItemQuantity(productWithQuantity(3));
 
       expectCartAction('add', 3);
     });
@@ -241,7 +241,7 @@ describe('headless commerce cart', () => {
     it('emits #ec.cartAction with "add" action and correct payload if item exists in cart and new quantity > current', () => {
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
-      cart.updateItem(productWithQuantity(5), productWithQuantity(5));
+      cart.updateItemQuantity(productWithQuantity(5));
 
       expectCartAction('add', 4);
     });
@@ -249,7 +249,7 @@ describe('headless commerce cart', () => {
     it('emits #ec.cartAction with "remove" action and correct payload if item exists in cart and new quantity < current', () => {
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
-      cart.updateItem(productWithQuantity(1), productWithQuantity(1));
+      cart.updateItemQuantity(productWithQuantity(1));
 
       expectCartAction('remove', 2);
     });

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.test.ts
@@ -175,17 +175,17 @@ describe('headless commerce cart', () => {
     };
 
     it('will not dispatch an action or emit an event if the item = cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItemQuantity);
+      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(3));
 
       cart.updateItemQuantity(productWithQuantity(3));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
-      expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
+      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(0);
     });
 
     it('will not dispatch an action or emit an event if item does not exist in cart and item.quantity <= 0', () => {
-      const mockedUpdateItem = jest.mocked(updateItemQuantity);
+      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
@@ -193,38 +193,38 @@ describe('headless commerce cart', () => {
       cart.updateItemQuantity(productWithQuantity(0));
 
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
-      expect(mockedUpdateItem).toHaveBeenCalledTimes(0);
+      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(0);
     });
 
     it('dispatches #updateItemQuantity when the item != cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItemQuantity);
+      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
       jest.mocked(itemSelector).mockReturnValue(productWithQuantity(1));
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
+      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches #updateItemQuantity when the item does not exist in the cart state and item.quantity > 0', () => {
-      const mockedUpdateItem = jest.mocked(updateItemQuantity);
+      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue(undefined as unknown as CartItemWithMetadata);
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
+      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches #updateItemQuantity but does not emit #ec.cartAction when the item.quantity = cartItem.quantity but item != cartItem', () => {
-      const mockedUpdateItem = jest.mocked(updateItemQuantity);
+      const mockedupdateItemQuantity = jest.mocked(updateItemQuantity);
       jest
         .mocked(itemSelector)
         .mockReturnValue({...productWithQuantity(3), name: 'bap'});
 
       cart.updateItemQuantity(productWithQuantity(3));
 
-      expect(mockedUpdateItem).toHaveBeenCalledTimes(1);
+      expect(mockedupdateItemQuantity).toHaveBeenCalledTimes(1);
       expect(engine.relay.emit).toHaveBeenCalledTimes(0);
     });
 

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -4,7 +4,7 @@ import {stateKey} from '../../../../app/state-key';
 import {
   purchase,
   setItems,
-  updateItem,
+  updateItemQuantity,
 } from '../../../../features/commerce/context/cart/cart-actions';
 import {
   Transaction,
@@ -84,7 +84,7 @@ export interface Cart extends Controller {
    *
    * @param item - The cart item to create, update, or delete.
    */
-  updateItem(item: CartItem, update: CartItem): void;
+  updateItemQuantity(item: CartItem): void;
 
   /**
    * Sets the quantity of each item in the cart to 0, effectively emptying the cart.
@@ -208,7 +208,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
 
     empty: function () {
       for (const item of itemsSelector(getState())) {
-        this.updateItem(item, {...item, quantity: 0});
+        this.updateItemQuantity({...item, quantity: 0});
       }
     },
 
@@ -216,7 +216,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
       dispatch(purchase(transaction));
     },
 
-    updateItem(item: CartItem, update: CartItem) {
+    updateItemQuantity(item: CartItem) {
       const prevItem = itemSelector(getState(), item);
       const doesNotNeedUpdate = !prevItem && item.quantity <= 0;
 
@@ -231,12 +231,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
         );
       }
 
-      dispatch(
-        updateItem({
-          item,
-          update,
-        })
-      );
+      dispatch(updateItemQuantity(item));
     },
 
     get state() {

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -249,7 +249,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
 export type CartKey = string;
 
 export function createCartKey(item: CartItem): CartKey {
-  return `${item.productId},${item.name}`;
+  return `${item.productId},${item.name},${item.price}`;
 }
 
 function loadBaseCartReducers(

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -249,7 +249,7 @@ export function buildCart(engine: CommerceEngine, props: CartProps = {}): Cart {
 export type CartKey = string;
 
 export function createCartKey(item: CartItem): CartKey {
-  return `${item.productId},${item.name},${item.price}`;
+  return `${item.productId},${item.name}`;
 }
 
 function loadBaseCartReducers(

--- a/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
+++ b/packages/headless/src/controllers/commerce/context/cart/headless-cart.ts
@@ -70,17 +70,19 @@ export interface Cart extends Controller {
    * Creates, updates, or deletes an item in the cart, and emits an `ec.cartAction` analytics event if the `quantity` of
    * the item in the cart changes.
    *
-   * If an item with the specified `productId` already exists in the cart:
-   * - Setting `quantity` to `0` deletes the item from the cart; `name` and `price` have no effect.
-   * - Setting `quantity` to a positive number updates the item's `name`, `price`, and `quantity` to the
-   * specified values.
+   * If an item with the specified `productId`, `name` and `price` already exists in the cart:
+   * - Setting `quantity` to `0` deletes the item from the cart.
+   * - Setting `quantity` to a positive number updates the item.
    *
    * Otherwise:
-   * - Setting `quantity` to a positive number creates the item in the cart with the specified `productName`,
-   * `pricePerUnit`, and `quantity`.
+   * - Setting `quantity` to a positive number creates the item in the cart with the specified `name`,
+   * `price`, and `quantity`.
    *
    * If the specified `quantity` is equivalent to the current quantity of the item in the cart, no analytics event is
    * emitted. Otherwise, the method emits an `ec.cartAction` event with the appropriate action (`add` or `remove`).
+   *
+   * Note: Updating the `name` or `price` will create a new item in the cart, leaving the previous item with the same
+   * `productId`, `name` and `price` unchanged. If you wish to change these items, delete and recreate the item.
    *
    * @param item - The cart item to create, update, or delete.
    */

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -26,7 +26,6 @@ describe('commerce common actions', () => {
         name: 'product_name',
         quantity: 1,
         price: 1,
-        sku: 'product_sku',
       };
 
       expected = {
@@ -72,7 +71,9 @@ describe('commerce common actions', () => {
       state.cart.cartItems = [product.productId];
       state.cart.cart = {
         [product.productId]: {
-          ...product,
+          [product.price]: {
+            ...product,
+          },
         },
       };
     });

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -51,7 +51,7 @@ describe('commerce common actions', () => {
           },
           cart: [
             {
-              sku: product.sku,
+              productId: product.productId,
               quantity: product.quantity,
             },
           ],

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -26,6 +26,7 @@ describe('commerce common actions', () => {
         name: 'product_name',
         quantity: 1,
         price: 1,
+        sku: 'product_sku',
       };
 
       expected = {
@@ -71,9 +72,7 @@ describe('commerce common actions', () => {
       state.cart.cartItems = [product.productId];
       state.cart.cart = {
         [product.productId]: {
-          [product.price]: {
-            ...product,
-          },
+          ...product,
         },
       };
     });

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -58,10 +58,10 @@ export const buildBaseCommerceAPIRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((id) => {
-        const {sku, quantity} = state.cart.cart[id];
+      cart: state.cart.cartItems.map((key) => {
+        const {productId, quantity} = state.cart.cart[key];
         return {
-          sku,
+          productId,
           quantity,
         };
       }),

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -58,13 +58,15 @@ export const buildBaseCommerceAPIRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((key) => {
-        const {productId, quantity} = state.cart.cart[key];
-        return {
-          productId,
-          quantity,
-        };
-      }),
+      cart: state.cart.cartItems.map((key) =>
+        Object.entries(state.cart.cart[key]).reduce(
+          (acc, [_, item]) => ({
+            productId: item.productId,
+            quantity: acc.quantity + item.quantity,
+          }),
+          {productId: '', quantity: 0}
+        )
+      ),
     },
     ...effectivePagination(state, slotId),
   };

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -15,6 +15,7 @@ import {
   FacetOrderSection,
   VersionSection,
 } from '../../../state/state-sections';
+import {getProductsFromCartState} from '../context/cart/cart-state';
 import {SortBy, SortCriterion} from '../sort/sort';
 
 export type StateNeededByQueryCommerceAPI = ConfigurationSection &
@@ -58,13 +59,7 @@ export const buildBaseCommerceAPIRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((key) => {
-        const {productId, quantity} = state.cart.cart[key];
-        return {
-          productId,
-          quantity,
-        };
-      }),
+      cart: getProductsFromCartState(state.cart),
     },
     ...effectivePagination(state, slotId),
   };

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -58,15 +58,13 @@ export const buildBaseCommerceAPIRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((key) =>
-        Object.entries(state.cart.cart[key]).reduce(
-          (acc, [_, item]) => ({
-            productId: item.productId,
-            quantity: acc.quantity + item.quantity,
-          }),
-          {productId: '', quantity: 0}
-        )
-      ),
+      cart: state.cart.cartItems.map((key) => {
+        const {productId, quantity} = state.cart.cart[key];
+        return {
+          productId,
+          quantity,
+        };
+      }),
     },
     ...effectivePagination(state, slotId),
   };

--- a/packages/headless/src/features/commerce/context/cart/cart-actions.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-actions.ts
@@ -1,6 +1,5 @@
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {AsyncThunkCommerceOptions} from '../../../../api/commerce/commerce-api-client';
-import {CartItemParam} from '../../../../api/commerce/commerce-api-params';
 import {CommerceEngineState} from '../../../../app/commerce-engine/commerce-engine';
 import {validatePayload} from '../../../../utils/validate-payload';
 import {Transaction, getECPurchasePayload} from './cart-selector';
@@ -9,6 +8,11 @@ import {
   setItemsPayloadDefinition,
   updateItemPayloadDefinition,
 } from './cart-validation';
+
+export interface updateItemPayload {
+  item: CartItemWithMetadata;
+  update: CartItemWithMetadata;
+}
 
 export const purchase = createAsyncThunk<
   void,
@@ -27,11 +31,11 @@ export const purchase = createAsyncThunk<
 export const setItems = createAction(
   'commerce/cart/setItems',
   (payload: CartItemWithMetadata[]) =>
-    validatePayload<CartItemParam[]>(payload, setItemsPayloadDefinition)
+    validatePayload<CartItemWithMetadata[]>(payload, setItemsPayloadDefinition)
 );
 
 export const updateItem = createAction(
   'commerce/cart/updateItem',
-  (payload: CartItemWithMetadata) =>
+  (payload: updateItemPayload) =>
     validatePayload(payload, updateItemPayloadDefinition)
 );

--- a/packages/headless/src/features/commerce/context/cart/cart-actions.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-actions.ts
@@ -6,13 +6,8 @@ import {Transaction, getECPurchasePayload} from './cart-selector';
 import {CartItemWithMetadata} from './cart-state';
 import {
   setItemsPayloadDefinition,
-  updateItemPayloadDefinition,
+  itemPayloadDefinition,
 } from './cart-validation';
-
-export interface updateItemPayload {
-  item: CartItemWithMetadata;
-  update: CartItemWithMetadata;
-}
 
 export const purchase = createAsyncThunk<
   void,
@@ -34,8 +29,8 @@ export const setItems = createAction(
     validatePayload<CartItemWithMetadata[]>(payload, setItemsPayloadDefinition)
 );
 
-export const updateItem = createAction(
-  'commerce/cart/updateItem',
-  (payload: updateItemPayload) =>
-    validatePayload(payload, updateItemPayloadDefinition)
+export const updateItemQuantity = createAction(
+  'commerce/cart/updateItemQuantity',
+  (payload: CartItemWithMetadata) =>
+    validatePayload(payload, itemPayloadDefinition)
 );

--- a/packages/headless/src/features/commerce/context/cart/cart-selector.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-selector.ts
@@ -4,6 +4,7 @@ import {CommerceEngineState} from '../../../../app/commerce-engine/commerce-engi
 import {CartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {getCurrency} from '../context-selector';
 import {CartState} from './cart-state';
+import {CartItemWithMetadata} from './cart-state';
 
 /**
  * The purchase transaction.
@@ -32,7 +33,13 @@ export const getECPurchasePayload = (
 export const itemsSelector = createSelector(
   (cartState: CartState) => cartState.cart,
   (cartState: CartState) => cartState.cartItems,
-  (cart, cartItems) => cartItems.map((key: CartKey) => cart[key])
+  (cart, cartItems) =>
+    cartItems.flatMap((key: CartKey) => {
+      return Object.entries(cart[key]).reduce((acc, [_, item]) => {
+        acc.push(item);
+        return acc;
+      }, [] as CartItemWithMetadata[]);
+    })
 );
 
 const productQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/features/commerce/context/cart/cart-selector.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-selector.ts
@@ -1,6 +1,7 @@
 import {Ec} from '@coveo/relay-event-types';
 import {createSelector} from '@reduxjs/toolkit';
 import {CommerceEngineState} from '../../../../app/commerce-engine/commerce-engine';
+import {CartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {getCurrency} from '../context-selector';
 import {CartState} from './cart-state';
 
@@ -31,11 +32,11 @@ export const getECPurchasePayload = (
 export const itemsSelector = createSelector(
   (cartState: CartState) => cartState.cart,
   (cartState: CartState) => cartState.cartItems,
-  (cart, cartItems) => cartItems.map((id: string) => cart[id])
+  (cart, cartItems) => cartItems.map((key: CartKey) => cart[key])
 );
 
 const productQuantitySelector = createSelector(itemsSelector, (items) =>
-  items.map(({quantity, sku, ...product}) => ({
+  items.map(({quantity, ...product}) => ({
     quantity,
     product,
   }))

--- a/packages/headless/src/features/commerce/context/cart/cart-selector.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-selector.ts
@@ -4,7 +4,6 @@ import {CommerceEngineState} from '../../../../app/commerce-engine/commerce-engi
 import {CartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {getCurrency} from '../context-selector';
 import {CartState} from './cart-state';
-import {CartItemWithMetadata} from './cart-state';
 
 /**
  * The purchase transaction.
@@ -33,13 +32,7 @@ export const getECPurchasePayload = (
 export const itemsSelector = createSelector(
   (cartState: CartState) => cartState.cart,
   (cartState: CartState) => cartState.cartItems,
-  (cart, cartItems) =>
-    cartItems.flatMap((key: CartKey) => {
-      return Object.entries(cart[key]).reduce((acc, [_, item]) => {
-        acc.push(item);
-        return acc;
-      }, [] as CartItemWithMetadata[]);
-    })
+  (cart, cartItems) => cartItems.map((key: CartKey) => cart[key])
 );
 
 const productQuantitySelector = createSelector(itemsSelector, (items) =>

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {createCartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {purchase, setItems, updateItem} from './cart-actions';
 import {cartReducer} from './cart-slice';
 import {
@@ -10,11 +11,11 @@ import {
 describe('cart-slice', () => {
   const someItem: CartItemWithMetadata = {
     productId: 'product-id',
-    sku: 'product-id-1',
     quantity: 10,
     name: 'product 1',
     price: 50,
   };
+  const someItemKey = createCartKey(someItem);
   let state: CartState;
   beforeEach(() => {
     state = getCartInitialState();
@@ -29,31 +30,31 @@ describe('cart-slice', () => {
   it('#setItems replaces current cart state with specified state', () => {
     const secondItem: CartItemWithMetadata = {
       productId: 'product-id',
-      sku: 'product-id-2',
       quantity: 20,
       name: 'product 2',
       price: 100,
     };
     const updatedState = cartReducer(state, setItems([someItem, secondItem]));
-    expect(updatedState.cartItems).toEqual([someItem.sku, secondItem.sku]);
-    expect(updatedState.cart).toEqual({
-      [someItem.sku]: someItem,
-      [secondItem.sku]: secondItem,
-    });
+    const updatedStatefirstItemKey = updatedState.cartItems[0];
+    const updatedStatefirstItem = updatedState.cart[updatedStatefirstItemKey];
+    expect(updatedStatefirstItem).toEqual(someItem);
+
+    const updatedStateSecondItemKey = updatedState.cartItems[1];
+    const updatedStateSecondItem = updatedState.cart[updatedStateSecondItemKey];
+    expect(updatedStateSecondItem).toEqual(secondItem);
   });
 
   it('#purchase.fulfilled replaces current cart state with empty state', async () => {
     const secondItem: CartItemWithMetadata = {
       productId: 'product-id',
-      sku: 'product-id-2',
       quantity: 20,
       name: 'product 2',
       price: 100,
     };
-    state.cartItems = [someItem.sku, secondItem.sku];
+    state.cartItems = [createCartKey(someItem), createCartKey(secondItem)];
     state.cart = {
-      [someItem.sku]: someItem,
-      [secondItem.sku]: secondItem,
+      [createCartKey(someItem)]: someItem,
+      [createCartKey(secondItem)]: secondItem,
     };
     const fakePurchaseAction = createAction(purchase.fulfilled.type);
     const updatedState = cartReducer(state, fakePurchaseAction());
@@ -63,17 +64,21 @@ describe('cart-slice', () => {
 
   describe('#updateItem', () => {
     it('adds new item to cart if item is not already in cart and specified quantity is positive', () => {
-      const updatedState = cartReducer(state, updateItem(someItem));
-      expect(updatedState.cartItems).toEqual([someItem.sku]);
+      const updatedState = cartReducer(
+        state,
+        updateItem({item: someItem, update: someItem})
+      );
+      const key = createCartKey(someItem);
+      expect(updatedState.cartItems).toEqual([key]);
       expect(updatedState.cart).toEqual({
-        [someItem.sku]: someItem,
+        [key]: someItem,
       });
     });
 
     it('does not add new item to cart if item is not already in cart and specified quantity is 0', () => {
       const updatedState = cartReducer(
         state,
-        updateItem({...someItem, quantity: 0})
+        updateItem({item: someItem, update: {...someItem, quantity: 0}})
       );
       expect(updatedState.cartItems).toEqual([]);
       expect(updatedState.cart).toEqual({});
@@ -82,37 +87,38 @@ describe('cart-slice', () => {
     it('removes existing item from cart if specified quantity is 0', () => {
       const updatedState = cartReducer(
         {
-          cartItems: [someItem.sku],
+          cartItems: [someItemKey],
           cart: {
-            [someItem.sku]: someItem,
+            [someItemKey]: someItem,
           },
         },
-        updateItem({...someItem, quantity: 0})
+        updateItem({item: someItem, update: {...someItem, quantity: 0}})
       );
       expect(updatedState.cartItems).toEqual([]);
       expect(updatedState.cart).toEqual({});
     });
 
     it('updates existing item in cart if specified quantity is greater than 0', () => {
+      const updatedItem = {
+        ...someItem,
+        name: 'renamed product',
+        quantity: 5,
+        price: 25,
+      };
       const updatedState = cartReducer(
         {
-          cartItems: [someItem.sku],
+          cartItems: [someItemKey],
           cart: {
-            [someItem.sku]: someItem,
+            [someItemKey]: someItem,
           },
         },
-        updateItem({
-          ...someItem,
-          name: 'renamed product',
-          quantity: 5,
-          price: 25,
-        })
+        updateItem({item: someItem, update: updatedItem})
       );
-      expect(updatedState.cartItems).toEqual([someItem.sku]);
+      const updatedItemKey = createCartKey(updatedItem);
+      expect(updatedState.cartItems).toEqual([updatedItemKey]);
       expect(updatedState.cart).toEqual({
-        [someItem.sku]: {
+        [updatedItemKey]: {
           productId: someItem.productId,
-          sku: someItem.sku,
           name: 'renamed product',
           quantity: 5,
           price: 25,

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
@@ -37,11 +37,15 @@ describe('cart-slice', () => {
     const updatedState = cartReducer(state, setItems([someItem, secondItem]));
     const updatedStatefirstItemKey = updatedState.cartItems[0];
     const updatedStatefirstItem = updatedState.cart[updatedStatefirstItemKey];
-    expect(updatedStatefirstItem).toEqual(someItem);
+    expect(updatedStatefirstItem).toEqual({
+      [someItem.price]: someItem,
+    });
 
     const updatedStateSecondItemKey = updatedState.cartItems[1];
     const updatedStateSecondItem = updatedState.cart[updatedStateSecondItemKey];
-    expect(updatedStateSecondItem).toEqual(secondItem);
+    expect(updatedStateSecondItem).toEqual({
+      [secondItem.price]: secondItem,
+    });
   });
 
   it('#purchase.fulfilled replaces current cart state with empty state', async () => {
@@ -53,8 +57,12 @@ describe('cart-slice', () => {
     };
     state.cartItems = [createCartKey(someItem), createCartKey(secondItem)];
     state.cart = {
-      [createCartKey(someItem)]: someItem,
-      [createCartKey(secondItem)]: secondItem,
+      [createCartKey(someItem)]: {
+        [someItem.price]: someItem,
+      },
+      [createCartKey(secondItem)]: {
+        [secondItem.price]: secondItem,
+      },
     };
     const fakePurchaseAction = createAction(purchase.fulfilled.type);
     const updatedState = cartReducer(state, fakePurchaseAction());
@@ -68,7 +76,9 @@ describe('cart-slice', () => {
       const key = createCartKey(someItem);
       expect(updatedState.cartItems).toEqual([key]);
       expect(updatedState.cart).toEqual({
-        [key]: someItem,
+        [key]: {
+          [someItem.price]: someItem,
+        },
       });
     });
 
@@ -86,7 +96,9 @@ describe('cart-slice', () => {
         {
           cartItems: [someItemKey],
           cart: {
-            [someItemKey]: someItem,
+            [someItemKey]: {
+              [someItem.price]: someItem,
+            },
           },
         },
         updateItemQuantity({...someItem, quantity: 0})
@@ -104,7 +116,9 @@ describe('cart-slice', () => {
         {
           cartItems: [someItemKey],
           cart: {
-            [someItemKey]: someItem,
+            [someItemKey]: {
+              [someItem.price]: someItem,
+            },
           },
         },
         updateItemQuantity(updatedItem)
@@ -113,10 +127,12 @@ describe('cart-slice', () => {
       expect(updatedState.cartItems).toEqual([updatedItemKey]);
       expect(updatedState.cart).toEqual({
         [updatedItemKey]: {
-          productId: someItem.productId,
-          name: someItem.name,
-          price: someItem.price,
-          quantity: 5,
+          [updatedItem.price]: {
+            productId: someItem.productId,
+            name: someItem.name,
+            price: someItem.price,
+            quantity: 5,
+          },
         },
       });
     });

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
@@ -37,15 +37,11 @@ describe('cart-slice', () => {
     const updatedState = cartReducer(state, setItems([someItem, secondItem]));
     const updatedStatefirstItemKey = updatedState.cartItems[0];
     const updatedStatefirstItem = updatedState.cart[updatedStatefirstItemKey];
-    expect(updatedStatefirstItem).toEqual({
-      [someItem.price]: someItem,
-    });
+    expect(updatedStatefirstItem).toEqual(someItem);
 
     const updatedStateSecondItemKey = updatedState.cartItems[1];
     const updatedStateSecondItem = updatedState.cart[updatedStateSecondItemKey];
-    expect(updatedStateSecondItem).toEqual({
-      [secondItem.price]: secondItem,
-    });
+    expect(updatedStateSecondItem).toEqual(secondItem);
   });
 
   it('#purchase.fulfilled replaces current cart state with empty state', async () => {
@@ -57,12 +53,8 @@ describe('cart-slice', () => {
     };
     state.cartItems = [createCartKey(someItem), createCartKey(secondItem)];
     state.cart = {
-      [createCartKey(someItem)]: {
-        [someItem.price]: someItem,
-      },
-      [createCartKey(secondItem)]: {
-        [secondItem.price]: secondItem,
-      },
+      [createCartKey(someItem)]: someItem,
+      [createCartKey(secondItem)]: secondItem,
     };
     const fakePurchaseAction = createAction(purchase.fulfilled.type);
     const updatedState = cartReducer(state, fakePurchaseAction());
@@ -76,9 +68,7 @@ describe('cart-slice', () => {
       const key = createCartKey(someItem);
       expect(updatedState.cartItems).toEqual([key]);
       expect(updatedState.cart).toEqual({
-        [key]: {
-          [someItem.price]: someItem,
-        },
+        [key]: someItem,
       });
     });
 
@@ -96,9 +86,7 @@ describe('cart-slice', () => {
         {
           cartItems: [someItemKey],
           cart: {
-            [someItemKey]: {
-              [someItem.price]: someItem,
-            },
+            [someItemKey]: someItem,
           },
         },
         updateItemQuantity({...someItem, quantity: 0})
@@ -116,9 +104,7 @@ describe('cart-slice', () => {
         {
           cartItems: [someItemKey],
           cart: {
-            [someItemKey]: {
-              [someItem.price]: someItem,
-            },
+            [someItemKey]: someItem,
           },
         },
         updateItemQuantity(updatedItem)
@@ -127,12 +113,10 @@ describe('cart-slice', () => {
       expect(updatedState.cartItems).toEqual([updatedItemKey]);
       expect(updatedState.cart).toEqual({
         [updatedItemKey]: {
-          [updatedItem.price]: {
-            productId: someItem.productId,
-            name: someItem.name,
-            price: someItem.price,
-            quantity: 5,
-          },
+          productId: someItem.productId,
+          name: someItem.name,
+          price: someItem.price,
+          quantity: 5,
         },
       });
     });

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.test.ts
@@ -1,6 +1,6 @@
 import {createAction} from '@reduxjs/toolkit';
 import {createCartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
-import {purchase, setItems, updateItem} from './cart-actions';
+import {purchase, setItems, updateItemQuantity} from './cart-actions';
 import {cartReducer} from './cart-slice';
 import {
   CartItemWithMetadata,
@@ -62,12 +62,9 @@ describe('cart-slice', () => {
     expect(updatedState.cart).toEqual({});
   });
 
-  describe('#updateItem', () => {
+  describe('#updateItemQuantity', () => {
     it('adds new item to cart if item is not already in cart and specified quantity is positive', () => {
-      const updatedState = cartReducer(
-        state,
-        updateItem({item: someItem, update: someItem})
-      );
+      const updatedState = cartReducer(state, updateItemQuantity(someItem));
       const key = createCartKey(someItem);
       expect(updatedState.cartItems).toEqual([key]);
       expect(updatedState.cart).toEqual({
@@ -78,7 +75,7 @@ describe('cart-slice', () => {
     it('does not add new item to cart if item is not already in cart and specified quantity is 0', () => {
       const updatedState = cartReducer(
         state,
-        updateItem({item: someItem, update: {...someItem, quantity: 0}})
+        updateItemQuantity({...someItem, quantity: 0})
       );
       expect(updatedState.cartItems).toEqual([]);
       expect(updatedState.cart).toEqual({});
@@ -92,7 +89,7 @@ describe('cart-slice', () => {
             [someItemKey]: someItem,
           },
         },
-        updateItem({item: someItem, update: {...someItem, quantity: 0}})
+        updateItemQuantity({...someItem, quantity: 0})
       );
       expect(updatedState.cartItems).toEqual([]);
       expect(updatedState.cart).toEqual({});
@@ -101,9 +98,7 @@ describe('cart-slice', () => {
     it('updates existing item in cart if specified quantity is greater than 0', () => {
       const updatedItem = {
         ...someItem,
-        name: 'renamed product',
         quantity: 5,
-        price: 25,
       };
       const updatedState = cartReducer(
         {
@@ -112,16 +107,16 @@ describe('cart-slice', () => {
             [someItemKey]: someItem,
           },
         },
-        updateItem({item: someItem, update: updatedItem})
+        updateItemQuantity(updatedItem)
       );
       const updatedItemKey = createCartKey(updatedItem);
       expect(updatedState.cartItems).toEqual([updatedItemKey]);
       expect(updatedState.cart).toEqual({
         [updatedItemKey]: {
           productId: someItem.productId,
-          name: 'renamed product',
+          name: someItem.name,
+          price: someItem.price,
           quantity: 5,
-          price: 25,
         },
       });
     });

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.ts
@@ -1,6 +1,6 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {createCartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
-import {purchase, setItems, updateItem} from './cart-actions';
+import {purchase, setItems, updateItemQuantity} from './cart-actions';
 import {
   CartItemWithMetadata,
   CartState,
@@ -26,20 +26,20 @@ export const cartReducer = createReducer(
 
         setItemsInState(state, cartItems, cart);
       })
-      .addCase(updateItem, (state, {payload}) => {
-        const updateKey = createCartKey(payload.update);
-        if (!(updateKey in state.cart)) {
-          deleteProductFromCart(payload.item, state);
-          createItemInCart(payload.update, state);
+      .addCase(updateItemQuantity, (state, {payload}) => {
+        const key = createCartKey(payload);
+        if (!(key in state.cart)) {
+          // deleteProductFromCart(payload.item, state);
+          createItemInCart(payload, state);
           return;
         }
 
-        if (payload.update.quantity <= 0) {
-          deleteProductFromCart(payload.item, state);
+        if (payload.quantity <= 0) {
+          deleteProductFromCart(payload, state);
           return;
         }
 
-        state.cart[updateKey] = payload.update;
+        state.cart[key] = payload;
         return;
       })
       .addCase(purchase.fulfilled, (state) => {

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.ts
@@ -29,7 +29,6 @@ export const cartReducer = createReducer(
       .addCase(updateItemQuantity, (state, {payload}) => {
         const key = createCartKey(payload);
         if (!(key in state.cart)) {
-          // deleteProductFromCart(payload.item, state);
           createItemInCart(payload, state);
           return;
         }

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.ts
@@ -2,7 +2,6 @@ import {createReducer} from '@reduxjs/toolkit';
 import {createCartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {purchase, setItems, updateItemQuantity} from './cart-actions';
 import {
-  Cart,
   CartItemWithMetadata,
   CartState,
   getCartInitialState,
@@ -16,17 +15,11 @@ export const cartReducer = createReducer(
       .addCase(setItems, (state, {payload}) => {
         const {cart, cartItems} = payload.reduce((acc, item) => {
           const key = createCartKey(item);
-          const cartItems = [...acc.cartItems, key];
           return {
-            cartItems,
+            cartItems: [...acc.cartItems, key],
             cart: {
               ...acc.cart,
-              [key]: acc.cart[key]
-                ? {
-                    ...acc.cart[key],
-                    [item.price]: item,
-                  }
-                : {[item.price]: item},
+              [key]: item,
             },
           };
         }, getCartInitialState());
@@ -34,18 +27,19 @@ export const cartReducer = createReducer(
         setItemsInState(state, cartItems, cart);
       })
       .addCase(updateItemQuantity, (state, {payload}) => {
-        if (payload.quantity <= 0) {
-          deleteItemFromCart(payload, state);
-          return;
-        }
-
         const key = createCartKey(payload);
         if (!(key in state.cart)) {
-          createProductInCart(payload, state);
+          // deleteProductFromCart(payload.item, state);
+          createItemInCart(payload, state);
           return;
         }
 
-        state.cart[key][payload.price] = payload;
+        if (payload.quantity <= 0) {
+          deleteProductFromCart(payload, state);
+          return;
+        }
+
+        state.cart[key] = payload;
         return;
       })
       .addCase(purchase.fulfilled, (state) => {
@@ -55,28 +49,27 @@ export const cartReducer = createReducer(
   }
 );
 
-function setItemsInState(state: CartState, cartItems: string[], cart: Cart) {
+function setItemsInState(
+  state: CartState,
+  cartItems: string[],
+  cart: Record<string, CartItemWithMetadata>
+) {
   state.cartItems = cartItems;
   state.cart = cart;
 }
 
-function createProductInCart(item: CartItemWithMetadata, state: CartState) {
+function createItemInCart(item: CartItemWithMetadata, state: CartState) {
   if (item.quantity <= 0) {
     return;
   }
 
   const key = createCartKey(item);
   state.cartItems = [...state.cartItems, key];
-  state.cart[key] = {[item.price]: item};
+  state.cart[key] = item;
 }
 
-function deleteItemFromCart(item: CartItemWithMetadata, state: CartState) {
+function deleteProductFromCart(item: CartItemWithMetadata, state: CartState) {
   const key = createCartKey(item);
   state.cartItems = state.cartItems.filter((cartKey) => cartKey !== key);
-  if (key in state.cart) {
-    delete state.cart[key][item.price];
-    if (!Object.keys(state.cart[key]).length) {
-      delete state.cart[key];
-    }
-  }
+  delete state.cart[key];
 }

--- a/packages/headless/src/features/commerce/context/cart/cart-slice.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-slice.ts
@@ -2,6 +2,7 @@ import {createReducer} from '@reduxjs/toolkit';
 import {createCartKey} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {purchase, setItems, updateItemQuantity} from './cart-actions';
 import {
+  Cart,
   CartItemWithMetadata,
   CartState,
   getCartInitialState,
@@ -15,11 +16,17 @@ export const cartReducer = createReducer(
       .addCase(setItems, (state, {payload}) => {
         const {cart, cartItems} = payload.reduce((acc, item) => {
           const key = createCartKey(item);
+          const cartItems = [...acc.cartItems, key];
           return {
-            cartItems: [...acc.cartItems, key],
+            cartItems,
             cart: {
               ...acc.cart,
-              [key]: item,
+              [key]: acc.cart[key]
+                ? {
+                    ...acc.cart[key],
+                    [item.price]: item,
+                  }
+                : {[item.price]: item},
             },
           };
         }, getCartInitialState());
@@ -27,19 +34,18 @@ export const cartReducer = createReducer(
         setItemsInState(state, cartItems, cart);
       })
       .addCase(updateItemQuantity, (state, {payload}) => {
+        if (payload.quantity <= 0) {
+          deleteItemFromCart(payload, state);
+          return;
+        }
+
         const key = createCartKey(payload);
         if (!(key in state.cart)) {
-          // deleteProductFromCart(payload.item, state);
-          createItemInCart(payload, state);
+          createProductInCart(payload, state);
           return;
         }
 
-        if (payload.quantity <= 0) {
-          deleteProductFromCart(payload, state);
-          return;
-        }
-
-        state.cart[key] = payload;
+        state.cart[key][payload.price] = payload;
         return;
       })
       .addCase(purchase.fulfilled, (state) => {
@@ -49,27 +55,28 @@ export const cartReducer = createReducer(
   }
 );
 
-function setItemsInState(
-  state: CartState,
-  cartItems: string[],
-  cart: Record<string, CartItemWithMetadata>
-) {
+function setItemsInState(state: CartState, cartItems: string[], cart: Cart) {
   state.cartItems = cartItems;
   state.cart = cart;
 }
 
-function createItemInCart(item: CartItemWithMetadata, state: CartState) {
+function createProductInCart(item: CartItemWithMetadata, state: CartState) {
   if (item.quantity <= 0) {
     return;
   }
 
   const key = createCartKey(item);
   state.cartItems = [...state.cartItems, key];
-  state.cart[key] = item;
+  state.cart[key] = {[item.price]: item};
 }
 
-function deleteProductFromCart(item: CartItemWithMetadata, state: CartState) {
+function deleteItemFromCart(item: CartItemWithMetadata, state: CartState) {
   const key = createCartKey(item);
   state.cartItems = state.cartItems.filter((cartKey) => cartKey !== key);
-  delete state.cart[key];
+  if (key in state.cart) {
+    delete state.cart[key][item.price];
+    if (!Object.keys(state.cart[key]).length) {
+      delete state.cart[key];
+    }
+  }
 }

--- a/packages/headless/src/features/commerce/context/cart/cart-state.test.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.test.ts
@@ -1,0 +1,54 @@
+import {getProductsFromCartState} from './cart-state';
+
+describe('cart-state', () => {
+  it('should aggregate products with a different price', () => {
+    const state = {
+      cartItems: ['5', '1', '3', '2', '4'],
+      cart: {
+        '1': {
+          productId: 'product-id-1',
+          quantity: 1,
+          name: 'product-name-1',
+          price: 100,
+        },
+        '2': {
+          productId: 'product-id-2',
+          quantity: 2,
+          name: 'product-name-2',
+          price: 25,
+        },
+        '3': {
+          productId: 'product-id-1',
+          quantity: 3,
+          name: 'product-name-3',
+          price: 50,
+        },
+        '4': {
+          productId: 'product-id-2',
+          quantity: 2,
+          name: 'product-name-4',
+          price: 75,
+        },
+        '5': {
+          productId: 'product-id-1',
+          quantity: 3,
+          name: 'product-name-5',
+          price: 50,
+        },
+      },
+    };
+
+    const products = getProductsFromCartState(state);
+
+    expect(products).toEqual([
+      {
+        productId: 'product-id-1',
+        quantity: 7,
+      },
+      {
+        productId: 'product-id-2',
+        quantity: 4,
+      },
+    ]);
+  });
+});

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -28,7 +28,7 @@ export function getProductsFromCartState(state: CartState): CartItemParam[] {
       if (!(productId in acc)) {
         acc[productId] = {
           productId,
-          0
+          quantity: 0,
         };
       }
       acc[productId].quantity += quantity;

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -11,12 +11,9 @@ export interface CartItemWithMetadata extends CartItemParam {
   price: number;
 }
 
-export interface Cart
-  extends Record<string, Record<number, CartItemWithMetadata>> {}
-
 export interface CartState {
   cartItems: string[];
-  cart: Cart;
+  cart: Record<string, CartItemWithMetadata>;
 }
 
 export const getCartInitialState = (): CartState => ({

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -28,11 +28,10 @@ export function getProductsFromCartState(state: CartState): CartItemParam[] {
       if (!(productId in acc)) {
         acc[productId] = {
           productId,
-          quantity,
+          0
         };
-      } else {
-        acc[productId].quantity += quantity;
       }
+      acc[productId].quantity += quantity;
 
       return acc;
     },

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -11,9 +11,12 @@ export interface CartItemWithMetadata extends CartItemParam {
   price: number;
 }
 
+export interface Cart
+  extends Record<string, Record<number, CartItemWithMetadata>> {}
+
 export interface CartState {
   cartItems: string[];
-  cart: Record<string, CartItemWithMetadata>;
+  cart: Cart;
 }
 
 export const getCartInitialState = (): CartState => ({

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -2,10 +2,6 @@ import {CartItemParam} from '../../../../api/commerce/commerce-api-params';
 
 export interface CartItemWithMetadata extends CartItemParam {
   /**
-   * The unique identifier of the product.
-   */
-  productId: string;
-  /**
    * The name of the cart item.
    */
   name: string;

--- a/packages/headless/src/features/commerce/context/cart/cart-state.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-state.ts
@@ -20,3 +20,24 @@ export const getCartInitialState = (): CartState => ({
   cartItems: [],
   cart: {},
 });
+
+export function getProductsFromCartState(state: CartState): CartItemParam[] {
+  const itemMap = state.cartItems.reduce(
+    (acc, key) => {
+      const {productId, quantity} = state.cart[key];
+      if (!(productId in acc)) {
+        acc[productId] = {
+          productId,
+          quantity,
+        };
+      } else {
+        acc[productId].quantity += quantity;
+      }
+
+      return acc;
+    },
+    {} as Record<string, CartItemParam>
+  );
+
+  return [...Object.values(itemMap)];
+}

--- a/packages/headless/src/features/commerce/context/cart/cart-validation.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-validation.ts
@@ -8,9 +8,8 @@ import {
 import {CartInitialState} from '../../../../controllers/commerce/context/cart/headless-cart';
 import {requiredNonEmptyString} from '../../../../utils/validate-payload';
 
-export const updateItemPayloadDefinition = {
+export const itemPayloadDefinition = {
   productId: requiredNonEmptyString,
-  sku: requiredNonEmptyString,
   quantity: new NumberValue({
     required: true,
     min: 0,
@@ -19,10 +18,15 @@ export const updateItemPayloadDefinition = {
   price: new NumberValue({required: false, min: 0}),
 };
 
+export const updateItemPayloadDefinition = {
+  item: new RecordValue({values: itemPayloadDefinition}),
+  update: new RecordValue({values: itemPayloadDefinition}),
+};
+
 export const setItemsPayloadDefinition = new ArrayValue({
   each: new RecordValue({
     values: {
-      ...updateItemPayloadDefinition,
+      ...itemPayloadDefinition,
     },
   }),
 });

--- a/packages/headless/src/features/commerce/context/cart/cart-validation.ts
+++ b/packages/headless/src/features/commerce/context/cart/cart-validation.ts
@@ -18,11 +18,6 @@ export const itemPayloadDefinition = {
   price: new NumberValue({required: false, min: 0}),
 };
 
-export const updateItemPayloadDefinition = {
-  item: new RecordValue({values: itemPayloadDefinition}),
-  update: new RecordValue({values: itemPayloadDefinition}),
-};
-
 export const setItemsPayloadDefinition = new ArrayValue({
   each: new RecordValue({
     values: {

--- a/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
@@ -78,15 +78,7 @@ export const buildQuerySuggestRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((key) =>
-        Object.entries(state.cart.cart[key]).reduce(
-          (acc, [_, item]) => ({
-            productId: item.productId,
-            quantity: acc.quantity + item.quantity,
-          }),
-          {productId: '', quantity: 0}
-        )
-      ),
+      cart: state.cart.cartItems.map((id) => state.cart.cart[id]),
     },
   };
 };

--- a/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
@@ -18,6 +18,7 @@ import {
   FetchQuerySuggestionsActionCreatorPayload,
   idDefinition,
 } from '../../query-suggest/query-suggest-actions';
+import {getProductsFromCartState} from '../context/cart/cart-state';
 
 export type StateNeededByQuerySuggest = ConfigurationSection &
   CommerceContextSection &
@@ -78,7 +79,7 @@ export const buildQuerySuggestRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((id) => state.cart.cart[id]),
+      cart: getProductsFromCartState(state.cart),
     },
   };
 };

--- a/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
+++ b/packages/headless/src/features/commerce/query-suggest/query-suggest-actions.ts
@@ -78,7 +78,15 @@ export const buildQuerySuggestRequest = async (
     context: {
       user,
       view,
-      cart: state.cart.cartItems.map((id) => state.cart.cart[id]),
+      cart: state.cart.cartItems.map((key) =>
+        Object.entries(state.cart.cart[key]).reduce(
+          (acc, [_, item]) => ({
+            productId: item.productId,
+            quantity: acc.quantity + item.quantity,
+          }),
+          {productId: '', quantity: 0}
+        )
+      ),
     },
   };
 };

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -45,20 +45,20 @@ describe.skip('commerce', () => {
     });
 
     const cart = buildCart(engine);
-    cart.updateItem({
+    const item1 = {
       productId: 'p1',
-      sku: 'p1_1',
       quantity: 2,
       price: 100,
       name: 'Nice Shoes',
-    });
-    cart.updateItem({
+    };
+    const item2 = {
       productId: 'p1',
-      sku: 'p1_2',
       quantity: 3,
       price: 200,
       name: 'Nicer Shoes',
-    });
+    };
+    cart.updateItem(item1, item1);
+    cart.updateItem(item2, item2);
   });
 
   const fetchProductListing = async (): Promise<ProductListing> => {

--- a/packages/headless/src/integration-tests/commerce.test.ts
+++ b/packages/headless/src/integration-tests/commerce.test.ts
@@ -45,20 +45,18 @@ describe.skip('commerce', () => {
     });
 
     const cart = buildCart(engine);
-    const item1 = {
+    cart.updateItemQuantity({
       productId: 'p1',
       quantity: 2,
       price: 100,
       name: 'Nice Shoes',
-    };
-    const item2 = {
+    });
+    cart.updateItemQuantity({
       productId: 'p1',
       quantity: 3,
       price: 200,
       name: 'Nicer Shoes',
-    };
-    cart.updateItem(item1, item1);
-    cart.updateItem(item2, item2);
+    });
   });
 
   const fetchProductListing = async (): Promise<ProductListing> => {


### PR DESCRIPTION
# [CAPI-851](https://coveord.atlassian.net/browse/CAPI-851)

The cart controller stored products according to `sku` value. Sku isn't returned from the Commerce API, nor is used by any Coveo systems. Consequently `sku` has been removed from the keys. This poses an additional problem now, in that the events should contain duplicate `productId` when a product is in the cart at different prices. To address this the cart stores products grouped by price, to cater to this use case.

Updates have been made to Commerce base request builder and QuerySuggest to return cart products with deduped productIds.

[CAPI-851]: https://coveord.atlassian.net/browse/CAPI-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ