### PR TITLE
fix(headless): potential issue with props in insight did you mean controller

### DIFF
--- a/packages/headless/src/controllers/insight/did-you-mean/headless-insight-did-you-mean.test.ts
+++ b/packages/headless/src/controllers/insight/did-you-mean/headless-insight-did-you-mean.test.ts
@@ -8,17 +8,26 @@ import {
   MockedInsightEngine,
 } from '../../../test/mock-engine-v2.js';
 import {buildMockInsightState} from '../../../test/mock-insight-state.js';
-import {buildDidYouMean, DidYouMean} from './headless-insight-did-you-mean.js';
+import {
+  buildDidYouMean,
+  DidYouMean,
+  DidYouMeanOptions,
+} from './headless-insight-did-you-mean.js';
 
 vi.mock('../../../features/insight-search/insight-search-actions');
 vi.mock('../../../features/did-you-mean/did-you-mean-actions');
+
+const defaultDidYouMeanOptions: DidYouMeanOptions = {
+  automaticallyCorrectQuery: true,
+  queryCorrectionMode: 'legacy',
+};
 
 describe('did you mean', () => {
   let dym: DidYouMean;
   let engine: MockedInsightEngine;
 
   function initDidYouMean() {
-    dym = buildDidYouMean(engine);
+    dym = buildDidYouMean(engine, {options: defaultDidYouMeanOptions});
   }
 
   beforeEach(() => {

--- a/packages/headless/src/controllers/insight/did-you-mean/headless-insight-did-you-mean.ts
+++ b/packages/headless/src/controllers/insight/did-you-mean/headless-insight-did-you-mean.ts
@@ -23,6 +23,11 @@ export type {
   DidYouMeanOptions,
 };
 
+const defaultDidYouMeanOptions: DidYouMeanOptions = {
+  automaticallyCorrectQuery: true,
+  queryCorrectionMode: 'legacy',
+};
+
 /**
  * The insight DidYouMean controller is responsible for handling query corrections.
  * When a query returns no result but finds a possible query correction, the controller either suggests the correction or
@@ -36,13 +41,14 @@ export type {
  */
 export function buildDidYouMean(
   engine: InsightEngine,
-  props: DidYouMeanProps = {
-    options: {
-      queryCorrectionMode: 'legacy',
-    },
-  }
+  props: DidYouMeanProps
 ): DidYouMean {
-  const controller = buildCoreDidYouMean(engine, props);
+  const options = {
+    ...defaultDidYouMeanOptions,
+    ...props.options,
+  };
+
+  const controller = buildCoreDidYouMean(engine, {options});
   const {dispatch} = engine;
 
   return {


### PR DESCRIPTION
[SFINT-5829](https://coveord.atlassian.net/browse/SFINT-5829)

## Issue:

With the current iteration, if we pass engine like : `buildDidYouMean(engine, {automaticallyCorrectQuery: false})`  we will not have the `queryCorrectionMode` set to `legacy` but rather to `next` since the 2nd param is not null it will not take the default value.

## Solution:

Creating a defaultOptions object and spread it into an options object along with the props before passing it to the controller build method.



[SFINT-5829]: https://coveord.atlassian.net/browse/SFINT-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ