### PR TITLE
fix(quantic): styling of the search box input adjusted

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.css
@@ -48,7 +48,6 @@ textarea.searchbox__input {
 .searchbox__container-wrapper {
   position: relative;
   min-height: 3.125rem;
-  min-width: 300px;
 }
 
 .searchbox_floating-container {


### PR DESCRIPTION
## [SFINT-5595](https://coveord.atlassian.net/browse/SFINT-5595)

- Min width removed from the styling of the search box input to avoid the following issue:

<img width="1487" alt="Screenshot 2024-06-26 at 3 09 45 PM" src="https://github.com/user-attachments/assets/3de93e18-c990-48fc-81d2-81d531b94b4e">


[SFINT-5595]: https://coveord.atlassian.net/browse/SFINT-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ