### PR TITLE
chore: commit generated files w/ GitHub App

### DIFF
--- a/.github/actions/commit-generated-files/action.yml
+++ b/.github/actions/commit-generated-files/action.yml
@@ -6,7 +6,7 @@ runs:
     - run: |
         if [ ! -z "$(git status --porcelain)" ]; then
           git fetch --depth=1
-          git checkout ${{ github.head_ref }}
+          git switch ${{ github.head_ref }}
           git add 'packages/atomic/**/*.d.ts' 'packages/atomic-hosted-page/**/*.d.ts' 'packages/atomic-react/src/components/stencil-generated/*' 'packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/*'
 
           git config --global user.name "GitHub Actions Bot"

--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -34,7 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: PR Artifacts
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/actions/build
       - uses: ./.github/actions/commit-generated-files
   lint-check:


### PR DESCRIPTION
This ensures that the CI does not skip generated files that are auto-commited.

See #4035 for demonstration

