### PR TITLE
docs(headless): updates the Headless typedoc uploading logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Copy the docs into the version folder
         run: |
           mkdir -p typedoc-headless-react-site/${{ env.version }}/
-          cp -r packages/headless/docs/* typedoc-headless-react-site/${{ env.version }}/
+          cp -r packages/headless-react/docs/* typedoc-headless-react-site/${{ env.version }}/
           echo "Copied docs to: typedoc-headless-react-site/${{ env.version }}/"
 
       - name: Upload documentation artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,37 +127,39 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: 'release/v3'
-      - uses: ./.github/actions/setup
+
+      - name: Set up and build the project 
+        uses: ./.github/actions/setup
+
       - name: Build typedoc site
         run: npm run build:typedoc
         working-directory: packages/headless
         shell: bash
+
       - name: Read version from package.json
         id: read_version
         run: |
           VERSION=$(jq -r '.version' packages/headless/package.json)
           echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_ENV
-      - name: Zip documentation folder
-        run: |
-          DOCS_DIR="packages/headless/docs"
-          if [ ! -d "$DOCS_DIR" ]; then
-            echo "Documentation folder $DOCS_DIR not found."
-            exit 1
-          fi
 
-          ZIP_NAME="headless-docs-${{ env.version }}.zip"
-          zip -r "$ZIP_NAME" "$DOCS_DIR"
-          echo "Created zip file: $ZIP_NAME"
+      - name: Copy the docs into the version folder
+        run: |
+          mkdir -p typedoc-headless-site/${{ env.version }}/
+          cp -r packages/headless/docs/* typedoc-headless-site/${{ env.version }}/
+          echo "Copied docs to: typedoc-headless-site/${{ env.version }}/"
+
       - name: Upload documentation artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: headless-docs-${{ env.version }}
-          path: headless-docs-${{ env.version }}.zip
+          path: typedoc-headless-site/
+
   typedoc-headless-react:
     needs: release
     runs-on: ubuntu-latest
@@ -167,36 +169,37 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: 'release/v3'
-      - uses: ./.github/actions/setup
+
+      - name: Set up and build the project 
+        uses: ./.github/actions/setup
+
       - name: Build typedoc site
         run: npm run build:typedoc
         working-directory: packages/headless-react
         shell: bash
+
       - name: Read version from package.json
         id: read_version
         run: |
           VERSION=$(jq -r '.version' packages/headless-react/package.json)
           echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_ENV
-      - name: Zip documentation folder
-        run: |
-          DOCS_DIR="packages/headless-react/docs"
-          if [ ! -d "$DOCS_DIR" ]; then
-            echo "Documentation folder $DOCS_DIR not found."
-            exit 1
-          fi
 
-          ZIP_NAME="headless-react-docs-${{ env.version }}.zip"
-          zip -r "$ZIP_NAME" "$DOCS_DIR"
-          echo "Created zip file: $ZIP_NAME"
+      - name: Copy the docs into the version folder
+        run: |
+          mkdir -p typedoc-headless-react-site/${{ env.version }}/
+          cp -r packages/headless/docs/* typedoc-headless-react-site/${{ env.version }}/
+          echo "Copied docs to: typedoc-headless-react-site/${{ env.version }}/"
+
       - name: Upload documentation artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: headless-react-docs-${{ env.version }}
-          path: headless-react-docs-${{ env.version }}.zip
+          name: headless-docs-${{ env.version }}
+          path: typedoc-headless-react-site/
 
   # TODO KIT-3074 Fix the publication into the GitHub Packages, and uncomment
   # github-prod:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,13 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
-      
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: 'release/v3'
 
-      - name: Set up and build the project 
+      - name: Set up and build the project
         uses: ./.github/actions/setup
 
       - name: Build typedoc site
@@ -174,7 +174,7 @@ jobs:
         with:
           ref: 'release/v3'
 
-      - name: Set up and build the project 
+      - name: Set up and build the project
         uses: ./.github/actions/setup
 
       - name: Build typedoc site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Upload documentation artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: headless-docs-${{ env.version }}
+          name: headless-react-docs-${{ env.version }}
           path: typedoc-headless-react-site/
 
   # TODO KIT-3074 Fix the publication into the GitHub Packages, and uncomment


### PR DESCRIPTION
JIRA: https://coveord.atlassian.net/browse/KIT-3424

This PR changes the logic of how the Typedoc site is uploaded as an artifact. This is to streamline the process of publishing the generated docs at docs.coveo.com (the project that I'm working on these days).

I tested this approach in a local fork of this repo, you can look at the latest run that uses the same logic as suggested in this PR: https://github.com/npushkarskii/ui-kit/actions/runs/12832730326

----
> [!NOTE]
> * archiving in the workflow wasn't required as it resulted in creating an archive inside an archive. GH automatically creates an archive when we upload anything as an artifact.
>
> * the archive's names stays `headless-docs-{VERSION}.zip` (didn't change)

The structure of the resulting archive will now be in the format: 

  1. The folder in the archive bears the name of the version.

  1. Inside the version folder, there are the generated files

![image](https://github.com/user-attachments/assets/2d53f93b-a564-4bb6-8984-768a4595f3ba)

