### PR TITLE
test(quantic): fixed quantic e2e after salesforce 25 winter release

### DIFF
--- a/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-1/case-classification/case-classification-selectors.ts
@@ -55,7 +55,9 @@ export const CaseClassificationSelectors: CaseClassificationSelector &
       .find('.case-classification-option input')
       .eq(idx),
   error: () =>
-    CaseClassificationSelectors.get().find('.slds-form-element__help'),
+    CaseClassificationSelectors.get().find(
+      '[data-cy="case-classification-error-message"]'
+    ),
   loadingSpinner: () =>
     CaseClassificationSelectors.get().find('lightning-spinner'),
   componentError: () =>

--- a/packages/quantic/cypress/e2e/default-1/refine-modal-content/refine-modal-content.cypress.ts
+++ b/packages/quantic/cypress/e2e/default-1/refine-modal-content/refine-modal-content.cypress.ts
@@ -77,6 +77,7 @@ describe('quantic-refine-content', () => {
         Expect.displayClearAllFiltersButton(true);
         Expect.displayDuplicatedTimeframeFacetClearFiltersButton(true);
         Expect.displayTimeframeFacetClearFiltersButton(true);
+        Actions.clickClearAllFilters();
         Actions.clickDuplicatedFacetExpandButton();
         Actions.clickDuplicatedFacetFirstOption();
         Expect.displayClearAllFiltersButton(true);

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-selectors.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet-selectors.ts
@@ -58,5 +58,8 @@ export const TimeframeFacetSelectors: TimeframeFacetSelector = {
   applyButton: () =>
     TimeframeFacetSelectors.get().find('.timeframe-facet__apply'),
   form: () => TimeframeFacetSelectors.get().find('form'),
-  validationError: () => TimeframeFacetSelectors.form().find('.slds-has-error'),
+  validationError: () =>
+    TimeframeFacetSelectors.form().find(
+      '.slds-form-element__help[data-error-message]'
+    ),
 };

--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
@@ -314,7 +314,7 @@ describe('quantic-timeframe-facet', () => {
               Actions.submitForm();
 
               Expect.numberOfValidationErrors(2);
-              Expect.validationError('Complete this field.');
+              Expect.validationError('Complete this field');
             });
 
             scope('when entering then erasing dates', () => {
@@ -322,7 +322,7 @@ describe('quantic-timeframe-facet', () => {
               Actions.submitForm();
 
               Expect.numberOfValidationErrors(1);
-              Expect.validationError('Complete this field.');
+              Expect.validationError('Complete this field');
 
               Actions.typeEndDate(validRange.end);
               Actions.submitForm();
@@ -343,7 +343,7 @@ describe('quantic-timeframe-facet', () => {
 
               Expect.numberOfValidationErrors(1);
               Expect.validationError(
-                'Your entry does not match the allowed format yyyy-MM-dd.'
+                'Your entry does not match the allowed format'
               );
             });
 
@@ -352,7 +352,7 @@ describe('quantic-timeframe-facet', () => {
 
               Expect.numberOfValidationErrors(1);
               Expect.validationError(
-                'Your entry does not match the allowed format yyyy-MM-dd.'
+                'Your entry does not match the allowed format'
               );
             });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
@@ -64,7 +64,7 @@
           </div>
         </div>
         <template if:true={hasError}>
-          <div class="slds-form-element__help" id="case-classification-error-message">
+          <div data-cy="case-classification-error-message" class="slds-form-element__help" id="case-classification-error-message">
             {errorMessage}
           </div>
         </template>


### PR DESCRIPTION
[SFINT-5779](https://coveord.atlassian.net/browse/SFINT-5779)

This PR backports the fix made [here](https://github.com/coveo/ui-kit/pull/4559).

It is mandatory in order to be able to merge other Quantic fixes in `v2`.

[SFINT-5779]: https://coveord.atlassian.net/browse/SFINT-5779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ