### PR TITLE
fix(headless): fix answer state using the new pattern

### DIFF
--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -100,13 +100,8 @@ const subscribeToSearchRequest = (
       return;
     }
     if (JSON.stringify(triggerParams) === JSON.stringify(lastTriggerParams)) {
-      // engine.dispatch(resetAnswer());
       return;
     }
-    // if (lastTriggerParams && JSON.stringify(triggerParams) !== JSON.stringify(lastTriggerParams)) {
-    //   lastTriggerParams = triggerParams;
-    //   engine.dispatch(resetAnswer());
-    // }
     lastTriggerParams = triggerParams;
     engine.dispatch(resetAnswer());
     engine.dispatch(fetchAnswer(state));

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -13,6 +13,7 @@ import {
 import {SearchEngine} from '../../../app/search-engine/search-engine';
 import {
   resetAnswer,
+  sendGeneratedAnswerFeedback,
   updateAnswerConfigurationId,
 } from '../../../features/generated-answer/generated-answer-actions';
 import {GeneratedAnswerFeedbackV2} from '../../../features/generated-answer/generated-answer-analytics-actions';
@@ -99,9 +100,15 @@ const subscribeToSearchRequest = (
       return;
     }
     if (JSON.stringify(triggerParams) === JSON.stringify(lastTriggerParams)) {
+      // engine.dispatch(resetAnswer());
       return;
     }
+    // if (lastTriggerParams && JSON.stringify(triggerParams) !== JSON.stringify(lastTriggerParams)) {
+    //   lastTriggerParams = triggerParams;
+    //   engine.dispatch(resetAnswer());
+    // }
     lastTriggerParams = triggerParams;
+    engine.dispatch(resetAnswer());
     engine.dispatch(fetchAnswer(state));
   };
   engine.subscribe(strictListener);
@@ -172,6 +179,7 @@ export function buildAnswerApiGeneratedAnswer(
         answerApiState: selectAnswer(engine.state).data!,
       });
       engine.dispatch(answerEvaluation.endpoints.post.initiate(args));
+      engine.dispatch(sendGeneratedAnswerFeedback());
     },
   };
 }


### PR DESCRIPTION
[SVCC-4040](https://coveord.atlassian.net/browse/SVCC-4040)

**Problems:**

1. states of the answer aren't reset after a new request: when you click on like/dislike/expand for example, the new query doesn't reset the state, we still can see the button liked or disliked clicked for example from the previous query.
2. When you submit a feedback, and re-click on likes/disliked, the feedback modal still shows even if the feedback was successfully submitted.

**Solutions:**

1. Reset the state when we perform a new query.
2. update `feedbackSumbitted` state when calling `sendFeedback` in the new pattern.

**DEMO:**

https://github.com/user-attachments/assets/3377b367-5985-4045-8ad6-e072f81c9645



[SVCC-4040]: https://coveord.atlassian.net/browse/SVCC-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ