### PR TITLE
feat(headless): add the capability to pass a answerConfigurationId to the insight engine 

### DIFF
--- a/packages/headless/src/api/generated-answer/generated-answer-client.ts
+++ b/packages/headless/src/api/generated-answer/generated-answer-client.ts
@@ -18,7 +18,7 @@ export interface AsyncThunkGeneratedAnswerOptions<
   T extends Partial<SearchAppState>,
 > extends AsyncThunkOptions<
     T,
-    ClientThunkExtraArguments<GeneratedAnswerAPIClient>
+    ClientThunkExtraArguments<LegacyGeneratedAnswerAPIClient>
   > {}
 
 const buildStreamingUrl = (url: string, orgId: string, streamId: string) =>
@@ -62,7 +62,7 @@ class TimeoutStateManager {
   }
 }
 
-export class GeneratedAnswerAPIClient {
+export class LegacyGeneratedAnswerAPIClient {
   private logger: Logger;
 
   constructor(options: GeneratedAnswerAPIClientOptions) {

--- a/packages/headless/src/app/insight-engine/insight-engine.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.ts
@@ -1,6 +1,6 @@
 import {StateFromReducersMapObject} from '@reduxjs/toolkit';
 import {Logger} from 'pino';
-import {GeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client';
 import {NoopPreprocessRequest} from '../../api/preprocess-request';
 import {InsightAPIClient} from '../../api/service/insight/insight-api-client';
 import {interfaceLoad} from '../../features/analytics/analytics-actions';
@@ -150,7 +150,7 @@ function createInsightAPIClient(
 }
 
 function createGeneratedAnswerAPIClient(logger: Logger) {
-  return new GeneratedAnswerAPIClient({
+  return new LegacyGeneratedAnswerAPIClient({
     logger,
   });
 }

--- a/packages/headless/src/app/search-engine/search-engine-configuration.ts
+++ b/packages/headless/src/app/search-engine/search-engine-configuration.ts
@@ -29,6 +29,11 @@ export interface SearchEngineConfiguration
    * The global headless engine configuration options specific to the SearchAPI.
    */
   search?: SearchConfigurationOptions;
+  /**
+   * Specifies the unique identifier for a  answer configuration.
+   * When this identifier is utilized, the `answerApi` is engaged to deliver responses, thereby activating Coveo's answer management capabilities.
+   */
+  answerConfigurationId?: string;
 }
 
 export interface SearchConfigurationOptions {

--- a/packages/headless/src/app/search-engine/search-engine.test.ts
+++ b/packages/headless/src/app/search-engine/search-engine.test.ts
@@ -118,6 +118,25 @@ describe('searchEngine', () => {
       });
     });
 
+    describe('answer config', () => {
+      it('will dispatch an action to update the answer config if present in the options', () => {
+        const answerConfigurationId = 'answerConfigId';
+        options.configuration.answerConfigurationId = answerConfigurationId;
+        initEngine();
+
+        expect(engine.state.configuration.knowledge.answerConfigurationId).toBe(
+          answerConfigurationId
+        );
+      });
+      it('will not dispatch an action to update the answer config if not present in the options', () => {
+        initEngine();
+
+        expect(engine.state.configuration.knowledge.answerConfigurationId).toBe(
+          ''
+        );
+      });
+    });
+
     describe('when passing a search configuration', () => {
       const pipeline = 'newPipe';
       const searchHub = 'newHub';

--- a/packages/headless/src/app/search-thunk-extra-arguments.ts
+++ b/packages/headless/src/app/search-thunk-extra-arguments.ts
@@ -1,9 +1,9 @@
-import {GeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
 import {SearchAPIClient} from '../api/search/search-api-client';
 import {ClientThunkExtraArguments} from './thunk-extra-arguments';
 
 export interface SearchThunkExtraArguments
   extends ClientThunkExtraArguments<
     SearchAPIClient,
-    GeneratedAnswerAPIClient
+    LegacyGeneratedAnswerAPIClient
   > {}

--- a/packages/headless/src/app/thunk-extra-arguments.ts
+++ b/packages/headless/src/app/thunk-extra-arguments.ts
@@ -1,15 +1,17 @@
 import {Relay} from '@coveo/relay';
 import {AnalyticsClientSendEventHook} from 'coveo.analytics';
 import {Logger} from 'pino';
-import {GeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client';
 import {PreprocessRequest} from '../api/preprocess-request';
 import {NoopPreprocessRequest} from '../api/preprocess-request';
 import {validatePayloadAndThrow} from '../utils/validate-payload';
 import {EngineConfiguration} from './engine-configuration';
 import {NavigatorContext} from './navigatorContextProvider';
 
-export interface ClientThunkExtraArguments<T, K = GeneratedAnswerAPIClient>
-  extends ThunkExtraArguments {
+export interface ClientThunkExtraArguments<
+  T,
+  K = LegacyGeneratedAnswerAPIClient,
+> extends ThunkExtraArguments {
   apiClient: T;
   streamingClient?: K;
   relay: Relay;

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -1,5 +1,5 @@
 import {Unsubscribe} from '@reduxjs/toolkit';
-import {GeneratedAnswerAPIClient} from '../../../api/generated-answer/generated-answer-client';
+import {LegacyGeneratedAnswerAPIClient} from '../../../api/generated-answer/generated-answer-client';
 import {GeneratedAnswerCitation} from '../../../api/generated-answer/generated-answer-event-payload';
 import {CoreEngine} from '../../../app/engine';
 import {ClientThunkExtraArguments} from '../../../app/thunk-extra-arguments';
@@ -158,7 +158,7 @@ interface SubscribeStateManager {
   subscribeToSearchRequests: (
     engine: CoreEngine<
       GeneratedAnswerSection & SearchSection & DebugSection,
-      ClientThunkExtraArguments<GeneratedAnswerAPIClient>
+      ClientThunkExtraArguments<LegacyGeneratedAnswerAPIClient>
     >
   ) => Unsubscribe;
 }

--- a/packages/headless/src/features/configuration/configuration-actions.ts
+++ b/packages/headless/src/features/configuration/configuration-actions.ts
@@ -37,6 +37,13 @@ export interface UpdateBasicConfigurationActionCreatorPayload {
   platformUrl?: string;
 }
 
+interface UpdateAnswerConfigurationActionCreatorPayload {
+  /**
+   * Specifies the unique identifier for a  answer configuration.
+   */
+  answerConfigurationId: string;
+}
+
 export const updateBasicConfiguration = createAction(
   'configuration/updateBasicConfiguration',
   (payload: UpdateBasicConfigurationActionCreatorPayload) =>
@@ -44,6 +51,14 @@ export const updateBasicConfiguration = createAction(
       accessToken: nonEmptyString,
       organizationId: nonEmptyString,
       platformUrl: nonEmptyString,
+    })
+);
+
+export const updateAnswerConfiguration = createAction(
+  'configuration/updateKnowledgeConfiguration',
+  (payload: UpdateAnswerConfigurationActionCreatorPayload) =>
+    validatePayload(payload, {
+      answerConfigurationId: nonEmptyString,
     })
 );
 

--- a/packages/headless/src/features/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.test.ts
@@ -10,6 +10,7 @@ import {
   updateAnalyticsConfiguration,
   setOriginLevel3,
   setOriginLevel2,
+  updateAnswerConfiguration,
 } from './configuration-actions';
 import {configurationReducer} from './configuration-slice';
 import {
@@ -325,6 +326,17 @@ describe('configuration slice', () => {
 
     const finalState = configurationReducer(state, updateActiveTab('tab'));
     expect(finalState.analytics.originLevel2).toBe('tab');
+  });
+
+  describe('#updateAnswerConfiguration', () => {
+    it('updates the answerConfigurationId', () => {
+      const state = getConfigurationInitialState();
+      const finalState = configurationReducer(
+        state,
+        updateAnswerConfiguration({answerConfigurationId: 'answer'})
+      );
+      expect(finalState.knowledge.answerConfigurationId).toBe('answer');
+    });
   });
 
   describe('#restoreSearchParameters', () => {

--- a/packages/headless/src/features/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/configuration/configuration-slice.ts
@@ -17,6 +17,7 @@ import {
   updateAnalyticsConfiguration,
   setOriginLevel2,
   setOriginLevel3,
+  updateAnswerConfiguration,
 } from './configuration-actions';
 import {
   getConfigurationInitialState,
@@ -134,6 +135,12 @@ export const configurationReducer = createReducer(
         }
         if (!isNullOrUndefined(action.payload.documentLocation)) {
           state.analytics.documentLocation = action.payload.documentLocation;
+        }
+      })
+      .addCase(updateAnswerConfiguration, (state, action) => {
+        if (!isNullOrUndefined(action.payload.answerConfigurationId)) {
+          state.knowledge.answerConfigurationId =
+            action.payload.answerConfigurationId;
         }
       })
       .addCase(disableAnalytics, (state) => {


### PR DESCRIPTION
## Summary

Addition of the capability to pass a `answerConfigurationId` to the engine when initiating it. When the `answerConfigurationId` is passed, the configuration state will be updated with it. 

## Why is this needed

When an interface will initiate the engine with an `answerConfigurationId`, the engine must dispatch the id to the configuration state.
- To be used by the AnswerApi
- To flip the switch between the legacy Generated Answer Client and the new one
- To flip the switch between the controller leveraging the Search API pattern and the Controller using the new Stream