### PR TITLE
feat(answer): configuration ID init

### DIFF
--- a/packages/headless/src/api/generated-answer/generated-answer-client.ts
+++ b/packages/headless/src/api/generated-answer/generated-answer-client.ts
@@ -18,7 +18,7 @@ export interface AsyncThunkGeneratedAnswerOptions<
   T extends Partial<SearchAppState>,
 > extends AsyncThunkOptions<
     T,
-    ClientThunkExtraArguments<GeneratedAnswerAPIClient>
+    ClientThunkExtraArguments<LegacyGeneratedAnswerAPIClient>
   > {}
 
 const buildStreamingUrl = (url: string, orgId: string, streamId: string) =>
@@ -62,7 +62,7 @@ class TimeoutStateManager {
   }
 }
 
-export class GeneratedAnswerAPIClient {
+export class LegacyGeneratedAnswerAPIClient {
   private logger: Logger;
 
   constructor(options: GeneratedAnswerAPIClientOptions) {

--- a/packages/headless/src/api/knowledge/knowledge-answer-api.ts
+++ b/packages/headless/src/api/knowledge/knowledge-answer-api.ts
@@ -1,0 +1,287 @@
+import {
+  ArrayValue,
+  BooleanValue,
+  RecordValue,
+  Schema,
+  StringValue,
+} from '@coveo/bueno';
+import {
+  EventSourceMessage,
+  fetchEventSource,
+} from '@microsoft/fetch-event-source';
+import {
+  GeneratedAnswerStyle,
+  GeneratedContentFormat,
+} from '../../features/generated-answer/generated-response-format';
+import {selectPipeline} from '../../features/pipeline/select-pipeline';
+import {selectQuery} from '../../features/query/query-selectors';
+import {QueryState} from '../../features/query/query-state';
+import {selectSearchHub} from '../../features/search-hub/search-hub-selectors';
+import {
+  ConfigurationSection,
+  DebugSection,
+  GeneratedAnswerSection,
+  SearchSection,
+} from '../../state/state-sections';
+import {GeneratedAnswerCitation} from '../generated-answer/generated-answer-event-payload';
+import {SearchRequest} from '../search/search/search-request';
+import {knowledgeApi} from './knowledge-api';
+
+type StateNeededByAnswerAPI = ConfigurationSection &
+  GeneratedAnswerSection &
+  SearchSection &
+  DebugSection & {knowledge: ReturnType<typeof answerAPI.reducer>};
+
+interface ErrorPayload {
+  message?: string;
+  code?: number;
+}
+
+class FatalError extends Error {
+  constructor(public payload: ErrorPayload) {
+    super(payload.message);
+  }
+}
+
+interface GeneratedAnswerStream {
+  answerStyle: GeneratedAnswerStyle | undefined;
+  contentFormat: GeneratedContentFormat | undefined;
+  answer: string | undefined;
+  citations: GeneratedAnswerCitation[] | undefined;
+  generated: boolean;
+  isStreaming: boolean;
+  isLoading: boolean;
+}
+interface HeaderMessage {
+  answerStyle: GeneratedAnswerStyle;
+  contentFormat: GeneratedContentFormat;
+}
+
+type PayloadType =
+  | 'genqa.headerMessageType'
+  | 'genqa.messageType'
+  | 'genqa.citationsType'
+  | 'genqa.endOfStreamType';
+
+const headerMessageSchema = new Schema<HeaderMessage>({
+  answerStyle: new StringValue(),
+  contentFormat: new StringValue(),
+});
+
+const messageSchema = new Schema({
+  textDelta: new StringValue(),
+});
+
+const citationsSchema = new Schema({
+  citation: new ArrayValue(
+    new RecordValue({
+      values: {
+        clickUri: new StringValue(),
+        id: new StringValue(),
+        permanentid: new StringValue(),
+        text: new StringValue(),
+        title: new StringValue(),
+        uri: new StringValue(),
+      },
+    })
+  ),
+});
+
+const validateHeaderMessage = (headerMessage: HeaderMessage) => {
+  headerMessageSchema.validate(headerMessage);
+};
+
+const validateMessage = (message: {textDelta: string}) => {
+  messageSchema.validate(message);
+};
+
+const validateCitationsMessage = (citations: {
+  citation: GeneratedAnswerCitation[];
+}) => {
+  citationsSchema.validate(citations);
+};
+
+const validateEndOfStream = (endOfStream: {answerGenerated: boolean}) => {
+  new Schema({
+    answerGenerated: new BooleanValue(),
+  }).validate(endOfStream);
+};
+
+const handleHeaderMessage = (
+  draft: GeneratedAnswerStream,
+  payload: HeaderMessage
+) => {
+  validateHeaderMessage(payload);
+  const {answerStyle, contentFormat} = payload;
+  draft.answerStyle = answerStyle;
+  draft.contentFormat = contentFormat;
+  draft.isStreaming = true;
+  draft.isLoading = false;
+};
+
+const handleMessage = (
+  draft: GeneratedAnswerStream,
+  payload: {textDelta: string}
+) => {
+  validateMessage(payload);
+  if (draft.answer === undefined) {
+    draft.answer = payload.textDelta;
+  } else {
+    draft.answer = draft.answer.concat(payload.textDelta);
+  }
+};
+
+const handleCitations = (
+  draft: GeneratedAnswerStream,
+  payload: {citation: GeneratedAnswerCitation[]}
+) => {
+  validateCitationsMessage(payload);
+  draft.citations = payload.citation;
+};
+
+const handleEndOfStream = (
+  draft: GeneratedAnswerStream,
+  payload: {answerGenerated: boolean}
+) => {
+  validateEndOfStream(payload);
+  draft.generated = payload.answerGenerated;
+  draft.isStreaming = false;
+};
+
+const updateCacheWithEvent = (
+  event: EventSourceMessage,
+  draft: GeneratedAnswerStream
+) => {
+  const message: {payloadType: PayloadType; payload: string} = JSON.parse(
+    event.data
+  );
+  const parsedPayload = JSON.parse(message.payload);
+  switch (message.payloadType) {
+    case 'genqa.headerMessageType':
+      handleHeaderMessage(draft, parsedPayload);
+      break;
+    case 'genqa.messageType':
+      handleMessage(draft, parsedPayload);
+      break;
+    case 'genqa.citationsType':
+      handleCitations(draft, parsedPayload);
+      break;
+    case 'genqa.endOfStreamType':
+      handleEndOfStream(draft, parsedPayload);
+      break;
+  }
+};
+
+const onOpenStream = async (response: Response) => {
+  if (
+    response.ok &&
+    response.headers.get('content-type')?.includes('text/event-stream')
+  ) {
+    return;
+  }
+
+  const isClientSideError =
+    response.status >= 400 && response.status < 500 && response.status !== 429;
+
+  if (isClientSideError) {
+    throw new FatalError({
+      message: 'Error opening stream',
+      code: response.status,
+    });
+  } else {
+    throw new Error();
+  }
+};
+
+const onError = (err: Error) => {
+  if (err instanceof FatalError) {
+    throw err;
+  }
+};
+
+export const answerAPI = knowledgeApi.injectEndpoints({
+  overrideExisting: true,
+  endpoints: (builder) => ({
+    getAnswer: builder.query<GeneratedAnswerStream, Partial<SearchRequest>>({
+      queryFn: () => ({
+        data: {
+          answerStyle: undefined,
+          contentFormat: undefined,
+          answer: undefined,
+          citations: undefined,
+          generated: false,
+          isStreaming: true,
+          isLoading: true,
+        },
+      }),
+      async onCacheEntryAdded(
+        args,
+        {getState, cacheDataLoaded, updateCachedData}
+      ) {
+        await cacheDataLoaded;
+        /**
+         * createApi has to be called prior to create the redux store and is used as part of the store setup sequence.
+         * It cannot use the inferred state used by Redux, thus the casting.
+         * https://redux-toolkit.js.org/rtk-query/usage-with-typescript#typing-dispatch-and-getstate
+         */
+        const {configuration} = getState() as unknown as StateNeededByAnswerAPI;
+        const {platformUrl, organizationId, accessToken, knowledge} =
+          configuration;
+        await fetchEventSource(
+          `${platformUrl}/rest/organizations/${organizationId}/answer/v1/configs/${knowledge.answerConfigurationId}/generate`,
+          {
+            method: 'POST',
+            body: JSON.stringify(args),
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+              'Accept-Encoding': '*',
+            },
+            fetch,
+            onopen: onOpenStream,
+            onmessage: (event) => {
+              updateCachedData((draft) => {
+                updateCacheWithEvent(event, draft);
+              });
+            },
+            onerror: onError,
+          }
+        );
+      },
+    }),
+  }),
+});
+
+export const fetchAnswer = (
+  state: StateNeededByAnswerAPI & {
+    knowledge: ReturnType<typeof answerAPI.reducer>;
+    query?: QueryState;
+    searchHub?: string;
+    pipeline?: string;
+  }
+) => {
+  const query = selectQuery(state)?.q;
+  const searchHub = selectSearchHub(state);
+  const pipeline = selectPipeline(state);
+
+  return answerAPI.endpoints.getAnswer.initiate({
+    q: query,
+    ...(searchHub?.length && {searchHub}),
+    ...(pipeline?.length && {pipeline}),
+  });
+};
+
+export const selectAnswer = (
+  state: StateNeededByAnswerAPI & {
+    knowledge: ReturnType<typeof answerAPI.reducer>;
+    query?: QueryState;
+    searchHub?: string;
+    pipeline?: string;
+  }
+) =>
+  answerAPI.endpoints.getAnswer.select({
+    q: selectQuery(state)?.q,
+    ...(selectSearchHub(state)?.length && {searchHub: selectSearchHub(state)}),
+    ...(selectPipeline(state)?.length && {pipeline: selectPipeline(state)}),
+  })(state);

--- a/packages/headless/src/api/knowledge/knowledge-api.ts
+++ b/packages/headless/src/api/knowledge/knowledge-api.ts
@@ -1,0 +1,45 @@
+import {
+  BaseQueryFn,
+  createApi,
+  FetchArgs,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+  retry,
+} from '@reduxjs/toolkit/query';
+import {ConfigurationSection} from '../../state/state-sections';
+
+type StateNeededByKnowledgeAPI = ConfigurationSection;
+
+/**
+ * `dynamicBaseQuery` is passed to the baseQuery of the createApi,
+ * but note that the baseQuery will not be used if a queryFn is provided in the createApi endpoint
+ */
+const dynamicBaseQuery: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  const state = api.getState() as StateNeededByKnowledgeAPI;
+  const {accessToken, organizationId, platformUrl} = state.configuration;
+  const updatedArgs = {
+    ...(args as FetchArgs),
+    headers: {
+      ...((args as FetchArgs)?.headers || {}),
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+  try {
+    const data = fetchBaseQuery({
+      baseUrl: `${platformUrl}/rest/organizations/${organizationId}`,
+    })(updatedArgs, api, extraOptions);
+    return {data};
+  } catch (error) {
+    return {error: error as FetchBaseQueryError};
+  }
+};
+
+export const knowledgeApi = createApi({
+  reducerPath: 'knowledge',
+  baseQuery: retry(dynamicBaseQuery, {maxRetries: 3}),
+  endpoints: () => ({}),
+});

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -51,6 +51,11 @@ export interface EngineConfiguration<
    */
   accessToken: string;
   /**
+   * Specifies the unique identifier for a Knowledge configuration.
+   * When this identifier is utilized, the `answerApi` is engaged to deliver responses, thereby activating Coveo's answer management capabilities.
+   */
+  answerConfigurationId?: string;
+  /**
    * A function that fetches a new access token. The function must return a Promise that resolves to a string (the new access token).
    */
   renewAccessToken?: () => Promise<string>;

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -189,6 +189,25 @@ describe('engine', () => {
     expect(() => initEngine()).toThrowErrorMatchingSnapshot();
   });
 
+  describe('answer config', () => {
+    it('will dispatch an action to update the answer config if present in the options', () => {
+      const answerConfigurationId = 'answerConfigId';
+      options.configuration.answerConfigurationId = answerConfigurationId;
+      initEngine();
+
+      expect(engine.state.configuration.knowledge.answerConfigurationId).toBe(
+        answerConfigurationId
+      );
+    });
+    it('will not dispatch an action to update the answer config if not present in the options', () => {
+      initEngine();
+
+      expect(engine.state.configuration.knowledge.answerConfigurationId).toBe(
+        ''
+      );
+    });
+  });
+
   describe('with preloaded state', () => {
     const testAction = createAction('increment');
     const testReducer = createReducer(0, (builder) =>

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -18,6 +18,7 @@ import {
   enableAnalytics,
   updateAnalyticsConfiguration,
   UpdateAnalyticsConfigurationActionCreatorPayload,
+  updateAnswerConfiguration,
   updateBasicConfiguration,
 } from '../features/configuration/configuration-actions';
 import {versionReducer as version} from '../features/debug/version-slice';
@@ -260,6 +261,14 @@ export function buildEngine<
       platformUrl,
     })
   );
+
+  if (options.configuration.answerConfigurationId) {
+    engine.dispatch(
+      updateAnswerConfiguration({
+        answerConfigurationId: options.configuration.answerConfigurationId,
+      })
+    );
+  }
 
   const analyticsPayload = getUpdateAnalyticsConfigurationPayload(
     options.configuration,

--- a/packages/headless/src/app/insight-engine/insight-engine.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.ts
@@ -1,6 +1,6 @@
 import {StateFromReducersMapObject} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
-import {GeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
 import {NoopPreprocessRequest} from '../../api/preprocess-request';
 import {InsightAPIClient} from '../../api/service/insight/insight-api-client';
 import {interfaceLoad} from '../../features/analytics/analytics-actions';
@@ -150,7 +150,7 @@ function createInsightAPIClient(
 }
 
 function createGeneratedAnswerAPIClient(logger: Logger) {
-  return new GeneratedAnswerAPIClient({
+  return new LegacyGeneratedAnswerAPIClient({
     logger,
   });
 }

--- a/packages/headless/src/app/search-engine/search-engine-configuration.ts
+++ b/packages/headless/src/app/search-engine/search-engine-configuration.ts
@@ -45,6 +45,11 @@ export interface SearchConfigurationOptions {
    */
   searchHub?: string;
   /**
+   * Specifies the unique identifier for a Knowledge configuration.
+   * When this identifier is utilized, the `answerApi` is engaged to deliver responses, thereby activating Coveo's answer management capabilities.
+   */
+  answerConfigurationId?: string;
+  /**
    * The locale of the current user. Must comply with IETF’s BCP 47 definition: https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
    *
    * Notes:

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -1,6 +1,7 @@
 import {StateFromReducersMapObject} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
-import {GeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
+import {answerAPI} from '../../api/knowledge/knowledge-answer-api';
 import {NoopPreprocessRequest} from '../../api/preprocess-request';
 import {SearchAPIClient} from '../../api/search/search-api-client';
 import {
@@ -111,20 +112,25 @@ export interface SearchEngineOptions
 export function buildSearchEngine(options: SearchEngineOptions): SearchEngine {
   const logger = buildLogger(options.loggerOptions);
   validateConfiguration(options.configuration, logger);
-
   const searchAPIClient = createSearchAPIClient(options.configuration, logger);
-  const generatedAnswerClient = createGeneratedAnswerAPIClient(logger);
 
   const thunkArguments = {
     ...buildThunkExtraArguments(options.configuration, logger),
     apiClient: searchAPIClient,
-    streamingClient: generatedAnswerClient,
+    // The legacy client is used when the knowledgeConfigurationId is not provided
+    ...(options.configuration.answerConfigurationId
+      ? {}
+      : {streamingClient: createLegacyGeneratedAnswerAPIClient(logger)}),
   };
 
   const augmentedOptions: EngineOptions<SearchEngineReducers> = {
     ...options,
     reducers: searchEngineReducers,
     crossReducer: jwtReducer(logger),
+    // The middleware for the answer API is only added when the knowledgeConfigurationId is provided
+    ...(options.configuration.answerConfigurationId
+      ? {middlewares: [answerAPI.middleware]}
+      : {}),
   };
 
   const engine = buildEngine(augmentedOptions, thunkArguments);
@@ -208,8 +214,8 @@ function createSearchAPIClient(
   });
 }
 
-function createGeneratedAnswerAPIClient(logger: Logger) {
-  return new GeneratedAnswerAPIClient({
+function createLegacyGeneratedAnswerAPIClient(logger: Logger) {
+  return new LegacyGeneratedAnswerAPIClient({
     logger,
   });
 }

--- a/packages/headless/src/app/search-thunk-extra-arguments.ts
+++ b/packages/headless/src/app/search-thunk-extra-arguments.ts
@@ -1,9 +1,9 @@
-import {GeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
 import {SearchAPIClient} from '../api/search/search-api-client';
 import {ClientThunkExtraArguments} from './thunk-extra-arguments';
 
 export interface SearchThunkExtraArguments
   extends ClientThunkExtraArguments<
     SearchAPIClient,
-    GeneratedAnswerAPIClient
+    LegacyGeneratedAnswerAPIClient
   > {}

--- a/packages/headless/src/app/thunk-extra-arguments.ts
+++ b/packages/headless/src/app/thunk-extra-arguments.ts
@@ -1,15 +1,17 @@
 import {Relay} from '@coveo/relay';
 import {AnalyticsClientSendEventHook} from 'coveo.analytics';
 import {Logger} from 'pino';
-import {GeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
 import {PreprocessRequest} from '../api/preprocess-request';
 import {NoopPreprocessRequest} from '../api/preprocess-request';
 import {validatePayloadAndThrow} from '../utils/validate-payload';
 import {EngineConfiguration} from './engine-configuration';
 import {NavigatorContext} from './navigatorContextProvider';
 
-export interface ClientThunkExtraArguments<T, K = GeneratedAnswerAPIClient>
-  extends ThunkExtraArguments {
+export interface ClientThunkExtraArguments<
+  T,
+  K = LegacyGeneratedAnswerAPIClient,
+> extends ThunkExtraArguments {
   apiClient: T;
   streamingClient?: K;
   relay: Relay;

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -1,5 +1,5 @@
 import {Unsubscribe} from '@reduxjs/toolkit';
-import {GeneratedAnswerAPIClient} from '../../../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../../../api/generated-answer/generated-answer-client';
 import {GeneratedAnswerCitation} from '../../../api/generated-answer/generated-answer-event-payload';
 import {CoreEngine} from '../../../app/engine';
 import {ClientThunkExtraArguments} from '../../../app/thunk-extra-arguments';
@@ -152,7 +152,7 @@ interface SubscribeStateManager {
   subscribeToSearchRequests: (
     engine: CoreEngine<
       GeneratedAnswerSection & SearchSection & DebugSection,
-      ClientThunkExtraArguments<GeneratedAnswerAPIClient>
+      ClientThunkExtraArguments<LegacyGeneratedAnswerAPIClient>
     >
   ) => Unsubscribe;
 }

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -37,6 +37,13 @@ export interface UpdateBasicConfigurationActionCreatorPayload {
   platformUrl?: string;
 }
 
+interface UpdateAnswerConfigurationActionCreatorPayload {
+  /**
+   * The Answer Configuration ID to use.
+   */
+  answerConfigurationId: string;
+}
+
 export const updateBasicConfiguration = createAction(
   'configuration/updateBasicConfiguration',
   (payload: UpdateBasicConfigurationActionCreatorPayload) =>
@@ -44,6 +51,14 @@ export const updateBasicConfiguration = createAction(
       accessToken: nonEmptyString,
       organizationId: nonEmptyString,
       platformUrl: nonEmptyString,
+    })
+);
+
+export const updateAnswerConfiguration = createAction(
+  'configuration/updateKnowledgeConfiguration',
+  (payload: UpdateAnswerConfigurationActionCreatorPayload) =>
+    validatePayload(payload, {
+      answerConfigurationId: nonEmptyString,
     })
 );
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -10,6 +10,7 @@ import {
   updateAnalyticsConfiguration,
   setOriginLevel3,
   setOriginLevel2,
+  updateAnswerConfiguration,
 } from './configuration-actions';
 import {configurationReducer} from './configuration-slice';
 import {
@@ -325,6 +326,17 @@ describe('configuration slice', () => {
 
     const finalState = configurationReducer(state, updateActiveTab('tab'));
     expect(finalState.analytics.originLevel2).toBe('tab');
+  });
+
+  describe('#updateAnswerConfiguration', () => {
+    it('updates the answerConfigurationId', () => {
+      const state = getConfigurationInitialState();
+      const finalState = configurationReducer(
+        state,
+        updateAnswerConfiguration({answerConfigurationId: 'answer'})
+      );
+      expect(finalState.knowledge.answerConfigurationId).toBe('answer');
+    });
   });
 
   describe('#restoreSearchParameters', () => {

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -17,6 +17,7 @@ import {
   updateAnalyticsConfiguration,
   setOriginLevel2,
   setOriginLevel3,
+  updateAnswerConfiguration,
 } from './configuration-actions';
 import {
   getConfigurationInitialState,
@@ -134,6 +135,12 @@ export const configurationReducer = createReducer(
         }
         if (!isNullOrUndefined(action.payload.documentLocation)) {
           state.analytics.documentLocation = action.payload.documentLocation;
+        }
+      })
+      .addCase(updateAnswerConfiguration, (state, action) => {
+        if (!isNullOrUndefined(action.payload.answerConfigurationId)) {
+          state.knowledge.answerConfigurationId =
+            action.payload.answerConfigurationId;
         }
       })
       .addCase(disableAnalytics, (state) => {

--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -51,6 +51,10 @@ export interface ConfigurationState {
    * The global headless engine Usage Analytics API configuration.
    */
   analytics: AnalyticsState;
+  /**
+   * The global headless engine Knowledge API configuration.
+   */
+  knowledge: KnowledgeState;
 }
 
 export interface AnalyticsState {
@@ -148,6 +152,10 @@ export interface AnalyticsState {
 export const searchAPIEndpoint = '/rest/search/v2';
 export const analyticsAPIEndpoint = '/rest/ua';
 
+interface KnowledgeState {
+  answerConfigurationId: string;
+}
+
 export const getConfigurationInitialState: () => ConfigurationState = () => ({
   organizationId: '',
   accessToken: '',
@@ -172,5 +180,8 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     trackingId: '',
     analyticsMode: 'legacy',
     source: {},
+  },
+  knowledge: {
+    answerConfigurationId: '',
   },
 });

--- a/packages/headless/src/features/pipeline/select-pipeline.ts
+++ b/packages/headless/src/features/pipeline/select-pipeline.ts
@@ -1,0 +1,6 @@
+import {createSelector} from '@reduxjs/toolkit';
+
+export const selectPipeline = createSelector(
+  (state: {pipeline?: string}) => state.pipeline,
+  (pipeline) => pipeline
+);

--- a/packages/headless/src/features/query/query-selectors.ts
+++ b/packages/headless/src/features/query/query-selectors.ts
@@ -1,0 +1,7 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {QueryState} from './query-state';
+
+export const selectQuery = createSelector(
+  (state: {query?: QueryState}) => state.query,
+  (query) => query
+);

--- a/packages/headless/src/features/search-hub/search-hub-selectors.ts
+++ b/packages/headless/src/features/search-hub/search-hub-selectors.ts
@@ -1,0 +1,6 @@
+import {createSelector} from '@reduxjs/toolkit';
+
+export const selectSearchHub = createSelector(
+  (state: {searchHub?: string}) => state.searchHub,
+  (searchHub) => searchHub
+);


### PR DESCRIPTION
## Summary

Addition of the capability to pass a `answerConfigurationId` to the engine when initiating it. When the `answerConfigurationId` is passed, the configuration state will be updated with it. 

## Why is this needed

When an interface will initiate the engine with an `answerConfigurationId`, the engine must dispatch the id to the configuration state.
- To be used by the AnswerApi
- To flip the switch between the legacy Generated Answer Client and the new one
- To flip the switch between the controller leveraging the Search API pattern and the Controller using the new Stream