### PR TITLE
fix(atomic): search-box suggestions should be resilient to search-box redirection-url changes

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -204,7 +204,6 @@ export class AtomicCommerceSearchBox
   @AriaLiveRegion('search-suggestions', true)
   protected suggestionsAriaMessage!: string;
   public disconnectedCallback = () => {};
-  private hasRegisterSuggestions: boolean = false;
 
   private isStandaloneSearchBox(
     searchBox: SearchBox | StandaloneSearchBox
@@ -303,11 +302,7 @@ export class AtomicCommerceSearchBox
         this.suggestionBindings
       );
     });
-  }
-
-  public componentDidLoad() {
-    this.registerSearchboxSuggestionEvents();
-    this.hasRegisterSuggestions = true;
+    return true;
   }
 
   @Watch('redirectionUrl')
@@ -704,6 +699,9 @@ export class AtomicCommerceSearchBox
     const isDisabled = this.isSearchDisabledForEndUser(
       this.searchBoxState.value
     );
+    if (!this.suggestionManager.suggestions.length) {
+      this.registerSearchboxSuggestionEvents();
+    }
 
     return (
       <Host>
@@ -732,13 +730,12 @@ export class AtomicCommerceSearchBox
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,
-          this.hasRegisterSuggestions &&
-            !this.suggestionManager.suggestions.length && (
-              <slot>
-                <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
-                <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
-              </slot>
-            ),
+          !this.suggestionManager.suggestions.length && (
+            <slot>
+              <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
+              <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
+            </slot>
+          ),
         ]}
       </Host>
     );

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -204,6 +204,7 @@ export class AtomicCommerceSearchBox
   @AriaLiveRegion('search-suggestions', true)
   protected suggestionsAriaMessage!: string;
   public disconnectedCallback = () => {};
+  private hasRegisterSuggestions: boolean = false;
 
   private isStandaloneSearchBox(
     searchBox: SearchBox | StandaloneSearchBox
@@ -306,6 +307,7 @@ export class AtomicCommerceSearchBox
 
   public componentDidLoad() {
     this.registerSearchboxSuggestionEvents();
+    this.hasRegisterSuggestions = true;
   }
 
   @Watch('redirectionUrl')
@@ -730,12 +732,13 @@ export class AtomicCommerceSearchBox
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,
-          !this.suggestionManager.suggestions.length && (
-            <slot>
-              <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
-              <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
-            </slot>
-          ),
+          this.hasRegisterSuggestions &&
+            !this.suggestionManager.suggestions.length && (
+              <slot>
+                <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
+                <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
+              </slot>
+            ),
         ]}
       </Host>
     );

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -302,7 +302,7 @@ export class AtomicCommerceSearchBox
         this.suggestionBindings
       );
     });
-    return true;
+    this.searchBoxSuggestionEventsQueue = [];
   }
 
   @Watch('redirectionUrl')

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -215,7 +215,7 @@ export class AtomicCommerceSearchBox
     this.id ??= randomID('atomic-commerce-search-box-');
 
     this.initializeSearchboxController();
-    !this.suggestionManager && this.initializeSuggestionManager();
+    this.initializeSuggestionManager();
   }
 
   private updateRedirectionUrl() {
@@ -294,7 +294,7 @@ export class AtomicCommerceSearchBox
     this.suggestionManager.forceUpdate();
   }
 
-  public registerSearchboxSuggestionEvents() {
+  private registerSearchboxSuggestionEvents() {
     this.searchBoxSuggestionEventsQueue.forEach((evt) => {
       this.suggestionManager.registerSuggestionsFromEvent(
         evt,
@@ -313,6 +313,10 @@ export class AtomicCommerceSearchBox
   }
 
   private initializeSuggestionManager() {
+    if (this.suggestionManager) {
+      return;
+    }
+
     this.suggestionManager = new SuggestionManager({
       getNumberOfSuggestionsToDisplay: () => this.numberOfQueries,
       updateQuery: (query) => this.searchBox.updateText(query),

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -237,6 +237,7 @@ export class AtomicCommerceSearchBox
           options: {
             ...this.searchBoxOptions,
             redirectionUrl: this.redirectionUrl,
+            overwrite: true,
           },
         })
       : buildSearchBox(this.bindings.engine, {

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
@@ -274,6 +274,35 @@ test.describe('with instant results & query suggestions', () => {
         await expect(searchBox.searchInput).toHaveValue('surf');
       });
     });
+
+    test.describe('after updating the redirect-url attribute', () => {
+      test.beforeEach(async ({searchBox}) => {
+        await searchBox.component.evaluate((node) =>
+          node.setAttribute(
+            'redirection-url',
+            './iframe.html?id=atomic-commerce-search-box--in-page&viewMode=story&args=enable-query-syntax:!true;suggestion-timeout:5000'
+          )
+        );
+      });
+
+      test('should redirect to the specified url after selecting a suggestion', async ({
+        page,
+        searchBox,
+      }) => {
+        const suggestionText = await searchBox
+          .searchSuggestions()
+          .first()
+          .textContent();
+
+        expect(suggestionText).not.toBeNull();
+
+        await searchBox.searchSuggestions().first().click();
+        await page.waitForURL(
+          '**/iframe.html?id=atomic-commerce-search-box--in-page*'
+        );
+        await expect(searchBox.searchInput).toHaveValue(suggestionText ?? '');
+      });
+    });
   });
 });
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/page-object.ts
@@ -6,6 +6,10 @@ export class SearchBoxPageObject extends BasePageObject<'atomic-commerce-search-
     super(page, 'atomic-commerce-search-box');
   }
 
+  get component() {
+    return this.page.locator('atomic-commerce-search-box');
+  }
+
   get submitButton() {
     return this.page.getByLabel('Search', {exact: true});
   }

--- a/packages/atomic/src/components/commerce/product-template/atomic-product-template.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/product-template/atomic-product-template.new.stories.tsx
@@ -94,7 +94,7 @@ export const InASearchBoxInstantProducts: Story = {
     commerceInterfaceDecorator,
   ],
   play: async (context) => {
-    initializeCommerceInterface(context);
+    await initializeCommerceInterface(context);
     const {canvasElement, step} = context;
     const canvas = within(canvasElement);
     await step('Click Searchbox', async () => {

--- a/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.tsx
+++ b/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.tsx
@@ -176,10 +176,10 @@ export class AtomicCommerceSearchBoxInstantProducts
         content: <InstantItemShowAllButton i18n={this.bindings.i18n} />,
         onSelect: () => {
           this.bindings.clearSuggestions();
-          this.bindings.searchBoxController.updateText(
-            this.instantProducts.state.query
-          );
-          this.bindings.searchBoxController.submit();
+          this.bindings
+            .searchBoxController()
+            .updateText(this.instantProducts.state.query);
+          this.bindings.searchBoxController().submit();
         },
       });
     }
@@ -226,7 +226,7 @@ export class AtomicCommerceSearchBoxInstantProducts
   private onSuggestedQueryChange() {
     if (
       !this.bindings.getSuggestionElements().length &&
-      !this.bindings.searchBoxController.state.value
+      !this.bindings.searchBoxController().state.value
     ) {
       console.warn(
         "There doesn't seem to be any query suggestions configured. Make sure to include either an atomic-commerce-search-box-query-suggestions or atomic-commerce-search-box-recent-queries in your search box in order to see some instant products."

--- a/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.tsx
+++ b/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.tsx
@@ -87,15 +87,16 @@ export class AtomicCommerceSearchBoxQuerySuggestions {
   }
 
   private renderItems(): SearchBoxSuggestionElement[] {
-    const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const hasQuery = this.bindings.searchBoxController().state.value !== '';
     const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
-    return this.bindings.searchBoxController.state.suggestions
-      .slice(0, max)
+    return this.bindings
+      .searchBoxController()
+      .state.suggestions.slice(0, max)
       .map((suggestion) => this.renderItem(suggestion));
   }
 
   private renderItem(suggestion: Suggestion) {
-    const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const hasQuery = this.bindings.searchBoxController().state.value !== '';
     const partialItem = getPartialSearchBoxSuggestionElement(
       suggestion,
       this.bindings.i18n
@@ -114,7 +115,9 @@ export class AtomicCommerceSearchBoxQuerySuggestions {
         </QuerySuggestionContainer>
       ),
       onSelect: () => {
-        this.bindings.searchBoxController.selectSuggestion(suggestion.rawValue);
+        this.bindings
+          .searchBoxController()
+          .selectSuggestion(suggestion.rawValue);
       },
     };
   }

--- a/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.tsx
@@ -123,7 +123,7 @@ export class AtomicCommerceSearchBoxRecentQueries {
       return [];
     }
 
-    const query = this.bindings.searchBoxController.state.value;
+    const query = this.bindings.searchBoxController().state.value;
     const hasQuery = query !== '';
     const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
     const filteredQueries = this.recentQueriesList.state.queries
@@ -157,7 +157,7 @@ export class AtomicCommerceSearchBoxRecentQueries {
   }
 
   private renderItem(value: string): SearchBoxSuggestionElement {
-    const query = this.bindings.searchBoxController.state.value;
+    const query = this.bindings.searchBoxController().state.value;
     const partialItem = getPartialRecentQueryElement(value, this.bindings.i18n);
     return {
       ...partialItem,
@@ -169,9 +169,9 @@ export class AtomicCommerceSearchBoxRecentQueries {
       ),
 
       onSelect: () => {
-        if (this.bindings.isStandalone) {
-          this.bindings.searchBoxController.updateText(value);
-          this.bindings.searchBoxController.submit();
+        if (this.bindings.isStandalone()) {
+          this.bindings.searchBoxController().updateText(value);
+          this.bindings.searchBoxController().submit();
           return;
         }
 

--- a/packages/atomic/src/components/common/suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestions-common.ts
@@ -141,11 +141,11 @@ export type SearchBoxSuggestionsBindings<
   /**
    * Whether the search box is [standalone](https://docs.coveo.com/en/atomic/latest/usage/ssb/).
    */
-  isStandalone: boolean;
+  isStandalone(): boolean;
   /**
    * The search box headless controller.
    */
-  searchBoxController: SearchBoxController;
+  searchBoxController(): SearchBoxController;
   /**
    * The number of queries to display when the user interacts with the search box.
    */

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
@@ -1,7 +1,11 @@
 import {parameters} from '@coveo/atomic/storybookUtils/common/common-meta-parameters';
 import {renderComponent} from '@coveo/atomic/storybookUtils/common/render-component';
-import {wrapInSearchInterface} from '@coveo/atomic/storybookUtils/search/search-interface-wrapper';
+import {
+  playExecuteFirstSearch,
+  wrapInSearchInterface,
+} from '@coveo/atomic/storybookUtils/search/search-interface-wrapper';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
+import {html} from 'lit/static-html.js';
 
 const {decorator, play} = wrapInSearchInterface(
   {
@@ -41,5 +45,387 @@ export const RichSearchBox: Story = {
       <atomic-search-box-instant-results
         image-size="small"
       ></atomic-search-box-instant-results>`,
+  },
+};
+
+export const InPage: Story = {
+  name: 'In a page',
+  decorators: [
+    (story) =>
+      html`<atomic-search-layout>
+        <div class="header-bg"></div>
+        <atomic-layout-section section="search">
+          ${story()}
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facet-manager>
+            <atomic-automatic-facet-generator
+              desired-count="3"
+            ></atomic-automatic-facet-generator>
+            <atomic-category-facet
+              field="geographicalhierarchy"
+              label="World Atlas"
+              with-search
+            >
+            </atomic-category-facet>
+            <atomic-facet field="author" label="Authors"></atomic-facet>
+            <atomic-facet
+              field="source"
+              label="Source"
+              display-values-as="link"
+            ></atomic-facet>
+            <atomic-facet
+              field="year"
+              label="Year"
+              display-values-as="box"
+            ></atomic-facet>
+            <atomic-numeric-facet
+              field="ytviewcount"
+              label="Youtube Views"
+              depends-on-filetype="YouTubeVideo"
+              with-input="integer"
+            ></atomic-numeric-facet>
+            <atomic-numeric-facet
+              field="ytlikecount"
+              label="Youtube Likes"
+              depends-on-filetype="YouTubeVideo"
+              display-values-as="link"
+            >
+              <atomic-numeric-range
+                start="0"
+                end="1000"
+                label="Unpopular"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="1000"
+                end="8000"
+                label="Well liked"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="8000"
+                end="100000"
+                label="Popular"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="100000"
+                end="999999999"
+                label="Treasured"
+              ></atomic-numeric-range>
+            </atomic-numeric-facet>
+            <atomic-numeric-facet field="sncost" label="Cost Range (auto)">
+              <atomic-format-currency currency="CAD"></atomic-format-currency>
+            </atomic-numeric-facet>
+            <atomic-timeframe-facet label="Timeframe" with-date-picker>
+              <atomic-timeframe unit="hour"></atomic-timeframe>
+              <atomic-timeframe unit="day"></atomic-timeframe>
+              <atomic-timeframe unit="week"></atomic-timeframe>
+              <atomic-timeframe unit="month"></atomic-timeframe>
+              <atomic-timeframe unit="quarter"></atomic-timeframe>
+              <atomic-timeframe unit="year"></atomic-timeframe>
+              <atomic-timeframe
+                unit="year"
+                amount="10"
+                period="next"
+              ></atomic-timeframe>
+            </atomic-timeframe-facet>
+            <atomic-rating-facet
+              field="snrating"
+              label="Rating"
+              number-of-intervals="5"
+            >
+            </atomic-rating-facet>
+            <atomic-rating-range-facet
+              facet-id="snrating_range"
+              field="snrating"
+              label="Rating Range (auto)"
+              number-of-intervals="5"
+            >
+            </atomic-rating-range-facet>
+            <atomic-color-facet
+              field="filetype"
+              label="Files"
+              number-of-values="6"
+              sort-criteria="occurrences"
+            ></atomic-color-facet>
+          </atomic-facet-manager>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-layout-section section="horizontal-facets">
+            <atomic-segmented-facet-scrollable>
+              <atomic-segmented-facet
+                field="inat_kingdom"
+                label="Kingdom"
+              ></atomic-segmented-facet>
+            </atomic-segmented-facet-scrollable>
+            <atomic-popover>
+              <atomic-facet
+                field="inat_family"
+                label="Family"
+                sort-criteria="alphanumericDescending"
+              ></atomic-facet>
+            </atomic-popover>
+            <atomic-popover>
+              <atomic-facet field="inat_class" label="Class"></atomic-facet>
+            </atomic-popover>
+          </atomic-layout-section>
+          <atomic-layout-section section="status">
+            <atomic-breadbox></atomic-breadbox>
+            <atomic-query-summary></atomic-query-summary>
+            <atomic-refine-toggle></atomic-refine-toggle>
+            <atomic-sort-dropdown>
+              <atomic-sort-expression
+                label="relevance"
+                expression="relevancy"
+              ></atomic-sort-expression>
+            </atomic-sort-dropdown>
+            <atomic-did-you-mean
+              query-correction-mode="next"
+            ></atomic-did-you-mean>
+            <atomic-notifications></atomic-notifications>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <atomic-smart-snippet></atomic-smart-snippet>
+            <atomic-smart-snippet-suggestions></atomic-smart-snippet-suggestions>
+            <atomic-result-list>
+              <atomic-result-template must-match-sourcetype="YouTube">
+                <template>
+                  <atomic-result-section-actions
+                    ><atomic-quickview></atomic-quickview
+                  ></atomic-result-section-actions>
+                  <atomic-result-section-visual image-size="small">
+                    <img
+                      loading="lazy"
+                      src="https://picsum.photos/350"
+                      class="thumbnail"
+                    />
+                  </atomic-result-section-visual>
+                  <atomic-result-section-title
+                    ><atomic-result-link></atomic-result-link
+                  ></atomic-result-section-title>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
+                </template>
+              </atomic-result-template>
+
+              <atomic-result-template>
+                <template>
+                  <style>
+                    .field {
+                      display: inline-flex;
+                      align-items: center;
+                    }
+
+                    .field-label {
+                      font-weight: bold;
+                      margin-right: 0.25rem;
+                    }
+
+                    .thumbnail {
+                      display: none;
+                      width: 100%;
+                      height: 100%;
+                    }
+
+                    .icon {
+                      display: none;
+                    }
+
+                    .result-root.image-small .thumbnail,
+                    .result-root.image-large .thumbnail {
+                      display: inline-block;
+                    }
+
+                    .result-root.image-icon .icon {
+                      display: inline-block;
+                    }
+
+                    .result-root.image-small atomic-result-section-visual,
+                    .result-root.image-large atomic-result-section-visual {
+                      border-radius: var(--atomic-border-radius-xl);
+                    }
+
+                    .salesforce-badge::part(result-badge-element) {
+                      background-color: #44a1da;
+                      color: white;
+                    }
+                  </style>
+                  <atomic-result-section-actions
+                    ><atomic-quickview></atomic-quickview
+                  ></atomic-result-section-actions>
+                  <atomic-result-section-visual>
+                    <atomic-result-icon class="icon"></atomic-result-icon>
+                    <img
+                      loading="lazy"
+                      src="https://picsum.photos/350"
+                      class="thumbnail"
+                    />
+                  </atomic-result-section-visual>
+                  <atomic-result-section-badges>
+                    <atomic-field-condition must-match-sourcetype="Salesforce">
+                      <atomic-result-badge
+                        label="Salesforce"
+                        class="salesforce-badge"
+                      ></atomic-result-badge>
+                    </atomic-field-condition>
+                    <atomic-result-badge
+                      icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"
+                    >
+                      <atomic-result-multi-value-text
+                        field="language"
+                      ></atomic-result-multi-value-text>
+                    </atomic-result-badge>
+                    <atomic-field-condition must-match-is-recommendation="true">
+                      <atomic-result-badge
+                        label="Recommended"
+                      ></atomic-result-badge>
+                    </atomic-field-condition>
+                    <atomic-field-condition must-match-is-top-result="true">
+                      <atomic-result-badge
+                        label="Top Result"
+                      ></atomic-result-badge>
+                    </atomic-field-condition>
+                  </atomic-result-section-badges>
+                  <atomic-result-section-title
+                    ><atomic-result-link></atomic-result-link
+                  ></atomic-result-section-title>
+                  <atomic-result-section-title-metadata>
+                    <atomic-field-condition class="field" if-defined="snrating">
+                      <atomic-result-rating
+                        field="snrating"
+                      ></atomic-result-rating>
+                    </atomic-field-condition>
+                    <atomic-field-condition
+                      class="field"
+                      if-not-defined="snrating"
+                    >
+                      <atomic-result-printable-uri
+                        max-number-of-parts="3"
+                      ></atomic-result-printable-uri>
+                    </atomic-field-condition>
+                  </atomic-result-section-title-metadata>
+                  <atomic-result-section-excerpt
+                    ><atomic-result-text field="excerpt"></atomic-result-text
+                  ></atomic-result-section-excerpt>
+                  <atomic-result-section-bottom-metadata>
+                    <atomic-result-fields-list>
+                      <atomic-field-condition class="field" if-defined="author">
+                        <span class="field-label"
+                          ><atomic-text value="author"></atomic-text>:</span
+                        >
+                        <atomic-result-multi-value-text
+                          field="author"
+                        ></atomic-result-multi-value-text>
+                      </atomic-field-condition>
+
+                      <atomic-field-condition class="field" if-defined="source">
+                        <span class="field-label"
+                          ><atomic-text value="source"></atomic-text>:</span
+                        >
+                        <atomic-result-text field="source"></atomic-result-text>
+                      </atomic-field-condition>
+
+                      <atomic-field-condition
+                        class="field"
+                        if-defined="language"
+                      >
+                        <span class="field-label"
+                          ><atomic-text value="language"></atomic-text>:</span
+                        >
+                        <atomic-result-multi-value-text
+                          field="language"
+                        ></atomic-result-multi-value-text>
+                      </atomic-field-condition>
+
+                      <atomic-field-condition
+                        class="field"
+                        if-defined="filetype"
+                      >
+                        <span class="field-label"
+                          ><atomic-text value="fileType"></atomic-text>:</span
+                        >
+                        <atomic-result-text
+                          field="filetype"
+                        ></atomic-result-text>
+                      </atomic-field-condition>
+
+                      <atomic-field-condition class="field" if-defined="sncost">
+                        <span class="field-label">Cost:</span>
+                        <atomic-result-number field="sncost">
+                          <atomic-format-currency
+                            currency="CAD"
+                          ></atomic-format-currency>
+                        </atomic-result-number>
+                      </atomic-field-condition>
+
+                      <span class="field">
+                        <span class="field-label">Date:</span>
+                        <atomic-result-date
+                          format="ddd MMM D YYYY"
+                        ></atomic-result-date>
+                      </span>
+                    </atomic-result-fields-list>
+                  </atomic-result-section-bottom-metadata>
+                  <atomic-table-element label="Description">
+                    <atomic-result-section-title
+                      ><atomic-result-link></atomic-result-link
+                    ></atomic-result-section-title>
+                    <atomic-result-section-title-metadata>
+                      <atomic-field-condition
+                        class="field"
+                        if-defined="snrating"
+                      >
+                        <atomic-result-rating
+                          field="snrating"
+                        ></atomic-result-rating>
+                      </atomic-field-condition>
+                      <atomic-field-condition
+                        class="field"
+                        if-not-defined="snrating"
+                      >
+                        <atomic-result-printable-uri
+                          max-number-of-parts="3"
+                        ></atomic-result-printable-uri>
+                      </atomic-field-condition>
+                    </atomic-result-section-title-metadata>
+                    <atomic-result-section-excerpt>
+                      <atomic-result-text field="excerpt"></atomic-result-text>
+                    </atomic-result-section-excerpt>
+                  </atomic-table-element>
+                  <atomic-table-element label="author">
+                    <atomic-result-multi-value-text
+                      field="author"
+                    ></atomic-result-multi-value-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="source">
+                    <atomic-result-text field="source"></atomic-result-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="language">
+                    <atomic-result-multi-value-text
+                      field="language"
+                    ></atomic-result-multi-value-text>
+                  </atomic-table-element>
+                  <atomic-table-element label="file-type">
+                    <atomic-result-text field="filetype"></atomic-result-text>
+                  </atomic-table-element>
+                </template>
+              </atomic-result-template>
+            </atomic-result-list>
+            <atomic-query-error></atomic-query-error>
+            <atomic-no-results></atomic-no-results>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-load-more-results></atomic-load-more-results>
+            <!-- Alternative pagination
+              <atomic-pager></atomic-pager>
+              <atomic-results-per-page></atomic-results-per-page>
+              -->
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-search-layout>`,
+  ],
+  play: async (context) => {
+    await play(context);
+    await playExecuteFirstSearch(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -236,7 +236,6 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
 
   @AriaLiveRegion('search-suggestions', true)
   protected suggestionsAriaMessage!: string;
-  private hasRegisterSuggestions: boolean = false;
 
   private isStandaloneSearchBox(
     searchBox: SearchBox | StandaloneSearchBox
@@ -332,11 +331,6 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
       );
     });
     this.searchBoxSuggestionEventsQueue = [];
-  }
-
-  public componentDidLoad() {
-    this.registerSearchboxSuggestionEvents();
-    this.hasRegisterSuggestions = true;
   }
 
   @Watch('redirectionUrl')
@@ -734,6 +728,9 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
     const isDisabled = this.isSearchDisabledForEndUser(
       this.searchBoxState.value
     );
+    if (!this.suggestionManager.suggestions.length) {
+      this.registerSearchboxSuggestionEvents();
+    }
 
     return (
       <Host>
@@ -762,13 +759,12 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,
-          this.hasRegisterSuggestions &&
-            !this.suggestionManager.suggestions.length && (
-              <slot>
-                <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
-                <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
-              </slot>
-            ),
+          !this.suggestionManager.suggestions.length && (
+            <slot>
+              <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
+              <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+            </slot>
+          ),
         ]}
       </Host>
     );

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -244,7 +244,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
   }
 
   public initialize() {
-    this.id ??= randomID('atomic-commerce-search-box-');
+    this.id ??= randomID('atomic-search-box-');
 
     this.initializeSearchboxController();
     this.initializeSuggestionManager();
@@ -305,7 +305,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
     }
   }
 
-  public disconnectedCallback: () => void = () => {};
+  public disconnectedCallback = () => {};
 
   @Listen('atomic/searchBoxSuggestion/register')
   public registerSuggestions(

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -269,6 +269,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
           options: {
             ...this.searchBoxOptions,
             redirectionUrl: this.redirectionUrl,
+            overwrite: true,
           },
         })
       : buildSearchBox(this.bindings.engine, {

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -236,6 +236,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
 
   @AriaLiveRegion('search-suggestions', true)
   protected suggestionsAriaMessage!: string;
+  private hasRegisterSuggestions: boolean = false;
 
   private isStandaloneSearchBox(
     searchBox: SearchBox | StandaloneSearchBox
@@ -335,6 +336,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
 
   public componentDidLoad() {
     this.registerSearchboxSuggestionEvents();
+    this.hasRegisterSuggestions = true;
   }
 
   @Watch('redirectionUrl')
@@ -760,12 +762,13 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,
-          !this.suggestionManager.suggestions.length && (
-            <slot>
-              <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
-              <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
-            </slot>
-          ),
+          this.hasRegisterSuggestions &&
+            !this.suggestionManager.suggestions.length && (
+              <slot>
+                <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
+                <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+              </slot>
+            ),
         ]}
       </Host>
     );

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -361,8 +361,8 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
     return {
       ...this.bindings,
       id: this.id,
-      isStandalone: !!this.redirectionUrl,
-      searchBoxController: this.searchBox,
+      isStandalone: () => !!this.redirectionUrl,
+      searchBoxController: () => this.searchBox,
       numberOfQueries: this.numberOfQueries,
       clearFilters: this.clearFilters,
     };

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -289,6 +289,8 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
     }
   }
 
+  public disconnectedCallback: () => void = () => {};
+
   @Listen('atomic/searchBoxSuggestion/register')
   public registerSuggestions(
     event: CustomEvent<
@@ -317,6 +319,7 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
 
   @Watch('redirectionUrl')
   watchRedirectionUrl() {
+    this.disconnectedCallback();
     this.initialize();
   }
 

--- a/packages/atomic/src/components/search/atomic-search-box/e2e/atomic-search-box.e2e.ts
+++ b/packages/atomic/src/components/search/atomic-search-box/e2e/atomic-search-box.e2e.ts
@@ -126,6 +126,33 @@ test.describe('with instant results & query suggestions', () => {
         await expect(searchBox.searchInput).toHaveValue('shoe');
       });
     });
+
+    test.describe('after updating the redirect-url attribute', () => {
+      test.beforeEach(async ({searchBox}) => {
+        await searchBox.component.evaluate((node) =>
+          node.setAttribute(
+            'redirection-url',
+            './iframe.html?id=atomic-search-box--in-page&viewMode=story&args=enable-query-syntax:!true;suggestion-timeout:5000'
+          )
+        );
+      });
+
+      test('should redirect to the specified url after selecting a suggestion', async ({
+        page,
+        searchBox,
+      }) => {
+        const suggestionText = await searchBox
+          .searchSuggestions()
+          .first()
+          .textContent();
+
+        expect(suggestionText).not.toBeNull();
+
+        await searchBox.searchSuggestions().first().click();
+        await page.waitForURL('**/iframe.html?id=atomic-search-box--in-page*');
+        await expect(searchBox.searchInput).toHaveValue(suggestionText ?? '');
+      });
+    });
   });
 });
 

--- a/packages/atomic/src/components/search/atomic-search-box/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-search-box/e2e/page-object.ts
@@ -6,6 +6,10 @@ export class SearchBoxPageObject extends BasePageObject<'atomic-search-box'> {
     super(page, 'atomic-search-box');
   }
 
+  get component() {
+    return this.page.locator('atomic-search-box');
+  }
+
   get submitButton() {
     return this.page.getByLabel('Search', {exact: true});
   }

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-instant-results/atomic-search-box-instant-results.tsx
@@ -178,10 +178,10 @@ export class AtomicSearchBoxInstantResults implements InitializableComponent {
         content: <InstantItemShowAllButton i18n={this.bindings.i18n} />,
         onSelect: () => {
           this.bindings.clearSuggestions();
-          this.bindings.searchBoxController.updateText(
-            this.instantResults.state.q
-          );
-          this.bindings.searchBoxController.submit();
+          this.bindings
+            .searchBoxController()
+            .updateText(this.instantResults.state.q);
+          this.bindings.searchBoxController().submit();
         },
       });
     }
@@ -223,7 +223,7 @@ export class AtomicSearchBoxInstantResults implements InitializableComponent {
   private onSuggestedQueryChange() {
     if (
       !this.bindings.getSuggestionElements().length &&
-      !this.bindings.searchBoxController.state.value
+      !this.bindings.searchBoxController().state.value
     ) {
       console.warn(
         "There doesn't seem to be any query suggestions configured. Make sure to include either an atomic-search-box-query-suggestions or atomic-search-box-recent-queries in your search box in order to see some instant results."

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.tsx
@@ -92,15 +92,16 @@ export class AtomicSearchBoxQuerySuggestions {
   }
 
   private renderItems(): SearchBoxSuggestionElement[] {
-    const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const hasQuery = this.bindings.searchBoxController().state.value !== '';
     const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
-    return this.bindings.searchBoxController.state.suggestions
-      .slice(0, max)
+    return this.bindings
+      .searchBoxController()
+      .state.suggestions.slice(0, max)
       .map((suggestion) => this.renderItem(suggestion));
   }
 
   private renderItem(suggestion: Suggestion) {
-    const hasQuery = this.bindings.searchBoxController.state.value !== '';
+    const hasQuery = this.bindings.searchBoxController().state.value !== '';
     const partialItem = getPartialSearchBoxSuggestionElement(
       suggestion,
       this.bindings.i18n
@@ -119,7 +120,9 @@ export class AtomicSearchBoxQuerySuggestions {
         </QuerySuggestionContainer>
       ),
       onSelect: () => {
-        this.bindings.searchBoxController.selectSuggestion(suggestion.rawValue);
+        this.bindings
+          .searchBoxController()
+          .selectSuggestion(suggestion.rawValue);
       },
     };
   }

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -121,7 +121,7 @@ export class AtomicSearchBoxRecentQueries {
       return [];
     }
 
-    const query = this.bindings.searchBoxController.state.value;
+    const query = this.bindings.searchBoxController().state.value;
     const hasQuery = query !== '';
     const max = hasQuery ? this.maxWithQuery : this.maxWithoutQuery;
     const filteredQueries = this.recentQueriesList.state.queries
@@ -155,7 +155,7 @@ export class AtomicSearchBoxRecentQueries {
   }
 
   private renderItem(value: string): SearchBoxSuggestionElement {
-    const query = this.bindings.searchBoxController.state.value;
+    const query = this.bindings.searchBoxController().state.value;
     const partialItem = getPartialRecentQueryElement(value, this.bindings.i18n);
     return {
       ...partialItem,
@@ -167,9 +167,9 @@ export class AtomicSearchBoxRecentQueries {
       ),
 
       onSelect: () => {
-        if (this.bindings.isStandalone) {
-          this.bindings.searchBoxController.updateText(value);
-          this.bindings.searchBoxController.submit();
+        if (this.bindings.isStandalone()) {
+          this.bindings.searchBoxController().updateText(value);
+          this.bindings.searchBoxController().submit();
           return;
         }
 

--- a/packages/atomic/storybookUtils/search/search-interface-wrapper.tsx
+++ b/packages/atomic/storybookUtils/search/search-interface-wrapper.tsx
@@ -40,3 +40,17 @@ export const wrapInSearchInterface = (
     });
   },
 });
+
+export const playExecuteFirstSearch: (
+  context: StoryContext
+) => Promise<void> = async ({canvasElement, step}) => {
+  const canvas = within(canvasElement);
+
+  const searchInterface =
+    await canvas.findByTestId<HTMLAtomicSearchInterfaceElement>(
+      'root-interface'
+    );
+  await step('Execute the first search', async () => {
+    await searchInterface!.executeFirstSearch();
+  });
+};

--- a/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box-options.ts
+++ b/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box-options.ts
@@ -1,4 +1,4 @@
-import {Schema, StringValue} from '@coveo/bueno';
+import {BooleanValue, Schema, StringValue} from '@coveo/bueno';
 import {
   searchBoxOptionDefinitions,
   SearchBoxOptions,
@@ -10,6 +10,10 @@ export interface StandaloneSearchBoxOptions extends SearchBoxOptions {
    * If a query pipeline redirect is triggered, it will redirect to that Url instead.
    */
   redirectionUrl: string;
+  /**
+   * Whether to overwrite the existing standalone search box with the same id.
+   */
+  overwrite?: boolean;
 }
 
 export const standaloneSearchBoxSchema = new Schema<
@@ -19,5 +23,8 @@ export const standaloneSearchBoxSchema = new Schema<
   redirectionUrl: new StringValue({
     required: true,
     emptyAllowed: false,
+  }),
+  overwrite: new BooleanValue({
+    required: false,
   }),
 });

--- a/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.test.ts
@@ -80,6 +80,7 @@ describe('headless standalone searchBox', () => {
     expect(registerStandaloneSearchBox).toHaveBeenCalledWith({
       id,
       redirectionUrl: options.redirectionUrl,
+      overwrite: false,
     });
   });
 

--- a/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
@@ -8,6 +8,7 @@ import {
   fetchRedirectUrl,
   registerStandaloneSearchBox,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from '../../../features/commerce/standalone-search-box-set/standalone-search-box-set-actions';
 import {commerceStandaloneSearchBoxSetReducer as commerceStandaloneSearchBoxSet} from '../../../features/commerce/standalone-search-box-set/standalone-search-box-set-slice';
 import {querySuggestReducer as querySuggest} from '../../../features/query-suggest/query-suggest-slice';
@@ -37,6 +38,11 @@ export interface StandaloneSearchBox extends SearchBox {
    * Triggers a redirection.
    */
   submit(): void;
+  /**
+   * Updates the redirection url of the standalone search box.
+   * @param url - The new URL to redirect to.
+   */
+  updateRedirectUrl(url: string): void;
   /**
    * Resets the standalone search box state. To be dispatched on single page applications after the redirection has been triggered.
    */
@@ -107,6 +113,12 @@ export function buildStandaloneSearchBox(
 
     afterRedirection() {
       dispatch(resetStandaloneSearchBox({id}));
+    },
+
+    updateRedirectUrl(url: string) {
+      dispatch(
+        updateStandaloneSearchBoxRedirectionUrl({id, redirectionUrl: url})
+      );
     },
 
     submit() {

--- a/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/commerce/standalone-search-box/headless-standalone-search-box.ts
@@ -83,6 +83,7 @@ export function buildStandaloneSearchBox(
     id,
     highlightOptions: {...props.options.highlightOptions},
     ...defaultSearchBoxOptions,
+    ...{overwrite: false},
     ...props.options,
   };
 
@@ -95,7 +96,11 @@ export function buildStandaloneSearchBox(
 
   const searchBox = buildSearchBox(engine, {options});
   dispatch(
-    registerStandaloneSearchBox({id, redirectionUrl: options.redirectionUrl})
+    registerStandaloneSearchBox({
+      id,
+      redirectionUrl: options.redirectionUrl,
+      overwrite: options.overwrite,
+    })
   );
 
   return {

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box-options.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box-options.ts
@@ -1,4 +1,4 @@
-import {Schema, StringValue} from '@coveo/bueno';
+import {BooleanValue, Schema, StringValue} from '@coveo/bueno';
 import {
   searchBoxOptionDefinitions,
   SearchBoxOptions,
@@ -10,6 +10,10 @@ export interface StandaloneSearchBoxOptions extends SearchBoxOptions {
    * If a query pipeline redirect is triggered, it will redirect to that Url instead.
    */
   redirectionUrl: string;
+  /**
+   * Whether to overwrite the existing standalone search box with the same id.
+   */
+  overwrite?: boolean;
 }
 
 export const standaloneSearchBoxSchema = new Schema<
@@ -19,5 +23,8 @@ export const standaloneSearchBoxSchema = new Schema<
   redirectionUrl: new StringValue({
     required: true,
     emptyAllowed: false,
+  }),
+  overwrite: new BooleanValue({
+    required: false,
   }),
 });

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.test.ts
@@ -81,6 +81,7 @@ describe('headless standalone searchBox', () => {
     expect(registerStandaloneSearchBox).toHaveBeenCalledWith({
       id,
       redirectionUrl: options.redirectionUrl,
+      overwrite: false,
     });
   });
 

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -103,6 +103,7 @@ export function buildStandaloneSearchBox(
     id,
     highlightOptions: {...props.options.highlightOptions},
     ...defaultSearchBoxOptions,
+    ...{overwrite: false},
     ...props.options,
   };
 
@@ -115,7 +116,11 @@ export function buildStandaloneSearchBox(
 
   const searchBox = buildSearchBox(engine, {options});
   dispatch(
-    registerStandaloneSearchBox({id, redirectionUrl: options.redirectionUrl})
+    registerStandaloneSearchBox({
+      id,
+      redirectionUrl: options.redirectionUrl,
+      overwrite: options.overwrite,
+    })
   );
 
   return {

--- a/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
+++ b/packages/headless/src/controllers/standalone-search-box/headless-standalone-search-box.ts
@@ -11,6 +11,7 @@ import {
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from '../../features/standalone-search-box-set/standalone-search-box-set-actions';
 import {standaloneSearchBoxSetReducer as standaloneSearchBoxSet} from '../../features/standalone-search-box-set/standalone-search-box-set-slice';
 import {StandaloneSearchBoxAnalytics} from '../../features/standalone-search-box-set/standalone-search-box-set-state';
@@ -49,6 +50,12 @@ export interface StandaloneSearchBox extends SearchBox {
    * Triggers a redirection.
    */
   submit(): void;
+
+  /**
+   * Updates the redirection url of the standalone search box.
+   * @param url - The new URL to redirect to.
+   */
+  updateRedirectUrl(url: string): void;
 
   /**
    * Resets the standalone search box state. To be dispatched on single page applications after the redirection has been triggered.
@@ -133,6 +140,12 @@ export function buildStandaloneSearchBox(
 
     afterRedirection() {
       dispatch(resetStandaloneSearchBox({id}));
+    },
+
+    updateRedirectUrl(url: string) {
+      dispatch(
+        updateStandaloneSearchBoxRedirectionUrl({id, redirectionUrl: url})
+      );
     },
 
     submit() {

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
@@ -10,6 +10,7 @@ import {
   fetchRedirectUrl,
   registerStandaloneSearchBox,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 
 export type {
@@ -55,6 +56,15 @@ export interface StandaloneSearchBoxSetActionCreators {
   resetStandaloneSearchBox(
     payload: ResetStandaloneSearchBoxPayload
   ): PayloadAction<ResetStandaloneSearchBoxPayload>;
+
+  /**
+   * Updates the redirection URL of the standalone search box.
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  updateStandaloneSearchBoxRedirectionUrl(
+    payload: RegisterStandaloneSearchBoxPayload
+  ): PayloadAction<RegisterStandaloneSearchBoxPayload>;
 }
 
 /**
@@ -70,6 +80,7 @@ export function loadStandaloneSearchBoxSetActions(
   return {
     fetchRedirectUrl,
     registerStandaloneSearchBox,
+    updateStandaloneSearchBoxRedirectionUrl,
     resetStandaloneSearchBox,
   };
 }

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -1,4 +1,4 @@
-import {StringValue} from '@coveo/bueno';
+import {BooleanValue, StringValue} from '@coveo/bueno';
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {
   AsyncThunkCommerceOptions,
@@ -67,6 +67,23 @@ export interface RegisterStandaloneSearchBoxPayload {
    * The default URL to which to redirect the user.
    */
   redirectionUrl: string;
+
+  /**
+   * Whether to overwrite the existing standalone search box with the same id.
+   */
+  overwrite?: boolean;
+}
+
+export interface UpdateStandaloneSearchBoxPayload {
+  /**
+   * The standalone search box id.
+   */
+  id: string;
+
+  /**
+   * The default URL to which to redirect the user.
+   */
+  redirectionUrl: string;
 }
 
 export const registerStandaloneSearchBox = createAction(
@@ -75,12 +92,13 @@ export const registerStandaloneSearchBox = createAction(
     validatePayload(payload, {
       id: requiredNonEmptyString,
       redirectionUrl: requiredNonEmptyString,
+      overwrite: new BooleanValue({required: false}),
     })
 );
 
 export const updateStandaloneSearchBoxRedirectionUrl = createAction(
   'commerce/standaloneSearchBox/updateRedirectionUrl',
-  (payload: RegisterStandaloneSearchBoxPayload) =>
+  (payload: UpdateStandaloneSearchBoxPayload) =>
     validatePayload(payload, {
       id: requiredNonEmptyString,
       redirectionUrl: requiredNonEmptyString,

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -78,6 +78,15 @@ export const registerStandaloneSearchBox = createAction(
     })
 );
 
+export const updateStandaloneSearchBoxRedirectionUrl = createAction(
+  'commerce/standaloneSearchBox/updateRedirectionUrl',
+  (payload: RegisterStandaloneSearchBoxPayload) =>
+    validatePayload(payload, {
+      id: requiredNonEmptyString,
+      redirectionUrl: requiredNonEmptyString,
+    })
+);
+
 export interface ResetStandaloneSearchBoxPayload {
   /**
    * The standalone search box id.

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.test.ts
@@ -3,6 +3,7 @@ import {
   fetchRedirectUrl,
   registerStandaloneSearchBox,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 import {commerceStandaloneSearchBoxSetReducer} from './standalone-search-box-set-slice';
 import {CommerceStandaloneSearchBoxSetState} from './standalone-search-box-set-state';
@@ -43,6 +44,43 @@ describe('commerce standalone search box slice', () => {
       const finalState = commerceStandaloneSearchBoxSetReducer(state, action);
 
       expect(state[id]).toEqual(finalState[id]);
+    });
+
+    it('when the id exists and the overwrite option is true, it registers the payload', () => {
+      const action = registerStandaloneSearchBox({
+        id,
+        redirectionUrl: 'url',
+        overwrite: true,
+      });
+      const finalState = commerceStandaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState[id]).toEqual(
+        buildMockCommerceStandaloneSearchBoxEntry({
+          defaultRedirectionUrl: 'url',
+        })
+      );
+    });
+  });
+
+  describe('#updateStandaloneSearchBoxRedirectionUrl', () => {
+    it('when the id exists, it sets the default redirection url', () => {
+      const action = updateStandaloneSearchBoxRedirectionUrl({
+        id,
+        redirectionUrl: '/newpage',
+      });
+      const finalState = commerceStandaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState[id]!.defaultRedirectionUrl).toBe('/newpage');
+    });
+
+    it('when the id does not exist, it does not edit the state', () => {
+      const action = updateStandaloneSearchBoxRedirectionUrl({
+        id: 'invalid',
+        redirectionUrl: '/newpage',
+      });
+      const finalState = commerceStandaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState).toBe(state);
     });
   });
 

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -3,6 +3,7 @@ import {
   fetchRedirectUrl,
   registerStandaloneSearchBox,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 import {
   getCommerceStandaloneSearchBoxSetInitialState,
@@ -17,6 +18,15 @@ export const commerceStandaloneSearchBoxSetReducer = createReducer(
         const {id, redirectionUrl} = action.payload;
 
         if (id in state) {
+          return;
+        }
+
+        state[id] = buildStandaloneSearchBoxEntry(redirectionUrl);
+      })
+      .addCase(updateStandaloneSearchBoxRedirectionUrl, (state, action) => {
+        const {id, redirectionUrl} = action.payload;
+
+        if (!(id in state)) {
           return;
         }
 

--- a/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/commerce/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -15,9 +15,9 @@ export const commerceStandaloneSearchBoxSetReducer = createReducer(
   (builder) =>
     builder
       .addCase(registerStandaloneSearchBox, (state, action) => {
-        const {id, redirectionUrl} = action.payload;
+        const {id, redirectionUrl, overwrite} = action.payload;
 
-        if (id in state) {
+        if (!overwrite && id in state) {
           return;
         }
 
@@ -25,12 +25,13 @@ export const commerceStandaloneSearchBoxSetReducer = createReducer(
       })
       .addCase(updateStandaloneSearchBoxRedirectionUrl, (state, action) => {
         const {id, redirectionUrl} = action.payload;
+        const searchBox = state[id];
 
-        if (!(id in state)) {
+        if (!searchBox) {
           return;
         }
 
-        state[id] = buildStandaloneSearchBoxEntry(redirectionUrl);
+        searchBox.defaultRedirectionUrl = redirectionUrl;
       })
       .addCase(resetStandaloneSearchBox, (state, action) => {
         const {id} = action.payload;

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions-loader.ts
@@ -14,6 +14,7 @@ import {
   StateNeededForRedirect,
   resetStandaloneSearchBox,
   ResetStandaloneSearchBoxActionCreatorPayload,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 
 export type {
@@ -63,6 +64,15 @@ export interface StandaloneSearchBoxSetActionCreators {
   >;
 
   /**
+   * Updates the redirection URL of the standalone search box.
+   * @param payload - The action creator payload.
+   * @returns A dispatchable action.
+   */
+  updateStandaloneSearchBoxRedirectionUrl(
+    payload: RegisterStandaloneSearchBoxActionCreatorPayload
+  ): PayloadAction<RegisterStandaloneSearchBoxActionCreatorPayload>;
+
+  /**
    * Updates the standalone search box analytics data to reflect a search submitted using the search box.
    *
    * @param payload - The action creator payload.
@@ -97,6 +107,7 @@ export function loadStandaloneSearchBoxSetActions(
   return {
     registerStandaloneSearchBox,
     fetchRedirectUrl,
+    updateStandaloneSearchBoxRedirectionUrl,
     updateAnalyticsToSearchFromLink,
     updateAnalyticsToOmniboxFromLink,
     resetStandaloneSearchBox,

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -45,6 +45,15 @@ export const registerStandaloneSearchBox = createAction(
     })
 );
 
+export const updateStandaloneSearchBoxRedirectionUrl = createAction(
+  'standaloneSearchBox/updateRedirectionUrl',
+  (payload: RegisterStandaloneSearchBoxActionCreatorPayload) =>
+    validatePayload(payload, {
+      id: requiredNonEmptyString,
+      redirectionUrl: requiredNonEmptyString,
+    })
+);
+
 export interface ResetStandaloneSearchBoxActionCreatorPayload {
   /**
    * The standalone search box id.

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-actions.ts
@@ -1,4 +1,4 @@
-import {StringValue} from '@coveo/bueno';
+import {BooleanValue, StringValue} from '@coveo/bueno';
 import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import {getVisitorID} from '../../api/analytics/coveo-analytics-utils';
 import {ExecutionPlan} from '../../api/search/plan/plan-endpoint';
@@ -34,6 +34,23 @@ export interface RegisterStandaloneSearchBoxActionCreatorPayload {
    * The default URL to which to redirect the user.
    */
   redirectionUrl: string;
+
+  /**
+   * Whether to overwrite the existing standalone search box with the same id.
+   */
+  overwrite?: boolean;
+}
+
+export interface UpdateStandaloneSearchBoxPayload {
+  /**
+   * The standalone search box id.
+   */
+  id: string;
+
+  /**
+   * The default URL to which to redirect the user.
+   */
+  redirectionUrl: string;
 }
 
 export const registerStandaloneSearchBox = createAction(
@@ -42,12 +59,13 @@ export const registerStandaloneSearchBox = createAction(
     validatePayload(payload, {
       id: requiredNonEmptyString,
       redirectionUrl: requiredNonEmptyString,
+      overwrite: new BooleanValue({required: false}),
     })
 );
 
 export const updateStandaloneSearchBoxRedirectionUrl = createAction(
   'standaloneSearchBox/updateRedirectionUrl',
-  (payload: RegisterStandaloneSearchBoxActionCreatorPayload) =>
+  (payload: UpdateStandaloneSearchBoxPayload) =>
     validatePayload(payload, {
       id: requiredNonEmptyString,
       redirectionUrl: requiredNonEmptyString,

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.test.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.test.ts
@@ -6,6 +6,7 @@ import {
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
   resetStandaloneSearchBox,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 import {standaloneSearchBoxSetReducer} from './standalone-search-box-set-slice';
 import {StandaloneSearchBoxSetState} from './standalone-search-box-set-state';
@@ -44,6 +45,41 @@ describe('standalone search box slice', () => {
       const finalState = standaloneSearchBoxSetReducer(state, action);
 
       expect(state[id]).toEqual(finalState[id]);
+    });
+
+    it('when the id exists and the overwrite option is true, it registers the payload', () => {
+      const action = registerStandaloneSearchBox({
+        id,
+        redirectionUrl: 'url',
+        overwrite: true,
+      });
+      const finalState = standaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState[id]).toEqual(
+        buildMockStandaloneSearchBoxEntry({defaultRedirectionUrl: 'url'})
+      );
+    });
+  });
+
+  describe('#updateStandaloneSearchBoxRedirectionUrl', () => {
+    it('when the id exists, it sets the default redirection url', () => {
+      const action = updateStandaloneSearchBoxRedirectionUrl({
+        id,
+        redirectionUrl: '/newpage',
+      });
+      const finalState = standaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState[id]!.defaultRedirectionUrl).toBe('/newpage');
+    });
+
+    it('when the id does not exist, it does not edit the state', () => {
+      const action = updateStandaloneSearchBoxRedirectionUrl({
+        id: 'invalid',
+        redirectionUrl: '/newpage',
+      });
+      const finalState = standaloneSearchBoxSetReducer(state, action);
+
+      expect(finalState).toBe(state);
     });
   });
 

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -5,6 +5,7 @@ import {
   resetStandaloneSearchBox,
   updateAnalyticsToOmniboxFromLink,
   updateAnalyticsToSearchFromLink,
+  updateStandaloneSearchBoxRedirectionUrl,
 } from './standalone-search-box-set-actions';
 import {
   getStandaloneSearchBoxSetInitialState,
@@ -33,6 +34,13 @@ export const standaloneSearchBoxSetReducer = createReducer(
             searchBox.defaultRedirectionUrl
           );
           return;
+        }
+      })
+      .addCase(updateStandaloneSearchBoxRedirectionUrl, (state, action) => {
+        const {id, redirectionUrl} = action.payload;
+        const searchBox = state[id];
+        if (searchBox) {
+          searchBox.defaultRedirectionUrl = redirectionUrl;
         }
       })
       .addCase(fetchRedirectUrl.pending, (state, action) => {

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -17,9 +17,9 @@ export const standaloneSearchBoxSetReducer = createReducer(
   (builder) =>
     builder
       .addCase(registerStandaloneSearchBox, (state, action) => {
-        const {id, redirectionUrl} = action.payload;
+        const {id, redirectionUrl, overwrite} = action.payload;
 
-        if (id in state) {
+        if (!overwrite && id in state) {
           return;
         }
 

--- a/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
+++ b/packages/headless/src/features/standalone-search-box-set/standalone-search-box-set-slice.ts
@@ -38,10 +38,12 @@ export const standaloneSearchBoxSetReducer = createReducer(
       })
       .addCase(updateStandaloneSearchBoxRedirectionUrl, (state, action) => {
         const {id, redirectionUrl} = action.payload;
-        const searchBox = state[id];
-        if (searchBox) {
-          searchBox.defaultRedirectionUrl = redirectionUrl;
+
+        if (!(id in state)) {
+          return;
         }
+
+        state[id] = buildStandaloneSearchBoxEntry(redirectionUrl);
       })
       .addCase(fetchRedirectUrl.pending, (state, action) => {
         const searchBox = state[action.meta.arg.id];


### PR DESCRIPTION
When updating the `redirection-url`, references to the 'old' controller persisted and broke the suggestions.

To alleviate this issue:
0. Ensure SB ID unicity per component
1. Allow SSB controllers to receive an update to their redirection URL.
2. Clean-up then rebuild controllers when the redirection-url attribute is updated. When rebuilding a SSB controller, allow the state associated to the ID to be overwritten.
3. Use 'getter-like' functions instead of direct reference for the controller in the suggestion-manager.

KIT-3471
