### PR TITLE
feat(atomic): add variable for collapsed rga height

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -76,7 +76,7 @@
  */
 [part='generated-container'] {
   &.answer-collapsed {
-    @apply relative max-h-64 overflow-hidden content-[''];
+    @apply relative overflow-hidden content-[''];
     max-height: var(--atomic-crga-collapsed-height, 16rem);
 
     .feedback-buttons {

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -74,6 +74,7 @@
 [part='generated-container'] {
   &.answer-collapsed {
     @apply relative max-h-64 overflow-hidden content-[''];
+    max-height: var(--atomic-crga-collapsed-height, 16rem);
 
     .feedback-buttons {
       @apply hidden;
@@ -81,7 +82,10 @@
   }
   &.answer-collapsed:before {
     @apply absolute left-0 top-0 h-full w-full content-[''];
-    background: linear-gradient(transparent 11.25rem, var(--atomic-background));
+    background: linear-gradient(
+      transparent calc(var(--atomic-crga-collapsed-height, 16rem) - 4.75rem),
+      var(--atomic-background)
+    );
   }
 }
 

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -71,6 +71,9 @@
   }
 }
 
+/**
+ * @prop --atomic-crga-collapsed-height: The maximum height of the collapsed generated answer container.
+ */
 [part='generated-container'] {
   &.answer-collapsed {
     @apply relative max-h-64 overflow-hidden content-[''];

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-answer.pcss
@@ -86,7 +86,7 @@
   &.answer-collapsed:before {
     @apply absolute left-0 top-0 h-full w-full content-[''];
     background: linear-gradient(
-      transparent calc(var(--atomic-crga-collapsed-height, 16rem) - 4.75rem),
+      transparent calc(var(--atomic-crga-collapsed-height, 16rem) * 0.7),
       var(--atomic-background)
     );
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-4300

We need to support a more compact RGA component for IPX use case. This adds a variable to the collapsed height of the component.

To test, you can add that style to the IPX demo page: 

```
          (with
          search: {
            pipeline: 'genqatest',
          },)


      :root {
        --atomic-crga-collapsed-height: 8rem;
      }
      atomic-generated-answer::part(container) {
        padding: 1.5rem;
      }
      atomic-generated-answer::part(generated-container) {
        margin-top: 1rem;
      }
      atomic-generated-answer::part(generated-answer-footer) {
        margin-top: 1rem;
      }
```
and it will now look like that:




https://github.com/user-attachments/assets/e1d5aee0-38dd-4058-8dda-af199e864ef4


