### PR TITLE
fix(atomic): use the hrefTemplate value in atomic-product-link

### DIFF
--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-link/atomic-product-link.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-link/atomic-product-link.tsx
@@ -15,6 +15,7 @@ import {
   InteractiveProductContext,
   ProductContext,
 } from '../product-template-decorators';
+import {buildStringTemplateFromProduct} from '../product-utils';
 
 /**
  * @internal
@@ -82,7 +83,11 @@ export class AtomicProductLink
   public render() {
     const href = isUndefined(this.hrefTemplate)
       ? this.product.clickUri
-      : 'test';
+      : buildStringTemplateFromProduct(
+          this.hrefTemplate,
+          this.product,
+          this.bindings
+        );
 
     if (!this.interactiveProduct) {
       return;

--- a/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
@@ -37,10 +37,20 @@ export function buildStringTemplateFromProduct(
   });
 }
 
-function readFromObject<T>(object: T, key: string): string | undefined {
-  if (object && typeof object === 'object' && key in object) {
-    const value = (object as Record<string, unknown>)[key];
-    return typeof value === 'string' ? value : undefined;
+function readFromObject<T extends object>(
+  object: T,
+  key: string
+): string | undefined {
+  const keys = key.split('.');
+  let current: unknown = object;
+
+  for (const k of keys) {
+    if (current && typeof current === 'object' && k in current) {
+      current = (current as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
   }
-  return undefined;
+
+  return typeof current === 'string' ? current : undefined;
 }

--- a/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
@@ -28,7 +28,7 @@ export function buildStringTemplateFromProduct(
 
     if (!newValue) {
       bindings.engine.logger.warn(
-        `${key} used in the href template is undefined for this product: ${product.permanentid} and not found in the window object.`
+        `${key} used in the href template is undefined for this product: ${product.permanentid} and could not be found in the window object.`
       );
       return '';
     }
@@ -37,20 +37,10 @@ export function buildStringTemplateFromProduct(
   });
 }
 
-function readFromObject<T extends object>(
-  object: T,
-  key: string
-): string | undefined {
-  const keys = key.split('.');
-  let current: unknown = object;
-
-  for (const k of keys) {
-    if (current && typeof current === 'object' && k in current) {
-      current = (current as Record<string, unknown>)[k];
-    } else {
-      return undefined;
-    }
+function readFromObject<T>(object: T, key: string): string | undefined {
+  if (object && typeof object === 'object' && key in object) {
+    const value = (object as Record<string, unknown>)[key];
+    return typeof value === 'string' ? value : undefined;
   }
-
-  return typeof current === 'string' ? current : undefined;
+  return undefined;
 }

--- a/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
@@ -22,13 +22,13 @@ export function buildStringTemplateFromProduct(
   return template.replace(/\${(.*?)}/g, (value: string) => {
     const key = value.substring(2, value.length - 1);
     let newValue = readFromObject(product, key);
-    if (!newValue) {
+    if (!newValue && typeof window !== 'undefined') {
       newValue = readFromObject(window, key);
     }
 
     if (!newValue) {
       bindings.engine.logger.warn(
-        `${key} used in the href template is undefined for this product: ${product.permanentid}`
+        `${key} used in the href template is undefined for this product: ${product.permanentid} and not found in the window object.`
       );
       return '';
     }
@@ -37,13 +37,10 @@ export function buildStringTemplateFromProduct(
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function readFromObject(object: any, key: string): string {
-  const firstPeriodIndex = key.indexOf('.');
-  if (object && firstPeriodIndex !== -1) {
-    const newKey = key.substring(firstPeriodIndex + 1);
-    key = key.substring(0, firstPeriodIndex);
-    return readFromObject(object[key], newKey);
+function readFromObject<T>(object: T, key: string): string | undefined {
+  if (object && typeof object === 'object' && key in object) {
+    const value = (object as Record<string, unknown>)[key];
+    return typeof value === 'string' ? value : undefined;
   }
-  return object ? object[key] : undefined;
+  return undefined;
 }

--- a/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/product-utils.ts
@@ -1,4 +1,5 @@
 import {Product, ProductTemplatesHelpers} from '@coveo/headless/commerce';
+import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 
 export function getStringValueFromProductOrNull(
   product: Product,
@@ -11,4 +12,38 @@ export function getStringValueFromProductOrNull(
   }
 
   return value;
+}
+
+export function buildStringTemplateFromProduct(
+  template: string,
+  product: Product,
+  bindings: CommerceBindings
+) {
+  return template.replace(/\${(.*?)}/g, (value: string) => {
+    const key = value.substring(2, value.length - 1);
+    let newValue = readFromObject(product, key);
+    if (!newValue) {
+      newValue = readFromObject(window, key);
+    }
+
+    if (!newValue) {
+      bindings.engine.logger.warn(
+        `${key} used in the href template is undefined for this product: ${product.permanentid}`
+      );
+      return '';
+    }
+
+    return newValue;
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readFromObject(object: any, key: string): string {
+  const firstPeriodIndex = key.indexOf('.');
+  if (object && firstPeriodIndex !== -1) {
+    const newKey = key.substring(firstPeriodIndex + 1);
+    key = key.substring(0, firstPeriodIndex);
+    return readFromObject(object[key], newKey);
+  }
+  return object ? object[key] : undefined;
 }

--- a/packages/atomic/src/utils/result-utils.ts
+++ b/packages/atomic/src/utils/result-utils.ts
@@ -83,10 +83,20 @@ export function getStringValueFromResultOrNull(result: Result, field: string) {
   return value;
 }
 
-function readFromObject<T>(object: T, key: string): string | undefined {
-  if (object && typeof object === 'object' && key in object) {
-    const value = (object as Record<string, unknown>)[key];
-    return typeof value === 'string' ? value : undefined;
+function readFromObject<T extends object>(
+  object: T,
+  key: string
+): string | undefined {
+  const keys = key.split('.');
+  let current: unknown = object;
+
+  for (const k of keys) {
+    if (current && typeof current === 'object' && k in current) {
+      current = (current as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
   }
-  return undefined;
+
+  return typeof current === 'string' ? current : undefined;
 }

--- a/packages/atomic/src/utils/result-utils.ts
+++ b/packages/atomic/src/utils/result-utils.ts
@@ -64,7 +64,7 @@ export function buildStringTemplateFromResult(
 
     if (!newValue) {
       bindings.engine.logger.warn(
-        `${key} used in the href template is undefined for this result: ${result.uniqueId} and not found in the window object.`
+        `${key} used in the href template is undefined for this result: ${result.uniqueId} and could not be found in the window object.`
       );
       return '';
     }


### PR DESCRIPTION
This PR ensures that atomic-product-link uses the value of hrefTemplate to generate the href attribute value.

https://coveord.atlassian.net/browse/KIT-3455