### PR TITLE
docs(headless-react): pagination typedoc reference 

### DIFF
--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.ts
@@ -11,9 +11,16 @@ import {
   PaginationProps,
   PaginationState,
   PaginationOptions,
+  CorePaginationOptions,
 } from './headless-core-commerce-pagination.js';
 
-export type {Pagination, PaginationProps, PaginationState, PaginationOptions};
+export type {
+  Pagination,
+  PaginationProps,
+  PaginationState,
+  PaginationOptions,
+  CorePaginationOptions,
+};
 
 /**
  * Defines a `Pagination` controller instance.

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.ts
@@ -10,9 +10,10 @@ import {
   Pagination,
   PaginationProps,
   PaginationState,
+  PaginationOptions,
 } from './headless-core-commerce-pagination.js';
 
-export type {Pagination, PaginationProps, PaginationState};
+export type {Pagination, PaginationProps, PaginationState, PaginationOptions};
 
 /**
  * Defines a `Pagination` controller instance.

--- a/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
+++ b/packages/headless/src/controllers/commerce/core/pagination/headless-core-commerce-pagination.ts
@@ -75,6 +75,9 @@ export interface PaginationState {
 }
 
 export interface CorePaginationOptions {
+  /**
+   * For internal use by Headless.
+   */
   slotId?: string;
   /**
    * The number of products to fetch per page.

--- a/packages/headless/src/ssr-commerce.index.ts
+++ b/packages/headless/src/ssr-commerce.index.ts
@@ -180,6 +180,7 @@ export type {
   PaginationProps,
   PaginationState,
   PaginationOptions,
+  CorePaginationOptions,
 } from './controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.js';
 export {definePagination} from './controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.js';
 

--- a/packages/headless/src/ssr-commerce.index.ts
+++ b/packages/headless/src/ssr-commerce.index.ts
@@ -179,6 +179,7 @@ export type {
   Pagination,
   PaginationProps,
   PaginationState,
+  PaginationOptions,
 } from './controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.js';
 export {definePagination} from './controllers/commerce/core/pagination/headless-core-commerce-pagination.ssr.js';
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3950

I noticed that we weren't documenting PaginationOptions.
https://docs.coveo.com/en/headless-react/latest/reference/interfaces/SSR_Commerce.index.PaginationProps.html#options

This PR fixes it:
<img width="1541" alt="Screenshot 2025-02-06 at 4 14 03 PM" src="https://github.com/user-attachments/assets/c71ca770-c275-41d1-adeb-5ad43be3b308" />
<img width="1492" alt="Screenshot 2025-02-06 at 4 14 15 PM" src="https://github.com/user-attachments/assets/6c7c200b-252a-41b1-a7bf-76ba36bb9bf2" />
