### PR TITLE
fix(atomic): fix IPX with high zoom levels

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.pcss
@@ -4,6 +4,7 @@
   position: relative;
   overflow: hidden;
   height: inherit;
+  max-height: calc(100vh - 4.25rem);
 
   &::part(container) {
     @apply rounded;
@@ -11,6 +12,7 @@
     grid-area: modal;
     height: inherit;
     box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
+    max-height: calc(100vh - 4.25rem);
   }
 
   &::part(header-wrapper) {

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.pcss
@@ -8,6 +8,8 @@ atomic-focus-trap {
 :host {
   width: var(--atomic-ipx-width, 31.25rem);
   height: var(--atomic-ipx-height, 43.75rem);
+  max-width: calc(100vw - 3rem);
+  max-height: calc(100vh - 4.25rem);
   box-shadow: rgb(0 0 0 / 50%) 0 0 0.5rem;
   inset: auto 3rem 4.25rem auto;
   position: fixed;
@@ -20,6 +22,7 @@ atomic-focus-trap {
   &::part(backdrop) {
     @apply pointer-events-auto;
     height: inherit;
+    max-height: calc(100vh - 4.25rem);
   }
 }
 

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.pcss
@@ -2,4 +2,5 @@
 
 :host::part(container) {
   @apply rounded;
+  max-height: calc(100vh - 4.25rem);
 }


### PR DESCRIPTION
[SVCC-4253](https://coveord.atlassian.net/browse/SVCC-4253)

Adds some style to IPX to handle big zoom levels and mobile view. See video.

Before

https://github.com/user-attachments/assets/26f6ff5f-b8ac-4477-8ba3-8836d08ae6fc


After

https://github.com/user-attachments/assets/7018a7e1-fd03-430b-b2bb-780e5c876692



[SVCC-4253]: https://coveord.atlassian.net/browse/SVCC-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ