### PR TITLE
fix(atomic): prevent clicks on atomic-product-image indicators from opening the product page

### DIFF
--- a/packages/atomic/src/components/common/image-carousel/image-carousel-indicators.tsx
+++ b/packages/atomic/src/components/common/image-carousel/image-carousel-indicators.tsx
@@ -51,7 +51,10 @@ const CarouselIndicator: FunctionalComponent<CarouselIndicatorProps> = ({
                 ? 'pointer-events-auto opacity-80'
                 : 'pointer-events-none hidden opacity-0'
             }`}
-            onClick={() => navigateToImage(index)}
+            onClick={(event) => {
+              event.stopPropagation();
+              navigateToImage(index);
+            }}
           ></li>
         );
       })}


### PR DESCRIPTION
This PR prevents the product page from opening when clicking the indicator buttons of the atomic-product-image carousel.

https://coveord.atlassian.net/browse/KIT-3652