### PR TITLE
test(quantic): fixed quantic e2e after salesforce 25 winter release

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/refine-modal-content/refine-modal-content.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/refine-modal-content/refine-modal-content.cypress.ts
@@ -54,7 +54,7 @@ describe('quantic-refine-content', () => {
   }
 
   describe('when using default options', () => {
-    it.skip('should render the duplicated facets and the sort component', () => {
+    it('should render the duplicated facets and the sort component', () => {
       visitRefineContent();
 
       scope('when loading the page', () => {
@@ -77,6 +77,7 @@ describe('quantic-refine-content', () => {
         Expect.displayClearAllFiltersButton(true);
         Expect.displayDuplicatedTimeframeFacetClearFiltersButton(true);
         Expect.displayTimeframeFacetClearFiltersButton(true);
+        Actions.clickClearAllFilters();
         Actions.clickDuplicatedFacetExpandButton();
         Actions.clickDuplicatedFacetFirstOption();
         Expect.displayClearAllFiltersButton(true);

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-selectors.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-selectors.ts
@@ -58,5 +58,8 @@ export const TimeframeFacetSelectors: TimeframeFacetSelector = {
   applyButton: () =>
     TimeframeFacetSelectors.get().find('.timeframe-facet__apply'),
   form: () => TimeframeFacetSelectors.get().find('form'),
-  validationError: () => TimeframeFacetSelectors.form().find('.slds-has-error'),
+  validationError: () =>
+    TimeframeFacetSelectors.form().find(
+      '.slds-form-element__help[data-error-message]'
+    ),
 };

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
@@ -252,7 +252,7 @@ describe('quantic-timeframe-facet', () => {
       });
 
       describe('with with-date-picker', () => {
-        it.skip('should activate manual range', () => {
+        it('should activate manual range', () => {
           visitTimeframeFacet({
             withDatePicker: true,
             useCase: param.useCase,
@@ -314,7 +314,7 @@ describe('quantic-timeframe-facet', () => {
               Actions.submitForm();
 
               Expect.numberOfValidationErrors(2);
-              Expect.validationError('Complete this field.');
+              Expect.validationError('Complete this field');
             });
 
             scope('when entering then erasing dates', () => {
@@ -322,7 +322,7 @@ describe('quantic-timeframe-facet', () => {
               Actions.submitForm();
 
               Expect.numberOfValidationErrors(1);
-              Expect.validationError('Complete this field.');
+              Expect.validationError('Complete this field');
 
               Actions.typeEndDate(validRange.end);
               Actions.submitForm();
@@ -343,7 +343,7 @@ describe('quantic-timeframe-facet', () => {
 
               Expect.numberOfValidationErrors(1);
               Expect.validationError(
-                'Your entry does not match the allowed format yyyy-MM-dd.'
+                'Your entry does not match the allowed format'
               );
             });
 
@@ -352,7 +352,7 @@ describe('quantic-timeframe-facet', () => {
 
               Expect.numberOfValidationErrors(1);
               Expect.validationError(
-                'Your entry does not match the allowed format yyyy-MM-dd.'
+                'Your entry does not match the allowed format'
               );
             });
 


### PR DESCRIPTION
## [SFINT-5769](https://coveord.atlassian.net/browse/SFINT-5769)

- Fixed E2E tests for the refine modal content and the timeframe facet.
- Timeframe facet tests failed because of changes that came up with the new SF winter 25 release, the way of displaying errors on the timeframe inputs was changed by SF and caused the failure of some of our tests.
- The refine modal content tests failed  because we were trying to select a a standard facet value after applying a timeframe facet filter, the issue was that with this timeframe filter no facet value of the standard facet was found so the facet was not displayed, to fix this I added a command to clear all filter before testing the standard facet.

[SFINT-5769]: https://coveord.atlassian.net/browse/SFINT-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ