### PR TITLE
chore: revert auto merge all dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,17 +9,8 @@
   "packageRules": [
     {
       "groupName": "all dependencies",
-      "groupSlug": "all-safe",
-      "matchPackageNames": ["*"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "groupName": "all dependencies (major)",
-      "groupSlug": "all-major",
-      "matchPackageNames": ["*"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false
+      "groupSlug": "all",
+      "matchPackageNames": ["*"]
     },
     {
       "groupName": "typedoc",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-282

The reason for this is that currently, [renovate groups a patch of tailwindcss with the major-all PR](https://github.com/coveo/ui-kit/pull/5057). I suspect that the current groups are the root cause. I put it back to how it was.


Anyway, the automerge stuff was not working and it seems like there is more setup needed to do on the Coveo side to enable this. We can do it properly another time.
