### PR TITLE
fix(quantic): Search Interface not triggering an empty search request when pressing browser back button

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -181,6 +181,9 @@ export default class QuanticSearchInterface extends LightningElement {
   }
 
   updateHash() {
+    if (this.urlManager.state.fragment === '') {
+      return;
+    }
     window.history.pushState(
       null,
       document.title,


### PR DESCRIPTION
[SFINT-5539](https://coveord.atlassian.net/browse/SFINT-5539)

### ISSUE:
- When navigating to the Hosted search page from the hosted searchbox with an empty query, it would push `this.urlManager.state.fragment  => ''` in the window history which would mess with the redirection when pressing the browser back button since its not `#q=`. It would redirect from HSP with `#` in url to HSP with `#q=` in the url.

BEFORE:


https://github.com/coveo/ui-kit/assets/73316533/fde48eb1-3826-4e6d-b0e6-02526484ac28


### SOLUTION:
- Modified the `updateHash` method to check if `this.urlManager.state.fragment === ''` before pushing the fragment from the url Manager to the window history. If its equal to '' then it returns instead of adding it to the window history.
- Will add E2E test for this edge case in the SFINT package in the HSP/Hosted searchbox test suite.

### DEMO:

https://github.com/coveo/ui-kit/assets/73316533/7888b1ac-2f79-4833-a843-e1259e28836e


