### PR TITLE
chore(atomic): remove 'children' from FunctionalComponentWithChildren interface

### DIFF
--- a/packages/atomic/src/components/common/button.spec.ts
+++ b/packages/atomic/src/components/common/button.spec.ts
@@ -1,6 +1,6 @@
 import {createRipple} from '@/src/utils/ripple';
 import {fireEvent, within} from '@storybook/test';
-import {html, render} from 'lit';
+import {html, nothing, render} from 'lit';
 import {vi} from 'vitest';
 import {button, ButtonProps} from './button';
 
@@ -27,8 +27,7 @@ describe('button', () => {
           ...props,
           style: props.style ?? 'primary',
         },
-        children: html``,
-      })}`,
+      })(nothing)}`,
       container
     );
     return within(container).getByRole('button') as HTMLButtonElement;

--- a/packages/atomic/src/components/common/button.ts
+++ b/packages/atomic/src/components/common/button.ts
@@ -41,33 +41,35 @@ export interface ButtonProps {
   title?: string;
 }
 
-export const button: FunctionalComponentWithChildren<ButtonProps> = ({
-  props,
-  children,
-}) => {
-  const rippleColor = getRippleColorForButtonStyle(props.style);
-  const className = getClassNameForButtonStyle(props.style);
+export const button: FunctionalComponentWithChildren<ButtonProps> =
+  ({props}) =>
+  (children) => {
+    const rippleColor = getRippleColorForButtonStyle(props.style);
+    const className = getClassNameForButtonStyle(props.style);
 
-  return html`<button
-    type=${ifDefined(props.type)}
-    title=${ifDefined(props.title)}
-    tabindex=${ifDefined(props.tabIndex)}
-    role=${ifDefined(props.role)}
-    part=${ifDefined(props.part)}
-    form=${ifDefined(props.form)}
-    class=${props.class ? `${className} ${props.class}` : className}
-    aria-pressed=${ifDefined(props.ariaPressed)}
-    aria-label=${ifDefined(props.ariaLabel)}
-    aria-hidden=${ifDefined(props.ariaHidden)}
-    aria-expanded=${ifDefined(props.ariaExpanded)}
-    aria-current=${ifDefined(props.ariaCurrent)}
-    aria-controls=${ifDefined(props.ariaControls)}
-    aria-checked=${ifDefined(props.ariaChecked)}
-    @mousedown=${(e: MouseEvent) => createRipple(e, {color: rippleColor})}
-    @click=${props.onClick}
-    ?disabled=${props.disabled}
-  >
-    ${when(props.text, () => html`<span class="truncate">${props.text}</span>`)}
-    ${children}
-  </button>`;
-};
+    return html`<button
+      type=${ifDefined(props.type)}
+      title=${ifDefined(props.title)}
+      tabindex=${ifDefined(props.tabIndex)}
+      role=${ifDefined(props.role)}
+      part=${ifDefined(props.part)}
+      form=${ifDefined(props.form)}
+      class=${props.class ? `${className} ${props.class}` : className}
+      aria-pressed=${ifDefined(props.ariaPressed)}
+      aria-label=${ifDefined(props.ariaLabel)}
+      aria-hidden=${ifDefined(props.ariaHidden)}
+      aria-expanded=${ifDefined(props.ariaExpanded)}
+      aria-current=${ifDefined(props.ariaCurrent)}
+      aria-controls=${ifDefined(props.ariaControls)}
+      aria-checked=${ifDefined(props.ariaChecked)}
+      @mousedown=${(e: MouseEvent) => createRipple(e, {color: rippleColor})}
+      @click=${props.onClick}
+      ?disabled=${props.disabled}
+    >
+      ${when(
+        props.text,
+        () => html`<span class="truncate">${props.text}</span>`
+      )}
+      ${children}
+    </button>`;
+  };

--- a/packages/atomic/src/components/common/heading.spec.ts
+++ b/packages/atomic/src/components/common/heading.spec.ts
@@ -21,8 +21,7 @@ describe('heading', () => {
     render(
       html` ${heading({
         props: {...props, level: props.level ?? 1},
-        children: html`${children}`,
-      })}`,
+      })(html`${children}`)}`,
       container
     );
     return within(container).getByRole(

--- a/packages/atomic/src/components/common/heading.ts
+++ b/packages/atomic/src/components/common/heading.ts
@@ -19,16 +19,15 @@ export interface HeadingProps {
   part?: string;
 }
 
-export const heading: FunctionalComponentWithChildren<HeadingProps> = ({
-  props,
-  children,
-}) => {
-  const {level, class: classname, part} = props;
+export const heading: FunctionalComponentWithChildren<HeadingProps> =
+  ({props}) =>
+  (children) => {
+    const {level, class: classname, part} = props;
 
-  const headingTag =
-    level > 0 && level <= 6 ? unsafeStatic(`h${level}`) : literal`div`;
+    const headingTag =
+      level > 0 && level <= 6 ? unsafeStatic(`h${level}`) : literal`div`;
 
-  return html`<${headingTag} class="${ifDefined(classname)}" part="${ifDefined(part)}">
-    ${children}
-  </${headingTag}>`;
-};
+    return html`<${headingTag} class="${ifDefined(classname)}" part="${ifDefined(part)}">
+      ${children}
+    </${headingTag}>`;
+  };

--- a/packages/atomic/src/components/common/load-more/button.ts
+++ b/packages/atomic/src/components/common/load-more/button.ts
@@ -25,6 +25,5 @@ export const loadMoreButton: FunctionalComponent<LoadMoreButtonProps> = ({
   };
   return button({
     props: buttonProps,
-    children: html`${i18n.t(label)}`,
-  });
+  })(html`${i18n.t(label)}`);
 };

--- a/packages/atomic/src/utils/functional-component-utils.ts
+++ b/packages/atomic/src/utils/functional-component-utils.ts
@@ -7,12 +7,9 @@ export interface FunctionalComponent<T> {
 export interface FunctionalComponentWithChildren<T> {
   ({
     props,
-    children,
   }: {
     props: T;
-    children:
-      | TemplateResult
-      | TemplateResult[]
-      | (TemplateResult | typeof nothing)[];
-  }): TemplateResult;
+  }): (children: FunctionalComponentChildren) => TemplateResult;
 }
+
+type FunctionalComponentChildren = TemplateResult | typeof nothing;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4081

Removing 'children' from the interface to make it easier to read render functions in larger sets of functional lit components.