### PR TITLE
feat: update search action cause to browseResults in insight-search and pagination

### DIFF
--- a/packages/headless/src/controllers/insight/pager/headless-insight-pager.ts
+++ b/packages/headless/src/controllers/insight/pager/headless-insight-pager.ts
@@ -1,10 +1,6 @@
 import {InsightEngine} from '../../../app/insight-engine/insight-engine';
 import {fetchPage} from '../../../features/insight-search/insight-search-actions';
-import {
-  pagerNext,
-  pagerNumber,
-  pagerPrevious,
-} from '../../../features/pagination/pagination-analytics-actions';
+import {browseResults} from '../../../features/pagination/pagination-analytics-actions';
 import {
   logPageNumber,
   logPageNext,
@@ -44,17 +40,17 @@ export function buildPager(
 
     selectPage(page: number) {
       pager.selectPage(page);
-      dispatch(fetchPage({legacy: logPageNumber(), next: pagerNumber()}));
+      dispatch(fetchPage({legacy: logPageNumber(), next: browseResults()}));
     },
 
     nextPage() {
       pager.nextPage();
-      dispatch(fetchPage({legacy: logPageNext(), next: pagerNext()}));
+      dispatch(fetchPage({legacy: logPageNext(), next: browseResults()}));
     },
 
     previousPage() {
       pager.previousPage();
-      dispatch(fetchPage({legacy: logPagePrevious(), next: pagerPrevious()}));
+      dispatch(fetchPage({legacy: logPagePrevious(), next: browseResults()}));
     },
   };
 }

--- a/packages/headless/src/controllers/insight/results-per-page/headless-insight-results-per-page.ts
+++ b/packages/headless/src/controllers/insight/results-per-page/headless-insight-results-per-page.ts
@@ -2,7 +2,7 @@ import {InsightEngine} from '../../../app/insight-engine/insight-engine';
 import {executeSearch} from '../../../features/insight-search/insight-search-actions';
 import {
   logPagerResize,
-  pagerResize,
+  browseResults,
 } from '../../../features/pagination/pagination-analytics-actions';
 import {
   ResultsPerPage,
@@ -44,7 +44,9 @@ export function buildResultsPerPage(
 
     set(num: number) {
       coreController.set(num);
-      dispatch(executeSearch({legacy: logPagerResize(), next: pagerResize()}));
+      dispatch(
+        executeSearch({legacy: logPagerResize(), next: browseResults()})
+      );
     },
   };
 }

--- a/packages/headless/src/controllers/pager/headless-pager.ts
+++ b/packages/headless/src/controllers/pager/headless-pager.ts
@@ -3,6 +3,7 @@ import {
   logPageNumber,
   logPageNext,
   logPagePrevious,
+  browseResults,
 } from '../../features/pagination/pagination-analytics-actions';
 import {fetchPage} from '../../features/search/search-actions';
 import {
@@ -39,17 +40,17 @@ export function buildPager(
 
     selectPage(page: number) {
       pager.selectPage(page);
-      dispatch(fetchPage({legacy: logPageNumber()}));
+      dispatch(fetchPage({legacy: logPageNumber(), next: browseResults()}));
     },
 
     nextPage() {
       pager.nextPage();
-      dispatch(fetchPage({legacy: logPageNext()}));
+      dispatch(fetchPage({legacy: logPageNext(), next: browseResults()}));
     },
 
     previousPage() {
       pager.previousPage();
-      dispatch(fetchPage({legacy: logPagePrevious()}));
+      dispatch(fetchPage({legacy: logPagePrevious(), next: browseResults()}));
     },
   };
 }

--- a/packages/headless/src/features/analytics/legacy-search-action-cause.ts
+++ b/packages/headless/src/features/analytics/legacy-search-action-cause.ts
@@ -1,0 +1,22 @@
+export enum LegacySearchPageEvents {
+  /**
+   * Identifies the custom event that gets logged when the Results per page component is selected.
+   */
+  pagerResize = 'pagerResize',
+  /**
+   * Identifies the custom event that gets logged when a page number is selected and more items are loaded.
+   */
+  pagerNumber = 'pagerNumber',
+  /**
+   * Identifies the custom event that gets logged when the Next Page link is selected and more items are loaded.
+   */
+  pagerNext = 'pagerNext',
+  /**
+   * Identifies the custom event that gets logged when the Previous Page link is selected and more items are loaded.
+   */
+  pagerPrevious = 'pagerPrevious',
+  /**
+   * Identifies the custom event that gets logged when the user scrolls to the bottom of the item page and more results are loaded.
+   */
+  pagerScrolling = 'pagerScrolling',
+}

--- a/packages/headless/src/features/analytics/search-action-cause.ts
+++ b/packages/headless/src/features/analytics/search-action-cause.ts
@@ -80,25 +80,9 @@ export enum SearchPageEvents {
    */
   triggerRedirect = 'redirect',
   /**
-   * Identifies the custom event that gets logged when the Results per page component is selected.
+   * Identifies the search cause that gets logged for pagination and other user navigation that do not express a new search intent.
    */
-  pagerResize = 'pagerResize',
-  /**
-   * Identifies the custom event that gets logged when a page number is selected and more items are loaded.
-   */
-  pagerNumber = 'pagerNumber',
-  /**
-   * Identifies the custom event that gets logged when the Next Page link is selected and more items are loaded.
-   */
-  pagerNext = 'pagerNext',
-  /**
-   * Identifies the custom event that gets logged when the Previous Page link is selected and more items are loaded.
-   */
-  pagerPrevious = 'pagerPrevious',
-  /**
-   * Identifies the custom event that gets logged when the user scrolls to the bottom of the item page and more results are loaded.
-   */
-  pagerScrolling = 'pagerScrolling',
+  browseResults = 'browseResults',
   /**
    * Identifies the search event that gets logged when the clearing all selected values of a static filter.
    */

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -184,7 +184,7 @@ export const fetchMoreResults = createAsyncThunk<
   });
 
   const eventDescription = buildEventDescription({
-    actionCause: SearchPageEvents.pagerScrolling,
+    actionCause: SearchPageEvents.browseResults,
   });
 
   const request = await buildInsightFetchMoreResultsRequest(

--- a/packages/headless/src/features/insight-search/insight-search-analytics-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-analytics-actions.ts
@@ -8,7 +8,7 @@ import {getCaseContextAnalyticsMetadata} from '../case-context/case-context-stat
 import {getQueryInitialState} from '../query/query-state';
 
 export const logFetchMoreResults = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.pagerScrolling)(
+  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
     'search/logFetchMoreResults',
     (client, state) =>
       client.logFetchMoreResults(

--- a/packages/headless/src/features/pagination/pagination-analytics-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-analytics-actions.ts
@@ -39,18 +39,6 @@ export const logPagePrevious = (): LegacySearchAction =>
   );
 
 // TODO KIT-2983
-export const pagerResize = (): SearchAction => ({
-  actionCause: SearchPageEvents.pagerResize,
-});
-
-export const pagerNext = (): SearchAction => ({
-  actionCause: SearchPageEvents.pagerNext,
-});
-
-export const pagerPrevious = (): SearchAction => ({
-  actionCause: SearchPageEvents.pagerPrevious,
-});
-
-export const pagerNumber = (): SearchAction => ({
-  actionCause: SearchPageEvents.pagerNumber,
+export const browseResults = (): SearchAction => ({
+  actionCause: SearchPageEvents.browseResults,
 });

--- a/packages/headless/src/features/pagination/pagination-insight-analytics-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-insight-analytics-actions.ts
@@ -3,12 +3,12 @@ import {
   makeInsightAnalyticsActionFactory,
   InsightAction,
 } from '../analytics/analytics-utils';
-import {SearchPageEvents} from '../analytics/search-action-cause';
+import {LegacySearchPageEvents} from '../analytics/legacy-search-action-cause';
 import {getCaseContextAnalyticsMetadata} from '../case-context/case-context-state';
 import {currentPageSelector} from './pagination-selectors';
 
 export const logPageNumber = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
+  makeInsightAnalyticsActionFactory(LegacySearchPageEvents.pagerNumber)(
     'analytics/pager/number',
     (client, state) =>
       client.logPagerNumber({
@@ -18,7 +18,7 @@ export const logPageNumber = (): InsightAction =>
   );
 
 export const logPageNext = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
+  makeInsightAnalyticsActionFactory(LegacySearchPageEvents.pagerNext)(
     'analytics/pager/next',
     (client, state) =>
       client.logPagerNext({
@@ -28,7 +28,7 @@ export const logPageNext = (): InsightAction =>
   );
 
 export const logPagePrevious = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
+  makeInsightAnalyticsActionFactory(LegacySearchPageEvents.pagerPrevious)(
     'analytics/pager/previous',
     (client, state) =>
       client.logPagerPrevious({

--- a/packages/headless/src/features/pagination/pagination-insight-analytics-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-insight-analytics-actions.ts
@@ -8,7 +8,7 @@ import {getCaseContextAnalyticsMetadata} from '../case-context/case-context-stat
 import {currentPageSelector} from './pagination-selectors';
 
 export const logPageNumber = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.pagerNumber)(
+  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
     'analytics/pager/number',
     (client, state) =>
       client.logPagerNumber({
@@ -18,7 +18,7 @@ export const logPageNumber = (): InsightAction =>
   );
 
 export const logPageNext = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.pagerNext)(
+  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
     'analytics/pager/next',
     (client, state) =>
       client.logPagerNext({
@@ -28,7 +28,7 @@ export const logPageNext = (): InsightAction =>
   );
 
 export const logPagePrevious = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(SearchPageEvents.pagerPrevious)(
+  makeInsightAnalyticsActionFactory(SearchPageEvents.browseResults)(
     'analytics/pager/previous',
     (client, state) =>
       client.logPagerPrevious({

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -183,7 +183,7 @@ export const fetchMoreResults = createAsyncThunk<
   }
 
   const analyticsAction = makeBasicNewSearchAnalyticsAction(
-    SearchPageEvents.pagerScrolling,
+    SearchPageEvents.browseResults,
     config.getState
   );
 

--- a/packages/headless/src/integration-tests/analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/analytics-migration.test.ts
@@ -126,15 +126,34 @@ const legacySearchEngine = buildSearchEngine({
   },
 });
 
-export function assertNextEqualsLegacy(call: jest.SpyInstance) {
-  expect(extractAndExcludeProperties(call, 0)).toEqual(
-    extractAndExcludeProperties(call, 1)
+export function assertNextEqualsLegacy(
+  call: jest.SpyInstance,
+  excludedProperties: string[] = excludedBaseProperties
+) {
+  expect(extractAndExcludeProperties(call, 0, excludedProperties)).toEqual(
+    extractAndExcludeProperties(call, 1, excludedProperties)
+  );
+}
+
+export function assertActionCause(
+  call: jest.SpyInstance,
+  callIndex: number,
+  expectedActionCause: string
+) {
+  expect(call).toHaveBeenNthCalledWith(
+    callIndex,
+    expect.objectContaining({
+      requestParams: expect.objectContaining({
+        analytics: expect.objectContaining({actionCause: expectedActionCause}),
+      }),
+    })
   );
 }
 
 export function extractAndExcludeProperties(
   call: jest.SpyInstance,
-  callIndex: number
+  callIndex: number,
+  excludedProperties: string[]
 ): Record<string, unknown> {
   const {
     requestParams: {analytics = {} as Record<string, unknown>},
@@ -142,7 +161,7 @@ export function extractAndExcludeProperties(
     requestParams: {analytics?: Record<string, unknown>};
   };
   let result = analytics;
-  result = excludeProperties(result, excludedBaseProperties);
+  result = excludeProperties(result, excludedProperties);
   return result;
 }
 
@@ -155,7 +174,7 @@ function excludeProperties(
   return result;
 }
 
-const excludedBaseProperties = [
+export const excludedBaseProperties = [
   'clientId',
   'capture',
   'clientTimestamp',

--- a/packages/headless/src/integration-tests/insight-analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/insight-analytics-migration.test.ts
@@ -62,11 +62,7 @@ import {
   logInsightInterfaceChange,
   logInsightInterfaceLoad,
 } from '../features/insight-search/insight-search-analytics-actions';
-import {
-  pagerNext,
-  pagerNumber,
-  pagerPrevious,
-} from '../features/pagination/pagination-analytics-actions';
+import {browseResults} from '../features/pagination/pagination-analytics-actions';
 import {
   logPageNext,
   logPagePrevious,
@@ -442,7 +438,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/pager/next', async () => {
     const action = fetchPage({
       legacy: logPageNext(),
-      next: pagerNext(),
+      next: browseResults(),
     });
 
     legacyInsightEngine.dispatch(action);
@@ -455,7 +451,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/pager/previous', async () => {
     const action = fetchPage({
       legacy: logPagePrevious(),
-      next: pagerPrevious(),
+      next: browseResults(),
     });
 
     legacyInsightEngine.dispatch(action);
@@ -468,7 +464,7 @@ describe('Analytics Search Migration', () => {
   it('analytics/pager/number', async () => {
     const action = fetchPage({
       legacy: logPageNumber(),
-      next: pagerNumber(),
+      next: browseResults(),
     });
 
     legacyInsightEngine.dispatch(action);

--- a/packages/headless/src/integration-tests/insight-analytics-migration.test.ts
+++ b/packages/headless/src/integration-tests/insight-analytics-migration.test.ts
@@ -78,7 +78,11 @@ import {
 } from '../features/static-filter-set/static-filter-set-actions';
 import {logInsightStaticFilterDeselect} from '../features/static-filter-set/static-filter-set-insight-analytics-actions';
 import {clearMicrotaskQueue} from '../test/unit-test-utils';
-import {assertNextEqualsLegacy} from './analytics-migration.test';
+import {
+  assertActionCause,
+  assertNextEqualsLegacy,
+  excludedBaseProperties,
+} from './analytics-migration.test';
 
 function getSampleInsightEngineConfiguration(): InsightEngineConfiguration {
   return {
@@ -442,10 +446,13 @@ describe('Analytics Search Migration', () => {
     });
 
     legacyInsightEngine.dispatch(action);
+    await clearMicrotaskQueue();
     nextInsightEngine.dispatch(action);
     await clearMicrotaskQueue();
 
-    assertNextEqualsLegacy(callSpy);
+    assertNextEqualsLegacy(callSpy, [...excludedBaseProperties, 'actionCause']);
+    assertActionCause(callSpy, 1, 'pagerNext');
+    assertActionCause(callSpy, 2, 'browseResults');
   });
 
   it('analytics/pager/previous', async () => {
@@ -455,10 +462,13 @@ describe('Analytics Search Migration', () => {
     });
 
     legacyInsightEngine.dispatch(action);
+    await clearMicrotaskQueue();
     nextInsightEngine.dispatch(action);
     await clearMicrotaskQueue();
 
-    assertNextEqualsLegacy(callSpy);
+    assertNextEqualsLegacy(callSpy, [...excludedBaseProperties, 'actionCause']);
+    assertActionCause(callSpy, 1, 'pagerPrevious');
+    assertActionCause(callSpy, 2, 'browseResults');
   });
 
   it('analytics/pager/number', async () => {
@@ -468,10 +478,13 @@ describe('Analytics Search Migration', () => {
     });
 
     legacyInsightEngine.dispatch(action);
+    await clearMicrotaskQueue();
     nextInsightEngine.dispatch(action);
     await clearMicrotaskQueue();
 
-    assertNextEqualsLegacy(callSpy);
+    assertNextEqualsLegacy(callSpy, [...excludedBaseProperties, 'actionCause']);
+    assertActionCause(callSpy, 1, 'pagerNumber');
+    assertActionCause(callSpy, 2, 'browseResults');
   });
 
   it('analytics/facet/showMore', async () => {


### PR DESCRIPTION
The search action cause `pagerScrolling` has been updated to `browseResults` in the `insight-search` and `pagination` features. This change ensures consistent logging of user navigation actions.

https://coveord.atlassian.net/browse/KIT-2983
