### PR TITLE
chore: do not rebuild everytime the container starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
   // "forwardPorts": [],
 
   // Use 'updateContentCommand ' to run commands when the prebuild is created or updated https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds#configuring-time-consuming-tasks-to-be-included-in-the-prebuild
-  "updateContentCommand": "CI=true bash -c 'npm ci && npm run build'"
+  "onCreateCommand": "CI=true bash -c 'npm ci && npm run build'"
 
   // Configure tool-specific properties.
   // "customizations": {},


### PR DESCRIPTION
Instead, rebuild when changes are made in master.

Codespaces should be ready to use in less than 5' with that.
