### PR TITLE
fix(atomic): fix styling issues with atomic tabs

### DIFF
--- a/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
@@ -10,7 +10,12 @@ export const TabDropdownOption: FunctionalComponent<TabDropdownOptionProps> = (
   props
 ) => {
   return (
-    <option key={props.value} value={props.value} selected={props.isSelected}>
+    <option
+      class={'text-black'}
+      key={props.value}
+      value={props.value}
+      selected={props.isSelected}
+    >
       {props.label}
     </option>
   );

--- a/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
@@ -11,7 +11,7 @@ export const TabDropdownOption: FunctionalComponent<TabDropdownOptionProps> = (
 ) => {
   return (
     <option
-      class='text-black'
+      class="text-black"
       key={props.value}
       value={props.value}
       selected={props.isSelected}

--- a/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-dropdown-option.tsx
@@ -11,7 +11,7 @@ export const TabDropdownOption: FunctionalComponent<TabDropdownOptionProps> = (
 ) => {
   return (
     <option
-      class={'text-black'}
+      class='text-black'
       key={props.value}
       value={props.value}
       selected={props.isSelected}

--- a/packages/atomic/src/components/common/tab-manager/tab-dropdown.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-dropdown.tsx
@@ -17,7 +17,7 @@ export const TabDropdown: FunctionalComponent<TabDropdownProps> = (
     >
       <select
         aria-label="tab-dropdown"
-        class="btn-text-primary cursor-pointer py-2 text-xl font-bold"
+        class="btn-text-primary mobile-only:w-full cursor-pointer py-2 text-xl font-bold"
         onChange={(e) =>
           props.onTabChange((e.target as HTMLSelectElement).value)
         }


### PR DESCRIPTION
This PR fixes a text color issue with the select dropdown of tabs. This issue is specific to window/linux. Additionally, the select dropdown is now full width on mobile.

https://coveord.atlassian.net/browse/KIT-3549