### PR TITLE
fix(headless-commerce-react): prevent duplicate /querySuggest request in samples

### DIFF
--- a/packages/samples/headless-commerce-react/src/components/search-box/search-box.tsx
+++ b/packages/samples/headless-commerce-react/src/components/search-box/search-box.tsx
@@ -45,7 +45,6 @@ export default function SearchBox(props: ISearchBoxProps) {
 
     controller.updateText(e.target.value);
     instantProductsController.updateQuery(e.target.value);
-    controller.showSuggestions();
     showDropdown();
   };
 

--- a/packages/samples/headless-commerce-react/src/components/standalone-search-box/standalone-search-box.tsx
+++ b/packages/samples/headless-commerce-react/src/components/standalone-search-box/standalone-search-box.tsx
@@ -55,7 +55,6 @@ export default function StandaloneSearchBox(props: IStandaloneSearchBoxProps) {
 
     controller.updateText(e.target.value);
     instantProductsController.updateQuery(e.target.value);
-    controller.showSuggestions();
     showDropdown();
   };
 


### PR DESCRIPTION
`updateText` already calls `showSuggestions()`
https://coveord.atlassian.net/browse/KIT-3992