### PR TITLE
fix(headless commerce): add product.excerptHighlights property and deprecate misspelled one

### DIFF
--- a/packages/headless/src/api/commerce/common/product.ts
+++ b/packages/headless/src/api/commerce/common/product.ts
@@ -132,6 +132,12 @@ export interface BaseProduct {
   /**
    * The length and offset of each word to highlight in the product excerpt string.
    */
+  excerptHighlights?: HighlightKeyword[];
+  /**
+   * @deprecated Use `excerptHighlights` instead.
+   *
+   * The length and offset of each word to highlight in the product excerpt string.
+   */
   excerptsHighlights?: HighlightKeyword[];
 }
 


### PR DESCRIPTION
Keeping the misspelled property to avoid introducing a breaking change.

https://coveord.atlassian.net/browse/KIT-3983