### PR TITLE
feat(ci): python 3.8 eol

### DIFF
--- a/.github/actions/create-deployment-package/action.yml
+++ b/.github/actions/create-deployment-package/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
       with:
-        python-version: '3.8'
+        python-version: '3.12'
     - name: Install deployment package
       shell: bash
       run: pip install --index-url https://pypi.dev.cloud.coveo.com/simple 'deployment-package==7.*'


### PR DESCRIPTION
Python 3.8 (end-of-life)

This PR is offered as a courtesy; a best effort had been done using simple text search in the most commonly affected areas. It's not possible for us to analyze all python setups thoroughly. Don't hesitate to contact me (preferably through DM if you want a quicker reply!) for any questions, requests, next steps or if you need to postpone this.

Overall, we searched for:
- terraform runtimes
- pyproject.toml
- dockerfiles
- github actions

Your team may be forced to setup a newer local Python version in order to continue working with this repository.

For those of you who would like to align with the main OS, please note that the current LTS Ubuntu 22.04 offers 3.10 and 3.11 while the subsequent version (24.10) offers 3.12 and 3.13.

Additionally, if your project _requires_ running on older python versions, we recommend adding some sort of comment that explains why, and maybe explain when/how the EOL python will be phased out. 

https://coveord.atlassian.net/browse/DT-7320

**Please merge this pull request when approving it! Thank you!**
