### PR TITLE
fix(atomic-angular): add @Prop decorator to @MapProp props so they are generated in the angular-output

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -873,14 +873,14 @@ export declare interface AtomicFacetManager extends Components.AtomicFacetManage
 
 
 @ProxyCmp({
-  inputs: ['ifDefined', 'ifNotDefined']
+  inputs: ['ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch']
 })
 @Component({
   selector: 'atomic-field-condition',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ifDefined', 'ifNotDefined'],
+  inputs: ['ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch'],
 })
 export class AtomicFieldCondition {
   protected el: HTMLElement;
@@ -1300,14 +1300,14 @@ export declare interface AtomicProductDescription extends Components.AtomicProdu
 
 
 @ProxyCmp({
-  inputs: ['ifDefined', 'ifNotDefined']
+  inputs: ['ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch']
 })
 @Component({
   selector: 'atomic-product-field-condition',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ifDefined', 'ifNotDefined'],
+  inputs: ['ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch'],
 })
 export class AtomicProductFieldCondition {
   protected el: HTMLElement;
@@ -1893,7 +1893,7 @@ export declare interface AtomicRecsResult extends Components.AtomicRecsResult {}
 
 
 @ProxyCmp({
-  inputs: ['conditions', 'ifDefined', 'ifNotDefined'],
+  inputs: ['conditions', 'ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch'],
   methods: ['getTemplate']
 })
 @Component({
@@ -1901,7 +1901,7 @@ export declare interface AtomicRecsResult extends Components.AtomicRecsResult {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['conditions', 'ifDefined', 'ifNotDefined'],
+  inputs: ['conditions', 'ifDefined', 'ifNotDefined', 'mustMatch', 'mustNotMatch'],
 })
 export class AtomicRecsResultTemplate {
   protected el: HTMLElement;
@@ -2052,7 +2052,7 @@ export declare interface AtomicResultChildren extends Components.AtomicResultChi
 
 
 @ProxyCmp({
-  inputs: ['conditions'],
+  inputs: ['conditions', 'mustMatch', 'mustNotMatch'],
   methods: ['getTemplate']
 })
 @Component({
@@ -2060,7 +2060,7 @@ export declare interface AtomicResultChildren extends Components.AtomicResultChi
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['conditions'],
+  inputs: ['conditions', 'mustMatch', 'mustNotMatch'],
 })
 export class AtomicResultChildrenTemplate {
   protected el: HTMLElement;
@@ -2228,14 +2228,14 @@ export declare interface AtomicResultList extends Components.AtomicResultList {}
 
 
 @ProxyCmp({
-  inputs: ['fieldCount', 'localeKey']
+  inputs: ['field', 'fieldCount', 'localeKey']
 })
 @Component({
   selector: 'atomic-result-localized-text',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['fieldCount', 'localeKey'],
+  inputs: ['field', 'fieldCount', 'localeKey'],
 })
 export class AtomicResultLocalizedText {
   protected el: HTMLElement;
@@ -2528,7 +2528,7 @@ export declare interface AtomicResultSectionVisual extends Components.AtomicResu
 
 
 @ProxyCmp({
-  inputs: ['conditions'],
+  inputs: ['conditions', 'mustMatch', 'mustNotMatch'],
   methods: ['getTemplate']
 })
 @Component({
@@ -2536,7 +2536,7 @@ export declare interface AtomicResultSectionVisual extends Components.AtomicResu
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['conditions'],
+  inputs: ['conditions', 'mustMatch', 'mustNotMatch'],
 })
 export class AtomicResultTemplate {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -946,6 +946,16 @@ export namespace Components {
           * Verifies whether the specified fields are not defined.
          */
         "ifNotDefined"?: string;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch": Record<string, string[]>;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch": Record<string, string[]>;
     }
     interface AtomicFocusTrap {
         "active": boolean;
@@ -1444,6 +1454,20 @@ export namespace Components {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch": Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch": Record<
+    string,
+    string[]
+  >;
     }
     interface AtomicInsightResultList {
         /**
@@ -1477,6 +1501,20 @@ export namespace Components {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch": Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch": Record<
+    string,
+    string[]
+  >;
     }
     interface AtomicInsightSearchBox {
         /**
@@ -2047,6 +2085,16 @@ export namespace Components {
           * Verifies whether the specified fields are not defined.
          */
         "ifNotDefined"?: string;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch": Record<string, string[]>;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch": Record<string, string[]>;
     }
     /**
      * The `atomic-product-image` component renders an image from a product field.
@@ -2621,6 +2669,20 @@ export namespace Components {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch": Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch": Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-refine-modal` is automatically created as a child of the `atomic-search-interface` when the `atomic-refine-toggle` is initialized.
@@ -2781,6 +2843,22 @@ export namespace Components {
           * Gets the appropriate result template based on conditions applied.
          */
         "getTemplate": () => Promise<ResultTemplate<DocumentFragment> | null>;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch": Record<
+    string,
+    string[]
+  >;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch": Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-result-date` component renders the value of a date result field.
@@ -2896,6 +2974,10 @@ export namespace Components {
      * @MapProp name: field;attr: field;docs: The field from which to extract the target string and the variable used to map it to the target i18n parameter. For example, the following configuration extracts the value of `author` from a result, and assign it to the i18n parameter `name`: `field-author="name"`;type: Record<string, string> ;default: {}
      */
     interface AtomicResultLocalizedText {
+        /**
+          * The field value to dynamically evaluate.
+         */
+        "field": Record<string, string>;
         /**
           * The numerical field value used to determine whether to use the singular or plural value of a translation.
          */
@@ -3081,6 +3163,22 @@ export namespace Components {
           * Gets the appropriate result template based on conditions applied.
          */
         "getTemplate": () => Promise<ResultTemplate<DocumentFragment> | null>;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch": Record<
+    string,
+    string[]
+  >;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch": Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-result-text` component renders the value of a string result field.
@@ -6887,6 +6985,16 @@ declare namespace LocalJSX {
           * Verifies whether the specified fields are not defined.
          */
         "ifNotDefined"?: string;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch"?: Record<string, string[]>;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch"?: Record<string, string[]>;
     }
     interface AtomicFocusTrap {
         "active"?: boolean;
@@ -7364,6 +7472,20 @@ declare namespace LocalJSX {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch"?: Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch"?: Record<
+    string,
+    string[]
+  >;
     }
     interface AtomicInsightResultList {
         /**
@@ -7388,6 +7510,20 @@ declare namespace LocalJSX {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch"?: Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch"?: Record<
+    string,
+    string[]
+  >;
     }
     interface AtomicInsightSearchBox {
         /**
@@ -7944,6 +8080,16 @@ declare namespace LocalJSX {
           * Verifies whether the specified fields are not defined.
          */
         "ifNotDefined"?: string;
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch"?: Record<string, string[]>;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch"?: Record<string, string[]>;
     }
     /**
      * The `atomic-product-image` component renders an image from a product field.
@@ -8473,6 +8619,20 @@ declare namespace LocalJSX {
           * The field that, when defined on a result item, would prevent the template from being applied.  For example, a template with the following attribute only applies to result items whose `filetype` and `sourcetype` fields are NOT defined: `if-not-defined="filetype,sourcetype"`
          */
         "ifNotDefined"?: string;
+        /**
+          * The field and values that define which result items the condition must be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
+         */
+        "mustMatch"?: Record<
+    string,
+    string[]
+  >;
+        /**
+          * The field and values that define which result items the condition must not be applied to.  For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
+         */
+        "mustNotMatch"?: Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-refine-modal` is automatically created as a child of the `atomic-search-interface` when the `atomic-refine-toggle` is initialized.
@@ -8630,6 +8790,22 @@ declare namespace LocalJSX {
           * A function that must return true on results for the result template to apply. Set programmatically before initialization, not via attribute.  For example, the following targets a template and sets a condition to make it apply only to results whose `title` contains `singapore`: `document.querySelector('#target-template').conditions = [(result) => /singapore/i.test(result.title)];`
          */
         "conditions"?: ResultTemplateCondition[];
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch"?: Record<
+    string,
+    string[]
+  >;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch"?: Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-result-date` component renders the value of a date result field.
@@ -8740,6 +8916,10 @@ declare namespace LocalJSX {
      * @MapProp name: field;attr: field;docs: The field from which to extract the target string and the variable used to map it to the target i18n parameter. For example, the following configuration extracts the value of `author` from a result, and assign it to the i18n parameter `name`: `field-author="name"`;type: Record<string, string> ;default: {}
      */
     interface AtomicResultLocalizedText {
+        /**
+          * The field value to dynamically evaluate.
+         */
+        "field"?: Record<string, string>;
         /**
           * The numerical field value used to determine whether to use the singular or plural value of a translation.
          */
@@ -8921,6 +9101,22 @@ declare namespace LocalJSX {
           * A function that must return true on results for the result template to apply. Set programmatically before initialization, not via attribute.  For example, the following targets a template and sets a condition to make it apply only to results whose `title` contains `singapore`: `document.querySelector('#target-template').conditions = [(result) => /singapore/i.test(result.title)];`
          */
         "conditions"?: ResultTemplateCondition[];
+        /**
+          * Verifies whether the specified fields match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustMatch"?: Record<
+    string,
+    string[]
+  >;
+        /**
+          * Verifies whether the specified fields do not match the specified values.
+          * @type {Record<string, string[]>}
+         */
+        "mustNotMatch"?: Record<
+    string,
+    string[]
+  >;
     }
     /**
      * The `atomic-result-text` component renders the value of a string result field.

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-field-condition/atomic-product-field-condition.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-field-condition/atomic-product-field-condition.tsx
@@ -28,9 +28,19 @@ export class AtomicProductFieldCondition {
    */
   @Prop({reflect: true}) ifNotDefined?: string;
 
-  @MapProp({splitValues: true}) mustMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) mustMatch: Record<string, string[]> =
+    {};
 
-  @MapProp({splitValues: true}) mustNotMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields do not match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) mustNotMatch: Record<string, string[]> =
+    {};
 
   private conditions: ProductTemplateCondition[] = [];
   private shouldBeRemoved = false;

--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children-template/atomic-insight-result-children-template.tsx
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children-template/atomic-insight-result-children-template.tsx
@@ -47,15 +47,20 @@ export class AtomicInsightResultChildrenTemplate {
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
    */
-  @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
+  @Prop() @MapProp({splitValues: true}) public mustMatch: Record<
+    string,
+    string[]
+  > = {};
 
   /**
    * The field and values that define which result items the condition must not be applied to.
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
    */
-  @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
-    {};
+  @Prop() @MapProp({splitValues: true}) public mustNotMatch: Record<
+    string,
+    string[]
+  > = {};
 
   public resultTemplateCommon: ResultTemplateCommon;
 

--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-template/atomic-insight-result-template.tsx
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-template/atomic-insight-result-template.tsx
@@ -50,15 +50,20 @@ export class AtomicInsightResultTemplate {
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
    */
-  @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
+  @Prop() @MapProp({splitValues: true}) public mustMatch: Record<
+    string,
+    string[]
+  > = {};
 
   /**
    * The field and values that define which result items the condition must not be applied to.
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
    */
-  @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
-    {};
+  @Prop() @MapProp({splitValues: true}) public mustNotMatch: Record<
+    string,
+    string[]
+  > = {};
 
   constructor() {
     this.resultTemplateCommon = new ResultTemplateCommon({

--- a/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
@@ -56,15 +56,20 @@ export class AtomicRecsResultTemplate {
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is `lithiummessage` or `YouTubePlaylist`: `must-match-filetype="lithiummessage,YouTubePlaylist"`
    */
-  @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
+  @Prop() @MapProp({splitValues: true}) public mustMatch: Record<
+    string,
+    string[]
+  > = {};
 
   /**
    * The field and values that define which result items the condition must not be applied to.
    *
    * For example, a template with the following attribute only applies to result items whose `filetype` is not `lithiummessage`: `must-not-match-filetype="lithiummessage"`
    */
-  @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
-    {};
+  @Prop() @MapProp({splitValues: true}) public mustNotMatch: Record<
+    string,
+    string[]
+  > = {};
 
   constructor() {
     this.resultTemplateCommon = new ResultTemplateCommon({

--- a/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.tsx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.tsx
@@ -34,9 +34,19 @@ export class AtomicFieldCondition {
    */
   @Prop({reflect: true}) ifNotDefined?: string;
 
-  @MapProp({splitValues: true}) mustMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) mustMatch: Record<string, string[]> =
+    {};
 
-  @MapProp({splitValues: true}) mustNotMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields do not match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) mustNotMatch: Record<string, string[]> =
+    {};
 
   private conditions: ResultTemplateCondition[] = [];
   private shouldBeRemoved = false;

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-localized-text/atomic-result-localized-text.ts
@@ -41,7 +41,7 @@ export class AtomicResultLocalizedText implements InitializableComponent {
   /**
    * The field value to dynamically evaluate.
    */
-  @MapProp() field: Record<string, string> = {};
+  @Prop() @MapProp() field: Record<string, string> = {};
   /**
    * The numerical field value used to determine whether to use the singular or plural value of a translation.
    * */

--- a/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
@@ -31,10 +31,23 @@ export class AtomicResultChildrenTemplate {
    */
   @Prop() public conditions: ResultTemplateCondition[] = [];
 
-  @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) public mustMatch: Record<
+    string,
+    string[]
+  > = {};
 
-  @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
-    {};
+  /**
+   * Verifies whether the specified fields do not match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) public mustNotMatch: Record<
+    string,
+    string[]
+  > = {};
 
   public resultTemplateCommon: ResultTemplateCommon;
 

--- a/packages/atomic/src/components/search/result-templates/atomic-result-template/atomic-result-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-template/atomic-result-template.tsx
@@ -36,10 +36,23 @@ export class AtomicResultTemplate {
    */
   @Prop() public conditions: ResultTemplateCondition[] = [];
 
-  @MapProp({splitValues: true}) public mustMatch: Record<string, string[]> = {};
+  /**
+   * Verifies whether the specified fields match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) public mustMatch: Record<
+    string,
+    string[]
+  > = {};
 
-  @MapProp({splitValues: true}) public mustNotMatch: Record<string, string[]> =
-    {};
+  /**
+   * Verifies whether the specified fields do not match the specified values.
+   * @type {Record<string, string[]>}
+   */
+  @Prop() @MapProp({splitValues: true}) public mustNotMatch: Record<
+    string,
+    string[]
+  > = {};
 
   constructor() {
     this.resultTemplateCommon = new ResultTemplateCommon({


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3663

If you look in …/atomic-angular/…/stencil-generated/component.ts and look for atomic-field-condition, you can find that mustMatch and mustNotMatch are not in “inputs”.

A solution for this is to add @Prop before every @MapProp, I will see if I can try to add the Prop decorator behavior inside of the @MapProp code.
