### PR TITLE
feat(headless): add a way to disable/enable the generated answer controller

### DIFF
--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1031,6 +1031,7 @@ export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
   generatedAnswer: {
     id: '',
     isVisible: true,
+    isEnabled: true,
     isLoading: false,
     isStreaming: false,
     citations: [],

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -245,14 +245,6 @@ describe('generated answer', () => {
 
         expect(setIsEnabled).toHaveBeenCalledWith(true);
       });
-
-      it('should dispatch the analytics action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: false});
-        initGeneratedAnswer();
-
-        generatedAnswer.show();
-        expect(logGeneratedAnswerExpand).toHaveBeenCalled();
-      });
     });
   });
 
@@ -274,15 +266,7 @@ describe('generated answer', () => {
 
         generatedAnswer.disable();
 
-        expect(setIsEnabled).toHaveBeenCalledWith(false);
-      });
-
-      it('should dispatch the analytics action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: false});
-        initGeneratedAnswer();
-
-        generatedAnswer.show();
-        expect(logGeneratedAnswerCollapse).toHaveBeenCalled();
+        expect(setIsEnabled).toHaveBeenCalledWith(true);
       });
     });
   });

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -9,6 +9,7 @@ import {
   registerFieldsToIncludeInCitations,
   expandGeneratedAnswer,
   collapseGeneratedAnswer,
+  setIsEnabled,
 } from '../../../features/generated-answer/generated-answer-actions';
 import {
   generatedAnswerAnalyticsClient,
@@ -220,6 +221,68 @@ describe('generated answer', () => {
 
         generatedAnswer.hide();
         expect(logGeneratedAnswerHideAnswers).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('#enable', () => {
+    describe('when already enabled', () => {
+      it('should not make any changes', () => {
+        engine = buildEngineWithGeneratedAnswer({isEnabled: true});
+        initGeneratedAnswer();
+
+        generatedAnswer.enable();
+        expect(setIsEnabled).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when not enabled', () => {
+      it('should dispatch the setIsEnabled action', () => {
+        engine = buildEngineWithGeneratedAnswer({isEnabled: false});
+        initGeneratedAnswer();
+
+        generatedAnswer.enable();
+
+        expect(setIsEnabled).toHaveBeenCalledWith(true);
+      });
+
+      it('should dispatch the analytics action', () => {
+        engine = buildEngineWithGeneratedAnswer({isVisible: false});
+        initGeneratedAnswer();
+
+        generatedAnswer.show();
+        expect(logGeneratedAnswerExpand).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('#disable', () => {
+    describe('when already disabled', () => {
+      it('should not make any changes', () => {
+        engine = buildEngineWithGeneratedAnswer({isEnabled: false});
+        initGeneratedAnswer();
+
+        generatedAnswer.disable();
+        expect(setIsEnabled).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when not disabled', () => {
+      it('should dispatch the setIsEnabled action', () => {
+        engine = buildEngineWithGeneratedAnswer({isEnabled: true});
+        initGeneratedAnswer();
+
+        generatedAnswer.disable();
+
+        expect(setIsEnabled).toHaveBeenCalledWith(false);
+      });
+
+      it('should dispatch the analytics action', () => {
+        engine = buildEngineWithGeneratedAnswer({isVisible: false});
+        initGeneratedAnswer();
+
+        generatedAnswer.show();
+        expect(logGeneratedAnswerCollapse).toHaveBeenCalled();
       });
     });
   });

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -266,7 +266,7 @@ describe('generated answer', () => {
 
         generatedAnswer.disable();
 
-        expect(setIsEnabled).toHaveBeenCalledWith(true);
+        expect(setIsEnabled).toHaveBeenCalledWith(false);
       });
     });
   });

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -135,6 +135,10 @@ export interface GeneratedAnswerPropsInitialState {
      */
     isVisible?: boolean;
     /**
+     * Sets the component enabled state on load.
+     */
+    isEnabled?: boolean;
+    /**
      * The initial formatting options applied to generated answers when the controller first loads.
      */
     responseFormat?: GeneratedResponseFormat;

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -270,12 +270,14 @@ export function buildCoreGeneratedAnswer(
     enable() {
       if (!this.state.isEnabled) {
         dispatch(setIsEnabled(true));
+        dispatch(analyticsClient.logGeneratedAnswerExpand());
       }
     },
 
     disable() {
       if (this.state.isEnabled) {
         dispatch(setIsEnabled(false));
+        dispatch(analyticsClient.logGeneratedAnswerCollapse());
       }
     },
 

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -15,6 +15,7 @@ import {
   registerFieldsToIncludeInCitations,
   expandGeneratedAnswer,
   collapseGeneratedAnswer,
+  setIsEnabled,
 } from '../../../features/generated-answer/generated-answer-actions';
 import {GeneratedAnswerFeedback} from '../../../features/generated-answer/generated-answer-analytics-actions';
 import {generatedAnswerReducer as generatedAnswer} from '../../../features/generated-answer/generated-answer-slice';
@@ -88,6 +89,14 @@ export interface GeneratedAnswer extends Controller {
    * Collapses the generated answer.
    */
   collapse(): void;
+  /**
+   * Enables the generated answer.
+   */
+  enable(): void;
+  /**
+   * Disables the generated answer.
+   */
+  disable(): void;
   /**
    * Logs a custom event indicating the generated answer was copied to the clipboard.
    */
@@ -255,6 +264,18 @@ export function buildCoreGeneratedAnswer(
       if (this.state.expanded) {
         dispatch(collapseGeneratedAnswer());
         dispatch(analyticsClient.logGeneratedAnswerCollapse());
+      }
+    },
+
+    enable() {
+      if (!this.state.isEnabled) {
+        dispatch(setIsEnabled(true));
+      }
+    },
+
+    disable() {
+      if (this.state.isEnabled) {
+        dispatch(setIsEnabled(false));
       }
     },
 

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -270,14 +270,12 @@ export function buildCoreGeneratedAnswer(
     enable() {
       if (!this.state.isEnabled) {
         dispatch(setIsEnabled(true));
-        dispatch(analyticsClient.logGeneratedAnswerExpand());
       }
     },
 
     disable() {
       if (this.state.isEnabled) {
         dispatch(setIsEnabled(false));
-        dispatch(analyticsClient.logGeneratedAnswerCollapse());
       }
     },
 

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
@@ -5,8 +5,10 @@ import {
   likeGeneratedAnswer,
   openGeneratedAnswerFeedbackModal,
   registerFieldsToIncludeInCitations,
+  resetAnswer,
   sendGeneratedAnswerFeedback,
   setIsVisible,
+  streamAnswer,
   updateResponseFormat,
 } from '../../../features/generated-answer/generated-answer-actions';
 import {
@@ -27,7 +29,10 @@ import {
   GeneratedAnswerProps,
   GeneratedResponseFormat,
 } from '../../generated-answer/headless-generated-answer';
-import {buildSearchAPIGeneratedAnswer} from './headless-searchapi-generated-answer';
+import {
+  buildSearchAPIGeneratedAnswer,
+  subscribeStateManager,
+} from './headless-searchapi-generated-answer';
 
 jest.mock('../../../features/generated-answer/generated-answer-actions');
 jest.mock(
@@ -291,6 +296,89 @@ describe('searchapi-generated-answer', () => {
       engine.dispatch.mockClear();
       createGeneratedAnswer();
       expect(engine.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#enable', () => {
+    let subscribeStateManagerMock: any;
+
+    const setupEngine = (isEnabled: boolean) => {
+      engine = buildEngineWithGeneratedAnswer({
+        id: 'genQaEngineId',
+        isEnabled,
+      });
+      createGeneratedAnswer({
+        initialState: {isEnabled},
+      });
+
+      engine.state.search = {
+        ...engine.state.search,
+        extendedResults: {
+          generativeQuestionAnsweringId: 'streamId',
+        },
+      };
+
+      subscribeStateManagerMock.subscribeToSearchRequests(engine);
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      subscribeStateManagerMock = {
+        engines: {
+          genQaEngineId: {
+            lastStreamId: '',
+          },
+        },
+        subscribeToSearchRequests:
+          subscribeStateManager.subscribeToSearchRequests,
+      };
+
+      subscribeStateManager.engines = subscribeStateManagerMock.engines;
+    });
+
+    it('should stream answer when generated answer is enabled', () => {
+      setupEngine(true);
+
+      expect(engine.subscribe).toHaveBeenCalled();
+
+      const listener = engine.subscribe.mock.calls[0][0];
+      listener();
+
+      expect(streamAnswer).toHaveBeenCalled();
+    });
+
+    it('should not stream answer when generated answer is disabled', () => {
+      setupEngine(false);
+
+      expect(engine.subscribe).toHaveBeenCalled();
+
+      const listener = engine.subscribe.mock.calls[0][0];
+      listener();
+
+      expect(streamAnswer).not.toHaveBeenCalled();
+    });
+
+    it('should reset answer when generated answer is enabled', () => {
+      setupEngine(true);
+
+      expect(engine.subscribe).toHaveBeenCalled();
+
+      const listener = engine.subscribe.mock.calls[0][0];
+      listener();
+
+      expect(resetAnswer).toHaveBeenCalled();
+    });
+
+    it('should not reset answer when generated answer is disabled', () => {
+      setupEngine(false);
+
+      expect(engine.subscribe).toHaveBeenCalled();
+
+      const listener = engine.subscribe.mock.calls[0][0];
+      listener();
+
+      expect(resetAnswer).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
@@ -49,7 +49,7 @@ interface SubscribeStateManager {
   ) => Unsubscribe;
 }
 
-const subscribeStateManager: SubscribeStateManager = {
+export const subscribeStateManager: SubscribeStateManager = {
   engines: {},
 
   setAbortControllerRef: (ref: AbortController, genQaEngineId: string) => {

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
@@ -82,6 +82,10 @@ const subscribeStateManager: SubscribeStateManager = {
       ) {
         subscribeStateManager.engines[genQaEngineId].lastRequestId = requestId;
         subscribeStateManager.engines[genQaEngineId].abortController?.abort();
+        if (state.generatedAnswer.isEnabled === false) {
+          return;
+        }
+
         engine.dispatch(resetAnswer());
       }
 
@@ -93,6 +97,9 @@ const subscribeStateManager: SubscribeStateManager = {
         streamId !== subscribeStateManager.engines[genQaEngineId].lastStreamId
       ) {
         subscribeStateManager.engines[genQaEngineId].lastStreamId = streamId;
+        if (state.generatedAnswer.isEnabled === false) {
+          return;
+        }
         engine.dispatch(
           streamAnswer({
             setAbortControllerRef: (ref: AbortController) =>

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
@@ -8,6 +8,7 @@ import {
   updateResponseFormat,
   registerFieldsToIncludeInCitations,
   setAnswerContentFormat,
+  setIsEnabled,
 } from './generated-answer-actions';
 import {
   GeneratedContentFormat,
@@ -89,6 +90,12 @@ describe('generated answer', () => {
   describe('#setIsVisible', () => {
     it('should accept a valid payload', () => {
       expect(() => setIsVisible(true)).not.toThrow();
+    });
+  });
+
+  describe('#setIsEnabled', () => {
+    it('should accept a valid payload', () => {
+      expect(() => setIsEnabled(true)).not.toThrow();
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -65,6 +65,11 @@ export const setIsVisible = createAction(
   (payload: boolean) => validatePayload(payload, booleanValue)
 );
 
+export const setIsEnabled = createAction(
+  'generatedAnswer/setIsEnabled',
+  (payload: boolean) => validatePayload(payload, booleanValue)
+);
+
 export const updateMessage = createAction(
   'generatedAnswer/updateMessage',
   (payload: GeneratedAnswerMessagePayload) =>

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -19,6 +19,7 @@ import {
   setIsAnswerGenerated,
   expandGeneratedAnswer,
   collapseGeneratedAnswer,
+  setIsEnabled,
 } from './generated-answer-actions';
 import {generatedAnswerReducer} from './generated-answer-slice';
 import {getGeneratedAnswerInitialState} from './generated-answer-state';
@@ -224,6 +225,7 @@ describe('generated answer slice', () => {
       const persistentGeneratedAnswerState = {
         isVisible: false,
         responseFormat,
+        isEnabled: true,
         fieldsToIncludeInCitations: ['foo'],
       };
       const state = {
@@ -469,6 +471,26 @@ describe('generated answer slice', () => {
       );
 
       expect(finalState.isVisible).toEqual(false);
+    });
+  });
+
+  describe('#setIsEnabled', () => {
+    it('should set isEnabled to true when given true', () => {
+      const finalState = generatedAnswerReducer(
+        {...baseState, isEnabled: false},
+        setIsEnabled(true)
+      );
+
+      expect(finalState.isEnabled).toEqual(true);
+    });
+
+    it('should set isEnabled to false when given false', () => {
+      const finalState = generatedAnswerReducer(
+        {...baseState, isEnabled: true},
+        setIsEnabled(false)
+      );
+
+      expect(finalState.isEnabled).toEqual(false);
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -22,6 +22,7 @@ import {
   expandGeneratedAnswer,
   collapseGeneratedAnswer,
   updateAnswerConfigurationId,
+  setIsEnabled,
 } from './generated-answer-actions';
 import {getGeneratedAnswerInitialState} from './generated-answer-state';
 
@@ -31,6 +32,9 @@ export const generatedAnswerReducer = createReducer(
     builder
       .addCase(setIsVisible, (state, {payload}) => {
         state.isVisible = payload;
+      })
+      .addCase(setIsEnabled, (state, {payload}) => {
+        state.isEnabled = payload;
       })
       .addCase(setId, (state, {payload}) => {
         state.id = payload.id;

--- a/packages/headless/src/features/generated-answer/generated-answer-state.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-state.ts
@@ -19,6 +19,10 @@ export interface GeneratedAnswerState {
    */
   isStreaming: boolean;
   /**
+   * Determines if the generated answer is enabled.
+   */
+  isEnabled: boolean;
+  /**
    * The generated answer.
    */
   answer?: string;
@@ -82,6 +86,7 @@ export function getGeneratedAnswerInitialState(): GeneratedAnswerState {
   return {
     id: '',
     isVisible: true,
+    isEnabled: true,
     isLoading: false,
     isStreaming: false,
     citations: [],


### PR DESCRIPTION
This PR adds a way to disable/enable the generated answer controller.

https://coveord.atlassian.net/browse/CDX-1587