### PR TITLE
fix: add atomic version in the analytics initial config for Headless

### DIFF
--- a/packages/atomic/src/components/common/interface/analytics-config.ts
+++ b/packages/atomic/src/components/common/interface/analytics-config.ts
@@ -66,7 +66,7 @@ export function getNextAnalyticsConfig(
     analyticsConfiguration,
     augmentAnalyticsConfigWithAtomicVersion()
   );
-  Object.assign(configuration, searchEngineConfig.analytics);
+  Object.assign(configuration, analyticsConfiguration);
 
   return configuration;
 }

--- a/packages/atomic/src/components/common/interface/analytics-config.ts
+++ b/packages/atomic/src/components/common/interface/analytics-config.ts
@@ -55,17 +55,18 @@ export function getNextAnalyticsConfig(
   searchEngineConfig: EngineConfiguration,
   enabled: boolean
 ): AnalyticsConfiguration {
-  const defaultConfiguration: AnalyticsConfiguration = {
+  const configuration: AnalyticsConfiguration = {
     enabled,
     documentLocation: document.location.href,
     ...(document.referrer && {originLevel3: document.referrer}),
   };
 
-  if (searchEngineConfig.analytics) {
-    return {
-      ...defaultConfiguration,
-      ...searchEngineConfig.analytics,
-    };
-  }
-  return defaultConfiguration;
+  const analyticsConfiguration = searchEngineConfig.analytics ?? {};
+  Object.assign(
+    analyticsConfiguration,
+    augmentAnalyticsConfigWithAtomicVersion()
+  );
+  Object.assign(configuration, searchEngineConfig.analytics);
+
+  return configuration;
 }

--- a/packages/headless/src/api/analytics/analytics-selectors.test.ts
+++ b/packages/headless/src/api/analytics/analytics-selectors.test.ts
@@ -16,8 +16,8 @@ describe('#getAnalyticsSources', () => {
       '@coveo/atomic': '1.2.3',
     };
     expect(getAnalyticsSource(state.configuration.analytics)).toEqual([
-      `@coveo/headless@${VERSION}`,
       '@coveo/atomic@1.2.3',
+      `@coveo/headless@${VERSION}`,
     ]);
   });
 });

--- a/packages/headless/src/api/analytics/analytics-selectors.ts
+++ b/packages/headless/src/api/analytics/analytics-selectors.ts
@@ -5,10 +5,10 @@ import {VERSION} from '../../utils/version';
 export const getAnalyticsSource = createSelector(
   (state: AnalyticsState) => state.source,
   (source) =>
-    [`@coveo/headless@${VERSION}`].concat(
-      Object.entries(source).map(
+    Object.entries(source)
+      .map(
         ([frameworkName, frameworkVersion]) =>
           `${frameworkName}@${frameworkVersion}`
       )
-    )
+      .concat(`@coveo/headless@${VERSION}`)
 );

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -66,7 +66,7 @@ describe('commerce common actions', () => {
               quantity: product.quantity,
             },
           ],
-          source: [`@coveo/headless@${VERSION}`, '@coveo/atomic@version'],
+          source: ['@coveo/atomic@version', `@coveo/headless@${VERSION}`],
         },
       };
 


### PR DESCRIPTION
Also, append instead of prepend Headless version to replace Headless-Atomic-Relay order by Atomic-Headless-Relay

https://coveord.atlassian.net/browse/KIT-3308
