### PR TITLE
chore(atomic): prettier generated lit files

### DIFF
--- a/packages/atomic-react/scripts/build-lit.mjs
+++ b/packages/atomic-react/scripts/build-lit.mjs
@@ -46,6 +46,10 @@ export const ${declaration.name} = createComponent({
 `;
 
 for (const module of cem.modules) {
+  if(module.declarations.length === 0 ){
+    continue;
+  }
+  module.declarations.sort((a, b) => a.name.localCompare(b.name))
   for (const declaration of module.declarations) {
     if (isLitDeclaration(declaration)) {
       for (const entry of entries) {

--- a/packages/atomic-react/scripts/build-lit.mjs
+++ b/packages/atomic-react/scripts/build-lit.mjs
@@ -49,7 +49,7 @@ for (const module of cem.modules) {
   if(module.declarations.length === 0 ){
     continue;
   }
-  module.declarations.sort((a, b) => a.name.localCompare(b.name))
+  module.declarations.sort((a, b) => a.name.localeCompare(b.name))
   for (const declaration of module.declarations) {
     if (isLitDeclaration(declaration)) {
       for (const entry of entries) {

--- a/packages/atomic/scripts/build.mjs
+++ b/packages/atomic/scripts/build.mjs
@@ -74,8 +74,6 @@ function emit(program) {
  * Info: https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
  */
 function compileWithTransformer() {
-  generateLitExports();
-
   console.log(
     chalk.blue('Using tsconfig:'),
     chalk.green(basename(tsConfigPath))
@@ -120,4 +118,5 @@ function compileWithTransformer() {
   process.exit(exitCode);
 }
 
+await generateLitExports();
 compileWithTransformer();

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -126,7 +126,9 @@ watch('src', {recursive: true}, async (_, filename) => {
     filename.endsWith('.mdx') ||
     filename.endsWith('.new.stories.tsx') ||
     filename.endsWith('.spec.ts') ||
-    filename.includes('e2e')
+    filename.includes('e2e') ||
+    filename.endsWith('index.ts') ||
+    filename.endsWith('lazy-index.ts')
   ) {
     return;
   }

--- a/packages/atomic/scripts/format-with-prettier.mjs
+++ b/packages/atomic/scripts/format-with-prettier.mjs
@@ -1,0 +1,11 @@
+import prettier from 'prettier';
+
+export async function formatWithPrettier(content, filePath) {
+  try {
+    const options = await prettier.resolveConfig(filePath);
+    return prettier.format(content, {...options, filepath: filePath});
+  } catch (error) {
+    console.warn(`Failed to format ${filePath} with Prettier`, error);
+    return content;
+  }
+}

--- a/packages/atomic/scripts/generate-component.mjs
+++ b/packages/atomic/scripts/generate-component.mjs
@@ -1,20 +1,10 @@
 import fs from 'fs-extra';
 import handlebars from 'handlebars';
 import path from 'path';
-import prettier from 'prettier';
+import {formatWithPrettier} from './format-with-prettier.mjs';
 
 const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 const kebabToPascal = (str) => str.split('-').map(capitalize).join('');
-
-async function formatWithPrettier(content, filePath) {
-  try {
-    const options = await prettier.resolveConfig(filePath);
-    return prettier.format(content, {...options, filepath: filePath});
-  } catch (error) {
-    console.warn(`Failed to format ${filePath} with Prettier`, error);
-    return content;
-  }
-}
 
 async function generateFiles(name, outputDir) {
   const templatesDir = path.resolve(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4090

Currently building Lit results in a uncommitted file because the generated files are not being formatted by prettier. 

<img width="1621" alt="image" src="https://github.com/user-attachments/assets/a63b65b6-f3d1-435f-a4f4-cdd155cd296e" />


This PR fixes that and formats index & lazy-index files.