### PR TITLE
feat(RGACustomEvents): send answer id

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -4,6 +4,8 @@ on:
   merge_group:
 env:
   CYPRESS_VERIFY_TIMEOUT: 60000
+concurrency:
+  group: ci
 jobs:
   report-size:
     if: github.event_name == 'pull_request'

--- a/packages/headless/src/features/generated-answer/generated-answer-selectors.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-selectors.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {streamAnswerAPIStateMock} from '../../api/knowledge/tests/stream-answer-api-state-mock';
+import {generativeQuestionAnsweringIdSelector} from './generated-answer-selectors';
+
+jest.mock('../../api/knowledge/stream-answer-api', () => ({
+  ...jest.requireActual<Record<string, any>>(
+    '../../api/knowledge/stream-answer-api'
+  ),
+  selectAnswer: (_state: any) => ({
+    data: {
+      answerId: 'answerId1234',
+    },
+  }),
+}));
+
+describe('generated-answer-selectors', () => {
+  describe('generativeQuestionAnsweringIdSelector', () => {
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+    it('returns the answerId if an answer configuration id is in state', () => {
+      const state = {
+        ...(streamAnswerAPIStateMock as any),
+        generatedAnswer: {
+          answerConfigurationId: 'answerConfigurationId',
+        },
+      } as any;
+
+      const result = generativeQuestionAnsweringIdSelector(state);
+      expect(result).toEqual('answerId1234');
+    });
+
+    it('returns the generativeQuestionAnsweringId if an answer configuration id is not in state', () => {
+      const state = {
+        ...(streamAnswerAPIStateMock as any),
+        generatedAnswer: {
+          answerConfigurationId: undefined,
+        },
+        search: {
+          response: {
+            extendedResults: {
+              generativeQuestionAnsweringId:
+                'generativeQuestionAnsweringId4321',
+            },
+          },
+        },
+      } as any;
+
+      const result = generativeQuestionAnsweringIdSelector(state);
+      expect(result).toEqual('generativeQuestionAnsweringId4321');
+    });
+  });
+});

--- a/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
@@ -1,12 +1,41 @@
+import {isNullOrUndefined} from '@coveo/bueno';
 import {createSelector} from '@reduxjs/toolkit';
+import {
+  selectAnswer,
+  StateNeededByAnswerAPI,
+} from '../../api/knowledge/stream-answer-api';
 import {GeneratedAnswerCitation} from '../../controllers/generated-answer/headless-generated-answer';
 import {SearchAppState} from '../../state/search-app-state';
-import {GeneratedAnswerSection} from '../../state/state-sections';
+import {
+  GeneratedAnswerSection,
+  SearchSection,
+} from '../../state/state-sections';
 import {selectQuery} from '../query/query-selectors';
 
 export const generativeQuestionAnsweringIdSelector = (
   state: Partial<SearchAppState>
-) => state.search?.response?.extendedResults?.generativeQuestionAnsweringId;
+) => {
+  if (isGeneratedAnswerSection(state)) {
+    return selectAnswer(state).data?.answerId;
+  }
+
+  if (isSearchSection(state)) {
+    return state.search.response.extendedResults.generativeQuestionAnsweringId;
+  }
+
+  return undefined;
+};
+
+const isSearchSection = (
+  state: Partial<SearchAppState> | StateNeededByAnswerAPI
+): state is SearchSection => 'search' in state;
+
+const isGeneratedAnswerSection = (
+  state: Partial<SearchAppState>
+): state is StateNeededByAnswerAPI =>
+  'answer' in state &&
+  'generatedAnswer' in state &&
+  !isNullOrUndefined(state.generatedAnswer?.answerConfigurationId);
 
 export const selectFieldsToIncludeInCitation = (
   state: Partial<GeneratedAnswerSection>


### PR DESCRIPTION
SVCC-4021

# Managing the answer api flow rga components custom events

## With the answer api flow
The answer id will be sent to the custom event
![2024-08-22_15-54](https://github.com/user-attachments/assets/b2b07d85-720d-445a-afca-7908be0bf374)

## With the search Api flow
The search api stream ID will be sent with the custom event
![2024-08-22_15-59](https://github.com/user-attachments/assets/62538264-5b9c-47cb-95fd-c6520549cb09)

