### PR TITLE
fix(atomic): prevent touch events on atomic-product-children from opening the product page

### DIFF
--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-children/atomic-product-children.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-children/atomic-product-children.tsx
@@ -132,7 +132,11 @@ export class AtomicProductChildren
           event.key === 'Enter' && this.onSelectChild(child)
         }
         onMouseEnter={() => this.onSelectChild(child)}
-        onTouchStart={() => this.onSelectChild(child)}
+        onTouchStart={(event) => {
+          event.stopPropagation();
+          event.preventDefault();
+          this.onSelectChild(child);
+        }}
       >
         <img
           class="aspect-square p-1"


### PR DESCRIPTION
This PR prevents the product page from opening when touching the product variants/children on mobile. This was preventing switching between variants on mobile devices.

https://coveord.atlassian.net/browse/KIT-3649