### PR TITLE
feat(knowledgeAPI): api slice

### DIFF
--- a/packages/headless/src/api/knowledge/answer-slice.ts
+++ b/packages/headless/src/api/knowledge/answer-slice.ts
@@ -1,0 +1,45 @@
+import {
+  BaseQueryFn,
+  createApi,
+  FetchArgs,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+  retry,
+} from '@reduxjs/toolkit/query';
+import {ConfigurationSection} from '../../state/state-sections';
+
+type StateNeededByAnswerSlice = ConfigurationSection;
+
+/**
+ * `dynamicBaseQuery` is passed to the baseQuery of the createApi,
+ * but note that the baseQuery will not be used if a queryFn is provided in the createApi endpoint
+ */
+const dynamicBaseQuery: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  const state = api.getState() as StateNeededByAnswerSlice;
+  const {accessToken, organizationId, platformUrl} = state.configuration;
+  const updatedArgs = {
+    ...(args as FetchArgs),
+    headers: {
+      ...((args as FetchArgs)?.headers || {}),
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+  try {
+    const data = fetchBaseQuery({
+      baseUrl: `${platformUrl}/rest/organizations/${organizationId}`,
+    })(updatedArgs, api, extraOptions);
+    return {data};
+  } catch (error) {
+    return {error: error as FetchBaseQueryError};
+  }
+};
+
+export const answerSlice = createApi({
+  reducerPath: 'answer',
+  baseQuery: retry(dynamicBaseQuery, {maxRetries: 3}),
+  endpoints: () => ({}),
+});

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -1,0 +1,287 @@
+import {
+  ArrayValue,
+  BooleanValue,
+  RecordValue,
+  Schema,
+  StringValue,
+} from '@coveo/bueno';
+import {
+  EventSourceMessage,
+  fetchEventSource,
+} from '@microsoft/fetch-event-source';
+import {
+  GeneratedAnswerStyle,
+  GeneratedContentFormat,
+} from '../../features/generated-answer/generated-response-format';
+import {selectPipeline} from '../../features/pipeline/select-pipeline';
+import {selectQuery} from '../../features/query/query-selectors';
+import {QueryState} from '../../features/query/query-state';
+import {selectSearchHub} from '../../features/search-hub/search-hub-selectors';
+import {
+  ConfigurationSection,
+  DebugSection,
+  GeneratedAnswerSection,
+  SearchSection,
+} from '../../state/state-sections';
+import {GeneratedAnswerCitation} from '../generated-answer/generated-answer-event-payload';
+import {SearchRequest} from '../search/search/search-request';
+import {answerSlice} from './answer-slice';
+
+type StateNeededByAnswerAPI = ConfigurationSection &
+  GeneratedAnswerSection &
+  SearchSection &
+  DebugSection & {answer: ReturnType<typeof answerApi.reducer>};
+
+interface ErrorPayload {
+  message?: string;
+  code?: number;
+}
+
+class FatalError extends Error {
+  constructor(public payload: ErrorPayload) {
+    super(payload.message);
+  }
+}
+
+interface GeneratedAnswerStream {
+  answerStyle: GeneratedAnswerStyle | undefined;
+  contentFormat: GeneratedContentFormat | undefined;
+  answer: string | undefined;
+  citations: GeneratedAnswerCitation[] | undefined;
+  generated: boolean;
+  isStreaming: boolean;
+  isLoading: boolean;
+}
+interface HeaderMessage {
+  answerStyle: GeneratedAnswerStyle;
+  contentFormat: GeneratedContentFormat;
+}
+
+type PayloadType =
+  | 'genqa.headerMessageType'
+  | 'genqa.messageType'
+  | 'genqa.citationsType'
+  | 'genqa.endOfStreamType';
+
+const headerMessageSchema = new Schema<HeaderMessage>({
+  answerStyle: new StringValue(),
+  contentFormat: new StringValue(),
+});
+
+const messageSchema = new Schema({
+  textDelta: new StringValue(),
+});
+
+const citationsSchema = new Schema({
+  citation: new ArrayValue(
+    new RecordValue({
+      values: {
+        clickUri: new StringValue(),
+        id: new StringValue(),
+        permanentid: new StringValue(),
+        text: new StringValue(),
+        title: new StringValue(),
+        uri: new StringValue(),
+      },
+    })
+  ),
+});
+
+const validateHeaderMessage = (headerMessage: HeaderMessage) => {
+  headerMessageSchema.validate(headerMessage);
+};
+
+const validateMessage = (message: {textDelta: string}) => {
+  messageSchema.validate(message);
+};
+
+const validateCitationsMessage = (citations: {
+  citation: GeneratedAnswerCitation[];
+}) => {
+  citationsSchema.validate(citations);
+};
+
+const validateEndOfStream = (endOfStream: {answerGenerated: boolean}) => {
+  new Schema({
+    answerGenerated: new BooleanValue(),
+  }).validate(endOfStream);
+};
+
+const handleHeaderMessage = (
+  draft: GeneratedAnswerStream,
+  payload: HeaderMessage
+) => {
+  validateHeaderMessage(payload);
+  const {answerStyle, contentFormat} = payload;
+  draft.answerStyle = answerStyle;
+  draft.contentFormat = contentFormat;
+  draft.isStreaming = true;
+  draft.isLoading = false;
+};
+
+const handleMessage = (
+  draft: GeneratedAnswerStream,
+  payload: {textDelta: string}
+) => {
+  validateMessage(payload);
+  if (draft.answer === undefined) {
+    draft.answer = payload.textDelta;
+  } else {
+    draft.answer = draft.answer.concat(payload.textDelta);
+  }
+};
+
+const handleCitations = (
+  draft: GeneratedAnswerStream,
+  payload: {citation: GeneratedAnswerCitation[]}
+) => {
+  validateCitationsMessage(payload);
+  draft.citations = payload.citation;
+};
+
+const handleEndOfStream = (
+  draft: GeneratedAnswerStream,
+  payload: {answerGenerated: boolean}
+) => {
+  validateEndOfStream(payload);
+  draft.generated = payload.answerGenerated;
+  draft.isStreaming = false;
+};
+
+const updateCacheWithEvent = (
+  event: EventSourceMessage,
+  draft: GeneratedAnswerStream
+) => {
+  const message: {payloadType: PayloadType; payload: string} = JSON.parse(
+    event.data
+  );
+  const parsedPayload = JSON.parse(message.payload);
+  switch (message.payloadType) {
+    case 'genqa.headerMessageType':
+      handleHeaderMessage(draft, parsedPayload);
+      break;
+    case 'genqa.messageType':
+      handleMessage(draft, parsedPayload);
+      break;
+    case 'genqa.citationsType':
+      handleCitations(draft, parsedPayload);
+      break;
+    case 'genqa.endOfStreamType':
+      handleEndOfStream(draft, parsedPayload);
+      break;
+  }
+};
+
+const onOpenStream = async (response: Response) => {
+  if (
+    response.ok &&
+    response.headers.get('content-type')?.includes('text/event-stream')
+  ) {
+    return;
+  }
+
+  const isClientSideError =
+    response.status >= 400 && response.status < 500 && response.status !== 429;
+
+  if (isClientSideError) {
+    throw new FatalError({
+      message: 'Error opening stream',
+      code: response.status,
+    });
+  } else {
+    throw new Error();
+  }
+};
+
+const onError = (err: Error) => {
+  if (err instanceof FatalError) {
+    throw err;
+  }
+};
+
+export const answerApi = answerSlice.injectEndpoints({
+  overrideExisting: true,
+  endpoints: (builder) => ({
+    getAnswer: builder.query<GeneratedAnswerStream, Partial<SearchRequest>>({
+      queryFn: () => ({
+        data: {
+          answerStyle: undefined,
+          contentFormat: undefined,
+          answer: undefined,
+          citations: undefined,
+          generated: false,
+          isStreaming: true,
+          isLoading: true,
+        },
+      }),
+      async onCacheEntryAdded(
+        args,
+        {getState, cacheDataLoaded, updateCachedData}
+      ) {
+        await cacheDataLoaded;
+        /**
+         * createApi has to be called prior to creating the redux store and is used as part of the store setup sequence.
+         * It cannot use the inferred state used by Redux, thus the casting.
+         * https://redux-toolkit.js.org/rtk-query/usage-with-typescript#typing-dispatch-and-getstate
+         */
+        const {configuration} = getState() as unknown as StateNeededByAnswerAPI;
+        const {platformUrl, organizationId, accessToken, knowledge} =
+          configuration;
+        await fetchEventSource(
+          `${platformUrl}/rest/organizations/${organizationId}/answer/v1/configs/${knowledge.answerConfigurationId}/generate`,
+          {
+            method: 'POST',
+            body: JSON.stringify(args),
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+              'Accept-Encoding': '*',
+            },
+            fetch,
+            onopen: onOpenStream,
+            onmessage: (event) => {
+              updateCachedData((draft) => {
+                updateCacheWithEvent(event, draft);
+              });
+            },
+            onerror: onError,
+          }
+        );
+      },
+    }),
+  }),
+});
+
+export const fetchAnswer = (
+  state: StateNeededByAnswerAPI & {
+    knowledge: ReturnType<typeof answerApi.reducer>;
+    query?: QueryState;
+    searchHub?: string;
+    pipeline?: string;
+  }
+) => {
+  const query = selectQuery(state)?.q;
+  const searchHub = selectSearchHub(state);
+  const pipeline = selectPipeline(state);
+
+  return answerApi.endpoints.getAnswer.initiate({
+    q: query,
+    ...(searchHub?.length && {searchHub}),
+    ...(pipeline?.length && {pipeline}),
+  });
+};
+
+export const selectAnswer = (
+  state: StateNeededByAnswerAPI & {
+    knowledge: ReturnType<typeof answerApi.reducer>;
+    query?: QueryState;
+    searchHub?: string;
+    pipeline?: string;
+  }
+) =>
+  answerApi.endpoints.getAnswer.select({
+    q: selectQuery(state)?.q,
+    ...(selectSearchHub(state)?.length && {searchHub: selectSearchHub(state)}),
+    ...(selectPipeline(state)?.length && {pipeline: selectPipeline(state)}),
+  })(state);

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -51,6 +51,10 @@ export interface ConfigurationState {
    * The global headless engine Usage Analytics API configuration.
    */
   analytics: AnalyticsState;
+  /**
+   * The global headless engine Knowledge configuration.
+   */
+  knowledge: KnowledgeState;
 }
 
 export interface AnalyticsState {
@@ -148,6 +152,10 @@ export interface AnalyticsState {
 export const searchAPIEndpoint = '/rest/search/v2';
 export const analyticsAPIEndpoint = '/rest/ua';
 
+interface KnowledgeState {
+  answerConfigurationId: string;
+}
+
 export const getConfigurationInitialState: () => ConfigurationState = () => ({
   organizationId: '',
   accessToken: '',
@@ -172,5 +180,8 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     trackingId: '',
     analyticsMode: 'legacy',
     source: {},
+  },
+  knowledge: {
+    answerConfigurationId: '',
   },
 });

--- a/packages/headless/src/features/pipeline/select-pipeline.ts
+++ b/packages/headless/src/features/pipeline/select-pipeline.ts
@@ -1,0 +1,6 @@
+import {createSelector} from '@reduxjs/toolkit';
+
+export const selectPipeline = createSelector(
+  (state: {pipeline?: string}) => state.pipeline,
+  (pipeline) => pipeline
+);

--- a/packages/headless/src/features/query/query-selectors.ts
+++ b/packages/headless/src/features/query/query-selectors.ts
@@ -1,0 +1,7 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {QueryState} from './query-state';
+
+export const selectQuery = createSelector(
+  (state: {query?: QueryState}) => state.query,
+  (query) => query
+);

--- a/packages/headless/src/features/search-hub/search-hub-selectors.ts
+++ b/packages/headless/src/features/search-hub/search-hub-selectors.ts
@@ -1,0 +1,6 @@
+import {createSelector} from '@reduxjs/toolkit';
+
+export const selectSearchHub = createSelector(
+  (state: {searchHub?: string}) => state.searchHub,
+  (searchHub) => searchHub
+);


### PR DESCRIPTION
## Overview
This update introduces a client to manage the new AnswerApi stream, serving RGA model answers. The client leverages [Redux Toolkit Query](https://redux-toolkit.js.org/rtk-query/overview).

## Tech
`baseKnowledgeAPISlice.ts`
This file contains the baseQuery, which can be used for simple API implementations, and the main slice definition, which can be used to create the Redux entry in the state.

`answerApiSlice.ts`
This file defines the endpoint that will manage the streaming, completing the Redux API slice.

While the `dynamicBaseQuery` pattern sets up a basic structure for adding new knowledge endpoints in the future, the code-splitting pattern is useful for maintaining a separation of concerns between generic code and endpoint-specific code.

## The Feature
This feature creates an entry in the state, forming the foundation of the new answer controller for the answer generation stream. It manages everything that is currently manually dispatched regarding API-level activity, such as `isStreaming`, `isLoading`, `answer`, and `citations`.

The RTK/Query library already handles the multi-query pattern, eliminating the need for complex ID management through a custom random ID implementation.

![image](https://github.com/coveo/ui-kit/assets/45688129/fcb4d6ce-f810-4937-bd5f-befd92d03d22)

**Edit** Now works with the new AnswerApi endpoint
![image](https://github.com/coveo/ui-kit/assets/45688129/bdbf1be2-a076-4dba-875f-d15fc4f1c5f2)


