### PR TITLE
feat(headless commerce): retrieve clientId from Relay instead of coveoua when building commerce API requests

### DIFF
--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -89,15 +89,15 @@ describe('commerce common actions', () => {
       };
     });
 
-    it('given a state with no commercePagination section, returns the expected base request', async () => {
+    it('given a state with no commercePagination section, returns the expected base request', () => {
       delete state.commercePagination;
 
-      const request = await Actions.buildBaseCommerceAPIRequest(state, relay);
+      const request = Actions.buildBaseCommerceAPIRequest(state, relay);
 
       expect(request).toEqual({...expected});
     });
 
-    it('given a state that has the commercePagination section, returns expected base request with expected #page and #perPage', async () => {
+    it('given a state that has the commercePagination section, returns expected base request with expected #page and #perPage', () => {
       state.commercePagination = {
         ...getCommercePaginationInitialState(),
         principal: {
@@ -113,12 +113,12 @@ describe('commerce common actions', () => {
         perPage: state.commercePagination.principal.perPage,
       };
 
-      const request = await Actions.buildBaseCommerceAPIRequest(state, relay);
+      const request = Actions.buildBaseCommerceAPIRequest(state, relay);
 
       expect(request).toEqual(expectedWithPagination);
     });
 
-    it('given a slotId, returns expected base request with the effective pagination for that slot', async () => {
+    it('given a slotId, returns expected base request with the effective pagination for that slot', () => {
       const slotId = 'slot_id';
       state.commercePagination = {
         ...getCommercePaginationInitialState(),
@@ -137,11 +137,7 @@ describe('commerce common actions', () => {
         perPage: state.commercePagination.recommendations[slotId]!.perPage,
       };
 
-      const request = await Actions.buildBaseCommerceAPIRequest(
-        state,
-        relay,
-        slotId
-      );
+      const request = Actions.buildBaseCommerceAPIRequest(state, relay, slotId);
 
       expect(request).toEqual(expectedWithPagination);
     });
@@ -159,12 +155,12 @@ describe('commerce common actions', () => {
       );
     });
 
-    it('given a state with none of the optional sections, returns the expected base request along an empty #facets array', async () => {
+    it('given a state with none of the optional sections, returns the expected base request along an empty #facets array', () => {
       delete state.commerceSort;
       delete state.facetOrder;
       delete state.commerceFacetSet;
 
-      const request = await Actions.buildCommerceAPIRequest(state, relay);
+      const request = Actions.buildCommerceAPIRequest(state, relay);
 
       expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
         state,
@@ -172,18 +168,18 @@ describe('commerce common actions', () => {
       );
 
       expect(request).toEqual({
-        ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+        ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
         facets: [],
       });
     });
 
-    it('given a state that has the facetOrder section but not the commerceFacetSet section, returns the expected base request with an empty #facets array', async () => {
+    it('given a state that has the facetOrder section but not the commerceFacetSet section, returns the expected base request with an empty #facets array', () => {
       delete state.commerceSort;
       delete state.commerceFacetSet;
 
       state.facetOrder = ['facet_id'];
 
-      const request = await Actions.buildCommerceAPIRequest(state, relay);
+      const request = Actions.buildCommerceAPIRequest(state, relay);
 
       expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
         state,
@@ -191,12 +187,12 @@ describe('commerce common actions', () => {
       );
 
       expect(request).toEqual({
-        ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+        ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
         facets: [],
       });
     });
 
-    it('given a state that has the commerceFacetSet section but not the facetOrder section, returns the expected base request with an empty #facets array', async () => {
+    it('given a state that has the commerceFacetSet section but not the facetOrder section, returns the expected base request with an empty #facets array', () => {
       delete state.commerceSort;
       delete state.commerceFacetSet;
 
@@ -204,7 +200,7 @@ describe('commerce common actions', () => {
         facet_id: buildMockCommerceFacetSlice(),
       };
 
-      const request = await Actions.buildCommerceAPIRequest(state, relay);
+      const request = Actions.buildCommerceAPIRequest(state, relay);
 
       expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
         state,
@@ -212,17 +208,17 @@ describe('commerce common actions', () => {
       );
 
       expect(request).toEqual({
-        ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+        ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
         facets: [],
       });
     });
 
     it.each([true, false])(
       'sets the capture property from the analytics configuration',
-      async (analyticsEnabled) => {
+      (analyticsEnabled) => {
         state.configuration.analytics.enabled = analyticsEnabled;
 
-        const request = await Actions.buildCommerceAPIRequest(state, relay);
+        const request = Actions.buildCommerceAPIRequest(state, relay);
 
         expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
           state,
@@ -265,8 +261,8 @@ describe('commerce common actions', () => {
           [facet2.request.facetId]: facet2,
         };
       });
-      it('includes all non-empty facets in the #facets array of the returned request', async () => {
-        const request = await Actions.buildCommerceAPIRequest(state, relay);
+      it('includes all non-empty facets in the #facets array of the returned request', () => {
+        const request = Actions.buildCommerceAPIRequest(state, relay);
 
         expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
           state,
@@ -274,12 +270,12 @@ describe('commerce common actions', () => {
         );
 
         expect(request).toEqual({
-          ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+          ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
           facets: [facet1.request, facet2.request],
         });
       });
 
-      it('does not include empty facets in the #facets array of the returned request', async () => {
+      it('does not include empty facets in the #facets array of the returned request', () => {
         const facet3 = buildMockCommerceFacetSlice({
           request: {
             ...buildMockCommerceFacetRequest({
@@ -293,7 +289,7 @@ describe('commerce common actions', () => {
         state.commerceFacetSet![facet3.request.facetId] = facet3;
         state.facetOrder.push(facet3.request.facetId);
 
-        const request = await Actions.buildCommerceAPIRequest(state, relay);
+        const request = Actions.buildCommerceAPIRequest(state, relay);
 
         expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
           state,
@@ -301,7 +297,7 @@ describe('commerce common actions', () => {
         );
 
         expect(request).toEqual({
-          ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+          ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
           facets: [facet1.request, facet2.request],
         });
       });
@@ -313,7 +309,7 @@ describe('commerce common actions', () => {
         delete state.commerceFacetSet;
       });
 
-      it('when applied sort is "relevance", returns expected base request with expected #sort.sortCriteria', async () => {
+      it('when applied sort is "relevance", returns expected base request with expected #sort.sortCriteria', () => {
         state.commerceSort = {
           ...getCommerceSortInitialState(),
           appliedSort: {
@@ -321,7 +317,7 @@ describe('commerce common actions', () => {
           },
         };
 
-        const request = await Actions.buildCommerceAPIRequest(state, relay);
+        const request = Actions.buildCommerceAPIRequest(state, relay);
 
         expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
           state,
@@ -329,7 +325,7 @@ describe('commerce common actions', () => {
         );
 
         const expectedWithSort: CommerceAPIRequest = {
-          ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+          ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
           facets: [],
           sort: {
             sortCriteria: SortBy.Relevance,
@@ -339,7 +335,7 @@ describe('commerce common actions', () => {
         expect(request).toEqual(expectedWithSort);
       });
 
-      it('when applied sort is "fields", returns expected base request with expected #sort.sortCriteria and #sort.fields', async () => {
+      it('when applied sort is "fields", returns expected base request with expected #sort.sortCriteria and #sort.fields', () => {
         const sortCriterion: SortCriterion = {
           by: SortBy.Fields,
           fields: [
@@ -355,7 +351,7 @@ describe('commerce common actions', () => {
           appliedSort: sortCriterion,
         };
 
-        const request = await Actions.buildCommerceAPIRequest(state, relay);
+        const request = Actions.buildCommerceAPIRequest(state, relay);
 
         expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
           state,
@@ -363,7 +359,7 @@ describe('commerce common actions', () => {
         );
 
         const expectedWithSort: CommerceAPIRequest = {
-          ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
+          ...mockedBuildBaseCommerceAPIRequest.mock.results[0].value,
           facets: [],
           sort: {
             sortCriteria: sortCriterion.by,

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -1,3 +1,4 @@
+import {Relay, createRelay} from '@coveo/relay';
 import {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {
   BaseCommerceAPIRequest,
@@ -18,6 +19,14 @@ import {getCommerceSortInitialState} from '../sort/sort-state';
 import * as Actions from './actions';
 
 describe('commerce common actions', () => {
+  let relay: Relay;
+  beforeEach(() => {
+    relay = createRelay({
+      token: 'token',
+      trackingId: 'trackingId',
+      url: 'url',
+    });
+  });
   describe('#buildBaseCommerceAPIRequest', () => {
     let expected: BaseCommerceAPIRequest;
     let state: Actions.StateNeededByQueryCommerceAPI;
@@ -83,7 +92,7 @@ describe('commerce common actions', () => {
     it('given a state with no commercePagination section, returns the expected base request', async () => {
       delete state.commercePagination;
 
-      const request = await Actions.buildBaseCommerceAPIRequest(state);
+      const request = await Actions.buildBaseCommerceAPIRequest(state, relay);
 
       expect(request).toEqual({...expected});
     });
@@ -104,7 +113,7 @@ describe('commerce common actions', () => {
         perPage: state.commercePagination.principal.perPage,
       };
 
-      const request = await Actions.buildBaseCommerceAPIRequest(state);
+      const request = await Actions.buildBaseCommerceAPIRequest(state, relay);
 
       expect(request).toEqual(expectedWithPagination);
     });
@@ -128,7 +137,11 @@ describe('commerce common actions', () => {
         perPage: state.commercePagination.recommendations[slotId]!.perPage,
       };
 
-      const request = await Actions.buildBaseCommerceAPIRequest(state, slotId);
+      const request = await Actions.buildBaseCommerceAPIRequest(
+        state,
+        relay,
+        slotId
+      );
 
       expect(request).toEqual(expectedWithPagination);
     });
@@ -151,9 +164,12 @@ describe('commerce common actions', () => {
       delete state.facetOrder;
       delete state.commerceFacetSet;
 
-      const request = await Actions.buildCommerceAPIRequest(state);
+      const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+        state,
+        relay
+      );
 
       expect(request).toEqual({
         ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -167,9 +183,12 @@ describe('commerce common actions', () => {
 
       state.facetOrder = ['facet_id'];
 
-      const request = await Actions.buildCommerceAPIRequest(state);
+      const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+        state,
+        relay
+      );
 
       expect(request).toEqual({
         ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -185,9 +204,12 @@ describe('commerce common actions', () => {
         facet_id: buildMockCommerceFacetSlice(),
       };
 
-      const request = await Actions.buildCommerceAPIRequest(state);
+      const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+      expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+        state,
+        relay
+      );
 
       expect(request).toEqual({
         ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -200,9 +222,12 @@ describe('commerce common actions', () => {
       async (analyticsEnabled) => {
         state.configuration.analytics.enabled = analyticsEnabled;
 
-        const request = await Actions.buildCommerceAPIRequest(state);
+        const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+          state,
+          relay
+        );
 
         expect(request.context.capture).toEqual(analyticsEnabled);
       }
@@ -241,9 +266,12 @@ describe('commerce common actions', () => {
         };
       });
       it('includes all non-empty facets in the #facets array of the returned request', async () => {
-        const request = await Actions.buildCommerceAPIRequest(state);
+        const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+          state,
+          relay
+        );
 
         expect(request).toEqual({
           ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -265,9 +293,12 @@ describe('commerce common actions', () => {
         state.commerceFacetSet![facet3.request.facetId] = facet3;
         state.facetOrder.push(facet3.request.facetId);
 
-        const request = await Actions.buildCommerceAPIRequest(state);
+        const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+          state,
+          relay
+        );
 
         expect(request).toEqual({
           ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -276,7 +307,7 @@ describe('commerce common actions', () => {
       });
     });
 
-    describe('give a state that has the commerceSort section', () => {
+    describe('given a state that has the commerceSort section', () => {
       beforeEach(() => {
         delete state.facetOrder;
         delete state.commerceFacetSet;
@@ -290,9 +321,12 @@ describe('commerce common actions', () => {
           },
         };
 
-        const request = await Actions.buildCommerceAPIRequest(state);
+        const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+          state,
+          relay
+        );
 
         const expectedWithSort: CommerceAPIRequest = {
           ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),
@@ -321,9 +355,12 @@ describe('commerce common actions', () => {
           appliedSort: sortCriterion,
         };
 
-        const request = await Actions.buildCommerceAPIRequest(state);
+        const request = await Actions.buildCommerceAPIRequest(state, relay);
 
-        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(state);
+        expect(mockedBuildBaseCommerceAPIRequest).toHaveBeenCalledWith(
+          state,
+          relay
+        );
 
         const expectedWithSort: CommerceAPIRequest = {
           ...(await mockedBuildBaseCommerceAPIRequest.mock.results[0].value),

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -33,12 +33,12 @@ export interface QueryCommerceAPIThunkReturn {
   response: CommerceSuccessResponse;
 }
 
-export const buildCommerceAPIRequest = async (
+export const buildCommerceAPIRequest = (
   state: ListingAndSearchStateNeededByQueryCommerceAPI,
   relay: Relay
-): Promise<CommerceAPIRequest> => {
+): CommerceAPIRequest => {
   return {
-    ...(await buildBaseCommerceAPIRequest(state, relay)),
+    ...buildBaseCommerceAPIRequest(state, relay),
     facets: getFacets(state),
     ...(state.commerceSort && {
       sort: getSort(state.commerceSort.appliedSort),
@@ -46,11 +46,11 @@ export const buildCommerceAPIRequest = async (
   };
 };
 
-export const buildBaseCommerceAPIRequest = async (
+export const buildBaseCommerceAPIRequest = (
   state: StateNeededByQueryCommerceAPI,
   relay: Relay,
   slotId?: string
-): Promise<BaseCommerceAPIRequest> => {
+): BaseCommerceAPIRequest => {
   const {view, user, ...restOfContext} = state.commerceContext;
   return {
     accessToken: state.configuration.accessToken,

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -1,5 +1,5 @@
+import {Relay} from '@coveo/relay';
 import {getAnalyticsSource} from '../../../api/analytics/analytics-selectors';
-import {getVisitorID} from '../../../api/analytics/coveo-analytics-utils';
 import {SortParam} from '../../../api/commerce/commerce-api-params';
 import {
   BaseCommerceAPIRequest,
@@ -34,10 +34,11 @@ export interface QueryCommerceAPIThunkReturn {
 }
 
 export const buildCommerceAPIRequest = async (
-  state: ListingAndSearchStateNeededByQueryCommerceAPI
+  state: ListingAndSearchStateNeededByQueryCommerceAPI,
+  relay: Relay
 ): Promise<CommerceAPIRequest> => {
   return {
-    ...(await buildBaseCommerceAPIRequest(state)),
+    ...(await buildBaseCommerceAPIRequest(state, relay)),
     facets: getFacets(state),
     ...(state.commerceSort && {
       sort: getSort(state.commerceSort.appliedSort),
@@ -47,6 +48,7 @@ export const buildCommerceAPIRequest = async (
 
 export const buildBaseCommerceAPIRequest = async (
   state: StateNeededByQueryCommerceAPI,
+  relay: Relay,
   slotId?: string
 ): Promise<BaseCommerceAPIRequest> => {
   const {view, user, ...restOfContext} = state.commerceContext;
@@ -56,7 +58,7 @@ export const buildBaseCommerceAPIRequest = async (
     organizationId: state.configuration.organizationId,
     trackingId: state.configuration.analytics.trackingId,
     ...restOfContext,
-    clientId: await getVisitorID(state.configuration.analytics),
+    clientId: relay.getMeta('').clientId,
     context: {
       user,
       view,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
@@ -1,3 +1,4 @@
+import {Relay, createRelay} from '@coveo/relay';
 import * as Actions from '../../../../../features/commerce/common/actions';
 import {CommerceAppState} from '../../../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../../../test/mock-category-facet-search';
@@ -11,6 +12,7 @@ import {buildCategoryFacetSearchRequest} from './commerce-category-facet-search-
 
 describe('#buildCategoryFacetSearchRequest', () => {
   let state: CommerceAppState;
+  let relay: Relay;
   let facetId: string;
   let query: string;
   let buildCommerceAPIRequestMock: jest.SpyInstance;
@@ -33,13 +35,16 @@ describe('#buildCategoryFacetSearchRequest', () => {
       Actions,
       'buildCommerceAPIRequest'
     );
+
+    relay = createRelay({token: 'token', url: 'url', trackingId: 'trackingId'});
   });
 
   it('returned object has a #facetId property whose value is the passed facet ID argument', async () => {
     const request = await buildCategoryFacetSearchRequest(
       facetId,
       state,
-      false
+      false,
+      relay
     );
 
     expect(request.facetId).toBe(facetId);
@@ -49,7 +54,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
     const request = await buildCategoryFacetSearchRequest(
       facetId,
       state,
-      false
+      false,
+      relay
     );
 
     expect(request.facetQuery).toBe(
@@ -62,7 +68,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
       const request = await buildCategoryFacetSearchRequest(
         facetId,
         state,
-        false
+        false,
+        relay
       );
 
       expect(request.ignorePaths).toStrictEqual([]);
@@ -74,7 +81,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
       const request = await buildCategoryFacetSearchRequest(
         facetId,
         state,
-        false
+        false,
+        relay
       );
 
       expect(request.ignorePaths).toStrictEqual([
@@ -106,7 +114,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
       const request = await buildCategoryFacetSearchRequest(
         facetId,
         state,
-        false
+        false,
+        relay
       );
 
       expect(request.ignorePaths).toStrictEqual([
@@ -137,7 +146,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
     const request = await buildCategoryFacetSearchRequest(
       facetId,
       state,
-      false
+      false,
+      relay
     );
 
     expect(request).toEqual({
@@ -150,7 +160,12 @@ describe('#buildCategoryFacetSearchRequest', () => {
   });
 
   it('when building a field suggestion request, returned request includes all properties returned by #buildCommerceAPIRequest except the #facets, #page, and #sort properties', async () => {
-    const request = await buildCategoryFacetSearchRequest(facetId, state, true);
+    const request = await buildCategoryFacetSearchRequest(
+      facetId,
+      state,
+      true,
+      relay
+    );
 
     const {facets, page, sort, ...expectedBaseRequest} =
       await buildCommerceAPIRequestMock.mock.results[0].value;

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -1,3 +1,4 @@
+import {Relay} from '@coveo/relay';
 import {CategoryFacetSearchRequest} from '../../../../../api/commerce/facet-search/facet-search-request';
 import {buildCommerceAPIRequest} from '../../../common/actions';
 import {
@@ -9,7 +10,8 @@ import {StateNeededForCategoryFacetSearch} from './commerce-category-facet-searc
 export const buildCategoryFacetSearchRequest = async (
   facetId: string,
   state: StateNeededForCategoryFacetSearch,
-  isFieldSuggestionsRequest: boolean
+  isFieldSuggestionsRequest: boolean,
+  relay: Relay
 ): Promise<CategoryFacetSearchRequest> => {
   const baseFacetQuery = state.categoryFacetSearchSet[facetId]!.options.query;
   const facetQuery = `*${baseFacetQuery}*`;
@@ -32,7 +34,7 @@ export const buildCategoryFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = await buildCommerceAPIRequest(state);
+  } = await buildCommerceAPIRequest(state, relay);
 
   return {
     url,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -34,7 +34,7 @@ export const buildCategoryFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = await buildCommerceAPIRequest(state, relay);
+  } = buildCommerceAPIRequest(state, relay);
 
   return {
     url,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
@@ -36,17 +36,26 @@ const getExecuteFacetSearchThunkPayloadCreator =
     ExecuteCommerceFacetSearchThunkArg,
     ExecuteCommerceFacetSearchThunkApiConfig
   > =>
-  async (facetId: string, {getState, extra: {apiClient, validatePayload}}) => {
+  async (
+    facetId: string,
+    {getState, extra: {validatePayload, relay, apiClient}}
+  ) => {
     const state = getState();
     validatePayload(facetId, requiredNonEmptyString);
     const req =
       isRegularFacetSearchState(state, facetId) ||
       isRegularFieldSuggestionsState(state, facetId)
-        ? buildFacetSearchRequest(facetId, state, isFieldSuggestionsRequest)
+        ? buildFacetSearchRequest(
+            facetId,
+            state,
+            isFieldSuggestionsRequest,
+            relay
+          )
         : buildCategoryFacetSearchRequest(
             facetId,
             state,
-            isFieldSuggestionsRequest
+            isFieldSuggestionsRequest,
+            relay
           );
 
     const response = await apiClient.facetSearch(await req);

--- a/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.test.ts
@@ -1,3 +1,4 @@
+import {Relay, createRelay} from '@coveo/relay';
 import * as Actions from '../../../../../features/commerce/common/actions';
 import {CommerceAppState} from '../../../../../state/commerce-app-state';
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
@@ -7,6 +8,7 @@ import {buildFacetSearchRequest} from './commerce-regular-facet-search-request-b
 
 describe('#buildFacetSearchRequest', () => {
   let state: CommerceAppState;
+  let relay: Relay;
   let facetId: string;
   let query: string;
   let buildCommerceAPIRequestMock: jest.SpyInstance;
@@ -25,16 +27,18 @@ describe('#buildFacetSearchRequest', () => {
       Actions,
       'buildCommerceAPIRequest'
     );
+
+    relay = createRelay({token: 'token', url: 'url', trackingId: 'trackingId'});
   });
 
   it('returned object has a #facetId property whose value is the passed facet ID argument', async () => {
-    const request = await buildFacetSearchRequest(facetId, state, false);
+    const request = await buildFacetSearchRequest(facetId, state, false, relay);
 
     expect(request.facetId).toBe(facetId);
   });
 
   it('returned object has a #facetQuery property whose value is the facet query from state between wildcard characters', async () => {
-    const request = await buildFacetSearchRequest(facetId, state, false);
+    const request = await buildFacetSearchRequest(facetId, state, false, relay);
 
     expect(request.facetQuery).toBe(
       `*${state.facetSearchSet[facetId].options.query}*`
@@ -47,7 +51,7 @@ describe('#buildFacetSearchRequest', () => {
       'buildCommerceAPIRequest'
     );
 
-    const request = await buildFacetSearchRequest(facetId, state, false);
+    const request = await buildFacetSearchRequest(facetId, state, false, relay);
 
     expect(request).toEqual({
       ...(await buildCommerceAPIRequestMock.mock.results[0].value),
@@ -58,7 +62,7 @@ describe('#buildFacetSearchRequest', () => {
   });
 
   it('when building a field suggestion request, returned request includes all properties returned by #buildCommerceAPIRequest except the #facets, #page, and #sort properties', async () => {
-    const request = await buildFacetSearchRequest(facetId, state, true);
+    const request = await buildFacetSearchRequest(facetId, state, true, relay);
 
     const {facets, page, sort, ...expectedBaseRequest} =
       await buildCommerceAPIRequestMock.mock.results[0].value;

--- a/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
@@ -30,7 +30,7 @@ export const buildFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = await buildCommerceAPIRequest(state, relay);
+  } = buildCommerceAPIRequest(state, relay);
 
   return {
     url,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
@@ -1,3 +1,4 @@
+import {Relay} from '@coveo/relay';
 import {CommerceFacetSearchRequest} from '../../../../../api/commerce/facet-search/facet-search-request';
 import {buildCommerceAPIRequest} from '../../../common/actions';
 import {StateNeededForRegularFacetSearch} from './commerce-regular-facet-search-state';
@@ -5,7 +6,8 @@ import {StateNeededForRegularFacetSearch} from './commerce-regular-facet-search-
 export const buildFacetSearchRequest = async (
   facetId: string,
   state: StateNeededForRegularFacetSearch,
-  isFieldSuggestionsRequest: boolean
+  isFieldSuggestionsRequest: boolean,
+  relay: Relay
 ): Promise<CommerceFacetSearchRequest> => {
   const baseFacetQuery = state.facetSearchSet[facetId]!.options.query;
   const facetQuery = `*${baseFacetQuery}*`;
@@ -28,7 +30,7 @@ export const buildFacetSearchRequest = async (
     clientId,
     context,
     ...restOfCommerceAPIRequest
-  } = await buildCommerceAPIRequest(state);
+  } = await buildCommerceAPIRequest(state, relay);
 
   return {
     url,

--- a/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
@@ -27,11 +27,13 @@ export const fetchProductListing = createAsyncThunk<
   AsyncThunkCommerceOptions<StateNeededByFetchProductListing>
 >(
   'commerce/productListing/fetch',
-  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
+  async (
+    _action,
+    {getState, dispatch, rejectWithValue, extra: {apiClient, relay}}
+  ) => {
     const state = getState();
-    const {apiClient} = extra;
     const fetched = await apiClient.getProductListing(
-      await buildCommerceAPIRequest(state)
+      await buildCommerceAPIRequest(state, relay)
     );
 
     if (isErrorResponse(fetched)) {
@@ -51,19 +53,21 @@ export const fetchMoreProducts = createAsyncThunk<
   AsyncThunkCommerceOptions<StateNeededByFetchProductListing>
 >(
   'commerce/productListing/fetchMoreProducts',
-  async (_action, {getState, dispatch, rejectWithValue, extra}) => {
+  async (
+    _action,
+    {getState, dispatch, rejectWithValue, extra: {apiClient, relay}}
+  ) => {
     const state = getState();
     const moreProductsAvailable = moreProductsAvailableSelector(state);
     if (!moreProductsAvailable) {
       return null;
     }
-    const {apiClient} = extra;
     const perPage = perPagePrincipalSelector(state);
     const numberOfProducts = numberOfProductsSelector(state);
     const nextPageToRequest = numberOfProducts / perPage;
 
     const fetched = await apiClient.getProductListing({
-      ...(await buildCommerceAPIRequest(state)),
+      ...(await buildCommerceAPIRequest(state, relay)),
       page: nextPageToRequest,
     });
 

--- a/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
+++ b/packages/headless/src/features/commerce/product-listing/product-listing-actions.ts
@@ -33,7 +33,7 @@ export const fetchProductListing = createAsyncThunk<
   ) => {
     const state = getState();
     const fetched = await apiClient.getProductListing(
-      await buildCommerceAPIRequest(state, relay)
+      buildCommerceAPIRequest(state, relay)
     );
 
     if (isErrorResponse(fetched)) {
@@ -67,7 +67,7 @@ export const fetchMoreProducts = createAsyncThunk<
     const nextPageToRequest = numberOfProducts / perPage;
 
     const fetched = await apiClient.getProductListing({
-      ...(await buildCommerceAPIRequest(state, relay)),
+      ...buildCommerceAPIRequest(state, relay),
       page: nextPageToRequest,
     });
 

--- a/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
+++ b/packages/headless/src/features/commerce/recommendations/recommendations-actions.ts
@@ -29,17 +29,13 @@ export interface QueryRecommendationsCommerceAPIThunkReturn {
 export type StateNeededByFetchRecommendations = StateNeededByQueryCommerceAPI &
   RecommendationsSection;
 
-const buildRecommendationCommerceAPIRequest = async (
+const buildRecommendationCommerceAPIRequest = (
   slotId: string,
   state: StateNeededByFetchRecommendations,
   relay: Relay,
   productId?: string
-): Promise<CommerceRecommendationsRequest> => {
-  const commerceAPIRequest = await buildBaseCommerceAPIRequest(
-    state,
-    relay,
-    slotId
-  );
+): CommerceRecommendationsRequest => {
+  const commerceAPIRequest = buildBaseCommerceAPIRequest(state, relay, slotId);
   return {
     ...commerceAPIRequest,
     context: {
@@ -67,7 +63,7 @@ export const fetchRecommendations = createAsyncThunk<
   'commerce/recommendations/fetch',
   async (payload, {getState, rejectWithValue, extra: {apiClient, relay}}) => {
     const {slotId, productId} = payload;
-    const request = await buildRecommendationCommerceAPIRequest(
+    const request = buildRecommendationCommerceAPIRequest(
       slotId,
       getState(),
       relay,
@@ -107,7 +103,7 @@ export const fetchMoreRecommendations = createAsyncThunk<
     const nextPageToRequest = numberOfProducts / perPage;
 
     const request = {
-      ...(await buildRecommendationCommerceAPIRequest(slotId, state, relay)),
+      ...buildRecommendationCommerceAPIRequest(slotId, state, relay),
       page: nextPageToRequest,
     };
     const fetched = await apiClient.getRecommendations(request);

--- a/packages/headless/src/features/commerce/search/search-actions-thunk-processor.test.ts
+++ b/packages/headless/src/features/commerce/search/search-actions-thunk-processor.test.ts
@@ -1,4 +1,4 @@
-import {Relay} from '@coveo/relay';
+import {createRelay} from '@coveo/relay';
 import {Logger} from 'pino';
 import {CommerceAPIClient} from '../../../api/commerce/commerce-api-client';
 import {CommerceAPIErrorStatusResponse} from '../../../api/commerce/commerce-api-error-response';
@@ -29,7 +29,11 @@ describe('commerce AsyncSearchThunkProcessor', () => {
         logger: jest.fn() as unknown as Logger,
         validatePayload: jest.fn(),
         preprocessRequest: jest.fn(),
-        relay: jest.fn() as unknown as Relay,
+        relay: createRelay({
+          token: 'token',
+          url: 'url',
+          trackingId: 'trackingId',
+        }),
         navigatorContext: defaultNodeJSNavigatorContextProvider(),
       },
       getState: jest.fn().mockReturnValue(state),
@@ -48,7 +52,7 @@ describe('commerce AsyncSearchThunkProcessor', () => {
       response,
       duration: 123,
       queryExecuted: 'foo',
-      requestExecuted: await buildCommerceAPIRequest(state),
+      requestExecuted: await buildCommerceAPIRequest(state, config.extra.relay),
     };
     return processor.process(fetched);
   }

--- a/packages/headless/src/features/commerce/search/search-actions-thunk-processor.test.ts
+++ b/packages/headless/src/features/commerce/search/search-actions-thunk-processor.test.ts
@@ -52,7 +52,7 @@ describe('commerce AsyncSearchThunkProcessor', () => {
       response,
       duration: 123,
       queryExecuted: 'foo',
-      requestExecuted: await buildCommerceAPIRequest(state, config.extra.relay),
+      requestExecuted: buildCommerceAPIRequest(state, config.extra.relay),
     };
     return processor.process(fetched);
   }

--- a/packages/headless/src/features/commerce/search/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/commerce/search/search-actions-thunk-processor.ts
@@ -191,7 +191,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
     );
     this.onUpdateQueryForCorrection(modified);
     const fetched = await this.fetchFromAPI({
-      ...(await buildCommerceAPIRequest(this.getState(), this.relay)),
+      ...buildCommerceAPIRequest(this.getState(), this.relay),
       query: modified,
     });
 

--- a/packages/headless/src/features/commerce/search/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/commerce/search/search-actions-thunk-processor.ts
@@ -191,7 +191,7 @@ export class AsyncSearchThunkProcessor<RejectionType> {
     );
     this.onUpdateQueryForCorrection(modified);
     const fetched = await this.fetchFromAPI({
-      ...(await buildCommerceAPIRequest(this.getState())),
+      ...(await buildCommerceAPIRequest(this.getState(), this.relay)),
       query: modified,
     });
 
@@ -208,6 +208,10 @@ export class AsyncSearchThunkProcessor<RejectionType> {
 
   private getState() {
     return this.config.getState();
+  }
+
+  private get relay() {
+    return this.config.extra.relay;
   }
 
   private getCurrentQuery() {

--- a/packages/headless/src/features/commerce/search/search-actions.ts
+++ b/packages/headless/src/features/commerce/search/search-actions.ts
@@ -73,8 +73,9 @@ export const executeSearch = createAsyncThunk<
 >('commerce/search/executeSearch', async (_action, config) => {
   const {getState} = config;
   const state = getState();
+  const {relay} = config.extra;
 
-  const request = await buildCommerceAPIRequest(state);
+  const request = await buildCommerceAPIRequest(state, relay);
   const query = querySelector(state);
 
   const processor = new AsyncSearchThunkProcessor<
@@ -92,6 +93,7 @@ export const fetchMoreProducts = createAsyncThunk<
 >('commerce/search/fetchMoreProducts', async (_action, config) => {
   const {getState} = config;
   const state = getState();
+  const {relay} = config.extra;
 
   const moreProductsAvailable = moreProductsAvailableSelector(state);
   if (!moreProductsAvailable) {
@@ -103,7 +105,7 @@ export const fetchMoreProducts = createAsyncThunk<
   const nextPageToRequest = numberOfProducts / perPage;
   const query = querySelector(state);
 
-  const request = await buildCommerceAPIRequest(state);
+  const request = await buildCommerceAPIRequest(state, relay);
 
   const processor = new AsyncSearchThunkProcessor<
     ReturnType<typeof config.rejectWithValue>
@@ -150,10 +152,10 @@ export const fetchInstantProducts = createAsyncThunk<
   'commerce/search/fetchInstantProducts',
   async (payload, {getState, dispatch, rejectWithValue, extra}) => {
     const state = getState();
+    const {apiClient, relay} = extra;
     const {q} = payload;
-    const {apiClient} = extra;
     const fetched = await apiClient.productSuggestions({
-      ...(await buildCommerceAPIRequest(state)),
+      ...(await buildCommerceAPIRequest(state, relay)),
       query: q,
     });
 

--- a/packages/headless/src/features/commerce/search/search-actions.ts
+++ b/packages/headless/src/features/commerce/search/search-actions.ts
@@ -75,7 +75,7 @@ export const executeSearch = createAsyncThunk<
   const state = getState();
   const {relay} = config.extra;
 
-  const request = await buildCommerceAPIRequest(state, relay);
+  const request = buildCommerceAPIRequest(state, relay);
   const query = querySelector(state);
 
   const processor = new AsyncSearchThunkProcessor<
@@ -105,7 +105,7 @@ export const fetchMoreProducts = createAsyncThunk<
   const nextPageToRequest = numberOfProducts / perPage;
   const query = querySelector(state);
 
-  const request = await buildCommerceAPIRequest(state, relay);
+  const request = buildCommerceAPIRequest(state, relay);
 
   const processor = new AsyncSearchThunkProcessor<
     ReturnType<typeof config.rejectWithValue>
@@ -155,7 +155,7 @@ export const fetchInstantProducts = createAsyncThunk<
     const {apiClient, relay} = extra;
     const {q} = payload;
     const fetched = await apiClient.productSuggestions({
-      ...(await buildCommerceAPIRequest(state, relay)),
+      ...buildCommerceAPIRequest(state, relay),
       query: q,
     });
 

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -78,7 +78,7 @@ export const fetchRedirectUrl = createAsyncThunk<
   async (payload, {getState, rejectWithValue, extra: {apiClient, relay}}) => {
     validatePayload(payload, {id: new StringValue({emptyAllowed: false})});
     const state = getState();
-    const request = await buildPlanRequest(state, relay);
+    const request = buildPlanRequest(state, relay);
     const response = await apiClient.plan(request);
     if (isErrorResponse(response)) {
       return rejectWithValue(response.error);
@@ -91,12 +91,12 @@ export const fetchRedirectUrl = createAsyncThunk<
   }
 );
 
-export const buildPlanRequest = async (
+export const buildPlanRequest = (
   state: StateNeededForRedirect,
   relay: Relay
-): Promise<CommerceSearchRequest> => {
+): CommerceSearchRequest => {
   return {
     query: state.commerceQuery.query,
-    ...(await buildBaseCommerceAPIRequest(state, relay)),
+    ...buildBaseCommerceAPIRequest(state, relay),
   };
 };

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -1,4 +1,5 @@
 import {StringValue} from '@coveo/bueno';
+import {Relay} from '@coveo/relay';
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {
   AsyncThunkCommerceOptions,
@@ -74,11 +75,10 @@ export const fetchRedirectUrl = createAsyncThunk<
   AsyncThunkCommerceOptions<StateNeededForRedirect>
 >(
   'commerce/standaloneSearchBox/fetchRedirect',
-  async (payload, {getState, rejectWithValue, extra}) => {
+  async (payload, {getState, rejectWithValue, extra: {apiClient, relay}}) => {
     validatePayload(payload, {id: new StringValue({emptyAllowed: false})});
     const state = getState();
-    const {apiClient} = extra;
-    const request = await buildPlanRequest(state);
+    const request = await buildPlanRequest(state, relay);
     const response = await apiClient.plan(request);
     if (isErrorResponse(response)) {
       return rejectWithValue(response.error);
@@ -92,10 +92,11 @@ export const fetchRedirectUrl = createAsyncThunk<
 );
 
 export const buildPlanRequest = async (
-  state: StateNeededForRedirect
+  state: StateNeededForRedirect,
+  relay: Relay
 ): Promise<CommerceSearchRequest> => {
   return {
     query: state.commerceQuery.query,
-    ...(await buildBaseCommerceAPIRequest(state)),
+    ...(await buildBaseCommerceAPIRequest(state, relay)),
   };
 };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3335