### PR TITLE
fix(atomic): fix collapse-facets-after support for atomic-commerce-facets

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -275,6 +275,10 @@ export namespace Components {
          */
         "facet": CategoryFacet;
         /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed": boolean;
+        /**
           * The summary controller instance.
          */
         "summary": SearchSummary | ListingSummary;
@@ -289,6 +293,10 @@ export namespace Components {
           * The facet controller instance.
          */
         "facet": RegularFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed": boolean;
         /**
           * The Summary controller instance.
          */
@@ -394,6 +402,10 @@ export namespace Components {
           * The numeric facet controller instance.
          */
         "facet": NumericFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed": boolean;
         /**
           * The Summary controller instance.
          */
@@ -658,6 +670,10 @@ export namespace Components {
           * The date facet controller instance.
          */
         "facet": DateFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed": boolean;
         /**
           * The summary controller instance.
          */
@@ -5664,6 +5680,10 @@ declare namespace LocalJSX {
          */
         "facet": CategoryFacet;
         /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed"?: boolean;
+        /**
           * The summary controller instance.
          */
         "summary": SearchSummary | ListingSummary;
@@ -5678,6 +5698,10 @@ declare namespace LocalJSX {
           * The facet controller instance.
          */
         "facet": RegularFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed"?: boolean;
         /**
           * The Summary controller instance.
          */
@@ -5772,6 +5796,10 @@ declare namespace LocalJSX {
           * The numeric facet controller instance.
          */
         "facet": NumericFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed"?: boolean;
         /**
           * The Summary controller instance.
          */
@@ -6008,6 +6036,10 @@ declare namespace LocalJSX {
           * The date facet controller instance.
          */
         "facet": DateFacet;
+        /**
+          * Specifies whether the facet is collapsed.
+         */
+        "isCollapsed"?: boolean;
         /**
           * The summary controller instance.
          */

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
@@ -64,13 +64,15 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
    * The category facet controller instance.
    */
   @Prop() public facet!: CategoryFacet;
+  /**
+   * Specifies whether the facet is collapsed.
+   */
+  @Prop({reflect: true, mutable: true}) public isCollapsed = false;
 
   @BindStateToController('facet')
   @State()
   public facetState!: CategoryFacetState;
   @State() public error!: Error;
-
-  @State() private isCollapsed = false;
 
   private resultIndexToFocusOnShowMore = 0;
   private showLessFocus?: FocusTargetController;

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
@@ -66,6 +66,10 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
    * The facet controller instance.
    */
   @Prop() public facet!: RegularFacet;
+  /**
+   * Specifies whether the facet is collapsed.
+   */
+  @Prop({reflect: true, mutable: true}) public isCollapsed = false;
 
   @BindStateToController('facet')
   @State()
@@ -73,7 +77,6 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
 
   @State() public error!: Error;
 
-  @State() private isCollapsed = false;
   private showLessFocus?: FocusTargetController;
   private showMoreFocus?: FocusTargetController;
   private headerFocus?: FocusTargetController;

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tsx
@@ -52,7 +52,6 @@ export class AtomicCommerceNumericFacet
 
   @State() public error!: Error;
 
-  @State() private isCollapsed = false;
   private manualRanges: (NumericRangeRequest & {label?: string})[] = [];
   private formatter: NumberFormatter = defaultNumberFormatter;
 
@@ -64,6 +63,10 @@ export class AtomicCommerceNumericFacet
    * The numeric facet controller instance.
    */
   @Prop({reflect: true}) public facet!: NumericFacet;
+  /**
+   * Specifies whether the facet is collapsed.
+   */
+  @Prop({reflect: true, mutable: true}) public isCollapsed = false;
 
   private headerFocus?: FocusTargetController;
 

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tsx
@@ -52,13 +52,16 @@ export class AtomicCommerceTimeframeFacet
    * The date facet controller instance.
    */
   @Prop() public facet!: DateFacet;
+  /**
+   * Specifies whether the facet is collapsed.
+   */
+  @Prop({reflect: true, mutable: true}) public isCollapsed = false;
 
   @BindStateToController('facet')
   @State()
   public facetState?: DateFacetState;
   @State() public error!: Error;
 
-  @State() private isCollapsed = false;
   @State() private inputRange?: DateFilterRange;
 
   private headerFocus?: FocusTargetController;


### PR DESCRIPTION
`atomic-commerce-facets` sets the `isCollapsed` prop in its `render()` function: However they were not configured as property correctly on each component, just an internal state variable. So nothing was happening.


https://coveord.atlassian.net/browse/KIT-3300