### PR TITLE
chore(atomic): replace HTMLStencilElement with HTMLElement

### DIFF
--- a/packages/atomic-react/src/components/stencil-generated/commerce/react-component-lib/createComponent.tsx
+++ b/packages/atomic-react/src/components/stencil-generated/commerce/react-component-lib/createComponent.tsx
@@ -2,10 +2,6 @@ import React, { createElement } from 'react';
 
 import { attachProps, camelToDashCase, createForwardRef, dashToPascalCase, isCoveredByReact, mergeRefs } from './utils/index.js';
 
-export interface HTMLStencilElement extends HTMLElement {
-  componentOnReady(): Promise<this>;
-}
-
 interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
   forwardedRef: React.RefObject<ElementType>;
   ref?: React.Ref<any>;
@@ -13,7 +9,7 @@ interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<El
 
 export const createReactComponent = <
   PropType,
-  ElementType extends HTMLStencilElement,
+  ElementType extends HTMLElement,
   ContextStateType = {},
   ExpandedPropsTypes = {}
 >(

--- a/packages/atomic-react/src/components/stencil-generated/search/react-component-lib/createComponent.tsx
+++ b/packages/atomic-react/src/components/stencil-generated/search/react-component-lib/createComponent.tsx
@@ -2,10 +2,6 @@ import React, { createElement } from 'react';
 
 import { attachProps, camelToDashCase, createForwardRef, dashToPascalCase, isCoveredByReact, mergeRefs } from './utils/index.js';
 
-export interface HTMLStencilElement extends HTMLElement {
-  componentOnReady(): Promise<this>;
-}
-
 interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<ElementType> {
   forwardedRef: React.RefObject<ElementType>;
   ref?: React.Ref<any>;
@@ -13,7 +9,7 @@ interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<El
 
 export const createReactComponent = <
   PropType,
-  ElementType extends HTMLStencilElement,
+  ElementType extends HTMLElement,
   ContextStateType = {},
   ExpandedPropsTypes = {}
 >(

--- a/packages/atomic/src/components/common/interface/bindings.ts
+++ b/packages/atomic/src/components/common/interface/bindings.ts
@@ -1,7 +1,6 @@
 import type {SearchEngine} from '@coveo/headless';
 import {CommerceEngine} from '@coveo/headless/commerce';
 import type {RecommendationEngine} from '@coveo/headless/recommendation';
-import {HTMLStencilElement} from '@stencil/core/internal';
 import {i18n} from 'i18next';
 import {InsightEngine} from '../../insight';
 import {AtomicCommonStore, AtomicCommonStoreData} from './store';
@@ -30,7 +29,7 @@ export interface CommonStencilStore<StoreData extends AtomicCommonStoreData> {
 export interface CommonBindings<
   Engine extends AnyEngineType,
   Store extends AtomicCommonStore<AtomicCommonStoreData>,
-  InterfaceElement extends HTMLStencilElement,
+  InterfaceElement extends HTMLElement,
 > {
   /**
    * A headless engine instance.
@@ -68,7 +67,7 @@ export interface NonceBindings {
 export type AnyBindings = CommonBindings<
   AnyEngineType,
   AtomicCommonStore<AtomicCommonStoreData>,
-  HTMLStencilElement
+  HTMLElement
 >;
 
 export type AnyEngineType =

--- a/packages/atomic/src/components/common/interface/interface-common.tsx
+++ b/packages/atomic/src/components/common/interface/interface-common.tsx
@@ -1,6 +1,5 @@
 import {LogLevel} from '@coveo/headless';
 import {ComponentInterface, h} from '@stencil/core';
-import {HTMLStencilElement} from '@stencil/core/internal';
 import {i18n, TFunction} from 'i18next';
 import Backend from 'i18next-http-backend';
 import {setCoveoGlobal} from '../../../global/environment';
@@ -23,7 +22,7 @@ export interface BaseAtomicInterface<EngineType extends AnyEngineType>
   iconAssetsPath: string;
   logLevel?: LogLevel;
   language?: string;
-  host: HTMLStencilElement;
+  host: HTMLElement;
   bindings: AnyBindings;
   error?: Error;
 


### PR DESCRIPTION
`HTMLStencilElement` is not used anywhere in the codebase. It's simply a type enhancer over HTMLElement.
Since we migrate to Lit, there is no point in keeping that type

https://coveord.atlassian.net/browse/KIT-3827