### PR TITLE
fix(headless): capi 1587 facets are duplicated in capi request payload when using manual numeric facets

### DIFF
--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
@@ -121,6 +121,7 @@ export function buildCommerceNumericFacet(
   return {
     ...coreController,
 
+    // Only one range stored, so last will override the previous ones
     setRanges(ranges: NumericRangeRequest[]) {
       ranges.forEach((range) => {
         dispatch(updateManualNumericFacetRange({facetId, ...range}));

--- a/packages/headless/src/features/commerce/common/actions.test.ts
+++ b/packages/headless/src/features/commerce/common/actions.test.ts
@@ -314,7 +314,7 @@ describe('commerce common actions', () => {
         facet1 = buildMockCommerceFacetSlice({
           request: {
             ...buildMockCommerceFacetRequest({
-              facetId: 'facet_1_id',
+              facetId: 'facet_id_1',
               values: [buildMockCommerceRegularFacetValue()],
             }),
           },

--- a/packages/headless/src/features/commerce/common/actions.ts
+++ b/packages/headless/src/features/commerce/common/actions.ts
@@ -19,7 +19,6 @@ import {
   VersionSection,
 } from '../../../state/state-sections.js';
 import {getProductsFromCartState} from '../context/cart/cart-state.js';
-import {AnyFacetRequest} from '../facets/facet-set/interfaces/request.js';
 import {SortBy, SortCriterion} from '../sort/sort.js';
 
 export type StateNeededByQueryCommerceAPI = CommerceConfigurationSection &
@@ -47,7 +46,7 @@ export const buildCommerceAPIRequest = (
 ): CommerceAPIRequest => {
   return {
     ...buildBaseCommerceAPIRequest(state, navigatorContext),
-    facets: [...getFacets(state), ...getManualNumericFacets(state)],
+    facets: [...getFacets(state)],
     ...(state.commerceSort && {
       sort: getSort(state.commerceSort.appliedSort),
     }),
@@ -119,31 +118,21 @@ function getFacets(state: ListingAndSearchStateNeededByQueryCommerceAPI) {
 
   return state.facetOrder
     .filter((facetId) => state.commerceFacetSet?.[facetId])
-    .map((facetId) => state.commerceFacetSet![facetId].request)
+    .map((facetId) => {
+      return state.manualNumericFacetSet?.[facetId]?.manualRange
+        ? {
+            facetId,
+            field: facetId,
+            numberOfValues: 1,
+            isFieldExpanded: false,
+            preventAutoSelect: true,
+            type: 'numericalRange' as const,
+            values: [state.manualNumericFacetSet[facetId].manualRange!],
+            initialNumberOfValues: 1,
+          }
+        : state.commerceFacetSet![facetId].request;
+    })
     .filter((facet) => facet && facet.values.length > 0);
-}
-
-function getManualNumericFacets(
-  state: ListingAndSearchStateNeededByQueryCommerceAPI
-): AnyFacetRequest[] {
-  if (!state.manualNumericFacetSet) {
-    return [];
-  }
-
-  return Object.entries(state.manualNumericFacetSet!)
-    .filter(
-      ([_, manualNumericFacet]) => manualNumericFacet.manualRange !== undefined
-    )
-    .map(([facetId, manualNumericFacet]) => ({
-      facetId,
-      field: facetId,
-      numberOfValues: 1,
-      isFieldExpanded: false,
-      preventAutoSelect: true,
-      type: 'numericalRange' as const,
-      values: [manualNumericFacet.manualRange!],
-      initialNumberOfValues: 1,
-    }));
 }
 
 function getSort(appliedSort: SortCriterion): SortParam['sort'] | undefined {

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-reducers.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-reducers.ts
@@ -30,7 +30,7 @@ export function restoreFromParameters(
     restoreRangeFacets(state, action.payload.nf, 'numericalRange');
   }
   if (action.payload.mnf) {
-    restoreRangeFacets(state, action.payload.mnf, 'numericalRange');
+    restoreManualRangeFacets(state, action.payload.mnf);
   }
   if (action.payload.df) {
     restoreRangeFacets(state, action.payload.df, 'dateRange');
@@ -93,6 +93,31 @@ function restoreRangeFacets<T extends NumericFacetRequest | DateFacetRequest>(
               return rangeValue as NumericRangeRequest;
           }
         }),
+      },
+    };
+  }
+}
+
+function restoreManualRangeFacets<T extends NumericFacetRequest>(
+  state: CommerceFacetSetState,
+  parameterFacets: Record<string, T['values']>
+) {
+  const entries = Object.entries(parameterFacets);
+  for (const [facetId, values] of entries) {
+    state[facetId] = {
+      request: {
+        ...restoreFacet(facetId),
+        type: 'numericalRange',
+        interval: 'continuous',
+        values: values.map(
+          (value) =>
+            ({
+              start: value.start,
+              end: value.end,
+              endInclusive: value.endInclusive,
+              ...restoreFacetValue(),
+            }) as NumericRangeRequest
+        ),
       },
     };
   }

--- a/packages/headless/src/features/commerce/parameters/parameters-selectors.ts
+++ b/packages/headless/src/features/commerce/parameters/parameters-selectors.ts
@@ -161,7 +161,10 @@ function getManualNumericFacet(section?: ManualNumericFacetSetState) {
 
   const manualNumericFacets = Object.entries(section)
     .map(([facetId, manualFacetRange]) => {
-      if (manualFacetRange.manualRange === undefined) {
+      if (
+        manualFacetRange.manualRange === undefined ||
+        manualFacetRange.manualRange.state === 'idle'
+      ) {
         return;
       }
       return {[facetId]: [manualFacetRange.manualRange]};
@@ -184,6 +187,12 @@ function facetIsOfType(
   type: FacetType
 ) {
   return (facetId: string) => {
+    if (
+      type === 'numericalRange' &&
+      state.commerceFacetSet![facetId].request.interval === 'continuous'
+    ) {
+      return false;
+    }
     return state.commerceFacetSet![facetId].request.type === type;
   };
 }


### PR DESCRIPTION
[CAPI-1587](https://coveord.atlassian.net/browse/CAPI-1587)

Fix for a couple of issues in headless, as found in Barca with numerical range facets (manual range facets in Headless)
- Remove duplicate facet's from the CAPI request
- Remove duplicate facet state from URL fragment
- Remove deselected numerical facet values from URL fragment

Curious I found a bug in the `actions.test.ts` file that meant the test should have been failing due to the duplicate facet in CAPI request bug but it passed. Fixing the bug now passes with the fixed code.

Current:
https://github.com/user-attachments/assets/9a075b2e-7dcb-4d65-b813-7f8ea8dc6129

Fix:
https://github.com/user-attachments/assets/0d78b0b2-dab0-400d-9483-23de0391912c




[CAPI-1587]: https://coveord.atlassian.net/browse/CAPI-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ