### PR TITLE
chore(atomic, headless): make typescript 5 an optional peer dependency

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -156,7 +156,13 @@
   },
   "peerDependencies": {
     "@coveo/bueno": "1.0.9",
-    "@coveo/headless": "3.20.0"
+    "@coveo/headless": "3.20.0",
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -150,7 +150,13 @@
   },
   "peerDependencies": {
     "encoding": "^0.1.13",
-    "pino-pretty": "^6.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0"
+    "pino-pretty": "^6.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@coveo/bueno": "1.0.9",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4041

Making typescript 5 an optional peer deps because of moduleResolution only being available in typescript 5 +
