### PR TITLE
feat(headless): added analytics section to fetch document suggestion call

### DIFF
--- a/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-request.ts
+++ b/packages/headless/src/api/service/case-assist/get-document-suggestions/get-document-suggestions-request.ts
@@ -6,6 +6,7 @@ import {
   LocaleParam,
   NumberOfResultsParam,
 } from '../../../platform-service-params.js';
+import {AnalyticsParam} from '../../../search/search-api-params.js';
 import {
   baseCaseAssistRequest,
   CaseAssistIdParam,
@@ -20,7 +21,8 @@ export type GetDocumentSuggestionsRequest = BaseParam &
   FieldsParam &
   ContextParam &
   NumberOfResultsParam &
-  DebugParam;
+  DebugParam &
+  AnalyticsParam;
 
 export const buildGetDocumentSuggestionsRequest = (
   req: GetDocumentSuggestionsRequest
@@ -50,4 +52,5 @@ const prepareRequestParams = (req: GetDocumentSuggestionsRequest) => ({
   locale: req.locale,
   fields: prepareSuggestionRequestFields(req.fields),
   context: req.context,
+  analytics: req.analytics,
 });

--- a/packages/headless/src/features/analytics/search-action-cause.ts
+++ b/packages/headless/src/features/analytics/search-action-cause.ts
@@ -88,6 +88,10 @@ export enum SearchPageEvents {
    */
   facetUpdateSort = 'facetUpdateSort',
   /**
+   * Identifies the search event that gets logged when the document suggestions are fetched.
+   */
+  documentSuggestion = 'documentSuggestion',
+  /**
    * The custom event that gets logged when an end-user expands a facet to see additional values.
    */
   facetShowMore = 'showMoreFacetResults',

--- a/packages/headless/src/features/document-suggestion/document-suggestion-actions.test.ts
+++ b/packages/headless/src/features/document-suggestion/document-suggestion-actions.test.ts
@@ -1,0 +1,38 @@
+import {CaseAssistAppState} from '../../state/case-assist-app-state.js';
+import {buildMockCaseAssistState} from '../../test/mock-case-assist-state.js';
+import {buildMockNavigatorContextProvider} from '../../test/mock-navigator-context-provider.js';
+import {buildFetchDocumentSuggestionsRequest} from './document-suggestion-actions.js';
+
+describe('buildFetchDocumentSuggestionsRequest', () => {
+  describe('when analytics are enabled', () => {
+    let state: CaseAssistAppState;
+    beforeEach(() => {
+      state = buildMockCaseAssistState();
+      state.configuration.analytics.enabled = true;
+    });
+
+    it('should include the #analytics section in the request', async () => {
+      const request = await buildFetchDocumentSuggestionsRequest(
+        state,
+        buildMockNavigatorContextProvider()()
+      );
+      expect(request.analytics).toBeDefined();
+    });
+  });
+
+  describe('when analytics are disabled', () => {
+    let state: CaseAssistAppState;
+    beforeEach(() => {
+      state = buildMockCaseAssistState();
+      state.configuration.analytics.enabled = false;
+    });
+
+    it('should not include the #analytics section in the request', async () => {
+      const request = await buildFetchDocumentSuggestionsRequest(
+        state,
+        buildMockNavigatorContextProvider()()
+      );
+      expect(request.analytics).not.toBeDefined();
+    });
+  });
+});

--- a/packages/headless/src/features/document-suggestion/document-suggestion-actions.ts
+++ b/packages/headless/src/features/document-suggestion/document-suggestion-actions.ts
@@ -6,6 +6,7 @@ import {AsyncThunkCaseAssistOptions} from '../../api/service/case-assist/case-as
 import {prepareContextFromFields} from '../../api/service/case-assist/case-assist-params.js';
 import {GetDocumentSuggestionsRequest} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-request.js';
 import {GetDocumentSuggestionsResponse} from '../../api/service/case-assist/get-document-suggestions/get-document-suggestions-response.js';
+import {NavigatorContext} from '../../app/navigatorContextProvider.js';
 import {
   CaseAssistConfigurationSection,
   DocumentSuggestionSection,
@@ -14,6 +15,8 @@ import {
   CaseInputSection,
   CaseFieldSection,
 } from '../../state/state-sections.js';
+import {SearchPageEvents} from '../analytics/search-action-cause.js';
+import {fromAnalyticsStateToAnalyticsParams} from '../configuration/analytics-params.js';
 
 export interface FetchDocumentSuggestionsThunkReturn {
   /** The successful document suggestions response. */
@@ -33,11 +36,14 @@ export const fetchDocumentSuggestions = createAsyncThunk<
   AsyncThunkCaseAssistOptions<StateNeededByFetchDocumentSuggestions>
 >(
   'caseAssist/documentSuggestions/fetch',
-  async (_, {getState, rejectWithValue, extra: {apiClient}}) => {
+  async (
+    _,
+    {getState, rejectWithValue, extra: {apiClient, navigatorContext}}
+  ) => {
     const state = getState();
 
     const fetched = await apiClient.getDocumentSuggestions(
-      await buildFetchDocumentSuggestionsRequest(state)
+      await buildFetchDocumentSuggestionsRequest(state, navigatorContext)
     );
 
     if (isErrorResponse(fetched)) {
@@ -51,7 +57,8 @@ export const fetchDocumentSuggestions = createAsyncThunk<
 );
 
 export const buildFetchDocumentSuggestionsRequest = async (
-  state: StateNeededByFetchDocumentSuggestions
+  state: StateNeededByFetchDocumentSuggestions,
+  navigatorContext: NavigatorContext
 ): Promise<GetDocumentSuggestionsRequest> => ({
   accessToken: state.configuration.accessToken,
   organizationId: state.configuration.organizationId,
@@ -65,6 +72,14 @@ export const buildFetchDocumentSuggestionsRequest = async (
   ...(state.configuration.analytics.enabled && {
     clientId: await getVisitorID(state.configuration.analytics),
   }),
+  ...(state.configuration.analytics.enabled &&
+    fromAnalyticsStateToAnalyticsParams(
+      state.configuration.analytics,
+      navigatorContext,
+      {
+        actionCause: SearchPageEvents.documentSuggestion,
+      }
+    )),
   fields: state.caseInput,
   context: state.caseField
     ? prepareContextFromFields(state.caseField.fields)


### PR DESCRIPTION
## [SFINT-5982](https://coveord.atlassian.net/browse/SFINT-5982)


- Added analytics payload to the payload of the request made to fetch document suggestions. 
- This change has been made in order to allow the Customer Service API to log a server side UA Search event when fetching document suggestions.
- This is  part of the initiative that we are working on focused on improving the analytics reporting of the document.
- The search cause that will be sent in this analytics section is `documentSuggestion`.
- Unit tests have been added.