### PR TITLE
ci: update upload-artifacts & download-artifacts to v4

### DIFF
--- a/.github/actions/e2e-atomic-angular/action.yml
+++ b/.github/actions/e2e-atomic-angular/action.yml
@@ -19,7 +19,7 @@ runs:
         wait-on-timeout: 600000
         install: false
         record: false
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: angular-screenshots

--- a/.github/actions/e2e-atomic-next/action.yml
+++ b/.github/actions/e2e-atomic-next/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: next-screenshots

--- a/.github/actions/e2e-atomic-react/action.yml
+++ b/.github/actions/e2e-atomic-react/action.yml
@@ -18,7 +18,7 @@ runs:
         wait-on-timeout: 600000
         install: false
         record: false
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: react-screenshots

--- a/.github/actions/e2e-atomic-screenshots/action.yml
+++ b/.github/actions/e2e-atomic-screenshots/action.yml
@@ -19,7 +19,7 @@ runs:
         wait-on-timeout: 600000
         install: false
         record: false
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: cancelled() || failure() || success()
       with:
         name: result-lists-screenshots

--- a/.github/actions/e2e-atomic/action.yml
+++ b/.github/actions/e2e-atomic/action.yml
@@ -32,7 +32,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         SPLIT: ${{ inputs.SPLIT }}
         SPLIT_INDEX: ${{ inputs.SPLIT_INDEX }}
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: atomic-e2e-screenshots-${{ inputs.spec }}

--- a/.github/actions/e2e-headless-ssr-app-dev/action.yml
+++ b/.github/actions/e2e-headless-ssr-app-dev/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: ssr-app-dev-screenshots

--- a/.github/actions/e2e-headless-ssr-app-prod/action.yml
+++ b/.github/actions/e2e-headless-ssr-app-prod/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: ssr-app-prd-screenshots

--- a/.github/actions/e2e-headless-ssr-pages-dev/action.yml
+++ b/.github/actions/e2e-headless-ssr-pages-dev/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: ssr-page-dev-screenshots

--- a/.github/actions/e2e-headless-ssr-pages-prod/action.yml
+++ b/.github/actions/e2e-headless-ssr-pages-prod/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: ssr-pages-prd-screenshots

--- a/.github/actions/e2e-iife/action.yml
+++ b/.github/actions/e2e-iife/action.yml
@@ -19,7 +19,7 @@ runs:
         install: false
         record: false
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: iife-screenshots

--- a/.github/actions/e2e-quantic/action.yml
+++ b/.github/actions/e2e-quantic/action.yml
@@ -26,7 +26,7 @@ runs:
         config: reporter=cypress/reporters/detailed-reporter.js
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: quantic-screenshots-${{ inputs.spec}}

--- a/.github/actions/e2e-stencil/action.yml
+++ b/.github/actions/e2e-stencil/action.yml
@@ -18,7 +18,7 @@ runs:
         wait-on-timeout: 600000
         install: false
         record: false
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: failure()
       with:
         name: stencil-sample-screenshots

--- a/.github/actions/e2e-vuejs/action.yml
+++ b/.github/actions/e2e-vuejs/action.yml
@@ -21,7 +21,7 @@ runs:
     #     wait-on-timeout: 600000
     #     install: false
     #     record: false
-    # - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    # - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
     #   if: failure()
     #   with:
     #     name: vue-screenshots


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3725

Main change are that they are immutable now. We were never mutating them so not much work to update to v4

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md