### PR TITLE
fix(atomic): fix layout issue on product variants with imageSize set to none

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.pcss
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.pcss
@@ -29,7 +29,8 @@
           }
         }
 
-        &.image-icon {
+        &.image-icon,
+        &.image-none {
           atomic-product-section-children .product-child {
             width: 2rem;
             height: 2rem;
@@ -46,7 +47,8 @@
           }
         }
 
-        &.image-icon {
+        &.image-icon,
+        &.image-none {
           atomic-product-section-children .product-child {
             width: 2rem;
             height: 2rem;


### PR DESCRIPTION
This PR fixes the product variant icons from taking the full width of the product element when the imageSize is set to none

<img width="397" alt="image" src="https://github.com/user-attachments/assets/94b78ab2-b4c6-43e0-86f7-4bd338298bd1">




https://coveord.atlassian.net/browse/KIT-3608