### PR TITLE
fix(atomic): hide carousel buttons when image size is set to icon

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.pcss
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.pcss
@@ -6,6 +6,13 @@
   @apply relative;
 
   .with-sections {
+    &.image-icon {
+      atomic-product-image::part(previous-button),
+      atomic-product-image::part(next-button),
+      atomic-product-image::part(indicator) {
+        display: none;
+      }
+    }
     &.display-grid {
       @screen desktop-only {
         &.image-large {


### PR DESCRIPTION
This PR hides the product image carousel buttons when **imageSize** is set to icon. This prevent the buttons from overlapping with the icon.

https://coveord.atlassian.net/browse/KIT-3612