### PR TITLE
fix(quantic): ignored e2e tests folder when building npm quantic package

### DIFF
--- a/packages/quantic/.npmignore
+++ b/packages/quantic/.npmignore
@@ -1,1 +1,3 @@
 scripts
+**/e2e/**
+**/__tests__/**


### PR DESCRIPTION
## [SFINT-5841](https://coveord.atlassian.net/browse/SFINT-5841)

ignored e2e folder in the `.npmignore` file to avoid having the e2e folders used for new playwright e2e tests included in the Quantic npm package.

[SFINT-5841]: https://coveord.atlassian.net/browse/SFINT-5841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ