### PR TITLE
fix(atomic): clear min/max for atomic-timeframe-facet when clearing filters

### DIFF
--- a/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
+++ b/packages/atomic/src/components/common/facets/facet-date-input/facet-date-input.tsx
@@ -40,6 +40,14 @@ export class FacetDateInput {
     this.start = range ? parseDate(range.start).toDate() : undefined;
     this.end = range ? parseDate(range.end).toDate() : undefined;
   }
+  public componentDidUpdate() {
+    if (!this.startRef.value && !this.endRef.value) {
+      this.startRef.min = this.min || this.formattedDateValue('1401-01-01');
+      this.endRef.max = this.max || '';
+      this.startRef.max = this.max || '';
+      this.endRef.min = this.min || '';
+    }
+  }
 
   private apply() {
     if (!this.startRef.validity.valid || !this.endRef.validity.valid) {
@@ -138,7 +146,7 @@ export class FacetDateInput {
           placeholder={placeholder}
           pattern={pattern}
           required
-          min={this.min || this.formattedDateValue(this.start)}
+          min={this.formattedDateValue(this.start) || this.min}
           max={this.max}
           value={this.formattedDateValue(range?.end)}
           onInput={(e) =>

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
@@ -10,7 +10,16 @@ const meta: Meta = {
   component: 'atomic-timeframe-facet',
   title: 'Atomic/TimeframeFacet',
   id: 'atomic-timeframe-facet',
-
+  argTypes: {
+    'attributes-min': {
+      name: 'min',
+      type: 'string',
+    },
+    'attributes-max': {
+      name: 'max',
+      type: 'string',
+    },
+  },
   render: renderComponent,
   decorators: [decorator],
   parameters,

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/atomic-timeframe-facet.e2e.ts
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/atomic-timeframe-facet.e2e.ts
@@ -1,0 +1,180 @@
+import {test, expect} from './fixture';
+
+test.describe('default', () => {
+  test.beforeEach(async ({facet}) => {
+    await facet.load({
+      args: {withDatePicker: true},
+    });
+  });
+
+  test.describe('when selecting a start date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputStart.click();
+      await facet.facetInputStart.fill('2021-01-01');
+    });
+
+    test('should limit the end date to the selected start date', async ({
+      facet,
+    }) => {
+      await facet.facetInputEnd.click();
+      await expect(facet.facetInputEnd).toHaveAttribute('min', '2021-01-01');
+    });
+  });
+
+  test.describe('when selecting an end date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputEnd.click();
+      await facet.facetInputEnd.fill('2021-01-01');
+    });
+
+    test('should limit the start date to the selected end date', async ({
+      facet,
+    }) => {
+      await facet.facetInputStart.click();
+      await expect(facet.facetInputStart).toHaveAttribute('max', '2021-01-01');
+    });
+  });
+
+  test.describe('when selecting a start date and an end date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputStart.click();
+      await facet.facetInputStart.fill('2021-01-01');
+      await facet.facetInputEnd.click();
+      await facet.facetInputEnd.fill('2021-01-31');
+    });
+
+    test.describe('when clicking the apply button', () => {
+      test.beforeEach(async ({facet}) => {
+        await facet.facetApplyButton.click();
+        await facet.facetClearFilter.waitFor({state: 'visible'});
+      });
+
+      test.describe('when clicking the clear filter button', () => {
+        test.beforeEach(async ({facet}) => {
+          await facet.facetClearFilter.click();
+        });
+
+        test('should clear the selected dates', async ({facet}) => {
+          await expect(facet.facetInputStart).toHaveValue('');
+          await expect(facet.facetInputEnd).toHaveValue('');
+        });
+
+        test('should reset the min and max values', async ({facet}) => {
+          await facet.facetInputStart.click();
+          await expect(facet.facetInputStart).toHaveAttribute(
+            'min',
+            '1401-01-01'
+          );
+          await facet.facetInputEnd.click();
+          await expect(facet.facetInputEnd).toHaveAttribute('max', '');
+        });
+
+        test('should hide the clear filter button', async ({facet}) => {
+          await expect(facet.facetClearFilter).not.toBeVisible();
+        });
+      });
+    });
+  });
+
+  test('should limit the start date to the default min value', async ({
+    facet,
+  }) => {
+    await facet.facetInputStart.click();
+    await expect(facet.facetInputStart).toHaveAttribute('min', '1401-01-01');
+  });
+
+  test('should not limit the end date', async ({facet}) => {
+    await facet.facetInputEnd.click();
+    await expect(facet.facetInputEnd).not.toHaveAttribute('max');
+  });
+});
+
+test.describe('with min and max values', () => {
+  test.beforeEach(async ({facet}) => {
+    await facet.load({
+      args: {withDatePicker: true, min: '2021-01-01', max: '2021-01-31'},
+    });
+  });
+
+  test.describe('when selecting a start date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputStart.click();
+      await facet.facetInputStart.fill('2021-01-01');
+    });
+
+    test('should limit the end date to the selected start date', async ({
+      facet,
+    }) => {
+      await facet.facetInputEnd.click();
+      await expect(facet.facetInputEnd).toHaveAttribute('min', '2021-01-01');
+    });
+  });
+
+  test.describe('when selecting an end date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputEnd.click();
+      await facet.facetInputEnd.fill('2021-01-01');
+    });
+
+    test('should limit the start date to the selected end date', async ({
+      facet,
+    }) => {
+      await facet.facetInputStart.click();
+      await expect(facet.facetInputStart).toHaveAttribute('max', '2021-01-01');
+    });
+  });
+
+  test.describe('when selecting a start date and an end date', () => {
+    test.beforeEach(async ({facet}) => {
+      await facet.facetInputStart.click();
+      await facet.facetInputStart.fill('2021-01-01');
+      await facet.facetInputEnd.click();
+      await facet.facetInputEnd.fill('2021-01-31');
+    });
+
+    test.describe('when clicking the apply button', () => {
+      test.beforeEach(async ({facet}) => {
+        await facet.facetApplyButton.click();
+        await facet.facetClearFilter.waitFor({state: 'visible'});
+      });
+
+      test.describe('when clicking the clear filter button', () => {
+        test.beforeEach(async ({facet}) => {
+          await facet.facetClearFilter.click();
+        });
+
+        test('should clear the selected dates', async ({facet}) => {
+          await expect(facet.facetInputStart).toHaveValue('');
+          await expect(facet.facetInputEnd).toHaveValue('');
+        });
+
+        test('should reset the min and max values', async ({facet}) => {
+          await facet.facetInputStart.click();
+          await expect(facet.facetInputStart).toHaveAttribute(
+            'min',
+            '2021-01-01'
+          );
+          await facet.facetInputEnd.click();
+          await expect(facet.facetInputEnd).toHaveAttribute(
+            'max',
+            '2021-01-31'
+          );
+        });
+
+        test('should hide the clear filter button', async ({facet}) => {
+          await expect(facet.facetClearFilter).not.toBeVisible();
+        });
+      });
+    });
+  });
+
+  test('should limit the start date to the min value', async ({facet}) => {
+    await facet.facetInputStart.click();
+    await expect(facet.facetInputStart).toHaveAttribute('min', '2021-01-01');
+  });
+
+  test('should limit the end date to the max value', async ({facet}) => {
+    await facet.facetInputEnd.click();
+    await expect(facet.facetInputEnd).toHaveAttribute('max', '2021-01-31');
+  });
+});

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/fixture.ts
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/fixture.ts
@@ -1,0 +1,19 @@
+import {test as base} from '@playwright/test';
+import {
+  AxeFixture,
+  makeAxeBuilder,
+} from '../../../../../../playwright-utils/base-fixture';
+import {AtomicTimeframeFacetPageObject as Facet} from './page-object';
+
+type MyFixture = {
+  facet: Facet;
+};
+
+export const test = base.extend<MyFixture & AxeFixture>({
+  makeAxeBuilder,
+  facet: async ({page}, use) => {
+    await use(new Facet(page));
+  },
+});
+
+export {expect} from '@playwright/test';

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/page-object.ts
@@ -1,0 +1,38 @@
+import type {Page} from '@playwright/test';
+import {BasePageObject} from '../../../../../../playwright-utils/base-page-object';
+
+export class AtomicTimeframeFacetPageObject extends BasePageObject<'atomic-timeframe-facet'> {
+  constructor(page: Page) {
+    super(page, 'atomic-timeframe-facet');
+  }
+
+  get getFacetSearch() {
+    return this.page.getByLabel('Search');
+  }
+
+  get facetInputStart() {
+    return this.page.getByLabel('Enter a start date for the No label facet');
+  }
+
+  get facetInputEnd() {
+    return this.page.getByLabel('Enter an end date for the No label facet');
+  }
+
+  get facetApplyButton() {
+    return this.page.getByRole('button', {
+      name: 'Apply custom start and end dates for the No label facet',
+    });
+  }
+
+  get facetClearFilter() {
+    return this.page.getByRole('button').filter({hasText: 'Clear filter'});
+  }
+
+  get getFacetValue() {
+    return this.page.locator('[part="value-box"]');
+  }
+
+  get facetSearchMoreMatchesFor() {
+    return this.page.getByRole('button', {name: 'More matches for p'});
+  }
+}


### PR DESCRIPTION
This PR ensures that the min/max attributes of the `atomic-timeframe-facet` date input get reset correctly when clearing the filters.

https://coveord.atlassian.net/browse/KIT-3448