### PR TITLE
fix(atomic): fix class title and overflow when message is too long

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
@@ -431,12 +431,12 @@ export class GeneratedAnswerCommon {
           <Heading
             level={0}
             part="header-label"
-            class="text-bg-primary inline-block rounded-md px-2.5 py-2 font-medium"
+            class="text-primary bg-primary-background inline-block rounded-md px-2.5 py-2 font-medium"
           >
             {i18n.t('generated-answer-title')}
           </Heading>
         </div>
-        <div part="generated-container" class="mt-6">
+        <div part="generated-container" class="mt-6 break-words">
           <slot name="no-answer-message"></slot>
         </div>
       </div>


### PR DESCRIPTION
[SVCC-4799](https://coveord.atlassian.net/browse/SVCC-4799) and also the bug fix for text overflow is included in this PR


**Before:**

![Screenshot 2025-03-04 at 2 11 52 PM](https://github.com/user-attachments/assets/f8bb9a3c-04ee-4555-b03c-8897f90a4c2b)

![Screenshot 2025-03-04 at 2 15 08 PM](https://github.com/user-attachments/assets/e6bf0ef0-d15e-48ed-a45a-f64d05a23311)


**After:**

![Screenshot 2025-03-04 at 2 13 34 PM](https://github.com/user-attachments/assets/b64682a2-ab59-47f2-852e-1e668d2c4107)

![Screenshot 2025-03-04 at 2 27 47 PM](https://github.com/user-attachments/assets/03f116d3-dba9-444b-9e8c-6ccce88bd0ad)

