### PR TITLE
fix(atomic): prevent item click when carousel buttons are clicked

### DIFF
--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/atomic-product-image.e2e.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/atomic-product-image.e2e.ts
@@ -1,0 +1,12 @@
+// import {test, expect} from './fixture';
+
+// test.describe('default', async () => {
+//   test.describe('when clicking on the next button', async ({productImage}) => {
+//     test.fixme('should navigate to the next image', () => {});
+//     test.fixme('should not open the product', () => {});
+//   });
+//   test.describe('when clicking on the previous button', async ({productImage}) => {
+//     test.fixme('should navigate to the previous image', () => {});
+//     test.fixme('should not open the product', () => {});
+//   });
+// });

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/fixture.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/fixture.ts
@@ -1,0 +1,18 @@
+import {test as base} from '@playwright/test';
+import {
+  AxeFixture,
+  makeAxeBuilder,
+} from '../../../../../../playwright-utils/base-fixture';
+import {ProductImageObject} from './page-object';
+
+interface TestFixture {
+  productImage: ProductImageObject;
+}
+
+export const test = base.extend<TestFixture & AxeFixture>({
+  makeAxeBuilder,
+  productImage: async ({page}, use) => {
+    await use(new ProductImageObject(page));
+  },
+});
+export {expect} from '@playwright/test';

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-image/e2e/page-object.ts
@@ -1,0 +1,9 @@
+import type {Page} from '@playwright/test';
+import {BasePageObject} from '../../../../../../playwright-utils/base-page-object';
+
+export class ProductImageObject extends BasePageObject<'atomic-product-image'> {
+  constructor(page: Page) {
+    super(page, 'atomic-product-image');
+  }
+  // TODO tests
+}

--- a/packages/atomic/src/components/common/image-carousel/image-carousel.tsx
+++ b/packages/atomic/src/components/common/image-carousel/image-carousel.tsx
@@ -27,7 +27,10 @@ export const ImageCarousel: FunctionalComponent<
       <Button
         style="text-primary"
         ariaLabel={props.bindings.i18n.t('previous')}
-        onClick={() => props.previousImage()}
+        onClick={(event) => {
+          event?.stopPropagation();
+          props.previousImage();
+        }}
         part="previous-button"
         class={`${commonPaginationClasses} left-0 ml-1`}
       >
@@ -44,7 +47,10 @@ export const ImageCarousel: FunctionalComponent<
       <Button
         style="text-primary"
         ariaLabel={props.bindings.i18n.t('next')}
-        onClick={() => props.nextImage()}
+        onClick={(event) => {
+          event?.stopPropagation();
+          props.nextImage();
+        }}
         part="next-button"
         class={`${commonPaginationClasses} right-0 mr-1`}
       >


### PR DESCRIPTION
When you click on an element within another, you are clicking both.
This is why you must 'stop' the event propagation at the target in this situation. (otherwise, if the parent & the child elements have listeners, both will be triggered)

https://coveord.atlassian.net/browse/KIT-3477