### PR TITLE
fix(quantic): breadcrumb value not displayed for date and numeric filters

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/__tests__/quanticBreadcrumbManager.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/__tests__/quanticBreadcrumbManager.test.js
@@ -5,6 +5,10 @@ import QuanticBreadcrumbManager from 'c/quanticBreadcrumbManager';
 import {createElement} from 'lwc';
 import * as mockHeadlessLoader from 'c/quanticHeadlessLoader';
 
+jest.mock('@salesforce/label/c.quantic_Colon', () => ({default: ':'}), {
+  virtual: true,
+});
+
 const initialBreadcrumbManagerState = {
   hasBreadcrumbs: false,
   numericFacetBreadcrumbs: [],
@@ -41,8 +45,12 @@ const selectors = {
     '[data-testid="category-facet-breadcrumb-value"]',
   numericFacetBreadcrumb: '[data-testid="numeric-facet-breadcrumb"]',
   numericFacetBreadcrumbValue: '[data-testid="numeric-facet-breadcrumb-value"]',
+  numericFacetBreadcrumbFieldName:
+    '[data-testid="numeric-facet-breadcrumb-field-name"]',
   dateFacetBreadcrumb: '[data-testid="date-facet-breadcrumb"]',
   dateFacetBreadcrumbValue: '[data-testid="date-facet-breadcrumb-value"]',
+  dateFacetBreadcrumbFieldName:
+    '[data-testid="date-facet-breadcrumb-field-name"]',
 };
 
 const exampleEngine = {
@@ -532,6 +540,76 @@ describe('c-quantic-breadcrumb-manager', () => {
         expect(labels).toEqual(values);
       });
     });
+
+    describe('when a numeric range is set with a numeric filter', () => {
+      const exampleLabel = 'Field one';
+      const exampleField = 'fieldOne';
+      const testNumericFacetBreadcrumbsWithFilter = [
+        {
+          field: exampleField,
+          facetId: `${exampleField}_input`,
+          values: [{value: {start: 10, end: 11}}],
+        },
+      ];
+
+      beforeAll(() => {
+        breadcrumbManagerState = {
+          ...breadcrumbManagerState,
+          numericFacetBreadcrumbs: testNumericFacetBreadcrumbsWithFilter,
+          hasBreadcrumbs: true,
+        };
+        storeState = {
+          [exampleField]: {
+            facetId: exampleField,
+            label: exampleLabel,
+            format: (item) => `${item.start} - ${item.end}`,
+          },
+        };
+      });
+
+      it('should display the breadcrumb values with correct labels', async () => {
+        const element = createTestComponent();
+        await flushPromises();
+
+        const numericFacetBreadcrumbs = element.shadowRoot.querySelectorAll(
+          selectors.numericFacetBreadcrumb
+        );
+
+        expect(numericFacetBreadcrumbs.length).toBe(
+          testNumericFacetBreadcrumbsWithFilter.length
+        );
+        numericFacetBreadcrumbs.forEach((numericFacetBreadcrumb, index) => {
+          const exampleFacetBreadcrumb =
+            testNumericFacetBreadcrumbsWithFilter[index];
+
+          const numericFacetBreadcrumbFieldName =
+            numericFacetBreadcrumb.querySelector(
+              selectors.numericFacetBreadcrumbFieldName
+            );
+          expect(numericFacetBreadcrumbFieldName.textContent).toBe(
+            `${exampleLabel}: `
+          );
+
+          const facetBreadcrumbValues = Array.from(
+            numericFacetBreadcrumb.querySelectorAll(
+              selectors.numericFacetBreadcrumbValue
+            )
+          );
+
+          expect(facetBreadcrumbValues.length).toBe(
+            exampleFacetBreadcrumb.values.length
+          );
+
+          const labels = facetBreadcrumbValues.map(
+            (facetBreadcrumbValue) => facetBreadcrumbValue.label
+          );
+          const values = exampleFacetBreadcrumb.values.map(
+            (item) => `${item.value.start} - ${item.value.end}`
+          );
+          expect(labels).toEqual(values);
+        });
+      });
+    });
   });
 
   describe('date facet breadcrumbs', () => {
@@ -598,6 +676,76 @@ describe('c-quantic-breadcrumb-manager', () => {
           (item) => `${item.value.start} - ${item.value.end}`
         );
         expect(labels).toEqual(values);
+      });
+    });
+
+    describe('when a date range is set with a date filter', () => {
+      const exampleLabel = 'Field one';
+      const exampleField = 'fieldOne';
+      const testDateFacetBreadcrumbsWithFilter = [
+        {
+          field: exampleField,
+          facetId: `${exampleField}_input`,
+          values: [{value: {start: 'last week', end: 'today'}}],
+        },
+      ];
+
+      beforeAll(() => {
+        breadcrumbManagerState = {
+          ...breadcrumbManagerState,
+          dateFacetBreadcrumbs: testDateFacetBreadcrumbsWithFilter,
+          hasBreadcrumbs: true,
+        };
+        storeState = {
+          [exampleField]: {
+            facetId: exampleField,
+            label: exampleLabel,
+            format: (item) => `${item.start} - ${item.end}`,
+          },
+        };
+      });
+
+      it('should display the breadcrumb values with correct labels', async () => {
+        const element = createTestComponent();
+        await flushPromises();
+
+        const dateFacetBreadcrumbs = element.shadowRoot.querySelectorAll(
+          selectors.dateFacetBreadcrumb
+        );
+
+        expect(dateFacetBreadcrumbs.length).toBe(
+          testDateFacetBreadcrumbsWithFilter.length
+        );
+        dateFacetBreadcrumbs.forEach((dateFacetBreadcrumb, index) => {
+          const exampleFacetBreadcrumb =
+            testDateFacetBreadcrumbsWithFilter[index];
+
+          const dateFacetBreadcrumbFieldName =
+            dateFacetBreadcrumb.querySelector(
+              selectors.dateFacetBreadcrumbFieldName
+            );
+          expect(dateFacetBreadcrumbFieldName.textContent).toBe(
+            `${exampleLabel}: `
+          );
+
+          const facetBreadcrumbValues = Array.from(
+            dateFacetBreadcrumb.querySelectorAll(
+              selectors.dateFacetBreadcrumbValue
+            )
+          );
+
+          expect(facetBreadcrumbValues.length).toBe(
+            exampleFacetBreadcrumb.values.length
+          );
+
+          const labels = facetBreadcrumbValues.map(
+            (facetBreadcrumbValue) => facetBreadcrumbValue.label
+          );
+          const values = exampleFacetBreadcrumb.values.map(
+            (item) => `${item.value.start} - ${item.value.end}`
+          );
+          expect(labels).toEqual(values);
+        });
       });
     });
   });

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.html
@@ -27,7 +27,7 @@
             </template>
             <template for:each={numericFacetBreadcrumbsValues} for:item="breadcrumb">
               <li data-testid="numeric-facet-breadcrumb" key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__numeric-facet-list breadcrumb-manager__line">
-                <span class="slds-col breadcrumb-manager__field-name">{breadcrumb.label}{labels.colon} </span>
+                <span data-testid="numeric-facet-breadcrumb-field-name" class="slds-col breadcrumb-manager__field-name">{breadcrumb.label}{labels.colon} </span>
                 <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                   <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                     <li key={breadcrumbValue.value} class="breadcrumb__container">
@@ -54,7 +54,7 @@
             </template>
             <template for:each={dateFacetBreadcrumbsValues} for:item="breadcrumb">
               <li data-testid="date-facet-breadcrumb" key={breadcrumb.facetId} class="slds-list_horizontal breadcrumb-manager__date-facet-list breadcrumb-manager__line">
-                <span class="slds-col breadcrumb-manager__field-name">{breadcrumb.label}{labels.colon} </span>
+                <span data-testid="date-facet-breadcrumb-field-name" class="slds-col breadcrumb-manager__field-name">{breadcrumb.label}{labels.colon} </span>
                 <ul class="slds-col slds-truncate slds-list_horizontal slds-grid slds-wrap">
                   <template for:each={breadcrumb.values} for:item="breadcrumbValue">
                     <li key={breadcrumbValue.value} class="breadcrumb__container">

--- a/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticBreadcrumbManager/quanticBreadcrumbManager.js
@@ -118,13 +118,14 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   formatRangeBreadcrumbValue(breadcrumb) {
     const data = getFromStore(this.engineId, Store.facetTypes.NUMERICFACETS);
+    const facetId = breadcrumb.facetId.replace('_input', '');
     return {
       ...breadcrumb,
-      label: data ? data[breadcrumb.facetId]?.label : breadcrumb.field,
+      label: data ? data[facetId]?.label : breadcrumb.field,
       values: breadcrumb.values.map((range) => ({
         ...range,
         value: `${range.value.start} - ${range.value.end}`,
-        formattedValue: data[breadcrumb.facetId]?.format(range.value),
+        formattedValue: data[facetId]?.format(range.value),
       })),
     };
   }
@@ -173,12 +174,13 @@ export default class QuanticBreadcrumbManager extends LightningElement {
 
   formatDateRangeBreadcrumbValue(breadcrumb) {
     const data = getFromStore(this.engineId, Store.facetTypes.DATEFACETS);
+    const facetId = breadcrumb.facetId.replace('_input', '');
     return {
       ...breadcrumb,
-      label: data ? data[breadcrumb.facetId]?.label : breadcrumb.field,
+      label: data ? data[facetId]?.label : breadcrumb.field,
       values: breadcrumb.values.map((range) => ({
         ...range,
-        value: data[breadcrumb.facetId]?.format(range.value),
+        value: data[facetId]?.format(range.value),
       })),
     };
   }


### PR DESCRIPTION
## [SFINT-6087](https://coveord.atlassian.net/browse/SFINT-6087)

### The issue:
Breadcrumb values were not displayed correctly when a numeric filter or a date filter were selected.
<img width="662" alt="Screenshot 2025-04-07 at 4 08 52 PM" src="https://github.com/user-attachments/assets/ffbf6195-8835-452d-abfb-430bfc0c5276" />

this is because the filters are registered in the Headless state always with the facet id of the facet that owns the filter in addition to the suffix `_input`:
https://github.com/coveo/ui-kit/blob/bbb30961fedc4168dcae81aad561f5c864d7c4a5/packages/quantic/force-app/main/default/lwc/quanticNumericFacet/quanticNumericFacet.js#L340-L344
https://github.com/coveo/ui-kit/blob/bbb30961fedc4168dcae81aad561f5c864d7c4a5/packages/quantic/force-app/main/default/lwc/quanticTimeframeFacet/quanticTimeframeFacet.js#L490-L492

However, in the Quantic store, only the facet id of the facet that owns the filter is stored.


### The solution:

In order to get the necessary data to display the breadcrumbs for a filter, we need to access the data of the facet that owns the filter an not the filter directly, that's why I added a logic always removes the suffix `_input` from the key we use to access the store, this way when we need the data of the filter `exampleField_inout`, we would get the data from the facet that owns this filter, aka the facet with the id `exampleField` .

https://github.com/user-attachments/assets/88bb41a6-0923-44ba-8c0a-dbe565afa57d




[SFINT-6087]: https://coveord.atlassian.net/browse/SFINT-6087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ