### PR TITLE
chore: specify version when invoking deployment pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-kit",
   "private": true,
-  "version": "3.0.0",
+  "version": "2.0.0",
   "scripts": {
     "postinstall": "husky install && patch-package && npx playwright install",
     "reset:install": "git checkout origin/v2 package-lock.json && npm i",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ui-kit",
   "private": true,
+  "version": "3.0.0",
   "scripts": {
     "postinstall": "husky install && patch-package && npx playwright install",
     "reset:install": "git checkout origin/v2 package-lock.json && npm i",
@@ -20,7 +21,7 @@
     "release": "npm run nx:graph && npm run release:phase0 && npm run release:phase1 && npm run release:phase2 && npm run release:phase3",
     "nx:graph": "nx graph --file=topology.json",
     "release:phase0": "npm run-script -w=@coveo/release git-lock",
-    "release:phase1": "nx run-many --targets=release:phase1 --all --parallel=false --output-style=stream",
+    "release:phase1": "nx run-many --targets=release:phase1 --all --parallel=false --output-style=stream; npm run-script -w=@coveo/release bump:root",
     "release:phase2": "npm run-script -w=@coveo/release reify",
     "release:phase3": "npm run-script -w=@coveo/release git-publish-all",
     "release:phase4": "nx run-many --targets=release:phase4 --all"
@@ -137,6 +138,5 @@
   "dependencies": {
     "upgrade": "1.1.0"
   },
-  "version": "0.0.0",
   "packageManager": "npm@10.8.2"
 }

--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -4,6 +4,7 @@ import atomicHostedPageJson from '../../packages/atomic-hosted-page/package.json
 import atomicReactJson from '../../packages/atomic-react/package.json' assert {type: 'json'};
 import atomicJson from '../../packages/atomic/package.json' assert {type: 'json'};
 import headlessJson from '../../packages/headless/package.json' assert {type: 'json'};
+import rootJson from '../../package.json' assert {type: 'json'};
 
 const releaseCommit = execSync('git rev-parse HEAD').toString().trim();
 
@@ -16,12 +17,14 @@ function getVersionComposants(version) {
   };
 }
 
+const root = getVersionComposants(rootJson.version);
 const headless = getVersionComposants(headlessJson.version);
 const atomic = getVersionComposants(atomicJson.version);
 const atomicReact = getVersionComposants(atomicReactJson.version);
 const atomicHostedPage = getVersionComposants(atomicHostedPageJson.version);
 console.log(execSync(`
   deployment-package package create --with-deploy \
+    --version ${root.major}.${root.minor}.${root.patch} \
     --resolve HEADLESS_MAJOR_VERSION=${headless.major} \
     --resolve HEADLESS_MINOR_VERSION=${headless.major}.${headless.minor} \
     --resolve HEADLESS_PATCH_VERSION=${headless.major}.${headless.minor}.${headless.patch} \

--- a/utils/release/bump-root.mjs
+++ b/utils/release/bump-root.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import {
+  getCurrentVersion,
+  getNextVersion,
+} from '@coveo/semantic-monorepo-tools';
+import {readFileSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+if (!process.env.INIT_CWD) {
+  throw new Error('Should be called using npm run-script');
+}
+process.chdir(process.env.INIT_CWD);
+
+(async () => {
+  const PATH = '.';
+
+  console.log('Bumping root package.json version');
+  const currentVersion = getCurrentVersion(PATH);
+  const nextVersion = getNextVersion(currentVersion, {type: 'patch'});
+
+  const packageJsonPath = resolve(PATH, 'package.json');
+  const packageJson = JSON.parse(
+    readFileSync(packageJsonPath, {encoding: 'utf-8'})
+  );
+  packageJson.version = nextVersion;
+
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  console.log(`Updated root package version to ${nextVersion}`);
+})();

--- a/utils/release/package.json
+++ b/utils/release/package.json
@@ -25,6 +25,7 @@
     "promote-npm-prod": "./promote-npm-tag-to-latest.mjs",
     "git-lock": "./git-lock.mjs",
     "bump": "./bump-package.mjs",
+    "bump:root": "./bump-root.mjs",
     "npm-publish": "./npm-publish-package.mjs",
     "git-publish-all": "./git-publish-all.mjs",
     "reify": "./reify.mjs",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3692

This PR specifies _a version_ when invoking the deployment pipeline. This is necessary since we deploy from two separate branches. The pipeline needs a better way to differentiate those two. This version will be the root pjson.version starting from 3.0.0 for v3 and 2.0.0 for v2.