### PR TITLE
fix(quantic): unneeded key attribute removed from quantic number button  element

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticNumberButton/quanticNumberButton.html
@@ -1,3 +1,3 @@
 <template>
-  <button class={buttonClasses} aria-pressed={isPressed} key={pageNumber} onclick={select} aria-label={ariaLabelValue}>{number}</button>
+  <button class={buttonClasses} aria-pressed={isPressed} onclick={select} aria-label={ariaLabelValue}>{number}</button>
 </template>


### PR DESCRIPTION
## [SFINT-5985](https://coveord.atlassian.net/browse/SFINT-5985)

- Unneeded key attribute removed from quantic number button  element


[SFINT-5985]: https://coveord.atlassian.net/browse/SFINT-5985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ