### PR TITLE
chore: enable back renovate, w/ dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
-  "enabled": false,
+  "enabled": true,
   "extends": [
     "github>coveo/renovate-presets",
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies"],
+  "dependencyDashboard": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-282
Let's try to enable it back to not let it pile up too much.
Let's try to use dependency dashboard to help us manage the dependency updates ;) 