### PR TITLE
chore(ci): fix release for atomic-angular

### DIFF
--- a/packages/atomic-angular/project.json
+++ b/packages/atomic-angular/project.json
@@ -5,6 +5,7 @@
     "negativeBuildOutputs": ["!{projectRoot}/projects/atomic-angular/dist"]
   },
   "targets": {
+    "release:phase1": {},
     "cached:build": {
       "outputs": ["{projectRoot}/projects/atomic-angular/dist"],
       "dependsOn": ["^build"],


### PR DESCRIPTION
This PR adds the release:phase1 target to the atomic-angular package. This should ensure that the package gets updated.

https://coveord.atlassian.net/browse/CDX-1585