### PR TITLE
docs(atomic): hide a component

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -2163,7 +2163,7 @@ export namespace Components {
         "hrefTemplate"?: string;
     }
     /**
-     * The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
+     * @alpha The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
      */
     interface AtomicProductMultiValueText {
         /**
@@ -4990,7 +4990,7 @@ declare global {
         new (): HTMLAtomicProductLinkElement;
     };
     /**
-     * The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
+     * @alpha The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
      */
     interface HTMLAtomicProductMultiValueTextElement extends Components.AtomicProductMultiValueText, HTMLStencilElement {
     }
@@ -8217,7 +8217,7 @@ declare namespace LocalJSX {
         "hrefTemplate"?: string;
     }
     /**
-     * The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
+     * @alpha The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
      */
     interface AtomicProductMultiValueText {
         /**
@@ -10373,7 +10373,7 @@ declare module "@stencil/core" {
              */
             "atomic-product-link": LocalJSX.AtomicProductLink & JSXBase.HTMLAttributes<HTMLAtomicProductLinkElement>;
             /**
-             * The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
+             * @alpha The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
              */
             "atomic-product-multi-value-text": LocalJSX.AtomicProductMultiValueText & JSXBase.HTMLAttributes<HTMLAtomicProductMultiValueTextElement>;
             /**

--- a/packages/atomic/src/components/commerce/product-template-components/atomic-product-multi-value-text/atomic-product-multi-value-text.tsx
+++ b/packages/atomic/src/components/commerce/product-template-components/atomic-product-multi-value-text/atomic-product-multi-value-text.tsx
@@ -16,6 +16,8 @@ import {CommerceBindings} from '../../atomic-commerce-interface/atomic-commerce-
 import {ProductContext} from '../product-template-decorators';
 
 /**
+ * @alpha
+ *
  * The `atomic-product-multi-value-text` component renders the values of a multi-value string field.
  * @part product-multi-value-text-list - The list of field values.
  * @part product-multi-value-text-separator - The separator to display between each of the field values.


### PR DESCRIPTION
In the release, I noticed this atomic commerce component that should be hidden, so here you go 🙂 

https://coveord.atlassian.net/browse/KIT-3723