### PR TITLE
feat(quantic): POC: supporting result templates with document suggestions

### DIFF
--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -118,3 +118,4 @@ export type {
 
 // Features
 export {ResultTemplatesHelpers} from './features/result-templates/result-templates-helpers.js';
+export {buildResultTemplatesManager} from './features/result-templates/result-templates-manager.js';

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticCaseClassification/exampleQuanticCaseClassification.html
@@ -17,7 +17,7 @@
     </c-configurator>
 
     <c-quantic-case-assist-interface
-      case-assist-id={caseAssistId}
+      case-assist-id="dea4aeba-3023-4709-bf21-113527ca31df"
       engine-id={config.engineId}
       search-hub="test origin"
       slot="preview"

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.html
@@ -4,13 +4,14 @@
       <c-action-fetch-suggestions slot="actions" disabled={notConfigured} engine-id={config.engineId}>
       </c-action-fetch-suggestions>
     </c-configurator>
-
-    <c-quantic-case-assist-interface case-assist-id={caseAssistId} engine-id={config.engineId} search-hub="test origin" slot="preview">
-      <c-quantic-document-suggestion engine-id={config.engineId} search-engine-id={config.searchEngineId}
-        max-documents={config.maxDocuments} fetch-on-init={config.fetchOnInit} without-quickview={config.withoutQuickview}
-        number-of-auto-opened-documents={config.numberOfAutoOpenedDocuments}>
-        <c-action-send-rating slot="actions"></c-action-send-rating>
-      </c-quantic-document-suggestion>
-    </c-quantic-case-assist-interface>
+    <div slot="preview" onquantic__registerresulttemplates={handleResultTemplateRegistration}>
+      <c-quantic-case-assist-interface case-assist-id="dea4aeba-3023-4709-bf21-113527ca31df" engine-id={config.engineId} search-hub="test origin">
+        <c-quantic-document-suggestion engine-id={config.engineId} search-engine-id={config.searchEngineId}
+          max-documents={config.maxDocuments} fetch-on-init={config.fetchOnInit} without-quickview={config.withoutQuickview}
+          number-of-auto-opened-documents={config.numberOfAutoOpenedDocuments}>
+          <c-action-send-rating slot="actions"></c-action-send-rating>
+        </c-quantic-document-suggestion>
+      </c-quantic-case-assist-interface>
+    </div>
   </c-example-layout>
 </template>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/exampleQuanticDocumentSuggestion.js
@@ -1,6 +1,8 @@
 // @ts-ignore
 import {getCaseAssistId} from 'c/caseAssistUtils';
 import {LightningElement, track} from 'lwc';
+// @ts-ignore
+import knowledgeTemplate from './templates/knowldgeTemplate.html';
 
 export default class ExampleQuanticDocumentSuggestion extends LightningElement {
   @track config = {};
@@ -57,5 +59,23 @@ export default class ExampleQuanticDocumentSuggestion extends LightningElement {
     this.caseAssistId = await getCaseAssistId('Demo');
     this.config = evt.detail;
     this.isConfigured = true;
+  }
+
+  handleResultTemplateRegistration(event) {
+    event.stopPropagation();
+
+    const resultTemplatesManager = event.detail;
+
+    const isKnowledge =
+      CoveoHeadlessCaseAssist.ResultTemplatesHelpers.fieldMustMatch(
+        'objecttype',
+        ['Knowledge']
+      );
+
+    resultTemplatesManager.registerTemplates({
+      content: knowledgeTemplate,
+      conditions: [isKnowledge],
+      fields: ['sfstatus', 'sfcasestatus', 'sfcasenumber'],
+    });
   }
 }

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/templates/knowldgeTemplate.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticDocumentSuggestion/templates/knowldgeTemplate.html
@@ -1,0 +1,35 @@
+<template>
+  <c-quantic-result-template is-any-preview-open={isAnyPreviewOpen} hide-border
+    result-preview-should-not-be-accessible={resultPreviewShouldNotBeAccessible}>
+    <div slot="label" class="slds-grid slds-grid_vertical-align-center">
+      <div class="slds-m-right_xx-small">
+        <c-quantic-result-label result={result}></c-quantic-result-label>
+      </div>
+    </div>
+    <div slot="badges" class="slds-grid slds-grid_vertical-align-center">
+      <div class="slds-m-right_xx-small">
+        <c-quantic-result-tag variant="recommended" result={result}></c-quantic-result-tag>
+      </div>
+      <c-quantic-result-tag variant="featured" result={result}></c-quantic-result-tag>
+    </div>
+    <template if:true={resultHasPreview}>
+      <c-quantic-result-quickview slot="actions" engine-id={engineId} result={result}></c-quantic-result-quickview>
+    </template>
+    <p slot="date" class="slds-size_xx-small">
+      <lightning-formatted-date-time value={result.raw.date}></lightning-formatted-date-time>
+    </p>
+    <div slot="title" class="slds-truncate">
+      <span class="slds-m-left_xx-small">
+        <c-quantic-result-link result={result} engine-id={engineId}></c-quantic-result-link>
+      </span>
+    </div>
+    <div slot="excerpt">
+      <c-quantic-result-highlighted-text-field engine-id={engineId} result={result}
+        field="excerpt"></c-quantic-result-highlighted-text-field>
+    </div>
+    <div slot="bottom-metadata" class="slds-m-top_x-small">
+      <c-quantic-result-printable-uri engine-id={engineId} result={result}
+        max-number-of-parts="3"></c-quantic-result-printable-uri>
+    </div>
+  </c-quantic-result-template>
+</template>

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.html
@@ -25,17 +25,9 @@
                       slds-var-p-horizontal_large
                       slds-var-p-vertical_x-small
                     ">
-                    <p class="excerpt">{it.value.excerpt}</p>
-                    <div class="row slds-var-p-top_medium">
-                      <template lwc:if={quickviewIsVisible}>
-                        <c-quantic-result-quickview engine-id={engineId}
-                          preview-button-icon="utility:new_window" preview-button-label={labels.readMore}
-                          preview-button-variant="outline-brand" result={it.value}>
-                          <slot slot="footer" name="quickview-footer" data-doc-id={it.value.uniqueId}></slot>
-                        </c-quantic-result-quickview>
-                      </template>
-                      <slot name="actions" data-doc-id={it.value.uniqueId}></slot>
-                    </div>
+                    <c-quantic-result engine-id={engineId} result={it.value}
+                      result-templates-manager={resultTemplatesManager} without-quickview={withoutQuickview}></c-quantic-result>
+                    <slot name="actions" data-doc-id={it.value.uniqueId}></slot>
                   </div>
                 </div>
               </lightning-accordion-section>

--- a/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticDocumentSuggestion/quanticDocumentSuggestion.js
@@ -106,6 +106,10 @@ export default class QuanticDocumentSuggestion extends LightningElement {
       this.updateDocumentSuggestionState()
     );
 
+    this.resultTemplatesManager =
+      CoveoHeadlessCaseAssist.buildResultTemplatesManager(engine);
+    this.registerTemplates();
+
     this.actions = {
       ...CoveoHeadlessCaseAssist.loadCaseAssistAnalyticsActions(engine),
       ...CoveoHeadlessCaseAssist.loadDocumentSuggestionActions(engine),
@@ -132,6 +136,15 @@ export default class QuanticDocumentSuggestion extends LightningElement {
       this.initializationErrorMessage =
         this.labels.invalidNumberOfAutoOpenedDocuments;
     }
+  }
+
+  registerTemplates() {
+    this.dispatchEvent(
+      new CustomEvent('quantic__registerresulttemplates', {
+        bubbles: true,
+        detail: this.resultTemplatesManager,
+      })
+    );
   }
 
   updateDocumentSuggestionState() {

--- a/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResult/quanticResult.js
@@ -56,6 +56,13 @@ export default class QuanticResult extends LightningElement {
    * @type {string}
    */
   @api openPreviewId;
+  /**
+   * Whether or not we want to hide the quick view for the result.
+   * @api
+   * @type {boolean}
+   * @defaultValue `false`
+   */
+  @api withoutQuickview = false;
 
   @track resultHasPreview = true;
 
@@ -100,7 +107,7 @@ export default class QuanticResult extends LightningElement {
   }
 
   onHasPreview = (evt) => {
-    this.resultHasPreview = evt.detail.hasPreview;
+    this.resultHasPreview = !this.withoutQuickview && evt.detail.hasPreview;
     evt.stopPropagation();
   };
 


### PR DESCRIPTION
## https://coveord.atlassian.net/browse/SFINT-5976


This is a POC demonstrating how we could improve the Quantic Document suggestion component to make it support more UI flexibility by allowing the end user to register result templates, similarly to what's currently possible in the Search use case, these result templates will then be used to display the document suggestions.

Adding templates for document suggestion can be done following these steps:

- Add an event listener to listen to the `quantic__registerresulttemplates` event in the component that wraps the QuanticDocumentSuggestion component.
- In that event listener, use the Headless `ResultTemplatesHelpers ` utility to register HTML templates that will be used to display document suggestions when certain conditions are met.


## Example Usage:

#### ExampleCaseAssistFlow.html
![image](https://github.com/user-attachments/assets/824237cc-dcfe-4a01-abfb-b1ccc2929607)

#### ExampleCaseAssistFlow.js
![image](https://github.com/user-attachments/assets/1eaa8c29-1dd7-4a4c-8e53-8c9774349a7b)

#### knowldgeTemplate.html
![image](https://github.com/user-attachments/assets/daa879ac-75b0-4ef8-84ba-5cd7cce49de0)



## Demo:

https://github.com/user-attachments/assets/57e76bb9-7c1a-4095-98cc-dd117b4ce3b9

