### PR TITLE
fix(headless): ensure each folded result keep a reference of its 'source' searchId V2

### DIFF
--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -47,6 +47,7 @@ export interface LoadCollectionFulfilledReturn {
   results: Result[];
   collectionId: CollectionId;
   rootResult: ResultWithFolding;
+  searchUid: string;
 }
 
 export const foldingOptionsSchemaDefinition: SchemaDefinition<
@@ -105,6 +106,7 @@ export const loadCollection = createAsyncThunk<
     return {
       collectionId,
       results: response.success.results,
+      searchUid: response.success.searchUid,
       rootResult: state.folding.collections[collectionId]!
         .result as ResultWithFolding,
     };

--- a/packages/headless/src/features/folding/folding-slice.test.ts
+++ b/packages/headless/src/features/folding/folding-slice.test.ts
@@ -166,6 +166,7 @@ describe('folding slice', () => {
         collectionId: results[0].raw.collection!,
         results,
         rootResult,
+        searchUid: 'some-search-uid',
       });
     }
 
@@ -204,6 +205,30 @@ describe('folding slice', () => {
           } as ClientThunkExtraArguments<SearchAPIClient>
         );
       };
+
+      it('when a fetchPage fulfilled is received, new results should contain the latest search #searchUid', () => {
+        const indexedResults = buildMockResultsFromHierarchy(
+          'thread',
+          testThreadHierarchy
+        );
+        const rootResult = emulateAPIFolding(indexedResults);
+        const response = {
+          ...buildMockSearchResponse({results: [rootResult]}),
+          searchUid: 'a_new_id',
+        };
+        const search = buildMockSearch({
+          response,
+        });
+
+        const finalState = foldingReducer(
+          state,
+          fetchMoreResults.fulfilled(search, '')
+        );
+
+        expect(finalState.collections.thread.children[0].result.searchUid).toBe(
+          'a_new_id'
+        );
+      });
 
       it('uses #cq with correct expression to obtain the full collection', async () => {
         await doLoadCollection();
@@ -257,7 +282,7 @@ describe('folding slice', () => {
         );
       });
 
-      it('does not uses facets to get the full collection', async () => {
+      it('does not use facets to get the full collection', async () => {
         await doLoadCollection();
         expect(apiClient.search).toHaveBeenCalledWith(
           expect.not.objectContaining({

--- a/packages/headless/src/features/folding/insight-folding-actions.ts
+++ b/packages/headless/src/features/folding/insight-folding-actions.ts
@@ -61,6 +61,7 @@ export const loadCollection = createAsyncThunk<
     return {
       collectionId,
       results: response.success.results,
+      searchUid: response.success.searchUid,
       rootResult: state.folding.collections[collectionId]!
         .result as ResultWithFolding,
     };

--- a/packages/headless/src/features/search/search-slice.test.ts
+++ b/packages/headless/src/features/search/search-slice.test.ts
@@ -236,6 +236,25 @@ describe('search-slice', () => {
       expect(finalState.results[1].searchUid).toBe('a_new_id');
     });
 
+    it('when a fetchPage fulfilled is received, new results should contain the latest search #searchUid', () => {
+      state.results = state.results.map((result) => ({
+        ...result,
+        searchUid: 'an_initial_id',
+      }));
+      const response = buildMockSearchResponse({results: [newResult]});
+      response.searchUid = 'a_new_id';
+      const search = buildMockSearch({
+        response,
+      });
+
+      const finalState = searchReducer(
+        state,
+        fetchPage.fulfilled(search, '', {legacy: logPageNext()})
+      );
+
+      expect(finalState.results[0].searchUid).toBe('a_new_id');
+    });
+
     it('when a fetchMoreResults fulfilled is received, keeps the previous #questionAnswer', () => {
       const originalQuestionAnswers = buildMockQuestionsAnswers({
         question: 'Why?',

--- a/packages/headless/src/features/search/search-slice.ts
+++ b/packages/headless/src/features/search/search-slice.ts
@@ -94,7 +94,12 @@ export const searchReducer = createReducer(
     });
     builder.addCase(fetchPage.fulfilled, (state, action) => {
       handleFulfilledSearch(state, action);
-      state.results = action.payload.response.results;
+      state.results = [
+        ...action.payload.response.results.map((result) => ({
+          ...result,
+          searchUid: action.payload.response.searchUid,
+        })),
+      ];
     });
     builder.addCase(fetchFacetValues.fulfilled, (state, action) => {
       state.response.facets = action.payload.response.facets;


### PR DESCRIPTION
Backporting #4628
https://coveord.atlassian.net/browse/KIT-3703