### PR TITLE
chore: add back nx legacy cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -131,5 +131,6 @@
   },
   "defaultBase": "master",
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "useInferencePlugins": false
+  "useInferencePlugins": false,
+  "useLegacyCache": true
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3817

https://nx.dev/deprecated/legacy-cache#nxrejectunknownlocalcache.

our ci currently rebuilds everytime without caching since nx 20
<img width="1595" alt="image" src="https://github.com/user-attachments/assets/0c886a88-4fa4-40e0-adf7-0378c8620d3a" />
