### PR TITLE
fix(headless): typo fixed in the insight user actions state declaration

### DIFF
--- a/packages/headless/src/controllers/insight/user-actions/headless-user-actions.ts
+++ b/packages/headless/src/controllers/insight/user-actions/headless-user-actions.ts
@@ -8,7 +8,7 @@ import {insightUserActionsReducer} from '../../../features/insight-user-actions/
 import {UserActionsState} from '../../../features/insight-user-actions/insight-user-actions-state';
 import {
   ConfigurationSection,
-  InsightUserActionSection,
+  InsightUserActionsSection,
 } from '../../../state/state-sections';
 import {loadReducerError} from '../../../utils/errors';
 import {
@@ -17,6 +17,10 @@ import {
 } from '../../controller/headless-controller';
 
 export type {UserActionsState} from '../../../features/insight-user-actions/insight-user-actions-state';
+export type {
+  UserAction,
+  UserSession,
+} from '../../../features/insight-user-actions/insight-user-actions-state';
 
 export interface UserActionsProps {
   /**
@@ -61,7 +65,7 @@ export function buildUserActions(
   }
 
   const {dispatch} = engine;
-  const getState = () => engine.state.insightUserAction;
+  const getState = () => engine.state.insightUserActions;
   const controller = buildController(engine);
   const {ticketCreationDate, excludedCustomActions} = props.options;
 
@@ -81,10 +85,10 @@ export function buildUserActions(
 
 function loadUserActionsReducers(
   engine: InsightEngine
-): engine is InsightEngine<ConfigurationSection & InsightUserActionSection> {
+): engine is InsightEngine<ConfigurationSection & InsightUserActionsSection> {
   engine.addReducers({
     configuration,
-    insightuserActions: insightUserActionsReducer,
+    insightUserActions: insightUserActionsReducer,
   });
   return true;
 }

--- a/packages/headless/src/features/insight-user-actions/insight-user-actions-actions.ts
+++ b/packages/headless/src/features/insight-user-actions/insight-user-actions-actions.ts
@@ -5,7 +5,7 @@ import {AsyncThunkInsightOptions} from '../../api/service/insight/insight-api-cl
 import {InsightUserActionsResponse} from '../../api/service/insight/user-actions/user-actions-response';
 import {
   ConfigurationSection,
-  InsightUserActionSection,
+  InsightUserActionsSection,
 } from '../../state/state-sections';
 import {nonEmptyString, validatePayload} from '../../utils/validate-payload';
 import {buildFetchUserActionsRequest} from './insight-user-actions-request';
@@ -38,7 +38,7 @@ export interface FetchUserActionsThunkReturn {
 }
 
 export type StateNeededByFetchUserActions = ConfigurationSection &
-  InsightUserActionSection;
+  InsightUserActionsSection;
 
 export type UserId = string;
 

--- a/packages/headless/src/state/insight-app-state.ts
+++ b/packages/headless/src/state/insight-app-state.ts
@@ -27,7 +27,7 @@ import {
   FoldingSection,
   GeneratedAnswerSection,
   ContextSection,
-  InsightUserActionSection,
+  InsightUserActionsSection,
 } from './state-sections';
 
 export type InsightSearchParametersState = FacetSection &
@@ -62,4 +62,4 @@ export type InsightAppState = InsightSearchParametersState &
   FoldingSection &
   GeneratedAnswerSection &
   ContextSection &
-  InsightUserActionSection;
+  InsightUserActionsSection;

--- a/packages/headless/src/state/state-sections.ts
+++ b/packages/headless/src/state/state-sections.ts
@@ -505,11 +505,11 @@ export interface GeneratedAnswerSection {
   generatedAnswer: GeneratedAnswerState;
 }
 
-export interface InsightUserActionSection {
+export interface InsightUserActionsSection {
   /**
-   * The insight user action state.
+   * The insight user actions state.
    */
-  insightUserAction: UserActionsState;
+  insightUserActions: UserActionsState;
 }
 
 export interface ManualRangeSection {

--- a/packages/headless/src/test/mock-insight-state.ts
+++ b/packages/headless/src/test/mock-insight-state.ts
@@ -60,7 +60,7 @@ export function buildMockInsightState(
     folding: getFoldingInitialState(),
     generatedAnswer: getGeneratedAnswerInitialState(),
     context: getContextInitialState(),
-    insightUserAction: getInsightUserActionsInitialState(),
+    insightUserActions: getInsightUserActionsInitialState(),
     ...config,
   };
 }


### PR DESCRIPTION
[SFINT-5675](https://coveord.atlassian.net/browse/SFINT-5675)

- fixed a typo in the insight user actions state declaration, updated `insightUserAction ` to be `insightUserActions ` 