### PR TITLE
fix(quantic): failing playwright tests for facet manager in quantic

### DIFF
--- a/packages/quantic/playwright/page-object/searchObject.ts
+++ b/packages/quantic/playwright/page-object/searchObject.ts
@@ -66,9 +66,9 @@ export class SearchObject {
         }
       });
 
-      await route.continue({
-        method: 'POST',
-        postData: JSON.stringify({
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
           ...originalBody,
           facets: reorderedFacets,
         }),


### PR DESCRIPTION
[SFINT-6040](https://coveord.atlassian.net/browse/SFINT-6040)

## ISSUE:

The search response was not properly overriden so it was not properly setting the facet order in the response and therefore was ordering facets with the default ordering.

## SOLUTION: 

Instead of using `route.continue` to override, we now use `route.fullfill` in the mocked search response
The tests now pass without flakyness (locally)

## TESTS:

<img width="669" alt="image" src="https://github.com/user-attachments/assets/a7e07406-f305-43c3-847f-927f8a87aba5" />

## DEMO With fulfill passing and continue failing:

https://github.com/user-attachments/assets/565af54f-86c6-4c3d-af9a-01cd748e6dd3



[SFINT-6040]: https://coveord.atlassian.net/browse/SFINT-6040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ