### PR TITLE
fix(headless): make props optional for instant products definition

### DIFF
--- a/packages/headless/src/controllers/commerce/instant-products/headless-instant-products.ssr.ts
+++ b/packages/headless/src/controllers/commerce/instant-products/headless-instant-products.ssr.ts
@@ -23,7 +23,7 @@ export interface InstantProductsDefinition
  * @internal
  */
 export function defineInstantProducts(
-  props: InstantProductsProps
+  props: InstantProductsProps = {options: {}}
 ): InstantProductsDefinition {
   return {
     listing: true,

--- a/packages/samples/headless-ssr-commerce/lib/commerce-engine-config.ts
+++ b/packages/samples/headless-ssr-commerce/lib/commerce-engine-config.ts
@@ -56,7 +56,7 @@ export default {
     standaloneSearchBox: defineStandaloneSearchBox({
       options: {redirectionUrl: '/search'},
     }),
-    instantProducts: defineInstantProducts({options: {}}),
+    instantProducts: defineInstantProducts(),
     pagination: definePagination({options: {pageSize: 9}}),
     sort: defineSort(),
     productView: defineProductView(),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3753

All the other definitions are like this : https://github.com/coveo/ui-kit/blob/master/packages/headless/src/controllers/commerce/search-box/headless-search-box.ssr.ts