### PR TITLE
fix(quantic): expandable searchbox not collapsing back to normal height after clearing 

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -311,6 +311,7 @@ export default class QuanticSearchBoxInput extends LightningElement {
 
   clearInput() {
     this.sendInputValueChangeEvent('');
+    this.input.value = '';
     this.input.focus();
     if (this.textarea) {
       this.adjustTextAreaHeight();


### PR DESCRIPTION
[SFINT-5700](https://coveord.atlassian.net/browse/SFINT-5700)

### ISSUE:

https://github.com/user-attachments/assets/92119536-8fd3-4d8e-8e48-3f6c7c27019c

When `clearInput` was called upon pressing the clear icon, it was sending an input value change event with an empty value, focusing on the input and then, if it was a textarea (expandable), it would call the `adjustTextAreaHeight` function.

This `adjustTextAreaHeight` function did the following: 

`    this.input.style.height = this.input.scrollHeight + 'px';
`

So the issue was that after focusing on the input, the `this.input.scrollHeight` would still be equal to the height of the content before clearing since the content itself was not wiped. It would therefore adjust the height of the textarea with the previous content height even though the value of the input was afterwards ''.

### SOLUTION:

By setting `this.input.value = ''` when clearing, we insure that whenever the user clears by clicking the clear icon, it resets the height of the textarea to its default height of 48px.

### DEMO:

https://github.com/user-attachments/assets/df2cc433-954f-4f95-9140-084e77c887e6


