### PR TITLE
fix(headless): add commerce executeSearch to slice

### DIFF
--- a/packages/headless/src/features/query-set/query-set-slice.test.ts
+++ b/packages/headless/src/features/query-set/query-set-slice.test.ts
@@ -1,5 +1,10 @@
+import {SearchCommerceSuccessResponse} from '../../api/commerce/search/response';
 import {buildMockSearch} from '../../test/mock-search';
 import {restoreSearchParameters as commerceRestoreSearchParameters} from '../commerce/search-parameters/search-parameters-actions';
+import {
+  QuerySearchCommerceAPIThunkReturn,
+  executeSearch as commerceExecuteSearch,
+} from '../commerce/search/search-actions';
 import {change} from '../history/history-actions';
 import {getHistoryInitialState} from '../history/history-state';
 import {selectQuerySuggestion} from '../query-suggest/query-suggest-actions';
@@ -99,6 +104,26 @@ describe('querySet slice', () => {
     const nextState = querySetReducer(
       state,
       executeSearch.fulfilled(searchState, '', {legacy: logSearchboxSubmit()})
+    );
+    expect(nextState).toEqual(expectedQuerySet);
+  });
+
+  it('sets all queries to queryExecuted on commerce executeSearch.fulfilled', () => {
+    registerQueryWithId('foo');
+    registerQueryWithId('bar');
+
+    const expectedQuerySet = {foo: 'world', bar: 'world'};
+    const nextState = querySetReducer(
+      state,
+      commerceExecuteSearch.fulfilled(
+        {
+          queryExecuted: 'world',
+          response: {
+            responseId: 'someid',
+          } as unknown as SearchCommerceSuccessResponse,
+        } as QuerySearchCommerceAPIThunkReturn,
+        ''
+      )
     );
     expect(nextState).toEqual(expectedQuerySet);
   });

--- a/packages/headless/src/features/query-set/query-set-slice.ts
+++ b/packages/headless/src/features/query-set/query-set-slice.ts
@@ -4,6 +4,7 @@ import {
   CommerceSearchParameters,
   restoreSearchParameters as commerceRestoreSearchParameters,
 } from '../commerce/search-parameters/search-parameters-actions';
+import {executeSearch as commerceExecuteSearch} from '../commerce/search/search-actions';
 import {change} from '../history/history-actions';
 import {selectQuerySuggestion} from '../query-suggest/query-suggest-actions';
 import {
@@ -34,6 +35,10 @@ export const querySetReducer = createReducer(
       .addCase(selectQuerySuggestion, (state, action) => {
         const {id, expression} = action.payload;
         updateQuery(state, id, expression);
+      })
+      .addCase(commerceExecuteSearch.fulfilled, (state, action) => {
+        const {queryExecuted} = action.payload;
+        updateAllQuerySetQuery(state, queryExecuted);
       })
       .addCase(executeSearch.fulfilled, (state, action) => {
         const {queryExecuted} = action.payload;


### PR DESCRIPTION
The `commerce/search/executeSearch` action was not added to the `querySetReducer`
https://coveord.atlassian.net/browse/KIT-3192