### PR TITLE
test(quantic): POC of testing with slots in LWCs

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSort/__tests__/quanticSort.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/__tests__/quanticSort.test.js
@@ -319,7 +319,7 @@ describe('c-quantic-sort', () => {
     };
     const exampleAssignedElements = [invalidExampleSlot];
 
-    it('should build the controller with the correct default sort option and display the custom sort options', async () => {
+    it('should display the component error', async () => {
       const element = createTestComponent(
         defaultOptions,
         exampleAssignedElements

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/quanticSort.js
@@ -280,8 +280,10 @@ export default class QuanticSort extends LightningElement {
    * @returns {SortOption[]} The specified custom sort options.
    */
   get customSortOptions() {
+    /** @type {HTMLSlotElement} */
+    const slot = this.template.querySelector('slot[name="sortOption"]');
     /** @type {SortOption[]} */
-    return Array.from(this.querySelectorAll('c-quantic-sort-option')).map(
+    return Array.from(Array.from(slot?.assignedNodes())).map(
       // @ts-ignore
       ({label, value, criterion}) => ({label, value, criterion})
     );


### PR DESCRIPTION
## Description

This is a POC applied to the Quantic Sort component showing how we can add unit tests that includes passing slots to our Lightning Web Components,

This PR for examples addresses as an example how we can unit test the scenarios where custom sort options and invalid sort options are passed to the Quantic Sort component as slots.

This method mainly relies on mocking the return value of the method `assignedNodes` with the following function:
```javascript
/**
 * Mocks the return value of the assignedNodes method.
 * @param {Array<Element>} assignedElements
 */
function mockSlotAssignedNodes(assignedElements) {
  HTMLSlotElement.prototype.assignedNodes = function () {
    return assignedElements;
  };
}

```