### PR TITLE
chore: change codeowners for IPX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 /packages/atomic/cypress/ @coveo/search @coveo/search-qa
 
 # Owners of Atomic IPX components
-/packages/atomic/src/components/ipx @coveo/service-integrations
+/packages/atomic/src/components/ipx @coveo/service-core
 
 # Owners of the Commerce headless sub-package
 /packages/headless/commerce/ @coveo/commerce-routemasters


### PR DESCRIPTION
Change code owners since the SVCINT team does not exist anymore

https://coveord.atlassian.net/browse/SVCC-4716