### PR TITLE
fix(rga): state reset keep configid

### DIFF
--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -261,6 +261,15 @@ describe('generated answer slice', () => {
       expect(finalState.responseFormat).toEqual(responseFormat);
     });
   });
+  it('should not reset the configuration id', () => {
+    const state = {
+      ...baseState,
+      answerConfigurationId: 'some-id',
+    };
+
+    const finalState = generatedAnswerReducer(state, resetAnswer());
+    expect(finalState.answerConfigurationId).toBe('some-id');
+  });
 
   test.each(generatedContentFormat)(
     '#setAnswerContentFormat should set the "%i" content format in the state',

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -87,6 +87,9 @@ export const generatedAnswerReducer = createReducer(
       .addCase(resetAnswer, (state) => {
         return {
           ...getGeneratedAnswerInitialState(),
+          ...(state.answerConfigurationId
+            ? {answerConfigurationId: state.answerConfigurationId}
+            : {}),
           responseFormat: state.responseFormat,
           fieldsToIncludeInCitations: state.fieldsToIncludeInCitations,
           isVisible: state.isVisible,


### PR DESCRIPTION
Fixing a regression when resetting the answer in the new answerAPI flow. 

## Problem

When we need to reset a RGA answer
e.g. right after a new query has been submitted
The `answerConfigurationId` must be kept in the state whenever the answer API flow is used.

## The Fix
We pass the actual state answerConfigurationID to the new state created by the reset action.

