### PR TITLE
fix(atomic): allow atomic loader to be deployed to the CDN

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,7 +14,6 @@ utils/**/.storybook/**
 scripts/deploy/execute-deployment-pipeline.mjs
 **/staticresources/**
 packages/atomic-hosted-page/loader/**/*
-packages/atomic/loader/**/*
 packages/atomic/docs/**/*
 packages/atomic/dist-storybook/**/*
 packages/atomic/src/components/search/atomic-search-interface/lang/*.json

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "nx build",
     "clean": "rimraf -rf dist",
+    "build:fixLoaderImportPaths": "node ./scripts/fix-loader-import-paths.js",
     "build:fixGeneratedImportPaths": "fix-esm-import-path src/components/stencil-generated",
     "build:bundles:esm": "tsc -p tsconfig.esm.json",
     "build:bundles:iife-cjs": "rollup --config rollup.config.mjs --bundleConfigAsCjs",

--- a/packages/atomic-react/project.json
+++ b/packages/atomic-react/project.json
@@ -8,6 +8,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
+          "npm run build:fixLoaderImportPaths",
           "npm run build:fixGeneratedImportPaths",
           "npm run build:bundles",
           "npm run build:assets"

--- a/packages/atomic-react/scripts/fix-loader-import-paths.js
+++ b/packages/atomic-react/scripts/fix-loader-import-paths.js
@@ -1,0 +1,29 @@
+import {promises as fs} from 'fs';
+import path from 'path';
+
+const files = [
+  path.resolve('src/components/stencil-generated/commerce/index.ts'),
+  path.resolve('src/components/stencil-generated/search/index.ts'),
+];
+
+const oldImport =
+  "import { defineCustomElements } from '@coveo/atomic/dist/loader';";
+const newImport =
+  "import { defineCustomElements } from '@coveo/atomic/loader';";
+
+const updateFiles = async () => {
+  await Promise.all(
+    files.map(async (filePath) => {
+      try {
+        let data = await fs.readFile(filePath, 'utf8');
+        const updatedData = data.replace(oldImport, newImport);
+        await fs.writeFile(filePath, updatedData, 'utf8');
+        console.log(`File updated: ${filePath}`);
+      } catch (err) {
+        console.error(`Error updating file: ${filePath}`, err);
+      }
+    })
+  );
+};
+
+updateFiles();

--- a/packages/atomic/.eslintrc.cjs
+++ b/packages/atomic/.eslintrc.cjs
@@ -13,7 +13,6 @@ module.exports = {
     'src/external-builds/**/*',
     'dist/**/*',
     'www/**/*',
-    'loader/**/*',
     'docs/**/*',
     'dist-storybook',
   ],

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -14,9 +14,9 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     "./loader": {
-      "types": "./loader/index.d.ts",
-      "import": "./loader/index.js",
-      "require": "./loader/index.cjs.js"
+      "types": "./dist/loader/index.d.ts",
+      "import": "./dist/loader/index.js",
+      "require": "./dist/loader/index.cjs.js"
     },
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -39,8 +39,7 @@
   "files": [
     "dist/",
     "docs/",
-    "licenses/",
-    "loader/"
+    "licenses/"
   ],
   "scripts": {
     "clean": "rimraf -rf dist/* dist-storybook/* www/* docs/* loader/* playwright-report/*",

--- a/packages/atomic/project.json
+++ b/packages/atomic/project.json
@@ -152,7 +152,7 @@
       "dependsOn": ["^build", "cached:build:stencil"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "rm ./loader/package.json",
+        "command": "rm ./dist/loader/package.json",
         "cwd": "packages/atomic"
       }
     }

--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -155,7 +155,6 @@ export const config: Config = {
     {
       type: 'dist',
       collectionDir: null,
-      esmLoaderPath: '../loader',
       copy: [
         {src: 'themes'},
         {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3666

This PR allows the `defineCustomElements()` function to be deployed to the CDN by simply adding it into the `/dist` folder instead of it's custom folder. 

It causes a problem in atomic-react where the `defineCustomElements` import becomes `"import { defineCustomElements } from '@coveo/atomic/dist/loader';"`. 
That import is invalid because of the added `exports` field in atomic V3. To fix this, we need to change the import back to how it was. I created a script to do this. It changes it back to `"import { defineCustomElements } from '@coveo/atomic/loader';"`.