### PR TITLE
feat(headless, quantic): added logic to automatically fetch insight interface when building in…

### DIFF
--- a/packages/headless/src/app/insight-engine/insight-engine.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.ts
@@ -8,6 +8,7 @@ import {LegacySearchAction} from '../../features/analytics/analytics-utils.js';
 import {updateSearchConfiguration} from '../../features/configuration/configuration-actions.js';
 import {setInsightConfiguration} from '../../features/insight-configuration/insight-configuration-actions.js';
 import {insightConfigurationReducer as insightConfiguration} from '../../features/insight-configuration/insight-configuration-slice.js';
+import {fetchInterface} from '../../features/insight-interface/insight-interface-actions.js';
 import {insightInterfaceReducer as insightInterface} from '../../features/insight-interface/insight-interface-slice.js';
 import {executeSearch} from '../../features/insight-search/insight-search-actions.js';
 import {logInsightInterfaceLoad} from '../../features/insight-search/insight-search-analytics-actions.js';
@@ -126,6 +127,7 @@ export function buildInsightEngine(
       insightId,
     })
   );
+  engine.dispatch(fetchInterface());
 
   if (search) {
     engine.dispatch(updateSearchConfiguration(search));

--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -133,18 +133,36 @@ export default class QuanticInsightInterface extends LightningElement {
     if (this.initialized) {
       return;
     }
-    this.dispatchEvent(
-      new CustomEvent(`quantic__insightinterfaceinitialized`, {
-        detail: {
-          engineId: this.engineId,
-          insightId: this.insightId,
-        },
-        bubbles: true,
-        composed: true,
-      })
+    const engine = getHeadlessBindings(this.engineId).engine;
+    this.insightInterface = CoveoHeadlessInsight.buildInsightInterface(engine);
+    this.unsubscribeInsightInterface = this.insightInterface.subscribe(() =>
+      this.updateInsightInterfaceState()
     );
-    this.initialized = true;
   };
+
+  updateInsightInterfaceState() {
+    if (this.initialized) {
+      return;
+    }
+    this.isInsightInterfaceReady =
+      !this.insightInterface.state.loading &&
+      !!this.insightInterface.state.config;
+
+    if (this.isInsightInterfaceReady) {
+      this.dispatchEvent(
+        new CustomEvent(`quantic__insightinterfaceinitialized`, {
+          detail: {
+            engineId: this.engineId,
+            insightId: this.insightId,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      this.unsubscribeInsightInterface();
+      this.initialized = true;
+    }
+  }
 
   /**
    * @returns {HTMLInputElement}


### PR DESCRIPTION
## [SFINT-6108](https://coveord.atlassian.net/browse/SFINT-6108)

## The Issue
In the Insight use case, the search hub value is derived from the Insight interface associated with a specific Insight configuration ID. This requires implementers to manually dispatch the fetchInterface action by calling the fetch method on the HeadlessInsightInterface controller. Without this step, the Insight panel defaults to using default as the search hub, and this value cannot be overridden via the Quantic or Atomic UI components.

This manual step is often overlooked, which can lead to an incorrect search hub value and inaccurate analytics reporting.

## The Solution
To ensure that the Insight panel is initialized with the correct search hub value, we now automatically fetch the Insight interface during Insight engine creation. This change reduces the implementation burden on users and helps prevent misconfigurations that could result in incorrect analytics data.

<img width="1728" alt="Screenshot 2025-04-18 at 9 00 21 AM" src="https://github.com/user-attachments/assets/a78b1607-01d3-4c20-acce-52d706648660" />
