### PR TITLE
chore(headless)!: change bundled files extension to .mjs to officially indicate they are modules

### DIFF
--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -46,7 +46,7 @@ function replaceHeadlessMap() {
       bundle[headlessBundle].map = null;
 
       bundle[headlessBundle].code +=
-        '//# sourceMappingURL=./headless/headless.esm.js.map';
+        '//# sourceMappingURL=./headless/headless.mjs.map';
       return bundle;
     },
   };
@@ -190,49 +190,49 @@ export const config: Config = {
               find: '@coveo/headless/case-assist',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/case-assist/headless.esm.js'
+                './src/external-builds/case-assist/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless/commerce',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/commerce/headless.esm.js'
+                './src/external-builds/commerce/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless/recommendation',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/recommendation/headless.esm.js'
+                './src/external-builds/recommendation/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless/commerce',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/commerce/headless.esm.js'
+                './src/external-builds/commerce/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless/product-recommendation',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/product-recommendation/headless.esm.js'
+                './src/external-builds/product-recommendation/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless/insight',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/insight/headless.esm.js'
+                './src/external-builds/insight/headless.mjs'
               ),
             },
             {
               find: '@coveo/headless',
               replacement: path.resolve(
                 __dirname,
-                './src/external-builds/headless.esm.js'
+                './src/external-builds/headless.mjs'
               ),
             },
           ],

--- a/packages/headless/case-assist/package.json
+++ b/packages/headless/case-assist/package.json
@@ -3,8 +3,8 @@
   "name": "case-assist",
   "description": "Headless Case Assist Module",
   "main": "../dist/case-assist/headless.js",
-  "module": "../dist/case-assist/headless.esm.js",
-  "browser": "../dist/browser/case-assist/headless.esm.js",
+  "module": "../dist/case-assist/headless.mjs",
+  "browser": "../dist/browser/case-assist/headless.mjs",
   "types": "../dist/definitions/case-assist.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/commerce/package.json
+++ b/packages/headless/commerce/package.json
@@ -3,8 +3,8 @@
   "name": "commerce",
   "description": "Headless Commerce Module",
   "main": "../dist/commerce/headless.js",
-  "module": "../dist/commerce/headless.esm.js",
-  "browser": "../dist/browser/commerce/headless.esm.js",
+  "module": "../dist/commerce/headless.mjs",
+  "browser": "../dist/browser/commerce/headless.mjs",
   "types": "../dist/definitions/commerce.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/contributors/adding-a-sub-package.md
+++ b/packages/headless/contributors/adding-a-sub-package.md
@@ -44,8 +44,8 @@ Headless provides exports through multiple sub packages. A sub-package groups to
      "name": "case-assist",
      "description": "Headless Case Assist Module",
      "main": "../dist/case-assist/headless.js",
-     "module": "../dist/case-assist/headless.esm.js",
-     "browser": "../dist/browser/case-assist/headless.esm.js",
+     "module": "../dist/case-assist/headless.mjs",
+     "browser": "../dist/browser/case-assist/headless.mjs",
      "types": "../dist/definitions/case-assist.index.d.ts",
      "license": "Apache-2.0"
    }

--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -78,7 +78,7 @@ const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map(
   (entry) => {
     const [useCase, entryPoint] = entry;
     const outDir = getUseCaseDir('../atomic/src/external-builds', useCase);
-    const outfile = `${outDir}/headless.esm.js`;
+    const outfile = `${outDir}/headless.mjs`;
 
     return buildBrowserConfig(
       {
@@ -96,7 +96,7 @@ const browserEsmForAtomicDevelopment = Object.entries(useCaseEntries).map(
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('dist/browser', useCase);
-  const outfile = `${outDir}/headless.esm.js`;
+  const outfile = `${outDir}/headless.mjs`;
 
   let config = {
     entryPoints: [entryPoint],
@@ -220,7 +220,7 @@ const nodeCjs = Object.entries(useCaseEntries).map((entry) => {
 const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const dir = getUseCaseDir('dist/', useCase);
-  const outfile = `${dir}/headless.esm.js`;
+  const outfile = `${dir}/headless.mjs`;
 
   return buildNodeConfig(
     {
@@ -280,7 +280,7 @@ function getNodeEsmBundlePaths() {
   return Object.entries(useCaseEntries).map((entry) => {
     const [useCase] = entry;
     const dir = getUseCaseDir('dist/', useCase);
-    return `${dir}/headless.esm.js`;
+    return `${dir}/headless.mjs`;
   });
 }
 

--- a/packages/headless/insight/package.json
+++ b/packages/headless/insight/package.json
@@ -3,8 +3,8 @@
   "name": "insight",
   "description": "Headless Insight Module",
   "main": "../dist/insight/headless.js",
-  "module": "../dist/insight/headless.esm.js",
-  "browser": "../dist/browser/insight/headless.esm.js",
+  "module": "../dist/insight/headless.mjs",
+  "browser": "../dist/browser/insight/headless.mjs",
   "types": "../dist/definitions/insight.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -7,9 +7,9 @@
     "directory": "packages/headless"
   },
   "main": "./dist/headless.js",
-  "module": "./dist/headless.esm.js",
+  "module": "./dist/headless.mjs",
   "browser": {
-    "./dist/headless.esm.js": "./dist/browser/headless.esm.js",
+    "./dist/headless.mjs": "./dist/browser/headless.mjs",
     "./dist/headless.js": "./dist/browser/headless.js"
   },
   "types": "./dist/definitions/index.d.ts",

--- a/packages/headless/product-listing/package.json
+++ b/packages/headless/product-listing/package.json
@@ -3,8 +3,8 @@
   "name": "product-listing",
   "description": "Headless Product Listing Module",
   "main": "../dist/product-listing/headless.js",
-  "module": "../dist/product-listing/headless.esm.js",
-  "browser": "../dist/browser/product-listing/headless.esm.js",
+  "module": "../dist/product-listing/headless.mjs",
+  "browser": "../dist/browser/product-listing/headless.mjs",
   "types": "../dist/definitions/product-listing.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/product-recommendation/package.json
+++ b/packages/headless/product-recommendation/package.json
@@ -3,8 +3,8 @@
   "name": "product-recommendation",
   "description": "Headless Product Recommendation Module",
   "main": "../dist/product-recommendation/headless.js",
-  "module": "../dist/product-recommendation/headless.esm.js",
-  "browser": "../dist/browser/product-recommendation/headless.esm.js",
+  "module": "../dist/product-recommendation/headless.mjs",
+  "browser": "../dist/browser/product-recommendation/headless.mjs",
   "types": "../dist/definitions/product-recommendation.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/recommendation/package.json
+++ b/packages/headless/recommendation/package.json
@@ -3,8 +3,8 @@
   "name": "recommendation",
   "description": "Headless Recommendation Module",
   "main": "../dist/recommendation/headless.js",
-  "module": "../dist/recommendation/headless.esm.js",
-  "browser": "../dist/browser/recommendation/headless.esm.js",
+  "module": "../dist/recommendation/headless.mjs",
+  "browser": "../dist/browser/recommendation/headless.mjs",
   "types": "../dist/definitions/recommendation.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/ssr-commerce/package.json
+++ b/packages/headless/ssr-commerce/package.json
@@ -3,8 +3,8 @@
   "name": "ssr-commerce",
   "description": "Server side rendering utilities for commerce",
   "main": "../dist/ssr-commerce/headless.js",
-  "module": "../dist/ssr-commerce/headless.esm.js",
-  "browser": "../dist/browser/ssr-commerce/headless.esm.js",
+  "module": "../dist/ssr-commerce/headless.mjs",
+  "browser": "../dist/browser/ssr-commerce/headless.mjs",
   "types": "../dist/definitions/ssr-commerce.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/packages/headless/ssr/package.json
+++ b/packages/headless/ssr/package.json
@@ -3,8 +3,8 @@
   "name": "ssr",
   "description": "Server side rendering utilities",
   "main": "../dist/ssr/headless.js",
-  "module": "../dist/ssr/headless.esm.js",
-  "browser": "../dist/browser/ssr/headless.esm.js",
+  "module": "../dist/ssr/headless.mjs",
+  "browser": "../dist/browser/ssr/headless.mjs",
   "types": "../dist/definitions/ssr.index.d.ts",
   "license": "Apache-2.0"
 }

--- a/scripts/reports/bundle-size/command.mjs
+++ b/scripts/reports/bundle-size/command.mjs
@@ -37,7 +37,7 @@ function getUseCasesAndFilePaths(dir) {
 
 function getEsmFilePaths(dir) {
   const paths = getFilePaths(dir);
-  return paths.filter((path) => path.endsWith('.esm.js'));
+  return paths.filter((path) => path.endsWith('.mjs'));
 }
 
 function getFilePaths(dir, files = []) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3512

could run into something like this eventually : https://github.com/FortAwesome/Font-Awesome/issues/16439

See this here https://github.com/FortAwesome/Font-Awesome/pull/19041#issuecomment-1198556784

- [ ] fix bundle size report