### PR TITLE
chore(atomic): add decorator for bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12152,6 +12152,15 @@
       "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@lit/context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.4.tgz",
+      "integrity": "sha512-0b8wOWNUPcXjGHFtVP+odwhrZBZw+PpCjKWn8IGO10iHT95Xd6FcUAxe1aE7PUtOBvHZoxvrfdBzweYnDW7VNQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
+    },
     "node_modules/@lit/react": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.6.tgz",
@@ -62389,6 +62398,7 @@
       "dependencies": {
         "@coveo/bueno": "1.0.8",
         "@coveo/headless": "3.18.0",
+        "@lit/context": "1.1.4",
         "@popperjs/core": "2.11.8",
         "@salesforce-ux/design-system": "2.26.2",
         "@stencil/core": "4.20.0",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@coveo/bueno": "1.0.8",
     "@coveo/headless": "3.18.0",
+    "@lit/context": "1.1.4",
     "@popperjs/core": "2.11.8",
     "@salesforce-ux/design-system": "2.26.2",
     "@stencil/core": "4.20.0",

--- a/packages/atomic/src/components/context/bindings-context.ts
+++ b/packages/atomic/src/components/context/bindings-context.ts
@@ -1,0 +1,4 @@
+import {AnyBindings} from '@/src/components';
+import {createContext} from '@lit/context';
+
+export const bindingsContext = createContext<AnyBindings>(Symbol('bindings'));

--- a/packages/atomic/src/decorators/bindings.spec.ts
+++ b/packages/atomic/src/decorators/bindings.spec.ts
@@ -1,15 +1,12 @@
+import {provide} from '@lit/context';
 import i18next from 'i18next';
 import {LitElement, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {Mock, vi} from 'vitest';
+import {vi} from 'vitest';
+import {bindingsContext} from '../components/context/bindings-context';
 import type {Bindings} from '../components/search/atomic-search-interface/interfaces';
-import {InitializableComponent} from '../decorators/types';
-import {fetchBindings} from '../utils/initialization-lit-stencil-common-utils';
-import {InitializeBindingsMixin} from './bindings-mixin';
-
-vi.mock('../utils/initialization-lit-stencil-common-utils', () => ({
-  fetchBindings: vi.fn(),
-}));
+import {bindings} from './bindings';
+import {InitializableComponent} from './types';
 
 const mockBindings = () =>
   ({
@@ -17,15 +14,16 @@ const mockBindings = () =>
   }) as Bindings;
 
 @customElement('test-element')
+@bindings()
 export class TestElement
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<Bindings>
 {
   @state()
-  public bindings!: Bindings;
+  public bindings: Bindings = {} as Bindings;
+  @state() public error!: Error;
 
   public initialized = false;
-  @state() public error!: Error;
 
   public render() {
     return html``;
@@ -33,75 +31,87 @@ export class TestElement
 
   initialize = vi.fn();
 }
+@customElement('test-interface-element')
+export class TestInterfaceElement extends LitElement {
+  @state()
+  @provide({context: bindingsContext})
+  public bindings: Bindings = {} as Bindings;
+  @state() public error!: Error;
 
-describe('InitializeBindingsMixin mixin', () => {
+  public initialized = false;
+
+  public render() {
+    return html`interface`;
+  }
+
+  public initialize() {
+    this.bindings = mockBindings();
+    this.bindings.i18n.init();
+  }
+}
+
+describe('bindings decorator', () => {
   let element: InitializableComponent<Bindings> & LitElement;
-  let bindings: Bindings;
+  let interfaceElement: TestInterfaceElement;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-  const mockedFetchBindings = fetchBindings as Mock;
 
   const setupElement = async <T extends LitElement>(tag = 'test-element') => {
     element = document.createElement(tag) as InitializableComponent<Bindings> &
       T;
-    document.body.appendChild(element);
-    element.bindings = bindings;
+    interfaceElement.appendChild(element);
+
     await element.updateComplete;
   };
 
   const teardownElement = async () => {
-    if (document.body.contains(element)) {
-      document.body.removeChild(element);
+    if (interfaceElement.contains(element)) {
+      interfaceElement.removeChild(element);
+    }
+    if (document.body.contains(interfaceElement)) {
+      document.body.removeChild(interfaceElement);
     }
   };
 
   beforeEach(async () => {
-    bindings = mockBindings();
-    bindings.i18n.init();
-    mockedFetchBindings.mockImplementation(() => Promise.resolve(bindings));
+    interfaceElement = document.createElement(
+      'test-interface-element'
+    ) as TestInterfaceElement;
+    document.body.appendChild(interfaceElement);
+    interfaceElement.initialize();
+
     consoleErrorSpy = vi.spyOn(console, 'error');
   });
 
   afterEach(() => {
     teardownElement();
     consoleErrorSpy.mockRestore();
-    mockedFetchBindings.mockRestore();
   });
 
   it('should subscribe to language changes', async () => {
-    vi.spyOn(bindings.i18n, 'on');
+    vi.spyOn(interfaceElement.bindings.i18n, 'on');
     await setupElement();
 
     expect(element.bindings?.i18n.on).toHaveBeenCalled();
   });
 
   it('should unsubscribe to language changes when the host is disconnected from the component tree', async () => {
-    vi.spyOn(bindings.i18n, 'off');
+    vi.spyOn(interfaceElement.bindings.i18n, 'off');
     await setupElement();
     await teardownElement();
     expect(element.bindings?.i18n.off).toHaveBeenCalled();
+    expect(interfaceElement.bindings?.i18n.off).toHaveBeenCalled();
   });
 
   it('should request a component update when the language changes', async () => {
     await setupElement();
     vi.spyOn(element, 'requestUpdate');
-    element.bindings?.i18n.changeLanguage('fr');
+    interfaceElement.bindings?.i18n.changeLanguage('fr');
     expect(element.requestUpdate).toHaveBeenCalled();
   });
 
   it('should call the initialize method when bindings are present', async () => {
     await setupElement();
+
     expect(element.initialize).toHaveBeenCalled();
-  });
-
-  test('should handle fetchBindings rejection gracefully', async () => {
-    // Mock fetchBindings to return a rejected promise
-    mockedFetchBindings.mockRejectedValue(
-      new Error('Failed to fetch bindings')
-    );
-
-    // Call the function and expect it to reject
-    await expect(fetchBindings(element)).rejects.toThrow(
-      'Failed to fetch bindings'
-    );
   });
 });

--- a/packages/atomic/src/decorators/bindings.ts
+++ b/packages/atomic/src/decorators/bindings.ts
@@ -1,0 +1,71 @@
+import {ContextConsumer} from '@lit/context';
+import {ReactiveElement} from 'lit';
+import {AnyBindings} from '../components';
+import {bindingsContext} from '../components/context/bindings-context';
+import {InitializableComponent} from './types';
+
+/**
+ * A decorator that will initialize the component with the bindings provided by the bindings context.
+ * It ensures that the component is initialized only once and that the language is updated when the language changes.
+ *
+ * @example
+ * ```ts
+ * import {bindings} from './decorators/bindings';
+ * import {InitializableComponent} from './decorators/types';
+ *
+ * @customElement('test-element')
+ * @bindings()
+ * export class TestElement extends LitElement implements InitializableComponent<Bindings> {
+ *
+ *    @state() public bindings: Bindings = {} as Bindings;
+ *    @state() public error!: Error;
+ *
+ *    public initialized = false;
+ *
+ *    public render() {
+ *     return html``;
+ *    }
+ * }
+ * ```
+ */
+export function bindings() {
+  return function (target: {
+    prototype: ReactiveElement & InitializableComponent<AnyBindings>;
+  }) {
+    const connectedCallback = target.prototype.connectedCallback;
+
+    target.prototype.connectedCallback = function () {
+      new ContextConsumer(this, {
+        context: bindingsContext,
+        callback: (value) => {
+          if (!this.initialized && this.bindings) {
+            this.bindings = value;
+
+            const updateLanguage = () => this.requestUpdate();
+            this.bindings.i18n.on('languageChanged', updateLanguage);
+            const unsubscribeLanguage = () =>
+              this.bindings?.i18n.off('languageChanged', updateLanguage);
+
+            this.initialize?.();
+            this.initialized = true;
+
+            this.unsubscribeLanguage = unsubscribeLanguage;
+          }
+        },
+        subscribe: true,
+      });
+
+      if (connectedCallback) {
+        connectedCallback.call(this);
+      }
+    };
+
+    const disconnectedCallback = target.prototype.disconnectedCallback;
+    target.prototype.disconnectedCallback = function () {
+      this.unsubscribeLanguage?.();
+      if (disconnectedCallback) {
+        disconnectedCallback.call(this);
+      }
+    };
+  };
+}

--- a/packages/atomic/src/decorators/bindings.ts
+++ b/packages/atomic/src/decorators/bindings.ts
@@ -38,19 +38,21 @@ export function bindings() {
       new ContextConsumer(this, {
         context: bindingsContext,
         callback: (value) => {
-          if (!this.initialized && this.bindings) {
-            this.bindings = value;
-
-            const updateLanguage = () => this.requestUpdate();
-            this.bindings.i18n.on('languageChanged', updateLanguage);
-            const unsubscribeLanguage = () =>
-              this.bindings?.i18n.off('languageChanged', updateLanguage);
-
-            this.initialize?.();
-            this.initialized = true;
-
-            this.unsubscribeLanguage = unsubscribeLanguage;
+          if (this.initialized) {
+            return;
           }
+
+          this.initialized = true;
+
+          this.bindings = value;
+          const updateLanguage = () => this.requestUpdate();
+          this.bindings.i18n.on('languageChanged', updateLanguage);
+          const unsubscribeLanguage = () =>
+            this.bindings?.i18n.off('languageChanged', updateLanguage);
+
+          this.initialize?.();
+
+          this.unsubscribeLanguage = unsubscribeLanguage;
         },
         subscribe: true,
       });

--- a/packages/atomic/src/decorators/types.ts
+++ b/packages/atomic/src/decorators/types.ts
@@ -24,6 +24,17 @@ export interface InitializableComponent<
    * Bindings passed from the `AtomicSearchInterface` to its children components.
    */
   bindings: SpecificBindings;
+
+  /**
+   * Flag to check if the component has been initialized.
+   */
+  initialized?: boolean;
+
+  /**
+   * Method called when the component is removed from the DOM.
+   */
+  unsubscribeLanguage?: () => void;
+
   /**
    * Method called right after the `bindings` property is defined. This is the method where Headless Framework controllers should be initialized.
    */

--- a/packages/atomic/src/mixins/bindings-mixin.ts
+++ b/packages/atomic/src/mixins/bindings-mixin.ts
@@ -14,24 +14,23 @@ function initializeBindings<
     InitializableComponent<SpecificBindings>,
 >(instance: InstanceType): Promise<() => void> {
   return new Promise((resolve, reject) => {
-    if (!instance.initialized && instance.bindings) {
-      fetchBindings<SpecificBindings>(instance)
-        .then((bindings) => {
-          instance.bindings = bindings;
+    instance.initialized = true;
+    fetchBindings<SpecificBindings>(instance)
+      .then((bindings) => {
+        instance.bindings = bindings;
 
-          const updateLanguage = () => instance.requestUpdate();
-          instance.bindings.i18n.on('languageChanged', updateLanguage);
-          const unsubscribeLanguage = () =>
-            instance.bindings?.i18n.off('languageChanged', updateLanguage);
-          resolve(unsubscribeLanguage);
+        const updateLanguage = () => instance.requestUpdate();
+        instance.bindings.i18n.on('languageChanged', updateLanguage);
+        const unsubscribeLanguage = () =>
+          instance.bindings?.i18n.off('languageChanged', updateLanguage);
+        resolve(unsubscribeLanguage);
 
-          instance.initialize?.();
-        })
-        .catch((error) => {
-          instance.error = error;
-          reject(error);
-        });
-    }
+        instance.initialize?.();
+      })
+      .catch((error) => {
+        instance.error = error;
+        reject(error);
+      });
   });
 }
 

--- a/packages/atomic/src/mixins/bindings-mixin.ts
+++ b/packages/atomic/src/mixins/bindings-mixin.ts
@@ -14,22 +14,24 @@ function initializeBindings<
     InitializableComponent<SpecificBindings>,
 >(instance: InstanceType): Promise<() => void> {
   return new Promise((resolve, reject) => {
-    fetchBindings<SpecificBindings>(instance)
-      .then((bindings) => {
-        instance.bindings = bindings;
+    if (!instance.initialized && instance.bindings) {
+      fetchBindings<SpecificBindings>(instance)
+        .then((bindings) => {
+          instance.bindings = bindings;
 
-        const updateLanguage = () => instance.requestUpdate();
-        instance.bindings.i18n.on('languageChanged', updateLanguage);
-        const unsubscribeLanguage = () =>
-          instance.bindings?.i18n.off('languageChanged', updateLanguage);
-        resolve(unsubscribeLanguage);
+          const updateLanguage = () => instance.requestUpdate();
+          instance.bindings.i18n.on('languageChanged', updateLanguage);
+          const unsubscribeLanguage = () =>
+            instance.bindings?.i18n.off('languageChanged', updateLanguage);
+          resolve(unsubscribeLanguage);
 
-        instance.initialize?.();
-      })
-      .catch((error) => {
-        instance.error = error;
-        reject(error);
-      });
+          instance.initialize?.();
+        })
+        .catch((error) => {
+          instance.error = error;
+          reject(error);
+        });
+    }
   });
 }
 


### PR DESCRIPTION
This PR adds a decorator to provide bindings to component, using @lit/context.

The `InitializeBindingsMixin` mixin should still be used until all the interfaces have been converted to lit, as the interface needs to provide the bindings with the @provide decorator:

```typescript
  @state()
  @provide({context: bindingsContext})
  public bindings: CommerceBindings = {} as CommerceBindings;
```

To use the decorator, add it to the component class:

```typescript
@customElement('atomic-icon')
@bindings()
export class AtomicIcon
  extends TailwindLitElement
  implements InitializableComponent<AnyBindings>
{
```
