### PR TITLE
ci: create new release phase for bumping the root package.json version

### DIFF
--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -37,8 +37,8 @@ jobs:
         run: |
           npm run nx:graph
           npm run release:phase1
-          npm run release:phase2
           npm run release:phase3
+          npm run release:phase4
         env:
           DEBUG: '*'
           IS_PRERELEASE: 'true'

--- a/internal-docs/release-process.md
+++ b/internal-docs/release-process.md
@@ -67,13 +67,17 @@ This task does not make any changes to the `package-lock.json` file at the root 
 
 The purpose of this sub-phase is to re-build a project right after it was bumped and before it gets published. This is needed because many packages contain information about their own version in their compiled code.
 
-## `release:phase2` (publish npm)
+## `release:phase2` (bump the root version)
+
+This phase bumps the root package.json version. This is used by the deployment-package `--version` attribute.
+
+## `release:phase3` (publish npm)
 
 This workflow works on the assumption that we can't bump a package's version if any of its dependencies isn't published to NPM. The purpose of this task is to publish packages to NPM before dependant packages bump their versions.
 
 If a package is already published to NPM, this task will exit without error. After a package is published, this task will repeatedly query NPM until it confirms that the package exists in the registry.
 
-## `release:phase3` (reify `package-lock.json`)
+## `release:phase4` (reify `package-lock.json`)
 
 This task is run once at the root of the repository after every package's version was bumped.
 
@@ -81,7 +85,7 @@ The purpose of this task is to re-generate the root `package-lock.json` file usi
 
 Scheduled releases will commit the new `package-lock.json` to the main branch, which ensures that contributors can run `npm install` without unnecessary changes being made to their `package-lock.json`.
 
-## `release:phase4` (commit version bumps)
+## `release:phase5` (commit version bumps)
 
 This task is only run for the scheduled release.
 

--- a/nx.json
+++ b/nx.json
@@ -106,8 +106,8 @@
         "cwd": "{projectRoot}"
       }
     },
-    "release:phase2": {
-      "dependsOn": ["^release:phase2"],
+    "release:phase3": {
+      "dependsOn": ["^release:phase3"],
       "executor": "nx:run-commands",
       "options": {
         "commands": ["npm run publish:npm"],

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "pre-commit": "lint-staged",
     "promote:npm:latest": "nx run-many --target=promote:npm:latest",
     "notify:docs": "node ./scripts/notify-docs/published-ui-kit.mjs",
-    "release": "npm run nx:graph && npm run release:phase0 && npm run release:phase1 && npm run release:phase2 && npm run release:phase3 && npm run release:phase4",
+    "release": "npm run nx:graph && npm run release:phase0 && npm run release:phase1 && npm run release:phase2 && npm run release:phase3 && npm run release:phase4 && npm run release:phase5",
     "nx:graph": "nx graph --file=topology.json",
     "release:phase0": "npm run-script -w=@coveo/release git-lock",
-    "release:phase1": "nx run-many --targets=release:phase1 --all --parallel=false --output-style=stream; npm run-script -w=@coveo/release bump:root",
-    "release:phase2": "nx run-many --targets=release:phase2 --all --parallel=false --output-style=stream",
-    "release:phase3": "npm run-script -w=@coveo/release reify",
-    "release:phase4": "npm run-script -w=@coveo/release git-publish-all"
+    "release:phase1": "nx run-many --targets=release:phase1 --all --parallel=false --output-style=stream",
+    "release:phase2": "npm run-script -w=@coveo/release bump:root",
+    "release:phase3": "nx run-many --targets=release:phase3 --all --parallel=false --output-style=stream",
+    "release:phase4": "npm run-script -w=@coveo/release reify",
+    "release:phase5": "npm run-script -w=@coveo/release git-publish-all"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",

--- a/packages/atomic-angular/project.json
+++ b/packages/atomic-angular/project.json
@@ -6,7 +6,7 @@
   },
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "outputs": ["{projectRoot}/projects/atomic-angular/dist"],
       "dependsOn": ["^build"],

--- a/packages/atomic-hosted-page/project.json
+++ b/packages/atomic-hosted-page/project.json
@@ -9,7 +9,7 @@
   },
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "dependsOn": ["^build"],
       "inputs": ["^production", "production"],

--- a/packages/atomic-react/project.json
+++ b/packages/atomic-react/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "dependsOn": ["^build", "clean"],
       "executor": "nx:run-commands",

--- a/packages/atomic/project.json
+++ b/packages/atomic/project.json
@@ -54,7 +54,7 @@
       }
     },
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "build": {
       "dependsOn": [
         "cached:build:stencil",

--- a/packages/auth/project.json
+++ b/packages/auth/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/bueno/project.json
+++ b/packages/bueno/project.json
@@ -11,7 +11,7 @@
   },
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "executor": "nx:run-commands",
       "outputs": [

--- a/packages/headless-react/project.json
+++ b/packages/headless-react/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/headless/project.json
+++ b/packages/headless/project.json
@@ -10,7 +10,7 @@
   },
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "outputs": [
         "{projectRoot}/dist",

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -11,7 +11,7 @@
   },
   "targets": {
     "release:phase1": {},
-    "release:phase2": {},
+    "release:phase3": {},
     "cached:build": {
       "outputs": [
         "{projectRoot}/docs/out",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4036

This is needed since we should not bump the root package.json when deploying the CDN to dev on each commit. It should stay the same. It was impossible since it was part of phase2.