### PR TITLE
fix(atomic): fix accessibility issues with pager/results per page buttons

### DIFF
--- a/packages/atomic/src/components/common/items-per-page/choices.tsx
+++ b/packages/atomic/src/components/common/items-per-page/choices.tsx
@@ -32,6 +32,58 @@ export const Choices: FunctionalComponent<ChoicesProps> = ({
     }
   };
 
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const {key} = event;
+    const radioGroup = (event.currentTarget as HTMLElement).parentNode;
+
+    if (!radioGroup || !isArrowKey(key)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const buttons = getRadioButtons(radioGroup);
+    const currentIndex = getCurrentIndex(
+      buttons,
+      event.currentTarget as HTMLInputElement
+    );
+    const newIndex = getNewIndex(key, currentIndex, buttons.length);
+
+    if (buttons[newIndex]) {
+      buttons[newIndex].focus();
+    }
+  };
+
+  const isArrowKey = (key: string) => {
+    return ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(key);
+  };
+
+  const getRadioButtons = (radioGroup: ParentNode) => {
+    return Array.from(
+      radioGroup.querySelectorAll('[type="radio"]')
+    ) as HTMLInputElement[];
+  };
+
+  const getCurrentIndex = (
+    buttons: HTMLInputElement[],
+    currentButton: HTMLInputElement
+  ) => {
+    return buttons.findIndex((button) => button === currentButton);
+  };
+
+  const getNewIndex = (key: string, currentIndex: number, length: number) => {
+    switch (key) {
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        return (currentIndex - 1 + length) % length;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        return (currentIndex + 1) % length;
+      default:
+        return currentIndex;
+    }
+  };
+
   return (
     <div
       part="buttons"
@@ -60,6 +112,7 @@ export const Choices: FunctionalComponent<ChoicesProps> = ({
             class="btn-page focus-visible:bg-neutral-light"
             part={parts.join(' ')}
             text={text}
+            onKeyDown={handleKeyDown} // Add the onKeyDown event handler
           ></RadioButton>
         );
       })}

--- a/packages/atomic/src/components/common/items-per-page/choices.tsx
+++ b/packages/atomic/src/components/common/items-per-page/choices.tsx
@@ -32,58 +32,6 @@ export const Choices: FunctionalComponent<ChoicesProps> = ({
     }
   };
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    const {key} = event;
-    const radioGroup = (event.currentTarget as HTMLElement).parentNode;
-
-    if (!radioGroup || !isArrowKey(key)) {
-      return;
-    }
-
-    event.preventDefault();
-
-    const buttons = getRadioButtons(radioGroup);
-    const currentIndex = getCurrentIndex(
-      buttons,
-      event.currentTarget as HTMLInputElement
-    );
-    const newIndex = getNewIndex(key, currentIndex, buttons.length);
-
-    if (buttons[newIndex]) {
-      buttons[newIndex].focus();
-    }
-  };
-
-  const isArrowKey = (key: string) => {
-    return ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(key);
-  };
-
-  const getRadioButtons = (radioGroup: ParentNode) => {
-    return Array.from(
-      radioGroup.querySelectorAll('[type="radio"]')
-    ) as HTMLInputElement[];
-  };
-
-  const getCurrentIndex = (
-    buttons: HTMLInputElement[],
-    currentButton: HTMLInputElement
-  ) => {
-    return buttons.findIndex((button) => button === currentButton);
-  };
-
-  const getNewIndex = (key: string, currentIndex: number, length: number) => {
-    switch (key) {
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        return (currentIndex - 1 + length) % length;
-      case 'ArrowRight':
-      case 'ArrowDown':
-        return (currentIndex + 1) % length;
-      default:
-        return currentIndex;
-    }
-  };
-
   return (
     <div
       part="buttons"
@@ -112,7 +60,7 @@ export const Choices: FunctionalComponent<ChoicesProps> = ({
             class="btn-page focus-visible:bg-neutral-light"
             part={parts.join(' ')}
             text={text}
-            onKeyDown={handleKeyDown} // Add the onKeyDown event handler
+            selectWhenFocused={false}
           ></RadioButton>
         );
       })}

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -66,9 +66,62 @@ export const PagerNextButton: FunctionalComponent<
 export const PagerPageButton: FunctionalComponent<PagerPageButtonProps> = (
   props
 ) => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const {key} = event;
+    const radioGroup = (event.currentTarget as HTMLElement).parentNode;
+
+    if (!radioGroup || !isArrowKey(key)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const buttons = getRadioButtons(radioGroup);
+    const currentIndex = getCurrentIndex(
+      buttons,
+      event.currentTarget as HTMLInputElement
+    );
+    const newIndex = getNewIndex(key, currentIndex, buttons.length);
+
+    if (buttons[newIndex]) {
+      buttons[newIndex].focus();
+    }
+  };
+
+  const isArrowKey = (key: string) => {
+    return ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(key);
+  };
+
+  const getRadioButtons = (radioGroup: ParentNode) => {
+    return Array.from(
+      radioGroup.querySelectorAll('[type="radio"]')
+    ) as HTMLInputElement[];
+  };
+
+  const getCurrentIndex = (
+    buttons: HTMLInputElement[],
+    currentButton: HTMLInputElement
+  ) => {
+    return buttons.findIndex((button) => button === currentButton);
+  };
+
+  const getNewIndex = (key: string, currentIndex: number, length: number) => {
+    switch (key) {
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        return (currentIndex - 1 + length) % length;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        return (currentIndex + 1) % length;
+      default:
+        return currentIndex;
+    }
+  };
+
   return (
     <RadioButton
       {...props}
+      onKeyDown={handleKeyDown}
       key={props.page}
       style="outline-neutral"
       checked={props.isSelected}

--- a/packages/atomic/src/components/common/pager/pager-buttons.tsx
+++ b/packages/atomic/src/components/common/pager/pager-buttons.tsx
@@ -66,62 +66,10 @@ export const PagerNextButton: FunctionalComponent<
 export const PagerPageButton: FunctionalComponent<PagerPageButtonProps> = (
   props
 ) => {
-  const handleKeyDown = (event: KeyboardEvent) => {
-    const {key} = event;
-    const radioGroup = (event.currentTarget as HTMLElement).parentNode;
-
-    if (!radioGroup || !isArrowKey(key)) {
-      return;
-    }
-
-    event.preventDefault();
-
-    const buttons = getRadioButtons(radioGroup);
-    const currentIndex = getCurrentIndex(
-      buttons,
-      event.currentTarget as HTMLInputElement
-    );
-    const newIndex = getNewIndex(key, currentIndex, buttons.length);
-
-    if (buttons[newIndex]) {
-      buttons[newIndex].focus();
-    }
-  };
-
-  const isArrowKey = (key: string) => {
-    return ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(key);
-  };
-
-  const getRadioButtons = (radioGroup: ParentNode) => {
-    return Array.from(
-      radioGroup.querySelectorAll('[type="radio"]')
-    ) as HTMLInputElement[];
-  };
-
-  const getCurrentIndex = (
-    buttons: HTMLInputElement[],
-    currentButton: HTMLInputElement
-  ) => {
-    return buttons.findIndex((button) => button === currentButton);
-  };
-
-  const getNewIndex = (key: string, currentIndex: number, length: number) => {
-    switch (key) {
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        return (currentIndex - 1 + length) % length;
-      case 'ArrowRight':
-      case 'ArrowDown':
-        return (currentIndex + 1) % length;
-      default:
-        return currentIndex;
-    }
-  };
-
   return (
     <RadioButton
       {...props}
-      onKeyDown={handleKeyDown}
+      selectWhenFocused={false}
       key={props.page}
       style="outline-neutral"
       checked={props.isSelected}

--- a/packages/atomic/src/components/common/pager/pager-navigation.tsx
+++ b/packages/atomic/src/components/common/pager/pager-navigation.tsx
@@ -10,8 +10,8 @@ export const PagerNavigation: FunctionalComponent<PagerNavigationProps> = (
   children
 ) => {
   return (
-    <nav role="toolbar" aria-label={props.i18n.t('pagination')}>
-      <div part="buttons" class="flex flex-wrap gap-2">
+    <nav aria-label={props.i18n.t('pagination')}>
+      <div part="buttons" role="toolbar" class="flex flex-wrap gap-2">
         {...children}
       </div>
     </nav>

--- a/packages/atomic/src/components/common/pager/pager-navigation.tsx
+++ b/packages/atomic/src/components/common/pager/pager-navigation.tsx
@@ -10,7 +10,7 @@ export const PagerNavigation: FunctionalComponent<PagerNavigationProps> = (
   children
 ) => {
   return (
-    <nav aria-label={props.i18n.t('pagination')}>
+    <nav role="toolbar" aria-label={props.i18n.t('pagination')}>
       <div part="buttons" class="flex flex-wrap gap-2">
         {...children}
       </div>

--- a/packages/atomic/src/components/common/radio-button.tsx
+++ b/packages/atomic/src/components/common/radio-button.tsx
@@ -9,7 +9,7 @@ import {
 
 export interface RadioButtonProps {
   groupName: string;
-  onKeyDown?(event: KeyboardEvent): void;
+  selectWhenFocused?: boolean;
   onChecked?(): void;
   style?: ButtonStyle;
   key?: string | number;
@@ -40,6 +40,61 @@ export const RadioButton: FunctionalComponent<RadioButtonProps> = (props) => {
     classNames.push(props.class);
   }
 
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (props.selectWhenFocused !== false) {
+      return;
+    }
+    const {key} = event;
+    const radioGroup = (event.currentTarget as HTMLElement).parentNode;
+
+    if (!radioGroup || !isArrowKey(key)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const buttons = getRadioButtons(radioGroup);
+    const currentIndex = getCurrentIndex(
+      buttons,
+      event.currentTarget as HTMLInputElement
+    );
+    const newIndex = getNewIndex(key, currentIndex, buttons.length);
+
+    if (buttons[newIndex]) {
+      buttons[newIndex].focus();
+    }
+  };
+
+  const isArrowKey = (key: string) => {
+    return ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp'].includes(key);
+  };
+
+  const getRadioButtons = (radioGroup: ParentNode) => {
+    return Array.from(
+      radioGroup.querySelectorAll('[type="radio"]')
+    ) as HTMLInputElement[];
+  };
+
+  const getCurrentIndex = (
+    buttons: HTMLInputElement[],
+    currentButton: HTMLInputElement
+  ) => {
+    return buttons.findIndex((button) => button === currentButton);
+  };
+
+  const getNewIndex = (key: string, currentIndex: number, length: number) => {
+    switch (key) {
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        return (currentIndex - 1 + length) % length;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        return (currentIndex + 1) % length;
+      default:
+        return currentIndex;
+    }
+  };
+
   const attributes = {
     name: props.groupName,
     key: props.key,
@@ -54,7 +109,7 @@ export const RadioButton: FunctionalComponent<RadioButtonProps> = (props) => {
 
   return (
     <input
-      onKeyDown={props.onKeyDown}
+      onKeyDown={handleKeyDown}
       type="radio"
       onChange={(e) =>
         (e.currentTarget as HTMLInputElement).checked && props.onChecked?.()

--- a/packages/atomic/src/components/common/radio-button.tsx
+++ b/packages/atomic/src/components/common/radio-button.tsx
@@ -9,6 +9,7 @@ import {
 
 export interface RadioButtonProps {
   groupName: string;
+  onKeyDown?(event: KeyboardEvent): void;
   onChecked?(): void;
   style?: ButtonStyle;
   key?: string | number;
@@ -53,6 +54,7 @@ export const RadioButton: FunctionalComponent<RadioButtonProps> = (props) => {
 
   return (
     <input
+      onKeyDown={props.onKeyDown}
       type="radio"
       onChange={(e) =>
         (e.currentTarget as HTMLInputElement).checked && props.onChecked?.()

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.tsx
@@ -102,7 +102,7 @@ export class AtomicResultsPerPage implements InitializableComponent {
         hasItems={this.searchStatusState.hasResults}
         isAppLoaded={this.bindings.store.isAppLoaded()}
       >
-        <div class="flex items-center">
+        <div class="flex items-center" role="toolbar" aria-label={this.label}>
           <Label>{this.label}</Label>
           <FieldsetGroup label={this.label}>
             <Choices


### PR DESCRIPTION
This PR fixes the accessibility issues with the pager/results per page buttons. More specifically, it was not possible to navigating between pager or results per page buttons without selecting one, triggering a refresh of the results. 

The solution is to have the buttons inside a toolbar and implement the logic described here:
https://www.w3.org/WAI/ARIA/apg/patterns/radio/#:~:text=For%20Radio%20Group%20Contained%20in%20a%20Toolbar

https://coveord.atlassian.net/browse/KIT-3767