### PR TITLE
fix(headless): bump relay version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5470,11 +5470,6 @@
       "resolved": "packages/bueno",
       "link": true
     },
-    "node_modules/@coveo/explorer-messenger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@coveo/explorer-messenger/-/explorer-messenger-0.1.1.tgz",
-      "integrity": "sha512-jZEtAc4BJ5MTEP9/FDwmkwM7bHVc/N3HHdnuOEJ+4vMnTBxBecndaxojFqoPcqJsINmRkD71XSUPQZUbbKXRrA=="
-    },
     "node_modules/@coveo/headless": {
       "resolved": "packages/headless",
       "link": true
@@ -5506,27 +5501,6 @@
     "node_modules/@coveo/quantic": {
       "resolved": "packages/quantic",
       "link": true
-    },
-    "node_modules/@coveo/relay": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@coveo/relay/-/relay-0.7.7.tgz",
-      "integrity": "sha512-hTnO/GN4WEx+3qVGWx+BnM9nRLk+TLM1GaTcX2emWIZBcvm9XHWkKHBz7d8onNn+ip54zbVXvm+9Rfdq0NDGvg==",
-      "dependencies": {
-        "@coveo/explorer-messenger": "^0.1.1",
-        "uuid": "^9.0.1"
-      }
-    },
-    "node_modules/@coveo/relay/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@coveo/release": {
       "resolved": "utils/release",
@@ -59938,7 +59912,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "0.45.9",
-        "@coveo/relay": "0.7.7",
+        "@coveo/relay": "0.7.10",
         "@coveo/relay-event-types": "9.2.0",
         "@microsoft/fetch-event-source": "2.0.1",
         "@reduxjs/toolkit": "2.2.6",
@@ -60045,6 +60019,20 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "packages/headless/node_modules/@coveo/explorer-messenger": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@coveo/explorer-messenger/-/explorer-messenger-0.4.0.tgz",
+      "integrity": "sha512-nVxwn+4Z+SZe6K94evxPaIeJWJq7hATNaUrTKznnauVptFMYcujts/nnhMplddm9ePg7NgZQjvcHwbi5kqw/EA=="
+    },
+    "packages/headless/node_modules/@coveo/relay": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@coveo/relay/-/relay-0.7.10.tgz",
+      "integrity": "sha512-d/4Vf8wwj746M0RV9xAek7SV/rZhv3ERoQoZo6I2IKAqzMxX8r0Vyrau+UZG1sdxybd6zzo8AVIzvRFHGXxvnA==",
+      "dependencies": {
+        "@coveo/explorer-messenger": "^0.4.0",
+        "uuid": "^9.0.1"
       }
     },
     "packages/headless/node_modules/@coveo/relay-event-types": {
@@ -60160,6 +60148,18 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "packages/headless/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/quantic": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@coveo/bueno": "0.45.9",
-    "@coveo/relay": "0.7.7",
+    "@coveo/relay": "0.7.10",
     "@coveo/relay-event-types": "9.2.0",
     "@microsoft/fetch-event-source": "2.0.1",
     "@reduxjs/toolkit": "2.2.6",

--- a/packages/headless/src/api/analytics/analytics-relay-client.test.ts
+++ b/packages/headless/src/api/analytics/analytics-relay-client.test.ts
@@ -11,7 +11,6 @@ describe('#getRelayInstanceFromState', () => {
     emit: jest.fn(),
     on: jest.fn(),
     off: jest.fn(),
-    clearStorage: jest.fn(),
     getMeta: jest.fn(),
     updateConfig: jest.fn(),
     version: 'test',

--- a/packages/headless/src/features/analytics/analytics-utils.test.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.test.ts
@@ -210,7 +210,6 @@ describe('analytics-utils', () => {
         emit: relayEmitSpy as unknown as ReturnType<typeof createRelay>['emit'],
         on: jest.fn(),
         off: jest.fn(),
-        clearStorage: jest.fn(),
         getMeta: jest.fn(),
         updateConfig: jest.fn(),
         version: 'test',

--- a/packages/headless/src/features/attached-results/attached-results-analytics-actions.test.ts
+++ b/packages/headless/src/features/attached-results/attached-results-analytics-actions.test.ts
@@ -39,7 +39,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/case-assist/case-assist-analytics-actions.test.ts
+++ b/packages/headless/src/features/case-assist/case-assist-analytics-actions.test.ts
@@ -43,7 +43,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
@@ -82,7 +82,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
@@ -51,7 +51,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/insight-search/insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/insight-search/insight-analytics-actions.test.ts
@@ -35,7 +35,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/instant-results/instant-result-analytics-actions.test.ts
+++ b/packages/headless/src/features/instant-results/instant-result-analytics-actions.test.ts
@@ -28,7 +28,6 @@ describe('#logRecommendationOpen', () => {
       on: jest.fn(),
       off: jest.fn(),
       updateConfig: jest.fn(),
-      clearStorage: jest.fn(),
       version: 'foo',
     });
   });

--- a/packages/headless/src/features/question-answering/question-answering-analytics-actions.test.ts
+++ b/packages/headless/src/features/question-answering/question-answering-analytics-actions.test.ts
@@ -82,7 +82,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/question-answering/question-answering-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/question-answering/question-answering-insight-analytics-actions.test.ts
@@ -53,7 +53,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/recommendation/recommendation-analytics-actions.test.ts
+++ b/packages/headless/src/features/recommendation/recommendation-analytics-actions.test.ts
@@ -28,7 +28,6 @@ describe('#logRecommendationOpen', () => {
       on: jest.fn(),
       off: jest.fn(),
       updateConfig: jest.fn(),
-      clearStorage: jest.fn(),
       version: 'foo',
     });
   });

--- a/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/result-actions/result-actions-insight-analytics-actions.test.ts
@@ -42,7 +42,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/result-preview/result-preview-analytics-actions.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-analytics-actions.test.ts
@@ -28,7 +28,6 @@ describe('#logDocumentQuickview', () => {
       on: jest.fn(),
       off: jest.fn(),
       updateConfig: jest.fn(),
-      clearStorage: jest.fn(),
       version: 'foo',
     });
   });

--- a/packages/headless/src/features/result-preview/result-preview-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/result-preview/result-preview-insight-analytics-actions.test.ts
@@ -35,7 +35,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/features/result/result-analytics-actions.test.ts
+++ b/packages/headless/src/features/result/result-analytics-actions.test.ts
@@ -28,7 +28,6 @@ describe('#logDocumentOpen', () => {
       on: jest.fn(),
       off: jest.fn(),
       updateConfig: jest.fn(),
-      clearStorage: jest.fn(),
       version: 'foo',
     });
   });

--- a/packages/headless/src/features/result/result-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/result/result-insight-analytics-actions.test.ts
@@ -34,7 +34,6 @@ jest.mocked(createRelay).mockReturnValue({
   on: jest.fn(),
   off: jest.fn(),
   updateConfig: jest.fn(),
-  clearStorage: jest.fn(),
   version: 'foo',
 });
 

--- a/packages/headless/src/test/mock-engine-v2.ts
+++ b/packages/headless/src/test/mock-engine-v2.ts
@@ -40,7 +40,6 @@ type MockedRelay = Relay & Pick<Relay, 'emit'>;
 
 export function mockRelay(): MockedRelay {
   return {
-    clearStorage: jest.fn(),
     emit: jest.fn(),
     getMeta: jest.fn().mockReturnValue({clientId: 'test'}),
     off: jest.fn(),


### PR DESCRIPTION
Includes changes about defensive access to local storage.

`clearStorage()` was also removed from relay interface in `0.7.9`

https://coveord.atlassian.net/browse/KIT-3374