### PR TITLE
fix(atomic): remove boundary validation on numeric inputs

### DIFF
--- a/packages/atomic/src/components/commerce/facets/facet-number-input/atomic-commerce-facet-number-input.tsx
+++ b/packages/atomic/src/components/commerce/facets/facet-number-input/atomic-commerce-facet-number-input.tsx
@@ -56,8 +56,14 @@ export class FacetNumberInput {
     ]);
   }
 
-  private get minimumInputValue() {
-    return isUndefined(this.start) ? Number.MIN_SAFE_INTEGER : this.start;
+  private get absoluteMinimum(): number {
+    const {field} = this.facet.state;
+    const isPriceField = ['ec_price', 'ec_promo_price'].includes(field);
+    return isPriceField ? 0 : Number.MIN_SAFE_INTEGER;
+  }
+
+  private get minimumInputValue(): number {
+    return isUndefined(this.start) ? this.absoluteMinimum : this.start;
   }
 
   private get maximumInputValue() {
@@ -105,7 +111,7 @@ export class FacetNumberInput {
           class={inputClasses}
           aria-label={minAria}
           required
-          min={Number.MIN_SAFE_INTEGER}
+          min={this.absoluteMinimum}
           max={this.maximumInputValue}
           value={this.range?.start}
           onInput={(e) =>


### PR DESCRIPTION
The boundary limit considers only the domain returned by the API and the input value. However, if the product price is determined by multiple fields (e.g., ec_price, ec_promo_price, ec_something_price, etc.), the boundary validation will fail (see image below).

To prevent this issue, I removed the validation that checks against the domain range returned by the API.

![image](https://github.com/coveo/ui-kit/assets/12199712/3f85d352-cc3c-4122-a4ae-c37a92ba693b)

https://coveord.atlassian.net/browse/KIT-3301