### PR TITLE
chore(atomic): fix tsconfig resolution for the e2e folders

### DIFF
--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -103,6 +103,7 @@ const isDevWatch: boolean =
   process.argv.indexOf('--watch') > -1;
 
 export const config: Config = {
+  tsconfig: 'tsconfig.stencil.json',
   namespace: 'atomic',
   taskQueue: 'async',
   sourceMap: true,

--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -1,32 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "declaration": false,
-    "experimentalDecorators": true,
-    "lib": ["dom", "ES2023", "ESNext.Collection"],
-    "moduleResolution": "Bundler",
-    "module": "ES2022",
-    "target": "ES2021",
-    "resolveJsonModule": true,
-    "useDefineForClassFields": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "jsx": "react",
-    "jsxFactory": "h"
-  },
-  "references": [
-    {
-      "path": "./tsconfig.storybook.json"
-    }
-  ],
-  "include": ["src", "types/jsx.d.ts"],
+  "extends": "./tsconfig.stencil.json",
   "exclude": [
     "node_modules",
     "src/external-builds",
     "**/*.stories.tsx",
     "**/*.stories.ts",
-    "**/*.stories.js",
-    "**/e2e/**/*"
+    "**/*.stories.js"
   ]
 }

--- a/packages/atomic/tsconfig.stencil.json
+++ b/packages/atomic/tsconfig.stencil.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "lib": ["dom", "ES2023", "ESNext.Collection"],
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2021",
+    "resolveJsonModule": true,
+    "useDefineForClassFields": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "jsx": "react",
+    "jsxFactory": "h"
+  },
+  "references": [
+    {
+      "path": "./tsconfig.storybook.json"
+    }
+  ],
+  "include": ["src", "types/jsx.d.ts"],
+  "exclude": [
+    "node_modules",
+    "src/external-builds",
+    "**/*.stories.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.js",
+    "**/e2e/**/*"
+  ]
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3604

In order to fix this problem, we have to tell the TS server to use     `"moduleResolution":"Bundler" & "module": "ES2022"` for the e2e/ folders. They are currently excluded in the atomic root tsconfig which is why we get the error here. 
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/a1956eda-a88b-4eb6-925d-c5d18cd8227f">

This is the solution I came up with, we would now have a tsconfig for the IDE, a tsconfig for the stencil compilation, a tsconfig for the storybook compilation and a tsconfig for playwright eslint rules 😅 . If anyone has a better idea I am very open to it.