### PR TITLE
feat(ipx): add exportparts to atomic-ipx-body

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.tsx
@@ -92,6 +92,7 @@ export class AtomicIPXModal implements InitializableComponent<AnyBindings> {
       <atomic-ipx-body
         isOpen={this.isOpen}
         displayFooterSlot={this.hasFooterSlotElements}
+        exportparts="container"
       >
         <slot name="header" slot="header" />
         <slot name="body" slot="body" />


### PR DESCRIPTION
We need a new export part to define a bit of CSS in the Search interface service for max-height/width. 
https://coveord.atlassian.net/browse/SVCC-4197