### PR TITLE
ci: fix failing quantic:release:phase1 during prerelease

### DIFF
--- a/.github/workflows/masterbot.yml
+++ b/.github/workflows/masterbot.yml
@@ -40,5 +40,4 @@ jobs:
           npm run release:phase3
           npm run release:phase4
         env:
-          DEBUG: '*'
           IS_PRERELEASE: 'true'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4049

Disabling DEBUG in that command will fix the failing prerelease since quantic won't have to print over `80mb` of text during it's build:doc phase 😆 . I am not sure why but it ends up exiting before the text can print. Not sure why but we definitely don't need to enable DEBUG for this.

I tested it with a custom github action and confirmed it was passing without `DEBUG: '*'` and was failing with it.