### PR TITLE
ci: replace release/v2 by release/v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
-          ref: 'release/v2'
+          ref: 'release/v3'
       - uses: ./.github/actions/setup
       - name: Promote NPM package to production
         run: npm run promote:npm:latest
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
-          ref: 'release/v2'
+          ref: 'release/v3'
       - uses: ./.github/actions/setup
       - name: Notify Docs
         run: npm run notify:docs
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
-          ref: 'release/v2'
+          ref: 'release/v3'
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Promote SFDX package to production

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -74,7 +74,7 @@ process.chdir(process.env.INIT_CWD);
 
   // Current release branch
   // TODO v3: Bump to release/v3
-  const currentReleaseBranch = 'release/v2';
+  const currentReleaseBranch = 'release/v3';
   await octokit.rest.git.updateRef({
     owner: REPO_OWNER,
     repo: REPO_NAME,


### PR DESCRIPTION
Akin to #4319 , but for the mainline: We now use the release/v3 branch as the tag for "where's the latest v3"

https://coveord.atlassian.net/browse/KIT-3497