### PR TITLE
fix(atomic): add hover effect for atomic-product clickable element in mobile/grid

### DIFF
--- a/packages/atomic/src/components/common/item-list/styles/mixins.pcss
+++ b/packages/atomic/src/components/common/item-list/styles/mixins.pcss
@@ -141,16 +141,14 @@
   [part~='outline'][part~='result-list-grid-clickable-container'] {
     position: relative;
 
-    & {
-      border: 1px solid transparent;
-      padding: 1rem;
-      border-radius: 1rem;
-      transition: all 0.12s ease-out;
-      &:hover {
-        border: 1px solid var(--atomic-neutral);
-        box-shadow: 0px 10px 25px var(--atomic-neutral);
-        cursor: pointer;
-      }
+    border: 1px solid transparent;
+    padding: 1rem;
+    border-radius: 1rem;
+    transition: all 0.12s ease-out;
+    &:hover {
+      border: 1px solid var(--atomic-neutral);
+      box-shadow: 0px 10px 25px var(--atomic-neutral);
+      cursor: pointer;
     }
   }
 

--- a/packages/atomic/src/components/common/item-list/styles/mixins.pcss
+++ b/packages/atomic/src/components/common/item-list/styles/mixins.pcss
@@ -141,17 +141,15 @@
   [part~='outline'][part~='result-list-grid-clickable-container'] {
     position: relative;
 
-    @screen desktop-only {
-      & {
-        border: 1px solid transparent;
-        padding: 1rem;
-        border-radius: 1rem;
-        transition: all 0.12s ease-out;
-        &:hover {
-          border: 1px solid var(--atomic-neutral);
-          box-shadow: 0px 10px 25px var(--atomic-neutral);
-          cursor: pointer;
-        }
+    & {
+      border: 1px solid transparent;
+      padding: 1rem;
+      border-radius: 1rem;
+      transition: all 0.12s ease-out;
+      &:hover {
+        border: 1px solid var(--atomic-neutral);
+        box-shadow: 0px 10px 25px var(--atomic-neutral);
+        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
This PR adds the hover effect and pointer cursor for atomic-product clickable elements in mobile screen size and grid display mode. This will communicate clearly that clicking anywhere on the element will open the product page.

![image](https://github.com/user-attachments/assets/848abe90-ba2e-4576-bfd5-ae59afcd44f4)

https://coveord.atlassian.net/browse/KIT-3643