### PR TITLE
fix(atomic): add space after ':' in breadcrumb buttons

### DIFF
--- a/packages/atomic/src/components/common/breadbox/breadcrumb-content.tsx
+++ b/packages/atomic/src/components/common/breadbox/breadcrumb-content.tsx
@@ -27,11 +27,11 @@ export const BreadcrumbContent: FunctionalComponent<BreadcrumbContentProps> = (
       </span>
       <span
         part="breadcrumb-value"
-        class={
+        class={`ml-1 ${
           props.breadcrumb.content
             ? ''
             : `max-w-snippet truncate ${props.breadcrumb.state}`
-        }
+        }`}
       >
         {props.breadcrumb.content ?? value}
       </span>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3733

## Before
<img width="402" alt="image" src="https://github.com/user-attachments/assets/b0b8b5c4-e48c-404e-86fb-f9482cdc90ac">

## After
<img width="389" alt="image" src="https://github.com/user-attachments/assets/63779f37-f8a7-4cec-9760-66d27848e6a3">
