### PR TITLE
fix(headless): add globalThis shim to quanticUmd build to fix a bug with Locker Service

### DIFF
--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -177,6 +177,7 @@ const quanticUmd = Object.entries(quanticUseCaseEntries).map((entry) => {
       },
       external: ['crypto'],
       inject: [
+        'ponyfills/global-this-shim.js',
         'ponyfills/abortable-fetch-shim.js',
         '../../node_modules/navigator.sendbeacon/dist/navigator.sendbeacon.cjs.js',
       ],

--- a/packages/headless/ponyfills/global-this-shim.js
+++ b/packages/headless/ponyfills/global-this-shim.js
@@ -1,4 +1,4 @@
 // Shim globalThis because Salesforce Locker Service doesn't support it.
-const globalThisShim = window;
+const globalThisShim = typeof globalThis !== 'undefined' ? globalThis : window;
 
 export {globalThisShim as globalThis};

--- a/packages/headless/ponyfills/global-this-shim.js
+++ b/packages/headless/ponyfills/global-this-shim.js
@@ -1,0 +1,4 @@
+// Shim globalThis because Salesforce Locker Service doesn't support it.
+const globalThisShim = window;
+
+export {globalThisShim as globalThis};

--- a/packages/quantic/config/project-scratch-def.json
+++ b/packages/quantic/config/project-scratch-def.json
@@ -12,11 +12,6 @@
     "languageSettings": {
       "enableTranslationWorkbench": true,
       "enableEndUserLanguages": true
-    },
-    "securitySettings": {
-      "sessionSettings": {
-        "lockerServiceNext": false
-      }
     }
   }
 }

--- a/packages/quantic/config/project-scratch-def.json
+++ b/packages/quantic/config/project-scratch-def.json
@@ -12,6 +12,11 @@
     "languageSettings": {
       "enableTranslationWorkbench": true,
       "enableEndUserLanguages": true
+    },
+    "securitySettings": {
+      "sessionSettings": {
+        "lockerServiceNext": false
+      }
     }
   }
 }


### PR DESCRIPTION
Locker Service doesn't support `globalThis` but this was added to the library coveo.analytics.js in the last version.

This meant all of Quantic components didn't load with Locker turned on.

This also made us realize that all of our Quantic test are only running with LWS and not Locker, while the SFINT package tests are running on Locker.

At least this way we cover both environments. Out of scope for this PR, but in the future we will probably revert to testing on Locker with Quantic too, and perhaps had smoke tests with LWS.

LWS being the "more recent" of the two, we expect less issues with LWS than with Locker.

![image](https://github.com/user-attachments/assets/5e6c9eeb-919a-4f79-a2d0-ed7ad62c9e7b)
