### PR TITLE
feat(atomic): localize tab name & label

### DIFF
--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.spec.tsx
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.spec.tsx
@@ -1,0 +1,47 @@
+import {newSpecPage} from '@stencil/core/testing';
+import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
+import {AtomicTabManager} from './atomic-tab-manager';
+
+describe('atomic-tab-manager', () => {
+  let bindings: Bindings;
+
+  beforeEach(() => {
+    bindings = {
+      i18n: {
+        t: jest.fn((key, options) => options?.defaultValue || key),
+      },
+    } as unknown as Bindings;
+  });
+
+  it('should localize the label parameter using bindings.i18n.t', async () => {
+    const page = await newSpecPage({
+      components: [AtomicTabManager],
+      html: '<atomic-tab-manager><atomic-tab label="test-label" name="test-name"></atomic-tab></atomic-tab-manager>',
+      supportsShadowDom: false,
+    });
+
+    const component = page.rootInstance as AtomicTabManager;
+    component.bindings = bindings;
+    component.initialize();
+
+    expect(bindings.i18n.t).toHaveBeenCalledWith('test-label', {
+      defaultValue: 'test-label',
+    });
+  });
+
+  it('should localize the name parameter using bindings.i18n.t', async () => {
+    const page = await newSpecPage({
+      components: [AtomicTabManager],
+      html: '<atomic-tab-manager><atomic-tab label="test-label" name="test-name"></atomic-tab></atomic-tab-manager>',
+      supportsShadowDom: false,
+    });
+
+    const component = page.rootInstance as AtomicTabManager;
+    component.bindings = bindings;
+    component.initialize();
+
+    expect(bindings.i18n.t).toHaveBeenCalledWith('test-name', {
+      defaultValue: 'test-name',
+    });
+  });
+});

--- a/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.tsx
+++ b/packages/atomic/src/components/search/tabs/atomic-tab-manager/atomic-tab-manager.tsx
@@ -77,8 +77,12 @@ export class AtomicTabManager {
       });
 
       this.tabs.push({
-        label: tabElement.label,
-        name: tabElement.name,
+        label: this.bindings.i18n.t(tabElement.label, {
+          defaultValue: tabElement.label,
+        }),
+        name: this.bindings.i18n.t(tabElement.name, {
+          defaultValue: tabElement.name,
+        }),
         tabController,
       });
     });


### PR DESCRIPTION
Adapt the `atomic-tab-manager.tsx` component to use the i18n library for localization of the `label` and `name` parameters.

* Update the `label` and `name` properties to use `this.bindings.i18n.t` for localization.
* Add a new test file `atomic-tab-manager.spec.tsx` to check if the `label` and `name` parameters are localized using `bindings.i18n.t`.


https://coveord.atlassian.net/browse/KIT-4051

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coveo/ui-kit/pull/5071?shareId=d7b4bdc1-b90a-48ba-bffd-f069c24e16cf).