### PR TITLE
fix(headless commerce): correctly set cf-facetId when selecting category facet search result

### DIFF
--- a/packages/headless/src/features/commerce/parameters/parameters-slice.test.ts
+++ b/packages/headless/src/features/commerce/parameters/parameters-slice.test.ts
@@ -630,7 +630,7 @@ describe('commerceParameters slice', () => {
       );
       expect(finalState.page).toBeUndefined();
     });
-    it('sets state.cf[payload.facetId] to payload.value.path', () => {
+    it('sets state.cf[payload.facetId] to [...payload.value.path, payload.value.rawValue]', () => {
       const finalState = parametersReducer(
         state,
         selectCategoryFacetSearchResult({
@@ -638,15 +638,15 @@ describe('commerceParameters slice', () => {
           value: {
             path: ['f2v1', 'f2v2'],
             count: 1,
-            displayValue: 'f2v2',
-            rawValue: 'f2v2',
+            displayValue: 'F2V3',
+            rawValue: 'f2v3',
           },
         })
       );
 
       expect(finalState).toEqual({
         ...state,
-        cf: {facetId1: ['f1v1'], facetId2: ['f2v1', 'f2v2']},
+        cf: {facetId1: ['f1v1'], facetId2: ['f2v1', 'f2v2', 'f2v3']},
       });
     });
   });

--- a/packages/headless/src/features/commerce/parameters/parameters-slice.ts
+++ b/packages/headless/src/features/commerce/parameters/parameters-slice.ts
@@ -337,7 +337,7 @@ const handleSelectCategoryFacetSearchResult = (
   state.page = undefined;
 
   state.cf ??= {};
-  state.cf[payload.facetId] = payload.value.path;
+  state.cf[payload.facetId] = [...payload.value.path, payload.value.rawValue];
 };
 
 const handleToggleSelectFacetValue = (


### PR DESCRIPTION
The `path` property of values in the category facet search response body does not include the `rawValue` itself, so we need to manually add it.

This is not the case for category facet values in the response body of search / product listing requests, so this part works fine.

https://coveord.atlassian.net/browse/KIT-3984