### PR TITLE
feat(headless commerce): expose deselectAll method on facet generator controller

### DIFF
--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
@@ -1,3 +1,4 @@
+import {deselectAllBreadcrumbs} from '../../../../../features/breadcrumb/breadcrumb-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
 import {facetOrderReducer as facetOrder} from '../../../../../features/facets/facet-order/facet-order-slice';
@@ -16,6 +17,8 @@ import {
   FacetGeneratorOptions,
 } from './headless-commerce-facet-generator';
 
+jest.mock('../../../../../features/breadcrumb/breadcrumb-actions');
+
 describe('FacetGenerator', () => {
   let engine: MockedCommerceEngine;
   let state: CommerceAppState;
@@ -25,6 +28,7 @@ describe('FacetGenerator', () => {
   const mockBuildRegularFacet = jest.fn();
   const mockBuildDateFacet = jest.fn();
   const mockBuildCategoryFacet = jest.fn();
+  const mockFetchProductsActionCreator = jest.fn();
 
   function initEngine(preloadedState = buildMockCommerceState()) {
     engine = buildMockCommerceEngine(preloadedState);
@@ -57,6 +61,7 @@ describe('FacetGenerator', () => {
       buildRegularFacet: mockBuildRegularFacet,
       buildDateFacet: mockBuildDateFacet,
       buildCategoryFacet: mockBuildCategoryFacet,
+      fetchProductsActionCreator: mockFetchProductsActionCreator,
     };
 
     state = buildMockCommerceState();
@@ -164,5 +169,17 @@ describe('FacetGenerator', () => {
     initCommerceFacetGenerator();
 
     expect(facetGenerator.state).toEqual(state.facetOrder);
+  });
+
+  describe('#deselectAll', () => {
+    it('dispatches #deselectAllBreadcrumbs', () => {
+      facetGenerator.deselectAll();
+      expect(deselectAllBreadcrumbs).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches #fetchProductsActionCreator', () => {
+      facetGenerator.deselectAll();
+      expect(mockFetchProductsActionCreator).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
@@ -172,7 +172,7 @@ describe('FacetGenerator', () => {
   });
 
   describe('#deselectAll', () => {
-    it('dispatches #deselectAllBreadcrumbs', () => {
+    it('dispatches #clearAllCoreFacets', () => {
       facetGenerator.deselectAll();
       expect(clearAllCoreFacets).toHaveBeenCalledTimes(1);
     });

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
@@ -1,4 +1,4 @@
-import {deselectAllBreadcrumbs} from '../../../../../features/breadcrumb/breadcrumb-actions';
+import {clearAllCoreFacets} from '../../../../../features/commerce/facets/core-facet/core-facet-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
 import {facetOrderReducer as facetOrder} from '../../../../../features/facets/facet-order/facet-order-slice';
@@ -174,7 +174,7 @@ describe('FacetGenerator', () => {
   describe('#deselectAll', () => {
     it('dispatches #deselectAllBreadcrumbs', () => {
       facetGenerator.deselectAll();
-      expect(deselectAllBreadcrumbs).toHaveBeenCalledTimes(1);
+      expect(clearAllCoreFacets).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches #fetchProductsActionCreator', () => {

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.test.ts
@@ -17,7 +17,9 @@ import {
   FacetGeneratorOptions,
 } from './headless-commerce-facet-generator';
 
-jest.mock('../../../../../features/breadcrumb/breadcrumb-actions');
+jest.mock(
+  '../../../../../features/commerce/facets/core-facet/core-facet-actions'
+);
 
 describe('FacetGenerator', () => {
   let engine: MockedCommerceEngine;
@@ -174,7 +176,7 @@ describe('FacetGenerator', () => {
   describe('#deselectAll', () => {
     it('dispatches #clearAllCoreFacets', () => {
       facetGenerator.deselectAll();
-      expect(clearAllCoreFacets).toHaveBeenCalledTimes(1);
+      expect(clearAllCoreFacets).toHaveBeenCalled();
     });
 
     it('dispatches #fetchProductsActionCreator', () => {

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
@@ -4,6 +4,7 @@ import {
   CommerceEngineState,
 } from '../../../../../app/commerce-engine/commerce-engine';
 import {stateKey} from '../../../../../app/state-key';
+import {deselectAllBreadcrumbs} from '../../../../../features/breadcrumb/breadcrumb-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {CommerceFacetSetState} from '../../../../../features/commerce/facets/facet-set/facet-set-state';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
@@ -19,6 +20,7 @@ import {
   Controller,
   buildController,
 } from '../../../../controller/headless-controller';
+import {FetchProductsActionCreator} from '../../common';
 import {CategoryFacet} from '../category/headless-commerce-category-facet';
 import {DateFacet} from '../date/headless-commerce-date-facet';
 import {
@@ -47,6 +49,11 @@ export interface FacetGenerator extends Controller {
    * The facet sub-controllers created by the facet generator.
    */
   facets: GeneratedFacetControllers;
+
+  /**
+   * Deselects all values in all facets.
+   * */
+  deselectAll(): void;
 }
 
 /**
@@ -100,6 +107,7 @@ export interface FacetGeneratorOptions {
   buildNumericFacet: CommerceFacetBuilder<NumericFacet>;
   buildDateFacet: CommerceFacetBuilder<DateFacet>;
   buildCategoryFacet: CommerceFacetBuilder<CategoryFacet>;
+  fetchProductsActionCreator: FetchProductsActionCreator;
 }
 
 /**
@@ -120,6 +128,7 @@ export function buildFacetGenerator(
   }
 
   const controller = buildController(engine);
+  const {dispatch} = engine;
 
   const createFacetControllers = createSelector(
     [
@@ -155,6 +164,11 @@ export function buildFacetGenerator(
 
   return {
     ...controller,
+
+    deselectAll: () => {
+      dispatch(deselectAllBreadcrumbs());
+      dispatch(options.fetchProductsActionCreator());
+    },
 
     get facets() {
       return createFacetControllers(engine[stateKey]);

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
@@ -4,7 +4,7 @@ import {
   CommerceEngineState,
 } from '../../../../../app/commerce-engine/commerce-engine';
 import {stateKey} from '../../../../../app/state-key';
-import {deselectAllBreadcrumbs} from '../../../../../features/breadcrumb/breadcrumb-actions';
+import {clearAllCoreFacets} from '../../../../../features/commerce/facets/core-facet/core-facet-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../../../features/commerce/facets/facet-set/facet-set-slice';
 import {CommerceFacetSetState} from '../../../../../features/commerce/facets/facet-set/facet-set-state';
 import {FacetType} from '../../../../../features/commerce/facets/facet-set/interfaces/common';
@@ -166,7 +166,7 @@ export function buildFacetGenerator(
     ...controller,
 
     deselectAll: () => {
-      dispatch(deselectAllBreadcrumbs());
+      dispatch(clearAllCoreFacets());
       dispatch(options.fetchProductsActionCreator());
     },
 

--- a/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.ts
+++ b/packages/headless/src/controllers/commerce/core/sub-controller/headless-sub-controller.ts
@@ -277,6 +277,7 @@ export function buildSearchAndListingsSubControllers<
           buildCommerceDateFacet(engine, {...options, ...commonOptions}),
         buildCategoryFacet: (_engine, options) =>
           buildCategoryFacet(engine, {...options, ...commonOptions}),
+        fetchProductsActionCreator,
       });
     },
     breadcrumbManager() {

--- a/packages/headless/src/controllers/facets/automatic-facet-generator/headless-automatic-facet-generator.test.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet-generator/headless-automatic-facet-generator.test.ts
@@ -1,5 +1,4 @@
 import {configuration} from '../../../app/common-reducers';
-import {deselectAllBreadcrumbs} from '../../../features/breadcrumb/breadcrumb-actions';
 import {setOptions} from '../../../features/facets/automatic-facet-set/automatic-facet-set-actions';
 import {NUMBER_OF_VALUE_DEFAULT} from '../../../features/facets/automatic-facet-set/automatic-facet-set-constants';
 import {automaticFacetSetReducer as automaticFacetSet} from '../../../features/facets/automatic-facet-set/automatic-facet-set-slice';
@@ -19,8 +18,6 @@ import {
 jest.mock(
   '../../../features/facets/automatic-facet-set/automatic-facet-set-actions'
 );
-
-jest.mock('../../../features/breadcrumb/breadcrumb-actions');
 
 describe('automatic facets', () => {
   let engine: MockedSearchEngine;
@@ -63,12 +60,5 @@ describe('automatic facets', () => {
 
   it('should return automatic facets as empty array if the response is empty', () => {
     expect(automaticFacets.state.automaticFacets).toEqual([]);
-  });
-
-  describe('#deselectAll', () => {
-    it('dispatches #deselectAllBreadcrumbs', () => {
-      automaticFacets.deselectAll();
-      expect(deselectAllBreadcrumbs).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/packages/headless/src/controllers/facets/automatic-facet-generator/headless-automatic-facet-generator.ts
+++ b/packages/headless/src/controllers/facets/automatic-facet-generator/headless-automatic-facet-generator.ts
@@ -1,7 +1,6 @@
 import {configuration} from '../../../app/common-reducers';
 import {CoreEngine} from '../../../app/engine';
 import {SearchEngine} from '../../../app/search-engine/search-engine';
-import {deselectAllBreadcrumbs} from '../../../features/breadcrumb/breadcrumb-actions';
 import {setOptions} from '../../../features/facets/automatic-facet-set/automatic-facet-set-actions';
 import {automaticFacetSetReducer as automaticFacetSet} from '../../../features/facets/automatic-facet-set/automatic-facet-set-slice';
 import {searchReducer as search} from '../../../features/search/search-slice';
@@ -37,10 +36,6 @@ export interface AutomaticFacetGenerator extends Controller {
    * The state of the `AutomaticFacetGenerator` controller.
    */
   state: AutomaticFacetGeneratorState;
-  /**
-   * Deselects all values in all facets.
-   * */
-  deselectAll(): void;
 }
 
 export interface AutomaticFacetGeneratorState {
@@ -122,10 +117,6 @@ export function buildAutomaticFacetGenerator(
 
   return {
     ...controller,
-
-    deselectAll: () => {
-      dispatch(deselectAllBreadcrumbs());
-    },
 
     get state() {
       const automaticFacets =


### PR DESCRIPTION
This PR exposes the `deselectAll` method on the commerce facet generator controller.

It also removes the method from automatic facet generator added in #4067

https://coveord.atlassian.net/browse/KIT-3358