### PR TITLE
fix(atomic): collapsed answer gradient colour

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -105,7 +105,7 @@
   }
   &.answer-collapsed:before {
     @apply h-full w-full absolute top-0 left-0 content-[''];
-    background: linear-gradient(transparent 11.25rem, white);
+    background: linear-gradient(transparent 11.25rem, var(--atomic-background));
   }
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3313

Right now, the linear-gradient is hardcoded to white rather than to the background atomic colour. This will create issues when clients modify their background colour to something other than white, like we doc on the docs site when in dark mode.

<img width="1222" alt="Screenshot 2024-06-11 at 3 34 27 PM" src="https://github.com/coveo/ui-kit/assets/39384459/967e0fdc-923d-4554-a290-a795c7b66b66">

It doesn't seem possible for clients to change the linear-gradient. Probably because it requires targeting a pseudo-element of a part with a certain class. So, in this PR, I use the atomic-background colour instead.