### PR TITLE
feat(headless SSR): define the SSR Commerce Engine

### DIFF
--- a/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
@@ -86,6 +86,7 @@ export interface CommerceEngineDefinition<
   > {}
 
 /**
+ * @internal
  * Initializes a Commerce engine definition in SSR with given controllers definitions and commerce engine config.
  * @param options - The commerce engine definition
  * @returns Three utility functions to fetch the initial state of the engine in SSR, hydrate the state in CSR,


### PR DESCRIPTION
In this PR:
* Defining a new `SSRCommerceEngine` interface supporting two solution types (listing, search)
* Implementing a `defineCommerceEngine()` method for commerce engine configuration (to stay consistent with the non-commerce SSR package)

> Note:
> Only supporting listing page in this PR.
> The support for search page will be tackled in KIT-3394

https://coveord.atlassian.net/browse/KIT-3390