### PR TITLE
Add atomic-product-field-condition component for commerce

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.tsx
@@ -1,0 +1,56 @@
+import {Component, Prop, h} from '@stencil/core';
+import {Product, ProductTemplatesHelpers} from '@coveo/headless/commerce';
+import {ProductContext} from '../product-template-decorators';
+
+/**
+ * The `atomic-product-field-condition` component takes a list of conditions that, if fulfilled, apply the template in which it's defined.
+ * The condition properties can be based on any top-level product property of the `product` object, not restricted to fields (e.g., `ec_brand`).
+ */
+@Component({
+  tag: 'atomic-product-field-condition',
+  shadow: true,
+})
+export class AtomicProductFieldCondition {
+  @ProductContext() private product!: Product;
+
+  /**
+   * Verifies whether the specified fields are defined.
+   */
+  @Prop({reflect: true}) ifDefined?: string;
+  /**
+   * Verifies whether the specified fields are not defined.
+   */
+  @Prop({reflect: true}) ifNotDefined?: string;
+
+  private shouldBeRemoved = false;
+  private conditions: ((product: Product) => boolean)[] = [];
+
+  public componentWillLoad() {
+    if (this.ifDefined) {
+      const fieldNames = this.ifDefined.split(',');
+      this.conditions.push(
+        ProductTemplatesHelpers.fieldsMustBeDefined(fieldNames)
+      );
+    }
+
+    if (this.ifNotDefined) {
+      const fieldNames = this.ifNotDefined.split(',');
+      this.conditions.push(
+        ProductTemplatesHelpers.fieldsMustNotBeDefined(fieldNames)
+      );
+    }
+  }
+
+  public render() {
+    if (!this.conditions.every((condition) => condition(this.product))) {
+      this.shouldBeRemoved = true;
+      return '';
+    }
+
+    return <slot />;
+  }
+
+  public componentDidLoad() {
+    this.shouldBeRemoved && this.host.remove();
+  }
+}


### PR DESCRIPTION
Related to #3956

Adds the `atomic-product-field-condition` component to the Coveo Atomic library to enable conditional rendering based on commerce-specific fields within product templates.

- Introduces a new component, `atomic-product-field-condition`, designed for use within commerce-related templates to conditionally render content based on the presence or absence of specified product fields.
- Utilizes `ifDefined` and `ifNotDefined` properties to manage the conditional rendering logic, allowing developers to specify which fields should or should not be present for the template to be applied.
- Implements logic to dynamically evaluate conditions against the `product` object, ensuring that the component can adapt to various product properties beyond just fields.
- Ensures the component is removed from the DOM if conditions are not met, maintaining clean and relevant output for end-users.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coveo/ui-kit/issues/3956?shareId=60129795-4839-4dea-af37-5f9e00c60e37).