### PR TITLE
fix(atomic): do not add click outside of grid layout

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tsx
@@ -263,7 +263,10 @@ export class AtomicCommerceProductList
         this.imageSize
       ),
       content: this.productTemplateProvider.getTemplateContent(product),
-      linkContent: this.productTemplateProvider.getLinkTemplateContent(product),
+      linkContent:
+        this.display === 'grid'
+          ? this.productTemplateProvider.getLinkTemplateContent(product)
+          : this.productTemplateProvider.getEmptyLinkTemplateContent(),
       store: this.bindings.store,
       density: this.density,
       imageSize: this.imageSize,

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
@@ -330,7 +330,10 @@ export class AtomicCommerceRecommendationList
         this.imageSize
       ),
       content: this.productTemplateProvider.getTemplateContent(product),
-      linkContent: this.productTemplateProvider.getLinkTemplateContent(product),
+      linkContent:
+        this.display === 'grid'
+          ? this.productTemplateProvider.getLinkTemplateContent(product)
+          : this.productTemplateProvider.getEmptyLinkTemplateContent(),
       store: this.bindings.store,
       density: this.density,
       display: this.display,

--- a/packages/atomic/src/components/common/template-provider/template-provider.ts
+++ b/packages/atomic/src/components/common/template-provider/template-provider.ts
@@ -73,6 +73,10 @@ export abstract class TemplateProvider<ItemType> {
     return this.templateManager.selectLinkTemplate(item)!;
   }
 
+  public getEmptyLinkTemplateContent() {
+    return document.createDocumentFragment();
+  }
+
   public get templatesRegistered() {
     return this.props.getResultTemplateRegistered();
   }

--- a/packages/atomic/src/components/search/atomic-result/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-result/e2e/page-object.ts
@@ -1,0 +1,8 @@
+import type {Page} from '@playwright/test';
+import {BasePageObject} from '../../../../../playwright-utils/base-page-object';
+
+export class AtomicResultPageObject extends BasePageObject<'atomic-result'> {
+  constructor(page: Page) {
+    super(page, 'atomic-result');
+  }
+}

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -3,7 +3,16 @@ import {renderComponent} from '@coveo/atomic/storybookUtils/common/render-compon
 import {wrapInSearchInterface} from '@coveo/atomic/storybookUtils/search/search-interface-wrapper';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
 
-const {decorator, play} = wrapInSearchInterface();
+const {decorator, play} = wrapInSearchInterface({
+  search: {
+    preprocessSearchResponseMiddleware: (r) => {
+      const [result] = r.body.results;
+      result.title = 'Manage the Coveo In-Product Experiences (IPX)';
+      result.clickUri = 'https://docs.coveo.com/en/3160';
+      return r;
+    },
+  },
+});
 const meta: Meta = {
   component: 'atomic-result-list',
   title: 'Atomic/ResultList',
@@ -18,5 +27,12 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {
-  name: 'atomic-result-list',
+  name: 'List Display',
+};
+
+export const Grid: Story = {
+  name: 'Grid Display',
+  args: {
+    'attributes-display': 'grid',
+  },
 };

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -269,7 +269,10 @@ export class AtomicResultList implements InitializableComponent {
         this.imageSize
       ),
       content: this.itemTemplateProvider.getTemplateContent(result),
-      linkContent: this.itemTemplateProvider.getLinkTemplateContent(result),
+      linkContent:
+        this.display === 'grid'
+          ? this.itemTemplateProvider.getLinkTemplateContent(result)
+          : this.itemTemplateProvider.getEmptyLinkTemplateContent(),
       store: this.bindings.store,
       density: this.density,
       imageSize: this.imageSize,

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/atomic-result-list.e2e.ts
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/atomic-result-list.e2e.ts
@@ -1,0 +1,35 @@
+import {test, expect} from './fixture';
+
+test.describe('When using a list layout', () => {
+  test.beforeEach(async ({resultList}) => {
+    await resultList.load();
+  });
+
+  test.describe('when clicking a result', () => {
+    test.beforeEach(async ({result}) => {
+      await result.hydrated.first().click();
+    });
+
+    test('should not navigate', async ({page}) => {
+      expect(page.url()).toContain('http://localhost:4400/iframe.html');
+    });
+  });
+});
+
+test.describe('When using a grid layout', () => {
+  test.beforeEach(async ({resultList}) => {
+    await resultList.load({story: 'grid'});
+  });
+
+  test.describe('when clicking a result', () => {
+    test.beforeEach(async ({result}) => {
+      await result.hydrated.first().click();
+    });
+
+    test('should navigate', async ({page}) => {
+      await expect
+        .poll(() => page.url())
+        .toContain('https://docs.coveo.com/en/3160');
+    });
+  });
+});

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/fixture.ts
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/fixture.ts
@@ -1,0 +1,24 @@
+import {test as base} from '@playwright/test';
+import {
+  AxeFixture,
+  makeAxeBuilder,
+} from '../../../../../../playwright-utils/base-fixture';
+import {AtomicResultPageObject as Result} from '../../../atomic-result/e2e/page-object';
+import {AtomicResultListPageObject as ResultList} from './page-object';
+
+type Fixture = {
+  resultList: ResultList;
+  result: Result;
+};
+
+export const test = base.extend<Fixture & AxeFixture>({
+  makeAxeBuilder,
+  resultList: async ({page}, use) => {
+    await use(new ResultList(page));
+  },
+  result: async ({page}, use) => {
+    await use(new Result(page));
+  },
+});
+
+export {expect} from '@playwright/test';

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/e2e/page-object.ts
@@ -1,0 +1,8 @@
+import type {Page} from '@playwright/test';
+import {BasePageObject} from '../../../../../../playwright-utils/base-page-object';
+
+export class AtomicResultListPageObject extends BasePageObject<'atomic-result-list'> {
+  constructor(page: Page) {
+    super(page, 'atomic-result-list');
+  }
+}


### PR DESCRIPTION
Current behaviour: All atomic-result/product are clickable and default to a 'default' atomic-result/product-link.

Expected behaviour: That should have been the case only with the grid layout.

[KIT-3508](https://coveord.atlassian.net/browse/KIT-3508)

[KIT-3508]: https://coveord.atlassian.net/browse/KIT-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ