### PR TITLE
fix(commerce): only expose breadcrumbs with values

### DIFF
--- a/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.test.ts
+++ b/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.test.ts
@@ -108,6 +108,23 @@ describe('core breadcrumb manager', () => {
     expect(breadcrumbManager.subscribe).toBeTruthy();
   });
 
+  it('#hasBreadcrumbs is false when there are no facet values', () => {
+    setFacetsState(
+      buildMockCommerceRegularFacetResponse({
+        facetId,
+        values: [],
+      })
+    );
+    setFacetsState(
+      buildMockCommerceNumericFacetResponse({
+        facetId,
+        values: [],
+      })
+    );
+
+    expect(breadcrumbManager.state.hasBreadcrumbs).toEqual(false);
+  });
+
   describe('#deselectAll', () => {
     it('deselects all breadcrumbs', () => {
       breadcrumbManager.deselectAll();

--- a/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
+++ b/packages/headless/src/controllers/commerce/core/breadcrumb-manager/headless-core-breadcrumb-manager.ts
@@ -236,7 +236,10 @@ export function buildCoreBreadcrumbManager(
           .map((facetId) =>
             options.facetResponseSelector(engine[stateKey], facetId)
           )
-          .filter((facet): facet is AnyFacetResponse => facet !== undefined)
+          .filter(
+            (facet): facet is AnyFacetResponse =>
+              facet !== undefined && facet.values.length > 0
+          )
           .map(createBreadcrumb) ?? [];
       return {
         facetBreadcrumbs: breadcrumbs,


### PR DESCRIPTION
By only exposing breadcrumbs with values, breadcrumbs without facet values will not be included. Since we also filter out breadcrumbs without values, the `hasBreadcrumbs` check will be `false` instead of `true` when there are facets with no values, which is the desired state.

[CAPI-1089]