### PR TITLE
chore(atomic): add a boolean converter for Lit

### DIFF
--- a/packages/atomic/src/converters/boolean-converter.spec.ts
+++ b/packages/atomic/src/converters/boolean-converter.spec.ts
@@ -1,0 +1,76 @@
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {page} from '@vitest/browser/context';
+import '@vitest/browser/matchers.d.ts';
+import {html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {describe, expect, it, vi} from 'vitest';
+import {booleanConverter} from './boolean-converter';
+
+describe('booleanConverter', () => {
+  @customElement('test-element')
+  class TestElement extends LitElement {
+    @property({
+      converter: booleanConverter(),
+    })
+    value = false;
+
+    render() {
+      return html`<div>${this.value}</div>`;
+    }
+  }
+
+  it('should convert "true" to true', async () => {
+    await fixture<TestElement>(
+      html`<test-element value="false"></test-element>`
+    );
+    await expect.element(page.getByText('false')).toBeInTheDocument();
+  });
+
+  it('should convert "true" to true', async () => {
+    await fixture<TestElement>(
+      html`<test-element value="true"></test-element>`
+    );
+
+    await expect.element(page.getByText('true')).toBeInTheDocument();
+  });
+
+  it('should convert "false" to false', async () => {
+    await fixture<TestElement>(
+      html`<test-element value="false"></test-element>`
+    );
+
+    await expect.element(page.getByText('false')).toBeInTheDocument();
+  });
+
+  it('should convert "other" to true', async () => {
+    await fixture<TestElement>(
+      html`<test-element value="other"></test-element>`
+    );
+
+    await expect.element(page.getByText('true')).toBeInTheDocument();
+  });
+
+  it('an attribute without values should convert to true', async () => {
+    await fixture<TestElement>(html`<test-element value></test-element>`);
+
+    await expect.element(page.getByText('true')).toBeInTheDocument();
+  });
+
+  it('an omitted attribute should convert to false', async () => {
+    await fixture<TestElement>(html`<test-element></test-element>`);
+
+    await expect.element(page.getByText('false')).toBeInTheDocument();
+  });
+
+  it('should print a warning when converting "false" to false', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn');
+    await fixture<TestElement>(
+      html`<test-element value="false"></test-element>`
+    );
+
+    await expect.element(page.getByText('false')).toBeInTheDocument();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Using `value="false"` for a boolean attribute is not compliant with HTML standards (see https://html.spec.whatwg.org/#boolean-attributes). This behavior will not be supported in Atomic v4. To set a boolean attribute to false, omit the attribute instead.'
+    );
+  });
+});

--- a/packages/atomic/src/converters/boolean-converter.spec.ts
+++ b/packages/atomic/src/converters/boolean-converter.spec.ts
@@ -11,6 +11,7 @@ describe('booleanConverter', () => {
   class TestElement extends LitElement {
     @property({
       converter: booleanConverter(),
+      type: Boolean,
     })
     value = false;
 
@@ -19,12 +20,6 @@ describe('booleanConverter', () => {
     }
   }
 
-  it('should convert "true" to true', async () => {
-    await fixture<TestElement>(
-      html`<test-element value="false"></test-element>`
-    );
-    await expect.element(page.getByText('false')).toBeInTheDocument();
-  });
 
   it('should convert "true" to true', async () => {
     await fixture<TestElement>(

--- a/packages/atomic/src/converters/boolean-converter.spec.ts
+++ b/packages/atomic/src/converters/boolean-converter.spec.ts
@@ -10,7 +10,7 @@ describe('booleanConverter', () => {
   @customElement('test-element')
   class TestElement extends LitElement {
     @property({
-      converter: booleanConverter(),
+      converter: booleanConverter,
       type: Boolean,
     })
     value = false;
@@ -19,7 +19,6 @@ describe('booleanConverter', () => {
       return html`<div>${this.value}</div>`;
     }
   }
-
 
   it('should convert "true" to true', async () => {
     await fixture<TestElement>(

--- a/packages/atomic/src/converters/boolean-converter.ts
+++ b/packages/atomic/src/converters/boolean-converter.ts
@@ -1,0 +1,16 @@
+import type {ComplexAttributeConverter} from 'lit';
+
+export const booleanConverter = (): ComplexAttributeConverter<boolean> => {
+  return {
+    fromAttribute: (value: string) => {
+      if (value === 'false') {
+        console.warn(
+          'Using `value="false"` for a boolean attribute is not compliant with HTML standards (see https://html.spec.whatwg.org/#boolean-attributes). ' +
+            'This behavior will not be supported in Atomic v4. To set a boolean attribute to false, omit the attribute instead.'
+        );
+        return false;
+      }
+      return true;
+    },
+  };
+};

--- a/packages/atomic/src/converters/boolean-converter.ts
+++ b/packages/atomic/src/converters/boolean-converter.ts
@@ -1,16 +1,14 @@
 import type {ComplexAttributeConverter} from 'lit';
 
-export const booleanConverter = (): ComplexAttributeConverter<boolean> => {
-  return {
-    fromAttribute: (value: string) => {
-      if (value === 'false') {
-        console.warn(
-          'Using `value="false"` for a boolean attribute is not compliant with HTML standards (see https://html.spec.whatwg.org/#boolean-attributes). ' +
-            'This behavior will not be supported in Atomic v4. To set a boolean attribute to false, omit the attribute instead.'
-        );
-        return false;
-      }
-      return true;
-    },
-  };
+export const booleanConverter: ComplexAttributeConverter<boolean> = {
+  fromAttribute: (value: string) => {
+    if (value === 'false') {
+      console.warn(
+        'Using `value="false"` for a boolean attribute is not compliant with HTML standards (see https://html.spec.whatwg.org/#boolean-attributes). ' +
+          'This behavior will not be supported in Atomic v4. To set a boolean attribute to false, omit the attribute instead.'
+      );
+      return false;
+    }
+    return true;
+  },
 };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3972

By default, with Lit, boolean attributes need to be omitted to be converted to `false`. `attribute="false"` is considered `true`. This is different from Stencil where attribute="false" is considered `false`. This PR adds a boolean converter so that `attribute="false"` gets converted to `false` and so we don't make breaking changes.
