### PR TITLE
fix(quantic): improved condition that indicates when to display timeframe facet 

### DIFF
--- a/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/quantic/cypress/e2e/facets-2/timeframe-facet/timeframe-facet.cypress.ts
@@ -31,8 +31,8 @@ describe('quantic-timeframe-facet', () => {
 
   const validRange = {
     start: '2000-01-01',
-    end: '2000-12-31',
-    filter: '2000/01/01@00:00:00..2000/12/31@23:59:59',
+    end: '2050-12-31',
+    filter: '2000/01/01@00:00:00..2050/12/31@23:59:59',
   };
   const invalidRange = {
     start: '2000-12-31',
@@ -285,7 +285,7 @@ describe('quantic-timeframe-facet', () => {
             if (param.useCase === useCaseEnum.search) {
               Expect.urlHashContains(
                 'Date_input',
-                '2000/01/01@00:00:00...2000/12/31@23:59:59'
+                '2000/01/01@00:00:00...2050/12/31@23:59:59'
               );
             }
 
@@ -375,7 +375,7 @@ describe('quantic-timeframe-facet', () => {
             if (param.useCase === useCaseEnum.search) {
               Expect.urlHashContains(
                 'Date_input',
-                '2000/01/01@00:00:00...2000/12/31@23:59:59'
+                '2000/01/01@00:00:00...2050/12/31@23:59:59'
               );
             }
             Expect.displayClearButton(true);
@@ -389,7 +389,7 @@ describe('quantic-timeframe-facet', () => {
                 if (param.useCase === useCaseEnum.search) {
                   Expect.urlHashContains(
                     'Date_input',
-                    '2000/01/01@00:00:00...2000/12/31@23:59:59'
+                    '2000/01/01@00:00:00...2050/12/31@23:59:59'
                   );
                 }
               }
@@ -476,13 +476,13 @@ describe('quantic-timeframe-facet', () => {
         });
 
         describe('when with-date-picker is true', () => {
-          it('should show the facet', () => {
+          it('should not show the facet', () => {
             setupWithNoResultsMatchingFacet({
               withDatePicker: true,
               useCase: param.useCase,
             });
 
-            Expect.displayLabel(true);
+            Expect.displayLabel(false);
           });
         });
       });

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.html
@@ -52,11 +52,11 @@
                 </template>
 
                 <template if:false={isCollapsed}>
-                  <template if:true={withDatePicker}>
+                  <template if:true={shouldDisplayDatePicker}>
                     <div
                       class="slds-grid slds-gutters slds-grid_vertical slds-p-around_x-small"
                     >
-                      <form onsubmit={handleApply}>
+                      <form data-testid="facet__date-picker" onsubmit={handleApply}>
                         <div class="slds-col slds-grid slds-gutters">
                           <div
                             class="slds-col slds-size_1-of-5 slds-var-p-top_xx-small slds-var-m-top_xxx-small"

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -259,13 +259,33 @@ export default class QuanticTimeframeFacet extends LightningElement {
   get showFacet() {
     const facetIsActivated =
       this.hasActiveValues || !!this.dateFilterState?.range;
-    const canRefineWithCustomRange = this.hasResults && this.withDatePicker;
+    const canRefineWithCustomRange =
+      this.hasResults && this.shouldDisplayDatePicker;
     const canRefineWithTimeframes =
       this.hasResults && this.formattedValues.length > 0;
 
     return (
       facetIsActivated || canRefineWithCustomRange || canRefineWithTimeframes
     );
+  }
+
+  /**
+   * Indicates whether to display the date picker.
+   */
+  get shouldDisplayDatePicker() {
+    if (!this.withDatePicker) {
+      return false;
+    }
+    if (this.dateFilterState?.range) {
+      return true;
+    }
+    if (!this.hasResults) {
+      return false;
+    }
+    const atLeastOneValueWithResultsOrActive = this.facetState?.values.some(
+      (value) => value.numberOfResults || value.state === 'selected'
+    );
+    return atLeastOneValueWithResultsOrActive;
   }
 
   /**
@@ -532,6 +552,7 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   updateDateFilterState() {
+    console.log(this.dateFilter.state);
     this.dateFilterState = this.dateFilter.state;
 
     if (this.dateFilterState.range) {

--- a/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js
@@ -552,7 +552,6 @@ export default class QuanticTimeframeFacet extends LightningElement {
   }
 
   updateDateFilterState() {
-    console.log(this.dateFilter.state);
     this.dateFilterState = this.dateFilter.state;
 
     if (this.dateFilterState.range) {


### PR DESCRIPTION
## [SFINT-6077](https://coveord.atlassian.net/browse/SFINT-6077)

## 🛠️ Summary

This PR addresses the issue described in [Jira: Quantic Timeframe Facet filter input is always displayed](https://coveord.atlassian.net/browse/SFINT-6077), where the **timeframe facet** displays the date picker inputs even when it doesn’t contain any facet values. This leads to unnecessary UI elements being shown when the facet field is irrelevant due to applied filters.


https://github.com/user-attachments/assets/735d4deb-18ac-4a79-bcdb-dba0fcefb0f1




## ✅ Expected Behavior

When the `with-date-picker` property is set to `true`, the date filter inputs **should only be displayed when the filter is actually applicable and can filter the current result set**.



## ✨ Implementation

Introduced a new computed property to determine when to show the date picker:

```ts
/**
 * Indicates whether to display the date picker.
 */
get shouldDisplayDatePicker() {
  if (!this.withDatePicker) {
    return false;
  }
  if (this.dateFilterState?.range) {
    return true;
  }
  if (!this.hasResults) {
    return false;
  }
  const atLeastOneValueWithResultsOrActive = this.facetState?.values.some(
    (value) => value.numberOfResults || value.state === 'selected'
  );
  return atLeastOneValueWithResultsOrActive;
}
```

This ensures the date picker is only shown when:

- `withDatePicker` is enabled  
**AND** at least one of the following is true:
  - A date range filter is already selected (`dateFilterState.range`)
  - The facet has results, and at least one value:
    - Has results (`numberOfResults > 0`)
    - **OR** is selected (`state === 'selected'`)


## 🫡 Demo

https://github.com/user-attachments/assets/a2b20c0a-07dd-4580-92ae-124bdd1ec93e







[SFINT-6077]: https://coveord.atlassian.net/browse/SFINT-6077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ