### PR TITLE
feat(genqa): fix citation flaky test

### DIFF
--- a/packages/atomic/cypress/e2e/generated-answer.cypress.ts
+++ b/packages/atomic/cypress/e2e/generated-answer.cypress.ts
@@ -477,7 +477,7 @@ describe('Generated Answer Test Suites', () => {
           beforeEach(() => {
             AnalyticsTracker.reset();
             GeneratedAnswerSelectors.citation()
-              .invoke('removeAttr', 'target') // Otherwise opens a new tab that messes with the tests
+              .invoke('removeAttr', 'target')
               .click();
           });
 

--- a/packages/atomic/cypress/e2e/generated-answer.cypress.ts
+++ b/packages/atomic/cypress/e2e/generated-answer.cypress.ts
@@ -423,6 +423,7 @@ describe('Generated Answer Test Suites', () => {
           mockStreamResponse(streamId, testCitationsPayload);
           setupGeneratedAnswer(streamId);
           cy.wait(getStreamInterceptAlias(streamId));
+          cy.wait(1000);
         });
 
         it('should display the citation link', () => {
@@ -476,9 +477,7 @@ describe('Generated Answer Test Suites', () => {
         describe('when a citation is clicked', () => {
           beforeEach(() => {
             AnalyticsTracker.reset();
-            GeneratedAnswerSelectors.citation()
-              .invoke('removeAttr', 'target')
-              .click();
+            GeneratedAnswerSelectors.citation().click();
           });
 
           it('should log an openGeneratedAnswerSource click event', () => {


### PR DESCRIPTION
[SVCC-3781](https://coveord.atlassian.net/browse/SVCC-3781)

Flaky test in citation test suite:

<img width="1130" alt="Screenshot 2024-05-23 at 1 53 51 PM" src="https://github.com/coveo/ui-kit/assets/119955059/b4aec2b5-5de7-4b56-995c-e5e45cbe253c">

The test `should display the citation card` is flaky due to the citation not available yet in the DOM.
The test `when a citation is right-clicked` is flaky due to the previous test click.

Before:

<img width="674" alt="Screenshot 2024-05-22 at 8 47 18 PM" src="https://github.com/coveo/ui-kit/assets/119955059/dde321dc-ea63-4502-8b2a-c25c6daa1994">

After:

<img width="659" alt="Screenshot 2024-05-23 at 4 04 45 PM" src="https://github.com/coveo/ui-kit/assets/119955059/555647ad-e234-44b7-8c06-5634606bbbe4">



[SVCC-3781]: https://coveord.atlassian.net/browse/SVCC-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ