### PR TITLE
fix(quantic): made sure test folders are excluded from quantic npm package

### DIFF
--- a/packages/quantic/.npmignore
+++ b/packages/quantic/.npmignore
@@ -1,3 +1,1 @@
 scripts
-**/e2e/**
-**/__tests__/**

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -98,6 +98,8 @@
     "force-app/main/default/cspTrustedSites/*",
     "force-app/main/default/staticresources/*",
     "scripts/npm",
-    "docs/out/quantic-docs.json"
+    "docs/out/quantic-docs.json",
+    "!force-app/main/default/lwc/**/__tests__",
+    "!force-app/main/default/lwc/**/e2e"
   ]
 }


### PR DESCRIPTION
## [SFINT-6078](https://coveord.atlassian.net/browse/SFINT-6078)

- Made sure test folders excluded from quantic npm package.
- previously the paths to the tests folder `.npmignore` have been overridden by the files specified in the `package.json`. 

### proof it works:
<img width="1544" alt="Screenshot 2025-03-28 at 9 55 52 AM" src="https://github.com/user-attachments/assets/30c8a405-b266-4a5f-909c-257132faccdb" />


[SFINT-6078]: https://coveord.atlassian.net/browse/SFINT-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ