### PR TITLE
fix(autoloader): wrap initial discovery and observer setup in DOMContentLoaded event

### DIFF
--- a/packages/atomic-hosted-page/src/autoloader/index.ts
+++ b/packages/atomic-hosted-page/src/autoloader/index.ts
@@ -62,9 +62,22 @@ if (typeof window !== 'undefined') {
       }
     }
   });
-  // Initial discovery
-  discover(document.body);
-  // Listen for new undefined elements
-  observer.observe(document.documentElement, {subtree: true, childList: true});
-  //# sourceMappingURL=index.js.map
+
+  const initializeDiscovery = () => {
+    // Initial discovery
+    discover(document.body);
+    // Listen for new undefined elements
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+    });
+  };
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event#checking_whether_loading_is_already_complete
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeDiscovery);
+  } else {
+    initializeDiscovery();
+  }
 }
+//# sourceMappingURL=index.js.map

--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -59,9 +59,22 @@ if (typeof window !== 'undefined') {
       }
     }
   });
-  // Initial discovery
-  discover(document.body);
-  // Listen for new undefined elements
-  observer.observe(document.documentElement, {subtree: true, childList: true});
-  //# sourceMappingURL=index.js.map
+
+  const initializeDiscovery = () => {
+    // Initial discovery
+    discover(document.body);
+    // Listen for new undefined elements
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+    });
+  };
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event#checking_whether_loading_is_already_complete
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeDiscovery);
+  } else {
+    initializeDiscovery();
+  }
 }
+//# sourceMappingURL=index.js.map


### PR DESCRIPTION
Ensures discovery logic runs after DOMContentLoaded

Wraps discovery logic in a function to improve readability
and registers it to execute after DOMContentLoaded.
Handles cases where the document is already loaded.

Improves reliability of dynamic element detection.

KIT-4094

https://coveord.atlassian.net/browse/KIT-4094
