### PR TITLE
ci: skip e2e headless-ssr sample in merge queue

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -571,10 +571,6 @@ jobs:
       - 'e2e-atomic-vuejs-test'
       - 'e2e-atomic-stencil-test'
       - 'e2e-atomic-insight-panel-test'
-      - 'e2e-headless-ssr-test-app-dev'
-      - 'e2e-headless-ssr-test-app-prod'
-      - 'e2e-headless-ssr-test-pages-dev'
-      - 'e2e-headless-ssr-test-pages-prod'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
These are flaky and should not make the merge queue fail. It is annoying.