### PR TITLE
fix(quantic)!: deleted unnecessary properties, methods and labels

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1128,13 +1128,6 @@
     <shortDescription>Navigate to the record</shortDescription>
   </labels>
   <labels>
-    <fullName>quantic_OpensInSalesforceSubTab</fullName>
-    <value>Opens in a Salesforce subtab</value>
-    <language>en_US</language>
-    <protected>false</protected>
-    <shortDescription>Opens in a Salesforce subtab</shortDescription>
-  </labels>
-  <labels>
     <fullName>quantic_OpensInBrowserTab</fullName>
     <value>Opens in the browser tab</value>
     <language>en_US</language>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -52,14 +52,6 @@ export default class QuanticResultLink extends NavigationMixin(
    */
   @api target = '_self';
   /**
-   * Indicates the use case where this component is used.
-   * @api
-   * @type {'search'|'case-assist'}
-   * @deprecated The component uses the same Headless bundle as the interface it is bound to.
-   * @defaultValue `'search'`
-   */
-  @api useCase = 'search';
-  /**
    * A function used to set focus to the link.
    * @api
    * @type {VoidFunction}

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -21,7 +21,7 @@ import {LightningElement, api, track} from 'lwc';
  * @category Result Template
  * @fires CustomEvent#haspreview
  * @example
- * <c-quantic-result-quickview engine-id={engineId} result={result} maximum-preview-size="100" use-case="search"></c-quantic-result-quickview>
+ * <c-quantic-result-quickview engine-id={engineId} result={result} maximum-preview-size="100"></c-quantic-result-quickview>
  */
 export default class QuanticResultQuickview extends LightningElement {
   /**
@@ -64,14 +64,6 @@ export default class QuanticResultQuickview extends LightningElement {
    * @defaultValue `undefined`
    */
   @api previewButtonVariant;
-  /**
-   * Indicates the use case where this quickview component is used.
-   * @api
-   * @type {'search'|'case-assist'}
-   * @deprecated The component uses the same Headless bundle as the interface it is bound to.
-   * @defaultValue `'search'`
-   */
-  @api useCase = 'search';
   /**
    * The label displayed in the tooltip of the quick view button.
    * @api

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -85,26 +85,6 @@ export default class QuanticSearchBoxInput extends LightningElement {
    * @defaultValue 7
    */
   @api maxNumberOfSuggestions = 7;
-  // TODO SFINT-5646: Remove deprecated method
-  /**
-   * The blur function.
-   * @deprecated
-   * @api
-   * @type {VoidFunction}
-   */
-  @api blur() {
-    this.input.blur();
-  }
-  // TODO SFINT-5646: Remove deprecated method
-  /**
-   * The reset selection function.
-   * @deprecated
-   * @api
-   * @type {VoidFunction}
-   */
-  @api resetSelection() {
-    this.suggestionListElement?.resetSelection();
-  }
 
   /** @type {boolean} */
   ignoreNextEnterKeyPress = false;

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
@@ -116,16 +116,6 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
     return null;
   }
 
-  // TODO SFINT-5646: Remove deprecated method
-  /**
-   * @deprecated
-   * Reset the current selection.
-   */
-  @api
-  resetSelection() {
-    this.selectionIndex = -1;
-  }
-
   /** @type {number} */
   selectionIndex = -1;
   /** @type {boolean} */

--- a/packages/quantic/force-app/main/translations/fr.translation-meta.xml
+++ b/packages/quantic/force-app/main/translations/fr.translation-meta.xml
@@ -609,10 +609,6 @@
     <name>quantic_NoRelatedItems</name>
   </customLabels>
   <customLabels>
-    <label>Ouvre dans un sous-onglet Salesforce</label>
-    <name>quantic_OpensInSalesforceSubTab</name>
-  </customLabels>
-  <customLabels>
     <label>Naviguer vers l'enregistrement</label>
     <name>quantic_NavigateToRecord</name>
   </customLabels>


### PR DESCRIPTION
[SFINT-4696](https://coveord.atlassian.net/browse/SFINT-4696)


- [SFINT-4696](https://coveord.atlassian.net/browse/SFINT-4696): 
 Removed unused `useCase` property from the `QuanticResultQuickview` and the `QuanticResultLink` components. 

- [SFINT-5319](https://coveord.atlassian.net/browse/SFINT-5319) : Removed unused custom label `quantic_OpensInSalesforceSubTab`.

- [SFINT-5646](https://coveord.atlassian.net/browse/SFINT-5646) : Removed unused exposed method of the Quantic Search Box input: `resetSelection` and `blur` cause they are no longer useful.

[SFINT-4696]: https://coveord.atlassian.net/browse/SFINT-4696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFINT-4696]: https://coveord.atlassian.net/browse/SFINT-4696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFINT-5319]: https://coveord.atlassian.net/browse/SFINT-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFINT-5646]: https://coveord.atlassian.net/browse/SFINT-5646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ