### PR TITLE
ci(headless-react): notify docs of headless-react releases

### DIFF
--- a/scripts/notify-docs/published-ui-kit.mjs
+++ b/scripts/notify-docs/published-ui-kit.mjs
@@ -11,11 +11,18 @@ const event_type = 'published_ui-kit_to_npm';
 async function notify() {
   const {version: headless_version} =
     getPackageDefinitionFromPackageDir('headless');
+  const {version: headless_react_version} =
+    getPackageDefinitionFromPackageDir('headless-react');
   const {version: atomic_version} =
     getPackageDefinitionFromPackageDir('atomic');
   const {version: quantic_version} =
     getPackageDefinitionFromPackageDir('quantic');
-  const client_payload = {headless_version, atomic_version, quantic_version};
+  const client_payload = {
+    headless_version,
+    headless_react_version,
+    atomic_version,
+    quantic_version,
+  };
 
   return github.repos.createDispatchEvent({
     owner,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3967

To facilitate the automation of headless-react reference documentation, it would help me to alert the documentation repo of headless-react releases, with the version number, like we already do for other packages.
