### PR TITLE
chore: isolate tailwind in a separate renovate PR for easier migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,13 @@
       "matchPackageNames": ["/typescript/"]
     },
     {
+      "groupName": "tailwindcss",
+      "groupSlug": "tailwindcss",
+      "rangeStrategy": "replace",
+      "description": "Isolate tailwind for v4",
+      "matchPackageNames": ["tailwindcss"]
+    },
+    {
       "groupName": "vite",
       "groupSlug": "vite",
       "rangeStrategy": "replace",


### PR DESCRIPTION
KIT-282

We are not immediately ready for this so we should separate it to not block renovate.