### PR TITLE
chore:  do not dispose esbuild context in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "husky install && patch-package && npx playwright install",
     "reset:install": "git checkout origin/master package-lock.json && npm i",
     "clean:install": "git clean -xfd && npm run reset:install",
-    "dev:atomic": "concurrently \"npm run -w @coveo/headless dev\" \"npm run -w @coveo/atomic dev\"",
+    "dev:atomic": "concurrently \"npm run -w @coveo/headless dev\" \"npm run -w @coveo/atomic start\"",
     "build": "nx run-many --target=build",
     "test": "nx run-many --target=test",
     "e2e": "nx run-many --target=e2e",

--- a/scripts/esbuild/build.mjs
+++ b/scripts/esbuild/build.mjs
@@ -9,7 +9,8 @@ export async function build(options) {
   const output = await esBuildContext.rebuild();
   if (watch) {
     await esBuildContext.watch();
+  } else {
+    await esBuildContext.dispose();
   }
-  await esBuildContext.dispose();
   return output;
 }


### PR DESCRIPTION
This PR prevents esbuild from stopping when in watch mode. This was preventing Hot Module Replacement from triggering when making changes in headless while using atomic in dev mode. 

https://coveord.atlassian.net/browse/KIT-3359