### PR TITLE
fix(atomic): fix commerce facets being re-attached to the DOM

### DIFF
--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-category-facet/atomic-commerce-category-facet.tsx
@@ -123,7 +123,7 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
   private showMoreFocus?: FocusTargetController;
   private headerFocus?: FocusTargetController;
   private activeValueFocus?: FocusTargetController;
-  private unsubscribeFacetController!: () => void;
+  private unsubscribeFacetController?: () => void | undefined;
 
   @AriaLiveRegion('facet-search')
   protected facetSearchAriaMessage!: string;
@@ -133,10 +133,7 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
       return;
     }
 
-    this.unsubscribeFacetController = this.facet.subscribe(
-      () => (this.facetState = this.facet.state)
-    );
-
+    this.ensureSubscribed();
     announceFacetSearchResultsWithAriaLive(
       this.facet,
       this.displayName,
@@ -188,7 +185,12 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
     if (this.host.isConnected) {
       return;
     }
-    this.unsubscribeFacetController();
+    this.unsubscribeFacetController?.();
+    this.unsubscribeFacetController = undefined;
+  }
+
+  public connectedCallback(): void {
+    this.ensureSubscribed();
   }
 
   private get isHidden() {
@@ -503,6 +505,15 @@ export class AtomicCategoryFacet implements InitializableComponent<Bindings> {
           </FacetContainer>
         }
       </FacetGuard>
+    );
+  }
+
+  private ensureSubscribed() {
+    if (this.unsubscribeFacetController) {
+      return;
+    }
+    this.unsubscribeFacetController = this.facet.subscribe(
+      () => (this.facetState = this.facet.state)
     );
   }
 }

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-facet/atomic-commerce-facet.tsx
@@ -123,7 +123,7 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
   private showLessFocus?: FocusTargetController;
   private showMoreFocus?: FocusTargetController;
   private headerFocus?: FocusTargetController;
-  private unsubscribeFacetController!: () => void;
+  private unsubscribeFacetController?: () => void | undefined;
 
   @AriaLiveRegion('facet-search')
   protected facetSearchAriaMessage!: string;
@@ -132,15 +132,18 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
     if (!this.facet) {
       return;
     }
-    this.unsubscribeFacetController = this.facet.subscribe(
-      () => (this.facetState = this.facet.state)
-    );
+    this.ensureSubscribed();
     this.initAriaLive();
     this.initPopover();
   }
 
+  public connectedCallback(): void {
+    this.ensureSubscribed();
+  }
+
   public disconnectedCallback(): void {
-    this.unsubscribeFacetController();
+    this.unsubscribeFacetController?.();
+    this.unsubscribeFacetController = undefined;
   }
 
   public componentShouldUpdate(
@@ -397,6 +400,15 @@ export class AtomicCommerceFacet implements InitializableComponent<Bindings> {
     return (
       propName === 'facetState' &&
       typeof (state as RegularFacetState)?.facetId === 'string'
+    );
+  }
+
+  private ensureSubscribed() {
+    if (this.unsubscribeFacetController) {
+      return;
+    }
+    this.unsubscribeFacetController = this.facet.subscribe(
+      () => (this.facetState = this.facet.state)
     );
   }
 }

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tsx
@@ -88,7 +88,7 @@ export class AtomicCommerceNumericFacet
     return this.headerFocus;
   }
 
-  private unsubscribeFacetController!: () => void;
+  private unsubscribeFacetController?: () => void | undefined;
 
   public initialize() {
     if (!this.facet) {
@@ -96,16 +96,17 @@ export class AtomicCommerceNumericFacet
     }
 
     this.context = buildContext(this.bindings.engine);
-
-    this.unsubscribeFacetController = this.facet.subscribe(
-      () => (this.facetState = this.facet.state)
-    );
-
+    this.ensureSubscribed();
     this.registerFacetToStore();
   }
 
+  public connectedCallback() {
+    this.ensureSubscribed();
+  }
+
   public disconnectedCallback() {
-    this.unsubscribeFacetController();
+    this.unsubscribeFacetController?.();
+    this.unsubscribeFacetController = undefined;
   }
 
   private get formatter() {
@@ -278,5 +279,14 @@ export class AtomicCommerceNumericFacet
     }
 
     return !!this.valuesToRender.length;
+  }
+
+  private ensureSubscribed() {
+    if (this.unsubscribeFacetController) {
+      return;
+    }
+    this.unsubscribeFacetController = this.facet.subscribe(
+      () => (this.facetState = this.facet.state)
+    );
   }
 }

--- a/packages/atomic/src/components/commerce/facets/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tsx
+++ b/packages/atomic/src/components/commerce/facets/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tsx
@@ -86,18 +86,18 @@ export class AtomicCommerceTimeframeFacet
     return this.headerFocus;
   }
 
-  private unsubscribeFacetController!: () => void;
+  private unsubscribeFacetController?: () => void | undefined;
 
   public initialize() {
     if (!this.facet) {
       return;
     }
-
-    this.unsubscribeFacetController = this.facet.subscribe(
-      () => (this.facetState = this.facet.state)
-    );
-
+    this.ensureSubscribed();
     this.registerFacetToStore();
+  }
+
+  public connectedCallback(): void {
+    this.ensureSubscribed();
   }
 
   @Listen('atomic/dateInputApply')
@@ -168,7 +168,8 @@ export class AtomicCommerceTimeframeFacet
     if (this.host.isConnected) {
       return;
     }
-    this.unsubscribeFacetController();
+    this.unsubscribeFacetController?.();
+    this.unsubscribeFacetController = undefined;
   }
 
   private get isHidden() {
@@ -316,6 +317,15 @@ export class AtomicCommerceTimeframeFacet
           </FacetContainer>
         }
       </FacetGuard>
+    );
+  }
+
+  private ensureSubscribed() {
+    if (this.unsubscribeFacetController) {
+      return;
+    }
+    this.unsubscribeFacetController = this.facet.subscribe(
+      () => (this.facetState = this.facet.state)
     );
   }
 }


### PR DESCRIPTION
In commerce facets, we were missing defensive code around unsubscribe/resubscribe VS connectedCallback/disconnectedCallback (ie: stencil lifecycle when a facet gets moved around in the DOM).

End result is that we end up with a facet that is no longer subscribed to controller state changes for re-render.

Technically could have done it with "unsubscribe only if the host is also disconnected" kinda logic, but this should do just as well.

https://coveord.atlassian.net/browse/KIT-3517