### PR TITLE
test(atomic): exclude lit console warning in cypress assert

### DIFF
--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -154,9 +154,18 @@ export function assertConsoleErrorMessage(msg: string) {
 
 export function assertConsoleWarning(warn = true) {
   it(`${should(warn)} log a warning to the console`, () => {
-    cy.get(TestFixture.consoleAliases.warn).should(
-      warn ? 'be.called' : 'not.be.called'
-    );
+    cy.get(TestFixture.consoleAliases.warn).should((spy) => {
+      const calls = spy.getCalls();
+      const filteredCalls = calls.filter(
+        (call) => !call.args[0].includes('Lit is in dev mode.')
+      );
+
+      if (warn) {
+        expect(filteredCalls).to.have.length.greaterThan(0);
+      } else {
+        expect(filteredCalls).to.have.lengthOf(0);
+      }
+    });
   });
 }
 

--- a/packages/atomic/cypress/e2e/search-interface.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-interface.cypress.ts
@@ -3,6 +3,7 @@ import {getSampleSearchEngineConfiguration} from '@coveo/headless';
 import {TestFixture} from '../fixtures/test-fixture';
 import {
   assertConsoleErrorMessage,
+  assertConsoleWarning,
   assertConsoleWarningMessage,
 } from './common-assertions';
 import {addQuerySummary} from './query-summary-actions';
@@ -171,7 +172,7 @@ describe('Search Interface Component', () => {
         );
 
         it('should not log any warning', () => {
-          cy.get(TestFixture.consoleAliases.warn).should('not.be.called');
+          assertConsoleWarning(false);
         });
 
         it("should update the interface's query pipeline and search hub to match the token", () => {
@@ -197,7 +198,7 @@ describe('Search Interface Component', () => {
         );
 
         it('should not log any warning', () => {
-          cy.get(TestFixture.consoleAliases.warn).should('not.be.called');
+          assertConsoleWarning(false);
         });
       });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4006

Many tests check that there are no console warnings, but with a lit component there will always be this message printed : “Lit is in dev mode. blablabla”. We need to exclude this warning from the tests.
