### PR TITLE
fix(atomic): Facets don't update correctly in the refine modal when changing tabs

### DIFF
--- a/packages/atomic/cypress/e2e/breadbox.cypress.ts
+++ b/packages/atomic/cypress/e2e/breadbox.cypress.ts
@@ -271,7 +271,7 @@ describe('Breadbox Test Suites', () => {
   });
 
   describe('when excluding from a standard facet', () => {
-    const selectionIndex = 2;
+    const selectionIndex = 1;
 
     function setupFacetWithMultipleExcludedValues() {
       new TestFixture()

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -16,6 +16,7 @@ import {
   TabManager,
   TabManagerState,
   buildTabManager,
+  loadSortCriteriaActions,
 } from '@coveo/headless';
 import {Component, h, State, Prop, Element, Watch} from '@stencil/core';
 import {
@@ -268,6 +269,22 @@ export class AtomicRefineModal implements InitializableComponent {
       (option) => option.expression === select.value
     );
     option && this.sort.sortBy(option.criteria);
+  }
+
+  public componentShouldUpdate(): void {
+    if (
+      this.options.some(
+        (option) => option.expression === this.sortState.sortCriteria
+      )
+    ) {
+      return;
+    }
+
+    const action = loadSortCriteriaActions(
+      this.bindings.engine
+    ).updateSortCriterion(this.options[0]?.criteria);
+
+    this.bindings.engine.dispatch(action);
   }
 
   private buildOption({expression, criteria, label, tabs}: SortDropdownOption) {

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.tsx
@@ -16,7 +16,6 @@ import {
   TabManager,
   TabManagerState,
   buildTabManager,
-  loadSortCriteriaActions,
 } from '@coveo/headless';
 import {Component, h, State, Prop, Element, Watch} from '@stencil/core';
 import {
@@ -269,22 +268,6 @@ export class AtomicRefineModal implements InitializableComponent {
       (option) => option.expression === select.value
     );
     option && this.sort.sortBy(option.criteria);
-  }
-
-  public componentShouldUpdate(): void {
-    if (
-      this.options.some(
-        (option) => option.expression === this.sortState.sortCriteria
-      )
-    ) {
-      return;
-    }
-
-    const action = loadSortCriteriaActions(
-      this.bindings.engine
-    ).updateSortCriterion(this.options[0]?.criteria);
-
-    this.bindings.engine.dispatch(action);
   }
 
   private buildOption({expression, criteria, label, tabs}: SortDropdownOption) {

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.tsx
@@ -16,7 +16,15 @@ import {
   TabManager,
   buildTabManager,
 } from '@coveo/headless';
-import {Component, h, State, Prop, Element, Fragment} from '@stencil/core';
+import {
+  Component,
+  h,
+  State,
+  Prop,
+  Element,
+  Fragment,
+  Watch,
+} from '@stencil/core';
 import {
   AriaLiveRegion,
   FocusTargetController,
@@ -340,17 +348,26 @@ export class AtomicCategoryFacet implements InitializableComponent {
     );
   }
 
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
+  }
+
   public componentShouldUpdate(
     next: unknown,
     prev: unknown,
     propName: keyof AtomicCategoryFacet
   ) {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
     if (
       this.isCategoryFacetState(prev, propName) &&
       this.isCategoryFacetState(next, propName)

--- a/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.tsx
@@ -17,7 +17,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, h, State, Prop, VNode, Element} from '@stencil/core';
+import {Component, h, State, Prop, VNode, Element, Watch} from '@stencil/core';
 import {
   AriaLiveRegion,
   FocusTargetController,
@@ -348,17 +348,26 @@ export class AtomicColorFacet implements InitializableComponent {
     );
   }
 
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
+  }
+
   public componentShouldUpdate(
     next: unknown,
     prev: unknown,
     propName: keyof AtomicColorFacet
   ) {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
     if (propName === 'facetState' && prev && this.withSearch) {
       return shouldUpdateFacetSearchComponent(
         (next as FacetState).facetSearch,

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.tsx
@@ -24,6 +24,7 @@ import {
   Element,
   VNode,
   Fragment,
+  Watch,
 } from '@stencil/core';
 import {
   AriaLiveRegion,
@@ -317,17 +318,26 @@ export class AtomicFacet implements InitializableComponent {
     this.facetConditionsManager?.stopWatching();
   }
 
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
+  }
+
   public componentShouldUpdate(
-    next: unknown,
-    prev: unknown,
+    next: FacetState,
+    prev: FacetState,
     propName: keyof AtomicFacet
   ) {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
     if (
       this.isFacetState(prev, propName) &&
       this.isFacetState(next, propName)

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.tsx
@@ -22,7 +22,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, Element, h, Listen, Prop, State} from '@stencil/core';
+import {Component, Element, h, Listen, Prop, State, Watch} from '@stencil/core';
 import {FocusTargetController} from '../../../../utils/accessibility-utils';
 import {
   BindStateToController,
@@ -265,13 +265,19 @@ export class AtomicNumericFacet implements InitializableComponent {
     this.tabManager = buildTabManager(this.bindings.engine);
   }
 
-  public componentShouldUpdate(): void {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facetForRange
-    );
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facetForRange
+      );
+    }
   }
 
   private initializeFacetForInput() {

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.tsx
@@ -18,7 +18,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, h, State, Prop, VNode, Element} from '@stencil/core';
+import {Component, h, State, Prop, VNode, Element, Watch} from '@stencil/core';
 import Star from '../../../../images/star.svg';
 import {FocusTargetController} from '../../../../utils/accessibility-utils';
 import {
@@ -271,13 +271,19 @@ export class AtomicRatingFacet implements InitializableComponent {
     this.dependenciesManager?.stopWatching();
   }
 
-  public componentShouldUpdate(): void {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
   }
 
   private get isHidden() {

--- a/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-range-facet/atomic-rating-range-facet.tsx
@@ -17,7 +17,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, h, State, Prop, VNode, Element} from '@stencil/core';
+import {Component, h, State, Prop, VNode, Element, Watch} from '@stencil/core';
 import Star from '../../../../images/star.svg';
 import {FocusTargetController} from '../../../../utils/accessibility-utils';
 import {
@@ -214,16 +214,20 @@ export class AtomicRatingRangeFacet implements InitializableComponent {
     this.initializeFacet();
     this.initializeDependenciesManager();
   }
-
-  public componentShouldUpdate(): void {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
   }
-
   public disconnectedCallback() {
     if (this.host.isConnected) {
       return;

--- a/packages/atomic/src/components/search/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-segmented-facet/atomic-segmented-facet.tsx
@@ -16,7 +16,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, h, Prop, State, VNode} from '@stencil/core';
+import {Component, h, Prop, State, VNode, Watch} from '@stencil/core';
 import {getFieldValueCaption} from '../../../../utils/field-utils';
 import {
   BindStateToController,
@@ -215,13 +215,19 @@ export class AtomicSegmentedFacet implements InitializableComponent {
     );
   }
 
-  public componentShouldUpdate(): void {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facet
-    );
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facet
+      );
+    }
   }
 
   disconnectedCallback() {

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.tsx
@@ -20,7 +20,7 @@ import {
   TabManager,
   TabManagerState,
 } from '@coveo/headless';
-import {Component, Element, h, Listen, Prop, State} from '@stencil/core';
+import {Component, Element, h, Listen, Prop, State, Watch} from '@stencil/core';
 import {FocusTargetController} from '../../../../utils/accessibility-utils';
 import {
   BindStateToController,
@@ -256,13 +256,19 @@ export class AtomicTimeframeFacet implements InitializableComponent {
     this.tabManager = buildTabManager(this.bindings.engine);
   }
 
-  public componentShouldUpdate(): void {
-    updateFacetVisibilityForActiveTab(
-      [...this.tabsIncluded],
-      [...this.tabsExcluded],
-      this.tabManagerState?.activeTab,
-      this.facetForDateRange
-    );
+  @Watch('tabManagerState')
+  watchTabManagerState(
+    newValue: {activeTab: string},
+    oldValue: {activeTab: string}
+  ) {
+    if (newValue?.activeTab !== oldValue?.activeTab) {
+      updateFacetVisibilityForActiveTab(
+        [...this.tabsIncluded],
+        [...this.tabsExcluded],
+        this.tabManagerState?.activeTab,
+        this.facetForDateRange
+      );
+    }
   }
 
   public disconnectedCallback() {

--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.new.stories.tsx
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.new.stories.tsx
@@ -61,176 +61,126 @@ export const Default: Story = {
   name: 'atomic-tab-manager',
   decorators: [
     (story) => html`
-      ${story()}
-      <atomic-refine-toggle></atomic-refine-toggle>
-      <div style="padding:10px;">
-        <atomic-sort-dropdown>
-          <atomic-sort-expression
-            tabs-excluded='["article"]'
-            label="Name descending"
-            expression="name descending"
-          ></atomic-sort-expression>
-          <atomic-sort-expression
-            tabs-excluded='["article"]'
-            label="Name ascending"
-            expression="name ascending"
-          ></atomic-sort-expression>
-          <atomic-sort-expression
-            tabs-included='["article"]'
-            label="Most Recent"
-            expression="date descending"
-          ></atomic-sort-expression>
-          <atomic-sort-expression
-            tabs-included='["article"]'
-            label="Least Recent"
-            expression="date ascending"
-          ></atomic-sort-expression>
-          <atomic-sort-expression
-            label="relevance"
-            expression="relevancy"
-          ></atomic-sort-expression>
-        </atomic-sort-dropdown>
-      </div>
-      <div style="display: flex;">
-        <atomic-smart-snippet
-          tabs-included='["article", "documentation"]'
-          style="padding: 10px;"
-        ></atomic-smart-snippet>
-      </div>
-      <div style="display: flex; justify-content: flex-start;">
-        <atomic-facet field="objecttype" label="Object type"></atomic-facet>
-        <atomic-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          field="filetype"
-          label="File type"
-        ></atomic-facet>
-        <atomic-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          field="source"
-          label="Source"
-        ></atomic-facet>
-      </div>
-      <div style="display: flex; justify-content: flex-start;">
-        <atomic-category-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          field="geographicalhierarchy"
-          label="World Atlas"
-          with-search
-        ></atomic-category-facet>
-        <atomic-category-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          field="geographicalhierarchy"
-          label="World Atlas"
-        ></atomic-category-facet>
-        <atomic-color-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          field="filetype"
-          label="Files"
-          number-of-values="6"
-          sort-criteria="occurrences"
-        ></atomic-color-facet>
-        <atomic-color-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          field="filetype"
-          label="Files"
-          number-of-values="6"
-          sort-criteria="occurrences"
-        ></atomic-color-facet>
-      </div>
-      <div style="display: flex; justify-content: flex-start;">
-        <atomic-rating-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          field="snrating"
-          label="Rating"
-          number-of-intervals="5"
-        ></atomic-rating-facet>
-        <atomic-rating-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          field="snrating"
-          label="Rating"
-          number-of-intervals="5"
-        ></atomic-rating-facet>
-        <atomic-rating-range-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          facet-id="snrating_range"
-          field="snrating"
-          label="Rating Range (auto)"
-          number-of-intervals="5"
-        ></atomic-rating-range-facet>
-        <atomic-rating-range-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          facet-id="snrating_range_2"
-          field="snrating"
-          label="Rating Range (auto)"
-          number-of-intervals="5"
-        ></atomic-rating-range-facet>
-      </div>
-      <div style="display: flex; justify-content: flex-start; padding:50px;">
-        <atomic-segmented-facet-scrollable>
-          <atomic-segmented-facet
-            aria-label="included-facet"
-            tabs-included='["article"]'
-            field="inat_kingdom"
-            label="Kingdom"
-          ></atomic-segmented-facet>
-        </atomic-segmented-facet-scrollable>
-        <atomic-segmented-facet-scrollable>
-          <atomic-segmented-facet
-            aria-label="excluded-facet"
-            tabs-excluded='["article"]'
-            field="inat_kingdom"
-            label="Kingdom"
-          ></atomic-segmented-facet>
-        </atomic-segmented-facet-scrollable>
-      </div>
-      <div style="display: flex; justify-content: flex-start;">
-        <atomic-timeframe-facet
-          aria-label="included-facet"
-          tabs-included='["article"]'
-          label="Timeframe"
-          with-date-picker
-        >
-          <atomic-timeframe unit="hour"></atomic-timeframe>
-          <atomic-timeframe unit="day"></atomic-timeframe>
-          <atomic-timeframe unit="week"></atomic-timeframe>
-          <atomic-timeframe unit="month"></atomic-timeframe>
-          <atomic-timeframe unit="quarter"></atomic-timeframe>
-          <atomic-timeframe unit="year"></atomic-timeframe>
-          <atomic-timeframe
-            unit="year"
-            amount="10"
-            period="next"
-          ></atomic-timeframe
-        ></atomic-timeframe-facet>
-        <atomic-timeframe-facet
-          aria-label="excluded-facet"
-          tabs-excluded='["article"]'
-          label="Timeframe"
-          with-date-picker
-        >
-          <atomic-timeframe unit="hour"></atomic-timeframe>
-          <atomic-timeframe unit="day"></atomic-timeframe>
-          <atomic-timeframe unit="week"></atomic-timeframe>
-          <atomic-timeframe unit="month"></atomic-timeframe>
-          <atomic-timeframe unit="quarter"></atomic-timeframe>
-          <atomic-timeframe unit="year"></atomic-timeframe>
-          <atomic-timeframe
-            unit="year"
-            amount="10"
-            period="next"
-          ></atomic-timeframe
-        ></atomic-timeframe-facet>
-      </div>
+      <atomic-search-layout>
+        <atomic-layout-section section="search">
+          <atomic-search-box></atomic-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facets>
+            <atomic-facet field="objecttype" label="Object type"></atomic-facet>
+            <atomic-facet aria-label="included-facet" tabs-included='["article"]' field="filetype"
+              label="File type (included facet)"></atomic-facet>
+            <atomic-facet aria-label="excluded-facet" tabs-excluded='["article"]' field="source"
+              label="Source (excluded facet)"></atomic-facet>
+            <atomic-category-facet aria-label="included-facet" tabs-included='["article"]' field="geographicalhierarchy"
+              label="World Atlas" with-search></atomic-category-facet>
+            <atomic-category-facet aria-label="excluded-facet" tabs-excluded='["article"]' field="geographicalhierarchy"
+              label="World Atlas"></atomic-category-facet>
+            <atomic-color-facet aria-label="included-facet" tabs-included='["article"]' field="filetype" label="Files"
+              number-of-values="6" sort-criteria="occurrences"></atomic-color-facet>
+            <atomic-color-facet aria-label="excluded-facet" tabs-excluded='["article"]' field="filetype" label="Files"
+              number-of-values="6" sort-criteria="occurrences"></atomic-color-facet>
+            <atomic-rating-facet aria-label="included-facet" tabs-included='["article"]' field="snrating" label="Rating"
+              number-of-intervals="5"></atomic-rating-facet>
+            <atomic-rating-facet aria-label="excluded-facet" tabs-excluded='["article"]' field="snrating" label="Rating"
+              number-of-intervals="5"></atomic-rating-facet>
+            <atomic-rating-range-facet aria-label="included-facet" tabs-included='["article"]' facet-id="snrating_range"
+              field="snrating" label="Rating Range (auto)" number-of-intervals="5"></atomic-rating-range-facet>
+            <atomic-rating-range-facet aria-label="excluded-facet" tabs-excluded='["article"]'
+              facet-id="snrating_range_2" field="snrating" label="Rating Range (auto)"
+              number-of-intervals="5"></atomic-rating-range-facet>
+            <atomic-timeframe-facet aria-label="included-facet" tabs-included='["article"]' label="Timeframe"
+              with-date-picker>
+              <atomic-timeframe unit="hour"></atomic-timeframe>
+              <atomic-timeframe unit="day"></atomic-timeframe>
+              <atomic-timeframe unit="week"></atomic-timeframe>
+              <atomic-timeframe unit="month"></atomic-timeframe>
+              <atomic-timeframe unit="quarter"></atomic-timeframe>
+              <atomic-timeframe unit="year"></atomic-timeframe>
+              <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe></atomic-timeframe-facet>
+            <atomic-timeframe-facet aria-label="excluded-facet" tabs-excluded='["article"]' label="Timeframe"
+              with-date-picker>
+              <atomic-timeframe unit="hour"></atomic-timeframe>
+              <atomic-timeframe unit="day"></atomic-timeframe>
+              <atomic-timeframe unit="week"></atomic-timeframe>
+              <atomic-timeframe unit="month"></atomic-timeframe>
+              <atomic-timeframe unit="quarter"></atomic-timeframe>
+              <atomic-timeframe unit="year"></atomic-timeframe>
+              <atomic-timeframe unit="year" amount="10" period="next"></atomic-timeframe></atomic-timeframe-facet>
+          </atomic-facets>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          ${story()}
+          <atomic-layout-section section="horizontal-facets">
+            <atomic-segmented-facet-scrollable>
+              <atomic-segmented-facet aria-label="included-facet" tabs-included='["article"]' field="inat_kingdom"
+                label="Kingdom"></atomic-segmented-facet>
+            </atomic-segmented-facet-scrollable>
+            <atomic-segmented-facet-scrollable>
+              <atomic-segmented-facet aria-label="excluded-facet" tabs-excluded='["article"]' field="inat_kingdom"
+                label="Kingdom"></atomic-segmented-facet>
+            </atomic-segmented-facet-scrollable>
+          </atomic-layout-section>
+          <atomic-layout-section section="status">
+            <atomic-breadbox></atomic-breadbox>
+            <atomic-query-summary></atomic-query-summary>
+            <atomic-refine-toggle></atomic-refine-toggle>
+            <atomic-sort-dropdown>
+              <atomic-sort-expression tabs-excluded='["article"]' label="Name descending"
+                expression="name descending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-excluded='["article"]' label="Name ascending"
+                expression="name ascending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-included='["article"]' label="Most Recent"
+                expression="date descending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-included='["article"]' label="Least Recent"
+                expression="date ascending"></atomic-sort-expression>
+              <atomic-sort-expression label="relevance" expression="relevancy"></atomic-sort-expression>
+            </atomic-sort-dropdown>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <atomic-smart-snippet tabs-included='["article", "documentation"]'
+              style="padding: 10px;"></atomic-smart-snippet>
+            <atomic-result-list tabs-included='["article"]' display="list" density="compact" image-size="small"
+              data-testid="included-result-list">
+              <atomic-result-template>
+
+                <template>
+
+                  <atomic-result-section-actions><atomic-quickview></atomic-quickview></atomic-result-section-actions>
+                  <atomic-result-section-visual>
+
+                    <img src="https://picsum.photos/350" class="thumbnail" />
+                  </atomic-result-section-visual>
+                  <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
+                  <atomic-result-section-excerpt>
+                    "included result list"
+                    <atomic-result-text field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                </template>
+              </atomic-result-template>
+            </atomic-result-list>
+            <atomic-result-list tabs-excluded='["article"]' display="grid" density="normal" image-size="icon"
+              data-testid="excluded-result-list">
+
+              <atomic-result-template>
+                <template>
+
+                  <atomic-result-section-actions><atomic-quickview></atomic-quickview></atomic-result-section-actions>
+                  <atomic-result-section-visual>
+
+                    <img src="https://picsum.photos/400" class="thumbnail" />
+                  </atomic-result-section-visual>
+                  <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
+                  <atomic-result-section-excerpt>
+                    "excluded result list"
+                    <atomic-result-text field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                </template>
+              </atomic-result-template>
+            </atomic-result-list>
+            <atomic-query-error></atomic-commerce-query-error>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination"></atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-search-layout>
     `,
   ],
 };

--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/e2e/atomic-tab-manager.e2e.ts
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/e2e/atomic-tab-manager.e2e.ts
@@ -11,13 +11,13 @@ test.describe('AtomicTabManager', () => {
   });
 
   test('should not display tabs dropdown', async ({tabManager}) => {
-    await expect(tabManager.tabDropdown).not.toBeVisible();
+    await expect(tabManager.tabDropdown).toBeHidden();
   });
 
   test('should display tab buttons for each atomic-tab elements', async ({
     tabManager,
   }) => {
-    await expect(tabManager.tabDropdown).not.toBeVisible();
+    await expect(tabManager.tabDropdown).toBeHidden();
 
     await expect(tabManager.tabButtons()).toHaveText([
       'All',
@@ -37,7 +37,7 @@ test.describe('AtomicTabManager', () => {
     });
 
     test('should not display tabs dropdown', async ({tabManager}) => {
-      await expect(tabManager.tabDropdown).not.toBeVisible();
+      await expect(tabManager.tabDropdown).toBeHidden();
     });
 
     test.describe('should change other component visibility', async () => {
@@ -47,7 +47,7 @@ test.describe('AtomicTabManager', () => {
       test('facets', async ({tabManager}) => {
         const includedFacets = await tabManager.includedFacet.all();
         for (let i = 0; i < includedFacets.length; i++) {
-          await expect(includedFacets[i]).not.toBeVisible();
+          await expect(includedFacets[i]).toBeHidden();
         }
 
         const excludedFacets = await tabManager.excludedFacet.all();
@@ -57,7 +57,7 @@ test.describe('AtomicTabManager', () => {
       });
 
       test('smart snippet', async ({tabManager}) => {
-        await expect(tabManager.smartSnippet).not.toBeVisible();
+        await expect(tabManager.smartSnippet).toBeHidden();
       });
 
       test('sort dropdown', async ({tabManager}) => {
@@ -74,7 +74,7 @@ test.describe('AtomicTabManager', () => {
     test('should display tab buttons for each atomic-tab elements', async ({
       tabManager,
     }) => {
-      await expect(tabManager.tabDropdown).not.toBeVisible();
+      await expect(tabManager.tabDropdown).toBeHidden();
 
       await expect(tabManager.tabButtons()).toHaveText([
         'All',
@@ -102,7 +102,7 @@ test.describe('AtomicTabManager', () => {
 
           const excludedFacets = await tabManager.excludedFacet.all();
           for (let i = 0; i < excludedFacets.length; i++) {
-            await expect(excludedFacets[i]).not.toBeVisible();
+            await expect(excludedFacets[i]).toBeHidden();
           }
         });
 
@@ -136,19 +136,18 @@ test.describe('AtomicTabManager', () => {
 
             const includedFacets = await tabManager.includedFacet.all();
             for (let i = 0; i < includedFacets.length; i++) {
-              await expect(includedFacets[i]).not.toBeVisible();
+              await expect(includedFacets[i]).toBeHidden();
             }
           });
 
           test('smart snippet', async ({tabManager}) => {
-            await expect(tabManager.smartSnippet).not.toBeVisible();
+            await expect(tabManager.smartSnippet).toBeHidden();
           });
 
           test('sort dropdown', async ({tabManager}) => {
-            await tabManager.refineModalButton.click();
-            await tabManager.refineModalHeader.waitFor({state: 'visible'});
+            await tabManager.sortDropdown.waitFor({state: 'visible'});
 
-            await expect(tabManager.refineModalSortDropdownOptions).toHaveText([
+            await expect(tabManager.sortDropdownOptions).toHaveText([
               'Name descending',
               'Name ascending',
               'Relevance',
@@ -167,7 +166,7 @@ test.describe('AtomicTabManager', () => {
         });
 
         test('should hide tabs area', async ({tabManager}) => {
-          await expect(tabManager.tabArea).not.toBeVisible();
+          await expect(tabManager.tabArea).toBeHidden();
         });
 
         test('should have the active tab selected in the dropdown', async ({
@@ -190,7 +189,7 @@ test.describe('AtomicTabManager', () => {
     });
 
     test('should not display tabs area', async ({tabManager}) => {
-      await expect(tabManager.tabArea).not.toBeVisible();
+      await expect(tabManager.tabArea).toBeHidden();
     });
 
     test('should display tabs dropdown', async ({tabManager}) => {
@@ -208,9 +207,8 @@ test.describe('AtomicTabManager', () => {
     });
 
     test.describe('when selecting a dropdown option', () => {
-      test.beforeEach(async ({tabManager, facets}) => {
+      test.beforeEach(async ({tabManager}) => {
         await tabManager.tabDropdown.selectOption('article');
-        await facets.getFacetValue.first().waitFor({state: 'visible'});
       });
 
       test('should change active tab', async ({tabManager}) => {
@@ -219,19 +217,22 @@ test.describe('AtomicTabManager', () => {
 
       test.describe('should change other component visibility', async () => {
         test('facets', async ({tabManager}) => {
-          const includedFacets = await tabManager.includedFacet.all();
+          await tabManager.refineModalButton.click();
+          await tabManager.refineModalHeader.waitFor({state: 'visible'});
+
+          const includedFacets = await tabManager.includedModalFacet.all();
           for (let i = 0; i < includedFacets.length; i++) {
             await expect(includedFacets[i]).toBeVisible();
           }
 
-          const excludedFacets = await tabManager.excludedFacet.all();
+          const excludedFacets = await tabManager.excludedModalFacet.all();
           for (let i = 0; i < excludedFacets.length; i++) {
-            await expect(excludedFacets[i]).not.toBeVisible();
+            await expect(excludedFacets[i]).toBeHidden();
           }
         });
 
         test('smart snippet', async ({tabManager}) => {
-          await expect(tabManager.smartSnippet).toBeVisible();
+          await expect(tabManager.smartSnippet).not.toBeHidden();
         });
 
         test('sort dropdown', async ({tabManager}) => {
@@ -247,26 +248,28 @@ test.describe('AtomicTabManager', () => {
       });
 
       test.describe('when selecting previous dropdown option', () => {
-        test.beforeEach(async ({tabManager, facets}) => {
+        test.beforeEach(async ({tabManager}) => {
           await tabManager.tabDropdown.selectOption('all');
-          await facets.getFacetValue.first().waitFor({state: 'visible'});
         });
 
         test.describe('should change other component visibility', async () => {
           test('facets', async ({tabManager}) => {
-            const excludedFacets = await tabManager.excludedFacet.all();
+            await tabManager.refineModalButton.click();
+            await tabManager.refineModalHeader.waitFor({state: 'visible'});
+
+            const excludedFacets = await tabManager.excludedModalFacet.all();
             for (let i = 0; i < excludedFacets.length; i++) {
               await expect(excludedFacets[i]).toBeVisible();
             }
 
-            const includedFacets = await tabManager.includedFacet.all();
+            const includedFacets = await tabManager.includedModalFacet.all();
             for (let i = 0; i < includedFacets.length; i++) {
-              await expect(includedFacets[i]).not.toBeVisible();
+              await expect(includedFacets[i]).toBeHidden();
             }
           });
 
           test('smart snippet', async ({tabManager}) => {
-            await expect(tabManager.smartSnippet).not.toBeVisible();
+            await expect(tabManager.smartSnippet).toBeHidden();
           });
 
           test('sort dropdown', async ({tabManager}) => {
@@ -288,7 +291,7 @@ test.describe('AtomicTabManager', () => {
         });
 
         test('should hide tabs dropdown', async ({tabManager}) => {
-          await expect(tabManager.tabDropdown).not.toBeVisible();
+          await expect(tabManager.tabDropdown).toBeHidden();
         });
 
         test('should display tabs area', async ({tabManager}) => {

--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/e2e/page-object.ts
@@ -25,9 +25,20 @@ export class TabManagerPageObject extends BasePageObject<'atomic-tab-manager'> {
   get includedFacet() {
     return this.page.getByLabel(/^included-facet$/);
   }
+  get excludedModalFacet() {
+    return this.page
+      .locator('atomic-refine-modal')
+      .getByLabel(/^excluded-facet$/);
+  }
+
+  get includedModalFacet() {
+    return this.page
+      .locator('atomic-refine-modal')
+      .getByLabel(/^included-facet$/);
+  }
 
   get smartSnippet() {
-    return this.page.locator('atomic-smart-snippet [part="smart-snippet"]');
+    return this.page.getByText('Creating an In-Product Experience (IPX)');
   }
 
   get sortDropdown() {


### PR DESCRIPTION
This PR ensures that the facets in the refine modal are shown/hidden based on which tab is open. Prior to this fix, the refine modal would show the facets of the previous active tab, not the current one.

https://coveord.atlassian.net/browse/CDX-1586