### PR TITLE
fix(quantic): alignment of time frame facet inputs fixed

### DIFF
--- a/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/packages/quantic/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -772,7 +772,7 @@
   </labels>
   <labels>
     <fullName>quantic_DatePatternMonth</fullName>
-    <value>M</value>
+    <value>m</value>
     <language>en_US</language>
     <protected>false</protected>
     <shortDescription>Month part of the date pattern</shortDescription>

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -45,8 +45,8 @@
               <template if:true={withDatePicker}>
                 <div class="slds-grid slds-gutters slds-grid_vertical slds-p-around_x-small">
                   <form onsubmit={handleApply}>
-                    <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center">
-                      <div class="slds-col slds-size_1-of-5">
+                    <div class="slds-col slds-grid slds-gutters">
+                      <div class="slds-col slds-size_1-of-5 slds-var-p-top_xx-small slds-var-m-top_xxx-small">
                         <span class="timeframe-facet__input-label">{labels.startLabel}</span>
                       </div>
                       <div class="slds-col slds-size_4-of-5">
@@ -65,8 +65,8 @@
                         </lightning-input>
                       </div>
                     </div>
-                    <div class="slds-col slds-grid slds-gutters slds-grid_vertical-align-center slds-p-top_x-small">
-                      <div class="slds-col slds-size_1-of-5">
+                    <div class="slds-col slds-grid slds-gutters slds-p-top_x-small">
+                      <div class="slds-col slds-size_1-of-5 slds-var-p-top_xx-small slds-var-m-top_xxx-small">
                         <span class="timeframe-facet__input-label">{labels.endLabel}</span>
                       </div>
                       <div class="slds-col slds-size_4-of-5">


### PR DESCRIPTION
## [SFINT-5722](https://coveord.atlassian.net/browse/SFINT-5722)

In Salesforce winter 25 version, Salesforce started displaying the format of the expected date format with the date inputs to improve the a11y: https://help.salesforce.com/s/articleView?id=release-notes.rn_lc_base_component_accessibility.htm&release=252&type=5

This broke the alignment of the label of these inputs in our timeframe facet:

## Before:
<img width="278" alt="Screenshot 2024-10-03 at 2 36 12 PM" src="https://github.com/user-attachments/assets/934dbe03-6d4e-4887-b5ba-7f0a6997ce77">


https://github.com/user-attachments/assets/0ce1083e-75ee-4520-993b-564aa1018072




## After:
<img width="273" alt="Screenshot 2024-10-03 at 2 33 38 PM" src="https://github.com/user-attachments/assets/bc229e6f-359f-47b2-a8c1-a5eaacb01a9e">


[SFINT-5722]: https://coveord.atlassian.net/browse/SFINT-5722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ