### PR TITLE
chore(ci): add headless versions to deployment config for CDN smoke tests

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -251,6 +251,9 @@
           "atomic-major": "$[ATOMIC_MAJOR_VERSION]",
           "atomic-minor": "$[ATOMIC_MINOR_VERSION]",
           "atomic-patch": "$[ATOMIC_PATCH_VERSION]",
+          "headless-major": "$[HEADLESS_MAJOR_VERSION]",
+          "headless-minor": "$[HEADLESS_MINOR_VERSION]",
+          "headless-patch": "$[HEADLESS_PATCH_VERSION]",
           "is-nightly": "$[IS_NIGHTLY]"
         }
       }


### PR DESCRIPTION
This PR ensures that the CDN smoke tests have access to the headless version numbers.
https://coveord.atlassian.net/browse/KIT-3765