### PR TITLE
chore(atomic): fix flaky theming smoke tests

### DIFF
--- a/packages/atomic/dev/tests/smoke.spec.ts
+++ b/packages/atomic/dev/tests/smoke.spec.ts
@@ -89,7 +89,7 @@ test.describe('theme customization', () => {
       .getByText(/Results 1-10 of \d*/)
       .first()
       .waitFor();
-    await searchBox.fill('connect');
+    await searchBox.fill('connect.coveo.com');
     await searchBox.press('Enter');
     const resultTitle = page
       .locator('atomic-result')

--- a/packages/atomic/dev/tests/smoke.spec.ts
+++ b/packages/atomic/dev/tests/smoke.spec.ts
@@ -81,6 +81,22 @@ test.describe('style encapsulation', () => {
 test.describe('theme customization', () => {
   test.beforeEach(async ({page}) => {
     await page.goto('http://localhost:3333/themingTests.html');
+    const searchBox = page.getByRole('textbox', {
+      name: 'Search field with suggestions',
+    });
+    await page
+      .locator('atomic-query-summary')
+      .getByText(/Results 1-10 of \d*/)
+      .first()
+      .waitFor();
+    await searchBox.fill('connect');
+    await searchBox.press('Enter');
+    const resultTitle = page
+      .locator('atomic-result')
+      .first()
+      .locator('atomic-result-section-title atomic-result-text')
+      .first();
+    await expect(resultTitle).toHaveText('Connect');
     await page
       .locator('atomic-query-summary')
       .getByText(/Results 1-10 of \d*/)

--- a/packages/atomic/dev/tests/smoke.spec.ts
+++ b/packages/atomic/dev/tests/smoke.spec.ts
@@ -97,11 +97,6 @@ test.describe('theme customization', () => {
       .locator('atomic-result-section-title atomic-result-text')
       .first();
     await expect(resultTitle).toHaveText('Connect');
-    await page
-      .locator('atomic-query-summary')
-      .getByText(/Results 1-10 of \d*/)
-      .first()
-      .waitFor();
   });
 
   const outsideResultTemplateTests = [


### PR DESCRIPTION
Some of the theming smoke tests where failing due to source changes. Added a query so that the results are always the same (connect.coveo.com).

https://coveord.atlassian.net/browse/KIT-4052
