### PR TITLE
fix(generated answer): fix citations not being reset correctly when clearing the query

### DIFF
--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -20,6 +20,7 @@ import {
   updateAnswerConfigurationId,
 } from '../../../features/generated-answer/generated-answer-actions.js';
 import {GeneratedAnswerFeedback} from '../../../features/generated-answer/generated-answer-analytics-actions.js';
+import {filterOutDuplicatedCitations} from '../../../features/generated-answer/utils/generated-answer-citation-utils.js';
 import {queryReducer as query} from '../../../features/query/query-slice.js';
 import {
   GeneratedAnswerSection,
@@ -163,6 +164,9 @@ export function buildAnswerApiGeneratedAnswer(
       return {
         ...getState().generatedAnswer,
         answer: answerApiState?.answer,
+        citations: filterOutDuplicatedCitations(
+          answerApiState?.citations ?? []
+        ),
         error: {
           message: answerApiState?.error?.message,
           statusCode: answerApiState?.error?.code,

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.test.ts
@@ -119,7 +119,7 @@ describe('generated answer slice', () => {
         updateCitations({citations: newCitations})
       );
 
-      expect(finalState.citations).toEqual([...newCitations]);
+      expect(finalState.citations).toEqual(existingCitations);
     });
   });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-slice.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-slice.ts
@@ -1,6 +1,5 @@
 import {createReducer} from '@reduxjs/toolkit';
 import {RETRYABLE_STREAM_ERROR_CODE} from '../../api/generated-answer/generated-answer-client.js';
-import {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload.js';
 import {
   closeGeneratedAnswerFeedbackModal,
   dislikeGeneratedAnswer,
@@ -26,6 +25,7 @@ import {
   setCannotAnswer,
 } from './generated-answer-actions.js';
 import {getGeneratedAnswerInitialState} from './generated-answer-state.js';
+import {filterOutDuplicatedCitations} from './utils/generated-answer-citation-utils.js';
 
 export const generatedAnswerReducer = createReducer(
   getGeneratedAnswerInitialState(),
@@ -53,13 +53,10 @@ export const generatedAnswerReducer = createReducer(
       .addCase(updateCitations, (state, {payload}) => {
         state.isLoading = false;
         state.isStreaming = true;
-        const citationMap = new Map<string, GeneratedAnswerCitation>();
-        for (const citationCollection of [state.citations, payload.citations]) {
-          for (const citation of citationCollection) {
-            citationMap.set(citation.uri, citation);
-          }
-        }
-        state.citations = Array.from(citationMap.values());
+        state.citations = filterOutDuplicatedCitations([
+          ...state.citations,
+          ...payload.citations,
+        ]);
         delete state.error;
       })
       .addCase(updateError, (state, {payload}) => {

--- a/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.test.ts
+++ b/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.test.ts
@@ -43,6 +43,26 @@ describe('filterOutDuplicatedCitations', () => {
     expect(actualCitations).toEqual(expectedCitations);
   });
 
+  it('should filter out citations based only on the uri', () => {
+    const RICK_ROLL_CITATION_TWO: GeneratedAnswerCitation = buildMockCitation({
+      uri: RICK_ROLL_CITATION.uri,
+      id: 'differentId',
+      permanentid: 'differentPermanentId',
+      title: 'differentTitle',
+      clickUri: 'differentClickUri',
+      source: 'differentSource',
+      text: 'differentText',
+    });
+
+    const actualCitations = filterOutDuplicatedCitations([
+      RICK_ROLL_CITATION,
+      RICK_ROLL_CITATION_TWO,
+    ]);
+
+    expect(actualCitations).toHaveLength(1);
+    expect(actualCitations).toEqual([RICK_ROLL_CITATION]);
+  });
+
   it('should process an empty list successfully', () => {
     const actualCitations = filterOutDuplicatedCitations([]);
 

--- a/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.test.ts
+++ b/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.test.ts
@@ -1,0 +1,51 @@
+import {GeneratedAnswerCitation} from '../../../api/generated-answer/generated-answer-event-payload.js';
+import {buildMockCitation} from '../../../test/mock-citation.js';
+import {filterOutDuplicatedCitations} from './generated-answer-citation-utils.js';
+
+const RICK_ROLL_CITATION: GeneratedAnswerCitation = buildMockCitation({
+  uri: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+});
+
+const JIRA_BUG_CITATION: GeneratedAnswerCitation = buildMockCitation({
+  uri: 'https://coveord.atlassian.net/browse/SVCC-4945',
+});
+
+describe('filterOutDuplicatedCitations', () => {
+  it('should return one citation when given a list containing the same citations multiple times', () => {
+    const actualCitations = filterOutDuplicatedCitations([
+      RICK_ROLL_CITATION,
+      RICK_ROLL_CITATION,
+      RICK_ROLL_CITATION,
+    ]);
+
+    expect(actualCitations).toHaveLength(1);
+    expect(actualCitations).toEqual([RICK_ROLL_CITATION]);
+  });
+
+  it('should not modify the citation list when there is no duplication', () => {
+    const expectedCitations = [RICK_ROLL_CITATION, JIRA_BUG_CITATION];
+
+    const actualCitations = filterOutDuplicatedCitations(expectedCitations);
+
+    expect(actualCitations).toHaveLength(2);
+    expect(actualCitations).toEqual(expectedCitations);
+  });
+
+  it('should remove only duplicated citations', () => {
+    const expectedCitations = [RICK_ROLL_CITATION, JIRA_BUG_CITATION];
+
+    const actualCitations = filterOutDuplicatedCitations([
+      ...expectedCitations,
+      RICK_ROLL_CITATION,
+    ]);
+
+    expect(actualCitations).toHaveLength(2);
+    expect(actualCitations).toEqual(expectedCitations);
+  });
+
+  it('should process an empty list successfully', () => {
+    const actualCitations = filterOutDuplicatedCitations([]);
+
+    expect(actualCitations).toHaveLength(0);
+  });
+});

--- a/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.ts
+++ b/packages/headless/src/features/generated-answer/utils/generated-answer-citation-utils.ts
@@ -1,0 +1,14 @@
+import {GeneratedAnswerCitation} from '../../../api/generated-answer/generated-answer-event-payload.js';
+
+export function filterOutDuplicatedCitations(
+  citations: GeneratedAnswerCitation[]
+): GeneratedAnswerCitation[] {
+  const citationUris = new Set<string>();
+  return citations.filter((citation: GeneratedAnswerCitation) => {
+    const isCitationUriUnique = !citationUris.has(citation.uri);
+    if (isCitationUriUnique) {
+      citationUris.add(citation.uri);
+    }
+    return isCitationUriUnique;
+  });
+}


### PR DESCRIPTION
Reverted this PR change https://github.com/coveo/ui-kit/commit/09ca081702d364d1379cc4cd7fc70747ee069652 and added the same citation duplicate filter logic from the reducer in the controller in order to fix the bug where the citations are not reset correctly.

[SVCC-4945](https://coveord.atlassian.net/browse/SVCC-4945)


Demo showing that there is no citation duplications and the generated answer component disappear correctly when resetting the query: https://github.com/user-attachments/assets/db0c594d-bb5c-434c-9b9b-cafae814eca6




[SVCC-4945]: https://coveord.atlassian.net/browse/SVCC-4945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ