### PR TITLE
fix(headless): set custom analytic provider

### DIFF
--- a/packages/headless/src/features/result-preview/result-preview-analytics-actions.ts
+++ b/packages/headless/src/features/result-preview/result-preview-analytics-actions.ts
@@ -1,4 +1,5 @@
 import {ItemClick} from '@coveo/relay-event-types';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics.js';
 import {Result} from '../../api/search/search/result.js';
 import {
   ClickAction,
@@ -16,6 +17,11 @@ export const logDocumentQuickview = (result: Result): ClickAction => {
       const info = partialDocumentInformation(result, state);
       const id = documentIdentifier(result);
       return client.makeDocumentQuickview(info, id);
+    },
+    __legacy__provider: (getState) => {
+      const customAnalyticsProvider = new SearchAnalyticsProvider(getState);
+      customAnalyticsProvider.getSearchUID = () => result.searchUid ?? '';
+      return customAnalyticsProvider;
     },
     analyticsType: 'itemClick',
     analyticsPayloadBuilder: (state): ItemClick => {

--- a/packages/headless/src/features/result/result-analytics-actions.ts
+++ b/packages/headless/src/features/result/result-analytics-actions.ts
@@ -1,4 +1,5 @@
 import {ItemClick} from '@coveo/relay-event-types';
+import {SearchAnalyticsProvider} from '../../api/analytics/search-analytics.js';
 import {Result} from '../../api/search/search/result.js';
 import {
   partialDocumentInformation,
@@ -17,6 +18,11 @@ export const logDocumentOpen = (result: Result): ClickAction =>
         partialDocumentInformation(result, state),
         documentIdentifier(result)
       );
+    },
+    __legacy__provider: (getState) => {
+      const customAnalyticsProvider = new SearchAnalyticsProvider(getState);
+      customAnalyticsProvider.getSearchUID = () => result.searchUid ?? '';
+      return customAnalyticsProvider;
     },
     analyticsType: 'itemClick',
     analyticsPayloadBuilder: (state): ItemClick => {


### PR DESCRIPTION
Porting Fix from #4391 to V2

This update overrides the `getSearchUID` method from the legacy provider. Instead of retrieving the search UID from the response, it now fetches it directly from the result.

https://coveord.atlassian.net/browse/KIT-3481