### PR TITLE
fix(atomic): fix atomic-commerce product card click invalid selector

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tsx
@@ -277,6 +277,7 @@ export class AtomicCommerceProductList
       const {interactiveProduct} = propsForAtomicProduct;
       return (
         <DisplayGrid
+          selectorForItem="atomic-product"
           item={{
             ...product,
             clickUri: product.clickUri,

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tsx
@@ -348,6 +348,7 @@ export class AtomicCommerceRecommendationList
     const {interactiveProduct} = propsForAtomicProduct;
     return (
       <DisplayGrid
+        selectorForItem="atomic-product"
         item={{
           ...product,
           clickUri: product.clickUri,

--- a/packages/atomic/src/components/common/item-list/display-grid.tsx
+++ b/packages/atomic/src/components/common/item-list/display-grid.tsx
@@ -1,6 +1,7 @@
 import {FunctionalComponent, h} from '@stencil/core';
 
 export interface DisplayGridProps {
+  selectorForItem: string;
   item: {clickUri: string; title: string};
   setRef: (element?: HTMLElement) => void;
   select: () => void;
@@ -9,7 +10,7 @@ export interface DisplayGridProps {
 }
 
 export const DisplayGrid: FunctionalComponent<DisplayGridProps> = (
-  {setRef},
+  {setRef, selectorForItem},
   children
 ) => {
   let ref: HTMLElement | undefined;
@@ -22,7 +23,7 @@ export const DisplayGrid: FunctionalComponent<DisplayGridProps> = (
       }}
       onClick={(event) => {
         event.preventDefault();
-        ref?.querySelector('atomic-product')?.click();
+        (ref?.querySelector(selectorForItem) as HTMLElement)?.click();
       }}
     >
       {...children}

--- a/packages/atomic/src/components/common/item-list/display-grid.tsx
+++ b/packages/atomic/src/components/common/item-list/display-grid.tsx
@@ -22,7 +22,7 @@ export const DisplayGrid: FunctionalComponent<DisplayGridProps> = (
       }}
       onClick={(event) => {
         event.preventDefault();
-        ref?.querySelector('atomic-result')?.click();
+        ref?.querySelector('atomic-product')?.click();
       }}
     >
       {...children}

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-recs-list/atomic-ipx-recs-list.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-recs-list/atomic-ipx-recs-list.tsx
@@ -385,6 +385,7 @@ export class AtomicIPXRecsList implements InitializableComponent<RecsBindings> {
       this.getPropsForAtomicRecsResult(recommendation);
     return (
       <DisplayGrid
+        selectorForItem="atomic-recs-result"
         item={recommendation}
         {...propsForAtomicRecsResult.interactiveResult}
         setRef={(element) =>

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.tsx
@@ -359,6 +359,7 @@ export class AtomicRecsList implements InitializableComponent<RecsBindings> {
       this.getPropsForAtomicRecsResult(recommendation);
     return (
       <DisplayGrid
+        selectorForItem="atomic-recs-result"
         item={recommendation}
         {...propsForAtomicRecsResult.interactiveResult}
         setRef={(element) =>

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.tsx
@@ -295,6 +295,7 @@ export class AtomicResultList implements InitializableComponent {
       const propsForAtomicResult = this.getPropsForAtomicResult(result);
       return (
         <DisplayGrid
+          selectorForItem="atomic-result"
           item={result}
           {...propsForAtomicResult.interactiveResult}
           setRef={(element) =>


### PR DESCRIPTION
`DisplayGrid` is a "generic" file, used by different use cases. However, it hardcoded `atomic-result` as a selector, which is specific to the search use case.

https://coveord.atlassian.net/browse/KIT-3513