### PR TITLE
feat(headless): restore range facet state after refresh

### DIFF
--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-reducers.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-reducers.ts
@@ -29,6 +29,9 @@ export function restoreFromParameters(
   if (action.payload.nf) {
     restoreRangeFacets(state, action.payload.nf, 'numericalRange');
   }
+  if (action.payload.mnf) {
+    restoreRangeFacets(state, action.payload.mnf, 'numericalRange');
+  }
   if (action.payload.df) {
     restoreRangeFacets(state, action.payload.df, 'dateRange');
   }

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -3024,6 +3024,67 @@ describe('commerceFacetSetReducer', () => {
       );
     });
 
+    it('populates manual numeric facet requests', () => {
+      const finalState = commerceFacetSetReducer(
+        state,
+        action({
+          mnf: {
+            manual_numeric_facet_1: [
+              {
+                start: 1,
+                end: 10,
+                endInclusive: false,
+              },
+              {
+                start: 15,
+                end: 20,
+                endInclusive: true,
+              },
+            ],
+            manual_numeric_facet_2: [
+              {
+                start: 11,
+                end: 20,
+                endInclusive: true,
+              },
+            ],
+          },
+        })
+      );
+
+      const firstRequest = finalState['manual_numeric_facet_1'].request;
+      expect(firstRequest.type).toEqual('numericalRange');
+      expect(firstRequest.values).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            start: 1,
+            end: 10,
+            endInclusive: false,
+            state: 'selected',
+          }),
+          expect.objectContaining({
+            start: 15,
+            end: 20,
+            endInclusive: true,
+            state: 'selected',
+          }),
+        ])
+      );
+
+      const secondRequest = finalState['manual_numeric_facet_2'].request;
+      expect(secondRequest.type).toEqual('numericalRange');
+      expect(secondRequest.values).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            start: 11,
+            end: 20,
+            endInclusive: true,
+            state: 'selected',
+          }),
+        ])
+      );
+    });
+
     it('populates date facet requests', () => {
       const finalState = commerceFacetSetReducer(
         state,


### PR DESCRIPTION
[CAPI-1470](https://coveord.atlassian.net/browse/CAPI-1470)

Barca is crashing on page refresh when a numerical range facet is used because headless isn't refresh the `facetSet` in the way it does for other facets.

Test on barca and now works as expected.
Before:

https://github.com/user-attachments/assets/6bf6faed-87df-42c2-90a1-5ad5193eaaf3

Now:

https://github.com/user-attachments/assets/55de9da9-9ad1-4bd3-b524-84a756342371



[CAPI-1470]: https://coveord.atlassian.net/browse/CAPI-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ