### PR TITLE
fix(answerAPI): controller search listener

### DIFF
--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -96,16 +96,24 @@ const subscribeToSearchRequest = (
   const strictListener = () => {
     const state = engine.state;
     const triggerParams = selectAnswerTriggerParams(state);
-    if (triggerParams.q.length === 0 || triggerParams.requestId.length === 0) {
+
+    if (!lastTriggerParams || triggerParams.q.length === 0) {
+      lastTriggerParams = triggerParams;
+    }
+
+    if (
+      triggerParams.q.length === 0 ||
+      triggerParams.requestId.length === 0 ||
+      triggerParams.requestId === lastTriggerParams.requestId
+    ) {
       return;
     }
-    if (triggerParams?.requestId === lastTriggerParams?.requestId) {
-      return;
-    }
+
     lastTriggerParams = triggerParams;
     engine.dispatch(resetAnswer());
     engine.dispatch(fetchAnswer(state));
   };
+
   engine.subscribe(strictListener);
 };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-4254 

SVCC-4254

# headless-answerapi-generated-answer fix
## Two triggers to fetchAnswer are made after an empty request. uselessly hitting the RTK query cache

### Problem description
When the answer-api is enabled

**TLDR**
Whenever a search request was made after a precedent search request is made with an empty query, the answerAPI was called two times with the same parameters. hitting the RTK query cache while painting red in the console.

**Further**
The last params with which a search was triggered are kept in a variable used to compare with the current params the listener current run uses. The comparison between the lastParams and the current ones determines if we should call the answerAPI or not. Because the query in the state is not updated at the same time than the request ID,the listener is run twice. If we do not update the `lastTriggerParams` when the query is empty, the condition will receive a wrong request ID the first run and let it pass through, calling the answerAPI twice with the same params.

### Fix description

The current fix is not changing the user behavior. Since RTK query was preventing the API to be called twice anyway. But we esteem that the implementation should not rely on RTK query being nice.
 
The `lastTriggerParams` are now updated even when the query is empty when the listener is called. Preventing the condition to let pass the query with the exact same parameters.  