### PR TITLE
chore: improve subscription cleanup and lifecycle management

### DIFF
--- a/packages/atomic/src/decorators/bind-state.spec.ts
+++ b/packages/atomic/src/decorators/bind-state.spec.ts
@@ -115,7 +115,7 @@ describe('@bindStateToController decorator', () => {
     element.initialize!();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'invalidProperty property is not defined on component',
-      element
+      element.tagName
     );
   });
 
@@ -124,7 +124,7 @@ describe('@bindStateToController decorator', () => {
     element.initialize!();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'ControllerState: The "initialize" method has to be defined and instantiate a controller for the property controller',
-      element
+      element.tagName
     );
   });
 
@@ -146,7 +146,7 @@ describe('@bindStateToController decorator', () => {
     controller.updateState({value: 'updated state'});
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'ControllerState: The onUpdateCallbackMethod property "nonExistentMethod" is not defined',
-      element
+      element.tagName
     );
   });
 });


### PR DESCRIPTION
Fix Memory Leaks and Detached Nodes by Improving Subscription Cleanup and Lifecycle Management

### Remove Hard references
Previously, when `console.error` logs the entire component object, it creates a reference to the component. This reference prevents the garbage collector from reclaiming the memory associated with the component, even after it has been removed from the DOM. This results in a detached node.

The solution is to not pass the reference of component to console.error. Instead, only log the tag name

### Controller subscription not cleaned up
Overriding the `disconnectedCallback` seems to conflicts with other mixins or decorators.
Instead of doing that (which is kinda hackish anyway), I created a reactive controller which automatically hooks itself to lit reactive system.

Image showing detached nodes because of bad cleaning...
![image](https://github.com/user-attachments/assets/e9ec8075-2d1f-43d1-a94e-ef2c366c2332)

https://coveord.atlassian.net/browse/KIT-4099

