### PR TITLE
feat(commerce): expose additional field suggestions properties on state

### DIFF
--- a/packages/headless/src/api/commerce/search/query-suggest/query-suggest-response.ts
+++ b/packages/headless/src/api/commerce/search/query-suggest/query-suggest-response.ts
@@ -28,6 +28,16 @@ export interface FieldSuggestionsFacet {
   facetId: string;
 
   /**
+   * The facet display name.
+   */
+  displayName: string;
+
+  /**
+   * The facet field.
+   */
+  field: string;
+
+  /**
    * The facet type.
    */
   type: 'regular' | 'hierarchical';

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -223,7 +223,13 @@ export type {
 } from './controllers/core/triggers/headless-core-notify-trigger';
 export {buildNotifyTrigger} from './controllers/commerce/triggers/headless-commerce-notify-trigger';
 
-export type {FieldSuggestions} from './controllers/commerce/field-suggestions/headless-field-suggestions';
-export type {CategoryFieldSuggestions} from './controllers/commerce/field-suggestions/headless-category-field-suggestions';
+export type {
+  FieldSuggestions,
+  FieldSuggestionsState,
+} from './controllers/commerce/field-suggestions/headless-field-suggestions';
+export type {
+  CategoryFieldSuggestions,
+  CategoryFieldSuggestionsState,
+} from './controllers/commerce/field-suggestions/headless-category-field-suggestions';
 export type {FieldSuggestionsGenerator} from './controllers/commerce/field-suggestions/headless-field-suggestions-generator';
 export {buildFieldSuggestionsGenerator} from './controllers/commerce/field-suggestions/headless-field-suggestions-generator';

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
@@ -1,3 +1,4 @@
+import {FieldSuggestionsFacet} from '../../../api/commerce/search/query-suggest/query-suggest-response';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-search';
@@ -33,14 +34,9 @@ describe('fieldSuggestionsGenerator', () => {
     fieldSuggestionsGenerator = buildFieldSuggestionsGenerator(engine);
   }
 
-  function setFacetState(
-    config: {facetId: string; type: 'regular' | 'hierarchical'}[] = []
-  ) {
+  function setFacetState(config: FieldSuggestionsFacet[] = []) {
     for (const facet of config) {
-      state.fieldSuggestionsOrder.push({
-        facetId: facet.facetId,
-        type: facet.type,
-      });
+      state.fieldSuggestionsOrder.push(facet);
       state.commerceFacetSet[facet.facetId] = {
         request: buildMockCommerceFacetRequest({
           facetId: facet.facetId,
@@ -80,7 +76,14 @@ describe('fieldSuggestionsGenerator', () => {
   describe('#fieldSuggestions', () => {
     it('when engine facet state contains a regular facet, generates a field suggestions controller', () => {
       const facetId = 'regular_facet_id';
-      setFacetState([{facetId, type: 'regular'}]);
+      setFacetState([
+        {
+          facetId,
+          field: 'regular_field',
+          displayName: 'Facet',
+          type: 'regular',
+        },
+      ]);
 
       expect(fieldSuggestionsGenerator.fieldSuggestions.length).toEqual(1);
       expect(fieldSuggestionsGenerator.fieldSuggestions[0].state).toEqual(
@@ -90,7 +93,14 @@ describe('fieldSuggestionsGenerator', () => {
 
     it('when engine facet state contains a category facet, generates a category field suggestions controller', () => {
       const facetId = 'category_facet_id';
-      setFacetState([{facetId, type: 'hierarchical'}]);
+      setFacetState([
+        {
+          facetId,
+          field: 'category_field',
+          displayName: 'Facet',
+          type: 'hierarchical',
+        },
+      ]);
 
       expect(fieldSuggestionsGenerator.fieldSuggestions.length).toEqual(1);
       expect(fieldSuggestionsGenerator.fieldSuggestions[0].state).toEqual(
@@ -99,13 +109,17 @@ describe('fieldSuggestionsGenerator', () => {
     });
 
     it('when engine facet state contains multiple facets, generates the proper facet controllers', () => {
-      const facets: {facetId: string; type: 'regular' | 'hierarchical'}[] = [
+      const facets: FieldSuggestionsFacet[] = [
         {
           facetId: 'regular_facet_id',
+          field: 'regular_field',
+          displayName: 'Regular Facet',
           type: 'regular',
         },
         {
           facetId: 'category_facet_id',
+          field: 'category_field',
+          displayName: 'Category Facet',
           type: 'hierarchical',
         },
       ];
@@ -134,6 +148,8 @@ describe('fieldSuggestionsGenerator', () => {
 
     state.fieldSuggestionsOrder.push({
       facetId: 'new_facet_id',
+      field: 'new_facet_field',
+      displayName: 'New Facet',
       type: 'regular',
     });
 

--- a/packages/headless/src/features/commerce/facets/field-suggestions-order/field-suggestions-order-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/field-suggestions-order/field-suggestions-order-slice.test.ts
@@ -39,10 +39,14 @@ describe('field suggestions order slice', () => {
     const facets: FieldSuggestionsFacet[] = [
       {
         facetId: 'facetA',
+        field: 'field_a',
+        displayName: 'Facet A',
         type: 'regular',
       },
       {
         facetId: 'facetB',
+        field: 'field_b',
+        displayName: 'Facet B',
         type: 'hierarchical',
       },
     ];

--- a/packages/headless/src/features/commerce/facets/field-suggestions-order/field-suggestions-order-state.ts
+++ b/packages/headless/src/features/commerce/facets/field-suggestions-order/field-suggestions-order-state.ts
@@ -1,18 +1,6 @@
-/**
- * A facet to use for field suggestions.
- */
-export interface FieldSuggestionsFacet {
-  /**
-   * The facet ID.
-   */
-  facetId: string;
+import {FieldSuggestionsFacet} from '../../../../api/commerce/search/query-suggest/query-suggest-response';
 
-  /**
-   * The facet type.
-   */
-  type: 'regular' | 'hierarchical';
-}
-
+export type {FieldSuggestionsFacet};
 export type FieldSuggestionsOrderState = FieldSuggestionsFacet[];
 
 export function getFieldSuggestionsOrderInitialState(): FieldSuggestionsOrderState {


### PR DESCRIPTION
These properties (`displayName` and `field`) should make it easier to build a field suggestions component.

[CAPI-868]

[CAPI-868]: https://coveord.atlassian.net/browse/CAPI-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ