### PR TITLE
fix(answerStream): handle end of stream

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -149,7 +149,7 @@ const updateCacheWithEvent = (
       }
       break;
     case 'genqa.endOfStreamType':
-      if (parsedPayload.answerGenerated) {
+      if (draft.answer?.length || parsedPayload.answerGenerated) {
         handleEndOfStream(draft, parsedPayload);
       }
       break;
@@ -236,9 +236,7 @@ const constructAnswerQueryParams = (state: StateNeededByAnswerAPI) => {
     q,
     pipelineRuleParameters: {
       mlGenerativeQuestionAnswering: {
-        responseFormat: {
-          answerStyle: state.generatedAnswer.responseFormat.answerStyle,
-        },
+        responseFormat: state.generatedAnswer.responseFormat,
         citationsFieldToInclude,
       },
     },


### PR DESCRIPTION
[SVCC-4057](https://coveord.atlassian.net/browse/SVCC-4057)

## Problem

The end of stream was no handled after a 'sorry' message.
The `answerGenerated` is false with the 'sorry' message, and this was the condition to handle the end of stream.

The effect of this bug was that the cursor was not removed when the answer was 'sorry'.  Plus, the buttons to rephrase weren't showing.  Removing the possibility to rephrase.

## Solution

We now check if there is an answer that was outputed beside the official `answerGenerated`.

## Side fix

We now send the `contentFormat` in the payload, like we do with the SearchApi
 

[SVCC-4057]: https://coveord.atlassian.net/browse/SVCC-4057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ