### PR TITLE
fix(SFINT-5598): Always send contentFormat even with rephrase RGA

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -331,7 +331,10 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   handleGeneratedAnswerRephrase = (event) => {
     event.stopPropagation();
-    this.generatedAnswer.rephrase({answerStyle: event?.detail});
+    this.generatedAnswer.rephrase({
+      ...this.state?.responseFormat,
+      answerStyle: event?.detail,
+    });
   };
 
   handleGeneratedAnswerCopyToClipboard = (event) => {


### PR DESCRIPTION
Fix a bug where after using the rephrase buttons, the contentFormat of the requested RGA response was not persisting to sending `text/markdown`.

Now on every search, we do send `['text/markdown', 'text/plain']` as the accepted format alongside the `answerStyle` parameter.