### PR TITLE
fix(headless): default value of originLevel3 updated to be a valid value

### DIFF
--- a/packages/headless/src/features/configuration/configuration-state.ts
+++ b/packages/headless/src/features/configuration/configuration-state.ts
@@ -172,7 +172,7 @@ export const getConfigurationInitialState: () => ConfigurationState = () => ({
     nextApiBaseUrl: '',
     originContext: 'Search',
     originLevel2: 'default',
-    originLevel3: 'default',
+    originLevel3: '',
     anonymous: false,
     deviceId: '',
     userDisplayName: '',


### PR DESCRIPTION
[SFINT-5663](https://coveord.atlassian.net/browse/SFINT-5663)


The previous default value of the originLevel3 was the following: `default`, this value is considered invalid as it is an invalid URL,  the DataHealth dashboard is showing the following message on analytics events where this invalid value was used:

<img width="1165" alt="Screenshot 2024-08-12 at 1 00 21 PM" src="https://github.com/user-attachments/assets/e36600bc-7f4f-4d8d-b3a9-256bf0988df5">

In this PR i'm updating this default value by making it an empty string which is considered a valid value for OriginLevel3.





[SFINT-5663]: https://coveord.atlassian.net/browse/SFINT-5663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ