### PR TITLE
ci: fix .tmp quantic folder breaking commit generated files 

### DIFF
--- a/packages/quantic/.gitignore
+++ b/packages/quantic/.gitignore
@@ -57,3 +57,5 @@ docs/out/*
 
 # Environment Variables
 .env
+
+.tmp

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -25,7 +25,6 @@
           "npm run babel:headless && npm run build:staticresources",
           "npm run build:doc"
         ],
-        "parallel": true,
         "cwd": "packages/quantic"
       }
     },

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -25,6 +25,7 @@
           "npm run babel:headless && npm run build:staticresources",
           "npm run build:doc"
         ],
+        "parallel": true,
         "cwd": "packages/quantic"
       }
     },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3736

The two commands were running in parallel and not deleting the .tmp folder so it showed in the git untracked files thus breaking the commit generated files action.