### PR TITLE
fix(quantic): fix quick view modal close icon after salesforce winter 25

### DIFF
--- a/packages/quantic/cypress/e2e/default-2/document-suggestion/document-suggestion-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/document-suggestion/document-suggestion-selectors.ts
@@ -49,7 +49,7 @@ export const DocumentSuggestionSelectors: DocumentSuggestionSelector &
     DocumentSuggestionSelectors.get().find('c-quantic-result-quickview'),
   quickviewCloseButton: () =>
     DocumentSuggestionSelectors.get().find(
-      'c-quantic-result-quickview section header button'
+      '[data-cy="quickview-modal__close-button"]'
     ),
   componentError: () =>
     DocumentSuggestionSelectors.get().find('c-quantic-component-error'),

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -1,7 +1,8 @@
 <template>
-  <div data-cy="quick-view-button__container" class={buttonContainerClass} onmouseenter={showTooltip} onmouseleave={hideTooltip}>
-    <button data-cy="quick-view-button" aria-hidden={isQuickviewOpen} class={buttonClass} onclick={openQuickview} title={buttonTitle}
-      disabled={hasNoPreview} aria-label={buttonAriaLabelValue}>
+  <div data-cy="quick-view-button__container" class={buttonContainerClass} onmouseenter={showTooltip}
+    onmouseleave={hideTooltip}>
+    <button data-cy="quick-view-button" aria-hidden={isQuickviewOpen} class={buttonClass} onclick={openQuickview}
+      title={buttonTitle} disabled={hasNoPreview} aria-label={buttonAriaLabelValue}>
       <template if:true={hasButtonLabel}> {previewButtonLabel} </template>
       <template if:true={hasIcon}>
         <lightning-icon size="x-small" icon-name={previewButtonIcon} alternative-text={buttonLabel}
@@ -20,12 +21,13 @@
       aria-modal="true" aria-describedby="quickview__content-container"
       class="slds-modal slds-modal_medium slds-fade-in-open">
       <div class="slds-modal__container">
+        <button class="slds-button slds-button_icon slds-modal__close" onclick={closeQuickview}
+          onkeydown={onCloseKeyDown}>
+          <lightning-icon class="slds-current-color" icon-name="utility:close" size="small"
+            alternative-text={labels.close}></lightning-icon>
+          <span class="slds-assistive-text">Cancel and close</span>
+        </button>
         <header class="slds-modal__header" onclick={stopPropagation}>
-          <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse"
-            onclick={closeQuickview} onkeydown={onCloseKeyDown}>
-            <lightning-icon class="slds-current-color slds-m-right_xx-small" icon-name="utility:close"
-              alternative-text={labels.close}></lightning-icon>
-          </button>
           <div id="quickview-modal-heading"
             class="slds-modal__title slds-truncate slds-grid slds-grid_vertical-align-center">
             <div class="slds-grid slds-truncate slds-grid_vertical-align-center slds-text-align_left">

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -21,7 +21,7 @@
       aria-modal="true" aria-describedby="quickview__content-container"
       class="slds-modal slds-modal_medium slds-fade-in-open">
       <div class="slds-modal__container">
-        <button class="slds-button slds-button_icon slds-modal__close" onclick={closeQuickview}
+        <button data-cy="quickview-modal__close-button" class="slds-button slds-button_icon slds-modal__close" onclick={closeQuickview}
           onkeydown={onCloseKeyDown}>
           <lightning-icon class="slds-current-color" icon-name="utility:close" size="small"
             alternative-text={labels.close}></lightning-icon>


### PR DESCRIPTION
[SFINT-5720](https://coveord.atlassian.net/browse/SFINT-5720)

## Fixed the display of the quick view modal close icon:

### Before:
<img width="400" alt="Screenshot 2024-10-03 at 1 17 04 PM" src="https://github.com/user-attachments/assets/b3a9d2b1-1fda-40fe-9a54-021e309cbd17">


### After:
<img width="400" alt="Screenshot 2024-10-03 at 1 15 59 PM" src="https://github.com/user-attachments/assets/300d64df-4d8d-4851-8cc6-2e1995ad9a39">


[SFINT-5720]: https://coveord.atlassian.net/browse/SFINT-5720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ