### PR TITLE
docs(atomic): remove internal flag for atomic-commerce-facet

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -139,13 +139,14 @@ export declare interface AtomicColorFacet extends Components.AtomicColorFacet {}
 
 
 @ProxyCmp({
+  inputs: ['facet', 'field', 'isCollapsed', 'summary']
 })
 @Component({
   selector: 'atomic-commerce-category-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [],
+  inputs: ['facet', 'field', 'isCollapsed', 'summary'],
 })
 export class AtomicCommerceCategoryFacet {
   protected el: HTMLElement;
@@ -160,13 +161,14 @@ export declare interface AtomicCommerceCategoryFacet extends Components.AtomicCo
 
 
 @ProxyCmp({
+  inputs: ['facet', 'field', 'isCollapsed', 'summary']
 })
 @Component({
   selector: 'atomic-commerce-facet',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [],
+  inputs: ['facet', 'field', 'isCollapsed', 'summary'],
 })
 export class AtomicCommerceFacet {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -307,7 +307,6 @@ export namespace Components {
     interface AtomicCommerceFacet {
         /**
           * The facet controller instance.
-          * @
          */
         "facet": RegularFacet;
         /**
@@ -5769,7 +5768,6 @@ declare namespace LocalJSX {
     interface AtomicCommerceFacet {
         /**
           * The facet controller instance.
-          * @
          */
         "facet": RegularFacet;
         /**

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
@@ -94,26 +94,18 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
 
   /**
    * The summary controller instance.
-   *
-   * @internal
    */
   @Prop() summary!: Summary<SearchSummaryState | ProductListingSummaryState>;
   /**
    * The category facet controller instance.
-   *
-   * @internal
    */
   @Prop() public facet!: CategoryFacet;
   /**
    * Specifies whether the facet is collapsed.
-   *
-   * @internal
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The field identifier for this facet.
-   *
-   * @internal
    */
   @Prop({reflect: true}) field?: string;
 

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
@@ -96,26 +96,18 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
 
   /**
    * The Summary controller instance.
-   *
-   * @internal
    */
   @Prop() summary!: Summary<SearchSummaryState | ProductListingSummaryState>;
   /**
    * The facet controller instance.
-   *
-   * @@internal
    */
   @Prop() public facet!: RegularFacet;
   /**
    * Specifies whether the facet is collapsed.
-   *
-   * @internal
    */
   @Prop({reflect: true, mutable: true}) public isCollapsed = false;
   /**
    * The field identifier for this facet.
-   *
-   * @internal
    */
   @Prop({reflect: true}) field?: string;
 


### PR DESCRIPTION
This was reported in our internal slack channel about support for atomic-commerce with PS.
They need access to these properties to power an advance customization

https://coveord.atlassian.net/browse/KIT-3373