### PR TITLE
ci: don't install dependencies and don't build in the should-e2e-quantic action

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -353,7 +353,10 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version-file: '.nvmrc'
       - run: node ./scripts/ci/hasFileChanged.mjs shouldRunQuantic 'packages/quantic/**/*' 'packages/headless/**/*' package.json package-lock.json
         id: shouldRunQuantic
   e2e-quantic:

--- a/packages/headless/src/controllers/facets/facet/headless-facet.ts
+++ b/packages/headless/src/controllers/facets/facet/headless-facet.ts
@@ -91,6 +91,7 @@ export interface FacetProps {
  * @category Facet
  * */
 export function buildFacet(engine: SearchEngine, props: FacetProps): Facet {
+  console.log('a');
   if (!loadFacetReducers(engine)) {
     throw loadReducerError;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3726

Only installing node here instead of all dependencies + building will save about **5 minutes** on every merge queue and pull request ci.

- [ ] tested