### PR TITLE
fix(quantic): Limit the document.referrer to 256 chars in quantic interfaces

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
@@ -62,7 +62,7 @@ export default class QuanticCaseAssistInterface extends LightningElement {
                     analytics: {
                       analyticsMode: 'legacy',
                       ...(document.referrer && {
-                        originLevel3: document.referrer,
+                        originLevel3: document.referrer.substring(0, 256),
                       }),
                     },
                     ...rest,

--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -78,7 +78,7 @@ export default class QuanticInsightInterface extends LightningElement {
                     analytics: {
                       analyticsMode: 'legacy',
                       ...(document.referrer && {
-                        originLevel3: document.referrer,
+                        originLevel3: document.referrer.substring(0, 256),
                       }),
                     },
                     ...rest,

--- a/packages/quantic/force-app/main/default/lwc/quanticRecommendationInterface/quanticRecommendationInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticRecommendationInterface/quanticRecommendationInterface.js
@@ -79,6 +79,9 @@ export default class QuanticRecommendationInterface extends LightningElement {
                 analytics: {
                   analyticsMode: 'legacy',
                   originContext: this.analyticsOriginContext,
+                  ...(document.referrer && {
+                    originLevel3: document.referrer.substring(0, 256),
+                  }),
                 },
                 ...rest,
               },

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchInterface/quanticSearchInterface.js
@@ -104,7 +104,9 @@ export default class QuanticSearchInterface extends LightningElement {
                   },
                   analytics: {
                     analyticsMode: 'legacy',
-                    ...(document.referrer && {originLevel3: document.referrer}),
+                    ...(document.referrer && {
+                      originLevel3: document.referrer.substring(0, 256),
+                    }),
                   },
                   ...rest,
                 },


### PR DESCRIPTION
[SFINT-5762](https://coveord.atlassian.net/browse/SFINT-5762)

### ISSUE:

The document referrer currently includes the query params which sometimes makes it exceed the limit of 256 characters and cause an error. 

We want to limit this before we send it in quantic interfaces to avoid such error. Moreover, the first 256 chars should be enough to indicate how and from where the end user landed in the search interface

For example : 
https://inspiration-page-9768-dev-ed.scratch.lightning.force.com/visualEditor/appBuilder.app?id=support__Case_rec_L_3col&recordId=500DR00000AaeL6YAJ&cloneable=true&retUrl=https%3A%2F%2Finspiration-page-9768-dev-ed.scratch.lightning.force.com%2Flightning%2Fr%2FCase%2F500DR00000AaeL6YAJ%2Fview”

was causing:

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/82ed3895-e88f-43be-8df7-3b848d0a0575">


### SOLUTION:

We keep only the first 256 chars

[SFINT-5762]: https://coveord.atlassian.net/browse/SFINT-5762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ