### PR TITLE
fix(quantic): Clear icon not being displayed after selecting a suggestion in quantic searchbox

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -470,6 +470,51 @@ describe('c-quantic-search-box-input', () => {
               expectedFirstSuggestionSelected
             );
           });
+
+          it('should display the selected suggestion in the input and display the clear input icon', async () => {
+            const element = createTestComponent({
+              ...defaultOptions,
+              suggestions: mockSuggestions,
+              textarea: textareaValue,
+            });
+            setupEventListeners(element);
+            await flushPromises();
+
+            const input = element.shadowRoot.querySelector(
+              textareaValue
+                ? selectors.searchBoxTextArea
+                : selectors.searchBoxInput
+            );
+            expect(input).not.toBeNull();
+
+            await input.focus();
+
+            const suggestionsList = element.shadowRoot.querySelector(
+              selectors.searchBoxSuggestionsList
+            );
+            expect(suggestionsList).not.toBeNull();
+
+            const querySuggestionIndex = 0;
+            const firstSuggestion = suggestionsList.shadowRoot.querySelectorAll(
+              selectors.suggestionOption
+            )[querySuggestionIndex];
+            expect(firstSuggestion).not.toBeNull();
+
+            firstSuggestion.dispatchEvent(new CustomEvent('mousedown'));
+
+            expect(
+              functionsMocks.exampleSelectSuggestion
+            ).toHaveBeenCalledTimes(1);
+
+            expect(input.value).toEqual(
+              mockSuggestions[querySuggestionIndex].value
+            );
+
+            const clearIcon = element.shadowRoot.querySelector(
+              selectors.searchBoxClearIcon
+            );
+            expect(clearIcon).not.toBeNull();
+          });
         });
 
         describe('when selecting the clear recent query option from the suggestions list', () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -470,47 +470,6 @@ describe('c-quantic-search-box-input', () => {
               expectedFirstSuggestionSelected
             );
           });
-
-          it('should display the clear input icon', async () => {
-            const element = createTestComponent({
-              ...defaultOptions,
-              suggestions: mockSuggestions,
-              textarea: textareaValue,
-            });
-            setupEventListeners(element);
-            await flushPromises();
-
-            const input = element.shadowRoot.querySelector(
-              textareaValue
-                ? selectors.searchBoxTextArea
-                : selectors.searchBoxInput
-            );
-            expect(input).not.toBeNull();
-
-            await input.focus();
-
-            const suggestionsList = element.shadowRoot.querySelector(
-              selectors.searchBoxSuggestionsList
-            );
-            expect(suggestionsList).not.toBeNull();
-
-            const querySuggestionIndex = 0;
-            const firstSuggestion = suggestionsList.shadowRoot.querySelectorAll(
-              selectors.suggestionOption
-            )[querySuggestionIndex];
-            expect(firstSuggestion).not.toBeNull();
-
-            firstSuggestion.dispatchEvent(new CustomEvent('mousedown'));
-
-            expect(
-              functionsMocks.exampleSelectSuggestion
-            ).toHaveBeenCalledTimes(1);
-
-            const clearIcon = element.shadowRoot.querySelector(
-              selectors.searchBoxClearIcon
-            );
-            expect(clearIcon).not.toBeNull();
-          });
         });
 
         describe('when selecting the clear recent query option from the suggestions list', () => {
@@ -841,6 +800,22 @@ describe('c-quantic-search-box-input', () => {
           expect(input.value).toEqual('');
           const expectedCollapsedInputHeight = textareaValue ? '0px' : '';
           expect(input.style.height).toEqual(expectedCollapsedInputHeight);
+        });
+      });
+
+      describe('when the component renders with a value in the input', () => {
+        it('should display the clear icon', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            inputValue: mockInputValue,
+            textarea: textareaValue,
+          });
+          await flushPromises();
+
+          const clearIcon = element.shadowRoot.querySelector(
+            selectors.searchBoxClearIcon
+          );
+          expect(clearIcon).not.toBeNull();
         });
       });
     });

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -471,7 +471,7 @@ describe('c-quantic-search-box-input', () => {
             );
           });
 
-          it('should display the selected suggestion in the input and display the clear input icon', async () => {
+          it('should display the clear input icon', async () => {
             const element = createTestComponent({
               ...defaultOptions,
               suggestions: mockSuggestions,
@@ -505,10 +505,6 @@ describe('c-quantic-search-box-input', () => {
             expect(
               functionsMocks.exampleSelectSuggestion
             ).toHaveBeenCalledTimes(1);
-
-            expect(input.value).toEqual(
-              mockSuggestions[querySuggestionIndex].value
-            );
 
             const clearIcon = element.shadowRoot.querySelector(
               selectors.searchBoxClearIcon

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -285,6 +285,9 @@ export default class QuanticSearchBoxInput extends LightningElement {
 
   handleSelection(event) {
     this.sendSelectSuggestionEvent(event.detail.selection);
+    if (event.detail.selection.value) {
+      this.input.value = event.detail.selection.value;
+    }
     this.inputIsFocused = false;
     this.input.blur();
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -285,9 +285,6 @@ export default class QuanticSearchBoxInput extends LightningElement {
 
   handleSelection(event) {
     this.sendSelectSuggestionEvent(event.detail.selection);
-    if (event.detail.selection.value) {
-      this.input.value = event.detail.selection.value;
-    }
     this.inputIsFocused = false;
     this.input.blur();
   }
@@ -351,7 +348,7 @@ export default class QuanticSearchBoxInput extends LightningElement {
   }
 
   get isQueryEmpty() {
-    return !this.input?.value?.length;
+    return !this.input?.value && !this.inputValue;
   }
 
   /**


### PR DESCRIPTION
[SFINT-5711](https://coveord.atlassian.net/browse/SFINT-5711)

### ISSUE:

**Description:**

The clear input button is not being displayed on first render when the query is not empty after selecting a suggestion/recent query on first render

https://github.com/user-attachments/assets/633ddd45-f993-454c-b571-42c8b8e55b34


### SOLUTION PROPOSED:

Modified the `isQueryEmpty` getter to add the `&& !this.inputValue;` to the check. This makes the `isQueryEmpty` getter evaluate properly and therefore display the clear icon.


### DEMO:


https://github.com/user-attachments/assets/a7b878c4-aaca-47ee-b3b7-3cebb07277ee




[SFINT-5711]: https://coveord.atlassian.net/browse/SFINT-5711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ