### PR TITLE
feat(answerApi): evaluations

### DIFF
--- a/packages/headless/src/api/knowledge/answer-slice.ts
+++ b/packages/headless/src/api/knowledge/answer-slice.ts
@@ -6,9 +6,12 @@ import {
   FetchBaseQueryError,
   retry,
 } from '@reduxjs/toolkit/query';
-import {ConfigurationSection} from '../../state/state-sections';
+import {
+  ConfigurationSection,
+  GeneratedAnswerSection,
+} from '../../state/state-sections';
 
-type StateNeededByAnswerSlice = ConfigurationSection;
+type StateNeededByAnswerSlice = ConfigurationSection & GeneratedAnswerSection;
 
 /**
  * `dynamicBaseQuery` is passed to the baseQuery of the createApi,
@@ -21,6 +24,7 @@ const dynamicBaseQuery: BaseQueryFn<
 > = async (args, api, extraOptions) => {
   const state = api.getState() as StateNeededByAnswerSlice;
   const {accessToken, organizationId, platformUrl} = state.configuration;
+  const answerConfigurationId = state.generatedAnswer.answerConfigurationId;
   const updatedArgs = {
     ...(args as FetchArgs),
     headers: {
@@ -30,7 +34,7 @@ const dynamicBaseQuery: BaseQueryFn<
   };
   try {
     const data = fetchBaseQuery({
-      baseUrl: `${platformUrl}/rest/organizations/${organizationId}`,
+      baseUrl: `${platformUrl}/rest/organizations/${organizationId}/answer/v1/configs/${answerConfigurationId}`,
     })(updatedArgs, api, extraOptions);
     return {data};
   } catch (error) {

--- a/packages/headless/src/api/knowledge/post-answer-evaluation.ts
+++ b/packages/headless/src/api/knowledge/post-answer-evaluation.ts
@@ -1,0 +1,31 @@
+import {answerSlice} from './answer-slice';
+
+export interface AnswerEvaluationPOSTParams {
+  question: string;
+  helpful: boolean;
+  answer: {
+    responseId: string;
+    text: string;
+    format: string;
+  };
+  details: {
+    readable: Boolean | null;
+    documented: Boolean | null;
+    correctTopic: Boolean | null;
+    hallucinationFree: Boolean | null;
+  };
+  correctAnswerUrl: string | null;
+  additionalNotes: string | null;
+}
+
+export const answerEvaluation = answerSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    post: builder.mutation<void, AnswerEvaluationPOSTParams>({
+      query: (body) => ({
+        url: '/evaluations',
+        method: 'POST',
+        body,
+      }),
+    }),
+  }),
+});

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -32,7 +32,8 @@ export type StateNeededByAnswerAPI = {
   DebugSection &
   GeneratedAnswerSection;
 
-interface GeneratedAnswerStream {
+export interface GeneratedAnswerStream {
+  answerId?: string;
   answerStyle?: GeneratedAnswerStyle;
   contentFormat?: GeneratedContentFormat;
   answer?: string;
@@ -196,6 +197,14 @@ export const answerApi = answerSlice.injectEndpoints({
               'Accept-Encoding': '*',
             },
             fetch,
+            onopen: async (res) => {
+              const answerId = res.headers.get('x-answer-id');
+              if (answerId) {
+                updateCachedData((draft) => {
+                  draft.answerId = answerId;
+                });
+              }
+            },
             onmessage: (event) => {
               updateCachedData((draft) => {
                 updateCacheWithEvent(event, draft);

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -1,14 +1,19 @@
-import {answerApi, fetchAnswer} from '../../../api/knowledge/stream-answer-api';
+import {answerEvaluation} from '../../../api/knowledge/post-answer-evaluation';
+import {
+  answerApi,
+  fetchAnswer,
+  StateNeededByAnswerAPI,
+} from '../../../api/knowledge/stream-answer-api';
 import {
   resetAnswer,
   updateAnswerConfigurationId,
   updateResponseFormat,
 } from '../../../features/generated-answer/generated-answer-actions';
-import {generatedAnswerAnalyticsClient} from '../../../features/generated-answer/generated-answer-analytics-actions';
 import {
-  GeneratedAnswerState,
-  getGeneratedAnswerInitialState,
-} from '../../../features/generated-answer/generated-answer-state';
+  generatedAnswerAnalyticsClient,
+  GeneratedAnswerFeedbackV2,
+} from '../../../features/generated-answer/generated-answer-analytics-actions';
+import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state';
 import {queryReducer} from '../../../features/query/query-slice';
 import {
   buildMockSearchEngine,
@@ -33,8 +38,20 @@ jest.mock('../../../api/knowledge/stream-answer-api', () => {
   return {
     ...originalStreamAnswerApi,
     fetchAnswer: jest.fn(),
+    selectAnswer: () => ({
+      data: {answer: 'This est une answer', answerId: '12345_6'},
+    }),
   };
 });
+jest.mock('../../../api/knowledge/post-answer-evaluation', () => ({
+  answerEvaluation: {
+    endpoints: {
+      post: {
+        initiate: jest.fn(),
+      },
+    },
+  },
+}));
 
 describe('knowledge-generated-answer', () => {
   it('should be tested', () => {
@@ -51,12 +68,12 @@ describe('knowledge-generated-answer', () => {
     );
 
   const buildEngineWithGeneratedAnswer = (
-    initialState: Partial<GeneratedAnswerState> = {}
+    initialState: Partial<StateNeededByAnswerAPI> = {}
   ) => {
     const state = createMockState({
+      ...initialState,
       generatedAnswer: {
         ...getGeneratedAnswerInitialState(),
-        ...initialState,
       },
     });
     return buildMockSearchEngine(state);
@@ -93,9 +110,9 @@ describe('knowledge-generated-answer', () => {
 
     expect(generatedAnswer.state).toEqual({
       ...engine.state.generatedAnswer,
-      answer: undefined,
+      answer: 'This est une answer',
       answerContentFormat: 'text/plain',
-      error: {message: undefined},
+      error: {message: undefined, statusCode: undefined},
     });
   });
 
@@ -125,5 +142,42 @@ describe('knowledge-generated-answer', () => {
     const generatedAnswer = createGeneratedAnswer();
     generatedAnswer.reset();
     expect(resetAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches a sendFeedback action', () => {
+    engine = buildEngineWithGeneratedAnswer({
+      query: {q: 'this est une question', enableQuerySyntax: false},
+    });
+    const generatedAnswer = createGeneratedAnswer();
+    const feedback: GeneratedAnswerFeedbackV2 = {
+      readable: 'unknown',
+      correctTopic: 'unknown',
+      documented: 'yes',
+      hallucinationFree: 'no',
+      helpful: false,
+      details: 'some details',
+    };
+    const expectedArgs = {
+      additionalNotes: 'some details',
+      answer: {
+        format: 'text/plain',
+        responseId: '12345_6',
+        text: 'This est une answer',
+      },
+      correctAnswerUrl: null,
+      details: {
+        correctTopic: null,
+        documented: true,
+        hallucinationFree: false,
+        readable: null,
+      },
+      helpful: false,
+      question: 'this est une question',
+    };
+    generatedAnswer.sendFeedback(feedback);
+    expect(answerEvaluation.endpoints.post.initiate).toHaveBeenCalledTimes(1);
+    expect(answerEvaluation.endpoints.post.initiate).toHaveBeenCalledWith(
+      expectedArgs
+    );
   });
 });


### PR DESCRIPTION
# Answer Api

[simplescreenrecorder-2024-07-30_16.55.09.webm](https://github.com/user-attachments/assets/79153f5a-19e6-42ec-8a3b-1c3921783e81)

## Summary

This PR make it so we can send CRGA evaluations from the feedback modal to the AnswerApi

- The endpoint that we can POST evaluations to has been added
- The Steam answer client will get the header of the stream response and set the Answer ID in its state
- The Controller now overrides the `SendFeedback` method in order to POST the feedback to the answer api

### Post Evaluation Endpoint

A RTK query Endpoint have been added to the Answer slice
A little modification to the dynamicBaseQuery was beneficial to make the endpoint definition simpler.

### Answer API Stream Headers recuperation

We use the `x-answer-id` from the stream call to identify the feedback when we send it to the evaluation endpoint.

### sendFeedback method override

The native `sendFeedback` method from the base controller has been modified to use the evaluation endpoint of the answerApi 
