### PR TITLE
fix(atomic): Fix for the label_name_visible from the IBM a11y checker

### DIFF
--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.tsx
@@ -18,7 +18,7 @@ export const FacetValueCheckbox: FunctionalComponent<
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
   const ariaLabelAttributes = {
     value: props.displayValue,
-    count: props.numberOfResults,
+    count,
     interpolation: {escapeValue: false},
   };
   const selectedAriaLabel = props.i18n.t('facet-value', ariaLabelAttributes);

--- a/packages/atomic/src/components/search/facets/color-facet-checkbox/color-facet-checkbox.tsx
+++ b/packages/atomic/src/components/search/facets/color-facet-checkbox/color-facet-checkbox.tsx
@@ -11,7 +11,7 @@ export const ColorFacetCheckbox: FunctionalComponent<FacetValueProps> = (
   const count = props.numberOfResults.toLocaleString(props.i18n.language);
   const ariaLabel = props.i18n.t('facet-value', {
     value: props.displayValue,
-    count: props.numberOfResults,
+    count,
   });
   const partValue = props.displayValue
     .match(new RegExp('-?[_a-zA-Z]+[_a-zA-Z0-9-]*'))


### PR DESCRIPTION
IBM Accessibility checker reports following violation "_Accessible name does not match or contain the visible label text_"  due to mismatch between aria-label and what is inside the label tag, so numbers in both places needs to be exact the same.

![OsV9upEXTp](https://github.com/user-attachments/assets/5e8dc9eb-2ff6-4cbd-bbdf-de27ccb083e8)
![VAWYebpHCv](https://github.com/user-attachments/assets/90ae6911-5bec-4059-b9e9-770685270fb6)
