### PR TITLE
fix(headless): update the rga events to send the searchId instead of the streamId as response id

### DIFF
--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-analytics-actions.test.ts.snap
@@ -5,7 +5,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "copyToClipboard",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -15,7 +15,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "dislike",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -25,7 +25,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "collapse",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -35,7 +35,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "expand",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -53,7 +53,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
       "readable": true,
     },
     "helpful": true,
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -63,7 +63,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "hide",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -73,7 +73,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "show",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -90,7 +90,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
       "uniqueFieldValue": "citation-permanent-id",
       "url": "http://localhost/citations/some-citation-id",
     },
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -100,7 +100,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
   "Rga.AnswerAction",
   {
     "action": "like",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -116,7 +116,7 @@ exports[`generated answer analytics actions > when analyticsMode is \`next\` > s
       "uniqueFieldValue": "citation-permanent-id",
       "url": "http://localhost/citations/some-citation-id",
     },
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;

--- a/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
+++ b/packages/headless/src/features/generated-answer/__snapshots__/generated-answer-insight-analytics-actions.test.ts.snap
@@ -5,7 +5,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "copyToClipboard",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -15,7 +15,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "dislike",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -25,7 +25,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "collapse",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -35,7 +35,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "expand",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -53,7 +53,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
       "readable": true,
     },
     "helpful": true,
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -63,7 +63,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "hide",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -73,7 +73,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "show",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -90,7 +90,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
       "uniqueFieldValue": "citation_permanentid",
       "url": "example: click uri",
     },
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -100,7 +100,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
   "Rga.AnswerAction",
   {
     "action": "like",
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;
@@ -116,7 +116,7 @@ exports[`generated answer insight analytics actions > when analyticsMode is \`ne
       "uniqueFieldValue": "citation_permanentid",
       "url": "example: click uri",
     },
-    "responseId": "123",
+    "responseId": "456",
   },
 ]
 `;

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -70,19 +70,16 @@ export const logOpenGeneratedAnswerSource = (
     analyticsType: 'Rga.CitationClick',
     analyticsPayloadBuilder: (state): Rga.CitationClick | undefined => {
       const citation = citationSourceSelector(state, citationId);
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID ?? '',
-          citationId,
-          itemMetadata: {
-            uniqueFieldName: 'permanentid',
-            uniqueFieldValue: citation?.permanentid ?? '',
-            title: citation?.title,
-            url: citation?.clickUri,
-          },
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        citationId,
+        itemMetadata: {
+          uniqueFieldName: 'permanentid',
+          uniqueFieldValue: citation?.permanentid ?? '',
+          title: citation?.title,
+          url: citation?.clickUri,
+        },
+      };
     },
   });
 
@@ -112,20 +109,17 @@ export const logHoverCitation = (
     analyticsType: 'Rga.CitationHover',
     analyticsPayloadBuilder: (state): Rga.CitationHover | undefined => {
       const citation = citationSourceSelector(state, citationId);
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          citationId,
-          itemMetadata: {
-            uniqueFieldName: 'permanentid',
-            uniqueFieldValue: citation?.permanentid ?? '',
-            title: citation?.title,
-            url: citation?.clickUri,
-          },
-          citationHoverTimeInMs,
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        citationId,
+        itemMetadata: {
+          uniqueFieldName: 'permanentid',
+          uniqueFieldValue: citation?.permanentid ?? '',
+          title: citation?.title,
+          url: citation?.clickUri,
+        },
+        citationHoverTimeInMs,
+      };
     },
   });
 
@@ -146,13 +140,10 @@ export const logLikeGeneratedAnswer = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'like',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'like',
+      };
     },
   });
 
@@ -173,13 +164,10 @@ export const logDislikeGeneratedAnswer = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'dislike',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'dislike',
+      };
     },
   });
 
@@ -203,30 +191,27 @@ export const logGeneratedAnswerFeedback = (
     },
     analyticsType: 'Rga.SubmitFeedback',
     analyticsPayloadBuilder: (state): Rga.SubmitFeedback | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        const {
-          helpful,
-          readable,
-          documented,
-          hallucinationFree,
-          correctTopic,
-          documentUrl,
-          details,
-        } = feedback;
-        return {
-          responseId: rgaID,
-          helpful,
-          details: {
-            readable: parseEvaluationDetails(readable),
-            documented: parseEvaluationDetails(documented),
-            correctTopic: parseEvaluationDetails(correctTopic),
-            hallucinationFree: parseEvaluationDetails(hallucinationFree),
-          },
-          additionalNotes: details,
-          correctAnswerUrl: documentUrl,
-        };
-      }
+      const {
+        helpful,
+        readable,
+        documented,
+        hallucinationFree,
+        correctTopic,
+        documentUrl,
+        details,
+      } = feedback;
+      return {
+        responseId: state.search?.response.searchUid || '',
+        helpful,
+        details: {
+          readable: parseEvaluationDetails(readable),
+          documented: parseEvaluationDetails(documented),
+          correctTopic: parseEvaluationDetails(correctTopic),
+          hallucinationFree: parseEvaluationDetails(hallucinationFree),
+        },
+        additionalNotes: details,
+        correctAnswerUrl: documentUrl,
+      };
     },
   });
 
@@ -256,13 +241,10 @@ export const logGeneratedAnswerStreamEnd = (
     },
     analyticsType: 'Rga.StreamEnd',
     analyticsPayloadBuilder: (state): Rga.StreamEnd | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          answerGenerated: true,
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        answerGenerated: true,
+      };
     },
   });
 
@@ -283,13 +265,10 @@ export const logGeneratedAnswerShowAnswers = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'show',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'show',
+      };
     },
   });
 
@@ -310,13 +289,10 @@ export const logGeneratedAnswerHideAnswers = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'hide',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'hide',
+      };
     },
   });
 
@@ -337,13 +313,10 @@ export const logGeneratedAnswerExpand = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'expand',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'expand',
+      };
     },
   });
 
@@ -364,13 +337,10 @@ export const logGeneratedAnswerCollapse = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'collapse',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'collapse',
+      };
     },
   });
 
@@ -391,13 +361,10 @@ export const logCopyGeneratedAnswer = (): CustomAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'copyToClipboard',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'copyToClipboard',
+      };
     },
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -55,19 +55,16 @@ export const logOpenGeneratedAnswerSource = (
       analyticsType: 'Rga.CitationClick',
       analyticsPayloadBuilder: (state): Rga.CitationClick | undefined => {
         const citation = citationSourceSelector(state, citationId);
-        const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-        if (rgaID) {
-          return {
-            responseId: rgaID ?? '',
-            citationId,
-            itemMetadata: {
-              uniqueFieldName: 'permanentid',
-              uniqueFieldValue: citation?.permanentid ?? '',
-              title: citation?.title,
-              url: citation?.clickUri,
-            },
-          };
-        }
+        return {
+          responseId: state.search?.response.searchUid || '',
+          citationId,
+          itemMetadata: {
+            uniqueFieldName: 'permanentid',
+            uniqueFieldValue: citation?.permanentid ?? '',
+            title: citation?.title,
+            url: citation?.clickUri,
+          },
+        };
       },
     }
   );
@@ -103,20 +100,17 @@ export const logHoverCitation = (
     analyticsType: 'Rga.CitationHover',
     analyticsPayloadBuilder: (state): Rga.CitationHover | undefined => {
       const citation = citationSourceSelector(state, citationId);
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          citationId,
-          itemMetadata: {
-            uniqueFieldName: 'permanentid',
-            uniqueFieldValue: citation?.permanentid ?? '',
-            title: citation?.title,
-            url: citation?.clickUri,
-          },
-          citationHoverTimeInMs,
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        citationId,
+        itemMetadata: {
+          uniqueFieldName: 'permanentid',
+          uniqueFieldValue: citation?.permanentid ?? '',
+          title: citation?.title,
+          url: citation?.clickUri,
+        },
+        citationHoverTimeInMs,
+      };
     },
   });
 
@@ -140,13 +134,10 @@ export const logLikeGeneratedAnswer = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'like',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'like',
+      };
     },
   });
 
@@ -170,13 +161,10 @@ export const logDislikeGeneratedAnswer = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'dislike',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'dislike',
+      };
     },
   });
 
@@ -205,30 +193,27 @@ export const logGeneratedAnswerFeedback = (
     },
     analyticsType: 'Rga.SubmitFeedback',
     analyticsPayloadBuilder: (state): Rga.SubmitFeedback | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        const {
-          helpful,
-          readable,
-          documented,
-          hallucinationFree,
-          correctTopic,
-          documentUrl,
-          details,
-        } = feedback;
-        return {
-          responseId: rgaID,
-          helpful,
-          details: {
-            readable: parseEvaluationDetails(readable),
-            documented: parseEvaluationDetails(documented),
-            correctTopic: parseEvaluationDetails(correctTopic),
-            hallucinationFree: parseEvaluationDetails(hallucinationFree),
-          },
-          additionalNotes: details,
-          correctAnswerUrl: documentUrl,
-        };
-      }
+      const {
+        helpful,
+        readable,
+        documented,
+        hallucinationFree,
+        correctTopic,
+        documentUrl,
+        details,
+      } = feedback;
+      return {
+        responseId: state.search?.response.searchUid || '',
+        helpful,
+        details: {
+          readable: parseEvaluationDetails(readable),
+          documented: parseEvaluationDetails(documented),
+          correctTopic: parseEvaluationDetails(correctTopic),
+          hallucinationFree: parseEvaluationDetails(hallucinationFree),
+        },
+        additionalNotes: details,
+        correctAnswerUrl: documentUrl,
+      };
     },
   });
 
@@ -261,13 +246,10 @@ export const logGeneratedAnswerStreamEnd = (
     },
     analyticsType: 'Rga.StreamEnd',
     analyticsPayloadBuilder: (state): Rga.StreamEnd | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          answerGenerated,
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        answerGenerated,
+      };
     },
   });
 
@@ -293,13 +275,10 @@ export const logGeneratedAnswerShowAnswers = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'show',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'show',
+      };
     },
   });
 
@@ -325,13 +304,10 @@ export const logGeneratedAnswerHideAnswers = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'hide',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'hide',
+      };
     },
   });
 
@@ -355,13 +331,10 @@ export const logGeneratedAnswerExpand = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'expand',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'expand',
+      };
     },
   });
 
@@ -385,13 +358,10 @@ export const logGeneratedAnswerCollapse = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'collapse',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'collapse',
+      };
     },
   });
 
@@ -417,13 +387,10 @@ export const logCopyGeneratedAnswer = (): InsightAction =>
     },
     analyticsType: 'Rga.AnswerAction',
     analyticsPayloadBuilder: (state): Rga.AnswerAction | undefined => {
-      const {id: rgaID} = generativeQuestionAnsweringIdSelector(state);
-      if (rgaID) {
-        return {
-          responseId: rgaID,
-          action: 'copyToClipboard',
-        };
-      }
+      return {
+        responseId: state.search?.response.searchUid || '',
+        action: 'copyToClipboard',
+      };
     },
   });
 


### PR DESCRIPTION
## [SFINT-5854](https://coveord.atlassian.net/browse/SFINT-5854)

We want to send the searchId with all the RGA EP events so every event can properly be tied back to a search event when processing the translations EP → UA events.

We were previously sending the `stream id` as a response id in the RGA events, but we figured that will this cause for us issue when it comes to trying to tie RGA events to the search events that were made with it so we are doing this update.


https://github.com/user-attachments/assets/a6e3e029-1e28-4576-8b36-7b04414a3c5f



[SFINT-5854]: https://coveord.atlassian.net/browse/SFINT-5854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ