### PR TITLE
chore(headless): add sourcemaps for nodejs esm build

### DIFF
--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -295,6 +295,7 @@ const nodeEsm = Object.entries(useCaseEntries).map((entry) => {
     {
       entryPoints: [entryPoint],
       outfile,
+      sourcemap: true,
       format: 'esm',
       external: ['pino'],
       mainFields: ['module', 'main'],


### PR DESCRIPTION
This PR ensures that the nodejs build for headless generates sourcemaps.

https://coveord.atlassian.net/browse/KIT-3771