### PR TITLE
ci: skip atomic-hosted-page publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui-kit",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui-kit",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/bueno",
@@ -56051,7 +56051,6 @@
         "@stencil/core": "4.20.0"
       },
       "devDependencies": {
-        "@coveo/release": "1.0.0",
         "@playwright/test": "1.45.3",
         "@types/node": "20.14.12"
       }

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -25,9 +25,9 @@
     "start": "node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --dev --watch --serve",
     "e2e": "playwright test",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
-    "publish:npm": "npm run-script -w=@coveo/release npm-publish",
-    "publish:bump": "npm run-script -w=@coveo/release bump",
-    "promote:npm:latest": "npm run-script -w=@coveo/release promote-npm-prod"
+    "publish:npm": "echo 'Skipping NPM package publication'",
+    "publish:bump": "echo 'Skipping NPM package bump'",
+    "promote:npm:latest": "echo 'Skipping NPM package Promotion to production'"
   },
   "dependencies": {
     "@coveo/bueno": "0.46.4",
@@ -35,7 +35,6 @@
     "@stencil/core": "4.20.0"
   },
   "devDependencies": {
-    "@coveo/release": "1.0.0",
     "@playwright/test": "1.45.3",
     "@types/node": "20.14.12"
   }


### PR DESCRIPTION
The atomic-hosted-page has the same major version in both v2 and master branches.
Thus, we do not want to bump its version on this branch

https://coveord.atlassian.net/browse/KIT-3717