### PR TITLE
feat(quantic): added origin context to quantic insight interface

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -45,6 +45,9 @@ export default class QuanticInsightInterface extends LightningElement {
   /** @type {boolean} */
   ariaLiveEventsBound = false;
 
+  /** @type {string} */
+  analyticsOriginContext = 'InsightPanel';
+
   disconnectedCallback() {
     destroyEngine(this.engineId);
     if (this.ariaLiveEventsBound) {
@@ -77,6 +80,7 @@ export default class QuanticInsightInterface extends LightningElement {
                     },
                     analytics: {
                       analyticsMode: 'legacy',
+                      originContext: this.analyticsOriginContext,
                       ...(document.referrer && {
                         originLevel3: document.referrer.substring(0, 256),
                       }),


### PR DESCRIPTION
## [SFINT-6058](https://coveord.atlassian.net/browse/SFINT-6058)

- Added the value `InsightPanel` as origin context in the Quantic Insight Interface component.
- Confirmed the Headless and the Quantic versions are sent in the payload of the analytics sent for the insight panel.

<img width="1727" alt="Screenshot 2025-04-07 at 9 14 36 AM" src="https://github.com/user-attachments/assets/90afec3a-3160-489d-8baf-49d204625cc7" />
