### PR TITLE
fix(atomic): prevent facet value checkbox and label overlap

### DIFF
--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.pcss
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.pcss
@@ -2,8 +2,8 @@
  * @prop --atomic-facet-checkbox-size: Size of the checkbox.
  */
 .value-checkbox {
-  width: var(--atomic-facet-checkbox-size, 16px);
-  height: var(--atomic-facet-checkbox-size, 16px);
+  width: var(--atomic-facet-checkbox-size, 1rem);
+  height: var(--atomic-facet-checkbox-size, 1rem);
 
   @apply absolute z-1 left-2;
 }


### PR DESCRIPTION
This PR prevents the checkbox and label from facet values from overlapping when a font-size value lower than 100%/16px is set on the root html element

Before:
<img width="232" alt="image" src="https://github.com/coveo/ui-kit/assets/1728218/37b0fb50-4ff3-4bc7-a7d5-7e72007c8aae">

After:
<img width="227" alt="image" src="https://github.com/coveo/ui-kit/assets/1728218/726acda5-7cc6-4bd2-984e-c789b9bba25f">

https://coveord.atlassian.net/browse/KIT-3215