### PR TITLE
chore(headless SSR): add `CoreEngineNext` type

### DIFF
--- a/packages/headless/src/app/ssr-engine/common.ts
+++ b/packages/headless/src/app/ssr-engine/common.ts
@@ -1,7 +1,7 @@
 import {AnyAction} from '@reduxjs/toolkit';
 import {Controller} from '../../controllers/controller/headless-controller';
 import {clone, mapObject} from '../../utils/utils';
-import {CoreEngine} from '../engine';
+import {CoreEngine, CoreEngineNext} from '../engine';
 import {
   ControllerDefinition,
   ControllerDefinitionsMap,
@@ -16,7 +16,7 @@ import {
 
 function buildControllerFromDefinition<
   TControllerDefinition extends ControllerDefinition<TEngine, Controller>,
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
 >({
   definition,
   engine,
@@ -35,10 +35,10 @@ function buildControllerFromDefinition<
 
 export function buildControllerDefinitions<
   TControllerDefinitionsMap extends ControllerDefinitionsMap<
-    CoreEngine,
+    CoreEngine | CoreEngineNext,
     Controller
   >,
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
 >({
   definitionsMap,
   engine,

--- a/packages/headless/src/app/ssr-engine/types/build.ts
+++ b/packages/headless/src/app/ssr-engine/types/build.ts
@@ -1,4 +1,4 @@
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 import {
   ControllersMap,
   ControllersPropsMap,
@@ -13,7 +13,7 @@ export interface BuildOptions<TEngineOptions> {
 }
 
 export interface Build<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TEngineOptions,
   TControllersMap extends ControllersMap,
   TControllersProps extends ControllersPropsMap,

--- a/packages/headless/src/app/ssr-engine/types/common.ts
+++ b/packages/headless/src/app/ssr-engine/types/common.ts
@@ -1,6 +1,6 @@
 import {AnyAction} from '@reduxjs/toolkit';
 import type {Controller} from '../../../controllers/controller/headless-controller';
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 
 export type HasKeys<TObject> = TObject extends {}
   ? keyof TObject extends never
@@ -44,7 +44,7 @@ export interface ControllerStaticStateMap {
 }
 
 export interface ControllerDefinitionWithoutProps<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TController extends Controller,
 > {
   /**
@@ -57,7 +57,7 @@ export interface ControllerDefinitionWithoutProps<
 }
 
 export interface ControllerDefinitionWithProps<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TController extends Controller,
   TProps,
 > {
@@ -72,21 +72,21 @@ export interface ControllerDefinitionWithProps<
 }
 
 export type ControllerDefinition<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TController extends Controller,
 > =
   | ControllerDefinitionWithoutProps<TEngine, TController>
   | ControllerDefinitionWithProps<TEngine, TController, unknown>;
 
 export interface ControllerDefinitionsMap<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TController extends Controller,
 > {
   [customName: string]: ControllerDefinition<TEngine, TController>;
 }
 
 export interface EngineDefinitionBuildResult<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
 > {
   engine: TEngine;
@@ -102,28 +102,34 @@ export interface EngineStaticState<
 }
 
 export interface HydratedState<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
 > extends EngineDefinitionBuildResult<TEngine, TControllers> {}
 
 export type InferControllerPropsFromDefinition<
-  TController extends ControllerDefinition<CoreEngine, Controller>,
+  TController extends ControllerDefinition<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > =
   TController extends ControllerDefinitionWithProps<
-    CoreEngine,
+    CoreEngine | CoreEngineNext,
     Controller,
     infer Props
   >
     ? Props
     : TController extends ControllerDefinitionWithoutProps<
-          CoreEngine,
+          CoreEngine | CoreEngineNext,
           Controller
         >
       ? {}
       : unknown;
 
 export type InferControllerPropsMapFromDefinitions<
-  TControllers extends ControllerDefinitionsMap<CoreEngine, Controller>,
+  TControllers extends ControllerDefinitionsMap<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > = {
   [K in keyof TControllers as HasKeys<
     InferControllerPropsFromDefinition<TControllers[K]>
@@ -133,14 +139,20 @@ export type InferControllerPropsMapFromDefinitions<
 };
 
 export type InferControllerFromDefinition<
-  TDefinition extends ControllerDefinition<CoreEngine, Controller>,
+  TDefinition extends ControllerDefinition<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > =
   TDefinition extends ControllerDefinition<infer _, infer TController>
     ? TController
     : never;
 
 export type InferControllersMapFromDefinition<
-  TControllers extends ControllerDefinitionsMap<CoreEngine, Controller>,
+  TControllers extends ControllerDefinitionsMap<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > = {[K in keyof TControllers]: InferControllerFromDefinition<TControllers[K]>};
 
 export type InferControllerStaticStateFromController<
@@ -148,7 +160,10 @@ export type InferControllerStaticStateFromController<
 > = ControllerStaticState<TController['state']>;
 
 export type InferControllerStaticStateMapFromDefinitions<
-  TControllers extends ControllerDefinitionsMap<CoreEngine, Controller>,
+  TControllers extends ControllerDefinitionsMap<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > = {
   [K in keyof TControllers]: InferControllerStaticStateFromController<
     InferControllerFromDefinition<TControllers[K]>

--- a/packages/headless/src/app/ssr-engine/types/core-engine.ts
+++ b/packages/headless/src/app/ssr-engine/types/core-engine.ts
@@ -1,6 +1,6 @@
 import {AnyAction} from '@reduxjs/toolkit';
 import type {Controller} from '../../../controllers/controller/headless-controller';
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 import {EngineConfiguration} from '../../engine-configuration';
 import {Build} from './build';
 import {
@@ -14,7 +14,10 @@ import {HydrateStaticState} from './hydrate-static-state';
 
 export type EngineDefinitionOptions<
   TOptions extends {configuration: EngineConfiguration},
-  TControllers extends ControllerDefinitionsMap<CoreEngine, Controller>,
+  TControllers extends ControllerDefinitionsMap<
+    CoreEngine | CoreEngineNext,
+    Controller
+  >,
 > = TOptions & {
   /**
    * The controllers to initialize with the search engine.
@@ -23,7 +26,7 @@ export type EngineDefinitionOptions<
 };
 
 export interface EngineDefinition<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllerDefinitionsMap<TEngine, Controller>,
   TEngineOptions,
 > {

--- a/packages/headless/src/app/ssr-engine/types/fetch-static-state.ts
+++ b/packages/headless/src/app/ssr-engine/types/fetch-static-state.ts
@@ -1,5 +1,5 @@
 import {AnyAction} from '@reduxjs/toolkit';
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 import {
   ControllerStaticStateMap,
   ControllersMap,
@@ -13,7 +13,7 @@ import {FromBuildResult} from './from-build-result';
 export type FetchStaticStateOptions = {};
 
 export type FetchStaticState<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
   TSearchAction extends AnyAction,
   TControllersStaticState extends ControllerStaticStateMap,

--- a/packages/headless/src/app/ssr-engine/types/from-build-result.ts
+++ b/packages/headless/src/app/ssr-engine/types/from-build-result.ts
@@ -1,15 +1,15 @@
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 import {ControllersMap, EngineDefinitionBuildResult} from './common';
 
 export interface FromBuildResultOptions<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
 > {
   buildResult: EngineDefinitionBuildResult<TEngine, TControllers>;
 }
 
 export interface FromBuildResult<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
   TOptions,
   TReturn,

--- a/packages/headless/src/app/ssr-engine/types/hydrate-static-state.ts
+++ b/packages/headless/src/app/ssr-engine/types/hydrate-static-state.ts
@@ -1,5 +1,5 @@
 import {AnyAction} from '@reduxjs/toolkit';
-import {CoreEngine} from '../../engine';
+import {CoreEngine, CoreEngineNext} from '../../engine';
 import {
   ControllersMap,
   ControllersPropsMap,
@@ -14,7 +14,7 @@ export interface HydrateStaticStateOptions<TSearchAction> {
 }
 
 export type HydrateStaticState<
-  TEngine extends CoreEngine,
+  TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllersMap,
   TSearchAction extends AnyAction,
   TControllersProps extends ControllersPropsMap,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3389

Building block so we can later use SSR utils with commerce engine and controllers