### PR TITLE
chore(pipeline): Migrate deployment configuration of ui-kit [DT-7842]

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -1,4 +1,5 @@
 {
+  "deployment_config_version": 19,
   "product": "ui-kit",
   "team_name": "searchui",
   "general": {
@@ -351,28 +352,34 @@
         "workflow_file": "prod.yml",
         "workflow_reference": "main",
         "workflow_repository": "coveo-platform/ui-kit-cd",
-        "prd": {
-          "disabled": $[IS_NIGHTLY]
-        },
         "extra_parameters": {
           "run-id": "$[GITHUB_RUN_ID]"
-        }
+        },
+        "overrides": [
+          {
+            "environments": ["prd"],
+            "content": {
+              "disabled": $[IS_NIGHTLY]
+            }
+          }
+        ]
       },
       "dependencies": ["smoke"]
     }
   ],
-  "observatory": {
-    "no_endpoint": true
-  },
-  "package_rollout": {
-    "only_consider_changesets_after": "b244fe702d8e96d016a52715e92c8131acfde3ba",
-    "jira_issues_discovery": {
-      "stop_after_first_issue": true,
-      "branch_name": false,
-      "commit_message": false,
-      "pull_request_title": true,
-      "pull_request_description": true
+  "certifiers": {
+    "observatory": {
+      "no_endpoint": true
+    },
+    "package_rollout": {
+      "only_consider_changesets_after": "b244fe702d8e96d016a52715e92c8131acfde3ba",
+      "jira_issues_discovery": {
+        "stop_after_first_issue": true,
+        "branch_name": false,
+        "commit_message": false,
+        "pull_request_title": true,
+        "pull_request_description": true
+      }
     }
-  },
-  "deployment_config_version": 7
+  }
 }


### PR DESCRIPTION
# PLEASE MERGE IT YOURSELF
  
Hi there 🤠!

In order to make the config easier to use in the context of the Multi-Account Framework, we are running 🏃‍️🎽👟 a script to migrate deployment configurations!

While the change is not breaking 💥 since the revise is done automatically when you create a package 📦, updating your code will just make it so that you don't have drift 🏎️ between the config you submit and what the pipeline actually see 👀.

See [the announcement 📢 in Confluence](https://coveord.atlassian.net/wiki/spaces/CM/pages/5024317641/Deployment+Config+version+19+Changes+for+Overrides+and+more) for the details

The script also updates `deployment_config_version` so that it does not need to run every time 🕛️ you create a package in the future. Please forgive any formatting changes as those are hard to avoid 🙏.

I hope you accept my little gift 🎁.
  
# PLEASE MERGE IT YOURSELF

Note (dblanchette): Opening this manually because the automated script breaks on the `$[IS_NIGHTLY]` placeholder