### PR TITLE
chore: use 'normal' npm cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,19 +16,13 @@ runs:
       with:
         registry-url: 'https://registry.npmjs.org'
         node-version-file: '.nvmrc'
+        cache: npm
     - name: Ensure Nx cache can be shared between different CI environments # Source: https://nx.dev/recipes/troubleshooting/unknown-local-cache
       run: echo "NX_REJECT_UNKNOWN_LOCAL_CACHE=0" >> $GITHUB_ENV
       shell: bash
     - name: Install npm
       run: npm i -g npm@11
       shell: bash
-    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-      id: npm-cache
-      with:
-        path: |
-          **/node_modules/
-          !.nx/cache/
-        key: npm-${{ hashFiles('package-lock.json', 'patches/*') }}
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
       with:
         path: packages/quantic/force-app/main/default/staticresources
@@ -43,8 +37,7 @@ runs:
       with:
         path: .nx/cache
         key: nx-${{ github.sha }}-${{ inputs.cache-suffix }}
-    - if: steps.npm-cache.outputs.cache-hit != 'true'
-      run: npm ci
+    - run: npm ci
       shell: bash
     # TODO KIT-3483: Move to artifact
     # - if: steps.nx-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Instead of caching node_modules, cache the local npm cache. This ensure npm globals are cached as well.

https://coveord.atlassian.net/browse/KIT-3836