### PR TITLE
fix(commerce): namespace field suggestions to prevent clash with facet search

### DIFF
--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.test.ts
@@ -4,6 +4,7 @@ import {CategoryFacetRequest} from '../../../features/commerce/facets/facet-set/
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-search';
 import {buildMockCommerceFacetRequest} from '../../../test/mock-commerce-facet-request';
@@ -33,7 +34,7 @@ describe('categoryFieldSuggestions', () => {
   let fieldSuggestions: CategoryFieldSuggestions;
   let options: CategoryFacetOptions;
 
-  function initFacet() {
+  function initFieldSuggestions() {
     engine = buildMockCommerceEngine(state);
     fieldSuggestions = buildCategoryFieldSuggestions(engine, options);
   }
@@ -41,7 +42,9 @@ describe('categoryFieldSuggestions', () => {
   function setFacetRequest(config: Partial<CategoryFacetRequest> = {}) {
     const request = buildMockCommerceFacetRequest({facetId, ...config});
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({request});
-    state.categoryFacetSearchSet[facetId] = buildMockCategoryFacetSearch({
+    state.categoryFacetSearchSet[
+      namespaceCommerceFieldSuggestionFacet(facetId)
+    ] = buildMockCategoryFacetSearch({
       initialNumberOfValues: 5,
     });
   }
@@ -58,7 +61,7 @@ describe('categoryFieldSuggestions', () => {
     state = buildMockCommerceState();
     setFacetRequest();
 
-    initFacet();
+    initFieldSuggestions();
   });
 
   it('adds correct reducers to engine', () => {
@@ -72,7 +75,7 @@ describe('categoryFieldSuggestions', () => {
   it('should dispatch an #updateFacetSearch and #executeFieldSuggest action on #updateText', () => {
     fieldSuggestions.updateText('foo');
     expect(updateFacetSearch).toHaveBeenCalledWith({
-      facetId,
+      facetId: namespaceCommerceFieldSuggestionFacet(facetId),
       query: 'foo',
       numberOfValues: 5,
     });

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.test.ts
@@ -1,10 +1,12 @@
-import {executeCommerceFieldSuggest} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
+import {
+  executeCommerceFieldSuggest,
+  getFacetIdWithCommerceFieldSuggestionNamespace,
+} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {CategoryFacetRequest} from '../../../features/commerce/facets/facet-set/interfaces/request';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-search';
 import {buildMockCommerceFacetRequest} from '../../../test/mock-commerce-facet-request';
@@ -43,7 +45,7 @@ describe('categoryFieldSuggestions', () => {
     const request = buildMockCommerceFacetRequest({facetId, ...config});
     state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({request});
     state.categoryFacetSearchSet[
-      namespaceCommerceFieldSuggestionFacet(facetId)
+      getFacetIdWithCommerceFieldSuggestionNamespace(facetId)
     ] = buildMockCategoryFacetSearch({
       initialNumberOfValues: 5,
     });
@@ -75,7 +77,7 @@ describe('categoryFieldSuggestions', () => {
   it('should dispatch an #updateFacetSearch and #executeFieldSuggest action on #updateText', () => {
     fieldSuggestions.updateText('foo');
     expect(updateFacetSearch).toHaveBeenCalledWith({
-      facetId: namespaceCommerceFieldSuggestionFacet(facetId),
+      facetId: getFacetIdWithCommerceFieldSuggestionNamespace(facetId),
       query: 'foo',
       numberOfValues: 5,
     });

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
@@ -8,6 +8,7 @@ import {stateKey} from '../../../app/state-key';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {
   CategoryFacetSearchSection,
   CommerceFacetSetSection,
@@ -83,7 +84,7 @@ export function buildCategoryFieldSuggestions(
 
   const facetSearch = buildCategoryFacetSearch(engine, {
     options: {
-      facetId: options.facetId,
+      facetId: namespaceCommerceFieldSuggestionFacet(options.facetId),
       ...options.facetSearch,
       numberOfValues: 10,
     },
@@ -105,7 +106,9 @@ export function buildCategoryFieldSuggestions(
 
   const facetSearchStateSelector = createSelector(
     (state: CommerceEngineState) =>
-      state.categoryFacetSearchSet[options.facetId],
+      state.categoryFacetSearchSet[
+        namespaceCommerceFieldSuggestionFacet(options.facetId)
+      ],
     (facetSearch) => ({
       isLoading: facetSearch.isLoading,
       moreValuesAvailable: facetSearch.response.moreValuesAvailable,

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
@@ -5,10 +5,10 @@ import {
   CommerceEngineState,
 } from '../../../app/commerce-engine/commerce-engine';
 import {stateKey} from '../../../app/state-key';
+import {getFacetIdWithCommerceFieldSuggestionNamespace} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {categoryFacetSearchSetReducer as categoryFacetSearchSet} from '../../../features/facets/facet-search-set/category/category-facet-search-set-slice';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {
   CategoryFacetSearchSection,
   CommerceFacetSetSection,
@@ -82,9 +82,12 @@ export function buildCategoryFieldSuggestions(
 
   const {dispatch} = engine;
 
+  const commerceFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
+    options.facetId
+  );
   const facetSearch = buildCategoryFacetSearch(engine, {
     options: {
-      facetId: namespaceCommerceFieldSuggestionFacet(options.facetId),
+      facetId: commerceFacetId,
       ...options.facetSearch,
       numberOfValues: 10,
     },
@@ -106,9 +109,7 @@ export function buildCategoryFieldSuggestions(
 
   const facetSearchStateSelector = createSelector(
     (state: CommerceEngineState) =>
-      state.categoryFacetSearchSet[
-        namespaceCommerceFieldSuggestionFacet(options.facetId)
-      ],
+      state.categoryFacetSearchSet[commerceFacetId],
     (facetSearch) => ({
       isLoading: facetSearch.isLoading,
       moreValuesAvailable: facetSearch.response.moreValuesAvailable,

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-category-field-suggestions.ts
@@ -82,12 +82,12 @@ export function buildCategoryFieldSuggestions(
 
   const {dispatch} = engine;
 
-  const commerceFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
+  const namespacedFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
     options.facetId
   );
   const facetSearch = buildCategoryFacetSearch(engine, {
     options: {
-      facetId: commerceFacetId,
+      facetId: namespacedFacetId,
       ...options.facetSearch,
       numberOfValues: 10,
     },
@@ -109,7 +109,7 @@ export function buildCategoryFieldSuggestions(
 
   const facetSearchStateSelector = createSelector(
     (state: CommerceEngineState) =>
-      state.categoryFacetSearchSet[commerceFacetId],
+      state.categoryFacetSearchSet[namespacedFacetId],
     (facetSearch) => ({
       isLoading: facetSearch.isLoading,
       moreValuesAvailable: facetSearch.response.moreValuesAvailable,

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
@@ -1,7 +1,7 @@
 import {FacetSearchType} from '../../../api/commerce/facet-search/facet-search-request';
 import {FieldSuggestionsFacet} from '../../../api/commerce/search/query-suggest/query-suggest-response';
+import {getFacetIdWithCommerceFieldSuggestionNamespace} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-search';
 import {buildMockCommerceFacetRequest} from '../../../test/mock-commerce-facet-request';
@@ -39,7 +39,7 @@ describe('fieldSuggestionsGenerator', () => {
 
   function setFacetState(config: FieldSuggestionsFacet[] = []) {
     for (const facet of config) {
-      const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+      const namespacedFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
         facet.facetId
       );
       state.fieldSuggestionsOrder.push(facet);

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions-generator.test.ts
@@ -1,6 +1,7 @@
 import {FacetSearchType} from '../../../api/commerce/facet-search/facet-search-request';
 import {FieldSuggestionsFacet} from '../../../api/commerce/search/query-suggest/query-suggest-response';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCategoryFacetSearch} from '../../../test/mock-category-facet-search';
 import {buildMockCommerceFacetRequest} from '../../../test/mock-commerce-facet-request';
@@ -38,16 +39,22 @@ describe('fieldSuggestionsGenerator', () => {
 
   function setFacetState(config: FieldSuggestionsFacet[] = []) {
     for (const facet of config) {
+      const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+        facet.facetId
+      );
       state.fieldSuggestionsOrder.push(facet);
-      state.commerceFacetSet[facet.facetId] = {
-        request: buildMockCommerceFacetRequest({
-          facetId: facet.facetId,
-          type: facet.type,
-        }),
-      };
-      state.facetSearchSet[facet.facetId] = buildMockFacetSearch();
-      state.categoryFacetSearchSet[facet.facetId] =
-        buildMockCategoryFacetSearch();
+      if (facet.type === 'regular') {
+        state.facetSearchSet[namespacedFacetId] = buildMockFacetSearch();
+      } else {
+        state.commerceFacetSet[facet.facetId] = {
+          request: buildMockCommerceFacetRequest({
+            facetId: facet.facetId,
+            type: facet.type,
+          }),
+        };
+        state.categoryFacetSearchSet[namespacedFacetId] =
+          buildMockCategoryFacetSearch();
+      }
     }
   }
 

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.test.ts
@@ -1,11 +1,11 @@
-import {executeCommerceFieldSuggest} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
+import {
+  executeCommerceFieldSuggest,
+  getFacetIdWithCommerceFieldSuggestionNamespace,
+} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
-import {
-  namespaceCommerceFieldSuggestionFacet,
-  specificFacetSearchSetReducer as facetSearchSet,
-} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
+import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
@@ -39,10 +39,11 @@ describe('fieldSuggestions', () => {
   }
 
   function setFacetSearchRequest() {
-    state.facetSearchSet[namespaceCommerceFieldSuggestionFacet(facetId)] =
-      buildMockFacetSearch({
-        initialNumberOfValues: 5,
-      });
+    state.facetSearchSet[
+      getFacetIdWithCommerceFieldSuggestionNamespace(facetId)
+    ] = buildMockFacetSearch({
+      initialNumberOfValues: 5,
+    });
   }
 
   beforeEach(() => {

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.test.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.test.ts
@@ -1,12 +1,12 @@
 import {executeCommerceFieldSuggest} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
-import {RegularFacetRequest} from '../../../features/commerce/facets/facet-set/interfaces/request';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
 import {updateFacetSearch} from '../../../features/facets/facet-search-set/specific/specific-facet-search-actions';
-import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
+import {
+  namespaceCommerceFieldSuggestionFacet,
+  specificFacetSearchSetReducer as facetSearchSet,
+} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CommerceAppState} from '../../../state/commerce-app-state';
-import {buildMockCommerceFacetRequest} from '../../../test/mock-commerce-facet-request';
-import {buildMockCommerceFacetSlice} from '../../../test/mock-commerce-facet-slice';
 import {buildMockCommerceState} from '../../../test/mock-commerce-state';
 import {
   buildMockCommerceEngine,
@@ -33,18 +33,16 @@ describe('fieldSuggestions', () => {
   let fieldSuggestions: FieldSuggestions;
   let options: RegularFacetOptions;
 
-  function initFacet() {
+  function initFieldSuggestions() {
     engine = buildMockCommerceEngine(state);
     fieldSuggestions = buildFieldSuggestions(engine, options);
   }
 
-  function setFacetRequest(config: Partial<RegularFacetRequest> = {}) {
-    state.commerceFacetSet[facetId] = buildMockCommerceFacetSlice({
-      request: buildMockCommerceFacetRequest({facetId, ...config}),
-    });
-    state.facetSearchSet[facetId] = buildMockFacetSearch({
-      initialNumberOfValues: 5,
-    });
+  function setFacetSearchRequest() {
+    state.facetSearchSet[namespaceCommerceFieldSuggestionFacet(facetId)] =
+      buildMockFacetSearch({
+        initialNumberOfValues: 5,
+      });
   }
 
   beforeEach(() => {
@@ -58,9 +56,9 @@ describe('fieldSuggestions', () => {
     };
 
     state = buildMockCommerceState();
-    setFacetRequest();
+    setFacetSearchRequest();
 
-    initFacet();
+    initFieldSuggestions();
   });
 
   it('adds correct reducers to engine', () => {

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.ts
@@ -6,12 +6,10 @@ import {
   CommerceEngineState,
 } from '../../../app/commerce-engine/commerce-engine';
 import {stateKey} from '../../../app/state-key';
+import {getFacetIdWithCommerceFieldSuggestionNamespace} from '../../../features/commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
-import {
-  namespaceCommerceFieldSuggestionFacet,
-  specificFacetSearchSetReducer as facetSearchSet,
-} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
+import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {
   CommerceFacetSetSection,
   FacetSearchSection,
@@ -102,7 +100,7 @@ export function buildFieldSuggestions(
 
   const {dispatch} = engine;
 
-  const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+  const namespacedFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
     options.facetId
   );
   const facetSearch = buildRegularFacetSearch(engine, {

--- a/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/commerce/field-suggestions/headless-field-suggestions.ts
@@ -8,7 +8,10 @@ import {
 import {stateKey} from '../../../app/state-key';
 import {commerceFacetSetReducer as commerceFacetSet} from '../../../features/commerce/facets/facet-set/facet-set-slice';
 import {fieldSuggestionsOrderReducer as fieldSuggestionsOrder} from '../../../features/commerce/facets/field-suggestions-order/field-suggestions-order-slice';
-import {specificFacetSearchSetReducer as facetSearchSet} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
+import {
+  namespaceCommerceFieldSuggestionFacet,
+  specificFacetSearchSetReducer as facetSearchSet,
+} from '../../../features/facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {
   CommerceFacetSetSection,
   FacetSearchSection,
@@ -99,8 +102,11 @@ export function buildFieldSuggestions(
 
   const {dispatch} = engine;
 
+  const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+    options.facetId
+  );
   const facetSearch = buildRegularFacetSearch(engine, {
-    options: {facetId: options.facetId, ...options.facetSearch},
+    options: {facetId: namespacedFacetId, ...options.facetSearch},
     select: () => {
       dispatch(options.fetchProductsActionCreator());
     },
@@ -121,7 +127,7 @@ export function buildFieldSuggestions(
   const controller = buildController(engine);
 
   const facetSearchStateSelector = createSelector(
-    (state: CommerceEngineState) => state.facetSearchSet[options.facetId],
+    (state: CommerceEngineState) => state.facetSearchSet[namespacedFacetId],
     (facetSearch) => ({
       isLoading: facetSearch.isLoading,
       moreValuesAvailable: facetSearch.response.moreValuesAvailable,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
@@ -8,9 +8,11 @@ import {buildMockCategoryFacetValue} from '../../../../../test/mock-commerce-fac
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
 import {buildMockFacetSearchRequestOptions} from '../../../../../test/mock-facet-search-request-options';
 import {buildMockNavigatorContextProvider} from '../../../../../test/mock-navigator-context-provider';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CategoryFacetValueRequest} from '../../facet-set/interfaces/request';
-import {removeCommerceFieldSuggestionNamespace} from '../regular/commerce-regular-facet-search-request-builder';
+import {
+  getFacetIdWithCommerceFieldSuggestionNamespace,
+  getFacetIdWithoutCommerceFieldSuggestionNamespace,
+} from '../commerce-facet-search-actions';
 import {buildCategoryFacetSearchRequest} from './commerce-category-facet-search-request-builder';
 
 describe('#buildCategoryFacetSearchRequest', () => {
@@ -71,7 +73,9 @@ describe('#buildCategoryFacetSearchRequest', () => {
       facetId: 'a_non_namespaced_facet_id',
     },
     {
-      facetId: namespaceCommerceFieldSuggestionFacet('a_namespaced_facet_id'),
+      facetId: getFacetIdWithCommerceFieldSuggestionNamespace(
+        'a_namespaced_facet_id'
+      ),
     },
   ])('returned object #ignorePaths property', ({facetId}) => {
     beforeEach(() => {
@@ -79,10 +83,11 @@ describe('#buildCategoryFacetSearchRequest', () => {
         options: {...buildMockFacetSearchRequestOptions(), query},
       });
 
-      state.commerceFacetSet[removeCommerceFieldSuggestionNamespace(facetId)] =
-        buildMockCommerceFacetSlice({
-          request: buildMockCommerceFacetRequest({type: 'hierarchical'}),
-        });
+      state.commerceFacetSet[
+        getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId)
+      ] = buildMockCommerceFacetSlice({
+        request: buildMockCommerceFacetRequest({type: 'hierarchical'}),
+      });
     });
 
     it('when the facet request has no selected value, is an empty array', () => {
@@ -98,7 +103,7 @@ describe('#buildCategoryFacetSearchRequest', () => {
 
     it('when the facet request has a selected value with no ancestry, is an array with a single array containing the selected value', () => {
       state.commerceFacetSet[
-        removeCommerceFieldSuggestionNamespace(facetId)
+        getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId)
       ].request.values[0] = buildMockCategoryFacetValue({
         state: 'selected',
         value: 'test',
@@ -114,7 +119,7 @@ describe('#buildCategoryFacetSearchRequest', () => {
         [
           (
             state.commerceFacetSet[
-              removeCommerceFieldSuggestionNamespace(facetId)
+              getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId)
             ].request.values[0] as CategoryFacetValueRequest
           ).value,
         ],
@@ -122,7 +127,8 @@ describe('#buildCategoryFacetSearchRequest', () => {
     });
 
     it('when the facet request has a selected value with ancestry, is an array with a single array containing the selected value and its ancestors', () => {
-      const nonNamespacedId = removeCommerceFieldSuggestionNamespace(facetId);
+      const nonNamespacedId =
+        getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId);
       state.commerceFacetSet[nonNamespacedId].request.values[0] =
         buildMockCategoryFacetValue({
           value: 'test',

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.test.ts
@@ -8,22 +8,24 @@ import {buildMockCategoryFacetValue} from '../../../../../test/mock-commerce-fac
 import {buildMockCommerceState} from '../../../../../test/mock-commerce-state';
 import {buildMockFacetSearchRequestOptions} from '../../../../../test/mock-facet-search-request-options';
 import {buildMockNavigatorContextProvider} from '../../../../../test/mock-navigator-context-provider';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {CategoryFacetValueRequest} from '../../facet-set/interfaces/request';
+import {removeCommerceFieldSuggestionNamespace} from '../regular/commerce-regular-facet-search-request-builder';
 import {buildCategoryFacetSearchRequest} from './commerce-category-facet-search-request-builder';
 
 describe('#buildCategoryFacetSearchRequest', () => {
   let state: CommerceAppState;
   let navigatorContext: NavigatorContext;
-  let facetId: string;
+  const facetId = '1';
   let query: string;
   let buildCommerceAPIRequestMock: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    facetId = '1';
     query = 'test';
     state = buildMockCommerceState();
+
     state.categoryFacetSearchSet[facetId] = buildMockCategoryFacetSearch({
       options: {...buildMockFacetSearchRequestOptions(), query},
     });
@@ -64,7 +66,25 @@ describe('#buildCategoryFacetSearchRequest', () => {
     );
   });
 
-  describe('returned object #ignorePaths property', () => {
+  describe.each([
+    {
+      facetId: 'a_non_namespaced_facet_id',
+    },
+    {
+      facetId: namespaceCommerceFieldSuggestionFacet('a_namespaced_facet_id'),
+    },
+  ])('returned object #ignorePaths property', ({facetId}) => {
+    beforeEach(() => {
+      state.categoryFacetSearchSet[facetId] = buildMockCategoryFacetSearch({
+        options: {...buildMockFacetSearchRequestOptions(), query},
+      });
+
+      state.commerceFacetSet[removeCommerceFieldSuggestionNamespace(facetId)] =
+        buildMockCommerceFacetSlice({
+          request: buildMockCommerceFacetRequest({type: 'hierarchical'}),
+        });
+    });
+
     it('when the facet request has no selected value, is an empty array', () => {
       const request = buildCategoryFacetSearchRequest(
         facetId,
@@ -77,8 +97,12 @@ describe('#buildCategoryFacetSearchRequest', () => {
     });
 
     it('when the facet request has a selected value with no ancestry, is an array with a single array containing the selected value', () => {
-      state.commerceFacetSet[facetId].request.values[0] =
-        buildMockCategoryFacetValue({state: 'selected', value: 'test'});
+      state.commerceFacetSet[
+        removeCommerceFieldSuggestionNamespace(facetId)
+      ].request.values[0] = buildMockCategoryFacetValue({
+        state: 'selected',
+        value: 'test',
+      });
       const request = buildCategoryFacetSearchRequest(
         facetId,
         state,
@@ -89,15 +113,17 @@ describe('#buildCategoryFacetSearchRequest', () => {
       expect(request.ignorePaths).toStrictEqual([
         [
           (
-            state.commerceFacetSet[facetId].request
-              .values[0] as CategoryFacetValueRequest
+            state.commerceFacetSet[
+              removeCommerceFieldSuggestionNamespace(facetId)
+            ].request.values[0] as CategoryFacetValueRequest
           ).value,
         ],
       ]);
     });
 
     it('when the facet request has a selected value with ancestry, is an array with a single array containing the selected value and its ancestors', () => {
-      state.commerceFacetSet[facetId].request.values[0] =
+      const nonNamespacedId = removeCommerceFieldSuggestionNamespace(facetId);
+      state.commerceFacetSet[nonNamespacedId].request.values[0] =
         buildMockCategoryFacetValue({
           value: 'test',
           children: [
@@ -122,15 +148,15 @@ describe('#buildCategoryFacetSearchRequest', () => {
       expect(request.ignorePaths).toStrictEqual([
         [
           (
-            state.commerceFacetSet[facetId].request
+            state.commerceFacetSet[nonNamespacedId].request
               .values[0] as CategoryFacetValueRequest
           ).value,
           (
-            state.commerceFacetSet[facetId].request
+            state.commerceFacetSet[nonNamespacedId].request
               .values[0] as CategoryFacetValueRequest
           ).children[0].value,
           (
-            state.commerceFacetSet[facetId].request
+            state.commerceFacetSet[nonNamespacedId].request
               .values[0] as CategoryFacetValueRequest
           ).children[0].children[0].value,
         ],

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -5,7 +5,7 @@ import {
   AnyFacetRequest,
   CategoryFacetRequest,
 } from '../../facet-set/interfaces/request';
-import {removeCommerceFieldSuggestionNamespace} from '../regular/commerce-regular-facet-search-request-builder';
+import {getFacetIdWithoutCommerceFieldSuggestionNamespace} from '../commerce-facet-search-actions';
 import {StateNeededForCategoryFacetSearch} from './commerce-category-facet-search-state';
 
 export const buildCategoryFacetSearchRequest = (
@@ -17,8 +17,9 @@ export const buildCategoryFacetSearchRequest = (
   const baseFacetQuery = state.categoryFacetSearchSet[facetId]!.options.query;
   const facetQuery = `*${baseFacetQuery}*`;
   const categoryFacet =
-    state.commerceFacetSet[removeCommerceFieldSuggestionNamespace(facetId)]
-      ?.request;
+    state.commerceFacetSet[
+      getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId)
+    ]?.request;
   const path =
     categoryFacet && isCategoryFacetRequest(categoryFacet)
       ? categoryFacet && getPathToSelectedCategoryFacetItem(categoryFacet)
@@ -43,7 +44,7 @@ export const buildCategoryFacetSearchRequest = (
     url,
     accessToken,
     organizationId,
-    facetId: removeCommerceFieldSuggestionNamespace(facetId),
+    facetId: getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId),
     facetQuery,
     ignorePaths,
     trackingId,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -5,6 +5,7 @@ import {
   AnyFacetRequest,
   CategoryFacetRequest,
 } from '../../facet-set/interfaces/request';
+import {removeCommerceFieldSuggestionNamespace} from '../regular/commerce-regular-facet-search-request-builder';
 import {StateNeededForCategoryFacetSearch} from './commerce-category-facet-search-state';
 
 export const buildCategoryFacetSearchRequest = (
@@ -40,7 +41,7 @@ export const buildCategoryFacetSearchRequest = (
     url,
     accessToken,
     organizationId,
-    facetId,
+    facetId: removeCommerceFieldSuggestionNamespace(facetId),
     facetQuery,
     ignorePaths,
     trackingId,

--- a/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/category/commerce-category-facet-search-request-builder.ts
@@ -16,7 +16,9 @@ export const buildCategoryFacetSearchRequest = (
 ): CategoryFacetSearchRequest => {
   const baseFacetQuery = state.categoryFacetSearchSet[facetId]!.options.query;
   const facetQuery = `*${baseFacetQuery}*`;
-  const categoryFacet = state.commerceFacetSet[facetId]?.request;
+  const categoryFacet =
+    state.commerceFacetSet[removeCommerceFieldSuggestionNamespace(facetId)]
+      ?.request;
   const path =
     categoryFacet && isCategoryFacetRequest(categoryFacet)
       ? categoryFacet && getPathToSelectedCategoryFacetItem(categoryFacet)

--- a/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/commerce-facet-search-actions.ts
@@ -114,3 +114,21 @@ export const isRegularFieldSuggestionsState = (
     (facet) => facet.facetId === facetId && facet.type === 'regular'
   );
 };
+
+const commerceFieldSuggestionNamespace = 'field_suggestion:';
+
+export function getFacetIdWithoutCommerceFieldSuggestionNamespace(
+  facetId: string
+) {
+  return facetId.startsWith(commerceFieldSuggestionNamespace)
+    ? facetId.slice(commerceFieldSuggestionNamespace.length)
+    : facetId;
+}
+
+export function getFacetIdWithCommerceFieldSuggestionNamespace(
+  facetId: string
+): string {
+  return facetId.startsWith(commerceFieldSuggestionNamespace)
+    ? facetId
+    : `${commerceFieldSuggestionNamespace}${facetId}`;
+}

--- a/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
@@ -30,7 +30,7 @@ export const buildFacetSearchRequest = (
     url,
     accessToken,
     organizationId,
-    facetId,
+    facetId: removeCommerceFieldSuggestionNamespace(facetId),
     facetQuery,
     trackingId,
     language,
@@ -42,3 +42,9 @@ export const buildFacetSearchRequest = (
     ...(!isFieldSuggestionsRequest && {...restOfCommerceAPIRequest, query: ''}),
   };
 };
+
+export function removeCommerceFieldSuggestionNamespace(facetId: string) {
+  return facetId.startsWith('field_suggestion:')
+    ? facetId.split(':')[1]
+    : facetId;
+}

--- a/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
+++ b/packages/headless/src/features/commerce/facets/facet-search-set/regular/commerce-regular-facet-search-request-builder.ts
@@ -1,6 +1,7 @@
 import {CommerceFacetSearchRequest} from '../../../../../api/commerce/facet-search/facet-search-request';
 import {NavigatorContext} from '../../../../../app/navigatorContextProvider';
 import {buildCommerceAPIRequest} from '../../../common/actions';
+import {getFacetIdWithoutCommerceFieldSuggestionNamespace} from '../commerce-facet-search-actions';
 import {StateNeededForRegularFacetSearch} from './commerce-regular-facet-search-state';
 
 export const buildFacetSearchRequest = (
@@ -30,7 +31,7 @@ export const buildFacetSearchRequest = (
     url,
     accessToken,
     organizationId,
-    facetId: removeCommerceFieldSuggestionNamespace(facetId),
+    facetId: getFacetIdWithoutCommerceFieldSuggestionNamespace(facetId),
     facetQuery,
     trackingId,
     language,
@@ -42,9 +43,3 @@ export const buildFacetSearchRequest = (
     ...(!isFieldSuggestionsRequest && {...restOfCommerceAPIRequest, query: ''}),
   };
 };
-
-export function removeCommerceFieldSuggestionNamespace(facetId: string) {
-  return facetId.startsWith('field_suggestion:')
-    ? facetId.split(':')[1]
-    : facetId;
-}

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -33,7 +33,6 @@ import {
   excludeFacetSearchResult,
   selectFacetSearchResult,
 } from '../../../facets/facet-search-set/specific/specific-facet-search-actions';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {convertFacetValueToRequest} from '../../../facets/facet-set/facet-set-slice';
 import * as FacetReducers from '../../../facets/generic/facet-reducer-helpers';
 import {convertToDateRangeRequests} from '../../../facets/range-facets/date-facet-set/date-facet-set-slice';
@@ -65,6 +64,7 @@ import {
   toggleSelectDateFacetValue,
   updateDateFacetValues,
 } from '../date-facet/date-facet-actions';
+import {getFacetIdWithCommerceFieldSuggestionNamespace} from '../facet-search-set/commerce-facet-search-actions';
 import {
   toggleExcludeNumericFacetValue,
   toggleSelectNumericFacetValue,
@@ -689,16 +689,17 @@ describe('commerceFacetSetReducer', () => {
         )
       );
       expect(finalState).toEqual({
-        [namespaceCommerceFieldSuggestionFacet('regular_field')]: {
+        [getFacetIdWithCommerceFieldSuggestionNamespace('regular_field')]: {
           request: {
             initialNumberOfValues: 10,
           },
         },
-        [namespaceCommerceFieldSuggestionFacet('hierarchical_field')]: {
-          request: {
-            initialNumberOfValues: 10,
+        [getFacetIdWithCommerceFieldSuggestionNamespace('hierarchical_field')]:
+          {
+            request: {
+              initialNumberOfValues: 10,
+            },
           },
-        },
       });
     });
   });

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -33,6 +33,7 @@ import {
   excludeFacetSearchResult,
   selectFacetSearchResult,
 } from '../../../facets/facet-search-set/specific/specific-facet-search-actions';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {convertFacetValueToRequest} from '../../../facets/facet-set/facet-set-slice';
 import * as FacetReducers from '../../../facets/generic/facet-reducer-helpers';
 import {convertToDateRangeRequests} from '../../../facets/range-facets/date-facet-set/date-facet-set-slice';
@@ -688,12 +689,12 @@ describe('commerceFacetSetReducer', () => {
         )
       );
       expect(finalState).toEqual({
-        regular_field: {
+        [namespaceCommerceFieldSuggestionFacet('regular_field')]: {
           request: {
             initialNumberOfValues: 10,
           },
         },
-        hierarchical_field: {
+        [namespaceCommerceFieldSuggestionFacet('hierarchical_field')]: {
           request: {
             initialNumberOfValues: 10,
           },

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -11,7 +11,6 @@ import {
   excludeFacetSearchResult,
   selectFacetSearchResult,
 } from '../../../facets/facet-search-set/specific/specific-facet-search-actions';
-import {namespaceCommerceFieldSuggestionFacet} from '../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {convertFacetValueToRequest} from '../../../facets/facet-set/facet-set-slice';
 import {handleFacetUpdateNumberOfValues} from '../../../facets/generic/facet-reducer-helpers';
 import {convertToDateRangeRequests} from '../../../facets/range-facets/date-facet-set/date-facet-set-slice';
@@ -41,7 +40,10 @@ import {
   toggleSelectDateFacetValue,
   updateDateFacetValues,
 } from '../date-facet/date-facet-actions';
-import {executeCommerceFieldSuggest} from '../facet-search-set/commerce-facet-search-actions';
+import {
+  executeCommerceFieldSuggest,
+  getFacetIdWithCommerceFieldSuggestionNamespace,
+} from '../facet-search-set/commerce-facet-search-actions';
 import {
   toggleExcludeNumericFacetValue,
   toggleSelectNumericFacetValue,
@@ -84,7 +86,7 @@ export const commerceFacetSetReducer = createReducer(
       .addCase(executeCommerceFieldSuggest.fulfilled, (state, action) =>
         handleFieldSuggestionsFulfilled(
           state,
-          namespaceCommerceFieldSuggestionFacet(action.payload.facetId)
+          getFacetIdWithCommerceFieldSuggestionNamespace(action.payload.facetId)
         )
       )
       .addCase(fetchQuerySuggestions.fulfilled, (state, action) => {
@@ -95,7 +97,7 @@ export const commerceFacetSetReducer = createReducer(
         for (const {facetId} of action.payload.fieldSuggestionsFacets) {
           handleFieldSuggestionsFulfilled(
             state,
-            namespaceCommerceFieldSuggestionFacet(facetId)
+            getFacetIdWithCommerceFieldSuggestionNamespace(facetId)
           );
         }
       })

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -11,6 +11,7 @@ import {
   excludeFacetSearchResult,
   selectFacetSearchResult,
 } from '../../../facets/facet-search-set/specific/specific-facet-search-actions';
+import {namespaceCommerceFieldSuggestionFacet} from '../../../facets/facet-search-set/specific/specific-facet-search-set-slice';
 import {convertFacetValueToRequest} from '../../../facets/facet-set/facet-set-slice';
 import {handleFacetUpdateNumberOfValues} from '../../../facets/generic/facet-reducer-helpers';
 import {convertToDateRangeRequests} from '../../../facets/range-facets/date-facet-set/date-facet-set-slice';
@@ -81,7 +82,10 @@ export const commerceFacetSetReducer = createReducer(
       .addCase(fetchProductListing.fulfilled, handleQueryFulfilled)
       .addCase(executeSearch.fulfilled, handleQueryFulfilled)
       .addCase(executeCommerceFieldSuggest.fulfilled, (state, action) =>
-        handleFieldSuggestionsFulfilled(state, action.payload.facetId)
+        handleFieldSuggestionsFulfilled(
+          state,
+          namespaceCommerceFieldSuggestionFacet(action.payload.facetId)
+        )
       )
       .addCase(fetchQuerySuggestions.fulfilled, (state, action) => {
         if (!action.payload.fieldSuggestionsFacets) {
@@ -89,7 +93,10 @@ export const commerceFacetSetReducer = createReducer(
         }
 
         for (const {facetId} of action.payload.fieldSuggestionsFacets) {
-          handleFieldSuggestionsFulfilled(state, facetId);
+          handleFieldSuggestionsFulfilled(
+            state,
+            namespaceCommerceFieldSuggestionFacet(facetId)
+          );
         }
       })
       .addCase(toggleSelectFacetValue, (state, action) => {

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
@@ -25,6 +25,7 @@ import {
   executeFacetSearch,
 } from '../generic/generic-facet-search-actions';
 import {updateFacetSearch} from '../specific/specific-facet-search-actions';
+import {namespaceCommerceFieldSuggestionFacet} from '../specific/specific-facet-search-set-slice';
 import {registerCategoryFacetSearch} from './category-facet-search-actions';
 import {getCategoryFacetSearchSetInitialState} from './category-facet-search-set-state';
 
@@ -57,7 +58,10 @@ export const categoryFacetSearchSetReducer = createReducer(
       })
       .addCase(executeCommerceFieldSuggest.rejected, (state, action) => {
         const {facetId} = action.meta.arg;
-        handleFacetSearchRejected(state, facetId);
+        handleFacetSearchRejected(
+          state,
+          namespaceCommerceFieldSuggestionFacet(facetId)
+        );
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {
         const facetId = action.meta.arg;

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-set-slice.ts
@@ -3,6 +3,7 @@ import {CategoryFacetSearchResponse} from '../../../../api/search/facet-search/c
 import {
   executeCommerceFacetSearch,
   executeCommerceFieldSuggest,
+  getFacetIdWithCommerceFieldSuggestionNamespace,
 } from '../../../commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {fetchProductListing} from '../../../commerce/product-listing/product-listing-actions';
 import {fetchQuerySuggestions} from '../../../commerce/query-suggest/query-suggest-actions';
@@ -25,7 +26,6 @@ import {
   executeFacetSearch,
 } from '../generic/generic-facet-search-actions';
 import {updateFacetSearch} from '../specific/specific-facet-search-actions';
-import {namespaceCommerceFieldSuggestionFacet} from '../specific/specific-facet-search-set-slice';
 import {registerCategoryFacetSearch} from './category-facet-search-actions';
 import {getCategoryFacetSearchSetInitialState} from './category-facet-search-set-state';
 
@@ -60,7 +60,7 @@ export const categoryFacetSearchSetReducer = createReducer(
         const {facetId} = action.meta.arg;
         handleFacetSearchRejected(
           state,
-          namespaceCommerceFieldSuggestionFacet(facetId)
+          getFacetIdWithCommerceFieldSuggestionNamespace(facetId)
         );
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
@@ -3,6 +3,7 @@ import {FacetSearchRequestOptions} from '../../../api/search/facet-search/base/b
 import {FacetSearchResponse} from '../../../api/search/facet-search/facet-search-response';
 import {FieldSuggestionsFacet} from '../../commerce/facets/field-suggestions-order/field-suggestions-order-state';
 import {FacetSearchOptions} from './facet-search-request-options';
+import {namespaceCommerceFieldSuggestionFacet} from './specific/specific-facet-search-set-slice';
 
 export type FacetSearchState<T extends FacetSearchResponse> = {
   /**
@@ -156,11 +157,16 @@ export function handleCommerceFacetFieldSuggestionsFulfilled<
   buildEmptyResponse: () => T
 ) {
   const {facetId, response} = payload;
-  let search = state[facetId];
+  const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(facetId);
+  let search = state[namespacedFacetId];
 
   if (!search) {
-    handleFacetSearchRegistration(state, {facetId}, buildEmptyResponse);
-    search = state[facetId];
+    handleFacetSearchRegistration(
+      state,
+      {facetId: namespacedFacetId},
+      buildEmptyResponse
+    );
+    search = state[namespacedFacetId];
   } else if (search.requestId !== requestId) {
     return;
   }
@@ -223,14 +229,17 @@ export function handleCommerceFetchQuerySuggestionsFulfilledForCategoryFacet<
   }
 
   for (const fieldSuggestionFacet of payload.fieldSuggestionsFacets) {
+    const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+      fieldSuggestionFacet.facetId
+    );
     if (
-      fieldSuggestionFacet.facetId in state ||
+      namespacedFacetId in state ||
       fieldSuggestionFacet.type !== 'hierarchical'
     ) {
       continue;
     }
 
-    state[fieldSuggestionFacet.facetId] = {
+    state[namespacedFacetId] = {
       options: {
         ...defaultFacetSearchOptions,
         query: payload.query ?? '',

--- a/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
+++ b/packages/headless/src/features/facets/facet-search-set/facet-search-reducer-helpers.ts
@@ -1,9 +1,9 @@
 import {CommerceAPIResponse} from '../../../api/commerce/commerce-api-client';
 import {FacetSearchRequestOptions} from '../../../api/search/facet-search/base/base-facet-search-request';
 import {FacetSearchResponse} from '../../../api/search/facet-search/facet-search-response';
+import {getFacetIdWithCommerceFieldSuggestionNamespace} from '../../commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {FieldSuggestionsFacet} from '../../commerce/facets/field-suggestions-order/field-suggestions-order-state';
 import {FacetSearchOptions} from './facet-search-request-options';
-import {namespaceCommerceFieldSuggestionFacet} from './specific/specific-facet-search-set-slice';
 
 export type FacetSearchState<T extends FacetSearchResponse> = {
   /**
@@ -157,7 +157,8 @@ export function handleCommerceFacetFieldSuggestionsFulfilled<
   buildEmptyResponse: () => T
 ) {
   const {facetId, response} = payload;
-  const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(facetId);
+  const namespacedFacetId =
+    getFacetIdWithCommerceFieldSuggestionNamespace(facetId);
   let search = state[namespacedFacetId];
 
   if (!search) {
@@ -229,7 +230,7 @@ export function handleCommerceFetchQuerySuggestionsFulfilledForCategoryFacet<
   }
 
   for (const fieldSuggestionFacet of payload.fieldSuggestionsFacets) {
-    const namespacedFacetId = namespaceCommerceFieldSuggestionFacet(
+    const namespacedFacetId = getFacetIdWithCommerceFieldSuggestionNamespace(
       fieldSuggestionFacet.facetId
     );
     if (

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
@@ -4,29 +4,32 @@ import {setView} from '../../../commerce/context/context-actions';
 import {
   executeCommerceFacetSearch,
   executeCommerceFieldSuggest,
+  getFacetIdWithCommerceFieldSuggestionNamespace,
 } from '../../../commerce/facets/facet-search-set/commerce-facet-search-actions';
 import {fetchProductListing} from '../../../commerce/product-listing/product-listing-actions';
 import {fetchQuerySuggestions} from '../../../commerce/query-suggest/query-suggest-actions';
 import {executeSearch as executeCommerceSearch} from '../../../commerce/search/search-actions';
 import {executeSearch} from '../../../search/search-actions';
 import {
-  handleFacetSearchRegistration,
-  handleFacetSearchUpdate,
-  handleFacetSearchPending,
-  handleFacetSearchRejected,
-  handleFacetSearchFulfilled,
-  handleFacetSearchClear,
-  handleFacetSearchSetClear,
-  handleCommerceFacetSearchFulfilled,
   handleCommerceFacetFieldSuggestionsFulfilled,
+  handleCommerceFacetSearchFulfilled,
   handleCommerceFetchQuerySuggestionsFulfilledForRegularFacet,
+  handleFacetSearchClear,
+  handleFacetSearchFulfilled,
+  handleFacetSearchPending,
+  handleFacetSearchRegistration,
+  handleFacetSearchRejected,
+  handleFacetSearchSetClear,
+  handleFacetSearchUpdate,
 } from '../facet-search-reducer-helpers';
 import {
   clearFacetSearch,
   executeFacetSearch,
 } from '../generic/generic-facet-search-actions';
-import {registerFacetSearch} from './specific-facet-search-actions';
-import {updateFacetSearch} from './specific-facet-search-actions';
+import {
+  registerFacetSearch,
+  updateFacetSearch,
+} from './specific-facet-search-actions';
 import {getFacetSearchSetInitialState} from './specific-facet-search-set-state';
 
 export const specificFacetSearchSetReducer = createReducer(
@@ -48,7 +51,7 @@ export const specificFacetSearchSetReducer = createReducer(
         const {facetId} = action.meta.arg;
         handleFacetSearchPending(
           state,
-          namespaceCommerceFieldSuggestionFacet(facetId),
+          getFacetIdWithCommerceFieldSuggestionNamespace(facetId),
           action.meta.requestId
         );
       })
@@ -64,7 +67,7 @@ export const specificFacetSearchSetReducer = createReducer(
         const {facetId} = action.meta.arg;
         handleFacetSearchRejected(
           state,
-          namespaceCommerceFieldSuggestionFacet(facetId)
+          getFacetIdWithCommerceFieldSuggestionNamespace(facetId)
         );
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {
@@ -118,13 +121,6 @@ export const specificFacetSearchSetReducer = createReducer(
       );
   }
 );
-
-export function namespaceCommerceFieldSuggestionFacet(facetId: string): string {
-  if (facetId.includes(':')) {
-    return facetId;
-  }
-  return 'field_suggestion:' + facetId;
-}
 
 function buildEmptyResponse(): SpecificFacetSearchResponse {
   return {

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-set-slice.ts
@@ -46,7 +46,11 @@ export const specificFacetSearchSetReducer = createReducer(
       })
       .addCase(executeCommerceFieldSuggest.pending, (state, action) => {
         const {facetId} = action.meta.arg;
-        handleFacetSearchPending(state, facetId, action.meta.requestId);
+        handleFacetSearchPending(
+          state,
+          namespaceCommerceFieldSuggestionFacet(facetId),
+          action.meta.requestId
+        );
       })
       .addCase(executeFacetSearch.pending, (state, action) => {
         const facetId = action.meta.arg;
@@ -58,7 +62,10 @@ export const specificFacetSearchSetReducer = createReducer(
       })
       .addCase(executeCommerceFieldSuggest.rejected, (state, action) => {
         const {facetId} = action.meta.arg;
-        handleFacetSearchRejected(state, facetId);
+        handleFacetSearchRejected(
+          state,
+          namespaceCommerceFieldSuggestionFacet(facetId)
+        );
       })
       .addCase(executeFacetSearch.rejected, (state, action) => {
         const facetId = action.meta.arg;
@@ -111,6 +118,13 @@ export const specificFacetSearchSetReducer = createReducer(
       );
   }
 );
+
+export function namespaceCommerceFieldSuggestionFacet(facetId: string): string {
+  if (facetId.includes(':')) {
+    return facetId;
+  }
+  return 'field_suggestion:' + facetId;
+}
 
 function buildEmptyResponse(): SpecificFacetSearchResponse {
   return {


### PR DESCRIPTION
Since facets in a global search configuration are used to power both field suggestions and facets, it's possible that field suggestions for a field be active at the same time that a facet search for the same field is. This means that updating the text on a field suggestions controller would cause a facet's facet search values to be updated as well. This is because both the field suggestions and facet search were powered by the same state.

To prevent this issue, I namespace the `facetId` used for field suggestions **only** on the facet search reducers (the regular, and category one).

I opted for this approach instead of reversing the dependency on the facet search controller to read state from selectors since it would've lead to much more changes in the controllers.

[CAPI-1201]

[CAPI-1201]: https://coveord.atlassian.net/browse/CAPI-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ