### PR TITLE
chore: skip sample build for cdn

### DIFF
--- a/packages/samples/atomic-react/project.json
+++ b/packages/samples/atomic-react/project.json
@@ -10,8 +10,8 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then tsc --noEmit",
-          "tsc --module es2022 --noEmit; fi"
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then tsc --noEmit; fi",
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then tsc --module es2022 --noEmit; fi"
         ],
         "parallel": true,
         "cwd": "packages/samples/atomic-react"

--- a/packages/samples/atomic-react/project.json
+++ b/packages/samples/atomic-react/project.json
@@ -9,7 +9,10 @@
       "outputs": ["{projectRoot}/public/dist"],
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["tsc --noEmit", "tsc --module es2022 --noEmit"],
+        "commands": [
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then tsc --noEmit",
+          "tsc --module es2022 --noEmit; fi"
+        ],
         "parallel": true,
         "cwd": "packages/samples/atomic-react"
       }

--- a/packages/samples/headless-commerce-react/project.json
+++ b/packages/samples/headless-commerce-react/project.json
@@ -5,7 +5,9 @@
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["npm run build:client"],
+        "commands": [
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:client; fi"
+        ],
         "parallel": true,
         "cwd": "packages/samples/headless-commerce-react"
       }

--- a/packages/samples/headless-react/project.json
+++ b/packages/samples/headless-react/project.json
@@ -5,7 +5,9 @@
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["npm run build:client"],
+        "commands": [
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:client; fi"
+        ],
         "parallel": true,
         "cwd": "packages/samples/headless-react"
       }

--- a/packages/samples/headless-ssr-commerce/project.json
+++ b/packages/samples/headless-ssr-commerce/project.json
@@ -5,7 +5,7 @@
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npm run build:next",
+        "command": "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:next; fi",
         "cwd": "packages/samples/headless-ssr-commerce"
       }
     },

--- a/packages/samples/headless-ssr/app-router/project.json
+++ b/packages/samples/headless-ssr/app-router/project.json
@@ -5,7 +5,7 @@
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npm run build:next",
+        "command": "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:next; fi",
         "cwd": "packages/samples/headless-ssr/app-router"
       }
     },

--- a/packages/samples/headless-ssr/pages-router/project.json
+++ b/packages/samples/headless-ssr/pages-router/project.json
@@ -5,7 +5,7 @@
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npm run build:next",
+        "command": "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:next; fi",
         "cwd": "packages/samples/headless-ssr/pages-router"
       }
     },

--- a/packages/samples/iife/project.json
+++ b/packages/samples/iife/project.json
@@ -10,7 +10,7 @@
       "outputs": ["{projectRoot}/www/cdn"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "npm run build:assets",
+        "command": "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:assets; fi",
         "cwd": "packages/samples/iife"
       }
     },

--- a/packages/samples/stencil/project.json
+++ b/packages/samples/stencil/project.json
@@ -14,7 +14,7 @@
       "outputs": ["{projectRoot}/www", "{projectRoot}/src/components.d.ts"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --max_old_space_size=6144 ../../../node_modules/@stencil/core/bin/stencil build",
+        "command": "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then node --max_old_space_size=6144 ../../../node_modules/@stencil/core/bin/stencil build; fi",
         "cwd": "packages/samples/stencil"
       }
     },

--- a/packages/samples/vuejs/project.json
+++ b/packages/samples/vuejs/project.json
@@ -6,7 +6,10 @@
       "dependsOn": ["^build", "clean"],
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["npm run build:assets", "npm run build:vue"],
+        "command": [
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:assets; fi",
+          "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:vue; fi"
+        ],
         "parallel": false,
         "cwd": "packages/samples/vuejs"
       }

--- a/packages/samples/vuejs/project.json
+++ b/packages/samples/vuejs/project.json
@@ -6,7 +6,7 @@
       "dependsOn": ["^build", "clean"],
       "executor": "nx:run-commands",
       "options": {
-        "command": [
+        "commands": [
           "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:assets; fi",
           "if [ \"$DEPLOYMENT_ENVIRONMENT\" != \"CDN\" ]; then npm run build:vue; fi"
         ],


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3602

Copy what was in the angular sample and other sample relying on Atomic, for the same reason (but expanded to all the sample now that Bueno is an external of Headless).

Will be revisited in post-ga tech debts