### PR TITLE
fix(atomic): Added missed "backdrop" part to the exported parts in the refine modal

### DIFF
--- a/packages/atomic/src/components/common/refine-modal/modal.tsx
+++ b/packages/atomic/src/components/common/refine-modal/modal.tsx
@@ -23,7 +23,7 @@ export const RefineModal: FunctionalComponent<RefineModalProps> = (
   children
 ) => {
   const exportparts =
-    'container,header,header-wrapper,header-ruler,body,body-wrapper,footer,footer-wrapper,footer-wrapper';
+    'backdrop,container,header,header-wrapper,header-ruler,body,body-wrapper,footer,footer-wrapper,footer-wrapper';
 
   const flushFacetElements = () => {
     props.host.querySelector('div[slot="facets"]')?.remove();


### PR DESCRIPTION
Added missing "backdrop" part to the exported parts to have a possibility to style this element by using CSS.

https://coveord.atlassian.net/browse/KIT-4011