### PR TITLE
fix(atomic-react)!: remove analytics from atomic search interface

### DIFF
--- a/packages/atomic-react/src/components/search/SearchInterfaceWrapper.tsx
+++ b/packages/atomic-react/src/components/search/SearchInterfaceWrapper.tsx
@@ -36,10 +36,6 @@ interface WrapperProps
    * @deprecated This option has no effect. Rather, set the search hub through the `engine` `search` configuration.
    */
   searchHub?: string;
-  /**
-   * @deprecated This option has no effect. Rather, set the analytics through the `engine` `analytics` `enabled` configuration.
-   */
-  analytics?: boolean;
 }
 
 const DefaultProps: Required<Pick<WrapperProps, 'onReady' | 'localization'>> = {


### PR DESCRIPTION
In the atomic-react library, there are two methods to enable/disable analytics:

```ts
buildSearchEngine({
  configuration: {
    ...getConfigurationForSample(sample),
    analytics: {enabled: false},
  },
});
```

Via AtomicSearchInterface:

```html
<AtomicSearchInterface analytics={false} />
```

### Issue
The second method, using AtomicSearchInterface, does not work as expected. This is because the SearchInterfaceWrapper in atomic-react reads the analytics configuration directly from the engine, ignoring the analytics prop passed to AtomicSearchInterface.

### Solution
Remove analytics prop from the SearchInterfaceWrapper

https://coveord.atlassian.net/browse/KIT-3495