### PR TITLE
fix(atomic): accessibility issues on "More" tab list

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -3816,6 +3816,7 @@ export namespace Components {
     interface TabManagerBar {
     }
     interface TabPopover {
+        "closePopoverOnFocusOut": (event: FocusEvent) => Promise<void>;
         "setButtonVisibility": (isVisible: boolean) => Promise<void>;
         "togglePopover": () => Promise<void>;
     }

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -3678,6 +3678,20 @@ export namespace Components {
          */
         "name": string;
     }
+    interface AtomicTabButton {
+        /**
+          * Whether the tab button is active.
+         */
+        "active": boolean;
+        /**
+          * The label to display on the tab button.
+         */
+        "label": string;
+        /**
+          * Click handler for the tab button.
+         */
+        "select": () => void;
+    }
     /**
      * @alpha 
      */
@@ -3686,6 +3700,8 @@ export namespace Components {
           * Whether to clear the filters when the active tab changes.
          */
         "clearFiltersOnTabChange"?: boolean;
+    }
+    interface AtomicTabManagerBar {
     }
     /**
      * The `atomic-table-element` element defines a table column in a result list.
@@ -3798,22 +3814,6 @@ export namespace Components {
         "i18n": i18n;
     }
     interface TabBar {
-    }
-    interface TabButton {
-        /**
-          * Whether the tab button is active.
-         */
-        "active": boolean;
-        /**
-          * The label to display on the tab button.
-         */
-        "label": string;
-        /**
-          * Click handler for the tab button.
-         */
-        "select": () => void;
-    }
-    interface TabManagerBar {
     }
     interface TabPopover {
         "closePopoverOnFocusOut": (event: FocusEvent) => Promise<void>;
@@ -6048,6 +6048,12 @@ declare global {
         prototype: HTMLAtomicTabElement;
         new (): HTMLAtomicTabElement;
     };
+    interface HTMLAtomicTabButtonElement extends Components.AtomicTabButton, HTMLStencilElement {
+    }
+    var HTMLAtomicTabButtonElement: {
+        prototype: HTMLAtomicTabButtonElement;
+        new (): HTMLAtomicTabButtonElement;
+    };
     /**
      * @alpha 
      */
@@ -6056,6 +6062,12 @@ declare global {
     var HTMLAtomicTabManagerElement: {
         prototype: HTMLAtomicTabManagerElement;
         new (): HTMLAtomicTabManagerElement;
+    };
+    interface HTMLAtomicTabManagerBarElement extends Components.AtomicTabManagerBar, HTMLStencilElement {
+    }
+    var HTMLAtomicTabManagerBarElement: {
+        prototype: HTMLAtomicTabManagerBarElement;
+        new (): HTMLAtomicTabManagerBarElement;
     };
     /**
      * The `atomic-table-element` element defines a table column in a result list.
@@ -6117,18 +6129,6 @@ declare global {
     var HTMLTabBarElement: {
         prototype: HTMLTabBarElement;
         new (): HTMLTabBarElement;
-    };
-    interface HTMLTabButtonElement extends Components.TabButton, HTMLStencilElement {
-    }
-    var HTMLTabButtonElement: {
-        prototype: HTMLTabButtonElement;
-        new (): HTMLTabButtonElement;
-    };
-    interface HTMLTabManagerBarElement extends Components.TabManagerBar, HTMLStencilElement {
-    }
-    var HTMLTabManagerBarElement: {
-        prototype: HTMLTabManagerBarElement;
-        new (): HTMLTabManagerBarElement;
     };
     interface HTMLTabPopoverElement extends Components.TabPopover, HTMLStencilElement {
     }
@@ -6330,15 +6330,15 @@ declare global {
         "atomic-sort-dropdown": HTMLAtomicSortDropdownElement;
         "atomic-sort-expression": HTMLAtomicSortExpressionElement;
         "atomic-tab": HTMLAtomicTabElement;
+        "atomic-tab-button": HTMLAtomicTabButtonElement;
         "atomic-tab-manager": HTMLAtomicTabManagerElement;
+        "atomic-tab-manager-bar": HTMLAtomicTabManagerBarElement;
         "atomic-table-element": HTMLAtomicTableElementElement;
         "atomic-text": HTMLAtomicTextElement;
         "atomic-timeframe": HTMLAtomicTimeframeElement;
         "atomic-timeframe-facet": HTMLAtomicTimeframeFacetElement;
         "follow-up-question-list-common": HTMLFollowUpQuestionListCommonElement;
         "tab-bar": HTMLTabBarElement;
-        "tab-button": HTMLTabButtonElement;
-        "tab-manager-bar": HTMLTabManagerBarElement;
         "tab-popover": HTMLTabPopoverElement;
     }
 }
@@ -9819,6 +9819,20 @@ declare namespace LocalJSX {
          */
         "name": string;
     }
+    interface AtomicTabButton {
+        /**
+          * Whether the tab button is active.
+         */
+        "active"?: boolean;
+        /**
+          * The label to display on the tab button.
+         */
+        "label": string;
+        /**
+          * Click handler for the tab button.
+         */
+        "select": () => void;
+    }
     /**
      * @alpha 
      */
@@ -9827,6 +9841,8 @@ declare namespace LocalJSX {
           * Whether to clear the filters when the active tab changes.
          */
         "clearFiltersOnTabChange"?: boolean;
+    }
+    interface AtomicTabManagerBar {
     }
     /**
      * The `atomic-table-element` element defines a table column in a result list.
@@ -9940,22 +9956,6 @@ declare namespace LocalJSX {
         "onSelectCandidate"?: (event: FollowUpQuestionListCommonCustomEvent<SelectFollowUpQuestionCandidatePayload>) => void;
     }
     interface TabBar {
-    }
-    interface TabButton {
-        /**
-          * Whether the tab button is active.
-         */
-        "active"?: boolean;
-        /**
-          * The label to display on the tab button.
-         */
-        "label": string;
-        /**
-          * Click handler for the tab button.
-         */
-        "select": () => void;
-    }
-    interface TabManagerBar {
     }
     interface TabPopover {
     }
@@ -10153,15 +10153,15 @@ declare namespace LocalJSX {
         "atomic-sort-dropdown": AtomicSortDropdown;
         "atomic-sort-expression": AtomicSortExpression;
         "atomic-tab": AtomicTab;
+        "atomic-tab-button": AtomicTabButton;
         "atomic-tab-manager": AtomicTabManager;
+        "atomic-tab-manager-bar": AtomicTabManagerBar;
         "atomic-table-element": AtomicTableElement;
         "atomic-text": AtomicText;
         "atomic-timeframe": AtomicTimeframe;
         "atomic-timeframe-facet": AtomicTimeframeFacet;
         "follow-up-question-list-common": FollowUpQuestionListCommon;
         "tab-bar": TabBar;
-        "tab-button": TabButton;
-        "tab-manager-bar": TabManagerBar;
         "tab-popover": TabPopover;
     }
 }
@@ -11025,10 +11025,12 @@ declare module "@stencil/core" {
              */
             "atomic-sort-expression": LocalJSX.AtomicSortExpression & JSXBase.HTMLAttributes<HTMLAtomicSortExpressionElement>;
             "atomic-tab": LocalJSX.AtomicTab & JSXBase.HTMLAttributes<HTMLAtomicTabElement>;
+            "atomic-tab-button": LocalJSX.AtomicTabButton & JSXBase.HTMLAttributes<HTMLAtomicTabButtonElement>;
             /**
              * @alpha 
              */
             "atomic-tab-manager": LocalJSX.AtomicTabManager & JSXBase.HTMLAttributes<HTMLAtomicTabManagerElement>;
+            "atomic-tab-manager-bar": LocalJSX.AtomicTabManagerBar & JSXBase.HTMLAttributes<HTMLAtomicTabManagerBarElement>;
             /**
              * The `atomic-table-element` element defines a table column in a result list.
              */
@@ -11049,8 +11051,6 @@ declare module "@stencil/core" {
             "atomic-timeframe-facet": LocalJSX.AtomicTimeframeFacet & JSXBase.HTMLAttributes<HTMLAtomicTimeframeFacetElement>;
             "follow-up-question-list-common": LocalJSX.FollowUpQuestionListCommon & JSXBase.HTMLAttributes<HTMLFollowUpQuestionListCommonElement>;
             "tab-bar": LocalJSX.TabBar & JSXBase.HTMLAttributes<HTMLTabBarElement>;
-            "tab-button": LocalJSX.TabButton & JSXBase.HTMLAttributes<HTMLTabButtonElement>;
-            "tab-manager-bar": LocalJSX.TabManagerBar & JSXBase.HTMLAttributes<HTMLTabManagerBarElement>;
             "tab-popover": LocalJSX.TabPopover & JSXBase.HTMLAttributes<HTMLTabPopoverElement>;
         }
     }

--- a/packages/atomic/src/components/common/button.tsx
+++ b/packages/atomic/src/components/common/button.tsx
@@ -9,7 +9,6 @@ import {
 export interface ButtonProps {
   style: ButtonStyle;
   onClick?(event?: MouseEvent): void;
-  onKeyDown?(event?: KeyboardEvent): void;
   class?: string;
   text?: string;
   part?: string;
@@ -65,7 +64,6 @@ export const Button: FunctionalComponent<ButtonProps> = (props, children) => {
   return (
     <button
       {...attributes}
-      onKeyDown={(e) => props.onKeyDown?.(e)}
       onMouseDown={(e) => createRipple(e, {color: rippleColor})}
     >
       {props.text ? <span class="truncate">{props.text}</span> : null}

--- a/packages/atomic/src/components/common/button.tsx
+++ b/packages/atomic/src/components/common/button.tsx
@@ -9,6 +9,7 @@ import {
 export interface ButtonProps {
   style: ButtonStyle;
   onClick?(event?: MouseEvent): void;
+  onKeyDown?(event?: KeyboardEvent): void;
   class?: string;
   text?: string;
   part?: string;
@@ -64,6 +65,7 @@ export const Button: FunctionalComponent<ButtonProps> = (props, children) => {
   return (
     <button
       {...attributes}
+      onKeyDown={(e) => props.onKeyDown?.(e)}
       onMouseDown={(e) => createRipple(e, {color: rippleColor})}
     >
       {props.text ? <span class="truncate">{props.text}</span> : null}

--- a/packages/atomic/src/components/common/tab-manager/tab-button.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-button.tsx
@@ -5,9 +5,9 @@ import {Button} from '../button';
  * @internal
  */
 @Component({
-  tag: 'tab-button',
+  tag: 'atomic-tab-button',
 })
-export class TabButton {
+export class AtomicTabButton {
   /**
    * The label to display on the tab button.
    */

--- a/packages/atomic/src/components/common/tab-manager/tab-button.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-button.tsx
@@ -1,4 +1,5 @@
 import {Component, Host, Prop, h} from '@stencil/core';
+import {Button} from '../button';
 
 /**
  * @internal
@@ -41,13 +42,14 @@ export class TabButton {
         aria-label={'tab for ' + this.label}
         part="button-container"
       >
-        <button
+        <Button
           class={`w-full truncate px-2 pb-1 text-xl sm:px-6 ${this.activeTabTextClass}`}
           part="tab-button"
           onClick={this.select}
+          style="text-transparent"
         >
           {this.label}
-        </button>
+        </Button>
       </Host>
     );
   }

--- a/packages/atomic/src/components/common/tab-manager/tab-manager-bar.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-manager-bar.tsx
@@ -143,20 +143,22 @@ export class TabManagerBar {
 
   private updatePopoverTabs = () => {
     this.popoverTabs = this.overflowingTabs.map((tab) => (
-      <Button
-        part="popover-tab"
-        style="text-transparent"
-        class="truncate rounded px-4 py-2"
-        ariaLabel={tab.label}
-        title={tab.label}
-        onClick={() => {
-          tab.select();
-          this.updatePopoverTabs();
-          this.tabPopover?.togglePopover();
-        }}
-      >
-        {tab.label}
-      </Button>
+      <li>
+        <Button
+          part="popover-tab"
+          style="text-transparent"
+          class="w-full truncate rounded px-4 py-2"
+          ariaLabel={tab.label}
+          title={tab.label}
+          onClick={() => {
+            tab.select();
+            this.updatePopoverTabs();
+            this.tabPopover?.togglePopover();
+          }}
+        >
+          {tab.label}
+        </Button>
+      </li>
     ));
   };
 

--- a/packages/atomic/src/components/common/tab-manager/tab-manager-bar.tsx
+++ b/packages/atomic/src/components/common/tab-manager/tab-manager-bar.tsx
@@ -6,11 +6,11 @@ import {TabCommonElement} from '../tabs/tab-common';
  * @internal
  */
 @Component({
-  tag: 'tab-manager-bar',
+  tag: 'atomic-tab-manager-bar',
   shadow: true,
   styleUrl: 'tab-manager-bar.pcss',
 })
-export class TabManagerBar {
+export class AtomicTabManagerBar {
   @Element() private host!: HTMLElement;
 
   @State()

--- a/packages/atomic/src/components/common/tabs/tab-bar.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-bar.tsx
@@ -143,19 +143,21 @@ export class TabBar {
 
   private updatePopoverTabs = () => {
     this.popoverTabs = this.overflowingTabs.map((tab) => (
-      <Button
-        part="popover-tab"
-        style="text-transparent"
-        class="truncate rounded px-4 py-2 font-semibold"
-        ariaLabel={tab.label}
-        title={tab.label}
-        onClick={() => {
-          tab.select();
-          this.tabPopover?.togglePopover();
-        }}
-      >
-        {tab.label}
-      </Button>
+      <li>
+        <Button
+          part="popover-tab"
+          style="text-transparent"
+          class="truncate rounded px-4 py-2 font-semibold"
+          ariaLabel={tab.label}
+          title={tab.label}
+          onClick={() => {
+            tab.select();
+            this.tabPopover?.togglePopover();
+          }}
+        >
+          {tab.label}
+        </Button>
+      </li>
     ));
   };
 

--- a/packages/atomic/src/components/common/tabs/tab-popover.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-popover.tsx
@@ -81,7 +81,14 @@ export class TabPopover implements InitializableComponent {
   private renderDropdownButton() {
     const label = this.bindings?.i18n.t('more');
     const ariaLabel = this.bindings?.i18n.t('tab-popover', {label});
-    const buttonClasses = ['relative', 'pb-1', 'mt-1', 'mr-6', 'font-semibold'];
+    const buttonClasses = [
+      'relative',
+      'pb-1',
+      'mt-1',
+      'group',
+      'mr-6',
+      'font-semibold',
+    ];
 
     return (
       <Button

--- a/packages/atomic/src/components/common/tabs/tab-popover.tsx
+++ b/packages/atomic/src/components/common/tabs/tab-popover.tsx
@@ -78,6 +78,30 @@ export class TabPopover implements InitializableComponent {
     this.show = isVisible;
   }
 
+  @Method()
+  public async closePopoverOnFocusOut(event: FocusEvent) {
+    const slot = this.popupRef.children[0] as HTMLSlotElement;
+    const assignedElements = slot.assignedElements() as HTMLElement[];
+
+    const isMovingToSlottedElement = assignedElements.some(
+      (element) =>
+        element === event.relatedTarget ||
+        element.contains(event.relatedTarget as Node)
+    );
+
+    if (isMovingToSlottedElement) {
+      return;
+    }
+
+    if (!this.popupRef.contains(event.relatedTarget as Node)) {
+      this.closePopover();
+    }
+  }
+
+  private closePopover() {
+    this.isOpen = false;
+  }
+
   private renderDropdownButton() {
     const label = this.bindings?.i18n.t('more');
     const ariaLabel = this.bindings?.i18n.t('tab-popover', {label});
@@ -135,7 +159,7 @@ export class TabPopover implements InitializableComponent {
     return (
       <div class={`relative ${this.isOpen ? 'z-[9999]' : ''}`}>
         {this.renderDropdownButton()}
-        <div
+        <ul
           id={this.popoverId}
           ref={(el) => (this.popupRef = el!)}
           part="overflow-tabs"
@@ -144,7 +168,7 @@ export class TabPopover implements InitializableComponent {
           }`}
         >
           <slot></slot>
-        </div>
+        </ul>
       </div>
     );
   }
@@ -168,18 +192,11 @@ export class TabPopover implements InitializableComponent {
   public render() {
     return (
       <Host
+        onFocusout={(event: FocusEvent) => this.closePopoverOnFocusOut(event)}
         class={this.show ? '' : 'visibility-hidden'}
         aria-hidden={!this.show}
       >
-        <atomic-focus-trap
-          source={this.buttonRef}
-          container={this.popupRef}
-          active={this.isOpen}
-          shouldHideSelf={false}
-          scope={this.bindings?.interfaceElement}
-        >
-          {this.renderPopover()}
-        </atomic-focus-trap>
+        {this.renderPopover()}
         {this.isOpen && this.renderBackdrop()}
       </Host>
     );

--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.tsx
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.tsx
@@ -83,7 +83,7 @@ export class AtomicTabManager {
   render() {
     return (
       <Host class="mb-2">
-        <tab-manager-bar>
+        <atomic-tab-manager-bar>
           <div
             role="list"
             aria-label="tab-area"
@@ -91,7 +91,7 @@ export class AtomicTabManager {
             class="mb-2 flex w-full flex-row border-b"
           >
             {this.tabs.map((tab) => (
-              <tab-button
+              <atomic-tab-button
                 active={this.tabManagerState.activeTab === tab.name}
                 label={tab.label}
                 select={() => {
@@ -99,10 +99,10 @@ export class AtomicTabManager {
                     tab.tabController.select();
                   }
                 }}
-              ></tab-button>
+              ></atomic-tab-button>
             ))}
           </div>
-        </tab-manager-bar>
+        </atomic-tab-manager-bar>
       </Host>
     );
   }


### PR DESCRIPTION
This PR ensures that the "More" tab list of atomic-tab-manager follows accessibility best practices.
It implements this pattern:
https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/

It also fixes the same issue for the insight panel tabs since they use tab-popover too.

https://coveord.atlassian.net/browse/KIT-3778