### PR TITLE
fix(atomic): prevent quickview from reopening when changing tab

### DIFF
--- a/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-quickview/atomic-quickview.tsx
@@ -139,9 +139,12 @@ export class AtomicQuickview implements InitializableComponent {
     this.quickview.fetchResultContent();
   }
 
-  public render() {
+  componentWillUpdate(): void {
     this.addQuickviewModalIfNeeded();
     this.updateModalContent();
+  }
+
+  public render() {
     if (this.quickviewState.resultHasPreview) {
       return (
         <Button


### PR DESCRIPTION
This PR prevents the quickview from reopening when changing tab. This issue occurs when the two tabs have different result lists enabled.

https://coveord.atlassian.net/browse/KIT-3557