### PR TITLE
chore: add atomic loader to CDN deployment config

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -148,6 +148,42 @@
       }
     },
     {
+      "id": "deploy-atomic-patch-loader-to-s3-version",
+      "s3": {
+        "disabled": $[IS_NIGHTLY],
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_PATCH_VERSION]/loader",
+        "source": "packages/atomic/dist/loader",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-minor-loader-to-s3-version",
+      "s3": {
+        "disabled": $[IS_NIGHTLY],
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]/loader",
+        "source": "packages/atomic/dist/loader",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "deploy-atomic-major-loader-to-s3-version",
+      "s3": {
+        "disabled": $[IS_NIGHTLY],
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]/loader",
+        "source": "packages/atomic/dist/loader",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
       "id": "deploy-atomic-minor-storybook-to-s3-version",
       "s3": {
         "disabled": $[IS_NIGHTLY],

--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -148,42 +148,6 @@
       }
     },
     {
-      "id": "deploy-atomic-patch-loader-to-s3-version",
-      "s3": {
-        "disabled": $[IS_NIGHTLY],
-        "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_PATCH_VERSION]/loader",
-        "source": "packages/atomic/dist/loader",
-        "parameters": {
-          "acl": "public-read"
-        }
-      }
-    },
-    {
-      "id": "deploy-atomic-minor-loader-to-s3-version",
-      "s3": {
-        "disabled": $[IS_NIGHTLY],
-        "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]/loader",
-        "source": "packages/atomic/dist/loader",
-        "parameters": {
-          "acl": "public-read"
-        }
-      }
-    },
-    {
-      "id": "deploy-atomic-major-loader-to-s3-version",
-      "s3": {
-        "disabled": $[IS_NIGHTLY],
-        "bucket": "{terraform.infra.infra.bucket_binaries}",
-        "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]/loader",
-        "source": "packages/atomic/dist/loader",
-        "parameters": {
-          "acl": "public-read"
-        }
-      }
-    },
-    {
       "id": "deploy-atomic-minor-storybook-to-s3-version",
       "s3": {
         "disabled": $[IS_NIGHTLY],

--- a/packages/atomic-react/scripts/fix-loader-import-paths.js
+++ b/packages/atomic-react/scripts/fix-loader-import-paths.js
@@ -7,7 +7,7 @@ const files = [
 ];
 
 const oldImport =
-  "import { defineCustomElements } from '@coveo/atomic/dist/loader';";
+  "import { defineCustomElements } from '@coveo/atomic/dist/atomic/loader';";
 const newImport =
   "import { defineCustomElements } from '@coveo/atomic/loader';";
 

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -14,9 +14,9 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     "./loader": {
-      "types": "./dist/loader/index.d.ts",
-      "import": "./dist/loader/index.js",
-      "require": "./dist/loader/index.cjs.js"
+      "types": "./dist/atomic/loader/index.d.ts",
+      "import": "./dist/atomic/loader/index.js",
+      "require": "./dist/atomic/loader/index.cjs.js"
     },
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -42,7 +42,7 @@
     "licenses/"
   ],
   "scripts": {
-    "clean": "rimraf -rf dist/* dist-storybook/* www/* docs/* loader/* playwright-report/*",
+    "clean": "rimraf -rf dist/* dist-storybook/* www/* docs/* playwright-report/*",
     "build": "nx build",
     "build:locales": "npx nx build:locales atomic",
     "start": "nx dev atomic",

--- a/packages/atomic/project.json
+++ b/packages/atomic/project.json
@@ -6,7 +6,6 @@
       "!{projectRoot}/dist",
       "!{projectRoot}/www",
       "!{projectRoot}/docs",
-      "!{projectRoot}/loader",
       "!{projectRoot}/src/components.d.ts"
     ],
     "buildInputs": [
@@ -28,7 +27,6 @@
         "{projectRoot}/dist",
         "{projectRoot}/www",
         "{projectRoot}/docs",
-        "{projectRoot}/loader",
         "{projectRoot}/src/components.d.ts"
       ],
       "executor": "nx:run-commands",
@@ -152,7 +150,7 @@
       "dependsOn": ["^build", "cached:build:stencil"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "rm ./dist/loader/package.json",
+        "command": "rm -f ./dist/atomic/loader/package.json",
         "cwd": "packages/atomic"
       }
     }

--- a/packages/atomic/stencil.config.ts
+++ b/packages/atomic/stencil.config.ts
@@ -154,6 +154,7 @@ export const config: Config = {
     },
     {
       type: 'dist',
+      esmLoaderPath: './atomic/loader',
       collectionDir: null,
       copy: [
         {src: 'themes'},


### PR DESCRIPTION
This PR ensures that the atomic loader is deployed to the CDN under the atomic/v*/loader path.

https://coveord.atlassian.net/browse/KIT-3710