### PR TITLE
fix(headless)!: removed unused parameters from logExpandToFullUI action

### DIFF
--- a/packages/headless/src/features/insight-search/insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/insight-search/insight-analytics-actions.test.ts
@@ -106,12 +106,11 @@ describe('insight analytics actions', () => {
 
     describe('logExpandToFullUI', () => {
       it('should call coveo.analytics.logExpandToFullUI properly', async () => {
-        await logExpandToFullUI(
-          exampleCaseId,
-          exampleCaseNumber,
-          'c__FullSearch',
-          'openFullSearchButton'
-        )()(engine.dispatch, () => engine.state, {} as ThunkExtraArguments);
+        await logExpandToFullUI('c__FullSearch', 'openFullSearchButton')()(
+          engine.dispatch,
+          () => engine.state,
+          {} as ThunkExtraArguments
+        );
 
         const expectedPayload = {
           caseContext: {
@@ -164,7 +163,7 @@ describe('insight analytics actions', () => {
 
     describe('logExpandToFullUI', () => {
       it('should call relay.emit properly', async () => {
-        await logExpandToFullUI(exampleCaseId, exampleCaseNumber, '', '')()(
+        await logExpandToFullUI('', '')()(
           engine.dispatch,
           () => engine.state,
           {} as ThunkExtraArguments

--- a/packages/headless/src/features/insight-search/insight-analytics-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-analytics-actions.ts
@@ -15,8 +15,6 @@ export interface CreateArticleMetadata {
 }
 
 export const logExpandToFullUI = (
-  _caseId: string,
-  _caseNumber: string,
   fullSearchComponentName: string,
   triggeredBy: string
 ): InsightAction =>


### PR DESCRIPTION
[SFINT-5419](https://coveord.atlassian.net/browse/SFINT-5419)

- removed unused parameters from the `logExpandToFullUI` action, `caseId` and `caseNumber` are grabbed from the state instead of from the passed parameters.

[SFINT-5419]: https://coveord.atlassian.net/browse/SFINT-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ