### PR TITLE
docs(atomic): default annotation name

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1060,17 +1060,17 @@ export namespace Components {
         "answerStyle": GeneratedAnswerStyle;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
-          * @default false
+          * @defaultValue false
          */
         "collapsible"?: boolean;
         /**
           * Whether to render the rephrase buttons that lets the user rephrase the answer.
-          * @default false
+          * @defaultValue false
          */
         "withRephraseButtons"?: boolean;
         /**
           * Whether to render a toggle button that lets the user hide or show the answer.
-          * @default false
+          * @defaultValue false
          */
         "withToggle"?: boolean;
     }
@@ -1206,17 +1206,17 @@ export namespace Components {
         "answerStyle": InsightGeneratedAnswerStyle;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
-          * @default false
+          * @defaultValue false
          */
         "collapsible"?: boolean;
         /**
           * Whether to render the rephrase buttons that lets the user rephrase the answer.
-          * @default false
+          * @defaultValue false
          */
         "withRephraseButtons"?: boolean;
         /**
           * Whether to render a toggle button that lets the user hide or show the answer.
-          * @default false
+          * @defaultValue false
          */
         "withToggle"?: boolean;
     }
@@ -6728,17 +6728,17 @@ declare namespace LocalJSX {
         "answerStyle"?: GeneratedAnswerStyle;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
-          * @default false
+          * @defaultValue false
          */
         "collapsible"?: boolean;
         /**
           * Whether to render the rephrase buttons that lets the user rephrase the answer.
-          * @default false
+          * @defaultValue false
          */
         "withRephraseButtons"?: boolean;
         /**
           * Whether to render a toggle button that lets the user hide or show the answer.
-          * @default false
+          * @defaultValue false
          */
         "withToggle"?: boolean;
     }
@@ -6871,17 +6871,17 @@ declare namespace LocalJSX {
         "answerStyle"?: InsightGeneratedAnswerStyle;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
-          * @default false
+          * @defaultValue false
          */
         "collapsible"?: boolean;
         /**
           * Whether to render the rephrase buttons that lets the user rephrase the answer.
-          * @default false
+          * @defaultValue false
          */
         "withRephraseButtons"?: boolean;
         /**
           * Whether to render a toggle button that lets the user hide or show the answer.
-          * @default false
+          * @defaultValue false
          */
         "withToggle"?: boolean;
     }

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
@@ -107,19 +107,19 @@ export class AtomicInsightGeneratedAnswer
 
   /**
    * Whether to render a toggle button that lets the user hide or show the answer.
-   * @default false
+   * @defaultValue false
    */
   @Prop() withToggle?: boolean;
 
   /**
    * Whether to allow the answer to be collapsed when the text is taller than 250px.
-   * @default false
+   * @defaultValue false
    */
   @Prop() collapsible?: boolean;
 
   /**
    * Whether to render the rephrase buttons that lets the user rephrase the answer.
-   * @default false
+   * @defaultValue false
    */
   @Prop() withRephraseButtons?: boolean;
 

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -104,19 +104,19 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
 
   /**
    * Whether to render a toggle button that lets the user hide or show the answer.
-   * @default false
+   * @defaultValue false
    */
   @Prop() withToggle?: boolean;
 
   /**
    * Whether to allow the answer to be collapsed when the text is taller than 250px.
-   * @default false
+   * @defaultValue false
    */
   @Prop() collapsible?: boolean;
 
   /**
    * Whether to render the rephrase buttons that lets the user rephrase the answer.
-   * @default false
+   * @defaultValue false
    */
   @Prop() withRephraseButtons?: boolean;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-15584
documentation extraction supports `@defaultValue`, not `@default`. If you know a quick way to fix this twice (e.g., linter config to prevent this re-happening), let me know, I'd be happy to oblige.