### PR TITLE
fix(headless): send referrer as null when originLevel3 is default

### DIFF
--- a/packages/headless/src/api/search/search-api-params.ts
+++ b/packages/headless/src/api/search/search-api-params.ts
@@ -119,7 +119,7 @@ export interface AnalyticsParam {
     deviceId?: string;
     pageId?: string;
     clientTimestamp: string;
-    documentReferrer: string;
+    documentReferrer: string | null;
     originContext: string;
     userDisplayName?: string;
     documentLocation?: string;

--- a/packages/headless/src/features/configuration/analytics-params.test.ts
+++ b/packages/headless/src/features/configuration/analytics-params.test.ts
@@ -1,0 +1,22 @@
+import {buildMockAnalyticsState} from '../../test/mock-analytics-state';
+import {fromAnalyticsStateToAnalyticsParams} from './analytics-params';
+
+describe('fromAnalyticsStateToAnalyticsParams', () => {
+  it('analyticsMode is next and originLevel3 is default, it sends documentReferrer as null', async () => {
+    const analytics = buildMockAnalyticsState({
+      analyticsMode: 'next',
+      originLevel3: 'default',
+    });
+    const res = await fromAnalyticsStateToAnalyticsParams(analytics);
+    expect(res.analytics?.documentReferrer).toBe(null);
+  });
+
+  it('analyticsMode is legacy and originLevel3 is default, it sends documentReferrer as default', async () => {
+    const analytics = buildMockAnalyticsState({
+      analyticsMode: 'legacy',
+      originLevel3: 'default',
+    });
+    const res = await fromAnalyticsStateToAnalyticsParams(analytics);
+    expect(res.analytics?.documentReferrer).toBe('default');
+  });
+});

--- a/packages/headless/src/features/configuration/analytics-params.ts
+++ b/packages/headless/src/features/configuration/analytics-params.ts
@@ -10,11 +10,13 @@ export const fromAnalyticsStateToAnalyticsParams = async (
   eventDescription?: EventDescription
 ): Promise<AnalyticsParam> => {
   const isNextAnalytics = s.analyticsMode === 'next';
+  const isDefaultReferrer = s.originLevel3 === 'default';
   return {
     analytics: {
       clientId: await getVisitorID(s),
       clientTimestamp: new Date().toISOString(),
-      documentReferrer: s.originLevel3,
+      documentReferrer:
+        isNextAnalytics && isDefaultReferrer ? null : s.originLevel3,
       originContext: s.originContext,
       ...(eventDescription && {
         actionCause: eventDescription.actionCause,

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -162,6 +162,7 @@ const excludedBaseProperties = [
   'trackingId',
   'source',
   'customData',
+  'documentReferrer',
 ];
 
 const ANY_FACET_VALUE = 'any facet value';


### PR DESCRIPTION
**Context**
The server event schema was recently tightened to require document referrer to be a url if specified. The schema definition is available [here](https://github.com/coveo-platform/analytics_schema/blob/master/schemas/common/types.json#L289).

Headless' behavior is to forward the originLevel3 value, which by default is set to the string `default`.
This causes all server events sent by headless to be marked as invalid.

**Approach**
When the `analyticsMode` is `next` and originLevel3 is `default`, headless will send `null` instead of `default`.