### PR TITLE
ci: add Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
@@ -23,7 +23,7 @@ _The `[component-name]` component is designed to [brief description of the compo
 
 - [Description of accessibility considerations, such as ARIA roles, keyboard navigation, etc.]
 
-## ⚡ Performance & Security
+## ⚡ Performance & Security (if applicable)
 
 <!--
     Describe performance considerations, such as asynchronous operations, lazy loading, etc.
@@ -33,7 +33,7 @@ _The `[component-name]` component is designed to [brief description of the compo
 - [Description of performance considerations, such as asynchronous operations, lazy loading, etc.]
 - [Description of security considerations, such as sanitization, preventing XSS attacks, etc.]
 
-## ⚠️ Risks and Challenges
+## ⚠️ Risks and Challenges (if applicable)
 
 <!--
     Identify potential risks and challenges associated with the component's implementation and usage.
@@ -46,9 +46,12 @@ _The `[component-name]` component is designed to [brief description of the compo
 
 ## ✅ Checklist
 
-- [ ] 🧪 A specification file (`.spec.ts`) has been added for each migrated Atomic component.
-- [ ] 📦 The Lit component has been exported via appropriate `index.ts` and `lazy-index.ts` files.
-- [ ] 🗑️ Stencil equivalent has been removed.
-- [ ] 🎨 CSS parts are still accessible.
+- [ ] 🧪 The component is [unit tested](https://docs.google.com/document/d/1lrsHAUROGMkRbsGlor02eYKF2mfrfBa0SOESxHFU3pI/edit?tab=t.0#heading=h.l9yzzrwf1i4k)
+- [ ] 🧪 The component includes [E2E tests](https://docs.google.com/document/d/1lrsHAUROGMkRbsGlor02eYKF2mfrfBa0SOESxHFU3pI/edit?tab=t.0#heading=h.z9tw07qe1lai)
+- [ ] ♿ The component complies with the [Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG21/).
+- [ ] 🌐 All strings intended for humans or assistive technology must be localized with i18n.
+- [ ] 📦 The Lit component is exported in the appropriate `index.ts` and `lazy-index.ts` files.
+- [ ] 🎨 CSS parts are documented still accessible.
+- [ ] 🦥 Slotted Content, public methods and properties are documented
 
 https://coveord.atlassian.net/browse/KIT-[____]

--- a/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
@@ -1,0 +1,54 @@
+# [Component Name] Component Specification
+
+## 📝 Requirements
+
+_The `[component-name]` component is designed to [brief description of the component's purpose]._
+
+<!--
+    Describe the main purpose and functionality of the component and its specific requirements.
+    e.g.:
+    - Functional Requirements: What the component should do.
+    - Constraints: Any limitations or constraints that must be considered.
+-->
+
+- [Requirement 1]: [Brief description of the first requirement]
+- [Requirement 2]: [Brief description of the second requirement]
+
+## ♿ Accessibility
+
+<!--
+    Describe accessibility considerations, such as ARIA roles, keyboard navigation, etc.
+    Ensure the component is usable by people with disabilities.
+-->
+
+- [Description of accessibility considerations, such as ARIA roles, keyboard navigation, etc.]
+
+## ⚡ Performance & Security
+
+<!--
+    Describe performance considerations, such as asynchronous operations, lazy loading, etc.
+    Describe security considerations, such as sanitization, preventing XSS attacks, etc.
+-->
+
+- [Description of performance considerations, such as asynchronous operations, lazy loading, etc.]
+- [Description of security considerations, such as sanitization, preventing XSS attacks, etc.]
+
+## ⚠️ Risks and Challenges
+
+<!--
+    Identify potential risks and challenges associated with the component's implementation and usage.
+-->
+
+- [Risk or challenge 1]
+- [Risk or challenge 2]
+
+---
+
+## ✅ Checklist
+
+- [ ] 🧪 A specification file (`.spec.ts`) has been added for each migrated Atomic component.
+- [ ] 📦 The Lit component has been exported via appropriate `index.ts` and `lazy-index.ts` files.
+- [ ] 🗑️ Stencil equivalent has been removed.
+- [ ] 🎨 CSS parts are still accessible.
+
+https://coveord.atlassian.net/browse/KIT-[____]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+For the Stencil to Lit migration, please tag the Pull Request with `new-lit-component`. Do not fill out the PR description initially; a template will be automatically generated for you to complete.
+
+For all other contributors, please disregard this instruction.

--- a/.github/workflows/apply_pr_template.yml
+++ b/.github/workflows/apply_pr_template.yml
@@ -1,0 +1,38 @@
+name: Update PR Template with Dynamic Values
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  update-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Get Label
+        id: get_label
+        run: echo "label=${{ github.event.label.name }}" >> $GITHUB_OUTPUT
+
+      - name: Read PR Template
+        if: steps.get_label.outputs.label == 'new-lit-component'
+        id: read_template
+        run: |
+          TEMPLATE_CONTENT=$(cat .github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md)
+          TEMPLATE_CONTENT_ESCAPED=$(echo "$TEMPLATE_CONTENT" | jq -Rs .)
+          echo "template_content=$TEMPLATE_CONTENT_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Replace Placeholders in PR Template
+        if: steps.get_label.outputs.label == 'new-lit-component'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TEMPLATE_CONTENT: ${{ steps.read_template.outputs.template_content }}
+        run: |
+          # Update PR description via GitHub API
+          echo "Updating PR description for PR #$PR_NUMBER"
+          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER \
+               -d "{\"body\": $TEMPLATE_CONTENT}"

--- a/.github/workflows/update-pr-template-lit-migration.yml
+++ b/.github/workflows/update-pr-template-lit-migration.yml
@@ -1,4 +1,4 @@
-name: Update PR Template with Dynamic Values
+name: Update PR for Lit Component Migration
 
 on:
   pull_request:


### PR DESCRIPTION
This pull request introduces a new PR template for the migration of Stencil components to Lit components, along with an automated workflow to apply this template dynamically based on specific labels. 

## New flow when migrating atomic components
1. Create the PR. You will see this new pull request template displayed
![image](https://github.com/user-attachments/assets/b5997abc-ba38-430f-b2f9-4cb1aa3c3047)

2. Select `new-lit-component` label and wait for the `Update PR for Lit Component Migration` action to complete
![image](https://github.com/user-attachments/assets/aa97fd14-28ab-4283-a38a-cc52fa8917ff)

3. The description will automatically be updated
![image](https://github.com/user-attachments/assets/57a5154e-37ae-4566-92cb-f715e2d691fe)


https://coveord.atlassian.net/browse/KIT-3986