### PR TITLE
fix(atomic) Fix dependent facet regression

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.tsx
@@ -182,6 +182,9 @@ export class AtomicInsightFacet
   }
 
   public disconnectedCallback() {
+    if (this.host.isConnected) {
+      return;
+    }
     this.facetConditionsManager?.stopWatching();
   }
 

--- a/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.tsx
@@ -183,6 +183,9 @@ export class AtomicInsightNumericFacet
   }
 
   public disconnectedCallback() {
+    if (this.host.isConnected) {
+      return;
+    }
     this.dependenciesManager?.stopWatching();
   }
 

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -267,6 +267,9 @@ export class AtomicFacet implements InitializableComponent {
   }
 
   public disconnectedCallback() {
+    if (this.host.isConnected) {
+      return;
+    }
     this.facetConditionsManager?.stopWatching();
   }
 

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -208,6 +208,9 @@ export class AtomicNumericFacet implements InitializableComponent {
   }
 
   public disconnectedCallback() {
+    if (this.host.isConnected) {
+      return;
+    }
     this.dependenciesManager?.stopWatching();
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3242

The regression was introduced in https://github.com/coveo/ui-kit/pull/3850.

`atomic-insight-timeframe-facet` and  `atomic-timeframe-facet` were not affected because they use the `timeframeFacetCommon`'s `disconnectedCallback` which has a guard to return when `this.props.host.isConnected` is `true`

Similarly, `atomic-color-facet`, `atomic-category-facet`, `atomic-rating-facet`, and `atomic-rating-range-facet` were not affected by the refactoring because they didn't rely on the `facetCommon`'s `disconnectedCallback` in the first place, and their respective `disconnectedCallback` methods already had a proper guard clause in place.
