### PR TITLE
fix(atomic): fix generated answer scrollable table overflow when table too small

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerContent/templates/generatedMarkdownContent.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerContent/templates/generatedMarkdownContent.css
@@ -108,6 +108,7 @@ blockquote {
   max-height: 24rem;
   border-color: var(--quantic-genqa-border-neutral-dim);
   border-radius: var(--quantic-genqa-border-radius);
+  max-width: 100%;
 }
 
 .scrollable-table th {


### PR DESCRIPTION
After some trials, I found that adding this small style to the `.scrollable-table` fix the overflow issue without changing the table style when it is bigger.

https://coveord.atlassian.net/browse/SVCC-4598
