### PR TITLE
feat(quantic): Add option for rephrase buttons, remove citations numbers

### DIFF
--- a/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer-expectations.ts
+++ b/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer-expectations.ts
@@ -201,17 +201,6 @@ function generatedAnswerExpectations(selector: GeneratedAnswerSelector) {
         );
     },
 
-    citationNumberContains: (index: number, value: string) => {
-      selector
-        .citationIndex(index)
-        .then((element) => {
-          expect(element.get(0).innerText).to.equal(value);
-        })
-        .log(
-          `the citation at the index ${index} should contain the number "${value}"`
-        );
-    },
-
     citationLinkContains: (index: number, value: string) => {
       selector
         .citationLink(index)

--- a/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer-selectors.ts
@@ -60,10 +60,6 @@ export const GeneratedAnswerSelectors: GeneratedAnswerSelector = {
     GeneratedAnswerSelectors.get()
       .find('[data-cy="generated-answer__citations"] .citation__title')
       .eq(index),
-  citationIndex: (index: number) =>
-    GeneratedAnswerSelectors.get()
-      .find('[data-cy="generated-answer__citations"] .citation__index')
-      .eq(index),
   citationLink: (index: number) =>
     GeneratedAnswerSelectors.get()
       .find('[data-cy="generated-answer__citations"] .citation__link')

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticGeneratedAnswer/exampleQuanticGeneratedAnswer.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticGeneratedAnswer/exampleQuanticGeneratedAnswer.html
@@ -26,6 +26,7 @@
         multiline-footer={config.multilineFooter}
         collapsible={config.collapsible}
         with-toggle={config.withToggle}
+        with-rephrase-buttons={config.withRephraseButtons}
       >
       </c-quantic-generated-answer>
     </c-example-use-case>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticGeneratedAnswer/exampleQuanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticGeneratedAnswer/exampleQuanticGeneratedAnswer.js
@@ -43,6 +43,13 @@ export default class ExampleQuanticGeneratedAnswer extends LightningElement {
       defaultValue: false,
     },
     {
+      attribute: 'withRephraseButtons',
+      label: 'With Rephrase Buttons',
+      description:
+        'Indicates whether the rephrase buttons should be available.',
+      defaultValue: false,
+    },
+    {
       attribute: 'useCase',
       label: 'Use Case',
       description:

--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/__tests__/quanticCitation.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/__tests__/quanticCitation.test.js
@@ -51,7 +51,6 @@ const defaultOptions = {
 
 const selectors = {
   citation: '.citation',
-  citationIndex: '.citation__index',
   citationLink: '.citation__link',
   citationTitle: '.citation__title',
   citationTooltip: 'c-quantic-tooltip',
@@ -113,9 +112,6 @@ describe('c-quantic-citation', () => {
     const citationLink = element.shadowRoot.querySelector(
       selectors.citationLink
     );
-    const citationIndex = element.shadowRoot.querySelector(
-      selectors.citationIndex
-    );
     const citationTitle = element.shadowRoot.querySelector(
       selectors.citationTitle
     );
@@ -125,13 +121,11 @@ describe('c-quantic-citation', () => {
 
     expect(citation).not.toBeNull();
     expect(citationLink).not.toBeNull();
-    expect(citationIndex).not.toBeNull();
     expect(citationTitle).not.toBeNull();
     expect(citationTooltip).not.toBeNull();
 
     expect(citationLink.href).toBe(exampleCitation.clickUri);
     expect(citationLink.target).toBe('_blank');
-    expect(citationIndex.textContent).toBe(exampleCitation.index);
     expect(citationTitle.textContent).toBe(exampleCitation.title);
   });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.css
@@ -17,20 +17,8 @@
   box-shadow: 0px 0px 3px 0px var(--lwc-brandAccessible, #0070d2);
 }
 
-.citation__link:hover .citation__index {
-  background-color: var(--lwc-colorBackgroundAlt, #ffffff);
-}
-
 .citation__link:hover .citation__title {
   color: var(--lwc-brandAccessible, #0176d3);
-}
-
-.citation__index {
-  color: var(--lwc-brandAccessible, #0176d3);
-  background-color: var(--lwc-brandLight, #f4f6fe);
-  width: 20px;
-  height: 20px;
-  border-radius: var(--lwc-borderRadiusCircle, 50%);
 }
 
 .citation__title {

--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.html
@@ -11,7 +11,6 @@
       onmouseleave={handleMouseLeave}
       onclick={handleClick} 
     >
-      <div class="citation__index slds-align_absolute-center">{index}</div>
       <p
         class="citation__title slds-m-left_x-small slds-truncate slds-has-flexi-truncate"
       >

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -100,6 +100,14 @@ export default class QuanticGeneratedAnswer extends LightningElement {
    */
   @api withToggle = false;
 
+  /**
+   * Whether the component should display the rephrase buttons.
+   * @api
+   * @type {boolean}
+   * @default {false}
+   */
+  @api withRephraseButtons = false;
+
   labels = {
     generatedAnswerForYou,
     thisAnswerWasNotHelpful,
@@ -443,7 +451,16 @@ export default class QuanticGeneratedAnswer extends LightningElement {
     return this?.state?.isStreaming;
   }
 
-  get shouldDisplayActions() {
+  get shouldDisplayRephraseButtons() {
+    return (
+      this.withRephraseButtons &&
+      this.isVisible &&
+      !this.isStreaming &&
+      !this.isAnswerCollapsed
+    );
+  }
+
+  get shouldDisplayFeedback() {
     return this.isVisible && !this.isStreaming && !this.isAnswerCollapsed;
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -460,7 +460,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
     );
   }
 
-  get shouldDisplayFeedback() {
+  get shouldDisplayActions() {
     return this.isVisible && !this.isStreaming && !this.isAnswerCollapsed;
   }
 

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
@@ -7,7 +7,7 @@
           >{labels.generatedAnswerForYou}</span
         >
         <div class="generated-answer__header-actions slds-grid">
-          <template lwc:if={shouldDisplayActions}>
+          <template lwc:if={shouldDisplayFeedback}>
             <div class="slds-grid flex-one slds-grid_align-end">
               <c-quantic-feedback
                 state={feedbackState}
@@ -67,7 +67,7 @@
                   ></c-quantic-source-citations>
                 </div>
               </template>
-              <template lwc:if={shouldDisplayActions}>
+              <template lwc:if={shouldDisplayRephraseButtons}>
                 <div class={rephraseButtonsCssClass}>
                   <c-quantic-generated-answer-rephrase-buttons
                     data-cy="generated-answer__rephrase-buttons"

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
@@ -7,7 +7,7 @@
           >{labels.generatedAnswerForYou}</span
         >
         <div class="generated-answer__header-actions slds-grid">
-          <template lwc:if={shouldDisplayFeedback}>
+          <template lwc:if={shouldDisplayActions}>
             <div class="slds-grid flex-one slds-grid_align-end">
               <c-quantic-feedback
                 state={feedbackState}

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -15,7 +15,9 @@
       "outputs": [
         "{projectRoot}/docs/out",
         "{projectRoot}/force-app/main/default/staticresources/coveobueno",
-        "{projectRoot}/force-app/main/default/staticresources/coveoheadless"
+        "{projectRoot}/force-app/main/default/staticresources/coveoheadless",
+        "{projectRoot}/force-app/main/default/staticresources/dompurify",
+        "{projectRoot}/force-app/main/default/staticresources/marked"
       ],
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
1. SFINT-5661: Add an option (default false), to show the rephrase buttons
    - We want to ultimately completely remove the rephrase buttons (with V3), but meanwhile we will simply hide them by default, customers can still bring them back with an option for now.
    - But the data proves very low usage, and most of the usage is to "try" and get an answer when there were no answer generated in the first place.
    - The display format will be markdown for everyone as it provides the best format of answer anyway.

2. SFINT-5660: Remove the numbers next to the citations in the RGA component. (They were judged not useful by product).

![image](https://github.com/user-attachments/assets/0e80ca15-3c8d-4b63-b260-07ccf3a8ecb9)


I also re-organized a little bit the e2e tests for the quanticGeneratedAnswer component.

The new logic is basically this:
1. When no streamID is returned
2. When a streamID is returned
    a. All the "happy path" tests here, completed event, markdown, end of stream, like/dislike, feedback, toggle button, collapsible, copyToClipboard, citations.
    b. All the options: fieldsToInclude, multilineFooter, collapsible, withRephraseButtons, answerStyle

That way it's a lot more readable, I personally think. Feel free to comment on that if you'd make other changes to the format of tests.

![image](https://github.com/user-attachments/assets/14ff1950-691c-4b25-9d4e-81f0ba2eaf0a)
