### PR TITLE
chore: +w discussions GH_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      discussions: write
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
         with:


### PR DESCRIPTION
Quantic release create a discussion, but needs the right perm for it