### PR TITLE
fix(quanticDocs): answer config id default value

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -92,6 +92,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
    * The unique identifier of the answer configuration to use to generate the answer.
    * @api
    * @type {string}
+   * @default {undefined}
    */
   @api answerConfigurationId;
   /**


### PR DESCRIPTION
This field shows as required in the generated doc and I assume its because no default value was specified.