### PR TITLE
fix(Commerce Atomic): prevent recs carousel buttons from overlapping with text

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
@@ -425,7 +425,9 @@ export class AtomicCommerceRecommendationList
             previousPage={() => this.previousPage()}
             numberOfPages={this.numberOfPages}
           >
-            {this.renderRecommendationList()}
+            <div class="px-3 bg-slate-500">
+              {this.renderRecommendationList()}
+            </div>
           </Carousel>
         ) : (
           this.renderRecommendationList()

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
@@ -425,9 +425,7 @@ export class AtomicCommerceRecommendationList
             previousPage={() => this.previousPage()}
             numberOfPages={this.numberOfPages}
           >
-            <div class="px-3 bg-slate-500">
-              {this.renderRecommendationList()}
-            </div>
+            <div class="px-3">{this.renderRecommendationList()}</div>
           </Carousel>
         ) : (
           this.renderRecommendationList()


### PR DESCRIPTION
This PR adds padding to the carousel to prevent the buttons from overlapping with the recommendations content.
![image](https://github.com/coveo/ui-kit/assets/1728218/42b6268b-cba3-4a34-8a82-d741ebfefce3)

https://coveord.atlassian.net/browse/KIT-3187