### PR TITLE
fix(headless commerce): handle action dispatched by renew access token middleware in commerce configuration slice

### DIFF
--- a/packages/headless/src/features/commerce/configuration/configuration-slice.test.ts
+++ b/packages/headless/src/features/commerce/configuration/configuration-slice.test.ts
@@ -1,8 +1,9 @@
+import {updateBasicConfiguration} from '../../configuration/configuration-actions.js';
 import {
   disableAnalytics,
   enableAnalytics,
   updateAnalyticsConfiguration,
-  updateBasicConfiguration,
+  updateBasicConfiguration as updateBasicCommerceConfiguration,
   updateProxyBaseUrl,
 } from './configuration-actions.js';
 import {configurationReducer} from './configuration-slice.js';
@@ -51,6 +52,44 @@ describe('commerce configuration slice', () => {
         configurationReducer(
           existingState,
           updateBasicConfiguration({
+            accessToken: 'my-new-access-token',
+            environment: 'hipaa',
+            organizationId: 'my-new-org-id',
+          })
+        )
+      ).toEqual({
+        ...existingState,
+        accessToken: 'my-new-access-token',
+        environment: 'hipaa',
+        organizationId: 'my-new-org-id',
+      });
+    });
+  });
+
+  describe('updateBasicCommerceConfiguration', () => {
+    it('works on initial state', () => {
+      expect(
+        configurationReducer(
+          undefined,
+          updateBasicCommerceConfiguration({
+            accessToken: 'my-new-access-token',
+            environment: 'hipaa',
+            organizationId: 'my-new-org-id',
+          })
+        )
+      ).toEqual({
+        ...getConfigurationInitialState(),
+        accessToken: 'my-new-access-token',
+        environment: 'hipaa',
+        organizationId: 'my-new-org-id',
+      });
+    });
+
+    it('works on an existing state', () => {
+      expect(
+        configurationReducer(
+          existingState,
+          updateBasicCommerceConfiguration({
             accessToken: 'my-new-access-token',
             environment: 'hipaa',
             organizationId: 'my-new-org-id',

--- a/packages/headless/src/features/commerce/configuration/configuration-slice.ts
+++ b/packages/headless/src/features/commerce/configuration/configuration-slice.ts
@@ -1,11 +1,12 @@
 import {isNullOrUndefined} from '@coveo/bueno';
 import {createReducer} from '@reduxjs/toolkit';
+import {updateBasicConfiguration} from '../../configuration/configuration-actions.js';
 import {
   disableAnalytics,
   enableAnalytics,
   updateAnalyticsConfiguration,
   UpdateAnalyticsConfigurationPayload,
-  updateBasicConfiguration,
+  updateBasicConfiguration as updateBasicCommerceConfiguration,
   UpdateBasicConfigurationPayload,
   updateProxyBaseUrl,
   UpdateProxyBaseUrlPayload,
@@ -19,6 +20,10 @@ export const configurationReducer = createReducer(
   getConfigurationInitialState(),
   (builder) =>
     builder
+      .addCase(updateBasicCommerceConfiguration, (state, action) => {
+        handleUpdateBasicConfiguration(state, action.payload);
+      })
+      // This is to handle the renew access token middleware
       .addCase(updateBasicConfiguration, (state, action) => {
         handleUpdateBasicConfiguration(state, action.payload);
       })


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3949

This is most likely what's causing issues in projects migrating from v2 to v3 that have a renewAccessToken function.

