### PR TITLE
feat(ssr): reorder headless react exports

### DIFF
--- a/packages/headless-react/src/ssr-commerce/index.ts
+++ b/packages/headless-react/src/ssr-commerce/index.ts
@@ -1,4 +1,4 @@
-export {defineCommerceEngine} from './commerce-engine.js';
+export * from '@coveo/headless/ssr-commerce';
 export type {ReactCommerceEngineDefinition} from './commerce-engine.js';
 export {MissingEngineProviderError} from '../errors.js';
-export * from '@coveo/headless/ssr-commerce';
+export {defineCommerceEngine} from './commerce-engine.js';


### PR DESCRIPTION
This PR reorders the ssr-commerce exports in headless-react to ensure that defineCommerceEngine is loaded from coveo/headless instead of coveo/headless-react

https://coveord.atlassian.net/browse/KIT-3737