### PR TITLE
chore: isolate tailwind dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62514,7 +62514,7 @@
         "rollup-plugin-html": "0.2.1",
         "shadow-dom-testing-library": "1.11.3",
         "storybook": "8.1.2",
-        "tailwindcss": "4.0.7",
+        "tailwindcss": "4.0.8",
         "ts-dedent": "2.2.0",
         "ts-lit-plugin": "2.0.2",
         "ts-node": "10.9.2",
@@ -63585,13 +63585,6 @@
         "vite": "^5.2.0 || ^6"
       }
     },
-    "packages/atomic/node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.8.tgz",
-      "integrity": "sha512-Me7N5CKR+D2A1xdWA5t5+kjjT7bwnxZOE6/yDI/ixJdJokszsn2n++mdU5yJwrsTpqFX2B9ZNMBJDwcqk9C9lw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/atomic/node_modules/@types/jest": {
       "version": "29.5.12",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
@@ -63718,9 +63711,9 @@
       }
     },
     "packages/atomic/node_modules/tailwindcss": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.7.tgz",
-      "integrity": "sha512-yH5bPPyapavo7L+547h3c4jcBXcrKwybQRjwdEIVAd9iXRvy/3T1CC6XSQEgZtRySjKfqvo3Cc0ZF1DTheuIdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.8.tgz",
+      "integrity": "sha512-Me7N5CKR+D2A1xdWA5t5+kjjT7bwnxZOE6/yDI/ixJdJokszsn2n++mdU5yJwrsTpqFX2B9ZNMBJDwcqk9C9lw==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -144,7 +144,7 @@
     "rollup-plugin-html": "0.2.1",
     "shadow-dom-testing-library": "1.11.3",
     "storybook": "8.1.2",
-    "tailwindcss": "4.0.7",
+    "tailwindcss": "4.0.8",
     "ts-dedent": "2.2.0",
     "ts-lit-plugin": "2.0.2",
     "ts-node": "10.9.2",

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,17 @@
       "matchPackageNames": ["/typedoc/"]
     },
     {
+      "groupName": "tailwind",
+      "groupSlug": "tailwind",
+      "rangeStrategy": "replace",
+      "description": "Isolate tailwind for breaking changes",
+      "matchPackageNames": [
+        "tailwindcss",
+        "@tailwindcss/postcss",
+        "@tailwindcss/vite"
+      ]
+    },
+    {
       "groupName": "typescript",
       "groupSlug": "typescript",
       "rangeStrategy": "replace",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-282

Currently this [all-dependencies renovate](https://github.com/coveo/ui-kit/pull/5068) PR is failing because there some problems with newer versions of tailwind.
Also, the [major update one](https://github.com/coveo/ui-kit/pull/5069) is grouping tailwind with it even though it is a patch. Don't know why. Isolating it makes it easier.

I also updated `tailwindcss` to match `@tailwindcss/vite` & `@tailwindcss/postcss.` With this they would all be 4.0.8.