### PR TITLE
feat(headless): Treat nav cookies as functional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9736,18 +9736,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@gerrit0/mini-shiki": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-oniguruma": "^1.27.2",
-        "@shikijs/types": "^1.27.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
-      }
-    },
     "node_modules/@github/catalyst": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.7.0.tgz",
@@ -18632,45 +18620,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.1.tgz",
-      "integrity": "sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "1.29.1",
-        "@shikijs/vscode-textmate": "^10.0.1"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.1.tgz",
-      "integrity": "sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/types/node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
-      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
       "dev": true,
       "license": "MIT"
     },
@@ -59398,29 +59347,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/typedoc": {
-      "version": "0.27.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.9.tgz",
-      "integrity": "sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^1.24.0",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.6.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
@@ -63784,7 +63710,7 @@
         "eslint-plugin-canonical": "4.18.0",
         "execa": "9.5.2",
         "ts-node": "10.9.2",
-        "typedoc": "0.27.9",
+        "typedoc": "0.28.0",
         "vitest": "3.0.6"
       },
       "engines": {
@@ -63811,7 +63737,7 @@
         "gts": "5.3.1",
         "publint": "0.3.6",
         "rimraf": "6.0.1",
-        "typedoc": "0.27.9",
+        "typedoc": "0.28.0",
         "typescript": "5.5.4",
         "vitest": "3.0.6"
       },
@@ -64220,6 +64146,57 @@
         "node": ">=12"
       }
     },
+    "packages/headless-react/node_modules/@gerrit0/mini-shiki": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
+      "integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.2.1",
+        "@shikijs/types": "^3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "packages/headless-react/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "packages/headless-react/node_modules/@shikijs/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "packages/headless-react/node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/headless-react/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "packages/headless-react/node_modules/@vitest/browser": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-2.1.9.tgz",
@@ -64519,6 +64496,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/headless-react/node_modules/typedoc": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.0.tgz",
+      "integrity": "sha512-UU+xxZXrpnUhEulBYRwY2afoYFC24J2fTFovOs3llj2foGShCoKVQL6cQCfQ+sBAOdiFn2dETpZ9xhah+CL3RQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.1",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.0 "
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
     "packages/headless-react/node_modules/vite": {
@@ -65088,6 +65089,57 @@
         "node": ">=12"
       }
     },
+    "packages/headless/node_modules/@gerrit0/mini-shiki": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
+      "integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.2.1",
+        "@shikijs/types": "^3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "packages/headless/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "packages/headless/node_modules/@shikijs/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "packages/headless/node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/headless/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "packages/headless/node_modules/@vitest/browser": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-2.1.9.tgz",
@@ -65394,6 +65446,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/headless/node_modules/typedoc": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.0.tgz",
+      "integrity": "sha512-UU+xxZXrpnUhEulBYRwY2afoYFC24J2fTFovOs3llj2foGShCoKVQL6cQCfQ+sBAOdiFn2dETpZ9xhah+CL3RQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.1",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.0 "
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
     "packages/headless/node_modules/vite": {

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -52,7 +52,7 @@
     "publint": "0.3.6",
     "rimraf": "6.0.1",
     "typescript": "5.5.4",
-    "typedoc": "0.27.9",
+    "typedoc": "0.28.0",
     "vitest": "3.0.6"
   },
   "peerDependencies": {

--- a/packages/headless-react/typedoc/package.json
+++ b/packages/headless-react/typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "devDependencies": {
-    "typedoc": "0.27.9"
+    "typedoc": "0.28.0"
   }
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -175,7 +175,7 @@
     "eslint-plugin-canonical": "4.18.0",
     "execa": "9.5.2",
     "ts-node": "10.9.2",
-    "typedoc": "0.27.9",
+    "typedoc": "0.28.0",
     "vitest": "3.0.6"
   },
   "engines": {

--- a/packages/headless/typedoc/lib/insertOneTrust.ts
+++ b/packages/headless/typedoc/lib/insertOneTrust.ts
@@ -1,3 +1,12 @@
+declare global {
+  interface Window {
+    TypeDoc: {
+      disableLocalStorage: () => void;
+      enableLocalStorage: () => void;
+    };
+  }
+}
+
 export function insertOneTrust() {
   document.addEventListener('DOMContentLoaded', () => {
     const areFunctionalCookiesEnabled = document.cookie
@@ -12,14 +21,9 @@ export function insertOneTrust() {
       if (settingsDiv) {
         (settingsDiv as HTMLElement).style.display = 'none';
       }
-
-      const itemsToDelete = [
-        'tsd-theme',
-        'filter-protected',
-        'filter-inherited',
-        'filter-external',
-      ];
-      itemsToDelete.forEach((item) => localStorage.removeItem(item));
+      window.TypeDoc.disableLocalStorage();
+    } else {
+      window.TypeDoc.enableLocalStorage();
     }
   });
 }

--- a/packages/headless/typedoc/package.json
+++ b/packages/headless/typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "devDependencies": {
-    "typedoc": "0.27.9"
+    "typedoc": "0.28.0"
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3964

Based on compliance for cookies, an update was made to TypeDoc to allow for disabling of local storage usage, and is contained in v0.28.0. This PR addresses the update to v0.28.0, and incorporates the change to disable local storage usage when functional cookies are disabled, respecting compliance requirements.

**Note:** Leveraging the `disableLocalStorage()` function clears the local storage, hence removing the manual step to do so.
