### PR TITLE
docs(headless): typedoc beta note for ssr-commerce

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -10,15 +10,15 @@ The `@coveo/headless` package exposes several entry points.
 
 The entry point from which you will import Coveo Headless resources depends on the engine type you are using:
 
-| Engine type           | Entry point                      |
-| --------------------- | -------------------------------- |
-| Search engine         | `@coveo/headless`                |
-| Search SSR engine     | `@coveo/headless/ssr`            |
-| CaseAssist engine     | `@coveo/headless/case-assist`    |
-| Commerce engine       | `@coveo/headless/commerce`       |
-| Commerce SSR engine   | `@coveo/headless/ssr-commerce`   |
-| Insight engine        | `@coveo/headless/insight`        |
-| Recommendation engine | `@coveo/headless/recommendation` |
+| Engine type                        | Entry point                      |
+| ---------------------------------- | -------------------------------- |
+| Search engine                      | `@coveo/headless`                |
+| Search SSR engine                  | `@coveo/headless/ssr`            |
+| CaseAssist engine                  | `@coveo/headless/case-assist`    |
+| Commerce engine                    | `@coveo/headless/commerce`       |
+| Commerce SSR engine (in open beta) | `@coveo/headless/ssr-commerce`   |
+| Insight engine                     | `@coveo/headless/insight`        |
+| Recommendation engine              | `@coveo/headless/recommendation` |
 
 ## Contributing
 

--- a/packages/headless/typedoc/lib/index.tsx
+++ b/packages/headless/typedoc/lib/index.tsx
@@ -5,6 +5,7 @@ import {fileURLToPath} from 'node:url';
 // eslint-disable-next-line n/no-unpublished-import
 import {Application, JSX, RendererEvent, Converter} from 'typedoc';
 import {insertAtomicSearchBox} from './insertAtomicSearchBox.js';
+import {insertBetaNote} from './insertBetaNote.js';
 import {insertCoveoLogo} from './insertCoveoLogo.js';
 import {insertCustomComments} from './insertCustomComments.js';
 import {insertOneTrust} from './insertOneTrust.js';
@@ -38,6 +39,9 @@ export function load(app: Application) {
       </script>
       <script>
         <JSX.Raw html={`(${insertOneTrust.toString()})();`} />
+      </script>
+      <script>
+        <JSX.Raw html={`(${insertBetaNote.toString()})();`} />
       </script>
       <script>
         <JSX.Raw

--- a/packages/headless/typedoc/lib/insertBetaNote.ts
+++ b/packages/headless/typedoc/lib/insertBetaNote.ts
@@ -1,0 +1,17 @@
+export function insertBetaNote() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const breadcrumbs = document.querySelector('ul.tsd-breadcrumb');
+    if (breadcrumbs) {
+      const IsSSRCommercePage = Array.from(
+        breadcrumbs.querySelectorAll('a')
+      ).find((link) => link.textContent?.trim() === 'SSR Commerce');
+
+      if (IsSSRCommercePage) {
+        const h1Element = document.querySelector('h1');
+        if (h1Element) {
+          h1Element.textContent += ' (Open Beta)';
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-16522

I only noticed yesterday that we have public reference documentation for the ssr-commerce package under headless (the one in headless-react is already covered). It's in open beta, so I add a string to that effect in the relevant titles.

E.g.:
<img width="1237" alt="Screenshot 2025-02-14 at 3 42 08 PM" src="https://github.com/user-attachments/assets/a18f026e-29f5-495d-994f-66807223d320" />
