### PR TITLE
feat(commerce ssr): add method to set view context dynamically

### DIFF
--- a/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
@@ -3,6 +3,7 @@
  */
 import {Action, UnknownAction} from '@reduxjs/toolkit';
 import {stateKey} from '../../app/state-key';
+import type {View} from '../../controllers/commerce/context/headless-context';
 import {buildProductListing} from '../../controllers/commerce/product-listing/headless-product-listing';
 import {buildSearch} from '../../controllers/commerce/search/headless-search';
 import type {Controller} from '../../controllers/controller/headless-controller';
@@ -145,10 +146,10 @@ export function defineCommerceEngine<
     engineOptions.navigatorContextProvider = navigatorContextProvider;
   };
 
-  const setURL = (url: string) => {
+  const setView = (view: View) => {
     engineOptions.configuration.context = {
       ...engineOptions.configuration.context,
-      view: {url},
+      view,
     };
   };
 
@@ -269,13 +270,14 @@ export function defineCommerceEngine<
       fetchStaticState: fetchStaticStateFactory(SolutionType.listing),
       hydrateStaticState: hydrateStaticStateFactory(SolutionType.listing),
       setNavigatorContextProvider,
-      setURL,
+      setView,
     } as CommerceEngineDefinition<TControllerDefinitions, SolutionType.listing>,
     searchEngineDefinition: {
       build: buildFactory(SolutionType.search),
       fetchStaticState: fetchStaticStateFactory(SolutionType.search),
       hydrateStaticState: hydrateStaticStateFactory(SolutionType.search),
       setNavigatorContextProvider,
+      setView,
     } as CommerceEngineDefinition<TControllerDefinitions, SolutionType.search>,
   };
 }

--- a/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
@@ -145,6 +145,13 @@ export function defineCommerceEngine<
     engineOptions.navigatorContextProvider = navigatorContextProvider;
   };
 
+  const setURL = (url: string) => {
+    engineOptions.configuration.context = {
+      ...engineOptions.configuration.context,
+      view: {url},
+    };
+  };
+
   const buildFactory =
     <T extends SolutionType>(solutionType: T) =>
     async (...[buildOptions]: BuildParameters) => {
@@ -262,6 +269,7 @@ export function defineCommerceEngine<
       fetchStaticState: fetchStaticStateFactory(SolutionType.listing),
       hydrateStaticState: hydrateStaticStateFactory(SolutionType.listing),
       setNavigatorContextProvider,
+      setURL,
     } as CommerceEngineDefinition<TControllerDefinitions, SolutionType.listing>,
     searchEngineDefinition: {
       build: buildFactory(SolutionType.search),

--- a/packages/headless/src/app/commerce-ssr-engine/types/core-engine.ts
+++ b/packages/headless/src/app/commerce-ssr-engine/types/core-engine.ts
@@ -1,4 +1,5 @@
 import {UnknownAction} from '@reduxjs/toolkit';
+import type {View} from '../../../controllers/commerce/context/headless-context';
 import type {Controller} from '../../../controllers/controller/headless-controller';
 import {CoreEngine, CoreEngineNext} from '../../engine';
 import {EngineConfiguration} from '../../engine-configuration';
@@ -75,7 +76,12 @@ export interface EngineDefinition<
     navigatorContextProvider: NavigatorContextProvider
   ) => void;
 
-  setURL: (url: string) => void;
+  /**
+   * Sets the view for the commerce engine.
+   *
+   * This method can be used to dynamically set the view (eg: URL) necessary for the commerce engine to function properly.
+   */
+  setView: (view: View) => void;
 }
 
 export type InferStaticState<

--- a/packages/headless/src/app/commerce-ssr-engine/types/core-engine.ts
+++ b/packages/headless/src/app/commerce-ssr-engine/types/core-engine.ts
@@ -74,6 +74,8 @@ export interface EngineDefinition<
   setNavigatorContextProvider: (
     navigatorContextProvider: NavigatorContextProvider
   ) => void;
+
+  setURL: (url: string) => void;
 }
 
 export type InferStaticState<


### PR DESCRIPTION
This is needed to allow implementers to set the "view context" (ie: the URL) dynamically, instead of a static definition.

For example, this allow to set something like this statically in a file (ie: `engine-definition.ts`)

```ts
export const commerceEngineDefinition = defineCommerceEngine({
  configuration: {
    // [...]
    context: {
      // [...]
      view: {
        url: `https://sports-dev.barca.group`,
      },
    },
    // [...]
});
```

And then in a listing page, dynamically set the view with something like this: 

```ts
export default async function ProductListingPage() {
 // [...]
  const currentURL = useRouter().pathname;
   commerceEngineDefinitiion.setView({url: currentURL});
   const staticState = await commerceEngineDefinition.listingEngineDefinition.fetchStaticState();

   // [...]
})
```

KIT-3496