### PR TITLE
refactor(atomic): no overwrite of the render function

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.tsx
@@ -35,6 +35,7 @@ import {
   StorageItems,
 } from '../../../utils/local-storage-utils';
 import {CommonBindings, NonceBindings} from '../../common/interface/bindings';
+import {InterfaceErrorGuard} from '../../common/interface/guard';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -465,6 +466,10 @@ export class AtomicCommerceInterface
   }
 
   public render() {
-    return [<slot></slot>];
+    return (
+      <InterfaceErrorGuard host={this.host} error={this.error}>
+        {[<slot></slot>]}
+      </InterfaceErrorGuard>
+    );
   }
 }

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.tsx
@@ -18,6 +18,7 @@ import {
 import i18next, {i18n} from 'i18next';
 import {InitializeEvent} from '../../../utils/initialization-utils';
 import {CommonBindings, NonceBindings} from '../../common/interface/bindings';
+import {InterfaceErrorGuard} from '../../common/interface/guard';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -263,6 +264,10 @@ export class AtomicCommerceRecommendationInterface
   }
 
   public render() {
-    return [<slot></slot>];
+    return (
+      <InterfaceErrorGuard host={this.host} error={this.error}>
+        {[<slot></slot>]}
+      </InterfaceErrorGuard>
+    );
   }
 }

--- a/packages/atomic/src/components/common/interface/guard.tsx
+++ b/packages/atomic/src/components/common/interface/guard.tsx
@@ -1,0 +1,22 @@
+import {Fragment, FunctionalComponent, h} from '@stencil/core';
+import {HTMLStencilElement} from '@stencil/core/internal';
+
+interface InterfaceErrorGuardProps {
+  host: HTMLStencilElement;
+  error?: Error;
+}
+
+export const InterfaceErrorGuard: FunctionalComponent<
+  InterfaceErrorGuardProps
+> = ({host, error}, children) => {
+  if (error) {
+    return (
+      <atomic-component-error
+        element={host}
+        error={error}
+      ></atomic-component-error>
+    );
+  }
+
+  return <Fragment>{children}</Fragment>;
+};

--- a/packages/atomic/src/components/common/interface/interface-common.tsx
+++ b/packages/atomic/src/components/common/interface/interface-common.tsx
@@ -1,5 +1,5 @@
 import {LogLevel} from '@coveo/headless';
-import {ComponentInterface, h} from '@stencil/core';
+import {ComponentInterface} from '@stencil/core';
 import {HTMLStencilElement} from '@stencil/core/internal';
 import {i18n, TFunction} from 'i18next';
 import Backend from 'i18next-http-backend';
@@ -26,9 +26,8 @@ export interface BaseAtomicInterface<EngineType extends AnyEngineType>
   host: HTMLStencilElement;
   bindings: AnyBindings;
   error?: Error;
-
   updateIconAssetsPath(): void;
-  registerFieldsToInclude?: () => void; // Fix: Removed the question mark and added a semicolon.
+  registerFieldsToInclude?: () => void;
 }
 
 export const mismatchedInterfaceAndEnginePropError = (
@@ -48,10 +47,7 @@ export class CommonAtomicInterfaceHelper<Engine extends AnyEngineType> {
     setCoveoGlobal(globalVariableName);
     loadFocusVisiblePolyfill();
 
-    const {
-      connectedCallback: originalConnectedCallback,
-      render: originalRender,
-    } = atomicInterface;
+    const {connectedCallback: originalConnectedCallback} = atomicInterface;
 
     atomicInterface.connectedCallback = () => {
       this.i18nPromise = init18n(atomicInterface);
@@ -60,19 +56,6 @@ export class CommonAtomicInterfaceHelper<Engine extends AnyEngineType> {
         originalConnectedCallback &&
         originalConnectedCallback.call(atomicInterface)
       );
-    };
-
-    atomicInterface.render = () => {
-      if (atomicInterface.error) {
-        return (
-          <atomic-component-error
-            element={atomicInterface.host}
-            error={atomicInterface.error}
-          ></atomic-component-error>
-        );
-      }
-
-      return originalRender && originalRender.call(atomicInterface);
     };
   }
 

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.tsx
@@ -21,6 +21,7 @@ import {
 import {InitializeEvent} from '../../../utils/initialization-utils';
 import {ArrayProp} from '../../../utils/props-utils';
 import {CommonBindings, NonceBindings} from '../../common/interface/bindings';
+import {InterfaceErrorGuard} from '../../common/interface/guard';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -270,12 +271,14 @@ export class AtomicInsightInterface
 
   render() {
     return (
-      this.engine && (
-        <host>
-          <slot name="full-search"></slot>
-          <slot></slot>
-        </host>
-      )
+      <InterfaceErrorGuard host={this.host} error={this.error}>
+        {this.engine && (
+          <host>
+            <slot name="full-search"></slot>
+            <slot></slot>
+          </host>
+        )}
+      </InterfaceErrorGuard>
     );
   }
 }

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.tsx
@@ -23,6 +23,7 @@ import {RecsLogLevel} from '..';
 import {InitializeEvent} from '../../../utils/initialization-utils';
 import {ArrayProp} from '../../../utils/props-utils';
 import {CommonBindings} from '../../common/interface/bindings';
+import {InterfaceErrorGuard} from '../../common/interface/guard';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -306,6 +307,10 @@ export class AtomicRecsInterface
   }
 
   public render() {
-    return this.engine && <slot></slot>;
+    return (
+      <InterfaceErrorGuard host={this.host} error={this.error}>
+        {this.engine && <slot></slot>}
+      </InterfaceErrorGuard>
+    );
   }
 }

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../../utils/local-storage-utils';
 import {ArrayProp} from '../../../utils/props-utils';
 import {CommonBindings, NonceBindings} from '../../common/interface/bindings';
+import {InterfaceErrorGuard} from '../../common/interface/guard';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -583,14 +584,18 @@ export class AtomicSearchInterface
   }
 
   public render() {
-    return [
-      this.engine && this.enableRelevanceInspector && (
-        <atomic-relevance-inspector
-          open={this.relevanceInspectorIsOpen}
-          bindings={this.bindings}
-        ></atomic-relevance-inspector>
-      ),
-      <slot></slot>,
-    ];
+    return (
+      <InterfaceErrorGuard host={this.host} error={this.error}>
+        {[
+          this.engine && this.enableRelevanceInspector && (
+            <atomic-relevance-inspector
+              open={this.relevanceInspectorIsOpen}
+              bindings={this.bindings}
+            ></atomic-relevance-inspector>
+          ),
+          <slot></slot>,
+        ]}
+      </InterfaceErrorGuard>
+    );
   }
 }


### PR DESCRIPTION
## Why do we need this ? 
Lit has a protected render function. This means we won't be able to override the render function in interface-common.tsx. This PR simply prepares the interfaces for Lit for an easier copy paste. 