### PR TITLE
feat: add answer configuration id to atomic-insight-generated-answer

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1213,6 +1213,7 @@ export namespace Components {
         "tooltip": string;
     }
     interface AtomicInsightGeneratedAnswer {
+        "answerConfigurationId"?: string;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
           * @default false
@@ -7133,6 +7134,7 @@ declare namespace LocalJSX {
         "tooltip"?: string;
     }
     interface AtomicInsightGeneratedAnswer {
+        "answerConfigurationId"?: string;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than 250px.
           * @default false

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
@@ -101,6 +101,12 @@ export class AtomicInsightGeneratedAnswer
    */
   @Prop() collapsible?: boolean;
 
+  /**
+   * @internal
+   * The unique identifier of the answer configuration to use to generate the answer.
+   */
+  @Prop() answerConfigurationId?: string;
+
   @AriaLiveRegion('generated-answer')
   protected ariaMessage!: string;
 
@@ -132,6 +138,9 @@ export class AtomicInsightGeneratedAnswer
           contentFormat: ['text/markdown', 'text/plain'],
         },
       },
+      ...(this.answerConfigurationId && {
+        answerConfigurationId: this.answerConfigurationId,
+      }),
     });
     this.searchStatus = buildInsightSearchStatus(this.bindings.engine);
     this.generatedAnswerCommon.insertFeedbackModal();

--- a/packages/headless/src/controllers/insight/generated-answer/headless-insight-generated-answer.ts
+++ b/packages/headless/src/controllers/insight/generated-answer/headless-insight-generated-answer.ts
@@ -10,6 +10,7 @@ import {
   GeneratedAnswerProps,
 } from '../../core/generated-answer/headless-core-generated-answer.js';
 import {buildSearchAPIGeneratedAnswer} from '../../core/generated-answer/headless-searchapi-generated-answer.js';
+import {buildAnswerApiGeneratedAnswer} from '../../knowledge/generated-answer/headless-answerapi-generated-answer.js';
 
 export type {
   GeneratedAnswerCitation,
@@ -31,11 +32,17 @@ export function buildGeneratedAnswer(
   props: GeneratedAnswerProps = {}
 ): GeneratedAnswer {
   const {dispatch} = engine;
-  const controller = buildSearchAPIGeneratedAnswer(
-    engine,
-    generatedAnswerInsightAnalyticsClient,
-    props
-  );
+  const controller = props.answerConfigurationId
+    ? buildAnswerApiGeneratedAnswer(
+        engine,
+        generatedAnswerInsightAnalyticsClient,
+        props
+      )
+    : buildSearchAPIGeneratedAnswer(
+        engine,
+        generatedAnswerInsightAnalyticsClient,
+        props
+      );
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -10,6 +10,7 @@ import {
   selectAnswerTriggerParams,
   StateNeededByAnswerAPI,
 } from '../../../api/knowledge/stream-answer-api.js';
+import {InsightEngine} from '../../../app/insight-engine/insight-engine.js';
 import {SearchEngine} from '../../../app/search-engine/search-engine.js';
 import {
   resetAnswer,
@@ -119,7 +120,7 @@ const subscribeToSearchRequest = (
  * @returns A `AnswerApiGeneratedAnswer` controller instance.
  */
 export function buildAnswerApiGeneratedAnswer(
-  engine: SearchEngine,
+  engine: SearchEngine | InsightEngine,
   analyticsClient: SearchAPIGeneratedAnswerAnalyticsClient,
   props: AnswerApiGeneratedAnswerProps = {}
 ): AnswerApiGeneratedAnswer {
@@ -175,7 +176,7 @@ export function buildAnswerApiGeneratedAnswer(
 }
 
 function loadAnswerApiReducers(
-  engine: SearchEngine
+  engine: SearchEngine | InsightEngine
 ): engine is SearchEngine<
   GeneratedAnswerSection &
     QuerySection & {answer: ReturnType<typeof answerApi.reducer>}


### PR DESCRIPTION
[SVCC-4206](https://coveord.atlassian.net/browse/SVCC-4206)

Add support for the `answer-configuration-id` parameter in `atomic-insight-generated-answer`, which switches from the Search API to the Answer API flow

[SVCC-4206]: https://coveord.atlassian.net/browse/SVCC-4206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ