### PR TITLE
fix(atomic): fix overflowing tables in generated answer components

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.pcss
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.pcss
@@ -61,7 +61,7 @@
   }
 
   [part='answer-table-container'] {
-    @apply border-neutral-dim mb-6 inline-block max-h-96 overflow-auto rounded-md border border-solid;
+    @apply border-neutral-dim mb-6 inline-block max-h-96 max-w-full overflow-auto rounded-md border border-solid;
 
     [part='answer-table-header'] {
       @apply sticky top-0;


### PR DESCRIPTION
fix overflowing tables on small screens in generated answer components

Before:
<img src="https://github.com/user-attachments/assets/e842777e-ae3d-4b44-8893-e639ff3f251f" width="300"/>

After:
![image](https://github.com/user-attachments/assets/608aa2d2-4dde-491c-8ddf-9a610f3ad207)

[SVCC-4598](https://coveord.atlassian.net/browse/SVCC-4598)

[SVCC-4598]: https://coveord.atlassian.net/browse/SVCC-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ