### PR TITLE
chore: remove mentions of release:phase4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,18 +199,3 @@ jobs:
         run: npm run notify:docs
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  # TODO KIT-3074 Fix the publication into the GitHub Packages, and uncomment
-  # github-prod:
-  #   needs: release
-  #   runs-on: ubuntu-latest
-  #   environment: 'GitHub Production'
-  #   steps:
-  #     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-  #       with:
-  #         registry-url: 'https://npm.pkg.github.com'
-  #         node-version-file: '.nvmrc'
-  #     - name: Publish to GitHub Packages
-  #       run: npm run release:phase4
-  #       env:
-  #         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         DEBUG: ${{ inputs.debug && '*' || '' }}

--- a/internal-docs/release-process.md
+++ b/internal-docs/release-process.md
@@ -94,13 +94,6 @@ This task will create a new "version bump" commit, which will contain:
 
 This task will also revert the changes from `release:phase0` to allow merging new features and fixes.
 
-## `release:phase4` (publish to GitHub Packages)
-
-> [!WARNING]
-> Currently disabled.
-
-This task will do the same thing as `release:phase1`, sub-phase 3, but is intended to publish the NPM package to GitHub Packages instead.
-
 # Deploying
 
 > [!NOTE]

--- a/nx.json
+++ b/nx.json
@@ -110,12 +110,6 @@
         "cwd": "{projectRoot}"
       }
     },
-    "release:phase4": {
-      "dependsOn": ["^release:phase4"],
-      "//": "Currently disabled TODO KIT-3074",
-      "executor": "nx:noop",
-      "options": {"script": "publish:bump"}
-    },
     "cached:build:stencil": {
       "cache": true
     },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "release:phase0": "npm run-script -w=@coveo/release git-lock",
     "release:phase1": "nx run-many --targets=release:phase1 --all --parallel=false --output-style=stream; npm run-script -w=@coveo/release bump:root",
     "release:phase2": "npm run-script -w=@coveo/release reify",
-    "release:phase3": "npm run-script -w=@coveo/release git-publish-all",
-    "release:phase4": "nx run-many --targets=release:phase4 --all"
+    "release:phase3": "npm run-script -w=@coveo/release git-publish-all"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4034

This phase was github packages and we are not doing that from now on https://coveord.atlassian.net/browse/KIT-3074 was rejected.
