### PR TITLE
test(quantic): ep analytics tests fixed in the e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57977,7 +57977,7 @@
       },
       "devDependencies": {
         "@ckeditor/jsdoc-plugins": "39.9.1",
-        "@coveo/relay-event-types": "7.14.1",
+        "@coveo/relay-event-types": "12.0.1",
         "@coveo/release": "1.0.0",
         "@lwc/compiler": "5.3.0",
         "@lwc/eslint-plugin-lwc": "1.8.2",
@@ -58201,12 +58201,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "packages/quantic/node_modules/@coveo/relay-event-types": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@coveo/relay-event-types/-/relay-event-types-7.14.1.tgz",
-      "integrity": "sha512-ezU4wuxe6TK+q2qo4YAHoCquixQBx4nJ9ssvDu//8J66j4VPFTQphDkJhNzlGLVoESdQwrtuI3PYbVce2TGU0w==",
-      "dev": true
     },
     "packages/quantic/node_modules/@lwc/babel-plugin-component": {
       "version": "6.5.0",

--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
@@ -42,7 +42,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
 
 exports[`generated answer analytics actions > when analyticsMode is \`next\` > should log #logGeneratedAnswerFeedback with the right payload 1`] = `
 [
-  "Rga.SubmitRgaFeedback",
+  "Rga.SubmitFeedback",
   {
     "additionalNotes": undefined,
     "correctAnswerUrl": undefined,

--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
@@ -42,7 +42,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
 
 exports[`generated answer insight analytics actions > when analyticsMode is \`next\` > should log #logGeneratedAnswerFeedback with the right payload 1`] = `
 [
-  "Rga.SubmitRgaFeedback",
+  "Rga.SubmitFeedback",
   {
     "additionalNotes": undefined,
     "correctAnswerUrl": undefined,

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -201,7 +201,7 @@ export const logGeneratedAnswerFeedback = (
         ...feedback,
       });
     },
-    analyticsType: 'Rga.SubmitRgaFeedback',
+    analyticsType: 'Rga.SubmitFeedback',
     analyticsPayloadBuilder: (state): Rga.SubmitFeedback | undefined => {
       const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
       if (rgaID) {

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -203,7 +203,7 @@ export const logGeneratedAnswerFeedback = (
         getCaseContextAnalyticsMetadata(state.insightCaseContext)
       );
     },
-    analyticsType: 'Rga.SubmitRgaFeedback',
+    analyticsType: 'Rga.SubmitFeedback',
     analyticsPayloadBuilder: (state): Rga.SubmitFeedback | undefined => {
       const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
       if (rgaID) {

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-selectors.ts
@@ -55,7 +55,9 @@ export const CaseClassificationSelectors: CaseClassificationSelector &
       .find('.case-classification-option input')
       .eq(idx),
   error: () =>
-    CaseClassificationSelectors.get().find('.slds-form-element__help'),
+    CaseClassificationSelectors.get().find(
+      '[data-cy="case-classification-error-message"]'
+    ),
   loadingSpinner: () =>
     CaseClassificationSelectors.get().find('lightning-spinner'),
   componentError: () =>

--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification.cypress.ts
@@ -1,5 +1,5 @@
 import {fetchClassifications} from '../../../page-objects/actions/action-fetch-classifications';
-import {AnalyticsModeEnum} from '../../../page-objects/analytics';
+import {analyticsModeTest} from '../../../page-objects/analytics';
 import {
   interceptCaseAssist,
   mockCaseClassification,
@@ -76,13 +76,7 @@ describe('quantic-case-classification', () => {
     configure(options);
   }
 
-  // TODO: (SFINT-5732)
-  [
-    {
-      mode: AnalyticsModeEnum.legacy,
-      label: 'when legacy analytics are sent',
-    },
-  ].forEach((analytics) => {
+  analyticsModeTest.forEach((analytics) => {
     describe(analytics.label, () => {
       before(() => {
         analyticsMode = analytics.mode;
@@ -119,16 +113,14 @@ describe('quantic-case-classification', () => {
             );
             Expect.numberOfInlineOptions(0);
             if (analyticsMode === 'next') {
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
+                {
+                  classificationId: allOptions[firstSuggestionIndex].id,
+                  responseId: exampleResponseId,
+                  autoselected: true,
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickedSuggestion(firstSuggestionIndex, true);
             }
@@ -140,18 +132,15 @@ describe('quantic-case-classification', () => {
 
             Actions.clickSuggestion(clickedIndex);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[clickedIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: false,
-              //   },
-              //   exampleTrackingId
-              // );
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
+                {
+                  classificationId: allOptions[clickedIndex].id,
+                  responseId: exampleResponseId,
+                  autoselected: false,
+                },
+                exampleTrackingId
+              );
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -176,7 +165,7 @@ describe('quantic-case-classification', () => {
             Actions.clickSelectOption(clickedIndex);
             Expect.hideSuggestions(true);
             if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -225,17 +214,14 @@ describe('quantic-case-classification', () => {
             Expect.displaySelectInput(false);
             Expect.displaySelectTitle(true);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
+                {
+                  classificationId: allOptions[firstSuggestionIndex].id,
+                  responseId: exampleResponseId,
+                  autoselected: true,
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickedSuggestion(firstSuggestionIndex, true);
             }
@@ -249,7 +235,7 @@ describe('quantic-case-classification', () => {
             Actions.openSelectInput();
             Actions.clickSelectOption(clickedIndex);
             if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -298,17 +284,14 @@ describe('quantic-case-classification', () => {
             Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
             Expect.displaySelectInput(false);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
+                {
+                  classificationId: allOptions[firstSuggestionIndex].id,
+                  responseId: exampleResponseId,
+                  autoselected: true,
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickedSuggestion(firstSuggestionIndex, true);
             }
@@ -320,18 +303,15 @@ describe('quantic-case-classification', () => {
 
             Actions.clickSuggestion(clickedIndex);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[clickedIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: false,
-              //   },
-              //   exampleTrackingId
-              // );
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
+                {
+                  classificationId: allOptions[clickedIndex].id,
+                  responseId: exampleResponseId,
+                  autoselected: false,
+                },
+                exampleTrackingId
+              );
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -353,7 +333,7 @@ describe('quantic-case-classification', () => {
 
             Actions.clickInlineOption(clickedIndex);
             if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex + suggestionsCount].value,
@@ -403,21 +383,6 @@ describe('quantic-case-classification', () => {
             Expect.numberOfSuggestions(suggestionsCount);
             Expect.numberOfInlineOptions(allOptions.length - suggestionsCount);
             Expect.displaySelectInput(false);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
           });
         });
@@ -444,20 +409,6 @@ describe('quantic-case-classification', () => {
 
             Actions.openSelectInput();
             Actions.clickSelectOption(clickedIndex);
-            if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
-                {
-                  fieldName: coveoDefaultField,
-                  fieldValue: allOptions[clickedIndex].value,
-                },
-                exampleTrackingId
-              );
-            } else {
-              Expect.logUpdatedClassificationFromSelectOption(
-                coveoDefaultField,
-                clickedIndex
-              );
-            }
             Actions.reportValidity();
             Expect.displayError(false);
           });
@@ -482,34 +433,8 @@ describe('quantic-case-classification', () => {
             Expect.displaySelectTitle(true);
             Expect.displaySelectInput(false);
             Expect.numberOfSuggestions(suggestionsCount);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
             Actions.clickSuggestion(firstSuggestionIndex);
-            if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
-                {
-                  fieldName: coveoDefaultField,
-                  fieldValue: '',
-                },
-                exampleTrackingId
-              );
-            } else {
-              Expect.logDeselect(coveoDefaultField);
-            }
             Expect.correctValue('');
             Actions.reportValidity();
             Expect.displayError(true);
@@ -529,32 +454,6 @@ describe('quantic-case-classification', () => {
             Expect.numberOfSuggestions(suggestionsCount);
             Actions.clickSuggestion(firstSuggestionIndex);
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: false,
-              //   },
-              //   exampleTrackingId
-              // );
-              NextAnalyticsExpectations.emitUpdateField(
-                {
-                  fieldName: coveoDefaultField,
-                  fieldValue: allOptions[firstSuggestionIndex].value,
-                },
-                exampleTrackingId
-              );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex);
-              Expect.logUpdatedClassificationFromSuggestion(
-                coveoDefaultField,
-                firstSuggestionIndex
-              );
-            }
             Actions.reportValidity();
             Expect.displayError(false);
           });
@@ -586,21 +485,6 @@ describe('quantic-case-classification', () => {
               exampleResponseId
             );
             fetchClassifications();
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
             Expect.displaySelectTitle(true);
             Expect.displaySelectInput(false);
@@ -666,52 +550,11 @@ describe('quantic-case-classification', () => {
               allOptions.slice(0, suggestionsCount)
             );
             Expect.numberOfInlineOptions(0);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
           });
 
           scope('when selecting a suggestion', () => {
             Actions.clickSuggestion(clickedIndex);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[clickedIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: false,
-              //   },
-              //   exampleTrackingId
-              // );
-              NextAnalyticsExpectations.emitUpdateField(
-                {
-                  fieldName: coveoDefaultField,
-                  fieldValue: allOptions[clickedIndex].value,
-                },
-                exampleTrackingId
-              );
-            } else {
-              Expect.logClickedSuggestion(clickedIndex);
-              Expect.logUpdatedClassificationFromSuggestion(
-                coveoDefaultField,
-                clickedIndex
-              );
-            }
             Expect.correctValue(allOptions[clickedIndex].value);
           });
 
@@ -768,53 +611,12 @@ describe('quantic-case-classification', () => {
                 allOptions.slice(0, suggestionsCount)
               );
               Expect.numberOfInlineOptions(0);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             }
           );
 
           scope('when selecting a suggestion', () => {
             Actions.clickSuggestion(clickedIndex);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[clickedIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: false,
-              //   },
-              //   exampleTrackingId
-              // );
-              NextAnalyticsExpectations.emitUpdateField(
-                {
-                  fieldName: coveoDefaultField,
-                  fieldValue: allOptions[clickedIndex].value,
-                },
-                exampleTrackingId
-              );
-            } else {
-              Expect.logClickedSuggestion(clickedIndex);
-              Expect.logUpdatedClassificationFromSuggestion(
-                coveoDefaultField,
-                clickedIndex
-              );
-            }
             Expect.correctValue(allOptions[clickedIndex].value);
           });
 
@@ -879,7 +681,7 @@ describe('quantic-case-classification', () => {
             Actions.openSelectInput();
             Actions.clickSelectOption(clickedIndex);
             if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -944,27 +746,11 @@ describe('quantic-case-classification', () => {
               allOptions.slice(0, suggestionsCount)
             );
             Expect.numberOfInlineOptions(0);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
           });
 
           scope('when fetching suggestions again', () => {
             const suggestionsCount = 2;
-            const firstDisplayedSuggestionIndex = 0;
             const firstSuggestionIndex = 1;
 
             mockCaseClassification(
@@ -986,21 +772,6 @@ describe('quantic-case-classification', () => {
               )
             );
             Expect.numberOfInlineOptions(0);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstDisplayedSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
           });
         });
@@ -1026,7 +797,7 @@ describe('quantic-case-classification', () => {
           scope('when selecting an inline option', () => {
             Actions.clickInlineOption(clickedIndex);
             if (analyticsMode === 'next') {
-              NextAnalyticsExpectations.emitUpdateField(
+              NextAnalyticsExpectations.emitCaseAssistUpdateField(
                 {
                   fieldName: coveoDefaultField,
                   fieldValue: allOptions[clickedIndex].value,
@@ -1095,52 +866,11 @@ describe('quantic-case-classification', () => {
                 allOptions.slice(0, suggestionsCount)
               );
               Expect.numberOfInlineOptions(0);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
             scope('when selecting a suggestion', () => {
               Actions.clickSuggestion(clickedIndex);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[clickedIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: false,
-                //   },
-                //   exampleTrackingId
-                // );
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue: allOptions[clickedIndex].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logClickedSuggestion(clickedIndex);
-                Expect.logUpdatedClassificationFromSuggestion(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.correctValue(allOptions[clickedIndex].value);
               Expect.fetchClassifications();
             });
@@ -1180,21 +910,6 @@ describe('quantic-case-classification', () => {
                 allOptions.length - suggestionsCount
               );
               Expect.displaySelectInput(false);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
@@ -1202,21 +917,6 @@ describe('quantic-case-classification', () => {
               const clickedIndex = 0;
 
               Actions.clickInlineOption(clickedIndex);
-              if (analyticsMode === 'next') {
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue:
-                      allOptions[clickedIndex + suggestionsCount].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logUpdatedClassificationFromInlineOption(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.correctValue(
                 allOptions[clickedIndex + suggestionsCount].value
               );
@@ -1257,21 +957,6 @@ describe('quantic-case-classification', () => {
                 allOptions.slice(0, suggestionsCount)
               );
               Expect.numberOfInlineOptions(0);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
@@ -1281,20 +966,6 @@ describe('quantic-case-classification', () => {
               Actions.openSelectInput();
               Actions.clickSelectOption(clickedIndex);
               Expect.correctValue(allOptions[clickedIndex].value);
-              if (analyticsMode === 'next') {
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue: allOptions[clickedIndex].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logUpdatedClassificationFromSelectOption(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.fetchClassifications();
             });
           });
@@ -1336,53 +1007,12 @@ describe('quantic-case-classification', () => {
                 allOptions.slice(0, suggestionsCount)
               );
               Expect.numberOfInlineOptions(0);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
             scope('when selecting a suggestion', () => {
               Actions.clickSuggestion(clickedIndex);
               Expect.correctValue(allOptions[clickedIndex].value);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[clickedIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: false,
-                //   },
-                //   exampleTrackingId
-                // );
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue: allOptions[clickedIndex].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logClickedSuggestion(clickedIndex);
-                Expect.logUpdatedClassificationFromSuggestion(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.fetchDocumentSuggestions();
             });
           });
@@ -1423,21 +1053,6 @@ describe('quantic-case-classification', () => {
                 allOptions.length - suggestionsCount
               );
               Expect.displaySelectInput(false);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
@@ -1445,21 +1060,6 @@ describe('quantic-case-classification', () => {
               const clickedIndex = 0;
 
               Actions.clickInlineOption(clickedIndex);
-              if (analyticsMode === 'next') {
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue:
-                      allOptions[clickedIndex + suggestionsCount].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logUpdatedClassificationFromInlineOption(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.correctValue(
                 allOptions[clickedIndex + suggestionsCount].value
               );
@@ -1501,21 +1101,6 @@ describe('quantic-case-classification', () => {
                 allOptions.slice(0, suggestionsCount)
               );
               Expect.numberOfInlineOptions(0);
-              if (analyticsMode === 'next') {
-                // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-                //   {
-                //     fieldClassification: {
-                //       id: allOptions[firstSuggestionIndex].id,
-                //       responseId: exampleResponseId,
-                //     },
-                //     autoselected: true,
-                //   },
-                //   exampleTrackingId
-                // );
-              } else {
-                Expect.logClickedSuggestion(firstSuggestionIndex, true);
-              }
               Expect.correctValue(allOptions[firstSuggestionIndex].value);
             });
 
@@ -1526,20 +1111,6 @@ describe('quantic-case-classification', () => {
               Actions.openSelectInput();
               Actions.clickSelectOption(clickedIndex);
               Expect.correctValue(allOptions[clickedIndex].value);
-              if (analyticsMode === 'next') {
-                NextAnalyticsExpectations.emitUpdateField(
-                  {
-                    fieldName: coveoDefaultField,
-                    fieldValue: allOptions[clickedIndex].value,
-                  },
-                  exampleTrackingId
-                );
-              } else {
-                Expect.logUpdatedClassificationFromSelectOption(
-                  coveoDefaultField,
-                  clickedIndex
-                );
-              }
               Expect.fetchDocumentSuggestions();
             });
           });
@@ -1570,21 +1141,6 @@ describe('quantic-case-classification', () => {
               allOptions.slice(0, suggestionsCount)
             );
             Expect.numberOfInlineOptions(0);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistSelectFieldClassification(
-              //   {
-              //     fieldClassification: {
-              //       id: allOptions[firstSuggestionIndex].id,
-              //       responseId: exampleResponseId,
-              //     },
-              //     autoselected: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logClickedSuggestion(firstSuggestionIndex, true);
-            }
             Expect.correctValue(allOptions[firstSuggestionIndex].value);
           });
         });

--- a/packages/quantic/cypress/e2e/default-2/document-suggestion/document-suggestion.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/document-suggestion/document-suggestion.cypress.ts
@@ -84,16 +84,19 @@ describe('quantic-document-suggestion', () => {
 
             Actions.clickSuggestion(clickIndex);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
-              //   {
-              //     documentSuggestion: {
-              //       id: allDocuments[clickIndex].uniqueId,
-              //       responseId: exampleResponseId,
-              //     },
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
+                {
+                  responseId: exampleResponseId,
+                  position: clickIndex + 1,
+                  itemMetadata: {
+                    uniqueFieldName: 'uniqueId',
+                    uniqueFieldValue: allDocuments[clickIndex].uniqueId,
+                    title: allDocuments[clickIndex].title,
+                    url: allDocuments[clickIndex].clickUri,
+                  },
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickingSuggestion(clickIndex, allDocuments);
             }
@@ -108,17 +111,19 @@ describe('quantic-document-suggestion', () => {
 
             sendRating(clickIndex);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionFeedback(
-              //   {
-              //     documentSuggestion: {
-              //       id: allDocuments[clickIndex].uniqueId,
-              //       responseId: exampleResponseId,
-              //     },
-              //     liked: true,
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionFeedback(
+                {
+                  responseId: exampleResponseId,
+                  itemMetadata: {
+                    uniqueFieldName: 'uniqueId',
+                    uniqueFieldValue: allDocuments[clickIndex].uniqueId,
+                    title: allDocuments[clickIndex].title,
+                    url: allDocuments[clickIndex].clickUri,
+                  },
+                  liked: true,
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logRatingSuggestion(clickIndex, allDocuments);
             }
@@ -130,21 +135,19 @@ describe('quantic-document-suggestion', () => {
             Actions.openQuickview(clickIndex);
             cy.wait(InterceptAliases.ResultHtml);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitItemClick(
-              //   {
-              //     position: clickIndex + 1,
-              //     actionCause: 'preview',
-              //     itemMetadata: {
-              //       uniqueFieldName: 'uniqueId',
-              //       uniqueFieldValue: allDocuments[clickIndex].uniqueId,
-              //       title: allDocuments[clickIndex].title,
-              //       url: allDocuments[clickIndex].clickUri,
-              //     },
-              //     searchUid: exampleResponseId,
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
+                {
+                  responseId: exampleResponseId,
+                  position: clickIndex + 1,
+                  itemMetadata: {
+                    uniqueFieldName: 'uniqueId',
+                    uniqueFieldValue: allDocuments[clickIndex].uniqueId,
+                    title: allDocuments[clickIndex].title,
+                    url: allDocuments[clickIndex].clickUri,
+                  },
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickingSuggestion(clickIndex, allDocuments, true);
             }
@@ -153,8 +156,7 @@ describe('quantic-document-suggestion', () => {
         });
       });
 
-      // TODO: (SFINT-5732)
-      describe.skip('when withoutQuickview is set to true', () => {
+      describe('when withoutQuickview is set to true', () => {
         it('should not render quick view button', () => {
           const exampleResponseId = crypto.randomUUID();
           visitDocumentSuggestion({
@@ -184,9 +186,13 @@ describe('quantic-document-suggestion', () => {
             if (analyticsMode === 'next') {
               NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
                 {
-                  documentSuggestion: {
-                    id: allDocuments[clickIndex].uniqueId,
-                    responseId: exampleResponseId,
+                  responseId: exampleResponseId,
+                  position: clickIndex + 1,
+                  itemMetadata: {
+                    uniqueFieldName: 'uniqueId',
+                    uniqueFieldValue: allDocuments[clickIndex].uniqueId,
+                    title: allDocuments[clickIndex].title,
+                    url: allDocuments[clickIndex].clickUri,
                   },
                 },
                 exampleTrackingId
@@ -228,42 +234,24 @@ describe('quantic-document-suggestion', () => {
 
             Actions.clickSuggestion(clickIndex);
             if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
-              //   {
-              //     documentSuggestion: {
-              //       id: similarDocuments[clickIndex].uniqueId,
-              //       responseId: exampleResponseId,
-              //     },
-              //   },
-              //   exampleTrackingId
-              // );
+              NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionClick(
+                {
+                  responseId: exampleResponseId,
+                  position: clickIndex + 1,
+                  itemMetadata: {
+                    uniqueFieldName: 'uniqueId',
+                    uniqueFieldValue: similarDocuments[clickIndex].uniqueId,
+                    title: similarDocuments[clickIndex].title,
+                    url: similarDocuments[clickIndex].clickUri,
+                  },
+                },
+                exampleTrackingId
+              );
             } else {
               Expect.logClickingSuggestion(clickIndex, similarDocuments);
             }
             Expect.displayAccordionSectionContent(false, 0);
             Expect.displayAccordionSectionContent(true, clickIndex);
-          });
-
-          scope('when rating a document suggestion', () => {
-            const clickIndex = 1;
-
-            sendRating(clickIndex);
-            if (analyticsMode === 'next') {
-              // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-              // NextAnalyticsExpectations.emitCaseAssistDocumentSuggestionFeedback(
-              //   {
-              //     documentSuggestion: {
-              //       id: similarDocuments[clickIndex].uniqueId,
-              //       responseId: exampleResponseId,
-              //     },
-              //     liked: true,
-              //   },
-              //   exampleTrackingId
-              // );
-            } else {
-              Expect.logRatingSuggestion(clickIndex, similarDocuments);
-            }
           });
         });
       });

--- a/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/generatedAnswer/generated-answer.cypress.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @cspell/spellchecker */
 import {performSearch} from '../../../page-objects/actions/action-perform-search';
-import {AnalyticsModeEnum} from '../../../page-objects/analytics';
+import {analyticsModeTest} from '../../../page-objects/analytics';
 import {configure} from '../../../page-objects/configurator';
 import {
   interceptSearch,
@@ -31,7 +31,6 @@ interface GeneratedAnswerOptions {
 
 let analyticsMode: 'legacy' | 'next' = 'legacy';
 const exampleTrackingId = 'tracking_id_123';
-const answerType = 'RGA';
 
 const GENERATED_ANSWER_DATA_KEY = 'coveo-generated-answer-data';
 
@@ -325,40 +324,42 @@ describe('quantic-generated-answer', () => {
           });
         });
 
-        describe('when an end of stream event is received', () => {
-          const streamId = crypto.randomUUID();
-
-          const testMessagePayload = {
-            payloadType: 'genqa.endOfStreamType',
-            payload: JSON.stringify({
-              textDelta: testText,
-            }),
-            finishReason: 'COMPLETED',
-          };
-
-          beforeEach(() => {
-            mockSearchWithGeneratedAnswer(streamId, param.useCase);
-            mockStreamResponse(streamId, testMessagePayload);
-            visitGeneratedAnswer({useCase: param.useCase});
-          });
-
-          it('should log the generated answer stream end event', () => {
-            if (analyticsMode === 'legacy') {
-              Expect.logGeneratedAnswerStreamEnd(streamId);
-            }
-          });
-        });
-
-        // TODO: (SFINT-5732)
-        [
-          {
-            mode: AnalyticsModeEnum.legacy,
-            label: 'when legacy analytics are sent',
-          },
-        ].forEach((analytics) => {
+        analyticsModeTest.forEach((analytics) => {
           describe(analytics.label, () => {
             before(() => {
               analyticsMode = analytics.mode;
+            });
+
+            describe('when an end of stream event is received', () => {
+              const streamId = crypto.randomUUID();
+
+              const testMessagePayload = {
+                payloadType: 'genqa.endOfStreamType',
+                payload: JSON.stringify({
+                  textDelta: testText,
+                }),
+                finishReason: 'COMPLETED',
+              };
+
+              beforeEach(() => {
+                mockSearchWithGeneratedAnswer(streamId, param.useCase);
+                mockStreamResponse(streamId, testMessagePayload);
+                visitGeneratedAnswer({useCase: param.useCase});
+              });
+
+              it('should log the generated answer stream end event', () => {
+                if (analyticsMode === 'next') {
+                  NextAnalyticsExpectations.emitRgaStreamEnd(
+                    {
+                      responseId: streamId,
+                      answerGenerated: true,
+                    },
+                    exampleTrackingId
+                  );
+                } else {
+                  Expect.logGeneratedAnswerStreamEnd(streamId);
+                }
+              });
             });
 
             describe('when liking the generated answer', () => {
@@ -384,13 +385,10 @@ describe('quantic-generated-answer', () => {
                 scope('should properly log the analytics', () => {
                   Actions.likeGeneratedAnswer();
                   if (analyticsMode === 'next') {
-                    NextAnalyticsExpectations.emitQnaAnswerActionEvent(
+                    NextAnalyticsExpectations.emitRgaAnswerAction(
                       {
+                        responseId: streamId,
                         action: 'like',
-                        answer: {
-                          responseId,
-                          type: answerType,
-                        },
                       },
                       exampleTrackingId
                     );
@@ -440,13 +438,10 @@ describe('quantic-generated-answer', () => {
                   scope('when disliking the generated answer', () => {
                     Actions.dislikeGeneratedAnswer();
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaAnswerActionEvent(
+                      NextAnalyticsExpectations.emitRgaAnswerAction(
                         {
+                          responseId: streamId,
                           action: 'dislike',
-                          answer: {
-                            responseId,
-                            type: answerType,
-                          },
                         },
                         exampleTrackingId
                       );
@@ -495,19 +490,17 @@ describe('quantic-generated-answer', () => {
                     Actions.clickFeedbackSubmitButton();
                     Expect.displaySuccessMessage(true);
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaSubmitRgaFeedbackEvent(
+                      NextAnalyticsExpectations.emitRgaSubmitFeedback(
                         {
-                          feedback: {
-                            helpful: false,
-                            readable: noOption,
-                            documented: yesOption,
-                            details: exampleDetails,
-                            hallucination_free: yesOption,
-                            document_url: exampleDocumentUrl,
+                          responseId: streamId,
+                          helpful: false,
+                          details: {
+                            readable: false,
+                            documented: true,
+                            hallucinationFree: true,
                           },
-                          answer: {
-                            responseId,
-                          },
+                          additionalNotes: exampleDetails,
+                          correctAnswerUrl: exampleDocumentUrl,
                         },
                         exampleTrackingId
                       );
@@ -555,8 +548,7 @@ describe('quantic-generated-answer', () => {
               }
             );
 
-            // TODO: SFINT-5538 - Completely toggle answer.
-            describe.skip('the generated answer toggle button', () => {
+            describe('the generated answer toggle button', () => {
               const streamId = crypto.randomUUID();
               const responseId = crypto.randomUUID();
 
@@ -585,13 +577,9 @@ describe('quantic-generated-answer', () => {
                   Expect.displayDislikeButton(false);
                   Expect.displayDisclaimer(false);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - New events for toggling the generated answer, or remove completely toggle answer.
-                    NextAnalyticsExpectations.emitQnaAnswerActionEvent(
+                    NextAnalyticsExpectations.emitRgaAnswerAction(
                       {
-                        answer: {
-                          responseId,
-                          type: answerType,
-                        },
+                        responseId: streamId,
                         action: 'hide',
                       },
                       exampleTrackingId
@@ -611,12 +599,9 @@ describe('quantic-generated-answer', () => {
                   Expect.displayLikeButton(true);
                   Expect.displayDislikeButton(true);
                   if (analyticsMode === 'next') {
-                    NextAnalyticsExpectations.emitQnaAnswerActionEvent(
+                    NextAnalyticsExpectations.emitRgaAnswerAction(
                       {
-                        answer: {
-                          responseId,
-                          type: answerType,
-                        },
+                        responseId: streamId,
                         action: 'show',
                       },
                       exampleTrackingId
@@ -665,17 +650,13 @@ describe('quantic-generated-answer', () => {
                   Expect.displayCitations(false);
                   Expect.displayDisclaimer(true);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - New events for generated answer to be updated.
-                    // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                    //   {
-                    //     answer: {
-                    //       responseId,
-                    //       type: answerType,
-                    //     },
-                    //     action: 'expand',
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    NextAnalyticsExpectations.emitRgaAnswerAction(
+                      {
+                        responseId: streamId,
+                        action: 'expand',
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logGeneratedAnswerExpand(streamId);
                   }
@@ -692,17 +673,13 @@ describe('quantic-generated-answer', () => {
                     Expect.displayCitations(false);
                     Expect.displayDisclaimer(true);
                     if (analyticsMode === 'next') {
-                      // TODO: SFINT-5670 - New events for generated answer to be updated.
-                      // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                      //   {
-                      //     answer: {
-                      //       responseId,
-                      //       type: answerType,
-                      //     },
-                      //     action: 'collapse',
-                      //   },
-                      //   exampleTrackingId
-                      // );
+                      NextAnalyticsExpectations.emitRgaAnswerAction(
+                        {
+                          responseId: streamId,
+                          action: 'collapse',
+                        },
+                        exampleTrackingId
+                      );
                     } else {
                       Expect.logGeneratedAnswerCollapse(streamId);
                     }
@@ -738,12 +715,9 @@ describe('quantic-generated-answer', () => {
                     Expect.displayCopyToClipboardButton(true);
                     Actions.clickCopyToClipboardButton();
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaAnswerActionEvent(
+                      NextAnalyticsExpectations.emitRgaAnswerAction(
                         {
-                          answer: {
-                            responseId,
-                            type: answerType,
-                          },
+                          responseId: streamId,
                           action: 'copyToClipboard',
                         },
                         exampleTrackingId
@@ -831,20 +805,22 @@ describe('quantic-generated-answer', () => {
                     false
                   );
 
-                  Actions.hoverOverCitation(0);
+                  Actions.hoverOverCitation(hoveredCitationIndex);
                   Expect.citationTooltipIsDisplayed(hoveredCitationIndex, true);
                   cy.tick(1000);
-                  Actions.stopHoverOverCitation(0);
+                  Actions.stopHoverOverCitation(hoveredCitationIndex);
                   if (analyticsMode === 'next') {
-                    NextAnalyticsExpectations.emitQnaCitationHover(
+                    const {id, title, permanentid, clickUri} =
+                      testCitations[hoveredCitationIndex];
+                    NextAnalyticsExpectations.emitRgaCitationHover(
                       {
-                        answer: {
-                          responseId,
-                          type: answerType,
-                        },
-                        citation: {
-                          id: testCitations[hoveredCitationIndex].id,
-                          type: 'Source',
+                        responseId: streamId,
+                        citationId: id,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: permanentid,
+                          title: title,
+                          url: clickUri,
                         },
                       },
                       exampleTrackingId
@@ -868,17 +844,19 @@ describe('quantic-generated-answer', () => {
 
                 Expect.displayCitations(true);
 
-                Actions.clickCitation(0);
+                Actions.clickCitation(clickedCitationIndex);
                 if (analyticsMode === 'next') {
-                  NextAnalyticsExpectations.emitQnaCitationClick(
+                  const {id, title, permanentid, clickUri} =
+                    testCitations[clickedCitationIndex];
+                  NextAnalyticsExpectations.emitRgaCitationClick(
                     {
-                      answer: {
-                        responseId,
-                        type: answerType,
-                      },
-                      citation: {
-                        id: testCitations[clickedCitationIndex].id,
-                        type: 'Source',
+                      responseId: streamId,
+                      citationId: id,
+                      itemMetadata: {
+                        uniqueFieldName: 'permanentid',
+                        uniqueFieldValue: permanentid,
+                        title: title,
+                        url: clickUri,
                       },
                     },
                     exampleTrackingId
@@ -977,104 +955,6 @@ describe('quantic-generated-answer', () => {
               Expect.searchQueryContainsCorrectFieldsToIncludeInCitations(
                 customFields.split(',')
               );
-            });
-          });
-        });
-
-        describe('when #collapsible is set to true', () => {
-          describe('when the generated answer is still streaming', () => {
-            it('should properly display the generating answer message', () => {
-              const streamId = crypto.randomUUID();
-
-              const testMessagePayload = {
-                payloadType: 'genqa.messageType',
-                payload: JSON.stringify({
-                  textDelta: testLongText,
-                }),
-              };
-
-              mockSearchWithGeneratedAnswer(streamId, param.useCase);
-              mockStreamResponse(streamId, testMessagePayload);
-              visitGeneratedAnswer({
-                collapsible: true,
-                useCase: param.useCase,
-              });
-
-              scope('when loading the page', () => {
-                Expect.displayGeneratedAnswerCard(true);
-                Expect.generatedAnswerCollapsed(true);
-                Expect.displayGeneratedAnswerToggleCollapseButton(false);
-                Expect.displayGeneratedAnswerGeneratingMessage(true);
-                Expect.displayCitations(false);
-                Expect.displayDisclaimer(false);
-              });
-            });
-          });
-
-          describe('when the generated answer is done streaming', () => {
-            it('should properly display the generated answer collapsed when the answer is too long', () => {
-              const streamId = crypto.randomUUID();
-
-              mockSearchWithGeneratedAnswer(streamId, param.useCase);
-              mockStreamResponse(streamId, genQaLongMessageTypePayload);
-              visitGeneratedAnswer({
-                collapsible: true,
-                useCase: param.useCase,
-              });
-
-              scope('when loading the page', () => {
-                Expect.displayGeneratedAnswerCard(true);
-                Expect.generatedAnswerCollapsed(true);
-                Expect.displayGeneratedAnswerToggleCollapseButton(true);
-                Expect.generatedAnswerToggleCollapseButtonContains('Show more');
-                Expect.displayCitations(false);
-                Expect.displayDisclaimer(true);
-              });
-
-              scope('when clicking the show more button to expand', () => {
-                Actions.clickToggleCollapseButton();
-                Expect.generatedAnswerCollapsed(false);
-                Expect.generatedAnswerToggleCollapseButtonContains('Show less');
-                Expect.displayCitations(false);
-                Expect.displayDisclaimer(true);
-                if (analyticsMode === 'legacy') {
-                  Expect.logGeneratedAnswerExpand(streamId);
-                }
-              });
-
-              scope(
-                'when clicking the show less button a second time to collapse',
-                () => {
-                  Actions.clickToggleCollapseButton();
-                  Expect.generatedAnswerCollapsed(true);
-                  Expect.generatedAnswerToggleCollapseButtonContains(
-                    'Show more'
-                  );
-                  Expect.displayCitations(false);
-                  Expect.displayDisclaimer(true);
-                  if (analyticsMode === 'legacy') {
-                    Expect.logGeneratedAnswerCollapse(streamId);
-                  }
-                }
-              );
-            });
-          });
-
-          it('should not display the answer collapsed when the answer is short', () => {
-            const newStreamId = crypto.randomUUID();
-
-            mockSearchWithGeneratedAnswer(newStreamId, param.useCase);
-            mockStreamResponse(newStreamId, genQaMessageTypePayload);
-            visitGeneratedAnswer({
-              collapsible: true,
-              useCase: param.useCase,
-            });
-
-            scope('when loading the page', () => {
-              Expect.displayGeneratedAnswerCard(true);
-              Expect.generatedAnswerCollapsed(false);
-              Expect.displayGeneratedAnswerToggleCollapseButton(false);
-              Expect.displayDisclaimer(true);
             });
           });
         });

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet-suggestions/smart-snippet-suggestions.cypress.ts
@@ -14,13 +14,13 @@ import {
 import {scope} from '../../../reporters/detailed-collector';
 import {setCookieToEnableNextAnalytics} from '../../../utils/analytics-utils';
 import {stubConsoleError} from '../../console-selectors';
-// import {NextAnalyticsExpectations} from '../../next-analytics-expectations';
+import {NextAnalyticsExpectations} from '../../next-analytics-expectations';
 import {SmartSnippetSuggestionsActions as Actions} from './smart-snippet-suggestions-actions';
 import {SmartSnippetSuggestionsExpectations as Expect} from './smart-snippet-suggestions-expectations';
 
 let analyticsMode: 'legacy' | 'next' = 'legacy';
 const exampleTrackingId = 'tracking_id_123';
-// const answerType = 'SmartSnippetSuggestion';
+const answerType = 'SmartSnippetSuggestion';
 const exampleResponseId = 'example response id';
 
 const exampleInlineLink = 'https://www.coveo.com/en';
@@ -120,17 +120,21 @@ describe('quantic-smart-snippet-suggestions', () => {
                   exampleRelatedQuestions.forEach((suggestion, index) => {
                     Actions.toggleSuggestion(index);
                     if (analyticsMode === 'next') {
-                      // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                      // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                      //   {
-                      //     answer: {
-                      //       responseId: exampleResponseId,
-                      //       type: answerType,
-                      //     },
-                      //     action: 'expand',
-                      //   },
-                      //   exampleTrackingId
-                      // );
+                      NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
+                        {
+                          responseId: exampleResponseId,
+                          snippetType: answerType,
+                          itemMetadata: {
+                            uniqueFieldName: suggestion.documentId.contentIdKey,
+                            uniqueFieldValue:
+                              suggestion.documentId.contentIdValue,
+                            title: suggestion.title,
+                            url: suggestion.uri,
+                          },
+                          action: 'expand',
+                        },
+                        exampleTrackingId
+                      );
                     } else {
                       Expect.logExpandSmartSnippetSuggestion({
                         answerSnippet: suggestion.answerSnippet,
@@ -159,17 +163,21 @@ describe('quantic-smart-snippet-suggestions', () => {
                     );
                     Actions.toggleSuggestion(index);
                     if (analyticsMode === 'next') {
-                      // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                      // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                      //   {
-                      //     answer: {
-                      //       responseId: exampleResponseId,
-                      //       type: answerType,
-                      //     },
-                      //     action: 'collapse',
-                      //   },
-                      //   exampleTrackingId
-                      // );
+                      NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
+                        {
+                          responseId: exampleResponseId,
+                          snippetType: answerType,
+                          itemMetadata: {
+                            uniqueFieldName: suggestion.documentId.contentIdKey,
+                            uniqueFieldValue:
+                              suggestion.documentId.contentIdValue,
+                            title: suggestion.title,
+                            url: suggestion.uri,
+                          },
+                          action: 'collapse',
+                        },
+                        exampleTrackingId
+                      );
                     } else {
                       Expect.logCollapseSmartSnippetSuggestion({
                         answerSnippet: suggestion.answerSnippet,
@@ -188,21 +196,21 @@ describe('quantic-smart-snippet-suggestions', () => {
                   Actions.toggleSuggestion(index);
                   Actions.clickSmartSnippetSuggestionsSourceTitle(index);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaCitationClick(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     citation: {
-                    //       id: exampleRelatedQuestions[index].documentId
-                    //         .contentIdValue,
-                    //       type: 'Source',
-                    //     },
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    const {documentId, title, uri} =
+                      exampleRelatedQuestions[index];
+                    NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: documentId.contentIdKey,
+                          uniqueFieldValue: documentId.contentIdValue,
+                          title: title,
+                          url: uri,
+                        },
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logOpenSmartSnippetSuggestionSource({
                       ...exampleRelatedQuestions[index],
@@ -220,21 +228,21 @@ describe('quantic-smart-snippet-suggestions', () => {
                   Actions.toggleSuggestion(index);
                   Actions.clickSmartSnippetSuggestionsSourceUri(index);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaCitationClick(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     citation: {
-                    //       id: exampleRelatedQuestions[index].documentId
-                    //         .contentIdValue,
-                    //       type: 'Source',
-                    //     },
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    const {documentId, title, uri} =
+                      exampleRelatedQuestions[index];
+                    NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: documentId.contentIdKey,
+                          uniqueFieldValue: documentId.contentIdValue,
+                          title: title,
+                          url: uri,
+                        },
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logOpenSmartSnippetSuggestionSource({
                       ...exampleRelatedQuestions[index],
@@ -252,21 +260,21 @@ describe('quantic-smart-snippet-suggestions', () => {
                   Actions.toggleSuggestion(index);
                   Actions.clickSmartSnippetSuggestionsInlineLink(index);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaCitationClick(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     citation: {
-                    //       id: exampleRelatedQuestions[index].documentId
-                    //         .contentIdValue,
-                    //       type: 'InlineLink',
-                    //     },
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    const {documentId, title, uri} =
+                      exampleRelatedQuestions[index];
+                    NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: documentId.contentIdKey,
+                          uniqueFieldValue: documentId.contentIdValue,
+                          title: title,
+                          url: uri,
+                        },
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logOpenSmartSnippetSuggestionInlineLink({
                       ...exampleRelatedQuestions[index],

--- a/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-2/smart-snippet/smart-snippet.cypress.ts
@@ -1,5 +1,5 @@
 import {performSearch} from '../../../page-objects/actions/action-perform-search';
-import {AnalyticsModeEnum} from '../../../page-objects/analytics';
+import {analyticsModeTest} from '../../../page-objects/analytics';
 import {configure} from '../../../page-objects/configurator';
 import {
   interceptSearch,
@@ -93,13 +93,7 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
         });
       });
 
-      // TODO: (SFINT-5732)
-      [
-        {
-          mode: AnalyticsModeEnum.legacy,
-          label: 'when legacy analytics are sent',
-        },
-      ].forEach((analytics) => {
+      analyticsModeTest.forEach((analytics) => {
         describe(analytics.label, () => {
           before(() => {
             analyticsMode = analytics.mode;
@@ -136,20 +130,19 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                 scope('when the source title is clicked', () => {
                   Actions.clickSmartSnippetSourceTitle();
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaCitationClick(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     citation: {
-                    //       id: examplePermanentId,
-                    //       type: 'Source',
-                    //     },
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: examplePermanentId,
+                          title: exampleSmartSnippetSourceTitle,
+                          url: exampleSmartSnippetSourceUri,
+                        },
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logOpenSmartSnippetSource({
                       title: exampleSmartSnippetSourceTitle,
@@ -163,20 +156,19 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                   visitPage({useCase: param.useCase});
                   Actions.clickSmartSnippetSourceUri();
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaCitationClick(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     citation: {
-                    //       id: examplePermanentId,
-                    //       type: 'Source',
-                    //     },
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: examplePermanentId,
+                          title: exampleSmartSnippetSourceTitle,
+                          url: exampleSmartSnippetSourceUri,
+                        },
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logOpenSmartSnippetSource({
                       title: exampleSmartSnippetSourceTitle,
@@ -194,15 +186,15 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                     Actions.clickSmartSnippetInlineLink();
 
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaCitationClick(
+                      NextAnalyticsExpectations.emitSmartSnippetsSourceClick(
                         {
-                          answer: {
-                            responseId: exampleResponseId,
-                            type: answerType,
-                          },
-                          citation: {
-                            id: examplePermanentId,
-                            type: 'InlineLink',
+                          responseId: exampleResponseId,
+                          snippetType: answerType,
+                          itemMetadata: {
+                            uniqueFieldName: 'permanentid',
+                            uniqueFieldValue: examplePermanentId,
+                            title: exampleSmartSnippetSourceTitle,
+                            url: exampleSmartSnippetSourceUri,
                           },
                         },
                         exampleTrackingId
@@ -250,17 +242,20 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                   Expect.displayExpandedSmartSnippetAnswer(true);
                   Expect.displaySmartSnippetShowLessButton(true);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     action: 'expand',
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: examplePermanentId,
+                          title: exampleSmartSnippetSourceTitle,
+                          url: exampleSmartSnippetSourceUri,
+                        },
+                        action: 'expand',
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logExpandSmartSnippet();
                   }
@@ -272,25 +267,27 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                   Expect.displayExpandedSmartSnippetAnswer(false);
                   Expect.displaySmartSnippetShowMoreButton(true);
                   if (analyticsMode === 'next') {
-                    // TODO: SFINT-5670 - Fix the Next Analytics expectations following schema changes
-                    // NextAnalyticsExpectations.emitQnaAnswerActionEvent(
-                    //   {
-                    //     answer: {
-                    //       responseId: exampleResponseId,
-                    //       type: answerType,
-                    //     },
-                    //     action: 'collapse',
-                    //   },
-                    //   exampleTrackingId
-                    // );
+                    NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
+                      {
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: examplePermanentId,
+                          title: exampleSmartSnippetSourceTitle,
+                          url: exampleSmartSnippetSourceUri,
+                        },
+                        action: 'collapse',
+                      },
+                      exampleTrackingId
+                    );
                   } else {
                     Expect.logCollapseSmartSnippet();
                   }
                 });
               });
             });
-            // Skipping temporarily will be fixed in SFINT-5514
-            describe.skip('when clicking the feedback like button', () => {
+            describe('when clicking the feedback like button', () => {
               it('should properly log the analytics', () => {
                 visitPage({useCase: param.useCase});
 
@@ -298,15 +295,17 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                   Expect.displaySmartSnippetCard(true);
                   Actions.clickSmartSnippetLikeButton();
                   if (analyticsMode === 'next') {
-                    NextAnalyticsExpectations.emitQnaLikeEvent(
+                    NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
                       {
-                        feedback: {
-                          liked: true,
+                        responseId: exampleResponseId,
+                        snippetType: answerType,
+                        itemMetadata: {
+                          uniqueFieldName: 'permanentid',
+                          uniqueFieldValue: examplePermanentId,
+                          title: exampleSmartSnippetSourceTitle,
+                          url: exampleSmartSnippetSourceUri,
                         },
-                        answer: {
-                          responseId: exampleResponseId,
-                          type: answerType,
-                        },
+                        action: 'like',
                       },
                       exampleTrackingId
                     );
@@ -317,6 +316,7 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                 });
               });
             });
+
             // Skipping temporarily will be fixed in SFINT-5514
             describe.skip(
               'when clicking the feedback dislike button',
@@ -331,15 +331,17 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                     Expect.displaySmartSnippetCard(true);
                     Actions.clickSmartSnippetDislikeButton();
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaDislikeEvent(
+                      NextAnalyticsExpectations.emitSmartSnippetsAnswerAction(
                         {
-                          feedback: {
-                            liked: false,
+                          responseId: exampleResponseId,
+                          snippetType: answerType,
+                          itemMetadata: {
+                            uniqueFieldName: 'permanentid',
+                            uniqueFieldValue: examplePermanentId,
+                            title: exampleSmartSnippetSourceTitle,
+                            url: exampleSmartSnippetSourceUri,
                           },
-                          answer: {
-                            responseId: exampleResponseId,
-                            type: answerType,
-                          },
+                          action: 'dislike',
                         },
                         exampleTrackingId
                       );
@@ -375,17 +377,18 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                     Actions.typeInFeedbackDetailsInput(exampleDetails);
                     Actions.clickFeedbackSubmitButton();
                     if (analyticsMode === 'next') {
-                      NextAnalyticsExpectations.emitQnaSubmitFeedbackReasonEvent(
+                      NextAnalyticsExpectations.emitSmartSnippetsSubmitFeedback(
                         {
-                          feedback: {
-                            liked: false,
-                            details: exampleDetails,
-                            reason: 'other',
+                          responseId: exampleResponseId,
+                          snippetType: answerType,
+                          itemMetadata: {
+                            uniqueFieldName: 'permanentid',
+                            uniqueFieldValue: examplePermanentId,
+                            title: exampleSmartSnippetSourceTitle,
+                            url: exampleSmartSnippetSourceUri,
                           },
-                          answer: {
-                            responseId: exampleResponseId,
-                            type: answerType,
-                          },
+                          reason: 'other',
+                          additionalNotes: exampleDetails,
                         },
                         exampleTrackingId
                       );
@@ -438,21 +441,6 @@ describe('quantic-smart-snippet', {browser: 'chrome'}, () => {
                       Expect.displaySmartSnippetCard(true);
                       Expect.displaySmartSnippetQuestion(exampleNewQuestion);
                       Actions.clickSmartSnippetDislikeButton();
-                      if (analyticsMode === 'next') {
-                        NextAnalyticsExpectations.emitQnaDislikeEvent(
-                          {
-                            feedback: {
-                              liked: false,
-                            },
-                            answer: {
-                              type: answerType,
-                            },
-                          },
-                          exampleTrackingId
-                        );
-                      } else {
-                        Expect.logDislikeSmartSnippet();
-                      }
                       Expect.displayExplainWhyButton(true);
                     }
                   );

--- a/packages/quantic/cypress/e2e/next-analytics-expectations.ts
+++ b/packages/quantic/cypress/e2e/next-analytics-expectations.ts
@@ -1,5 +1,4 @@
-import {Qna, CaseAssist, ItemClick} from '@coveo/relay-event-types';
-import {Interception} from 'cypress/types/net-stubbing';
+import {SmartSnippets, CaseAssist, Rga} from '@coveo/relay-event-types';
 import {InterceptAliases} from '../page-objects/search';
 
 interface EventMetadata {
@@ -36,231 +35,291 @@ async function validateEventWithEventAPI(request: {
   expect(parsedResponse).to.have.property('valid', true);
 }
 
-function validateSubmitFeedbackEvent(
-  interception: Interception,
-  expectedEvent: Qna.SubmitFeedback,
-  expectedTrackingId: string
-) {
-  const eventBody = interception?.request?.body?.[0];
-  const eventMeta: EventMetadata = eventBody.meta;
-
-  expect(eventBody.answer).to.deep.equal(expectedEvent.answer);
-  expect(eventBody.feedback).to.deep.equal(expectedEvent.feedback);
-
-  expect(eventMeta).to.have.property('type', 'Qna.SubmitFeedback');
-  expect(eventMeta.config).to.have.property('trackingId', expectedTrackingId);
-}
-
 function nextAnalyticsExpectations() {
   return {
-    emitQnaAnswerActionEvent: (
-      expectedEvent: Qna.AnswerAction,
+    emitSmartSnippetsSourceClick: (
+      expectedEvent: SmartSnippets.SourceClick,
       expectedTrackingId: string
     ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.AnswerAction)
+      cy.wait(InterceptAliases.NextAnalytics.SmartSnippets.SourceClick)
         .then((interception): void => {
           const eventBody = interception?.request?.body?.[0];
           const eventMeta: EventMetadata = eventBody.meta;
 
-          expect(eventBody).to.have.property('action', expectedEvent.action);
-          expect(eventBody.answer).to.deep.equal(expectedEvent.answer);
-          expect(eventMeta).to.have.property('type', 'Qna.AnswerAction');
-          expect(eventMeta.config).to.have.property(
-            'trackingId',
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail(
-          `should emit the Qna.AnswerAction event with action "${expectedEvent.action}"`
-        );
-    },
-
-    emitQnaCitationHover: (
-      expectedEvent: Qna.CitationHover,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.CitationHover)
-        .then((interception): void => {
-          const eventBody = interception?.request?.body?.[0];
-          const eventMeta: EventMetadata = eventBody.meta;
-
-          expect(eventBody.answer).to.deep.equal(expectedEvent.answer);
-          expect(eventBody.citation).to.deep.equal(expectedEvent.citation);
-          expect(eventMeta).to.have.property('type', 'Qna.CitationHover');
-          expect(eventMeta.config).to.have.property(
-            'trackingId',
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail('should emit the Qna.CitationHover event');
-    },
-
-    emitQnaCitationClick: (
-      expectedEvent: Qna.CitationClick,
-      expectedTrackingId: string
-    ) => {
-      const type: 'Source' | 'InlineLink' = expectedEvent.citation.type;
-      cy.wait(InterceptAliases.NextAnalytics.Qna.CitationClick[type])
-        .then((interception): void => {
-          const eventBody = interception?.request?.body?.[0];
-          const eventMeta: EventMetadata = eventBody.meta;
-
-          expect(eventBody.citation).to.deep.equal(expectedEvent.citation);
-          expect(eventBody.answer).to.deep.equal(expectedEvent.answer);
-          expect(eventMeta).to.have.property('type', 'Qna.CitationClick');
-          expect(eventMeta.config).to.have.property(
-            'trackingId',
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail('should emit the Qna.CitationClick event');
-    },
-
-    emitQnaLikeEvent: (
-      expectedEvent: Qna.SubmitFeedback,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.SubmitFeedback.Like)
-        .then((interception): void => {
-          validateSubmitFeedbackEvent(
-            interception,
-            expectedEvent,
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail(
-          'should emit the Qna.SubmitFeedback event for the like action'
-        );
-    },
-
-    emitQnaDislikeEvent: (
-      expectedEvent: Qna.SubmitFeedback,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.SubmitFeedback.Dislike)
-        .then((interception): void => {
-          validateSubmitFeedbackEvent(
-            interception,
-            expectedEvent,
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail(
-          'should emit the Qna.SubmitFeedback event for the dislike action'
-        );
-    },
-
-    emitQnaSubmitFeedbackReasonEvent: (
-      expectedEvent: Qna.SubmitFeedback,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.SubmitFeedback.ReasonSubmit)
-        .then((interception): void => {
-          validateSubmitFeedbackEvent(
-            interception,
-            expectedEvent,
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail(
-          'should emit the Qna.SubmitFeedback event for the feedback reason submission'
-        );
-    },
-
-    emitQnaSubmitRgaFeedbackEvent: (
-      expectedEvent: Qna.SubmitRgaFeedback,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(InterceptAliases.NextAnalytics.Qna.SubmitRgaFeedback)
-        .then((interception): void => {
-          const eventBody = interception?.request?.body?.[0];
-          const eventMeta: EventMetadata = eventBody.meta;
-          expect(eventBody.answer).to.deep.equal(expectedEvent.answer);
-          expect(eventBody.feedback).to.deep.equal(expectedEvent.feedback);
-
-          expect(eventMeta).to.have.property('type', 'Qna.SubmitRgaFeedback');
-          expect(eventMeta.config).to.have.property(
-            'trackingId',
-            expectedTrackingId
-          );
-
-          validateEventWithEventAPI(interception.request);
-        })
-        .logDetail(
-          'should emit the Qna.SubmitRgaFeedback event for submitting rga feedback'
-        );
-    },
-
-    emitCaseAssistSelectFieldClassification: (
-      expectedEvent: CaseAssist.SelectFieldClassification,
-      expectedTrackingId: string
-    ) => {
-      cy.wait(
-        InterceptAliases.NextAnalytics.CaseAssist.SelectFieldClassification
-      )
-        .then((interception): void => {
-          const eventBody = interception?.request?.body?.[0];
-          const eventMeta: EventMetadata = eventBody.meta;
-
-          expect(eventBody.fieldClassification).to.deep.equal(
-            expectedEvent.fieldClassification
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
           );
           expect(eventBody).to.have.property(
-            'autoselected',
-            expectedEvent.autoselected
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'snippetType',
+            expectedEvent.snippetType
           );
           expect(eventMeta).to.have.property(
             'type',
-            'caseAssist.selectFieldClassification'
+            'SmartSnippets.SourceClick'
           );
           expect(eventMeta.config).to.have.property(
             'trackingId',
             expectedTrackingId
           );
 
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
           validateEventWithEventAPI(interception.request);
         })
-        .logDetail('should emit the caseAssist.selectFieldClassification');
+        .logDetail('should emit the SmartSnippets.SourceClick event');
     },
 
-    emitUpdateField: (
-      expectedEvent: CaseAssist.UpdateField,
+    emitSmartSnippetsAnswerAction: (
+      expectedEvent: SmartSnippets.AnswerAction,
       expectedTrackingId: string
     ) => {
-      cy.wait(InterceptAliases.NextAnalytics.CaseAssist.UpdateField)
+      cy.wait(InterceptAliases.NextAnalytics.SmartSnippets.AnswerAction)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'snippetType',
+            expectedEvent.snippetType
+          );
+          expect(eventBody).to.have.property('action', expectedEvent.action);
+          expect(eventMeta).to.have.property(
+            'type',
+            'SmartSnippets.AnswerAction'
+          );
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail(
+          `should emit the SmartSnippets.AnswerAction event with action "${expectedEvent.action}"`
+        );
+    },
+
+    emitSmartSnippetsSubmitFeedback: (
+      expectedEvent: SmartSnippets.SubmitFeedback,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.SmartSnippets.SubmitFeedback)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'snippetType',
+            expectedEvent.snippetType
+          );
+          expect(eventBody).to.have.property('reason', expectedEvent.reason);
+          if (expectedEvent.additionalNotes) {
+            expect(eventBody).to.have.property(
+              'additionalNotes',
+              expectedEvent.additionalNotes
+            );
+          }
+          expect(eventMeta).to.have.property(
+            'type',
+            'SmartSnippets.SubmitFeedback'
+          );
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail(
+          'should emit the SmartSnippets.SubmitFeedback event with action'
+        );
+    },
+
+    emitRgaAnswerAction: (
+      expectedEvent: Rga.AnswerAction,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.Rga.AnswerAction)
         .then((interception): void => {
           const eventBody = interception?.request?.body?.[0];
           const eventMeta: EventMetadata = eventBody.meta;
 
           expect(eventBody).to.have.property(
-            'fieldName',
-            expectedEvent.fieldName
+            'responseId',
+            expectedEvent.responseId
           );
-          expect(eventBody).to.have.property(
-            'fieldValue',
-            expectedEvent.fieldValue
-          );
-          expect(eventMeta).to.have.property('type', 'caseAssist.updateField');
+          expect(eventBody).to.have.property('action', expectedEvent.action);
+          expect(eventMeta).to.have.property('type', 'Rga.AnswerAction');
           expect(eventMeta.config).to.have.property(
             'trackingId',
             expectedTrackingId
           );
 
+          eventBody.meta.ts = Date.now();
           validateEventWithEventAPI(interception.request);
         })
-        .logDetail('should emit the CaseAssist.DocumentSuggestionClick event');
+        .logDetail(
+          `should emit the Rga.AnswerAction event with action "${expectedEvent.action}"`
+        );
+    },
+
+    emitRgaStreamEnd: (
+      expectedEvent: Rga.StreamEnd,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.Rga.StreamEnd)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'answerGenerated',
+            expectedEvent.answerGenerated
+          );
+          expect(eventMeta).to.have.property('type', 'Rga.StreamEnd');
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+
+          eventBody.meta.ts = Date.now();
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail('should emit the Rga.StreamEnd event');
+    },
+
+    emitRgaSubmitFeedback: (
+      expectedEvent: Rga.SubmitFeedback,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.Rga.SubmitFeedback)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody.details).to.deep.equal(expectedEvent.details);
+          expect(eventBody).to.have.property('helpful', expectedEvent.helpful);
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          if (expectedEvent.additionalNotes) {
+            expect(eventBody).to.have.property(
+              'additionalNotes',
+              expectedEvent.additionalNotes
+            );
+          }
+          if (expectedEvent.correctAnswerUrl) {
+            expect(eventBody).to.have.property(
+              'correctAnswerUrl',
+              expectedEvent.correctAnswerUrl
+            );
+          }
+          expect(eventMeta).to.have.property('type', 'Rga.SubmitFeedback');
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail(
+          'should emit the Rga.SubmitFeedback event for submitting rga feedback'
+        );
+    },
+
+    emitRgaCitationHover: (
+      expectedEvent: Omit<Rga.CitationHover, 'citationHoverTimeInMs'>,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.Rga.CitationHover)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'citationId',
+            expectedEvent.citationId
+          );
+          expect(eventBody).to.have.property('citationHoverTimeInMs');
+          expect(eventMeta).to.have.property('type', 'Rga.CitationHover');
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+
+          eventBody.meta.ts = Date.now();
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail('should emit the Rga.CitationHover event');
+    },
+
+    emitRgaCitationClick: (
+      expectedEvent: Rga.CitationClick,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.Rga.CitationClick)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
+          );
+          expect(eventBody).to.have.property(
+            'citationId',
+            expectedEvent.citationId
+          );
+          expect(eventMeta).to.have.property('type', 'Rga.CitationClick');
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+
+          eventBody.meta.ts = Date.now();
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail('should emit the Rga.CitationClick event');
     },
 
     emitCaseAssistDocumentSuggestionClick: (
@@ -272,18 +331,28 @@ function nextAnalyticsExpectations() {
           const eventBody = interception?.request?.body?.[0];
           const eventMeta: EventMetadata = eventBody.meta;
 
-          expect(eventBody.documentSuggestion).to.deep.equal(
-            expectedEvent.documentSuggestion
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'position',
+            expectedEvent.position
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
           );
           expect(eventMeta).to.have.property(
             'type',
-            'caseAssist.documentSuggestionClick'
+            'CaseAssist.DocumentSuggestionClick'
           );
           expect(eventMeta.config).to.have.property(
             'trackingId',
             expectedTrackingId
           );
 
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
           validateEventWithEventAPI(interception.request);
         })
         .logDetail('should emit the CaseAssist.DocumentSuggestionClick event');
@@ -300,19 +369,25 @@ function nextAnalyticsExpectations() {
           const eventBody = interception?.request?.body?.[0];
           const eventMeta: EventMetadata = eventBody.meta;
 
-          expect(eventBody.documentSuggestion).to.deep.equal(
-            expectedEvent.documentSuggestion
+          expect(eventBody.itemMetadata).to.deep.equal(
+            expectedEvent.itemMetadata
+          );
+          expect(eventBody).to.have.property(
+            'responseId',
+            expectedEvent.responseId
           );
           expect(eventBody).to.have.property('liked', expectedEvent.liked);
           expect(eventMeta).to.have.property(
             'type',
-            'caseAssist.documentSuggestionFeedback'
+            'CaseAssist.DocumentSuggestionFeedback'
           );
           expect(eventMeta.config).to.have.property(
             'trackingId',
             expectedTrackingId
           );
 
+          // Updating the URL to a valid one, as '#' is used in the tests to simplify link testing
+          eventBody.itemMetadata.url = 'https://www.coveo.com/';
           validateEventWithEventAPI(interception.request);
         })
         .logDetail(
@@ -320,40 +395,66 @@ function nextAnalyticsExpectations() {
         );
     },
 
-    emitItemClick: (expectedEvent: ItemClick, expectedTrackingId: string) => {
-      cy.wait(InterceptAliases.NextAnalytics.ItemClick)
+    emitCaseAssistSelectFieldClassification: (
+      expectedEvent: CaseAssist.SelectFieldClassification,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(
+        InterceptAliases.NextAnalytics.CaseAssist.SelectFieldClassification
+      )
         .then((interception): void => {
           const eventBody = interception?.request?.body?.[0];
           const eventMeta: EventMetadata = eventBody.meta;
 
-          expect(eventBody.itemMetadata).to.deep.equal(
-            expectedEvent.itemMetadata
-          );
-          if (expectedEvent.actionCause) {
-            expect(eventBody).to.have.property(
-              'actionCause',
-              expectedEvent.actionCause
-            );
-          }
           expect(eventBody).to.have.property(
-            'position',
-            expectedEvent.position
+            'classificationId',
+            expectedEvent.classificationId
           );
           expect(eventBody).to.have.property(
-            'searchUid',
-            expectedEvent.searchUid
+            'responseId',
+            expectedEvent.responseId
           );
-          expect(eventMeta).to.have.property('type', 'itemClick');
+          expect(eventBody).to.have.property(
+            'autoselected',
+            expectedEvent.autoselected
+          );
+          expect(eventMeta).to.have.property(
+            'type',
+            'CaseAssist.SelectFieldClassification'
+          );
           expect(eventMeta.config).to.have.property(
             'trackingId',
             expectedTrackingId
           );
-
           validateEventWithEventAPI(interception.request);
         })
-        .logDetail(
-          'should emit the CaseAssist.DocumentSuggestionFeedback event'
-        );
+        .logDetail('should emit the CaseAssist.SelectFieldClassification');
+    },
+
+    emitCaseAssistUpdateField: (
+      expectedEvent: CaseAssist.UpdateField,
+      expectedTrackingId: string
+    ) => {
+      cy.wait(InterceptAliases.NextAnalytics.CaseAssist.UpdateField)
+        .then((interception): void => {
+          const eventBody = interception?.request?.body?.[0];
+          const eventMeta: EventMetadata = eventBody.meta;
+          expect(eventBody).to.have.property(
+            'fieldName',
+            expectedEvent.fieldName
+          );
+          expect(eventBody).to.have.property(
+            'fieldValue',
+            expectedEvent.fieldValue
+          );
+          expect(eventMeta).to.have.property('type', 'CaseAssist.UpdateField');
+          expect(eventMeta.config).to.have.property(
+            'trackingId',
+            expectedTrackingId
+          );
+          validateEventWithEventAPI(interception.request);
+        })
+        .logDetail('should emit the CaseAssist.UpdateField event');
     },
   };
 }

--- a/packages/quantic/cypress/page-objects/search.ts
+++ b/packages/quantic/cypress/page-objects/search.ts
@@ -104,31 +104,29 @@ export const InterceptAliases = {
     OmniboxAnalytics: uaAlias('omniboxAnalytics'),
   },
   NextAnalytics: {
-    Qna: {
-      AnswerAction: nextAnalyticsAlias('Qna.AnswerAction'),
-      CitationHover: nextAnalyticsAlias('Qna.CitationHover'),
-      CitationClick: {
-        Source: nextAnalyticsAlias('Qna.CitationClick.Source'),
-        InlineLink: nextAnalyticsAlias('Qna.CitationClick.InlineLink'),
-      },
-      SubmitFeedback: {
-        Like: nextAnalyticsAlias('Qna.SubmitFeedback.Like'),
-        Dislike: nextAnalyticsAlias('Qna.SubmitFeedback.Dislike'),
-        ReasonSubmit: nextAnalyticsAlias('Qna.SubmitFeedback.ReasonSubmit'),
-      },
-      SubmitRgaFeedback: nextAnalyticsAlias('Qna.SubmitRgaFeedback'),
+    SmartSnippets: {
+      SourceClick: nextAnalyticsAlias('SmartSnippets.SourceClick'),
+      AnswerAction: nextAnalyticsAlias('SmartSnippets.AnswerAction'),
+      SubmitFeedback: nextAnalyticsAlias('SmartSnippets.SubmitFeedback'),
+    },
+    Rga: {
+      AnswerAction: nextAnalyticsAlias('Rga.AnswerAction'),
+      SubmitFeedback: nextAnalyticsAlias('Rga.SubmitFeedback'),
+      CitationHover: nextAnalyticsAlias('Rga.CitationHover'),
+      CitationClick: nextAnalyticsAlias('Rga.CitationClick'),
+      StreamEnd: nextAnalyticsAlias('Rga.StreamEnd'),
     },
     CaseAssist: {
       DocumentSuggestionClick: nextAnalyticsAlias(
-        'caseAssist.documentSuggestionClick'
+        'CaseAssist.DocumentSuggestionClick'
       ),
       DocumentSuggestionFeedback: nextAnalyticsAlias(
-        'caseAssist.documentSuggestionFeedback'
+        'CaseAssist.DocumentSuggestionFeedback'
       ),
       SelectFieldClassification: nextAnalyticsAlias(
-        'caseAssist.selectFieldClassification'
+        'CaseAssist.SelectFieldClassification'
       ),
-      UpdateField: nextAnalyticsAlias('caseAssist.updateField'),
+      UpdateField: nextAnalyticsAlias('CaseAssist.UpdateField'),
     },
     ItemClick: nextAnalyticsAlias('itemClick'),
   },

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
@@ -64,7 +64,7 @@
           </div>
         </div>
         <template if:true={hasError}>
-          <div class="slds-form-element__help" id="case-classification-error-message">
+          <div data-cy="case-classification-error-message" class="slds-form-element__help" id="case-classification-error-message">
             {errorMessage}
           </div>
         </template>

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@ckeditor/jsdoc-plugins": "39.9.1",
-    "@coveo/relay-event-types": "7.14.1",
+    "@coveo/relay-event-types": "12.0.1",
     "@coveo/release": "1.0.0",
     "@lwc/compiler": "5.3.0",
     "@lwc/eslint-plugin-lwc": "1.8.2",


### PR DESCRIPTION
## [SFINT-5732](https://coveord.atlassian.net/browse/SFINT-5732)

## Changes made in this PR:

### In Headless:

1.  Fixed a typo in type of the event sent when submiting feedback for RGA, it's now `Rga.SubmitFeedback` instead of `Rga.SubmitRgaFeedback`.

### In Quantic: 

- Fixed all the E2E tests that were previously skipped because of the latest breaking changes that occurs to schemas of the EP events, in this tests we check that the right payload is sent and that each analytics call is valid by sending it to the `validate` endpoint of the Event api.




[SFINT-5732]: https://coveord.atlassian.net/browse/SFINT-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ