### PR TITLE
feat(genqa): filter citations that points to same document

### DIFF
--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -80,6 +80,7 @@ describe('generated answer slice', () => {
       const newCitations = [
         buildMockCitation({
           id: 'some-other-id',
+          uri: 'my-uri',
         }),
       ];
       const finalState = generatedAnswerReducer(
@@ -94,6 +95,30 @@ describe('generated answer slice', () => {
         ...existingCitations,
         ...newCitations,
       ]);
+    });
+
+    it('Shows only citations that have different Uris', () => {
+      const existingCitations = [
+        buildMockCitation({
+          id: 'current-id',
+          uri: 'my-uri',
+        }),
+      ];
+      const newCitations = [
+        buildMockCitation({
+          id: 'some-other-id',
+          uri: 'my-uri',
+        }),
+      ];
+      const finalState = generatedAnswerReducer(
+        {
+          ...getGeneratedAnswerInitialState(),
+          citations: existingCitations,
+        },
+        updateCitations({citations: newCitations})
+      );
+
+      expect(finalState.citations).toEqual([...newCitations]);
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -1,5 +1,6 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {RETRYABLE_STREAM_ERROR_CODE} from '../../api/generated-answer/generated-answer-client';
+import {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload';
 import {
   closeGeneratedAnswerFeedbackModal,
   dislikeGeneratedAnswer,
@@ -47,12 +48,13 @@ export const generatedAnswerReducer = createReducer(
       .addCase(updateCitations, (state, {payload}) => {
         state.isLoading = false;
         state.isStreaming = true;
-        const allCitations = state.citations.concat(payload.citations);
-        state.citations = allCitations.flatMap((citation, index, self) =>
-          self.findIndex((c) => c.uri === citation.uri) === index
-            ? [citation]
-            : []
-        );
+        const citationMap = new Map<string, GeneratedAnswerCitation>();
+        for (const citationCollection of [state.citations, payload.citations]) {
+          for (const citation of citationCollection) {
+            citationMap.set(citation.uri, citation);
+          }
+        }
+        state.citations = Array.from(citationMap.values());
         delete state.error;
       })
       .addCase(updateError, (state, {payload}) => {

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -47,7 +47,12 @@ export const generatedAnswerReducer = createReducer(
       .addCase(updateCitations, (state, {payload}) => {
         state.isLoading = false;
         state.isStreaming = true;
-        state.citations = state.citations.concat(payload.citations);
+        const allCitations = state.citations.concat(payload.citations);
+        state.citations = allCitations.flatMap((citation, index, self) =>
+          self.findIndex((c) => c.uri === citation.uri) === index
+            ? [citation]
+            : []
+        );
         delete state.error;
       })
       .addCase(updateError, (state, {payload}) => {

--- a/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer.cypress.ts
@@ -1124,7 +1124,7 @@ describe('quantic-generated-answer', () => {
               const firstTestCitation = {
                 id: 'some-id-1',
                 title: 'Some Title 1',
-                uri: 'https://www.coveo.com',
+                uri: 'https://www.coveo1.com',
                 permanentid: 'some-permanent-id-1',
                 clickUri: exampleLinkUrl,
                 text: 'example text 1',
@@ -1132,7 +1132,7 @@ describe('quantic-generated-answer', () => {
               const secondTestCitation = {
                 id: 'some-id-2',
                 title: 'Some Title 2',
-                uri: 'https://www.coveo.com',
+                uri: 'https://www.coveo2.com',
                 permanentid: 'some-permanent-id-2',
                 clickUri: exampleLinkUrl,
                 text: 'example text 2',


### PR DESCRIPTION
[SVCC-4029](https://coveord.atlassian.net/browse/SVCC-4029)

- Filter citations that points to same documents.

Before:

<img width="1137" alt="Screenshot 2024-08-01 at 3 14 46 PM" src="https://github.com/user-attachments/assets/9c68f065-e385-465e-8bb1-4cef70ed96f9">

After:
<img width="1138" alt="Screenshot 2024-08-02 at 3 11 39 PM" src="https://github.com/user-attachments/assets/22e1b814-2c7d-4b2a-a782-bb4cbfba204b">



[SVCC-4029]: https://coveord.atlassian.net/browse/SVCC-4029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ