### PR TITLE
docs(headless): fix broken link in comment

### DIFF
--- a/packages/headless/src/controllers/core/result-list/headless-core-result-list.ts
+++ b/packages/headless/src/controllers/core/result-list/headless-core-result-list.ts
@@ -56,7 +56,7 @@ export interface ResultListProps {
 /**
  * The `ResultList` headless controller offers a high-level interface for designing a common result list UI controller.
  *
- * Example: [result-list.fn.tsx](https://github.com/coveo/ui-kit/blob/example/packages/samples/headless-react/src/components/result-list/result-list.fn.tsx)
+ * Example: [result-list.fn.tsx](https://github.com/coveo/ui-kit/blob/master/packages/samples/headless-react/src/components/result-list/result-list.fn.tsx)
  *
  * @group Controllers
  * @category ResultList


### PR DESCRIPTION
I somehow made a mistake in one of the links in my Typedoc PR that was merged 1-2 weeks ago. Fix here.