### PR TITLE
chore(atomic): use nothing instead of undefined for functional components

### DIFF
--- a/packages/atomic/src/components/common/load-more/button.ts
+++ b/packages/atomic/src/components/common/load-more/button.ts
@@ -1,6 +1,6 @@
 import {FunctionalComponent} from '@/src/utils/functional-component-utils';
 import {i18n} from 'i18next';
-import {html} from 'lit';
+import {html, nothing} from 'lit';
 import {button, ButtonProps} from '../button';
 
 interface LoadMoreButtonProps {
@@ -15,7 +15,7 @@ export const loadMoreButton: FunctionalComponent<LoadMoreButtonProps> = ({
 }) => {
   const {i18n, onClick, moreAvailable, label} = props;
   if (!moreAvailable) {
-    return;
+    return nothing;
   }
   const buttonProps: ButtonProps = {
     style: 'primary',

--- a/packages/atomic/src/utils/functional-component-utils.ts
+++ b/packages/atomic/src/utils/functional-component-utils.ts
@@ -1,7 +1,7 @@
-import {TemplateResult} from 'lit';
+import {nothing, TemplateResult} from 'lit';
 
 export interface FunctionalComponent<T> {
-  ({props}: {props: T}): TemplateResult | undefined;
+  ({props}: {props: T}): TemplateResult | typeof nothing;
 }
 
 export interface FunctionalComponentWithChildren<T> {
@@ -13,6 +13,6 @@ export interface FunctionalComponentWithChildren<T> {
     children:
       | TemplateResult
       | TemplateResult[]
-      | (TemplateResult | undefined)[];
+      | (TemplateResult | typeof nothing)[];
   }): TemplateResult;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4033

From the lit doc

> Prefer using nothing over other falsy values as it provides a consistent behavior between various expression binding contexts.
> 
> In child expressions, undefined, null, '', and nothing all behave the same and render no nodes. In attribute expressions, nothing removes the attribute, while undefined and null will render an empty string. In property expressions nothing becomes undefined.

