### PR TITLE
fix(quantic,atomic): fixed timezone issue with user actions timeline

### DIFF
--- a/packages/atomic/src/utils/date-utils.ts
+++ b/packages/atomic/src/utils/date-utils.ts
@@ -44,12 +44,12 @@ export function parseTimestampToDateDetails(timestamp: number) {
 
   const date = new Date(timestamp);
 
-  const dayOfWeek = daysOfWeek[date.getUTCDay()];
-  const month = months[date.getUTCMonth()];
-  const day = date.getUTCDate();
-  const year = date.getUTCFullYear();
-  const hours = date.getUTCHours();
-  const minutes = date.getUTCMinutes();
+  const dayOfWeek = daysOfWeek[date.getDay()];
+  const month = months[date.getMonth()];
+  const day = date.getDate();
+  const year = date.getFullYear();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
 
   return {
     year,

--- a/packages/quantic/force-app/main/default/lwc/quanticUserAction/__tests__/quanticUserAction.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUserAction/__tests__/quanticUserAction.test.js
@@ -91,11 +91,13 @@ describe('c-quantic-user-action', () => {
     cleanup();
   });
 
+  let exampleDate = new Date('2024-09-25T04:06');
+  let exampleDateInUTC = new Date(exampleDate.toUTCString());
   describe('ticket creation action', () => {
     const exampleAction = {
       actionType: 'TICKET_CREATION',
       searchHub: expectedSearchHub,
-      timestamp: new Date('2024-09-25T04:06Z'),
+      timestamp: exampleDateInUTC,
     };
 
     it('should properly display the action icon', async () => {
@@ -140,10 +142,12 @@ describe('c-quantic-user-action', () => {
   });
 
   describe('custom action', () => {
+    exampleDate = new Date('2024-09-25T04:07');
+    exampleDateInUTC = new Date(exampleDate.toUTCString());
     const exampleAction = {
       actionType: 'CUSTOM',
       searchHub: expectedSearchHub,
-      timestamp: new Date('2024-09-25T04:07Z'),
+      timestamp: exampleDateInUTC,
       eventData: {
         value: expectedEventDataValue,
       },
@@ -214,10 +218,12 @@ describe('c-quantic-user-action', () => {
   });
 
   describe('click action', () => {
+    exampleDate = new Date('2024-09-25T05:07');
+    exampleDateInUTC = new Date(exampleDate.toUTCString());
     const exampleAction = {
       actionType: 'CLICK',
       searchHub: expectedSearchHub,
-      timestamp: new Date('2024-09-25T05:07Z'),
+      timestamp: exampleDateInUTC,
       document: {
         title: expectedTitle,
       },
@@ -265,10 +271,12 @@ describe('c-quantic-user-action', () => {
   });
 
   describe('search action', () => {
+    exampleDate = new Date('2024-09-25T06:08');
+    exampleDateInUTC = new Date(exampleDate.toUTCString());
     const exampleAction = {
       actionType: 'SEARCH',
       searchHub: expectedSearchHub,
-      timestamp: new Date('2024-09-25T06:08Z'),
+      timestamp: exampleDateInUTC,
       query: expectedQuery,
     };
 
@@ -331,6 +339,8 @@ describe('c-quantic-user-action', () => {
   });
 
   describe('view action', () => {
+    exampleDate = new Date('2024-09-25T04:07');
+    exampleDateInUTC = new Date(exampleDate.toUTCString());
     const exampleAction = {
       actionType: 'VIEW',
       document: {
@@ -338,7 +348,7 @@ describe('c-quantic-user-action', () => {
         contentIdValue: expectedUrl,
       },
       searchHub: expectedSearchHub,
-      timestamp: new Date('2024-09-25T04:07Z'),
+      timestamp: exampleDateInUTC,
     };
 
     it('should properly display the action icon', async () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -450,13 +450,12 @@ export class DateUtils {
     ];
 
     const date = new Date(timestamp);
-
-    const dayOfWeek = daysOfWeek[date.getUTCDay()];
-    const month = months[date.getUTCMonth()];
-    const day = date.getUTCDate();
-    const year = date.getUTCFullYear();
-    const hours = date.getUTCHours();
-    const minutes = date.getUTCMinutes();
+    const dayOfWeek = daysOfWeek[date.getDay()];
+    const month = months[date.getMonth()];
+    const day = date.getDate();
+    const year = date.getFullYear();
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
 
     return {
       year,


### PR DESCRIPTION
## [SFINT-5765](https://coveord.atlassian.net/browse/SFINT-5765)

- Fixed timezone of the dates displayed in the user actions timeline, instead of displaying the dates in the UTC timezone we need to display them in the local timezone.


[SFINT-5765]: https://coveord.atlassian.net/browse/SFINT-5765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ