### PR TITLE
fix(quantic): added origin context to quantic case assist interface

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseAssistInterface/quanticCaseAssistInterface.js
@@ -44,6 +44,8 @@ export default class QuanticCaseAssistInterface extends LightningElement {
   engineOptions;
   /** @type {boolean} */
   isCaseStartLogged = false;
+  /** @type {string} */
+  analyticsOriginContext = 'CaseAssist';
 
   connectedCallback() {
     loadDependencies(this, HeadlessBundleNames.caseAssist)
@@ -61,6 +63,7 @@ export default class QuanticCaseAssistInterface extends LightningElement {
                     searchHub: this.searchHub,
                     analytics: {
                       analyticsMode: 'legacy',
+                      originContext: this.analyticsOriginContext,
                       ...(document.referrer && {
                         originLevel3: document.referrer.substring(0, 256),
                       }),


### PR DESCRIPTION
## [SFINT-6030](https://coveord.atlassian.net/browse/SFINT-6030)

- Started to send the value `CaseAssist` as the **Origin Context** from the Quantic Case Assist interface.