### PR TITLE
fix(atomic): fix error when hovering recent result containing double quotes

### DIFF
--- a/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
@@ -392,7 +392,7 @@ export class SuggestionManager<SearchBoxController> {
     if (query) {
       const escaped = DOMPurify.sanitize(query);
       return !!panel?.querySelector(
-        `[${this.queryDataAttribute}="${escaped}"]`
+        `[${this.queryDataAttribute}="${CSS.escape(escaped)}"]`
       );
     }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3781

See the ticket