### PR TITLE
docs(headless): generate documentation for new headless commerce controllers

### DIFF
--- a/packages/headless/doc-parser/use-cases/commerce.ts
+++ b/packages/headless/doc-parser/use-cases/commerce.ts
@@ -12,7 +12,23 @@ const controllers: ControllerConfiguration[] = [
     samplePaths: {},
   },
   {
+    initializer: 'buildFieldSuggestionsGenerator',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildInstantProducts',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildNotifyTrigger',
+    samplePaths: {},
+  },
+  {
     initializer: 'buildProductListing',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildProductTemplatesManager',
     samplePaths: {},
   },
   {
@@ -20,7 +36,19 @@ const controllers: ControllerConfiguration[] = [
     samplePaths: {},
   },
   {
+    initializer: 'buildQueryTrigger',
+    samplePaths: {},
+  },
+  {
     initializer: 'buildRecommendations',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildRedirectionTrigger',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildRecentQueriesList',
     samplePaths: {},
   },
   {
@@ -29,6 +57,10 @@ const controllers: ControllerConfiguration[] = [
   },
   {
     initializer: 'buildSearchBox',
+    samplePaths: {},
+  },
+  {
+    initializer: 'buildStandaloneSearchBox',
     samplePaths: {},
   },
 ];

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -187,17 +187,29 @@ export type {
 
 export {buildRecentQueriesList} from './controllers/commerce/recent-queries-list/headless-recent-queries-list';
 export type {RecentQueriesList} from './controllers/commerce/recent-queries-list/headless-recent-queries-list';
+export type {
+  RecentQueriesListOptions,
+  RecentQueriesListProps,
+  RecentQueriesListInitialState,
+  RecentQueriesState,
+} from './controllers/recent-queries-list/headless-recent-queries-list.ts';
 
 export {buildInstantProducts} from './controllers/commerce/instant-products/headless-instant-products';
 export type {
   InstantProducts,
   InstantProductsState,
+  InstantProductsOptions,
+  InstantProductsProps,
 } from './controllers/commerce/instant-products/headless-instant-products';
 export {buildStandaloneSearchBox} from './controllers/commerce/standalone-search-box/headless-standalone-search-box';
 export type {
   StandaloneSearchBox,
   StandaloneSearchBoxState,
 } from './controllers/commerce/standalone-search-box/headless-standalone-search-box';
+export type {
+  StandaloneSearchBoxProps,
+  StandaloneSearchBoxOptions,
+} from './controllers/standalone-search-box/headless-standalone-search-box.ts';
 
 export type {
   UrlManagerProps,
@@ -206,6 +218,7 @@ export type {
   UrlManager,
 } from './controllers/commerce/core/url-manager/headless-core-url-manager';
 
+export type {Template} from './features/templates/templates-manager.ts';
 export type {
   ProductTemplate,
   ProductTemplateCondition,
@@ -270,6 +283,7 @@ export type {
   CategoryFieldSuggestionsState,
 } from './controllers/commerce/field-suggestions/headless-category-field-suggestions';
 export type {FieldSuggestionsGenerator} from './controllers/commerce/field-suggestions/headless-field-suggestions-generator';
+export type {FieldSuggestionsFacet} from './features/commerce/facets/field-suggestions-order/field-suggestions-order-state.ts';
 export {buildFieldSuggestionsGenerator} from './controllers/commerce/field-suggestions/headless-field-suggestions-generator';
 
 export type {FetchQuerySuggestionsActionCreatorPayload} from './features/query-suggest/query-suggest-actions';

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.ts
@@ -38,6 +38,11 @@ export interface FieldSuggestionsGenerator extends Controller {
   state: FieldSuggestionsFacet[];
 }
 
+/**
+ * Builds a field suggestions generator controller for a given commerce engine.
+ * @param engine The commerce engine.
+ * @returns The field suggestions generator controller.
+ */
 export function buildFieldSuggestionsGenerator(
   engine: CommerceEngine
 ): FieldSuggestionsGenerator {

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.ts
@@ -35,6 +35,9 @@ export interface FieldSuggestionsGenerator extends Controller {
    */
   fieldSuggestions: GeneratedFieldSuggestionsControllers;
 
+  /**
+   * The state of the field suggestions generator.
+   */
   state: FieldSuggestionsFacet[];
 }
 

--- a/packages/headless/src/controllers/commerce/recent-queries-list/headless-recent-queries-list.ts
+++ b/packages/headless/src/controllers/commerce/recent-queries-list/headless-recent-queries-list.ts
@@ -110,7 +110,6 @@ export function validateRecentQueriesProps(
  * @param props - The configuration `RecentQueriesList` properties.
  * @returns A `RecentQueriesList` controller instance.
  *
- * @internal
  * */
 export function buildRecentQueriesList(
   engine: CommerceEngine,

--- a/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
@@ -60,8 +60,6 @@ export interface StandaloneSearchBoxState extends SearchBoxState {
  * @param engine - The headless commerce engine.
  * @param props - The configurable `StandaloneSearchBox` properties.
  * @returns A `StandaloneSearchBox` controller instance.
- *
- * @internal
  */
 export function buildStandaloneSearchBox(
   engine: CommerceEngine,

--- a/packages/headless/src/features/commerce/product-templates/product-templates-manager.ts
+++ b/packages/headless/src/features/commerce/product-templates/product-templates-manager.ts
@@ -13,14 +13,14 @@ export interface ProductTemplatesManager<Content = unknown> {
    * Registers any number of product templates in the manager.
    * @param templates (...Template<Product, Content>) A list of templates to register.
    */
-  registerTemplates(...templates: Template<Product, Content>[]): void;
+  registerTemplates: (...templates: Template<Product, Content>[]) => void;
   /**
    * Selects the highest priority template for which the given product satisfies all conditions.
    * In the case where satisfied templates have equal priority, the template that was registered first is returned.
    * @param product (Product) The product for which to select a template.
    * @returns (Content) The content of the selected template, or null if no template can be selected for the given product.
    */
-  selectTemplate(product: Product): Content | null;
+  selectTemplate: (product: Product) => Content | null;
 }
 
 /**


### PR DESCRIPTION
We already generate [hidden docs](https://docs.coveo.com/en/headless/latest/reference/commerce) for several headless commerce controllers and actions, this PR covers more controllers.
https://coveord.atlassian.net/browse/KIT-3304