### PR TITLE
fix(headless): ensure facet value from URL are always considered for auto-facets

### DIFF
--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.test.ts
@@ -214,14 +214,28 @@ describe('automatic-facet-set slice', () => {
   describe('#restoreSearchParameters', () => {
     it('sets #values to the selected values in the payload when a facet is found in the #af payload', () => {
       const field = 'field';
-      const value = 'a';
+      const initialValue = buildMockFacetValue({value: 'a', state: 'idle'});
+      state.set[field] = {
+        response: {
+          field,
+          values: [initialValue],
+          moreValuesAvailable: true,
+          indexScore: 0.42,
+          label: 'potato',
+        },
+      };
+
+      const value = 'b';
       const af = {[field]: [value]};
       const action = restoreSearchParameters({af});
 
       const finalState = automaticFacetSetReducer(state, action);
       const selectedValue = buildMockFacetValue({value, state: 'selected'});
 
-      expect(finalState.set[field].response.values).toEqual([selectedValue]);
+      expect(finalState.set[field].response.values).toEqual([
+        initialValue,
+        selectedValue,
+      ]);
     });
   });
 

--- a/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/automatic-facet-set/automatic-facet-set-slice.ts
@@ -89,13 +89,19 @@ export const automaticFacetSetReducer = createReducer(
         for (const field in af) {
           const facet = state.set[field]?.response;
           if (facet) {
-            const values = facet.values;
-            for (const value of values) {
-              if (!af[field].includes(value.value)) {
-                value.state = 'idle';
-              } else if (value.state === 'idle') {
+            const stateFacetValues = facet.values;
+            const urlFacetValues = new Set<string>(af[field]);
+            for (const value of stateFacetValues) {
+              if (urlFacetValues.has(value.value)) {
                 value.state = 'selected';
+                urlFacetValues.delete(value.value);
+              } else {
+                value.state = 'idle';
               }
+            }
+
+            for (const value of urlFacetValues) {
+              facet.values.push(buildTemporarySelectedFacetValue(value));
             }
           }
         }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3417

Before:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/e6eececb-294f-447a-b545-fbbb2bf60eac">


After:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/c18b1176-2b89-47e1-a66d-9a03cfee2ed6">
