### PR TITLE
fix(headless): started logging a warning message when event protocol is used for coveo for service features

### DIFF
--- a/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
@@ -1,4 +1,5 @@
 import {getSampleEngineConfiguration} from '../engine-configuration.js';
+import {nextAnalyticsUsageWithServiceFeatureWarning} from '../engine.js';
 import {CaseAssistEngineConfiguration} from './case-assist-engine-configuration.js';
 import {
   buildCaseAssistEngine,
@@ -107,10 +108,7 @@ describe('buildCaseAssistEngine', () => {
 
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy).toHaveBeenCalledWith(
-          '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-            'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-            'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-            'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+          nextAnalyticsUsageWithServiceFeatureWarning
         );
       });
 

--- a/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
@@ -86,6 +86,43 @@ describe('buildCaseAssistEngine', () => {
       };
       expect(initEngine).toThrow();
     });
+
+    describe('the analytics mode', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('should log a warning when the case assist engine is used with the next analytics mode', () => {
+        options.configuration.analytics = {
+          analyticsMode: 'next',
+          trackingId: 'example_tracking_id',
+        };
+        initEngine();
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
+            'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
+            'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
+            'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+        );
+      });
+
+      it('should not log a warning when the case assist engine is used with the legacy analytics mode', () => {
+        options.configuration.analytics = {
+          analyticsMode: 'legacy',
+        };
+        initEngine();
+
+        expect(warnSpy).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
   it('passing an invalid case assist ID throws', () => {

--- a/packages/headless/src/app/case-assist-engine/case-assist-engine.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine.ts
@@ -15,6 +15,7 @@ import {
   CoreEngine,
   EngineOptions,
   ExternalEngineOptions,
+  warnIfUsingNextAnalyticsModeForServiceFeature,
 } from '../engine.js';
 import {buildLogger} from '../logger.js';
 import {buildThunkExtraArguments} from '../thunk-extra-arguments.js';
@@ -93,6 +94,9 @@ export function buildCaseAssistEngine(
   };
 
   const engine = buildEngine(augmentedOptions, thunkArguments);
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
 
   const {caseAssistId, locale, searchHub, proxyBaseUrl} = options.configuration;
 

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -413,15 +413,16 @@ class InvalidEngineConfiguration extends Error {
   }
 }
 
+export const nextAnalyticsUsageWithServiceFeatureWarning =
+  '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
+  'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
+  'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
+  'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol';
+
 export function warnIfUsingNextAnalyticsModeForServiceFeature(
   analyticsMode: 'next' | 'legacy'
 ) {
   if (analyticsMode === 'next') {
-    console.warn(
-      '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-        'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-        'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-        'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
-    );
+    console.warn(nextAnalyticsUsageWithServiceFeatureWarning);
   }
 }

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -412,3 +412,16 @@ class InvalidEngineConfiguration extends Error {
     this.name = 'InvalidEngineConfiguration';
   }
 }
+
+export function warnIfUsingNextAnalyticsModeForServiceFeature(
+  analyticsMode: 'next' | 'legacy'
+) {
+  if (analyticsMode === 'next') {
+    console.warn(
+      '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
+        'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
+        'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
+        'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+    );
+  }
+}

--- a/packages/headless/src/app/insight-engine/insight-engine.test.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.test.ts
@@ -90,6 +90,43 @@ describe('buildInsightEngine', () => {
       };
       expect(initEngine).toThrow();
     });
+
+    describe('the analytics mode', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('should log a warning when the case assist engine is used with the next analytics mode', () => {
+        options.configuration.analytics = {
+          analyticsMode: 'next',
+          trackingId: 'example_tracking_id',
+        };
+        initEngine();
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
+            'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
+            'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
+            'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+        );
+      });
+
+      it('should not log a warning when the case assist engine is used with the legacy analytics mode', () => {
+        options.configuration.analytics = {
+          analyticsMode: 'legacy',
+        };
+        initEngine();
+
+        expect(warnSpy).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
   it('passing an invalid insight ID throws', () => {

--- a/packages/headless/src/app/insight-engine/insight-engine.test.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.test.ts
@@ -102,7 +102,7 @@ describe('buildInsightEngine', () => {
         warnSpy.mockRestore();
       });
 
-      it('should log a warning when the case assist engine is used with the next analytics mode', () => {
+      it('should log a warning when the insight engine is used with the next analytics mode', () => {
         options.configuration.analytics = {
           analyticsMode: 'next',
           trackingId: 'example_tracking_id',
@@ -118,7 +118,7 @@ describe('buildInsightEngine', () => {
         );
       });
 
-      it('should not log a warning when the case assist engine is used with the legacy analytics mode', () => {
+      it('should not log a warning when the insight engine is used with the legacy analytics mode', () => {
         options.configuration.analytics = {
           analyticsMode: 'legacy',
         };

--- a/packages/headless/src/app/insight-engine/insight-engine.test.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.test.ts
@@ -1,4 +1,5 @@
 import {getSampleEngineConfiguration} from '../engine-configuration.js';
+import {nextAnalyticsUsageWithServiceFeatureWarning} from '../engine.js';
 import {
   buildInsightEngine,
   InsightEngine,
@@ -111,10 +112,7 @@ describe('buildInsightEngine', () => {
 
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy).toHaveBeenCalledWith(
-          '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-            'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-            'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-            'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+          nextAnalyticsUsageWithServiceFeatureWarning
         );
       });
 

--- a/packages/headless/src/app/insight-engine/insight-engine.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.ts
@@ -21,6 +21,7 @@ import {
   CoreEngine,
   EngineOptions,
   ExternalEngineOptions,
+  warnIfUsingNextAnalyticsModeForServiceFeature,
 } from '../engine.js';
 import {InsightThunkExtraArguments} from '../insight-thunk-extra-arguments.js';
 import {buildLogger} from '../logger.js';
@@ -114,6 +115,9 @@ export function buildInsightEngine(
   };
 
   const engine = buildEngine(augmentedOptions, thunkArguments);
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
 
   const {insightId, search} = options.configuration;
 

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
@@ -1,3 +1,4 @@
+import {nextAnalyticsUsageWithServiceFeatureWarning} from '../../app/engine.js';
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state.js';
 import {updateResponseFormat} from '../../features/generated-answer/generated-answer-actions.js';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state.js';
@@ -59,10 +60,7 @@ describe('generated answer', () => {
       initGeneratedAnswer();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-          'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-          'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-          'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+        nextAnalyticsUsageWithServiceFeatureWarning
       );
     });
   });

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -1,4 +1,5 @@
 import {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload.js';
+import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../app/engine.js';
 import {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {generatedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import {GeneratedAnswerState} from '../../features/generated-answer/generated-answer-state.js';
@@ -34,6 +35,9 @@ export function buildGeneratedAnswer(
   engine: SearchEngine,
   props: GeneratedAnswerProps = {}
 ): GeneratedAnswer {
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
   const controller = props.answerConfigurationId
     ? buildAnswerApiGeneratedAnswer(
         engine,

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -4,6 +4,7 @@ import {
   fetchAnswer,
   StateNeededByAnswerAPI,
 } from '../../../api/knowledge/stream-answer-api.js';
+import {getConfigurationInitialState} from '../../../features/configuration/configuration-state.js';
 import {
   resetAnswer,
   updateAnswerConfigurationId,
@@ -15,6 +16,7 @@ import {
 } from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state.js';
 import {queryReducer} from '../../../features/query/query-slice.js';
+import {buildMockAnalyticsState} from '../../../test/mock-analytics-state.js';
 import {
   buildMockSearchEngine,
   MockedSearchEngine,
@@ -211,6 +213,56 @@ describe('knowledge-generated-answer', () => {
       // new request id, call
       listener();
       expect(fetchAnswer).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('building the controller with the next analytics mode', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      engine = buildEngineWithGeneratedAnswer({
+        configuration: {
+          ...getConfigurationInitialState(),
+          analytics: buildMockAnalyticsState({analyticsMode: 'next'}),
+        },
+      });
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should log a warning when the controller is used with the next analytics mode', () => {
+      createGeneratedAnswer();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
+          'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
+          'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
+          'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+      );
+    });
+  });
+
+  describe('building the controller with the legacy analytics mode', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      engine = buildEngineWithGeneratedAnswer({
+        configuration: {
+          ...getConfigurationInitialState(),
+          analytics: buildMockAnalyticsState({analyticsMode: 'legacy'}),
+        },
+      });
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should not log a warning when the controller is used with the legacy analytics mode', () => {
+      createGeneratedAnswer();
+      expect(warnSpy).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -10,6 +10,7 @@ import {
   selectAnswerTriggerParams,
   StateNeededByAnswerAPI,
 } from '../../../api/knowledge/stream-answer-api.js';
+import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../../app/engine.js';
 import {InsightEngine} from '../../../app/insight-engine/insight-engine.js';
 import {SearchEngine} from '../../../app/search-engine/search-engine.js';
 import {
@@ -140,6 +141,9 @@ export function buildAnswerApiGeneratedAnswer(
   if (!loadAnswerApiReducers(engine)) {
     throw loadReducerError;
   }
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
 
   const {...controller} = buildCoreGeneratedAnswer(
     engine,

--- a/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.test.ts
+++ b/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.test.ts
@@ -1,3 +1,4 @@
+import {nextAnalyticsUsageWithServiceFeatureWarning} from '../../app/engine.js';
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state.js';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state.js';
 import {
@@ -37,10 +38,7 @@ describe('smart snippet', () => {
       initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-          'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-          'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-          'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+        nextAnalyticsUsageWithServiceFeatureWarning
       );
     });
   });

--- a/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.test.ts
+++ b/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.test.ts
@@ -1,41 +1,19 @@
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state.js';
-import {updateResponseFormat} from '../../features/generated-answer/generated-answer-actions.js';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state.js';
 import {
   buildMockSearchEngine,
   MockedSearchEngine,
 } from '../../test/mock-engine-v2.js';
 import {createMockState} from '../../test/mock-state.js';
-import {
-  buildGeneratedAnswer,
-  GeneratedAnswerProps,
-  GeneratedResponseFormat,
-} from './headless-generated-answer.js';
+import {SmartSnippetQuestionsListProps} from '../core/smart-snippet-questions-list/headless-core-smart-snippet-questions-list.js';
+import {buildSmartSnippetQuestionsList} from './headless-smart-snippet-questions-list.js';
 
-vi.mock('../../features/generated-answer/generated-answer-actions');
-vi.mock('../../features/search/search-actions');
-
-describe('generated answer', () => {
+describe('smart snippet', () => {
   let engine: MockedSearchEngine;
 
-  function initGeneratedAnswer(props: GeneratedAnswerProps = {}) {
-    buildGeneratedAnswer(engine, props);
+  function initSmartSnippet(props: SmartSnippetQuestionsListProps = {}) {
+    buildSmartSnippetQuestionsList(engine, props);
   }
-
-  beforeEach(() => {
-    engine = buildMockSearchEngine(createMockState());
-  });
-
-  it('initialize the format', () => {
-    const responseFormat: GeneratedResponseFormat = {
-      contentFormat: ['text/markdown'],
-    };
-    initGeneratedAnswer({
-      initialState: {responseFormat},
-    });
-
-    expect(updateResponseFormat).toHaveBeenCalledWith(responseFormat);
-  });
 
   describe('building the controller with the next analytics mode', () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -56,7 +34,7 @@ describe('generated answer', () => {
     });
 
     it('should log a warning when the controller is used with the next analytics mode', () => {
-      initGeneratedAnswer();
+      initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
@@ -86,7 +64,7 @@ describe('generated answer', () => {
     });
 
     it('should not log a warning when the controller is used with the legacy analytics mode', () => {
-      initGeneratedAnswer();
+      initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.ts
+++ b/packages/headless/src/controllers/smart-snippet-questions-list/headless-smart-snippet-questions-list.ts
@@ -1,3 +1,4 @@
+import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../app/engine.js';
 import {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {smartSnippetAnalyticsClient} from '../../features/question-answering/question-answering-analytics-actions.js';
 import {
@@ -119,6 +120,9 @@ export function buildSmartSnippetQuestionsList(
   engine: SearchEngine,
   props?: SmartSnippetQuestionsListProps
 ): SmartSnippetQuestionsList {
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
   const smartSnippetQuestionList = buildCoreSmartSnippetQuestionsList(
     engine,
     smartSnippetAnalyticsClient

--- a/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.test.ts
+++ b/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.test.ts
@@ -1,3 +1,4 @@
+import {nextAnalyticsUsageWithServiceFeatureWarning} from '../../app/engine.js';
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state.js';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state.js';
 import {
@@ -39,10 +40,7 @@ describe('smart snippet', () => {
       initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
-          'However, this mode is not available for Coveo for Service features, and this configuration may not work as expected.\n' +
-          'Please switch back to the "legacy" analytics mode to ensure proper functionality.\n' +
-          'For more information, refer to the documentation: https://docs.coveo.com/en/o3r90189/build-a-search-ui/event-protocol'
+        nextAnalyticsUsageWithServiceFeatureWarning
       );
     });
   });

--- a/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.test.ts
+++ b/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.test.ts
@@ -1,5 +1,4 @@
 import {getConfigurationInitialState} from '../../features/configuration/configuration-state.js';
-import {updateResponseFormat} from '../../features/generated-answer/generated-answer-actions.js';
 import {buildMockAnalyticsState} from '../../test/mock-analytics-state.js';
 import {
   buildMockSearchEngine,
@@ -7,35 +6,16 @@ import {
 } from '../../test/mock-engine-v2.js';
 import {createMockState} from '../../test/mock-state.js';
 import {
-  buildGeneratedAnswer,
-  GeneratedAnswerProps,
-  GeneratedResponseFormat,
-} from './headless-generated-answer.js';
+  buildSmartSnippet,
+  SmartSnippetProps,
+} from './headless-smart-snippet.js';
 
-vi.mock('../../features/generated-answer/generated-answer-actions');
-vi.mock('../../features/search/search-actions');
-
-describe('generated answer', () => {
+describe('smart snippet', () => {
   let engine: MockedSearchEngine;
 
-  function initGeneratedAnswer(props: GeneratedAnswerProps = {}) {
-    buildGeneratedAnswer(engine, props);
+  function initSmartSnippet(props: SmartSnippetProps = {}) {
+    buildSmartSnippet(engine, props);
   }
-
-  beforeEach(() => {
-    engine = buildMockSearchEngine(createMockState());
-  });
-
-  it('initialize the format', () => {
-    const responseFormat: GeneratedResponseFormat = {
-      contentFormat: ['text/markdown'],
-    };
-    initGeneratedAnswer({
-      initialState: {responseFormat},
-    });
-
-    expect(updateResponseFormat).toHaveBeenCalledWith(responseFormat);
-  });
 
   describe('building the controller with the next analytics mode', () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -56,7 +36,7 @@ describe('generated answer', () => {
     });
 
     it('should log a warning when the controller is used with the next analytics mode', () => {
-      initGeneratedAnswer();
+      initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         '[Warning] A component from the Coveo Headless library has been instantiated with the Analytics Mode: "Next".\n' +
@@ -86,7 +66,7 @@ describe('generated answer', () => {
     });
 
     it('should not log a warning when the controller is used with the legacy analytics mode', () => {
-      initGeneratedAnswer();
+      initSmartSnippet();
       expect(warnSpy).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.ts
+++ b/packages/headless/src/controllers/smart-snippet/headless-smart-snippet.ts
@@ -1,3 +1,4 @@
+import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../app/engine.js';
 import {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {smartSnippetAnalyticsClient} from '../../features/question-answering/question-answering-analytics-actions.js';
 import {
@@ -33,6 +34,9 @@ export function buildSmartSnippet(
   engine: SearchEngine,
   props?: SmartSnippetProps
 ): SmartSnippet {
+  warnIfUsingNextAnalyticsModeForServiceFeature(
+    engine.state.configuration.analytics.analyticsMode
+  );
   const smartSnippet = buildCoreSmartSnippet(
     engine,
     smartSnippetAnalyticsClient,


### PR DESCRIPTION
## [SFINT-6049](https://coveord.atlassian.net/browse/SFINT-6049)

### The reason behind this PR:
We are noticing an increasing number of clients that miss-configure their Quantic and Atomic interfaces by enabling the Event Protocol for analytics reporting while using the Coveo For Service feature.
These Coveo For Service can be identified as the following:

- Insight Panel.
- Case Assist.
- CRGA.
- Smart Snippets

Having Clients use EP while using these features is dangerous as all events schemas for these feature are not set in stone and are not GA,  and are likely to change considerably overtime, so having clients logging their events EP could expose them to various breaking changes.

### The proposed solution:
While we are limited to what we can do in this situation because we wanna avoid breaking changes, the solution here is by  raising awareness about this problem by logging this big message whenever we detect this situation, a warning that would hopefully notify the implementers about the issue while building their interfaces.

The warning message is triggered in the following situations:

1. Creating an Insight Engine while using Next analytics mode.
2. Creating a Case Assist Engine while using Next analytics mode.
3. Creating a SAPI RGA controller for the search use case while using Next analytics mode.
4. Creating an AAPI RGA controller for the search use case while using Next analytics mode.
5. Creating a Smart Snippets controller for the search use case  while using Next analytics mode.
6. Creating a Smart Snippet Question List controller for the search use case  while using Next analytics mode.

### Example of the warning when trying to use the insight panel with the Event protocol:
<img width="1685" alt="Screenshot 2025-03-20 at 9 41 13 AM" src="https://github.com/user-attachments/assets/cc544470-cc84-4c78-adf9-97412ae629cc" />


[SFINT-6049]: https://coveord.atlassian.net/browse/SFINT-6049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ