### PR TITLE
fix(quantic): added missing privilege to insight token provider class

### DIFF
--- a/packages/quantic/force-app/coveo-token/main/default/classes/InsightTokenProvider.cls
+++ b/packages/quantic/force-app/coveo-token/main/default/classes/InsightTokenProvider.cls
@@ -1,11 +1,14 @@
 global with sharing class InsightTokenProvider implements ITokenProvider {
   public static final String TYPE_VIEW = 'VIEW';
   public static final String TYPE_EDIT = 'EDIT';
+  public static final String TYPE_ENABLE = 'ENABLE';
   public static final String OWNER_USAGE_ANALYTICS = 'USAGE_ANALYTICS';
   public static final String OWNER_CUSTOMER_SERVICE = 'CUSTOMER_SERVICE';
+  public static final String OWNER_SEARCH_API = 'SEARCH_API';
   public static final String DOMAIN_ANALYTICS_ANALYTICS_DATA = 'ANALYTICS_DATA';
   public static final String DOMAIN_CUSTOMER_SERVICE_INSIGHT_PANEL_INTERFACE = 'INSIGHT_PANEL_INTERFACE';
   public static final String DOMAIN_CUSTOMER_SERVICE_INSIGHT_PANEL_DOCUMENTS = 'INSIGHT_PANEL_DOCUMENTS';
+  public static final String DOMAIN_SEARCH_API_EXECUTE_QUERY = 'EXECUTE_QUERY';
 
   /**
    * Returns the privileges needed to put in a Platform token in order to use the Hosted Insight Panel feature.
@@ -36,6 +39,13 @@ global with sharing class InsightTokenProvider implements ITokenProvider {
         OWNER_CUSTOMER_SERVICE,
         DOMAIN_CUSTOMER_SERVICE_INSIGHT_PANEL_DOCUMENTS,
         TYPE_VIEW
+      )
+    );
+    privileges.add(
+      new CoveoV2.PlatformToken.TokenPrivilege(
+        OWNER_SEARCH_API,
+        DOMAIN_SEARCH_API_EXECUTE_QUERY,
+        TYPE_ENABLE
       )
     );
     return privileges;


### PR DESCRIPTION
## [SFINT-5747](https://coveord.atlassian.net/browse/SFINT-5747)

The execute query privilege should be part of the Insight Token Provider.
This privilege is mandatory for RGA answers to be returned in the insight panel, otherwise it would return 403 errors.


[SFINT-5747]: https://coveord.atlassian.net/browse/SFINT-5747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ