### PR TITLE
fix(atomic, atomic-react): use root-relative URL for CDN

### DIFF
--- a/packages/atomic-react/rollup.config.mjs
+++ b/packages/atomic-react/rollup.config.mjs
@@ -47,22 +47,22 @@ function generateReplaceValues() {
 
 const packageMappings = {
   '@coveo/headless/commerce': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/commerce/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/commerce/headless.esm.js`,
   },
   '@coveo/headless/insight': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/insight/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/insight/headless.esm.js`,
   },
   '@coveo/headless/product-recommendation': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/product-recommendation/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/product-recommendation/headless.esm.js`,
   },
   '@coveo/headless/recommendation': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/recommendation/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/recommendation/headless.esm.js`,
   },
   '@coveo/headless/case-assist': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/case-assist/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/case-assist/headless.esm.js`,
   },
   '@coveo/headless': {
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/headless.esm.js`,
   },
 };
 

--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -36,43 +36,43 @@ const packageMappings: {[key: string]: {devWatch: string; cdn: string}} = {
       __dirname,
       './src/external-builds/commerce/headless.esm.js'
     ),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/commerce/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/commerce/headless.esm.js`,
   },
   '@coveo/headless/insight': {
     devWatch: path.resolve(
       __dirname,
       './src/external-builds/insight/headless.esm.js'
     ),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/insight/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/insight/headless.esm.js`,
   },
   '@coveo/headless/product-recommendation': {
     devWatch: path.resolve(
       __dirname,
       './src/external-builds/product-recommendation/headless.esm.js'
     ),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/product-recommendation/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/product-recommendation/headless.esm.js`,
   },
   '@coveo/headless/recommendation': {
     devWatch: path.resolve(
       __dirname,
       './src/external-builds/recommendation/headless.esm.js'
     ),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/recommendation/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/recommendation/headless.esm.js`,
   },
   '@coveo/headless/case-assist': {
     devWatch: path.resolve(
       __dirname,
       './src/external-builds/case-assist/headless.esm.js'
     ),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/case-assist/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/case-assist/headless.esm.js`,
   },
   '@coveo/headless': {
     devWatch: path.resolve(__dirname, './src/external-builds/headless.esm.js'),
-    cdn: `https://static.cloud.coveo.com/headless/${headlessVersion}/headless.esm.js`,
+    cdn: `/headless/${headlessVersion}/headless.esm.js`,
   },
   /*   '@coveo/bueno': {
     devWatch: path.resolve(__dirname, './src/external-builds/bueno.esm.js'),
-    cdn: `https://static.cloud.coveo.com/bueno/${headlessVersion}/bueno.esm.js`,
+    cdn: `/bueno/${headlessVersion}/bueno.esm.js`,
   }, */
 };
 


### PR DESCRIPTION
This ensures the code we deployed to the CDN is environment agnostic.
Currently for example, we try to use Headless from static.cloud.coveo.com in Atomic from staticdev.cloud.coveo.com

https://coveord.atlassian.net/browse/KIT-3571

See https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references#root_relative