### PR TITLE
docs(headless-react): address broken typedoc links

### DIFF
--- a/packages/headless-react/src/ssr-commerce/commerce-engine.tsx
+++ b/packages/headless-react/src/ssr-commerce/commerce-engine.tsx
@@ -45,7 +45,7 @@ export function createSingletonContext<
 /**
  * Returns engine and controller hooks, and context providers.
  *
- * See [Define the commerce engine and controllers](docs.coveo.com/en/obif0156#define-the-commerce-engine-and-controllers).
+ * See [Define the commerce engine and controllers](https://docs.coveo.com/en/obif0156#define-the-commerce-engine-and-controllers).
  *
  * @group Engine
  */

--- a/packages/headless-react/src/ssr-commerce/providers.tsx
+++ b/packages/headless-react/src/ssr-commerce/providers.tsx
@@ -39,7 +39,7 @@ function getController<T extends Controller>(
  * state, and then hydrating the state and displaying the page
  * with the hydrated state. They are required for your controller hooks to function.
  *
- * See [Create providers](docs.coveo.com/en/obif0156/#create-providers).
+ * See [Create providers](https://docs.coveo.com/en/obif0156/#create-providers).
  *
  * @group Providers
  */


### PR DESCRIPTION
[DOC-16854](https://coveord.atlassian.net/browse/DOC-16854)

Certain links in the TypeDoc site were showing up in a duplicated format:

i.e.

https://docs.coveo.com/en/headless-react/latest/reference/functions/docs.coveo.com/en/obif0156#define-the-commerce-engine-and-controllers

When they should have been in the format:

https://docs.coveo.com/en/obif0156#define-the-commerce-engine-and-controllers

The comments these links were pulled from were missing the scheme, "https://", and thus showing up in the above formatting. Upon adding the missing scheme to the links, they functioned again as expected.


[DOC-16854]: https://coveord.atlassian.net/browse/DOC-16854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ