### PR TITLE
draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,6 +2676,127 @@
         "playwright-core": ">= 1.0.0"
       }
     },
+    "node_modules/@babel/cli": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.6.tgz",
+      "integrity": "sha512-Z+Doemr4VtvSD2SNHTrkiFZ1LX+JI6tyRXAAOb4N9khIuPyoEPmTPJarPm8ljJV1D6bnMQjyHMWTT9NeKbQuXA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
@@ -8317,6 +8438,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -33382,6 +33510,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
       "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew=="
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -59836,6 +59970,8 @@
         "marked": "12.0.2"
       },
       "devDependencies": {
+        "@babel/cli": "7.25.6",
+        "@babel/plugin-transform-async-to-generator": "7.24.7",
         "@ckeditor/jsdoc-plugins": "39.9.1",
         "@coveo/relay-event-types": "7.14.1",
         "@coveo/release": "1.0.0",
@@ -59971,6 +60107,18 @@
         "node": ">=6.9.0"
       }
     },
+    "packages/quantic/node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "packages/quantic/node_modules/@babel/helper-compilation-targets": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
@@ -60027,6 +60175,32 @@
         "node": ">=6.9.0"
       }
     },
+    "packages/quantic/node_modules/@babel/helper-plugin-utils": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "packages/quantic/node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
+      "integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-wrap-function": "^7.25.0",
+        "@babel/traverse": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "packages/quantic/node_modules/@babel/helper-simple-access": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
@@ -60049,6 +60223,20 @@
         "node": ">=6.9.0"
       }
     },
+    "packages/quantic/node_modules/@babel/helper-wrap-function": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
+      "integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.0",
+        "@babel/types": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "packages/quantic/node_modules/@babel/helpers": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
@@ -60057,6 +60245,36 @@
       "dependencies": {
         "@babel/template": "^7.25.0",
         "@babel/types": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "packages/quantic/node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.7.tgz",
+      "integrity": "sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-remap-async-to-generator": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "packages/quantic/node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-module-imports": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -60336,6 +60554,23 @@
       "bin": {
         "lwc-jest": "bin/sfdx-lwc-jest",
         "sfdx-lwc-jest": "bin/sfdx-lwc-jest"
+      }
+    },
+    "packages/quantic/node_modules/@salesforce/sfdx-lwc-jest/node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
+      "integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-remap-async-to-generator": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "packages/quantic/node_modules/@salesforce/sfdx-lwc-jest/node_modules/@lwc/compiler": {

--- a/packages/quantic/babel.config.json
+++ b/packages/quantic/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@babel/plugin-transform-async-to-generator"]
+}

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -1,6 +1,7 @@
 const {promisify} = require('util');
 const ncp = promisify(require('ncp'));
 const mkdir = promisify(require('fs').mkdir);
+const rm = promisify(require('fs').rm);
 
 const copy = async (source, dest) => {
   try {
@@ -69,25 +70,27 @@ const copyHeadless = async () => {
     {recursive: true}
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic-compiled/headless.js',
+    '.tmp/quantic-compiled/headless.js',
     './force-app/main/default/staticresources/coveoheadless/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic-compiled/case-assist/headless.js',
+    '.tmp/quantic-compiled/case-assist/headless.js',
     './force-app/main/default/staticresources/coveoheadless/case-assist/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic-compiled/insight/headless.js',
+    '.tmp/quantic-compiled/insight/headless.js',
     './force-app/main/default/staticresources/coveoheadless/insight/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic-compiled/recommendation/headless.js',
+    '.tmp/quantic-compiled/recommendation/headless.js',
     './force-app/main/default/staticresources/coveoheadless/recommendation/headless.js'
   );
   await copy(
     '../../node_modules/@coveo/headless/dist/definitions',
     './force-app/main/default/staticresources/coveoheadless/definitions'
   );
+
+  await rm('.tmp', {recursive: true});
 
   console.info('Headless copied.');
 };

--- a/packages/quantic/copy-static-resources.js
+++ b/packages/quantic/copy-static-resources.js
@@ -69,19 +69,19 @@ const copyHeadless = async () => {
     {recursive: true}
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic/headless.js',
+    '../../node_modules/@coveo/headless/dist/quantic-compiled/headless.js',
     './force-app/main/default/staticresources/coveoheadless/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic/case-assist/headless.js',
+    '../../node_modules/@coveo/headless/dist/quantic-compiled/case-assist/headless.js',
     './force-app/main/default/staticresources/coveoheadless/case-assist/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic/insight/headless.js',
+    '../../node_modules/@coveo/headless/dist/quantic-compiled/insight/headless.js',
     './force-app/main/default/staticresources/coveoheadless/insight/headless.js'
   );
   await copy(
-    '../../node_modules/@coveo/headless/dist/quantic/recommendation/headless.js',
+    '../../node_modules/@coveo/headless/dist/quantic-compiled/recommendation/headless.js',
     './force-app/main/default/staticresources/coveoheadless/recommendation/headless.js'
   );
   await copy(

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -43,7 +43,7 @@
     "promote:npm:latest": "node ../../scripts/deploy/update-npm-tag.mjs latest",
     "preinstall": "node scripts/npm/check-sfdx-project.js",
     "postinstall": "node scripts/npm/setup-quantic.js",
-    "babel:headless": "babel ../../node_modules/@coveo/headless/dist/quantic --out-dir ../../node_modules/@coveo/headless/dist/quantic-compiled --extensions .js --plugins @babel/plugin-transform-async-to-generator --minified"
+    "babel:headless": "babel ../../node_modules/@coveo/headless/dist/quantic --out-dir .tmp/quantic-compiled --extensions .js --plugins @babel/plugin-transform-async-to-generator --minified"
   },
   "dependencies": {
     "@coveo/bueno": "0.46.1",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -42,7 +42,8 @@
     "publish:bump": "npm run-script -w=@coveo/release bump",
     "promote:npm:latest": "node ../../scripts/deploy/update-npm-tag.mjs latest",
     "preinstall": "node scripts/npm/check-sfdx-project.js",
-    "postinstall": "node scripts/npm/setup-quantic.js"
+    "postinstall": "node scripts/npm/setup-quantic.js",
+    "babel:headless": "babel ../../node_modules/@coveo/headless/dist/quantic --out-dir ../../node_modules/@coveo/headless/dist/quantic-compiled --extensions .js --plugins @babel/plugin-transform-async-to-generator --minified"
   },
   "dependencies": {
     "@coveo/bueno": "0.46.1",
@@ -54,6 +55,8 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
+    "@babel/cli": "7.25.6",
+    "@babel/plugin-transform-async-to-generator": "7.24.7",
     "@ckeditor/jsdoc-plugins": "39.9.1",
     "@coveo/relay-event-types": "7.14.1",
     "@coveo/release": "1.0.0",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -43,7 +43,7 @@
     "promote:npm:latest": "node ../../scripts/deploy/update-npm-tag.mjs latest",
     "preinstall": "node scripts/npm/check-sfdx-project.js",
     "postinstall": "node scripts/npm/setup-quantic.js",
-    "babel:headless": "babel ../../node_modules/@coveo/headless/dist/quantic --out-dir .tmp/quantic-compiled --extensions .js --plugins @babel/plugin-transform-async-to-generator --minified"
+    "babel:headless": "babel ../../node_modules/@coveo/headless/dist/quantic --out-dir .tmp/quantic-compiled --extensions .js --minified"
   },
   "dependencies": {
     "@coveo/bueno": "0.46.1",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/coveo/ui-kit.git"
   },
   "scripts": {
-    "test": "npm run build:staticresources && npm run lint:check:tests && npm run validate:types && npm run test:unit",
+    "test": "npm run babel:headless && npm run build:staticresources && npm run lint:check:tests && npm run validate:types && npm run test:unit",
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
     "lint:fix": "npm run lint:fix:js",
     "lint:fix:js": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --write",

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -22,8 +22,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "npm run babel:headless",
-          "npm run build:staticresources",
+          "npm run babel:headless && npm run build:staticresources",
           "npm run build:doc"
         ],
         "parallel": true,

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -21,7 +21,11 @@
       ],
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["npm run build:staticresources", "npm run build:doc"],
+        "commands": [
+          "npm run babel:headless",
+          "npm run build:staticresources",
+          "npm run build:doc"
+        ],
         "parallel": true,
         "cwd": "packages/quantic"
       }


### PR DESCRIPTION
Salesforce LWS has a problem with static resources files using async/await on Firefox.

This PR adds a script to use Babel to transform the headless.js files we use to transform async to promises.

- Add babel to quantic
- Use babel plugin @babel/plugin-transform-async-to-generator to transform built headless.js to transform async to promise.
- Added this step prior to running the copy-static-resource in the nx build script.

If I correctly understands Babel's documentation.
- If I don't set a `preset` in babel configuration, it won't do anything.
- So it should only apply the transformation included by the `@babel/plugin-transform-async-to-generator` included in the list of `plugins: []` in the `babel.config.json`
- I checked all other static resources we include in the package, and headless.js is the only one using `async/await` natively. (markedjs, dompurify, and Bueno don't use those)
-

---------------------------------------------------

## Comparison of bundle sizes

### Before Babel transformation

![image](https://github.com/user-attachments/assets/373dbca2-af66-4137-8b19-278f1aba2d18)


### After Babel transformation

![image](https://github.com/user-attachments/assets/6c08e476-988a-4b04-844e-8397a0be246d)
