### PR TITLE
chore(atomic): improve build for lit components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
     '.deployment.config.json',
     'packages/atomic-angular/scripts/build-lit.mjs',
     'packages/atomic-react/scripts/build-lit.mjs',
+    'packages/atomic/src/components/*/lazy-index.ts',
+    'packages/atomic/src/components/*/index.ts',
   ],
   env: {
     jest: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -59321,7 +59321,6 @@
       "devDependencies": {
         "cypress": "13.7.3",
         "cypress-repeat": "2.3.8",
-        "ncp": "2.0.0",
         "resolve": "1.22.10",
         "rimraf": "6.0.1",
         "serve": "14.2.4"

--- a/packages/atomic-angular/scripts/build-lit.mjs
+++ b/packages/atomic-angular/scripts/build-lit.mjs
@@ -113,8 +113,8 @@ if(litDeclarations.length > 0) {
   writeFileSync(
     atomicAngularModuleFilePath,
     atomicAngularModuleFileContent
-      .replace(/const DECLARATIONS = \[\n/m, `const DECLARATIONS = [\n${[...litDeclarations].join(',\n')},\n`)
-      .replace(/^import \{$/m, `import {\n${[...litDeclarations].join(',\n')},`)
+      .replace(/const DECLARATIONS = \[\n/m, `const DECLARATIONS = [\n${[...litDeclarations].sort().join(',\n')},\n`)
+      .replace(/^import \{$/m, `import {\n${[...litDeclarations].sort().join(',\n')},`)
   );
 }
 

--- a/packages/atomic/scripts/build.mjs
+++ b/packages/atomic/scripts/build.mjs
@@ -12,6 +12,7 @@ import {
   DiagnosticCategory,
 } from 'typescript';
 import resourceUrlTransformer from './asset-path-transformer.mjs';
+import {generateLitExports} from './generate-lit-exports.mjs';
 import pathTransformer from './path-transform.mjs';
 import svgTransformer from './svg-transform.mjs';
 import versionTransformer from './version-transform.mjs';
@@ -73,6 +74,8 @@ function emit(program) {
  * Info: https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
  */
 function compileWithTransformer() {
+  generateLitExports();
+
   console.log(
     chalk.blue('Using tsconfig:'),
     chalk.green(basename(tsConfigPath))

--- a/packages/atomic/scripts/generate-lit-exports.mjs
+++ b/packages/atomic/scripts/generate-lit-exports.mjs
@@ -1,0 +1,94 @@
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+
+const baseComponentsDir = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '../src/components'
+);
+
+function isLitComponent(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return content.includes('LitElement');
+}
+
+function toPascalCase(name) {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function generateLitExportsForDir(dir) {
+  const componentsDir = path.join(baseComponentsDir, dir);
+  const outputIndexFile = path.join(componentsDir, 'index.ts');
+  const outputLazyIndexFile = path.join(componentsDir, 'lazy-index.ts');
+
+  const files = fs.readdirSync(componentsDir, {withFileTypes: true});
+  const litComponents = files
+    .filter((file) => {
+      const componentPath = path.join(
+        componentsDir,
+        file.name,
+        `${file.name}.ts`
+      );
+      return (
+        file.isDirectory() &&
+        fs.existsSync(componentPath) &&
+        isLitComponent(componentPath)
+      );
+    })
+    .map((file) => file.name)
+    .sort();
+
+  if (litComponents.length === 0) {
+    fs.writeFileSync(outputIndexFile, `// Auto-generated file\nexport {};\n`);
+    fs.writeFileSync(
+      outputLazyIndexFile,
+      `// Auto-generated file\nexport default {} as Record<string, () => Promise<unknown>>;\n\nexport type * from './index.js';\n`
+    );
+    return;
+  }
+
+  const indexExports = litComponents
+    .map(
+      (component) =>
+        `export {${toPascalCase(component)}} from './${component}/${component}.js';`
+    )
+    .join('\n');
+
+  const lazyIndexExports = litComponents
+    .map(
+      (component) =>
+        `'${component}': async () => await import('./${component}/${component}.js'),`
+    )
+    .join('\n  ');
+
+  fs.writeFileSync(
+    outputIndexFile,
+    `// Auto-generated file\n${indexExports}\n`
+  );
+
+  fs.writeFileSync(
+    outputLazyIndexFile,
+    `// Auto-generated file\nexport default {\n  ${lazyIndexExports}\n} as Record<string, () => Promise<unknown>>;\n\nexport type * from './index.js';\n`
+  );
+}
+
+export function generateLitExports() {
+  const directories = [
+    'commerce',
+    'common',
+    'search',
+    'insight',
+    'ipx',
+    'recommendations',
+  ];
+  directories.forEach((dir) => {
+    console.log(chalk.blue('Directory:'), chalk.green(dir));
+    generateLitExportsForDir(dir);
+  });
+}

--- a/packages/atomic/src/components/commerce/index.ts
+++ b/packages/atomic/src/components/commerce/index.ts
@@ -1,3 +1,2 @@
-// Export the class of the components migrated to Lit here, like this:
-export {AtomicComponentError} from '../common/atomic-component-error/atomic-component-error';
-export {AtomicIcon} from '../common/atomic-icon/atomic-icon';
+// Auto-generated file
+export {};

--- a/packages/atomic/src/components/commerce/lazy-index.ts
+++ b/packages/atomic/src/components/commerce/lazy-index.ts
@@ -1,8 +1,4 @@
-export default {
-  // Add entries as such when new components are added/moved to Lit.
-  'atomic-icon': async () => await import('../common/atomic-icon/atomic-icon'),
-  'atomic-component-error': async () =>
-    await import('../common/atomic-component-error/atomic-component-error'),
-} as Record<string, () => Promise<unknown>>;
+// Auto-generated file
+export default {} as Record<string, () => Promise<unknown>>;
 
 export type * from './index.js';

--- a/packages/atomic/src/components/common/index.ts
+++ b/packages/atomic/src/components/common/index.ts
@@ -1,0 +1,3 @@
+// Auto-generated file
+export {AtomicComponentError} from './atomic-component-error/atomic-component-error.js';
+export {AtomicIcon} from './atomic-icon/atomic-icon.js';

--- a/packages/atomic/src/components/common/lazy-index.ts
+++ b/packages/atomic/src/components/common/lazy-index.ts
@@ -1,0 +1,8 @@
+// Auto-generated file
+export default {
+  'atomic-component-error': async () =>
+    await import('./atomic-component-error/atomic-component-error.js'),
+  'atomic-icon': async () => await import('./atomic-icon/atomic-icon.js'),
+} as Record<string, () => Promise<unknown>>;
+
+export type * from './index.js';

--- a/packages/atomic/src/components/index.ts
+++ b/packages/atomic/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './search/index.js';
 export * from './insight/index.js';
 export * from './commerce/index.js';
+export * from './common/index.js';
 export * from './ipx/index.js';
 export * from './recommendations/index.js';

--- a/packages/atomic/src/components/insight/index.ts
+++ b/packages/atomic/src/components/insight/index.ts
@@ -1,3 +1,2 @@
-// Export the class of the components migrated to Lit here, like this:
-export {AtomicComponentError} from '../common/atomic-component-error/atomic-component-error';
-export {AtomicIcon} from '../common/atomic-icon/atomic-icon';
+// Auto-generated file
+export {};

--- a/packages/atomic/src/components/insight/lazy-index.ts
+++ b/packages/atomic/src/components/insight/lazy-index.ts
@@ -1,8 +1,4 @@
-export default {
-  // Add entries as such when new components are added/moved to Lit.
-  'atomic-icon': async () => await import('../common/atomic-icon/atomic-icon'),
-  'atomic-component-error': async () =>
-    await import('../common/atomic-component-error/atomic-component-error'),
-} as Record<string, () => Promise<unknown>>;
+// Auto-generated file
+export default {} as Record<string, () => Promise<unknown>>;
 
 export type * from './index.js';

--- a/packages/atomic/src/components/ipx/index.ts
+++ b/packages/atomic/src/components/ipx/index.ts
@@ -1,3 +1,2 @@
-// Export the class of the components migrated to Lit here, like this:
-export {AtomicComponentError} from '../common/atomic-component-error/atomic-component-error';
-export {AtomicIcon} from '../common/atomic-icon/atomic-icon';
+// Auto-generated file
+export {};

--- a/packages/atomic/src/components/ipx/lazy-index.ts
+++ b/packages/atomic/src/components/ipx/lazy-index.ts
@@ -1,8 +1,4 @@
-export default {
-  // Add entries as such when new components are added/moved to Lit.
-  'atomic-icon': async () => await import('../common/atomic-icon/atomic-icon'),
-  'atomic-component-error': async () =>
-    await import('../common/atomic-component-error/atomic-component-error'),
-} as Record<string, () => Promise<unknown>>;
+// Auto-generated file
+export default {} as Record<string, () => Promise<unknown>>;
 
 export type * from './index.js';

--- a/packages/atomic/src/components/lazy-index.ts
+++ b/packages/atomic/src/components/lazy-index.ts
@@ -1,10 +1,12 @@
 import CommerceComponentMap from './commerce/lazy-index.js';
+import CommonComponentMap from './common/lazy-index.js';
 import InsightComponentMap from './insight/lazy-index.js';
 import IpxComponentMap from './ipx/lazy-index.js';
 import RecommendationsComponentMap from './recommendations/lazy-index.js';
 import SearchComponentMap from './search/lazy-index.js';
 
 export default {
+  ...CommonComponentMap,
   ...RecommendationsComponentMap,
   ...IpxComponentMap,
   ...InsightComponentMap,

--- a/packages/atomic/src/components/recommendations/index.ts
+++ b/packages/atomic/src/components/recommendations/index.ts
@@ -1,3 +1,2 @@
-// Export the class of the components migrated to Lit here, like this:
-export {AtomicComponentError} from '../common/atomic-component-error/atomic-component-error';
-export {AtomicIcon} from '../common/atomic-icon/atomic-icon';
+// Auto-generated file
+export {};

--- a/packages/atomic/src/components/recommendations/lazy-index.ts
+++ b/packages/atomic/src/components/recommendations/lazy-index.ts
@@ -1,8 +1,4 @@
-export default {
-  // Add entries as such when new components are added/moved to Lit.
-  'atomic-icon': async () => await import('../common/atomic-icon/atomic-icon'),
-  'atomic-component-error': async () =>
-    await import('../common/atomic-component-error/atomic-component-error'),
-} as Record<string, () => Promise<unknown>>;
+// Auto-generated file
+export default {} as Record<string, () => Promise<unknown>>;
 
 export type * from './index.js';

--- a/packages/atomic/src/components/search/index.ts
+++ b/packages/atomic/src/components/search/index.ts
@@ -1,4 +1,2 @@
-// Export the class of the components migrated to Lit here, like this:
-
-export {AtomicComponentError} from '../common/atomic-component-error/atomic-component-error';
-export {AtomicIcon} from '../common/atomic-icon/atomic-icon';
+// Auto-generated file
+export {};

--- a/packages/atomic/src/components/search/lazy-index.ts
+++ b/packages/atomic/src/components/search/lazy-index.ts
@@ -1,8 +1,4 @@
-export default {
-  // Add entries as such when new components are added/moved to Lit.
-  'atomic-icon': async () => await import('../common/atomic-icon/atomic-icon'),
-  'atomic-component-error': async () =>
-    await import('../common/atomic-component-error/atomic-component-error'),
-} as Record<string, () => Promise<unknown>>;
+// Auto-generated file
+export default {} as Record<string, () => Promise<unknown>>;
 
 export type * from './index.js';

--- a/packages/atomic/stencil-plugin/atomic-angular-module/index.ts
+++ b/packages/atomic/stencil-plugin/atomic-angular-module/index.ts
@@ -85,9 +85,13 @@ export function generateAngularModuleDefinition(options: {
       compilerCtx: CompilerCtx,
       buildCtx: BuildCtx
     ) {
-      const filteredComponents = buildCtx.components.filter((cmp) => {
-        return !cmp.internal;
-      });
+      const filteredComponents = buildCtx.components
+        .sort((a, b) =>
+          a.tagName.toLowerCase().localeCompare(b.tagName.toLowerCase())
+        )
+        .filter((cmp) => {
+          return !cmp.internal;
+        });
       const componentClassNames = filteredComponents.map((component) =>
         dashToPascalCase(component.tagName)
       );

--- a/packages/atomic/stencil-proxy/cjs/loader.cjs.js
+++ b/packages/atomic/stencil-proxy/cjs/loader.cjs.js
@@ -5,6 +5,9 @@ const searchComponents = import(
 const commerceComponents = import(
   '../atomic/components/components/commerce/lazy-index.js'
 );
+const commonComponents = import(
+  '../atomic/components/components/common/lazy-index.js'
+);
 const insightComponents = import(
   '../atomic/components/components/insight/lazy-index.js'
 );
@@ -16,6 +19,7 @@ const recommendationsComponents = import(
 );
 
 const allComponents = Promise.all([
+  commonComponents,
   searchComponents,
   commerceComponents,
   insightComponents,

--- a/packages/atomic/stencil-proxy/esm/index.js
+++ b/packages/atomic/stencil-proxy/esm/index.js
@@ -3,6 +3,7 @@ import '../atomic/autoloader/index.esm.js';
 export * from './_index.js';
 export * as SearchComponentMap from '../atomic/components/components/search/lazy-index.js';
 export * as CommerceComponentMap from '../atomic/components/components/commerce/lazy-index.js';
+export * as CommonComponentMap from '../atomic/components/components/common/lazy-index.js';
 export * as InsightComponentMap from '../atomic/components/components/insight/lazy-index.js';
 export * as IpxComponentMap from '../atomic/components/components/ipx/lazy-index.js';
 export * as RecommendationsComponentMap from '../atomic/components/components/recommendations/lazy-index.js';

--- a/packages/atomic/stencil-proxy/esm/loader.js
+++ b/packages/atomic/stencil-proxy/esm/loader.js
@@ -1,4 +1,5 @@
 import commerceComponents from '../atomic/components/components/commerce/lazy-index.js';
+import commonComponents from '../atomic/components/components/common/lazy-index.js';
 import insightComponents from '../atomic/components/components/insight/lazy-index.js';
 import ipxComponents from '../atomic/components/components/ipx/lazy-index.js';
 import recommendationsComponents from '../atomic/components/components/recommendations/lazy-index.js';
@@ -7,6 +8,7 @@ import {defineCustomElements as originalDefineCustomElements} from './_loader.js
 
 const defineCustomElements = function (...args) {
   Object.values({
+    ...commonComponents,
     ...recommendationsComponents,
     ...ipxComponents,
     ...insightComponents,

--- a/packages/samples/iife/build-assets.mjs
+++ b/packages/samples/iife/build-assets.mjs
@@ -1,11 +1,7 @@
-import ncp from 'ncp';
-import {mkdirSync, readFileSync} from 'node:fs';
+import {mkdirSync, readFileSync, cpSync} from 'node:fs';
 import {dirname, join, relative, resolve as resolvePath} from 'node:path';
 import resolve from 'resolve';
-import {promisify} from 'util';
 import {workspacesRoot} from '../../../scripts/packages.mjs';
-
-const ncpAsync = promisify(ncp);
 
 /**
  *
@@ -108,16 +104,16 @@ function getDependencyAssets() {
   }));
 }
 
-async function main() {
+function main() {
   const assets = [...getDeploymentPipelineAssets(), ...getDependencyAssets()];
   for (const asset of assets) {
     for (const relativeDestination of asset.relativeDestinations) {
       const sourceDir = join(workspacesRoot, asset.sourceDirectory);
       const destinationDir = resolvePath('www', 'cdn', relativeDestination);
       mkdirSync(destinationDir, {recursive: true});
-      await ncpAsync(sourceDir, destinationDir);
+      cpSync(sourceDir, destinationDir, {recursive: true});
     }
   }
 }
 
-await main();
+main();

--- a/packages/samples/iife/package.json
+++ b/packages/samples/iife/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "cypress": "13.7.3",
     "cypress-repeat": "2.3.8",
-    "ncp": "2.0.0",
     "resolve": "1.22.10",
     "rimraf": "6.0.1",
     "serve": "14.2.4"


### PR DESCRIPTION
This PR add a step to the Lit component build script that will automatically update the index.ts and lazy-index.ts files when Lit components are added/removed.

It also improves the console output for the build script
https://coveord.atlassian.net/browse/KIT-4090
