### PR TITLE
chore: - release:phase1 from ast plugin

### DIFF
--- a/packages/rollup-plugin-replace-with-ast/project.json
+++ b/packages/rollup-plugin-replace-with-ast/project.json
@@ -3,7 +3,6 @@
   "private": true,
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
-    "release:phase1": {},
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
This causes https://github.com/coveo/ui-kit/blob/1ba2c94a209c78447e7bd0cde8d1eaab72e15a41/nx.json#L100-L112
to run in the context of packages/rollup-plugin-replace-with-ast, which does not make sense (and fails because bump is missing in its package.json, rightfully so)

https://coveord.atlassian.net/browse/KIT-3569

For testing, I nooped most of the release:phase1 script in nx.json, except the bump itself.
Then, I analyzed the result of the bump to make sure it was sound and expected.