### PR TITLE
test(commerce): fix flaky commerce query summary tests

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/e2e/page-object.ts
@@ -15,7 +15,9 @@ export class QuerySummaryPageObject extends BasePageObject<'atomic-commerce-quer
   }
 
   text(summaryRegex: RegExp) {
-    return this.page.getByText(summaryRegex);
+    return this.page
+      .locator(':not([role="status"])')
+      .filter({hasText: summaryRegex});
   }
 
   get container() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3369

fixes this strict selector error : 

   Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
    Error: expect.toBeVisible: Error: strict mode violation: getByText(/^Product 1 of 1 for kayak$/) resolved to 2 elements:
        1) <div role="status" aria-live="polite" id="aria-live-eypty-query-summary">Product 1 of 1 for kayak</div> aka locator('#aria-live-eypty-query-summary')
        2) <div part="container" class="text-on-background">…</div> aka locator('#code-root').getByText('Product 1 of 1 for kayak')