### PR TITLE
chore(atomic): escape backslashes in css

### DIFF
--- a/packages/atomic/scripts/process-css.mjs
+++ b/packages/atomic/scripts/process-css.mjs
@@ -38,6 +38,10 @@ function loadTsConfig(configPath) {
   );
 }
 
+function escapeBackslashes(css) {
+  return css.replace(/\\/g, '\\\\');
+}
+
 async function processAndMinifyCss(content, filename) {
   const {plugins, options} = await postcssLoadConfig();
   const result = await postcss(plugins).process(content, {
@@ -46,6 +50,8 @@ async function processAndMinifyCss(content, filename) {
   });
 
   let processedCss = minifyCss(result, filename);
+
+  processedCss = escapeBackslashes(processedCss);
 
   return processedCss;
 }


### PR DESCRIPTION
Tailwind generates some utilities that has escaped characters:

```css
.py-3\.5 {
...
}

.py-\[50px\] {
...
}
```

Since Lit CSS templates use the same character to escape special characters, these utilities do not work currently.

This PR escapes the backslashes to fix this issue. 

https://coveord.atlassian.net/browse/KIT-4101
