### PR TITLE
fix(headless): export missing types for ssr facet generator

### DIFF
--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ssr.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ssr.ts
@@ -76,9 +76,9 @@ export type {
 
 export type FacetGeneratorState = MappedFacetStates;
 
-type MappedFacetStates = Array<MappedFacetState[FacetType]>;
+export type MappedFacetStates = Array<MappedFacetState[FacetType]>;
 
-type MappedFacetState = {
+export type MappedFacetState = {
   [T in FacetType]: T extends 'numericalRange'
     ? NumericFacetState
     : T extends 'regular'

--- a/packages/headless/src/ssr-commerce.index.ts
+++ b/packages/headless/src/ssr-commerce.index.ts
@@ -74,6 +74,8 @@ export type {
   RegularFacet,
   RegularFacetState,
   RegularFacetValue,
+  MappedFacetStates,
+  MappedFacetState,
 } from './controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ssr';
 export {defineFacetGenerator} from './controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ssr';
 


### PR DESCRIPTION
These types can be useful for implementers.

For example, in Barca, could use them to create custom react hook (something like `useHydratedFacet()`) and have the hook properly typed.

https://coveord.atlassian.net/browse/KIT-3461