### PR TITLE
fix(answerConfigurationId): remove internal tag

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -984,14 +984,14 @@ export declare interface AtomicFormatUnit extends Components.AtomicFormatUnit {}
 
 
 @ProxyCmp({
-  inputs: ['collapsible', 'maxCollapsedHeight', 'tabsExcluded', 'tabsIncluded', 'withToggle']
+  inputs: ['answerConfigurationId', 'collapsible', 'maxCollapsedHeight', 'tabsExcluded', 'tabsIncluded', 'withToggle']
 })
 @Component({
   selector: 'atomic-generated-answer',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['collapsible', 'maxCollapsedHeight', 'tabsExcluded', 'tabsIncluded', 'withToggle'],
+  inputs: ['answerConfigurationId', 'collapsible', 'maxCollapsedHeight', 'tabsExcluded', 'tabsIncluded', 'withToggle'],
 })
 export class AtomicGeneratedAnswer {
   protected el: HTMLElement;

--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -1085,6 +1085,9 @@ export namespace Components {
      * For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/)
      */
     interface AtomicGeneratedAnswer {
+        /**
+          * The unique identifier of the answer configuration to use to generate the answer.
+         */
         "answerConfigurationId"?: string;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than the specified `--atomic-crga-collapsed-height` value (16rem by default).
@@ -7277,6 +7280,9 @@ declare namespace LocalJSX {
      * For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/)
      */
     interface AtomicGeneratedAnswer {
+        /**
+          * The unique identifier of the answer configuration to use to generate the answer.
+         */
         "answerConfigurationId"?: string;
         /**
           * Whether to allow the answer to be collapsed when the text is taller than the specified `--atomic-crga-collapsed-height` value (16rem by default).

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -121,7 +121,6 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   @Prop() maxCollapsedHeight = this.DEFAULT_COLLAPSED_HEIGHT;
 
   /**
-   * @internal
    * The unique identifier of the answer configuration to use to generate the answer.
    */
   @Prop() answerConfigurationId?: string;

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -85,7 +85,6 @@ export default class QuanticGeneratedAnswer extends LightningElement {
    */
   @api withToggle = false;
   /**
-   * @internal
    * The unique identifier of the answer configuration to use to generate the answer.
    * @type {string}
    */

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -86,6 +86,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
   @api withToggle = false;
   /**
    * The unique identifier of the answer configuration to use to generate the answer.
+   * @api
    * @type {string}
    */
   @api answerConfigurationId;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-4631

As we are releasing the KnowledgeHub and the Answer manager. It is now legitimate to show this property on the Quantic an Atomic Generate Answer components.