### PR TITLE
feat(headless)!: logic to hide and show generated answer removed from headless

### DIFF
--- a/packages/headless/src/api/analytics/insight-analytics.test.ts
+++ b/packages/headless/src/api/analytics/insight-analytics.test.ts
@@ -1,7 +1,6 @@
 import {CoveoAnalyticsClient} from 'coveo.analytics';
 import pino from 'pino';
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state';
-import {getGeneratedAnswerInitialState} from '../../features/generated-answer/generated-answer-state';
 import {buildMockFacetRequest} from '../../test/mock-facet-request';
 import {buildMockFacetResponse} from '../../test/mock-facet-response';
 import {buildMockFacetSlice} from '../../test/mock-facet-slice';
@@ -141,15 +140,6 @@ describe('insight analytics', () => {
       expect(new InsightAnalyticsProvider(() => state).getSearchUID()).toEqual(
         'another_id'
       );
-    });
-
-    it('should properly return the generated answer metadata from the state', () => {
-      const state = getBaseState();
-      state.generatedAnswer = getGeneratedAnswerInitialState();
-      state.generatedAnswer.isVisible = false;
-      expect(
-        new InsightAnalyticsProvider(() => state).getGeneratedAnswerMetadata()
-      ).toEqual({showGeneratedAnswer: false});
     });
   });
 });

--- a/packages/headless/src/api/analytics/insight-analytics.ts
+++ b/packages/headless/src/api/analytics/insight-analytics.ts
@@ -87,15 +87,6 @@ export class InsightAnalyticsProvider
     return baseObject;
   }
 
-  public getGeneratedAnswerMetadata() {
-    const state = this.getState();
-    return {
-      ...(state.generatedAnswer?.isVisible !== undefined && {
-        showGeneratedAnswer: state.generatedAnswer.isVisible,
-      }),
-    };
-  }
-
   private get queryText() {
     return this.state.query?.q || getQueryInitialState().q;
   }

--- a/packages/headless/src/api/analytics/search-analytics.test.ts
+++ b/packages/headless/src/api/analytics/search-analytics.test.ts
@@ -5,7 +5,6 @@ import {getConfigurationInitialState} from '../../features/configuration/configu
 import {getCategoryFacetSetInitialState} from '../../features/facets/category-facet-set/category-facet-set-state';
 import {getFacetSetInitialState} from '../../features/facets/facet-set/facet-set-state';
 import {FacetSortCriterion} from '../../features/facets/facet-set/interfaces/request';
-import {getGeneratedAnswerInitialState} from '../../features/generated-answer/generated-answer-state';
 import {OmniboxSuggestionMetadata} from '../../features/query-suggest/query-suggest-analytics-actions';
 import {getQuerySuggestSetInitialState} from '../../features/query-suggest/query-suggest-state';
 import {StaticFilterValueMetadata} from '../../features/static-filter-set/static-filter-set-actions';
@@ -230,15 +229,6 @@ describe('#configureLegacyAnalytics', () => {
       expect(
         new SearchAnalyticsProvider(() => state).getSplitTestRunVersion()
       ).toBe('pipeline-from-state');
-    });
-
-    it('should properly return the generated answer metadata from the state', () => {
-      const state = getBaseState();
-      state.generatedAnswer = getGeneratedAnswerInitialState();
-      state.generatedAnswer.isVisible = false;
-      expect(
-        new SearchAnalyticsProvider(() => state).getGeneratedAnswerMetadata()
-      ).toEqual({showGeneratedAnswer: false});
     });
 
     it('should properly return the facet metadata from the state', () => {

--- a/packages/headless/src/api/analytics/search-analytics.ts
+++ b/packages/headless/src/api/analytics/search-analytics.ts
@@ -249,15 +249,6 @@ export class SearchAnalyticsProvider
     };
   }
 
-  public getGeneratedAnswerMetadata() {
-    const state = this.getState();
-    const formattedObject: Record<string, string | boolean> = {};
-    if (state.generatedAnswer?.isVisible !== undefined) {
-      formattedObject['showGeneratedAnswer'] = state.generatedAnswer.isVisible;
-    }
-    return formattedObject;
-  }
-
   private get resultURIs() {
     return this.results?.map((r) => ({
       documentUri: r.uri,

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1036,7 +1036,6 @@ export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
   },
   generatedAnswer: {
     id: '',
-    isVisible: true,
     isLoading: false,
     isStreaming: false,
     citations: [],

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -4,7 +4,6 @@ import {
   likeGeneratedAnswer,
   openGeneratedAnswerFeedbackModal,
   sendGeneratedAnswerFeedback,
-  setIsVisible,
   updateResponseFormat,
   registerFieldsToIncludeInCitations,
   expandGeneratedAnswer,
@@ -16,8 +15,6 @@ import {
   logDislikeGeneratedAnswer,
   logGeneratedAnswerDetailedFeedback,
   logGeneratedAnswerFeedback,
-  logGeneratedAnswerHideAnswers,
-  logGeneratedAnswerShowAnswers,
   logHoverCitation,
   logLikeGeneratedAnswer,
   logOpenGeneratedAnswerSource,
@@ -180,67 +177,6 @@ describe('generated answer', () => {
     expect(logCopyGeneratedAnswer).toHaveBeenCalled();
   });
 
-  describe('#show', () => {
-    describe('when already visible', () => {
-      it('should not make any changes', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: true});
-        initGeneratedAnswer();
-
-        generatedAnswer.show();
-        expect(setIsVisible).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when not visible', () => {
-      it('should dispatch the setIsVisible action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: false});
-        initGeneratedAnswer();
-
-        generatedAnswer.show();
-
-        expect(setIsVisible).toHaveBeenCalledWith(true);
-      });
-
-      it('should dispatch the analytics action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: false});
-        initGeneratedAnswer();
-
-        generatedAnswer.show();
-        expect(logGeneratedAnswerShowAnswers).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('#hide', () => {
-    describe('when not visible', () => {
-      it('should not make any changes', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: false});
-        initGeneratedAnswer();
-
-        generatedAnswer.hide();
-        expect(setIsVisible).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when visible', () => {
-      it('should dispatch the setIsVisible action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: true});
-        initGeneratedAnswer();
-
-        generatedAnswer.hide();
-        expect(setIsVisible).toHaveBeenCalledWith(false);
-      });
-
-      it('should dispatch the analytics action', () => {
-        engine = buildEngineWithGeneratedAnswer({isVisible: true});
-        initGeneratedAnswer();
-
-        generatedAnswer.hide();
-        expect(logGeneratedAnswerHideAnswers).toHaveBeenCalled();
-      });
-    });
-  });
-
   describe('#expand', () => {
     describe('when already expanded', () => {
       it('should not make any changes', () => {
@@ -290,19 +226,6 @@ describe('generated answer', () => {
   });
 
   describe('when passing initial state', () => {
-    describe('when #isVisible is set', () => {
-      it('should dispatch setIsVisible action when set to true', () => {
-        initGeneratedAnswer({initialState: {isVisible: true}});
-
-        expect(setIsVisible).toHaveBeenCalledWith(true);
-      });
-
-      it('should dispatch setIsVisible action when set to false', () => {
-        initGeneratedAnswer({initialState: {isVisible: false}});
-        expect(setIsVisible).toHaveBeenCalledWith(false);
-      });
-    });
-
     describe('when #responseFormat is set', () => {
       it('should dispatch updateResponseFormat action', () => {
         const responseFormat: GeneratedResponseFormat = {

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -10,7 +10,6 @@ import {
   updateResponseFormat,
   openGeneratedAnswerFeedbackModal,
   closeGeneratedAnswerFeedbackModal,
-  setIsVisible,
   sendGeneratedAnswerFeedback,
   registerFieldsToIncludeInCitations,
   expandGeneratedAnswer,
@@ -89,14 +88,6 @@ export interface GeneratedAnswer extends Controller {
    */
   logCitationClick(id: string): void;
   /**
-   * Displays the generated answer.
-   */
-  show(): void;
-  /**
-   * Hides the generated answer.
-   */
-  hide(): void;
-  /**
    * Expands the generated answer.
    */
   expand(): void;
@@ -128,8 +119,6 @@ export interface GeneratedAnswerAnalyticsClient {
     citationId: string,
     citationHoverTimeMs: number
   ) => CustomAction;
-  logGeneratedAnswerShowAnswers: () => CustomAction;
-  logGeneratedAnswerHideAnswers: () => CustomAction;
   logCopyGeneratedAnswer: () => CustomAction;
   logRephraseGeneratedAnswer: (
     responseFormat: GeneratedResponseFormat
@@ -141,10 +130,6 @@ export interface GeneratedAnswerAnalyticsClient {
 
 export interface GeneratedAnswerPropsInitialState {
   initialState?: {
-    /**
-     * Sets the component visibility state on load.
-     */
-    isVisible?: boolean;
     /**
      * The initial formatting options applied to generated answers when the controller first loads.
      */
@@ -187,10 +172,6 @@ export function buildCoreGeneratedAnswer(
   const controller = buildController(engine);
   const getState = () => engine.state;
 
-  const isVisible = props.initialState?.isVisible;
-  if (isVisible !== undefined) {
-    dispatch(setIsVisible(isVisible));
-  }
   const initialResponseFormat = props.initialState?.responseFormat;
   if (initialResponseFormat) {
     dispatch(updateResponseFormat(initialResponseFormat));
@@ -257,20 +238,6 @@ export function buildCoreGeneratedAnswer(
 
     rephrase(responseFormat: GeneratedResponseFormat) {
       dispatch(updateResponseFormat(responseFormat));
-    },
-
-    show() {
-      if (!this.state.isVisible) {
-        dispatch(setIsVisible(true));
-        dispatch(analyticsClient.logGeneratedAnswerShowAnswers());
-      }
-    },
-
-    hide() {
-      if (this.state.isVisible) {
-        dispatch(setIsVisible(false));
-        dispatch(analyticsClient.logGeneratedAnswerHideAnswers());
-      }
     },
 
     expand() {

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
@@ -6,7 +6,6 @@ import {
   openGeneratedAnswerFeedbackModal,
   registerFieldsToIncludeInCitations,
   sendGeneratedAnswerFeedback,
-  setIsVisible,
   updateResponseFormat,
 } from '../../../features/generated-answer/generated-answer-actions';
 import {
@@ -163,51 +162,6 @@ describe('searchapi-generated-answer', () => {
     ).toHaveBeenCalledWith(citationId, citationHoverTimeMs);
   });
 
-  it('dispatches a show action if the component is not already visible', () => {
-    engine = buildEngineWithGeneratedAnswer({isVisible: false});
-    const generatedAnswer = createGeneratedAnswer({
-      initialState: {isVisible: false},
-    });
-    generatedAnswer.show();
-    expect(setIsVisible).toHaveBeenCalledWith(true);
-    expect(
-      generatedAnswerAnalyticsClient.logGeneratedAnswerShowAnswers
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not dispatch a show action if the component is already visible', () => {
-    engine = buildEngineWithGeneratedAnswer({isVisible: true});
-    const generatedAnswer = createGeneratedAnswer({
-      initialState: {isVisible: true},
-    });
-    generatedAnswer.show();
-    expect(
-      generatedAnswerAnalyticsClient.logGeneratedAnswerShowAnswers
-    ).not.toHaveBeenCalled();
-  });
-
-  it('dispatches a hide action if the component is visible', () => {
-    engine = buildEngineWithGeneratedAnswer({isVisible: true});
-    const generatedAnswer = createGeneratedAnswer({
-      initialState: {isVisible: true},
-    });
-    generatedAnswer.hide();
-    expect(
-      generatedAnswerAnalyticsClient.logGeneratedAnswerHideAnswers
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not dispatch a hide action if the component is not visible', () => {
-    engine = buildEngineWithGeneratedAnswer({isVisible: false});
-    const generatedAnswer = createGeneratedAnswer({
-      initialState: {isVisible: false},
-    });
-    generatedAnswer.hide();
-    expect(
-      generatedAnswerAnalyticsClient.logGeneratedAnswerHideAnswers
-    ).not.toHaveBeenCalled();
-  });
-
   it('dispatches an expand action if the component is not already expanded', () => {
     engine = buildEngineWithGeneratedAnswer({expanded: false});
     const generatedAnswer = createGeneratedAnswer({
@@ -258,16 +212,6 @@ describe('searchapi-generated-answer', () => {
     expect(
       generatedAnswerAnalyticsClient.logCopyGeneratedAnswer
     ).toHaveBeenCalledTimes(1);
-  });
-
-  it('dispatches the setIsVisible with true when the initial state is set to true', () => {
-    createGeneratedAnswer({initialState: {isVisible: true}});
-    expect(setIsVisible).toHaveBeenCalledWith(true);
-  });
-
-  it('dispatches setIsVisible with false when the initial state is set to false', () => {
-    createGeneratedAnswer({initialState: {isVisible: false}});
-    expect(setIsVisible).toHaveBeenCalledWith(false);
   });
 
   it('dispatches the updateResponseFormat with the initial response format', () => {

--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
@@ -74,32 +74,6 @@ exports[`generated answer analytics actions when analyticsMode is \`next\` shoul
 ]
 `;
 
-exports[`generated answer analytics actions when analyticsMode is \`next\` should log #logGeneratedAnswerHideAnswers with the right payload 1`] = `
-[
-  "Qna.AnswerAction",
-  {
-    "action": "hide",
-    "answer": {
-      "responseId": "456",
-      "type": "RGA",
-    },
-  },
-]
-`;
-
-exports[`generated answer analytics actions when analyticsMode is \`next\` should log #logGeneratedAnswerShowAnswers with the right payload 1`] = `
-[
-  "Qna.AnswerAction",
-  {
-    "action": "show",
-    "answer": {
-      "responseId": "456",
-      "type": "RGA",
-    },
-  },
-]
-`;
-
 exports[`generated answer analytics actions when analyticsMode is \`next\` should log #logHoverCitation with the right payload 1`] = `
 [
   "Qna.CitationHover",

--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
@@ -74,32 +74,6 @@ exports[`generated answer insight analytics actions when analyticsMode is \`next
 ]
 `;
 
-exports[`generated answer insight analytics actions when analyticsMode is \`next\` should log #logGeneratedAnswerHideAnswers with the right payload 1`] = `
-[
-  "Qna.AnswerAction",
-  {
-    "action": "hide",
-    "answer": {
-      "responseId": "456",
-      "type": "RGA",
-    },
-  },
-]
-`;
-
-exports[`generated answer insight analytics actions when analyticsMode is \`next\` should log #logGeneratedAnswerShowAnswers with the right payload 1`] = `
-[
-  "Qna.AnswerAction",
-  {
-    "action": "show",
-    "answer": {
-      "responseId": "456",
-      "type": "RGA",
-    },
-  },
-]
-`;
-
 exports[`generated answer insight analytics actions when analyticsMode is \`next\` should log #logHoverCitation with the right payload 1`] = `
 [
   "Qna.CitationHover",

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
@@ -1,6 +1,5 @@
 import {buildMockCitation} from '../../test/mock-citation';
 import {
-  setIsVisible,
   setIsLoading,
   updateCitations,
   updateError,
@@ -93,12 +92,6 @@ describe('generated answer', () => {
       expect(() =>
         registerFieldsToIncludeInCitations(exampleFieldsToIncludeInCitations)
       ).not.toThrow();
-    });
-  });
-
-  describe('#setIsVisible', () => {
-    it('should accept a valid payload', () => {
-      expect(() => setIsVisible(true)).not.toThrow();
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -62,11 +62,6 @@ export interface GeneratedAnswerErrorPayload {
   code?: number;
 }
 
-export const setIsVisible = createAction(
-  'generatedAnswer/setIsVisible',
-  (payload: boolean) => validatePayload(payload, booleanValue)
-);
-
 export const updateMessage = createAction(
   'generatedAnswer/updateMessage',
   (payload: GeneratedAnswerMessagePayload) =>

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
@@ -14,8 +14,6 @@ import {
   logDislikeGeneratedAnswer,
   logGeneratedAnswerDetailedFeedback,
   logGeneratedAnswerFeedback,
-  logGeneratedAnswerHideAnswers,
-  logGeneratedAnswerShowAnswers,
   logGeneratedAnswerStreamEnd,
   logHoverCitation,
   logLikeGeneratedAnswer,
@@ -54,12 +52,6 @@ const mockMakeDislikeGeneratedAnswer = jest.fn(() => ({
 const mockMakeGeneratedAnswerStreamEnd = jest.fn(() => ({
   log: mockLogFunction,
 }));
-const mockMakeGeneratedAnswerShowAnswers = jest.fn(() => ({
-  log: mockLogFunction,
-}));
-const mockMakeGeneratedAnswerHideAnswers = jest.fn(() => ({
-  log: mockLogFunction,
-}));
 const mockMakeGeneratedAnswerCopyToClipboard = jest.fn(() => ({
   log: mockLogFunction,
 }));
@@ -96,8 +88,6 @@ jest.mock('coveo.analytics', () => {
     makeLikeGeneratedAnswer: mockMakeLikeGeneratedAnswer,
     makeDislikeGeneratedAnswer: mockMakeDislikeGeneratedAnswer,
     makeGeneratedAnswerStreamEnd: mockMakeGeneratedAnswerStreamEnd,
-    makeGeneratedAnswerShowAnswers: mockMakeGeneratedAnswerShowAnswers,
-    makeGeneratedAnswerHideAnswers: mockMakeGeneratedAnswerHideAnswers,
     makeGeneratedAnswerCopyToClipboard: mockMakeGeneratedAnswerCopyToClipboard,
     makeGeneratedAnswerExpand: mockMakeGeneratedAnswerExpand,
     makeGeneratedAnswerCollapse: mockMakeGeneratedAnswerCollapse,
@@ -380,38 +370,6 @@ describe('generated answer analytics actions', () => {
       expect(mockLogFunction).toHaveBeenCalledTimes(1);
     });
 
-    it('should log #logGeneratedAnswerShowAnswers with the right payload', async () => {
-      await logGeneratedAnswerShowAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      const mockToUse = mockMakeGeneratedAnswerShowAnswers;
-
-      expect(mockToUse).toHaveBeenCalledTimes(1);
-      expect(mockToUse).toHaveBeenCalledWith({
-        generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
-      });
-      expect(mockLogFunction).toHaveBeenCalledTimes(1);
-    });
-
-    it('should log #logGeneratedAnswerHideAnswers with the right payload', async () => {
-      await logGeneratedAnswerHideAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      const mockToUse = mockMakeGeneratedAnswerHideAnswers;
-
-      expect(mockToUse).toHaveBeenCalledTimes(1);
-      expect(mockToUse).toHaveBeenCalledWith({
-        generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
-      });
-      expect(mockLogFunction).toHaveBeenCalledTimes(1);
-    });
-
     it('should log #logGeneratedAnswerExpand with the right payload', async () => {
       await logGeneratedAnswerExpand()()(
         engine.dispatch,
@@ -537,28 +495,6 @@ describe('generated answer analytics actions', () => {
 
     it('should log #logGeneratedAnswerFeedback with the right payload', async () => {
       await logGeneratedAnswerFeedback(exampleFeedbackV2)()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      expect(emit).toHaveBeenCalledTimes(1);
-      expect(emit.mock.calls[0]).toMatchSnapshot();
-    });
-
-    it('should log #logGeneratedAnswerShowAnswers with the right payload', async () => {
-      await logGeneratedAnswerShowAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      expect(emit).toHaveBeenCalledTimes(1);
-      expect(emit.mock.calls[0]).toMatchSnapshot();
-    });
-
-    it('should log #logGeneratedAnswerHideAnswers with the right payload', async () => {
-      await logGeneratedAnswerHideAnswers()()(
         engine.dispatch,
         () => engine.state,
         {} as ThunkExtraArguments

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -279,56 +279,6 @@ export const logGeneratedAnswerStreamEnd = (
     }
   );
 
-export const logGeneratedAnswerShowAnswers = (): CustomAction =>
-  makeAnalyticsAction({
-    prefix: 'analytics/generatedAnswer/show',
-    __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
-        return null;
-      }
-      return client.makeGeneratedAnswerShowAnswers({
-        generativeQuestionAnsweringId,
-      });
-    },
-    analyticsType: 'Qna.AnswerAction',
-    analyticsPayloadBuilder: (state): Qna.AnswerAction => {
-      return {
-        action: 'show',
-        answer: {
-          responseId: state.search?.response.searchUid || '',
-          type: RGAType,
-        },
-      };
-    },
-  });
-
-export const logGeneratedAnswerHideAnswers = (): CustomAction =>
-  makeAnalyticsAction({
-    prefix: 'analytics/generatedAnswer/hide',
-    __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
-        return null;
-      }
-      return client.makeGeneratedAnswerHideAnswers({
-        generativeQuestionAnsweringId,
-      });
-    },
-    analyticsType: 'Qna.AnswerAction',
-    analyticsPayloadBuilder: (state): Qna.AnswerAction => {
-      return {
-        action: 'hide',
-        answer: {
-          responseId: state.search?.response.searchUid || '',
-          type: RGAType,
-        },
-      };
-    },
-  });
-
 export const logGeneratedAnswerExpand = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/expand',
@@ -414,8 +364,6 @@ export const rephraseGeneratedAnswer = (): SearchAction => ({
 
 export const generatedAnswerAnalyticsClient = {
   logCopyGeneratedAnswer,
-  logGeneratedAnswerHideAnswers,
-  logGeneratedAnswerShowAnswers,
   logGeneratedAnswerStreamEnd,
   logGeneratedAnswerDetailedFeedback,
   logGeneratedAnswerFeedback,

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
@@ -19,8 +19,6 @@ import {
   logLikeGeneratedAnswer,
   logDislikeGeneratedAnswer,
   logGeneratedAnswerStreamEnd,
-  logGeneratedAnswerShowAnswers,
-  logGeneratedAnswerHideAnswers,
   logCopyGeneratedAnswer,
   logGeneratedAnswerExpand,
   logGeneratedAnswerCollapse,
@@ -35,8 +33,6 @@ const mockLogHoverCitation = jest.fn();
 const mockLogLikeGeneratedAnswer = jest.fn();
 const mockLogDislikeGeneratedAnswer = jest.fn();
 const mockLogGeneratedAnswerStreamEnd = jest.fn();
-const mockLogGeneratedAnswerShowAnswers = jest.fn();
-const mockLogGeneratedAnswerHideAnswers = jest.fn();
 const mockLogCopyGeneratedAnswer = jest.fn();
 const mockLogGeneratedAnswerExpand = jest.fn();
 const mockLogGeneratedAnswerCollapse = jest.fn();
@@ -65,8 +61,6 @@ jest.mock('coveo.analytics', () => {
     logLikeGeneratedAnswer: mockLogLikeGeneratedAnswer,
     logDislikeGeneratedAnswer: mockLogDislikeGeneratedAnswer,
     logGeneratedAnswerStreamEnd: mockLogGeneratedAnswerStreamEnd,
-    logGeneratedAnswerShowAnswers: mockLogGeneratedAnswerShowAnswers,
-    logGeneratedAnswerHideAnswers: mockLogGeneratedAnswerHideAnswers,
     logGeneratedAnswerCopyToClipboard: mockLogCopyGeneratedAnswer,
     logGeneratedAnswerExpand: mockLogGeneratedAnswerExpand,
     logGeneratedAnswerCollapse: mockLogGeneratedAnswerCollapse,
@@ -355,44 +349,6 @@ describe('generated answer insight analytics actions', () => {
       );
     });
 
-    it('should log #logGeneratedAnswerShowAnswers with the right payload', async () => {
-      await logGeneratedAnswerShowAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      const mockToUse = mockLogGeneratedAnswerShowAnswers;
-      const expectedMetadata = {
-        generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
-      };
-
-      expect(mockToUse).toHaveBeenCalledTimes(1);
-      expect(mockToUse).toHaveBeenCalledWith(
-        expectedMetadata,
-        expectedCaseContext
-      );
-    });
-
-    it('should log #logGeneratedAnswerHideAnswers with the right payload', async () => {
-      await logGeneratedAnswerHideAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      const mockToUse = mockLogGeneratedAnswerHideAnswers;
-      const expectedMetadata = {
-        generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
-      };
-
-      expect(mockToUse).toHaveBeenCalledTimes(1);
-      expect(mockToUse).toHaveBeenCalledWith(
-        expectedMetadata,
-        expectedCaseContext
-      );
-    });
-
     it('should log #logGeneratedAnswerExpand with the right payload', async () => {
       await logGeneratedAnswerExpand()()(
         engine.dispatch,
@@ -525,28 +481,6 @@ describe('generated answer insight analytics actions', () => {
 
     it('should log #logGeneratedAnswerFeedback with the right payload', async () => {
       await logGeneratedAnswerFeedback(exampleFeedbackV2)()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      expect(emit).toHaveBeenCalledTimes(1);
-      expect(emit.mock.calls[0]).toMatchSnapshot();
-    });
-
-    it('should log #logGeneratedAnswerShowAnswers with the right payload', async () => {
-      await logGeneratedAnswerShowAnswers()()(
-        engine.dispatch,
-        () => engine.state,
-        {} as ThunkExtraArguments
-      );
-
-      expect(emit).toHaveBeenCalledTimes(1);
-      expect(emit.mock.calls[0]).toMatchSnapshot();
-    });
-
-    it('should log #logGeneratedAnswerHideAnswers with the right payload', async () => {
-      await logGeneratedAnswerHideAnswers()()(
         engine.dispatch,
         () => engine.state,
         {} as ThunkExtraArguments

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -300,66 +300,6 @@ export const logGeneratedAnswerStreamEnd = (
     }
   );
 
-export const logGeneratedAnswerShowAnswers = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(
-    SearchPageEvents.generatedAnswerShowAnswers
-  )({
-    prefix: 'analytics/generatedAnswer/show',
-    __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
-        return null;
-      }
-      return client.logGeneratedAnswerShowAnswers(
-        {
-          generativeQuestionAnsweringId,
-        },
-        getCaseContextAnalyticsMetadata(state.insightCaseContext)
-      );
-    },
-    analyticsType: 'Qna.AnswerAction',
-    analyticsPayloadBuilder: (state): Qna.AnswerAction => {
-      return {
-        action: 'show',
-        answer: {
-          responseId: state.search?.response.searchUid || '',
-          type: RGAType,
-        },
-      };
-    },
-  });
-
-export const logGeneratedAnswerHideAnswers = (): InsightAction =>
-  makeInsightAnalyticsActionFactory(
-    SearchPageEvents.generatedAnswerHideAnswers
-  )({
-    prefix: 'analytics/generatedAnswer/hide',
-    __legacy__getBuilder: (client, state) => {
-      const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
-      if (!generativeQuestionAnsweringId) {
-        return null;
-      }
-      return client.logGeneratedAnswerHideAnswers(
-        {
-          generativeQuestionAnsweringId,
-        },
-        getCaseContextAnalyticsMetadata(state.insightCaseContext)
-      );
-    },
-    analyticsType: 'Qna.AnswerAction',
-    analyticsPayloadBuilder: (state): Qna.AnswerAction => {
-      return {
-        action: 'hide',
-        answer: {
-          responseId: state.search?.response.searchUid || '',
-          type: RGAType,
-        },
-      };
-    },
-  });
-
 export const logGeneratedAnswerExpand = (): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.generatedAnswerExpand)({
     prefix: 'analytics/generatedAnswer/expand',
@@ -448,8 +388,6 @@ export const logCopyGeneratedAnswer = (): InsightAction =>
 
 export const generatedAnswerInsightAnalyticsClient = {
   logCopyGeneratedAnswer,
-  logGeneratedAnswerHideAnswers,
-  logGeneratedAnswerShowAnswers,
   logGeneratedAnswerStreamEnd,
   logGeneratedAnswerDetailedFeedback,
   logGeneratedAnswerFeedback,

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -4,7 +4,6 @@ import {
   dislikeGeneratedAnswer,
   likeGeneratedAnswer,
   resetAnswer,
-  setIsVisible,
   setIsLoading,
   setIsStreaming,
   updateCitations,
@@ -220,7 +219,6 @@ describe('generated answer slice', () => {
   describe('#resetAnswer', () => {
     it('should reset the answer', () => {
       const persistentGeneratedAnswerState = {
-        isVisible: false,
         responseFormat: {
           answerStyle: 'step' as GeneratedAnswerStyle,
         },
@@ -449,26 +447,6 @@ describe('generated answer slice', () => {
       expect(finalState.fieldsToIncludeInCitations).toEqual(
         exampleFieldsToIncludeInCitations
       );
-    });
-  });
-
-  describe('#setIsVisible', () => {
-    it('should set isVisible to true when given true', () => {
-      const finalState = generatedAnswerReducer(
-        {...baseState, isVisible: false},
-        setIsVisible(true)
-      );
-
-      expect(finalState.isVisible).toEqual(true);
-    });
-
-    it('should set isVisible to false when given false', () => {
-      const finalState = generatedAnswerReducer(
-        {...baseState, isVisible: true},
-        setIsVisible(false)
-      );
-
-      expect(finalState.isVisible).toEqual(false);
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -7,7 +7,6 @@ import {
   likeGeneratedAnswer,
   openGeneratedAnswerFeedbackModal,
   resetAnswer,
-  setIsVisible,
   setIsLoading,
   setIsStreaming,
   updateCitations,
@@ -29,9 +28,6 @@ export const generatedAnswerReducer = createReducer(
   getGeneratedAnswerInitialState(),
   (builder) =>
     builder
-      .addCase(setIsVisible, (state, {payload}) => {
-        state.isVisible = payload;
-      })
       .addCase(setId, (state, {payload}) => {
         state.id = payload.id;
       })
@@ -92,7 +88,6 @@ export const generatedAnswerReducer = createReducer(
             : {}),
           responseFormat: state.responseFormat,
           fieldsToIncludeInCitations: state.fieldsToIncludeInCitations,
-          isVisible: state.isVisible,
           id: state.id,
         };
       })

--- a/packages/headless/src/features/generated-answer/generated-answer-state.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-state.ts
@@ -7,10 +7,6 @@ import {
 export interface GeneratedAnswerState {
   id: string;
   /**
-   * Determines if the generated answer is visible.
-   */
-  isVisible: boolean;
-  /**
    * Determines if the generated answer is loading.
    */
   isLoading: boolean;
@@ -81,7 +77,6 @@ export interface GeneratedAnswerState {
 export function getGeneratedAnswerInitialState(): GeneratedAnswerState {
   return {
     id: '',
-    isVisible: true,
     isLoading: false,
     isStreaming: false,
     citations: [],


### PR DESCRIPTION
[SFINT-5712](https://coveord.atlassian.net/browse/SFINT-5712)

It was decided that the toggle On/Off feature in the Generated Answer component is no longer needed, so the plan is to delete it from Atomic, Quantic and Headless. This PR removes all the logic related to that feature from the Headless library:


- Removed  the `show`/`hide` methods from the generated answer controllers.
- Removed the `logGeneratedAnswerShowAnswers ` and `logGeneratedAnswerHideAnswers` analytics actions.
- Removed the `setIsVisible` action and its related logic from the generated answer slice.
-  Removed the property `isVisible` from the generated answer state.
-  Updated all unit tests accordingly. 

[SFINT-5712]: https://coveord.atlassian.net/browse/SFINT-5712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ