### PR TITLE
chore: disable automatic environment graduation

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -9,7 +9,7 @@
       "sequential": ["dev", "stg", "prd"]
     },
     "team_jenkins": "searchuibuilds",
-    "start_environment_automatically": true,
+    "start_environment_automatically": false,
     "notifications": {
       "slack_channels": ["#searchuibuilds"]
     }


### PR DESCRIPTION
This pull request includes a change to the `.deployment.config.json` file to modify the deployment behavior for the `searchuibuilds` team.

Deployment configuration change:

* [`.deployment.config.json`](diffhunk://#diff-b4ad9e880162c29d04fd77a0c4a3b154b4bbabd31a0c6b46ae8f4cac17d7eb76L12-R12): Changed the `start_environment_automatically` setting from `true` to `false` to prevent automatic starting of the environment.

CDX-764