### PR TITLE
feat(headless ssr): Improve server-side error logging

### DIFF
--- a/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
@@ -177,6 +177,12 @@ export function defineCommerceEngine<
   const buildFactory =
     <T extends SolutionType>(solutionType: T) =>
     async (...[buildOptions]: BuildParameters) => {
+      const logger = buildLogger(options.loggerOptions);
+      if (!getOptions().navigatorContextProvider) {
+        logger.warn(
+          '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
+        );
+      }
       const engine = buildSSRCommerceEngine(
         solutionType,
         buildOptions?.extend
@@ -203,12 +209,6 @@ export function defineCommerceEngine<
   ) => FetchStaticStateFunction = (solutionType: SolutionType) =>
     composeFunction(
       async (...params: FetchStaticStateParameters) => {
-        const logger = buildLogger(options.loggerOptions);
-        if (!getOptions().navigatorContextProvider) {
-          logger.warn(
-            '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
-          );
-        }
         const buildResult = await buildFactory(solutionType)(...params);
         const staticState = await fetchStaticStateFactory(
           solutionType
@@ -254,12 +254,6 @@ export function defineCommerceEngine<
   ) => HydrateStaticStateFunction = (solutionType: SolutionType) =>
     composeFunction(
       async (...params: HydrateStaticStateParameters) => {
-        const logger = buildLogger(options.loggerOptions);
-        if (!getOptions().navigatorContextProvider) {
-          logger.warn(
-            '[WARNING] Missing navigator context in client-side code. Make sure to set it with `setNavigatorContextProvider` before calling hydrateStaticState()'
-          );
-        }
         const buildResult = await buildFactory(solutionType)(
           ...(params as BuildParameters)
         );

--- a/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ssr.ts
@@ -17,6 +17,7 @@ import {
   EngineDefinition,
   EngineDefinitionOptions,
 } from '../commerce-ssr-engine/types/core-engine.js';
+import {buildLogger} from '../logger.js';
 import {NavigatorContextProvider} from '../navigatorContextProvider.js';
 import {composeFunction} from '../ssr-engine/common.js';
 import {createStaticState} from '../ssr-engine/common.js';
@@ -202,9 +203,9 @@ export function defineCommerceEngine<
   ) => FetchStaticStateFunction = (solutionType: SolutionType) =>
     composeFunction(
       async (...params: FetchStaticStateParameters) => {
+        const logger = buildLogger(options.loggerOptions);
         if (!getOptions().navigatorContextProvider) {
-          // TODO: KIT-3409 - implement a logger to log SSR warnings/errors
-          console.warn(
+          logger.warn(
             '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
           );
         }
@@ -253,9 +254,9 @@ export function defineCommerceEngine<
   ) => HydrateStaticStateFunction = (solutionType: SolutionType) =>
     composeFunction(
       async (...params: HydrateStaticStateParameters) => {
+        const logger = buildLogger(options.loggerOptions);
         if (!getOptions().navigatorContextProvider) {
-          // TODO: KIT-3409 - implement a logger to log SSR warnings/errors
-          console.warn(
+          logger.warn(
             '[WARNING] Missing navigator context in client-side code. Make sure to set it with `setNavigatorContextProvider` before calling hydrateStaticState()'
           );
         }

--- a/packages/headless/src/app/logger-middlewares.ts
+++ b/packages/headless/src/app/logger-middlewares.ts
@@ -7,7 +7,7 @@ import {
 import {Logger} from 'pino';
 
 type UnknownActionWithPossibleErrorPayload = UnknownAction & {
-  payload?: {ignored?: boolean};
+  payload?: {ignored?: boolean; message?: string; errorCode?: string};
   error?: SerializedError;
 };
 
@@ -20,9 +20,20 @@ export const logActionErrorMiddleware: (logger: Logger) => Middleware =
 
     const error: SerializedError = unknownAction.error;
 
+    const errorPayloadMessage = [
+      unknownAction.payload?.errorCode,
+      unknownAction.payload?.message,
+    ]
+      .filter(Boolean)
+      .join(' - ');
+
     if (!unknownAction.payload?.ignored) {
       logger.error(
-        error.stack || error.message || error.name || 'Error',
+        errorPayloadMessage ||
+          error.stack ||
+          error.message ||
+          error.name ||
+          'Error',
         `Action dispatch error ${unknownAction.type}`,
         action
       );

--- a/packages/headless/src/app/search-engine/search-engine.ssr.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ssr.ts
@@ -5,6 +5,7 @@ import {UnknownAction} from '@reduxjs/toolkit';
 import type {Controller} from '../../controllers/controller/headless-controller.js';
 import {LegacySearchAction} from '../../features/analytics/analytics-utils.js';
 import {createWaitForActionMiddleware} from '../../utils/utils.js';
+import {buildLogger} from '../logger.js';
 import {NavigatorContextProvider} from '../navigatorContextProvider.js';
 import {
   buildControllerDefinitions,
@@ -132,6 +133,12 @@ export function defineSearchEngine<
   };
 
   const build: BuildFunction = async (...[buildOptions]: BuildParameters) => {
+    const logger = buildLogger(options.loggerOptions);
+    if (!getOptions().navigatorContextProvider) {
+      logger.warn(
+        '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
+      );
+    }
     const engine = buildSSRSearchEngine(
       buildOptions?.extend
         ? await buildOptions.extend(getOptions())
@@ -152,12 +159,6 @@ export function defineSearchEngine<
 
   const fetchStaticState: FetchStaticStateFunction = composeFunction(
     async (...params: FetchStaticStateParameters) => {
-      if (!getOptions().navigatorContextProvider) {
-        // TODO: KIT-3409 - implement a logger to log SSR warnings/errors
-        console.warn(
-          '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
-        );
-      }
       const buildResult = await build(...params);
       const staticState = await fetchStaticState.fromBuildResult({
         buildResult,
@@ -188,12 +189,6 @@ export function defineSearchEngine<
 
   const hydrateStaticState: HydrateStaticStateFunction = composeFunction(
     async (...params: HydrateStaticStateParameters) => {
-      if (!getOptions().navigatorContextProvider) {
-        // TODO: KIT-3409 - implement a logger to log SSR warnings/errors
-        console.warn(
-          '[WARNING] Missing navigator context in client-side code. Make sure to set it with `setNavigatorContextProvider` before calling hydrateStaticState()'
-        );
-      }
       const buildResult = await build(...(params as BuildParameters));
       const staticState = await hydrateStaticState.fromBuildResult({
         buildResult,

--- a/packages/samples/headless-ssr-commerce/app/_lib/commerce-engine-config.ts
+++ b/packages/samples/headless-ssr-commerce/app/_lib/commerce-engine-config.ts
@@ -29,6 +29,8 @@ type CommerceEngineConfig = CommerceEngineDefinitionOptions<
 >;
 
 export default {
+  // By default, the logger level is set to 'warn'. This level may not provide enough information for some server-side errors. To get more detailed error messages, set the logger level to a more verbose level, such as 'debug'.
+  // loggerOptions: {level: 'debug'},
   configuration: {
     ...getSampleCommerceEngineConfiguration(),
     context: {


### PR DESCRIPTION
This PR improves the way error messages get logged in headless to ensure enough information is available in server-side errors. 

It does this by returning error code + message from the error payload if available.

Before:
> {"level":50,"time":1730911352023,"pid":41408,"hostname":"WKS-002579","name":"@coveo/headless","msg":"Rejected"}

After:
> {"level":50,"time":1730910931049,"pid":41408,"hostname":"WKS-002579","name":"@coveo/headless","msg":"NO_CATALOG_MATCHES_REQUEST - Could not find catalog mapping for organization 'searchuisamples', trackingId 'sports-ui-samples', language: 'egn', country: 'US', currency: 'USD'"}

https://coveord.atlassian.net/browse/KIT-3409