### PR TITLE
ci: use pure conventionalcommits.org commit convention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21928,7 +21928,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead"
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -25240,6 +25241,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
@@ -55315,7 +55317,6 @@
         "@coveo/relay-event-types": "9.4.0",
         "@microsoft/fetch-event-source": "2.0.1",
         "@reduxjs/toolkit": "2.2.7",
-        "abab": "2.0.6",
         "abortcontroller-polyfill": "1.7.5",
         "coveo.analytics": "2.30.26",
         "dayjs": "1.11.12",
@@ -62179,7 +62180,7 @@
         "@npmcli/arborist": "7.5.4",
         "@octokit/auth-app": "6.1.1",
         "async-retry": "1.3.3",
-        "conventional-changelog-angular": "7.0.0",
+        "conventional-changelog-conventionalcommits": "8.0.0",
         "dependency-graph": "1.0.0",
         "octokit": "3.2.1",
         "semver": "7.6.3",
@@ -62337,6 +62338,18 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "utils/release/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "utils/release/node_modules/hosted-git-info": {

--- a/utils/release/bump-package.mjs
+++ b/utils/release/bump-package.mjs
@@ -11,7 +11,7 @@ import {
   getSHA1fromRef,
 } from '@coveo/semantic-monorepo-tools';
 // @ts-ignore no dts is ok
-import angularChangelogConvention from 'conventional-changelog-angular';
+import changelogConvention from 'conventional-changelog-conventionalcommits';
 import {spawnSync} from 'node:child_process';
 import {appendFileSync, readFileSync, writeFileSync} from 'node:fs';
 import {resolve, join} from 'node:path';
@@ -81,7 +81,7 @@ await (async () => {
     readFileSync('package.json', {encoding: 'utf-8'})
   );
   const versionPrefix = `${packageJson.name}@`;
-  const convention = await angularChangelogConvention();
+  const convention = await changelogConvention();
   const lastTag = await getLastTag(versionPrefix);
   const commits = await getCommits(PATH, lastTag);
   if (commits.length === 0 && !hasPackageJsonChanged(PATH)) {
@@ -97,7 +97,7 @@ await (async () => {
   const isRedo = gt(currentNpmVersion, currentGitVersion);
   const bumpInfo = isRedo
     ? {type: 'patch'}
-    : convention.recommendedBumpOpts.whatBump(parsedCommits);
+    : convention.whatBump(parsedCommits);
   const nextGoldVersion = getNextVersion(
     isRedo ? currentNpmVersion : currentGitVersion,
     bumpInfo

--- a/utils/release/package.json
+++ b/utils/release/package.json
@@ -9,7 +9,7 @@
     "@npmcli/arborist": "7.5.4",
     "@octokit/auth-app": "6.1.1",
     "async-retry": "1.3.3",
-    "conventional-changelog-angular": "7.0.0",
+    "conventional-changelog-conventionalcommits": "8.0.0",
     "dependency-graph": "1.0.0",
     "octokit": "3.2.1",
     "semver": "7.6.3",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3522

Tested manually:
 - `npm run nx:graph`
 - `npm run publish:bump` -> See that v3 exists where it should
 - `IS_PRERELEASE=true npm run publish:bump` -> See that the bump is a pre of v3, and not a full fledge v3.
