### PR TITLE
feat(generatedAnswerAnalyticsAction): stream id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25501,10 +25501,9 @@
       }
     },
     "node_modules/coveo.analytics": {
-      "version": "2.30.26",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.30.26.tgz",
-      "integrity": "sha512-HeKmwt254jHws2w7nCklKa8VCo0vnmZGv79/rXqJcNZraig5XQxBQoLbpphP3/L+SoP4F/m5nAOdE1C0QbaSuQ==",
-      "license": "MIT",
+      "version": "2.30.38",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.30.38.tgz",
+      "integrity": "sha512-CxiBWV7XxDNAyCWS7gwikHjJYz8NigYVHSkGU23JkcQf2oK0XJEsxcU/eRN3VRBfLLmhBTRZbpWJ1SW2imDovQ==",
       "dependencies": {
         "@types/uuid": "^9.0.0",
         "cross-fetch": "^3.1.5",
@@ -25516,7 +25515,6 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
       "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -25529,7 +25527,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -55318,7 +55315,7 @@
         "@microsoft/fetch-event-source": "2.0.1",
         "@reduxjs/toolkit": "2.2.7",
         "abortcontroller-polyfill": "1.7.5",
-        "coveo.analytics": "2.30.26",
+        "coveo.analytics": "2.30.38",
         "dayjs": "1.11.12",
         "exponential-backoff": "3.1.0",
         "fast-equals": "5.0.1",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -54,7 +54,7 @@
     "@microsoft/fetch-event-source": "2.0.1",
     "@reduxjs/toolkit": "2.2.7",
     "abortcontroller-polyfill": "1.7.5",
-    "coveo.analytics": "2.30.26",
+    "coveo.analytics": "2.30.38",
     "dayjs": "1.11.12",
     "exponential-backoff": "3.1.0",
     "fast-equals": "5.0.1",

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -96,10 +96,10 @@ const subscribeToSearchRequest = (
   const strictListener = () => {
     const state = engine.state;
     const triggerParams = selectAnswerTriggerParams(state);
-    if (triggerParams.requestId === undefined) {
+    if (triggerParams.q.length === 0 || triggerParams.requestId.length === 0) {
       return;
     }
-    if (JSON.stringify(triggerParams) === JSON.stringify(lastTriggerParams)) {
+    if (triggerParams?.requestId === lastTriggerParams?.requestId) {
       return;
     }
     lastTriggerParams = triggerParams;

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -36,13 +36,15 @@ export const logRephraseGeneratedAnswer = (
   responseFormat: GeneratedResponseFormat
 ): LegacySearchAction =>
   makeAnalyticsAction('analytics/generatedAnswer/rephrase', (client, state) => {
-    const generativeQuestionAnsweringId =
+    const {id: rgaID, answerAPIEnabled} =
       generativeQuestionAnsweringIdSelector(state);
-    if (!generativeQuestionAnsweringId) {
+    if (!rgaID) {
       return null;
     }
     return client.makeRephraseGeneratedAnswer({
-      generativeQuestionAnsweringId,
+      ...(answerAPIEnabled
+        ? {answerAPIStreamId: rgaID}
+        : {generativeQuestionAnsweringId: rgaID}),
       rephraseFormat: responseFormat.answerStyle,
     });
   });
@@ -53,14 +55,17 @@ export const logOpenGeneratedAnswerSource = (
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/openAnswerSource',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
       const citation = citationSourceSelector(state, citationId);
-      if (!generativeQuestionAnsweringId || !citation) {
+      if (!rgaID || !citation) {
         return null;
       }
+
       return client.makeOpenGeneratedAnswerSource({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
         permanentId: citation.permanentid,
         citationId: citation.id,
       });
@@ -87,15 +92,17 @@ export const logHoverCitation = (
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/hoverCitation',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
       const citation = citationSourceSelector(state, citationId);
 
-      if (!generativeQuestionAnsweringId || !citation) {
+      if (!rgaID || !citation) {
         return null;
       }
       return client.makeGeneratedAnswerSourceHover({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
         permanentId: citation.permanentid,
         citationId: citation.id,
         citationHoverTimeMs: citationHoverTimeInMs,
@@ -121,13 +128,15 @@ export const logLikeGeneratedAnswer = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/like',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeLikeGeneratedAnswer({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -146,13 +155,15 @@ export const logDislikeGeneratedAnswer = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/dislike',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeDislikeGeneratedAnswer({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -173,13 +184,15 @@ export const logGeneratedAnswerFeedback = (
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/sendFeedback',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerFeedbackSubmitV2({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
         ...feedback,
       });
     },
@@ -221,17 +234,19 @@ export const logGeneratedAnswerStreamEnd = (
   makeAnalyticsAction(
     'analytics/generatedAnswer/streamEnd',
     (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
       const answerTextIsEmpty = answerGenerated
         ? !state.generatedAnswer?.answer ||
           !state.generatedAnswer?.answer.length
         : undefined;
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerStreamEnd({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
         answerGenerated,
         answerTextIsEmpty,
       });
@@ -242,13 +257,15 @@ export const logGeneratedAnswerShowAnswers = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/show',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerShowAnswers({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -267,13 +284,15 @@ export const logGeneratedAnswerHideAnswers = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/hide',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerHideAnswers({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -292,13 +311,15 @@ export const logGeneratedAnswerExpand = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/expand',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerExpand({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -317,13 +338,15 @@ export const logGeneratedAnswerCollapse = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/collapse',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerCollapse({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',
@@ -342,13 +365,15 @@ export const logCopyGeneratedAnswer = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/copy',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.makeGeneratedAnswerCopyToClipboard({
-        generativeQuestionAnsweringId,
+        ...(answerAPIEnabled
+          ? {answerAPIStreamId: rgaID}
+          : {generativeQuestionAnsweringId: rgaID}),
       });
     },
     analyticsType: 'Qna.AnswerAction',

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -31,14 +31,16 @@ export const logRephraseGeneratedAnswer = (
   makeInsightAnalyticsActionFactory(SearchPageEvents.rephraseGeneratedAnswer)(
     'analytics/generatedAnswer/rephrase',
     (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logRephraseGeneratedAnswer(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
           rephraseFormat: responseFormat.answerStyle,
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
@@ -53,16 +55,18 @@ export const logOpenGeneratedAnswerSource = (
     {
       prefix: 'analytics/generatedAnswer/openAnswerSource',
       __legacy__getBuilder: (client, state) => {
-        const generativeQuestionAnsweringId =
+        const {id: rgaID, answerAPIEnabled} =
           generativeQuestionAnsweringIdSelector(state);
         const citation = citationSourceSelector(state, citationId);
 
-        if (!generativeQuestionAnsweringId || !citation) {
+        if (!rgaID || !citation) {
           return null;
         }
         return client.logOpenGeneratedAnswerSource(
           {
-            generativeQuestionAnsweringId,
+            ...(answerAPIEnabled
+              ? {answerAPIStreamId: rgaID}
+              : {generativeQuestionAnsweringId: rgaID}),
             permanentId: citation.permanentid,
             citationId: citation.id,
           },
@@ -95,16 +99,18 @@ export const logHoverCitation = (
   )({
     prefix: 'analytics/generatedAnswer/hoverCitation',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
       const citation = citationSourceSelector(state, citationId);
 
-      if (!generativeQuestionAnsweringId || !citation) {
+      if (!rgaID || !citation) {
         return null;
       }
       return client.logGeneratedAnswerSourceHover(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
           permanentId: citation.permanentid,
           citationId: citation.id,
           citationHoverTimeMs: citationHoverTimeInMs,
@@ -133,14 +139,16 @@ export const logLikeGeneratedAnswer = (): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.likeGeneratedAnswer)({
     prefix: 'analytics/generatedAnswer/like',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logLikeGeneratedAnswer(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -161,14 +169,16 @@ export const logDislikeGeneratedAnswer = (): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.dislikeGeneratedAnswer)({
     prefix: 'analytics/generatedAnswer/dislike',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logDislikeGeneratedAnswer(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -193,14 +203,16 @@ export const logGeneratedAnswerFeedback = (
   )({
     prefix: 'analytics/generatedAnswer/sendFeedback',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerFeedbackSubmitV2(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
           ...feedback,
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
@@ -244,14 +256,16 @@ export const logGeneratedAnswerStreamEnd = (
   makeInsightAnalyticsActionFactory(SearchPageEvents.generatedAnswerStreamEnd)(
     'analytics/generatedAnswer/streamEnd',
     (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerStreamEnd(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
           answerGenerated,
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
@@ -265,14 +279,16 @@ export const logGeneratedAnswerShowAnswers = (): InsightAction =>
   )({
     prefix: 'analytics/generatedAnswer/show',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerShowAnswers(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -295,14 +311,16 @@ export const logGeneratedAnswerHideAnswers = (): InsightAction =>
   )({
     prefix: 'analytics/generatedAnswer/hide',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerHideAnswers(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -323,14 +341,16 @@ export const logGeneratedAnswerExpand = (): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.generatedAnswerExpand)({
     prefix: 'analytics/generatedAnswer/expand',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerExpand(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -351,14 +371,16 @@ export const logGeneratedAnswerCollapse = (): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.generatedAnswerCollapse)({
     prefix: 'analytics/generatedAnswer/collapse',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerCollapse(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
@@ -381,14 +403,16 @@ export const logCopyGeneratedAnswer = (): InsightAction =>
   )({
     prefix: 'analytics/generatedAnswer/copy',
     __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
+      const {id: rgaID, answerAPIEnabled} =
         generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
+      if (!rgaID) {
         return null;
       }
       return client.logGeneratedAnswerCopyToClipboard(
         {
-          generativeQuestionAnsweringId,
+          ...(answerAPIEnabled
+            ? {answerAPIStreamId: rgaID}
+            : {generativeQuestionAnsweringId: rgaID}),
         },
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );

--- a/packages/headless/src/features/generated-answer/generated-answer-selectors.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-selectors.test.ts
@@ -1,0 +1,56 @@
+import {streamAnswerAPIStateMock} from '../../api/knowledge/tests/stream-answer-api-state-mock';
+import {SearchAppState} from '../../state/search-app-state';
+import {generativeQuestionAnsweringIdSelector} from './generated-answer-selectors';
+
+jest.mock('../../api/knowledge/stream-answer-api', () => ({
+  ...jest.requireActual<Record<string, Partial<SearchAppState>>>(
+    '../../api/knowledge/stream-answer-api'
+  ),
+  selectAnswer: (_state: Partial<SearchAppState>) => ({
+    data: {
+      answerId: 'answerId1234',
+    },
+  }),
+}));
+
+describe('generated-answer-selectors', () => {
+  describe('generativeQuestionAnsweringIdSelector', () => {
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+    it('returns the answerId if an answer configuration id is in state', () => {
+      const state = {
+        ...(streamAnswerAPIStateMock as Partial<SearchAppState>),
+        generatedAnswer: {
+          answerConfigurationId: 'answerConfigurationId',
+        },
+      } as Partial<SearchAppState>;
+
+      const result = generativeQuestionAnsweringIdSelector(state);
+      expect(result).toEqual({id: 'answerId1234', answerAPIEnabled: true});
+    });
+
+    it('returns the generativeQuestionAnsweringId if an answer configuration id is not in state', () => {
+      const state = {
+        ...(streamAnswerAPIStateMock as Partial<SearchAppState>),
+        generatedAnswer: {
+          answerConfigurationId: undefined,
+        },
+        search: {
+          response: {
+            extendedResults: {
+              generativeQuestionAnsweringId:
+                'generativeQuestionAnsweringId4321',
+            },
+          },
+        },
+      } as Partial<SearchAppState>;
+
+      const result = generativeQuestionAnsweringIdSelector(state);
+      expect(result).toEqual({
+        id: 'generativeQuestionAnsweringId4321',
+        answerAPIEnabled: false,
+      });
+    });
+  });
+});

--- a/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-selectors.ts
@@ -1,12 +1,44 @@
+import {isNullOrUndefined} from '@coveo/bueno';
 import {createSelector} from '@reduxjs/toolkit';
+import {
+  selectAnswer,
+  StateNeededByAnswerAPI,
+} from '../../api/knowledge/stream-answer-api';
 import {GeneratedAnswerCitation} from '../../controllers/generated-answer/headless-generated-answer';
 import {SearchAppState} from '../../state/search-app-state';
-import {GeneratedAnswerSection} from '../../state/state-sections';
+import {
+  GeneratedAnswerSection,
+  SearchSection,
+} from '../../state/state-sections';
 import {selectQuery} from '../query/query-selectors';
 
 export const generativeQuestionAnsweringIdSelector = (
   state: Partial<SearchAppState>
-) => state.search?.response?.extendedResults?.generativeQuestionAnsweringId;
+): {answerAPIEnabled: boolean; id: string | undefined} => {
+  if (isGeneratedAnswerSection(state)) {
+    return {answerAPIEnabled: true, id: selectAnswer(state).data?.answerId};
+  }
+
+  if (isSearchSection(state)) {
+    return {
+      answerAPIEnabled: false,
+      id: state.search.response.extendedResults.generativeQuestionAnsweringId,
+    };
+  }
+
+  return {answerAPIEnabled: false, id: undefined};
+};
+
+const isSearchSection = (
+  state: Partial<SearchAppState> | StateNeededByAnswerAPI
+): state is SearchSection => 'search' in state;
+
+const isGeneratedAnswerSection = (
+  state: Partial<SearchAppState>
+): state is StateNeededByAnswerAPI =>
+  'answer' in state &&
+  'generatedAnswer' in state &&
+  !isNullOrUndefined(state.generatedAnswer?.answerConfigurationId);
 
 export const selectFieldsToIncludeInCitation = (
   state: Partial<GeneratedAnswerSection>

--- a/patches/coveo.analytics+2.30.38.patch
+++ b/patches/coveo.analytics+2.30.38.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/coveo.analytics/dist/browser.mjs b/node_modules/coveo.analytics/dist/browser.mjs
-index 3de0ed7..b7d2c0e 100644
+index 78efccc..115b8d3 100644
 --- a/node_modules/coveo.analytics/dist/browser.mjs
 +++ b/node_modules/coveo.analytics/dist/browser.mjs
-@@ -1093,8 +1093,6 @@ class NoopAnalyticsClient {
+@@ -1135,8 +1135,6 @@ class NoopAnalyticsClient {
      }
  }
  
@@ -11,7 +11,7 @@ index 3de0ed7..b7d2c0e 100644
  class AnalyticsFetchClient {
      constructor(opts) {
          this.opts = opts;
-@@ -1114,7 +1112,7 @@ class AnalyticsFetchClient {
+@@ -1156,7 +1154,7 @@ class AnalyticsFetchClient {
              const _a = Object.assign(Object.assign({}, defaultOptions), (preprocessRequest ? yield preprocessRequest(defaultOptions, 'analyticsFetch') : {})), { url } = _a, fetchData = __rest(_a, ["url"]);
              let response;
              try {
@@ -20,7 +20,7 @@ index 3de0ed7..b7d2c0e 100644
              }
              catch (error) {
                  console.error('An error has occured when sending the event.', error);
-@@ -1142,7 +1140,7 @@ class AnalyticsFetchClient {
+@@ -1184,7 +1182,7 @@ class AnalyticsFetchClient {
          return __awaiter(this, void 0, void 0, function* () {
              const { baseUrl } = this.opts;
              const url = `${baseUrl}/analytics/visit`;


### PR DESCRIPTION
SVCC-4021

# Managing the answer api flow rga components custom events

## With the answer api flow
The answer id will be sent to the custom event
![image](https://github.com/user-attachments/assets/6aee4ff8-7501-423b-b3f7-d42da8ec3310)


## With the search Api flow
The search api stream ID will be sent with the custom event
![image](https://github.com/user-attachments/assets/d6aecf4a-5743-47ec-99d4-f39504c2334a)

## Description

It was decided that we should send a distinct key in the custom event when using the answer api stream id. So I modified the selector to return the `answerAPIEnabled` is boolean that will help determine what key to use when sending the event. Not sure if this could have been done in a better way.