### PR TITLE
docs(headless): release headless typedoc site as an artifact

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -113,6 +113,24 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: ./.github/actions/setup
       - run: npm run package-compatibility
+  typedoc:
+    name: 'Build typedoc'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: ./.github/actions/setup
+      - name: 'Build headless typedoc'
+        run: npm run build:typedoc
+        working-directory: packages/headless
+      # - name: 'Build headless-react typedoc'
+      #   run: npm run build:typedoc
+      #   working-directory: packages/headless-react
   e2e-atomic-csp-test:
     name: 'Run e2e tests on Atomic CSP'
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,45 @@ jobs:
           SFDX_AUTH_JWT_KEY_FILE: ${{ vars.SFDX_AUTH_JWT_KEY_FILE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ./packages/quantic
+  typedoc-headless:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          ref: 'release/v3'
+      - uses: ./.github/actions/setup
+      - name: Build typedoc site
+        run: npm run build:typedoc
+        working-directory: packages/headless
+        shell: bash
+      - name: Read version from package.json
+        id: read_version
+        run: |
+          VERSION=$(jq -r '.version' package/headless/package.json)
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_ENV
+      - name: Zip documentation folder
+        run: |
+          DOCS_DIR="package/headless/docs"
+          if [ ! -d "$DOCS_DIR" ]; then
+            echo "Documentation folder $DOCS_DIR not found."
+            exit 1
+          fi
+
+          ZIP_NAME="headless-docs-${{ env.version }}.zip"
+          zip -r "$ZIP_NAME" "$DOCS_DIR"
+          echo "Created zip file: $ZIP_NAME"
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: headless-docs-${{ env.version }}
+          path: headless-docs-${{ env.version }}.zip
 
   # TODO KIT-3074 Fix the publication into the GitHub Packages, and uncomment
   # github-prod:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3423

See the github action to download it in the doc repo - > https://github.com/coveo/doc_jekyll-public-site/pull/12275

tested here as a similar repo to ui-kit (public repo): https://github.com/shutter-org/artifact-giver

tested here as a similar repo to docs jekyll getting the artifact from a public repo: https://github.com/shutter-org/artifact-receiver