### PR TITLE
fix(atomic): fix missing hover effect on more tab button

### DIFF
--- a/packages/atomic/src/components/common/button.tsx
+++ b/packages/atomic/src/components/common/button.tsx
@@ -9,7 +9,6 @@ import {
 export interface ButtonProps {
   style: ButtonStyle;
   onClick?(event?: MouseEvent): void;
-  onKeyDown?(event?: KeyboardEvent): void;
   class?: string;
   text?: string;
   part?: string;
@@ -65,7 +64,6 @@ export const Button: FunctionalComponent<ButtonProps> = (props, children) => {
   return (
     <button
       {...attributes}
-      onKeyDown={(e) => props.onKeyDown?.(e)}
       onMouseDown={(e) => createRipple(e, {color: rippleColor})}
     >
       {props.text ? <span class="truncate">{props.text}</span> : null}

--- a/packages/atomic/src/components/common/button.tsx
+++ b/packages/atomic/src/components/common/button.tsx
@@ -9,6 +9,7 @@ import {
 export interface ButtonProps {
   style: ButtonStyle;
   onClick?(event?: MouseEvent): void;
+  onKeyDown?(event?: KeyboardEvent): void;
   class?: string;
   text?: string;
   part?: string;
@@ -64,6 +65,7 @@ export const Button: FunctionalComponent<ButtonProps> = (props, children) => {
   return (
     <button
       {...attributes}
+      onKeyDown={(e) => props.onKeyDown?.(e)}
       onMouseDown={(e) => createRipple(e, {color: rippleColor})}
     >
       {props.text ? <span class="truncate">{props.text}</span> : null}

--- a/packages/atomic/src/components/common/tab-manager/tab-button.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-button.tsx
@@ -1,4 +1,5 @@
 import {Component, Host, Prop, h} from '@stencil/core';
+import {Button} from '../button';
 
 /**
  * @internal
@@ -41,13 +42,14 @@ export class TabButton {
         aria-label={'tab for ' + this.label}
         part="button-container"
       >
-        <button
+        <Button
           class={`w-full truncate px-2 pb-1 text-xl sm:px-6 ${this.activeTabTextClass}`}
           part="tab-button"
           onClick={this.select}
+          style="text-transparent"
         >
           {this.label}
-        </button>
+        </Button>
       </Host>
     );
   }

--- a/packages/atomic/src/components/common/tabs/tab-popover.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-popover.tsx
@@ -81,7 +81,14 @@ export class TabPopover implements InitializableComponent {
   private renderDropdownButton() {
     const label = this.bindings?.i18n.t('more');
     const ariaLabel = this.bindings?.i18n.t('tab-popover', {label});
-    const buttonClasses = ['relative', 'pb-1', 'mt-1', 'mr-6', 'font-semibold'];
+    const buttonClasses = [
+      'relative',
+      'pb-1',
+      'mt-1',
+      'group',
+      'mr-6',
+      'font-semibold',
+    ];
 
     return (
       <Button


### PR DESCRIPTION
This PR fixes the missing hover effect on tab buttons. To ensure consistent styling, the tabs now use our `Button` component instead of a `HTMLButtonElement`.

https://coveord.atlassian.net/browse/KIT-3777