### PR TITLE
fix(atomic): hide unhydrated results

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.pcss
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.pcss
@@ -45,3 +45,7 @@
     }
   }
 }
+
+atomic-product:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.pcss
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.pcss
@@ -18,3 +18,7 @@
   font-size: var(--atomic-text-2xl);
   font-weight: var(--atomic-font-bold);
 }
+
+atomic-product:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/insight/result-lists/atomic-insight-folded-result-list/atomic-insight-folded-result-list.pcss
+++ b/packages/atomic/src/components/insight/result-lists/atomic-insight-folded-result-list/atomic-insight-folded-result-list.pcss
@@ -1,2 +1,5 @@
 @import '../../../common/item-list/styles/placeholders.pcss';
 @import '../styles/list-display.pcss';
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.pcss
+++ b/packages/atomic/src/components/insight/result-lists/atomic-insight-result-list/atomic-insight-result-list.pcss
@@ -1,2 +1,5 @@
 @import '../../../common/item-list/styles/placeholders.pcss';
 @import '../styles/list-display.pcss';
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-recs-list/atomic-ipx-recs-list.pcss
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-recs-list/atomic-ipx-recs-list.pcss
@@ -22,3 +22,7 @@
   font-size: var(--atomic-text-2xl);
   font-weight: var(--atomic-font-bold);
 }
+
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.pcss
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.pcss
@@ -22,3 +22,7 @@
   font-size: var(--atomic-text-2xl);
   font-weight: var(--atomic-font-bold);
 }
+
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.pcss
+++ b/packages/atomic/src/components/search/result-lists/atomic-folded-result-list/atomic-folded-result-list.pcss
@@ -1,2 +1,5 @@
 @import '../../../common/item-list/styles/placeholders.pcss';
 @import '../../../common/item-list/styles/list-display.pcss';
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.pcss
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.pcss
@@ -2,3 +2,6 @@
 @import '../../../common/item-list/styles/table-display.pcss';
 @import '../../../common/item-list/styles/list-display.pcss';
 @import '../../../common/item-list/styles/grid-display.pcss';
+atomic-result:not(.hydrated) {
+  visibility: hidden;
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3775
Inspired by https://bbellmyers.github.io/2020/09/27/fouc-stencil.html.

Not a definitive fix: When Lit migration is done for the atomic-result, we should validate for regression on that front, and also try to improve the behavior even so slightly.
It might also be preferable to migrate all result components first, so that we can "cut" this behavior neatly. (would likely not happen because I _think_ we scan documentFragment from template element, so we should have all the element defined by then (tho maybe not because of race conditions, in which case https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements might be adapted for our needs)