### PR TITLE
fix(quantic): fixed how the quantic__loadingstatechange event is handled 

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewContent.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewContent.js
@@ -33,7 +33,12 @@ export default class QuanticQuickviewContent extends LightningElement {
 
   handleIframeLoaded() {
     this.isLoading = false;
-    this.dispatchEvent(new CustomEvent('quantic__loadingstatechange'));
+    this.dispatchEvent(
+      new CustomEvent('quantic__loadingstatechange', {
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   stopPropagation(evt) {

--- a/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewContent.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticQuickviewContent/quanticQuickviewContent.js
@@ -33,12 +33,7 @@ export default class QuanticQuickviewContent extends LightningElement {
 
   handleIframeLoaded() {
     this.isLoading = false;
-    this.dispatchEvent(
-      new CustomEvent('quantic__loadingstatechange', {
-        bubbles: true,
-        composed: true,
-      })
-    );
+    this.dispatchEvent(new CustomEvent('quantic__loadingstatechange'));
   }
 
   stopPropagation(evt) {

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.html
@@ -45,7 +45,7 @@
         </header>
         <c-quantic-quickview-content id="quickview__content-container" class="quickview__content-container slds-wrap"
           result={result} content-url={contentURL}
-          onloadingstatechange={handleLoadingStateChange}></c-quantic-quickview-content>
+          onquantic__loadingstatechange={handleLoadingStateChange}></c-quantic-quickview-content>
         <template if:false={isLoading}>
           <footer onclick={stopPropagation} class="slds-modal__footer slds-p-top_none slds-p-bottom_none">
             <slot name="footer"></slot>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -157,7 +157,7 @@ export default class QuanticResultQuickview extends LightningElement {
   disconnectedCallback() {
     this.unsubscribe?.();
     this.removeEventListener(
-      'loadingstatechange',
+      'quantic__loadingstatechange',
       this.handleLoadingStateChange
     );
   }
@@ -223,10 +223,10 @@ export default class QuanticResultQuickview extends LightningElement {
     });
   }
 
-  handleLoadingStateChange(event) {
+  handleLoadingStateChange = (event) => {
     event.stopPropagation();
     this._isLoading = false;
-  }
+  };
 
   showTooltip() {
     this.tooltipComponent?.showTooltip();

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -121,10 +121,6 @@ export default class QuanticResultQuickview extends LightningElement {
       );
       this.dispatchEvent(resultActionRegister);
     }
-    this.addEventListener(
-      'quantic__loadingstatechange',
-      this.handleLoadingStateChange
-    );
   }
 
   renderedCallback() {
@@ -156,10 +152,6 @@ export default class QuanticResultQuickview extends LightningElement {
 
   disconnectedCallback() {
     this.unsubscribe?.();
-    this.removeEventListener(
-      'quantic__loadingstatechange',
-      this.handleLoadingStateChange
-    );
   }
 
   updateState() {
@@ -223,10 +215,10 @@ export default class QuanticResultQuickview extends LightningElement {
     });
   }
 
-  handleLoadingStateChange = (event) => {
+  handleLoadingStateChange(event) {
     event.stopPropagation();
     this._isLoading = false;
-  };
+  }
 
   showTooltip() {
     this.tooltipComponent?.showTooltip();


### PR DESCRIPTION
## [SFINT-6042](https://coveord.atlassian.net/browse/SFINT-6042)

### Issue
This issue started to happen after adding `quantic__` as  prefix for the event names sent from Quantic. the event `loadingstatechange` was forgotten.
so the fix was going from `onloadingstatechange` to `onquantic___loadingstatechange`.
This should be tested as part of the following PR: https://github.com/coveo/ui-kit/pull/5087

### Before

https://github.com/user-attachments/assets/58645022-ec32-4ac1-a061-1f91d9e210ef


### After

https://github.com/user-attachments/assets/e6f03b74-6040-49aa-9796-c06c4c672cc2


[SFINT-6042]: https://coveord.atlassian.net/browse/SFINT-6042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ