### PR TITLE
fix(headless): send null instead of noResultsBack & undoQuery

### DIFF
--- a/packages/headless/src/controllers/history-manager/headless-history-manager.ts
+++ b/packages/headless/src/controllers/history-manager/headless-history-manager.ts
@@ -10,11 +10,13 @@ import {
   logNoResultsBack,
   historyBackward,
   historyForward,
-  noResultsBack,
 } from '../../features/history/history-analytics-actions.js';
 import {history} from '../../features/history/history-slice.js';
 import {HistoryState} from '../../features/history/history-state.js';
-import {executeSearch} from '../../features/search/search-actions.js';
+import {
+  executeSearch,
+  nullActionCause,
+} from '../../features/search/search-actions.js';
 import {
   ConfigurationSection,
   HistorySection,
@@ -146,7 +148,7 @@ export function buildHistoryManager(engine: SearchEngine): HistoryManager {
       dispatch(
         executeSearch({
           legacy: logNoResultsBack(),
-          next: noResultsBack(),
+          next: nullActionCause(),
         })
       );
     },

--- a/packages/headless/src/controllers/triggers/headless-query-trigger.ts
+++ b/packages/headless/src/controllers/triggers/headless-query-trigger.ts
@@ -1,11 +1,11 @@
 import {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {updateQuery} from '../../features/query/query-actions.js';
 import {queryReducer as query} from '../../features/query/query-slice.js';
-import {executeSearch} from '../../features/search/search-actions.js';
 import {
-  logUndoTriggerQuery,
-  undoTriggerQuery,
-} from '../../features/triggers/trigger-analytics-actions.js';
+  executeSearch,
+  nullActionCause,
+} from '../../features/search/search-actions.js';
+import {logUndoTriggerQuery} from '../../features/triggers/trigger-analytics-actions.js';
 import {updateIgnoreQueryTrigger} from '../../features/triggers/triggers-actions.js';
 import {triggerReducer as triggers} from '../../features/triggers/triggers-slice.js';
 import {TriggerSection, QuerySection} from '../../state/state-sections.js';
@@ -55,7 +55,7 @@ export function buildQueryTrigger(engine: SearchEngine): QueryTrigger {
           legacy: logUndoTriggerQuery({
             undoneQuery: modification(),
           }),
-          next: undoTriggerQuery(),
+          next: nullActionCause(),
         })
       );
     },

--- a/packages/headless/src/features/analytics/search-action-cause.ts
+++ b/packages/headless/src/features/analytics/search-action-cause.ts
@@ -72,10 +72,6 @@ export enum SearchPageEvents {
    */
   triggerQuery = 'query',
   /**
-   * Identifies the custom event that gets logged when a user undoes a query set in the effective query pipeline on the search page.
-   */
-  undoTriggerQuery = 'undoQuery',
-  /**
    * Identifies the custom event that gets logged when a user action redirects them to a URL set in the effective query pipeline on the search page.
    */
   triggerRedirect = 'redirect',
@@ -232,10 +228,6 @@ export enum SearchPageEvents {
    * Identifies the custom event that gets logged when a recently clicked results list gets cleared.
    */
   clearRecentResults = 'clearRecentResults',
-  /**
-   * Identifies the search event that gets logged when a user clicks the Cancel last action link when no results are returned following their last action.
-   */
-  noResultsBack = 'noResultsBack',
   /**
    * Identifies the click event that gets logged when a user clicks the Show More link under a search result that support the folding component.
    */

--- a/packages/headless/src/features/history/history-analytics-actions.ts
+++ b/packages/headless/src/features/history/history-analytics-actions.ts
@@ -36,7 +36,3 @@ export const historyForward = (): SearchAction => ({
 export const historyBackward = (): SearchAction => ({
   actionCause: SearchPageEvents.historyBackward,
 });
-
-export const noResultsBack = (): SearchAction => ({
-  actionCause: SearchPageEvents.noResultsBack,
-});

--- a/packages/headless/src/features/search/search-actions.ts
+++ b/packages/headless/src/features/search/search-actions.ts
@@ -50,6 +50,10 @@ export interface SearchAction {
   actionCause: string;
 }
 
+export const nullActionCause = (): SearchAction => ({
+  actionCause: null as unknown as string,
+});
+
 export type {StateNeededByExecuteSearch} from './search-actions-thunk-processor.js';
 
 export interface ExecuteSearchThunkReturn {

--- a/packages/headless/src/features/triggers/trigger-analytics-actions.ts
+++ b/packages/headless/src/features/triggers/trigger-analytics-actions.ts
@@ -7,8 +7,6 @@ import {
   makeAnalyticsAction,
   LegacySearchAction,
 } from '../analytics/analytics-utils.js';
-import {SearchPageEvents} from '../analytics/search-action-cause.js';
-import {SearchAction} from '../search/search-actions.js';
 
 export interface LogUndoTriggerQueryActionCreatorPayload {
   /**
@@ -72,6 +70,3 @@ export const logTriggerExecute = (): LegacySearchAction =>
   });
 
 // --------------------- KIT-2859 : Everything above this will get deleted ! :) ---------------------
-export const undoTriggerQuery = (): SearchAction => ({
-  actionCause: SearchPageEvents.undoTriggerQuery,
-});


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3742

These and many more events in headless executeSearch calls are invalid and should be removed. This is only the first two. The rest will come from [this spike](https://coveord.atlassian.net/browse/CDX-1600) . (more context in the spike)