### PR TITLE
feat(atomic): add tab support for atomic-generated-answer

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -984,14 +984,14 @@ export declare interface AtomicFormatUnit extends Components.AtomicFormatUnit {}
 
 
 @ProxyCmp({
-  inputs: ['collapsible', 'withToggle']
+  inputs: ['collapsible', 'tabsExcluded', 'tabsIncluded', 'withToggle']
 })
 @Component({
   selector: 'atomic-generated-answer',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['collapsible', 'withToggle'],
+  inputs: ['collapsible', 'tabsExcluded', 'tabsIncluded', 'withToggle'],
 })
 export class AtomicGeneratedAnswer {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1074,11 +1074,11 @@ export namespace Components {
          */
         "collapsible"?: boolean;
         /**
-          * The tabs on which this generated answer must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-excluded='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer won't be displayed on any of the specified tabs.
+          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
          */
         "tabsExcluded": string[] | string;
         /**
-          * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-included='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer can only be displayed on the specified tabs.
+          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
          */
         "tabsIncluded": string[] | string;
         /**
@@ -6996,11 +6996,11 @@ declare namespace LocalJSX {
          */
         "collapsible"?: boolean;
         /**
-          * The tabs on which this generated answer must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-excluded='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer won't be displayed on any of the specified tabs.
+          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
          */
         "tabsExcluded"?: string[] | string;
         /**
-          * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-included='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer can only be displayed on the specified tabs.
+          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
          */
         "tabsIncluded"?: string[] | string;
         /**

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1074,6 +1074,14 @@ export namespace Components {
          */
         "collapsible"?: boolean;
         /**
+          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
+         */
+        "tabsExcluded": string[] | string;
+        /**
+          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
+         */
+        "tabsIncluded": string[] | string;
+        /**
           * Whether to render a toggle button that lets the user hide or show the answer.
           * @default false
          */
@@ -6987,6 +6995,14 @@ declare namespace LocalJSX {
           * @default false
          */
         "collapsible"?: boolean;
+        /**
+          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
+         */
+        "tabsExcluded"?: string[] | string;
+        /**
+          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
+         */
+        "tabsIncluded"?: string[] | string;
         /**
           * Whether to render a toggle button that lets the user hide or show the answer.
           * @default false

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1074,11 +1074,11 @@ export namespace Components {
          */
         "collapsible"?: boolean;
         /**
-          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
+          * The tabs on which this generated answer must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-excluded='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer won't be displayed on any of the specified tabs.
          */
         "tabsExcluded": string[] | string;
         /**
-          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
+          * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-included='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer can only be displayed on the specified tabs.
          */
         "tabsIncluded": string[] | string;
         /**
@@ -6996,11 +6996,11 @@ declare namespace LocalJSX {
          */
         "collapsible"?: boolean;
         /**
-          * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
+          * The tabs on which this generated answer must not be displayed. This property should not be used at the same time as `tabs-included`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-excluded='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer won't be displayed on any of the specified tabs.
          */
         "tabsExcluded"?: string[] | string;
         /**
-          * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet> ``` If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
+          * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.  Set this property as a stringified JSON array, e.g., ```html  <atomic-generated-answer tabs-included='["tabIDA", "tabIDB"]'></atomic-generated-answer> ``` If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer can only be displayed on the specified tabs.
          */
         "tabsIncluded"?: string[] | string;
         /**

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -155,7 +155,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
       [...this.tabsExcluded].length > 0
     ) {
       console.warn(
-        'Values for both "tabs-included" and "tabs-excluded" have been provided. This is could lead to unexpected behaviors.'
+        'Values for both "tabs-included" and "tabs-excluded" have been provided. This could lead to unexpected behaviors.'
       );
     }
     this.generatedAnswerCommon = new GeneratedAnswerCommon({

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -117,26 +117,26 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   @Prop() answerConfigurationId?: string;
 
   /**
-   * The tabs on which the facet can be displayed. This property should not be used at the same time as `tabs-excluded`.
+   * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.
    *
    * Set this property as a stringified JSON array, e.g.,
    * ```html
-   *  <atomic-timeframe-facet tabs-included='["tabIDA", "tabIDB"]'></atomic-timeframe-facet>
+   *  <atomic-generated-answer tabs-included='["tabIDA", "tabIDB"]'></atomic-generated-answer>
    * ```
-   * If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet can only be displayed on the specified tabs.
+   * If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer can only be displayed on the specified tabs.
    */
   @ArrayProp()
   @Prop({reflect: true, mutable: true})
   public tabsIncluded: string[] | string = '[]';
 
   /**
-   * The tabs on which this facet must not be displayed. This property should not be used at the same time as `tabs-included`.
+   * The tabs on which this generated answer must not be displayed. This property should not be used at the same time as `tabs-included`.
    *
    * Set this property as a stringified JSON array, e.g.,
    * ```html
-   *  <atomic-timeframe-facet tabs-excluded='["tabIDA", "tabIDB"]'></atomic-timeframe-facet>
+   *  <atomic-generated-answer tabs-excluded='["tabIDA", "tabIDB"]'></atomic-generated-answer>
    * ```
-   * If you don't set this property, the facet can be displayed on any tab. Otherwise, the facet won't be displayed on any of the specified tabs.
+   * If you don't set this property, the generated answer can be displayed on any tab. Otherwise, the generated answer won't be displayed on any of the specified tabs.
    */
   @ArrayProp()
   @Prop({reflect: true, mutable: true})

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -199,15 +199,6 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
     this.tabManager = buildTabManager(this.bindings.engine);
   }
 
-  public testFunctionDisable() {
-    console.log(this.generatedAnswer.state);
-    this.generatedAnswer.disable();
-    console.log(this.generatedAnswer.state);
-  }
-  public testFunctionEnable() {
-    this.generatedAnswer.enable();
-  }
-
   @Watch('generatedAnswerState')
   public updateAnswerCollapsed(
     newState: GeneratedAnswerState,

--- a/packages/atomic/src/pages/examples/tabs.html
+++ b/packages/atomic/src/pages/examples/tabs.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html dir="ltr" lang="en">
+
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
@@ -17,6 +18,10 @@
         await searchInterface.initialize({
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
+          search: {
+            pipeline: 'genqatest',
+          },
+          organizationEndpoints: await searchInterface.getOrganizationEndpoints('searchuisamples'),
         });
 
         // Trigger a first search
@@ -141,28 +146,16 @@
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
             <!-- <atomic-automatic-facet-generator desired-count="3"></atomic-automatic-facet-generator> -->
-            <atomic-category-facet
-              tabs-included='["all"]'
-              field="geographicalhierarchy"
-              label="World Atlas"
-              with-search
-            >
+            <atomic-category-facet tabs-included='["all"]' field="geographicalhierarchy" label="World Atlas"
+              with-search>
             </atomic-category-facet>
             <atomic-facet tabs-included='["all","article"]' field="author" label="Authors"></atomic-facet>
             <atomic-facet tabs-included='["all"]' field="source" label="Source" display-values-as="link"></atomic-facet>
             <atomic-facet tabs-included='["all"]' field="year" label="Year" display-values-as="box"></atomic-facet>
-            <atomic-numeric-facet
-              field="ytviewcount"
-              label="Youtube Views"
-              depends-on-filetype="YouTubeVideo"
-              with-input="integer"
-            ></atomic-numeric-facet>
-            <atomic-numeric-facet
-              field="ytlikecount"
-              label="Youtube Likes"
-              depends-on-filetype="YouTubeVideo"
-              display-values-as="link"
-            >
+            <atomic-numeric-facet field="ytviewcount" label="Youtube Views" depends-on-filetype="YouTubeVideo"
+              with-input="integer"></atomic-numeric-facet>
+            <atomic-numeric-facet field="ytlikecount" label="Youtube Likes" depends-on-filetype="YouTubeVideo"
+              display-values-as="link">
               <atomic-numeric-range start="0" end="1000" label="Unpopular"></atomic-numeric-range>
               <atomic-numeric-range start="1000" end="8000" label="Well liked"></atomic-numeric-range>
               <atomic-numeric-range start="8000" end="100000" label="Popular"></atomic-numeric-range>
@@ -182,24 +175,15 @@
             </atomic-timeframe-facet>
             <atomic-rating-facet tabs-included='["all"]' field="snrating" label="Rating" number-of-intervals="5">
             </atomic-rating-facet>
-            <atomic-rating-range-facet
-              tabs-included='["all"]'
-              facet-id="snrating_range"
-              field="snrating"
-              label="Rating Range (auto)"
-              number-of-intervals="5"
-            >
+            <atomic-rating-range-facet tabs-included='["all"]' facet-id="snrating_range" field="snrating"
+              label="Rating Range (auto)" number-of-intervals="5">
             </atomic-rating-range-facet>
-            <atomic-color-facet
-              field="filetype"
-              label="Files"
-              number-of-values="6"
-              sort-criteria="occurrences"
-            ></atomic-color-facet>
+            <atomic-color-facet field="filetype" label="Files" number-of-values="6"
+              sort-criteria="occurrences"></atomic-color-facet>
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="main">
-          <atomic-tab-manager clear-filters-on-tab-change="true">
+          <atomic-tab-manager clear-filters-on-tab-change="false">
             <atomic-tab name="all" label="All"></atomic-tab>
             <atomic-tab name="article" label="Articles"></atomic-tab>
             <atomic-tab name="product" label="Products"></atomic-tab>
@@ -209,19 +193,12 @@
           </atomic-tab-manager>
           <atomic-layout-section section="horizontal-facets">
             <atomic-segmented-facet-scrollable>
-              <atomic-segmented-facet
-                tabs-included='["all"]'
-                field="inat_kingdom"
-                label="Kingdom"
-              ></atomic-segmented-facet>
+              <atomic-segmented-facet tabs-included='["all"]' field="inat_kingdom"
+                label="Kingdom"></atomic-segmented-facet>
             </atomic-segmented-facet-scrollable>
             <atomic-popover>
-              <atomic-facet
-                tabs-included='["all"]'
-                field="inat_family"
-                label="Family"
-                sort-criteria="alphanumericDescending"
-              ></atomic-facet>
+              <atomic-facet tabs-included='["all"]' field="inat_family" label="Family"
+                sort-criteria="alphanumericDescending"></atomic-facet>
             </atomic-popover>
             <atomic-popover>
               <atomic-facet tabs-included='["all"]' field="inat_class" label="Class"></atomic-facet>
@@ -232,32 +209,21 @@
             <atomic-query-summary></atomic-query-summary>
             <atomic-refine-toggle></atomic-refine-toggle>
             <atomic-sort-dropdown>
-              <atomic-sort-expression
-                tabs-excluded='["article"]'
-                label="Name descending"
-                expression="name descending"
-              ></atomic-sort-expression>
-              <atomic-sort-expression
-                tabs-excluded='["article"]'
-                label="Name ascending"
-                expression="name ascending"
-              ></atomic-sort-expression>
-              <atomic-sort-expression
-                tabs-included='["article"]'
-                label="Most Recent"
-                expression="date descending"
-              ></atomic-sort-expression>
-              <atomic-sort-expression
-                tabs-included='["article"]'
-                label="Least Recent"
-                expression="date ascending"
-              ></atomic-sort-expression>
               <atomic-sort-expression label="relevance" expression="relevancy"></atomic-sort-expression>
+              <atomic-sort-expression tabs-excluded='["article"]' label="Name descending"
+                expression="name descending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-excluded='["article"]' label="Name ascending"
+                expression="name ascending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-included='["article"]' label="Most Recent"
+                expression="date descending"></atomic-sort-expression>
+              <atomic-sort-expression tabs-included='["article"]' label="Least Recent"
+                expression="date ascending"></atomic-sort-expression>
             </atomic-sort-dropdown>
             <atomic-did-you-mean></atomic-did-you-mean>
             <atomic-notifications></atomic-notifications>
           </atomic-layout-section>
           <atomic-layout-section section="results">
+            <atomic-generated-answer tabs-included='["all","parts"]'></atomic-generated-answer>
             <atomic-smart-snippet></atomic-smart-snippet>
             <atomic-smart-snippet-suggestions></atomic-smart-snippet-suggestions>
             <atomic-result-list display="list" tabs-included='["all", "parts"]'>
@@ -268,9 +234,8 @@
                     <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
-                  <atomic-result-section-excerpt
-                    ><atomic-result-text field="excerpt"></atomic-result-text
-                  ></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt><atomic-result-text
+                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
                 </template>
               </atomic-result-template>
 
@@ -326,8 +291,7 @@
                       <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                     </atomic-field-condition>
                     <atomic-result-badge
-                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
-                    >
+                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg">
                       <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
                     </atomic-result-badge>
                     <atomic-field-condition must-match-is-recommendation="true">
@@ -346,9 +310,8 @@
                       <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
                     </atomic-field-condition>
                   </atomic-result-section-title-metadata>
-                  <atomic-result-section-excerpt
-                    ><atomic-result-text field="excerpt"></atomic-result-text
-                  ></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt><atomic-result-text
+                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
                   <atomic-result-section-bottom-metadata>
                     <atomic-result-fields-list>
                       <atomic-field-condition class="field" if-defined="author">
@@ -421,9 +384,8 @@
                     <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
-                  <atomic-result-section-excerpt
-                    ><atomic-result-text field="excerpt"></atomic-result-text
-                  ></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt><atomic-result-text
+                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
                 </template>
               </atomic-result-template>
 
@@ -479,8 +441,7 @@
                       <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                     </atomic-field-condition>
                     <atomic-result-badge
-                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
-                    >
+                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg">
                       <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
                     </atomic-result-badge>
                     <atomic-field-condition must-match-is-recommendation="true">
@@ -499,9 +460,8 @@
                       <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
                     </atomic-field-condition>
                   </atomic-result-section-title-metadata>
-                  <atomic-result-section-excerpt
-                    ><atomic-result-text field="excerpt"></atomic-result-text
-                  ></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt><atomic-result-text
+                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
                   <atomic-result-section-bottom-metadata>
                     <atomic-result-fields-list>
                       <atomic-field-condition class="field" if-defined="author">
@@ -581,4 +541,5 @@
     </atomic-search-interface>
     <script src="../header.js" type="text/javascript"></script>
   </body>
+
 </html>

--- a/packages/atomic/src/pages/examples/tabs.html
+++ b/packages/atomic/src/pages/examples/tabs.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html dir="ltr" lang="en">
-
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
@@ -146,16 +145,28 @@
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
             <!-- <atomic-automatic-facet-generator desired-count="3"></atomic-automatic-facet-generator> -->
-            <atomic-category-facet tabs-included='["all"]' field="geographicalhierarchy" label="World Atlas"
-              with-search>
+            <atomic-category-facet
+              tabs-included='["all"]'
+              field="geographicalhierarchy"
+              label="World Atlas"
+              with-search
+            >
             </atomic-category-facet>
             <atomic-facet tabs-included='["all","article"]' field="author" label="Authors"></atomic-facet>
             <atomic-facet tabs-included='["all"]' field="source" label="Source" display-values-as="link"></atomic-facet>
             <atomic-facet tabs-included='["all"]' field="year" label="Year" display-values-as="box"></atomic-facet>
-            <atomic-numeric-facet field="ytviewcount" label="Youtube Views" depends-on-filetype="YouTubeVideo"
-              with-input="integer"></atomic-numeric-facet>
-            <atomic-numeric-facet field="ytlikecount" label="Youtube Likes" depends-on-filetype="YouTubeVideo"
-              display-values-as="link">
+            <atomic-numeric-facet
+              field="ytviewcount"
+              label="Youtube Views"
+              depends-on-filetype="YouTubeVideo"
+              with-input="integer"
+            ></atomic-numeric-facet>
+            <atomic-numeric-facet
+              field="ytlikecount"
+              label="Youtube Likes"
+              depends-on-filetype="YouTubeVideo"
+              display-values-as="link"
+            >
               <atomic-numeric-range start="0" end="1000" label="Unpopular"></atomic-numeric-range>
               <atomic-numeric-range start="1000" end="8000" label="Well liked"></atomic-numeric-range>
               <atomic-numeric-range start="8000" end="100000" label="Popular"></atomic-numeric-range>
@@ -175,11 +186,20 @@
             </atomic-timeframe-facet>
             <atomic-rating-facet tabs-included='["all"]' field="snrating" label="Rating" number-of-intervals="5">
             </atomic-rating-facet>
-            <atomic-rating-range-facet tabs-included='["all"]' facet-id="snrating_range" field="snrating"
-              label="Rating Range (auto)" number-of-intervals="5">
+            <atomic-rating-range-facet
+              tabs-included='["all"]'
+              facet-id="snrating_range"
+              field="snrating"
+              label="Rating Range (auto)"
+              number-of-intervals="5"
+            >
             </atomic-rating-range-facet>
-            <atomic-color-facet field="filetype" label="Files" number-of-values="6"
-              sort-criteria="occurrences"></atomic-color-facet>
+            <atomic-color-facet
+              field="filetype"
+              label="Files"
+              number-of-values="6"
+              sort-criteria="occurrences"
+            ></atomic-color-facet>
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="main">
@@ -193,12 +213,19 @@
           </atomic-tab-manager>
           <atomic-layout-section section="horizontal-facets">
             <atomic-segmented-facet-scrollable>
-              <atomic-segmented-facet tabs-included='["all"]' field="inat_kingdom"
-                label="Kingdom"></atomic-segmented-facet>
+              <atomic-segmented-facet
+                tabs-included='["all"]'
+                field="inat_kingdom"
+                label="Kingdom"
+              ></atomic-segmented-facet>
             </atomic-segmented-facet-scrollable>
             <atomic-popover>
-              <atomic-facet tabs-included='["all"]' field="inat_family" label="Family"
-                sort-criteria="alphanumericDescending"></atomic-facet>
+              <atomic-facet
+                tabs-included='["all"]'
+                field="inat_family"
+                label="Family"
+                sort-criteria="alphanumericDescending"
+              ></atomic-facet>
             </atomic-popover>
             <atomic-popover>
               <atomic-facet tabs-included='["all"]' field="inat_class" label="Class"></atomic-facet>
@@ -210,14 +237,26 @@
             <atomic-refine-toggle></atomic-refine-toggle>
             <atomic-sort-dropdown>
               <atomic-sort-expression label="relevance" expression="relevancy"></atomic-sort-expression>
-              <atomic-sort-expression tabs-excluded='["article"]' label="Name descending"
-                expression="name descending"></atomic-sort-expression>
-              <atomic-sort-expression tabs-excluded='["article"]' label="Name ascending"
-                expression="name ascending"></atomic-sort-expression>
-              <atomic-sort-expression tabs-included='["article"]' label="Most Recent"
-                expression="date descending"></atomic-sort-expression>
-              <atomic-sort-expression tabs-included='["article"]' label="Least Recent"
-                expression="date ascending"></atomic-sort-expression>
+              <atomic-sort-expression
+                tabs-excluded='["article"]'
+                label="Name descending"
+                expression="name descending"
+              ></atomic-sort-expression>
+              <atomic-sort-expression
+                tabs-excluded='["article"]'
+                label="Name ascending"
+                expression="name ascending"
+              ></atomic-sort-expression>
+              <atomic-sort-expression
+                tabs-included='["article"]'
+                label="Most Recent"
+                expression="date descending"
+              ></atomic-sort-expression>
+              <atomic-sort-expression
+                tabs-included='["article"]'
+                label="Least Recent"
+                expression="date ascending"
+              ></atomic-sort-expression>
             </atomic-sort-dropdown>
             <atomic-did-you-mean></atomic-did-you-mean>
             <atomic-notifications></atomic-notifications>
@@ -234,8 +273,9 @@
                     <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
-                  <atomic-result-section-excerpt><atomic-result-text
-                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
                 </template>
               </atomic-result-template>
 
@@ -291,7 +331,8 @@
                       <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                     </atomic-field-condition>
                     <atomic-result-badge
-                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg">
+                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
+                    >
                       <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
                     </atomic-result-badge>
                     <atomic-field-condition must-match-is-recommendation="true">
@@ -310,8 +351,9 @@
                       <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
                     </atomic-field-condition>
                   </atomic-result-section-title-metadata>
-                  <atomic-result-section-excerpt><atomic-result-text
-                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
                   <atomic-result-section-bottom-metadata>
                     <atomic-result-fields-list>
                       <atomic-field-condition class="field" if-defined="author">
@@ -384,8 +426,9 @@
                     <img loading="lazy" src="https://picsum.photos/350" class="thumbnail" />
                   </atomic-result-section-visual>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
-                  <atomic-result-section-excerpt><atomic-result-text
-                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
                 </template>
               </atomic-result-template>
 
@@ -441,7 +484,8 @@
                       <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                     </atomic-field-condition>
                     <atomic-result-badge
-                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg">
+                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
+                    >
                       <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
                     </atomic-result-badge>
                     <atomic-field-condition must-match-is-recommendation="true">
@@ -460,8 +504,9 @@
                       <atomic-result-printable-uri max-number-of-parts="3"></atomic-result-printable-uri>
                     </atomic-field-condition>
                   </atomic-result-section-title-metadata>
-                  <atomic-result-section-excerpt><atomic-result-text
-                      field="excerpt"></atomic-result-text></atomic-result-section-excerpt>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
                   <atomic-result-section-bottom-metadata>
                     <atomic-result-fields-list>
                       <atomic-field-condition class="field" if-defined="author">
@@ -541,5 +586,4 @@
     </atomic-search-interface>
     <script src="../header.js" type="text/javascript"></script>
   </body>
-
 </html>

--- a/packages/samples/headless-ssr/common/components/common/tab.tsx
+++ b/packages/samples/headless-ssr/common/components/common/tab.tsx
@@ -1,4 +1,4 @@
-import {Tab, TabManager, TabState} from '@coveo/headless/ssr';
+import {Tab, TabState} from '@coveo/headless/ssr';
 
 interface TabCommonProps {
   state: TabState;

--- a/packages/samples/headless-ssr/common/components/react/tab.tsx
+++ b/packages/samples/headless-ssr/common/components/react/tab.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import {TabManager} from '@coveo/headless-react/ssr';
 import {
   useTabAll,
   useTabCountries,


### PR DESCRIPTION
This PR allows atomic-generated-answer to be visible/hidden based on the currently active tab in the tab manager.

https://coveord.atlassian.net/browse/CDX-1557