### PR TITLE
feat(answer): error handling

### DIFF
--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -13,6 +13,7 @@ import {
 } from '@reduxjs/toolkit';
 import {Logger} from 'pino';
 import {getRelayInstanceFromState} from '../api/analytics/analytics-relay-client';
+import {answerApi} from '../api/knowledge/stream-answer-api';
 import {
   disableAnalytics,
   enableAnalytics,
@@ -403,7 +404,7 @@ function createMiddleware<Reducers extends ReducersMapObject>(
     renewTokenMiddleware,
     logActionErrorMiddleware(logger),
     analyticsMiddleware,
-  ].concat(options.middlewares || []);
+  ].concat(answerApi.middleware, options.middlewares || []);
 }
 
 function shouldWarnAboutOrganizationEndpoints(

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -158,6 +158,10 @@ export interface GeneratedAnswerPropsInitialState {
 
 export interface GeneratedAnswerProps extends GeneratedAnswerPropsInitialState {
   /**
+   * The answer configuration ID used to leverage coveo answer management capabilities.
+   */
+  answerConfigurationId?: string;
+  /**
    * A list of indexed fields to include in the citations returned with the generated answer.
    */
   fieldsToIncludeInCitations?: string[];

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -160,6 +160,11 @@ export const updateResponseFormat = createAction(
     })
 );
 
+export const updateAnswerConfigurationId = createAction(
+  'knowledge/updateAnswerConfigurationId',
+  (payload: string) => validatePayload(payload, stringValue)
+);
+
 export const registerFieldsToIncludeInCitations = createAction(
   'generatedAnswer/registerFieldsToIncludeInCitations',
   (payload: string[]) => validatePayload<string[]>(payload, nonEmptyStringArray)

--- a/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
@@ -1,17 +1,23 @@
+import {createSelector} from '@reduxjs/toolkit';
 import {SearchAppState} from '../../state/search-app-state';
 import {GeneratedAnswerSection} from '../../state/state-sections';
 
-export function citationSourceSelector(
-  state: Partial<GeneratedAnswerSection>,
-  citationId: string
-) {
-  return state.generatedAnswer?.citations?.find(
-    (citation) => citation.id === citationId
-  );
-}
+export const citationSourceSelector = createSelector(
+  (state: Partial<GeneratedAnswerSection>, citationId: string) =>
+    state.generatedAnswer?.citations?.find(
+      (citation) => citation.id === citationId
+    ),
+  (citation) => citation
+);
 
-export function generativeQuestionAnsweringIdSelector(
-  state: Partial<SearchAppState>
-) {
-  return state.search?.response?.extendedResults?.generativeQuestionAnsweringId;
-}
+export const generativeQuestionAnsweringIdSelector = createSelector(
+  (state: Partial<SearchAppState>) =>
+    state.search?.response?.extendedResults?.generativeQuestionAnsweringId,
+  (generativeQuestionAnsweringId) => generativeQuestionAnsweringId
+);
+
+export const selectFieldsToIncludeInCitation = createSelector(
+  (state: Partial<GeneratedAnswerSection>) =>
+    state.generatedAnswer?.fieldsToIncludeInCitations,
+  (fieldsToInclude) => fieldsToInclude
+);

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -20,6 +20,7 @@ import {
   setIsAnswerGenerated,
   expandGeneratedAnswer,
   collapseGeneratedAnswer,
+  updateAnswerConfigurationId,
 } from './generated-answer-actions';
 import {getGeneratedAnswerInitialState} from './generated-answer-state';
 
@@ -110,5 +111,8 @@ export const generatedAnswerReducer = createReducer(
       })
       .addCase(collapseGeneratedAnswer, (state) => {
         state.expanded = false;
+      })
+      .addCase(updateAnswerConfigurationId, (state, {payload}) => {
+        state.answerConfigurationId = payload;
       })
 );

--- a/packages/headless/src/features/generated-answer/generated-answer-state.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-state.ts
@@ -72,6 +72,10 @@ export interface GeneratedAnswerState {
    * Whether the answer is expanded.
    */
   expanded: boolean;
+  /**
+   * The answer configuration unique identifier.
+   */
+  answerConfigurationId?: string;
 }
 
 export function getGeneratedAnswerInitialState(): GeneratedAnswerState {


### PR DESCRIPTION
## Summary

Updates to the Answer Api client to make sure the error handling is proper. Some little extras needed for it to work proper that will make the subsequent review a bit easier.

## Why

The Answer Api is almost just a proxy for the stream coming from reveal. And for some technical reasons, the call to the answer api will return an error message but will not return downright error status codes like 400s when the stream fails.
That said, we can rely on the stream end message in case the stream is not working properly, and since its better to give the user or the devs all the information we can, this increment makes sure that the error will appear in the logs and in the state in case we want to leverage the error message in the front end component.