### PR TITLE
test(atomic): searchbox regression E2E tests

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -372,14 +372,14 @@ export class AtomicCommerceSearchBox
   }
 
   private onSubmit() {
-    if (this.suggestionManager.isRightPanelInFocus()) {
-      this.suggestionManager.clickOnActiveElement();
+    this.isExpanded = false;
+
+    if (this.suggestionManager.hasActiveDescendant) {
+      this.suggestionManager.onSubmit();
       return;
     }
 
-    this.isExpanded = false;
     this.searchBox.submit();
-    this.suggestionManager.onSubmit();
   }
 
   private onKeyDown(e: KeyboardEvent) {

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
@@ -78,6 +78,25 @@ test.describe('with instant results & query suggestions', () => {
       const accessibilityResults = await makeAxeBuilder().analyze();
       expect(accessibilityResults.violations).toEqual([]);
     });
+
+    test('should display in the search box what has been submitted', async ({
+      searchBox,
+    }) => {
+      await searchBox.searchInput.fill('Rec');
+      await searchBox.searchInput.press('Enter');
+      await expect(searchBox.searchInput).toHaveValue('Rec');
+    });
+
+    test.describe('after focusing on suggestion with the mouse', () => {
+      test('should submit what is in the search box regardless of the mouse position', async ({
+        searchBox,
+      }) => {
+        await searchBox.searchInput.fill('Rec');
+        await searchBox.searchSuggestions({listSide: 'Left'}).first().hover();
+        await searchBox.searchInput.press('Enter');
+        await expect(searchBox.searchInput).toHaveValue('Rec');
+      });
+    });
   });
 });
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/page-object.ts
@@ -21,7 +21,7 @@ export class AtomicCommerceSearchBoxLocators {
   }: {index?: number; total?: number; listSide?: 'Left' | 'Right'} = {}) {
     return this.page.getByLabel(
       new RegExp(
-        `suggested query\\. ${index ?? '\\d'} of ${total ?? '\\d'}\\.${this.listSideAffix(listSide)}`
+        `suggested query\\..*? ${index ?? '\\d'} of ${total ?? '\\d'}\\.${this.listSideAffix(listSide)}`
       )
     );
   }

--- a/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
@@ -105,7 +105,7 @@ export class SuggestionManager<SearchBoxController> {
   }
 
   public onSubmit() {
-    this.updateActiveDescendant();
+    this.clickOnActiveElement();
     this.clearSuggestions();
   }
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -403,14 +403,14 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
   }
 
   private onSubmit() {
-    if (this.suggestionManager.isRightPanelInFocus()) {
-      this.suggestionManager.clickOnActiveElement();
+    this.isExpanded = false;
+
+    if (this.suggestionManager.hasActiveDescendant) {
+      this.suggestionManager.onSubmit();
       return;
     }
 
-    this.isExpanded = false;
     this.searchBox.submit();
-    this.suggestionManager.onSubmit();
   }
 
   private onKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
To avoid re-introducing the bug fixed by https://github.com/coveo/ui-kit/pull/3582.

This is an issue that was brought up by more than one client, so let's not bring it back :P 

_Also. it is expected that the playwright E2E test is failing_