### PR TITLE
feat(headless): Add answerConfigId to the InsightInterface to be supported in insight use case

### DIFF
--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -11,6 +11,7 @@ export interface InsightInterface {
   facets: Facet[];
   tabs: Tab[];
   settings: SettingsSection;
+  answerConfigId: string;
 }
 
 interface InsightResultTemplate {

--- a/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
+++ b/packages/headless/src/api/service/insight/get-interface/get-interface-config-response.ts
@@ -11,7 +11,7 @@ export interface InsightInterface {
   facets: Facet[];
   tabs: Tab[];
   settings: SettingsSection;
-  answerConfigId: string;
+  answerConfigId?: string;
 }
 
 interface InsightResultTemplate {

--- a/packages/headless/src/features/insight-interface/insight-interface-slice.test.ts
+++ b/packages/headless/src/features/insight-interface/insight-interface-slice.test.ts
@@ -116,6 +116,7 @@ describe('insight interface slice', () => {
               },
             },
           },
+          answerConfigId: '123',
         },
       },
     };


### PR DESCRIPTION
[SFINT-5919](https://coveord.atlassian.net/browse/SFINT-5919)

- Added answerConfigId to the InsightInterface to be supported in insight use case

[SFINT-5919]: https://coveord.atlassian.net/browse/SFINT-5919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ