### PR TITLE
docs(headless): navigator context annotations

### DIFF
--- a/packages/headless/src/app/navigatorContextProvider.ts
+++ b/packages/headless/src/app/navigatorContextProvider.ts
@@ -1,7 +1,21 @@
 export interface NavigatorContext {
+  /**
+   * The URL of the page that referred the user to the current page.
+   * See [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer)
+   */
   referrer: string | null;
+  /**
+   * The user agent string of the browser that made the request.
+   * See [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)
+   */
   userAgent: string | null;
+  /**
+   * The URL of the current page.
+   */
   location: string | null;
+  /** The unique identifier of the browser client in a Coveo-powered page.
+   * See [clientId](https://docs.coveo.com/en/masb0234).
+   */
   clientId: string;
 }
 

--- a/packages/headless/src/app/navigatorContextProvider.ts
+++ b/packages/headless/src/app/navigatorContextProvider.ts
@@ -1,3 +1,6 @@
+/**
+ * The `NavigatorContext` interface represents the context of the browser client.
+ */
 export interface NavigatorContext {
   /**
    * The URL of the page that referred the user to the current page.


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3758

While drafting Commerce SSR docs, I noticed that we had no annotations for NavigatorContext, which I thought would be useful.