### PR TITLE
fix(quantic): styling issue fixed with quantic facet search component

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticFacet/quanticFacet.html
@@ -138,7 +138,7 @@
                     </li>
                   </template>
                   <template if:true={canShowMoreSearchResults}>
-                    <li>
+                    <li class="slds-grid"> 
                       <span
                         class="slds-truncate facet__search-results_more-matches"
                         >{moreMatchesForLabel}</span


### PR DESCRIPTION
## [SFINT-5636](https://coveord.atlassian.net/browse/SFINT-5636)

- Fixed issue with the `more matches found` label in the Quantic Facet component.

### Before
 
<img width="694" alt="image-20240710-015445" src="https://github.com/user-attachments/assets/68f38ed7-27c4-4b83-b498-f2dd3cbeb457">


### After

<img width="234" alt="Screenshot 2024-08-08 at 11 39 57 AM" src="https://github.com/user-attachments/assets/dda0f752-4ab9-47a5-9cdb-6325e56dce4a">


[SFINT-5636]: https://coveord.atlassian.net/browse/SFINT-5636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ