### PR TITLE
fix(atomic): add label on atomic-pager radiogroup

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.tsx
@@ -112,17 +112,17 @@ export class AtomicCommercePager
         hasResults={this.pagerState.totalPages > 1}
         isAppLoaded={this.bindings.store.isAppLoaded()}
       >
-        <PagerNavigation label={this.bindings.i18n.t('pagination')}>
+        <PagerNavigation i18n={this.bindings.i18n}>
           <PagerPreviousButton
             icon={this.previousButtonIcon}
             disabled={this.pagerState.page === 0}
-            ariaLabel={this.bindings.i18n.t('previous')}
+            i18n={this.bindings.i18n}
             onClick={() => {
               this.pager.previousPage();
               this.focusOnFirstResultAndScrollToTop();
             }}
           />
-          <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
+          <PagerPageButtons i18n={this.bindings.i18n}>
             {pagesRange.map((pageNumber) => {
               return (
                 <PagerPageButton
@@ -152,7 +152,7 @@ export class AtomicCommercePager
           <PagerNextButton
             icon={this.nextButtonIcon}
             disabled={this.pagerState.page >= this.pagerState.totalPages}
-            ariaLabel={this.bindings.i18n.t('next')}
+            i18n={this.bindings.i18n}
             onClick={() => {
               this.pager.nextPage();
               this.focusOnFirstResultAndScrollToTop();

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.tsx
@@ -122,7 +122,7 @@ export class AtomicCommercePager
               this.focusOnFirstResultAndScrollToTop();
             }}
           />
-          <PagerPageButtons>
+          <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
             {pagesRange.map((pageNumber) => {
               return (
                 <PagerPageButton

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -1,10 +1,12 @@
 import {FunctionalComponent, h} from '@stencil/core';
+import {i18n} from 'i18next';
 import {Button, ButtonProps} from '../button';
 import {RadioButton, RadioButtonProps} from '../radio-button';
 
 export interface PagerNavigationButtonProps
   extends Omit<ButtonProps, 'style' | 'part' | 'class'> {
   icon: string;
+  i18n: i18n;
 }
 
 export interface PagerPageButtonProps
@@ -18,7 +20,7 @@ export interface PagerPageButtonProps
 }
 
 export interface PagerPageButtonsProps {
-  label: string;
+  i18n: i18n;
 }
 
 export const PagerPreviousButton: FunctionalComponent<
@@ -27,6 +29,7 @@ export const PagerPreviousButton: FunctionalComponent<
   return (
     <Button
       {...props}
+      ariaLabel={props.i18n.t('previous')}
       style="outline-primary"
       part="previous-button"
       class="p-1 min-w-[2.5rem] min-h-[2.5rem] flex justify-center items-center"
@@ -83,7 +86,7 @@ export const PagerPageButtons: FunctionalComponent<PagerPageButtonsProps> = (
     <div
       part="page-buttons"
       role="radiogroup"
-      aria-label={props.label}
+      aria-label={props.i18n.t('pagination')}
       class="contents"
     >
       {...children}

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -17,6 +17,10 @@ export interface PagerPageButtonProps
   text: string;
 }
 
+export interface PagerPageButtonsProps {
+  label: string;
+}
+
 export const PagerPreviousButton: FunctionalComponent<
   PagerNavigationButtonProps
 > = (props) => {
@@ -71,12 +75,15 @@ export const PagerPageButton: FunctionalComponent<PagerPageButtonProps> = (
   );
 };
 
-export const PagerPageButtons: FunctionalComponent = (_, children) => {
+export const PagerPageButtons: FunctionalComponent<PagerPageButtonsProps> = (
+  props,
+  children
+) => {
   return (
     <div
       part="page-buttons"
       role="radiogroup"
-      aria-label="Pagination"
+      aria-label={props.label}
       class="contents"
     >
       {...children}

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -73,7 +73,12 @@ export const PagerPageButton: FunctionalComponent<PagerPageButtonProps> = (
 
 export const PagerPageButtons: FunctionalComponent = (_, children) => {
   return (
-    <div part="page-buttons" role="radiogroup" class="contents">
+    <div
+      part="page-buttons"
+      role="radiogroup"
+      aria-label="Pagination"
+      class="contents"
+    >
       {...children}
     </div>
   );

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -49,6 +49,7 @@ export const PagerNextButton: FunctionalComponent<
   return (
     <Button
       {...props}
+      ariaLabel={props.i18n.t('next')}
       style="outline-primary"
       part="next-button"
       class="p-1 min-w-[2.5rem] min-h-[2.5rem] flex justify-center items-center"

--- a/packages/atomic/src/components/common/pager/pager-navigation.tsx
+++ b/packages/atomic/src/components/common/pager/pager-navigation.tsx
@@ -1,7 +1,8 @@
 import {FunctionalComponent, h} from '@stencil/core';
+import {i18n} from 'i18next';
 
 export interface PagerNavigationProps {
-  label: string;
+  i18n: i18n;
 }
 
 export const PagerNavigation: FunctionalComponent<PagerNavigationProps> = (
@@ -9,8 +10,8 @@ export const PagerNavigation: FunctionalComponent<PagerNavigationProps> = (
   children
 ) => {
   return (
-    <nav aria-label={props.label}>
-      <div part="buttons" class="flex gap-2 flex-wrap">
+    <nav aria-label={props.i18n.t('pagination')}>
+      <div part="buttons" class="flex flex-wrap gap-2">
         {...children}
       </div>
     </nav>

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
@@ -93,7 +93,7 @@ export class AtomicInsightPager
             this.focusOnFirstResultAndScrollToTop();
           }}
         />
-        <PagerPageButtons>
+        <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
           {this.pagerState.currentPages.map((pageNumber) => {
             return (
               <PagerPageButton

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.tsx
@@ -83,17 +83,17 @@ export class AtomicInsightPager
 
   public render() {
     return (
-      <PagerNavigation label={this.bindings.i18n.t('pagination')}>
+      <PagerNavigation i18n={this.bindings.i18n}>
         <PagerPreviousButton
           icon={ArrowLeftIcon}
           disabled={!this.pagerState.hasPreviousPage}
-          ariaLabel={this.bindings.i18n.t('previous')}
+          i18n={this.bindings.i18n}
           onClick={() => {
             this.pager.previousPage();
             this.focusOnFirstResultAndScrollToTop();
           }}
         />
-        <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
+        <PagerPageButtons i18n={this.bindings.i18n}>
           {this.pagerState.currentPages.map((pageNumber) => {
             return (
               <PagerPageButton
@@ -119,7 +119,7 @@ export class AtomicInsightPager
         <PagerNextButton
           icon={ArrowRightIcon}
           disabled={!this.pagerState.hasNextPage}
-          ariaLabel={this.bindings.i18n.t('next')}
+          i18n={this.bindings.i18n}
           onClick={() => {
             this.pager.nextPage();
             this.focusOnFirstResultAndScrollToTop();

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
@@ -110,7 +110,7 @@ export class AtomicPager implements InitializableComponent {
               this.focusOnFirstResultAndScrollToTop();
             }}
           />
-          <PagerPageButtons>
+          <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
             {this.pagerState.currentPages.map((pageNumber) => {
               return (
                 <PagerPageButton

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.tsx
@@ -100,17 +100,17 @@ export class AtomicPager implements InitializableComponent {
         {...this.searchStatusState}
         isAppLoaded={this.bindings.store.isAppLoaded()}
       >
-        <PagerNavigation label={this.bindings.i18n.t('pagination')}>
+        <PagerNavigation i18n={this.bindings.i18n}>
           <PagerPreviousButton
             icon={this.previousButtonIcon}
             disabled={!this.pagerState.hasPreviousPage}
-            ariaLabel={this.bindings.i18n.t('previous')}
+            i18n={this.bindings.i18n}
             onClick={() => {
               this.pager.previousPage();
               this.focusOnFirstResultAndScrollToTop();
             }}
           />
-          <PagerPageButtons label={this.bindings.i18n.t('pagination')}>
+          <PagerPageButtons i18n={this.bindings.i18n}>
             {this.pagerState.currentPages.map((pageNumber) => {
               return (
                 <PagerPageButton
@@ -136,7 +136,7 @@ export class AtomicPager implements InitializableComponent {
           <PagerNextButton
             icon={this.nextButtonIcon}
             disabled={!this.pagerState.hasNextPage}
-            ariaLabel={this.bindings.i18n.t('next')}
+            i18n={this.bindings.i18n}
             onClick={() => {
               this.pager.nextPage();
               this.focusOnFirstResultAndScrollToTop();


### PR DESCRIPTION
This PR adds a label to the role="radiogroup" element inside PagerPageButtons. This label is required on elements with this role.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role#associated_wai-aria_roles_states_and_properties:~:text=aria%2Dlabelledby%20/,aria%2Dlabel.

https://coveord.atlassian.net/browse/KIT-3211