### PR TITLE
fix(headless): prevent selected facet search values from replacing idle values

### DIFF
--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -922,6 +922,11 @@ describe('commerceFacetSetReducer', () => {
                   ).indexOf(newFacetValue)
                 ).toBe(2);
                 expect(finalState[facetId]?.request.values.length).toBe(4);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as FacetValueRequest[]
+                  ).at(-1)?.value
+                ).toBe('idle1');
               });
 
               it('sets #preventAutoSelect to true', () => {
@@ -1206,6 +1211,12 @@ describe('commerceFacetSetReducer', () => {
                   ).indexOf(newFacetValue)
                 ).toBe(2);
                 expect(finalState[facetId]?.request.values.length).toBe(4);
+                expect(
+                  (
+                    finalState[facetId]?.request
+                      .values as LocationFacetValueRequest[]
+                  ).at(-1)?.value
+                ).toBe('idle1');
               });
             });
             describe('when there are no idle values', () => {
@@ -1539,6 +1550,11 @@ describe('commerceFacetSetReducer', () => {
                   ).indexOf(newFacetValue)
                 ).toBe(2);
                 expect(finalState[facetId]?.request.values.length).toBe(4);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as NumericRangeRequest[]
+                  ).at(-1)?.start
+                ).toBe(16);
               });
             });
             describe('when there are no idle values', () => {
@@ -1888,6 +1904,11 @@ describe('commerceFacetSetReducer', () => {
                   ).indexOf(newFacetValue)
                 ).toBe(2);
                 expect(finalState[facetId]?.request.values.length).toBe(4);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as DateRangeRequest[]
+                  ).at(-1)?.start
+                ).toBe('2026-01-01');
               });
             });
             describe('when there are no idle values', () => {

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -879,61 +879,111 @@ describe('commerceFacetSetReducer', () => {
             facetValueState: FacetValueState;
             toggleAction: Function;
           }) => {
-            it('replaces the first idle value with the new value', () => {
-              const newFacetValue = buildMockCommerceRegularFacetValue({
-                value: 'TED',
-                state: facetValueState,
+            describe('when there are idle values', () => {
+              it('inserts the new value before the first idle value and removes the last value', () => {
+                const newFacetValue = buildMockCommerceRegularFacetValue({
+                  value: 'TED',
+                  state: facetValueState,
+                });
+
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    values: [
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active1',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active2',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'idle1',
+                        state: 'idle',
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'idle2',
+                        state: 'idle',
+                      }),
+                    ],
+                  }),
+                });
+
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
+
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as FacetValueRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(2);
+                expect(finalState[facetId]?.request.values.length).toBe(4);
               });
 
-              state[facetId] = buildMockCommerceFacetSlice({
-                request: buildMockCommerceFacetRequest({
-                  values: [
-                    buildMockCommerceRegularFacetValue({
-                      value: 'active1',
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceRegularFacetValue({
-                      value: 'active2',
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceRegularFacetValue({
-                      value: 'idle1',
-                      state: 'idle',
-                    }),
-                    buildMockCommerceRegularFacetValue({
-                      value: 'idle2',
-                      state: 'idle',
-                    }),
-                  ],
-                }),
-              });
+              it('sets #preventAutoSelect to true', () => {
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({values: []}),
+                });
 
-              const action = toggleAction({
-                facetId,
-                selection: newFacetValue,
-              });
+                const action = toggleAction({
+                  facetId,
+                  selection: buildMockCommerceRegularFacetValue({value: 'TED'}),
+                });
+                const finalState = commerceFacetSetReducer(state, action);
 
-              const finalState = commerceFacetSetReducer(state, action);
-              expect(
-                (
-                  finalState[facetId]?.request.values as FacetValueRequest[]
-                ).indexOf(newFacetValue)
-              ).toBe(2);
-              expect(finalState[facetId]?.request.values.length).toBe(4);
+                expect(finalState[facetId]?.request.preventAutoSelect).toBe(
+                  true
+                );
+              });
             });
+            describe('when there are no idle values', () => {
+              it('inserts the new value at the end', () => {
+                const newFacetValue = buildMockCommerceRegularFacetValue({
+                  value: 'TED',
+                  state: facetValueState,
+                });
 
-            it('sets #preventAutoSelect to true', () => {
-              state[facetId] = buildMockCommerceFacetSlice({
-                request: buildMockCommerceFacetRequest({values: []}),
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    values: [
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active1',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active2',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active3',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceRegularFacetValue({
+                        value: 'active4',
+                        state: facetValueState,
+                      }),
+                    ],
+                  }),
+                });
+
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
+
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as FacetValueRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(4);
+                expect(finalState[facetId]?.request.values.length).toBe(5);
               });
-
-              const action = toggleAction({
-                facetId,
-                selection: buildMockCommerceRegularFacetValue({value: 'TED'}),
-              });
-              const finalState = commerceFacetSetReducer(state, action);
-
-              expect(finalState[facetId]?.request.preventAutoSelect).toBe(true);
             });
           }
         );
@@ -1111,49 +1161,99 @@ describe('commerceFacetSetReducer', () => {
             facetValueState: FacetValueState;
             toggleAction: Function;
           }) => {
-            it('replaces the first idle value with the new value', () => {
-              const newFacetValue = buildMockCommerceLocationFacetValue({
-                value: 'TED',
-                state: facetValueState,
-              });
+            describe('when there are no idle values', () => {
+              it('inserts the new value before the first idle value', () => {
+                const newFacetValue = buildMockCommerceLocationFacetValue({
+                  value: 'TED',
+                  state: facetValueState,
+                });
 
-              state[facetId] = buildMockCommerceFacetSlice({
-                request: buildMockCommerceFacetRequest({
-                  type: 'location',
-                  values: [
-                    buildMockCommerceLocationFacetValue({
-                      value: 'active1',
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceLocationFacetValue({
-                      value: 'active2',
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceLocationFacetValue({
-                      value: 'idle1',
-                      state: 'idle',
-                    }),
-                    buildMockCommerceLocationFacetValue({
-                      value: 'idle2',
-                      state: 'idle',
-                    }),
-                  ],
-                }),
-              });
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'location',
+                    values: [
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active1',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active2',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'idle1',
+                        state: 'idle',
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'idle2',
+                        state: 'idle',
+                      }),
+                    ],
+                  }),
+                });
 
-              const action = toggleAction({
-                facetId,
-                selection: newFacetValue,
-              });
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
 
-              const finalState = commerceFacetSetReducer(state, action);
-              expect(
-                (
-                  finalState[facetId]?.request
-                    .values as LocationFacetValueRequest[]
-                ).indexOf(newFacetValue)
-              ).toBe(2);
-              expect(finalState[facetId]?.request.values.length).toBe(4);
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request
+                      .values as LocationFacetValueRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(2);
+                expect(finalState[facetId]?.request.values.length).toBe(4);
+              });
+            });
+            describe('when there are no idle values', () => {
+              it('inserts the new value at the end', () => {
+                const newFacetValue = buildMockCommerceLocationFacetValue({
+                  value: 'TED',
+                  state: facetValueState,
+                });
+
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'location',
+                    values: [
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active1',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active2',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active3',
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceLocationFacetValue({
+                        value: 'active4',
+                        state: facetValueState,
+                      }),
+                    ],
+                  }),
+                });
+
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
+
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request
+                      .values as LocationFacetValueRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(4);
+                expect(finalState[facetId]?.request.values.length).toBe(5);
+              });
             });
           }
         );
@@ -1385,58 +1485,117 @@ describe('commerceFacetSetReducer', () => {
             facetValueState: FacetValueState;
             toggleAction: Function;
           }) => {
-            it('replaces the first idle value with the new value', () => {
-              const newFacetValue = buildMockCommerceNumericFacetValue({
-                start: 0,
-                end: 5,
-                endInclusive: true,
-                state: facetValueState,
-              });
+            describe('when there are idle values', () => {
+              it('inserts the new value before the first idle value and removes the last value', () => {
+                const newFacetValue = buildMockCommerceNumericFacetValue({
+                  start: 0,
+                  end: 5,
+                  endInclusive: true,
+                  state: facetValueState,
+                });
 
-              state[facetId] = buildMockCommerceFacetSlice({
-                request: buildMockCommerceFacetRequest({
-                  type: 'numericalRange',
-                  values: [
-                    buildMockCommerceNumericFacetValue({
-                      start: 6,
-                      end: 10,
-                      endInclusive: true,
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceNumericFacetValue({
-                      start: 11,
-                      end: 15,
-                      endInclusive: true,
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceNumericFacetValue({
-                      start: 16,
-                      end: 20,
-                      endInclusive: true,
-                      state: 'idle',
-                    }),
-                    buildMockCommerceNumericFacetValue({
-                      start: 21,
-                      end: 25,
-                      endInclusive: true,
-                      state: 'idle',
-                    }),
-                  ],
-                }),
-              });
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'numericalRange',
+                    values: [
+                      buildMockCommerceNumericFacetValue({
+                        start: 6,
+                        end: 10,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 11,
+                        end: 15,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 16,
+                        end: 20,
+                        endInclusive: true,
+                        state: 'idle',
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 21,
+                        end: 25,
+                        endInclusive: true,
+                        state: 'idle',
+                      }),
+                    ],
+                  }),
+                });
 
-              const action = toggleAction({
-                facetId,
-                selection: newFacetValue,
-              });
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
 
-              const finalState = commerceFacetSetReducer(state, action);
-              expect(
-                (
-                  finalState[facetId]?.request.values as NumericRangeRequest[]
-                ).indexOf(newFacetValue)
-              ).toBe(2);
-              expect(finalState[facetId]?.request.values.length).toBe(4);
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as NumericRangeRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(2);
+                expect(finalState[facetId]?.request.values.length).toBe(4);
+              });
+            });
+            describe('when there are no idle values', () => {
+              it('inserts the new value at the end', () => {
+                const newFacetValue = buildMockCommerceNumericFacetValue({
+                  start: 0,
+                  end: 5,
+                  endInclusive: true,
+                  state: facetValueState,
+                });
+
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'numericalRange',
+                    values: [
+                      buildMockCommerceNumericFacetValue({
+                        start: 6,
+                        end: 10,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 11,
+                        end: 15,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 16,
+                        end: 20,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceNumericFacetValue({
+                        start: 21,
+                        end: 25,
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                    ],
+                  }),
+                });
+
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
+
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as NumericRangeRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(4);
+                expect(finalState[facetId]?.request.values.length).toBe(5);
+              });
             });
 
             it('sets #preventAutoSelect to true', () => {
@@ -1675,58 +1834,117 @@ describe('commerceFacetSetReducer', () => {
             facetValueState: FacetValueState;
             toggleAction: ActionCreator;
           }) => {
-            it('replaces the first idle value with the new value', () => {
-              const newFacetValue = buildMockCommerceDateFacetValue({
-                start: '2023-01-01',
-                end: '2024-01-01',
-                endInclusive: false,
-                state: facetValueState,
-              });
+            describe('when there are idle values', () => {
+              it('inserts the new value before the first idle value and removes the last value', () => {
+                const newFacetValue = buildMockCommerceDateFacetValue({
+                  start: '2023-01-01',
+                  end: '2024-01-01',
+                  endInclusive: false,
+                  state: facetValueState,
+                });
 
-              state[facetId] = buildMockCommerceFacetSlice({
-                request: buildMockCommerceFacetRequest({
-                  type: 'dateRange',
-                  values: [
-                    buildMockCommerceDateFacetValue({
-                      start: '2024-01-01',
-                      end: '2025-01-01',
-                      endInclusive: false,
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceDateFacetValue({
-                      start: '2025-01-01',
-                      end: '2026-01-01',
-                      endInclusive: false,
-                      state: facetValueState,
-                    }),
-                    buildMockCommerceDateFacetValue({
-                      start: '2026-01-01',
-                      end: '2027-01-01',
-                      endInclusive: false,
-                      state: 'idle',
-                    }),
-                    buildMockCommerceDateFacetValue({
-                      start: '2027-01-01',
-                      end: '2028-01-01',
-                      endInclusive: true,
-                      state: 'idle',
-                    }),
-                  ],
-                }),
-              });
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'dateRange',
+                    values: [
+                      buildMockCommerceDateFacetValue({
+                        start: '2024-01-01',
+                        end: '2025-01-01',
+                        endInclusive: false,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2025-01-01',
+                        end: '2026-01-01',
+                        endInclusive: false,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2026-01-01',
+                        end: '2027-01-01',
+                        endInclusive: false,
+                        state: 'idle',
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2027-01-01',
+                        end: '2028-01-01',
+                        endInclusive: true,
+                        state: 'idle',
+                      }),
+                    ],
+                  }),
+                });
 
-              const action = toggleAction({
-                facetId,
-                selection: newFacetValue,
-              });
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
 
-              const finalState = commerceFacetSetReducer(state, action);
-              expect(
-                (
-                  finalState[facetId]?.request.values as DateRangeRequest[]
-                ).indexOf(newFacetValue)
-              ).toBe(2);
-              expect(finalState[facetId]?.request.values.length).toBe(4);
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as DateRangeRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(2);
+                expect(finalState[facetId]?.request.values.length).toBe(4);
+              });
+            });
+            describe('when there are no idle values', () => {
+              it('inserts the new value at the end', () => {
+                const newFacetValue = buildMockCommerceDateFacetValue({
+                  start: '2023-01-01',
+                  end: '2024-01-01',
+                  endInclusive: false,
+                  state: facetValueState,
+                });
+
+                state[facetId] = buildMockCommerceFacetSlice({
+                  request: buildMockCommerceFacetRequest({
+                    numberOfValues: 4,
+                    type: 'dateRange',
+                    values: [
+                      buildMockCommerceDateFacetValue({
+                        start: '2024-01-01',
+                        end: '2025-01-01',
+                        endInclusive: false,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2025-01-01',
+                        end: '2026-01-01',
+                        endInclusive: false,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2026-01-01',
+                        end: '2027-01-01',
+                        endInclusive: false,
+                        state: facetValueState,
+                      }),
+                      buildMockCommerceDateFacetValue({
+                        start: '2027-01-01',
+                        end: '2028-01-01',
+                        endInclusive: true,
+                        state: facetValueState,
+                      }),
+                    ],
+                  }),
+                });
+
+                const action = toggleAction({
+                  facetId,
+                  selection: newFacetValue,
+                });
+
+                const finalState = commerceFacetSetReducer(state, action);
+                expect(
+                  (
+                    finalState[facetId]?.request.values as DateRangeRequest[]
+                  ).indexOf(newFacetValue)
+                ).toBe(4);
+                expect(finalState[facetId]?.request.values.length).toBe(5);
+              });
             });
 
             it('sets #preventAutoSelect to true', () => {

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -684,9 +684,16 @@ function insertNewValue(
     firstIdleIndex === -1 ? values.length : firstIdleIndex;
 
   const valuesBefore = values.slice(0, indexToInsertAt);
-  const valuesAfter = values.slice(indexToInsertAt + 1);
+  const valuesAfter = values.slice(indexToInsertAt);
 
   facetRequest.values = [...valuesBefore, facetValue, ...valuesAfter];
+
+  if (firstIdleIndex > -1) {
+    facetRequest.values = facetRequest.values.slice(
+      0,
+      facetRequest.numberOfValues
+    );
+  }
 
   facetRequest.numberOfValues = facetRequest.values.length;
 }

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -683,16 +683,10 @@ function insertNewValue(
   const indexToInsertAt =
     firstIdleIndex === -1 ? values.length : firstIdleIndex;
 
-  const valuesBefore = values.slice(0, indexToInsertAt);
-  const valuesAfter = values.slice(indexToInsertAt);
-
-  facetRequest.values = [...valuesBefore, facetValue, ...valuesAfter];
+  facetRequest.values.splice(indexToInsertAt, 0, facetValue);
 
   if (firstIdleIndex > -1) {
-    facetRequest.values = facetRequest.values.slice(
-      0,
-      facetRequest.numberOfValues
-    );
+    facetRequest.values.pop();
   }
 
   facetRequest.numberOfValues = facetRequest.values.length;

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.test.ts
@@ -295,7 +295,7 @@ describe('facet-set slice', () => {
     ])(
       'when the facet value does not exist',
       ({facetValueState, toggleAction}) => {
-        it('replaces the first idle value with the new value', () => {
+        it('inserts the new value before the first idle value and removes the last value', () => {
           const newFacetValue = buildMockFacetValue({
             value: 'TED',
             state: facetValueState,
@@ -303,6 +303,7 @@ describe('facet-set slice', () => {
 
           state[id] = buildMockFacetSlice({
             request: buildMockFacetRequest({
+              numberOfValues: 4,
               currentValues: [
                 buildMockFacetValue({
                   value: 'active1',
@@ -679,31 +680,35 @@ describe('facet-set slice', () => {
       expect(currentValues).toEqual([expectedSearchResultValue]);
     });
 
-    it('when there are idle values, the search result replaces the first idle value', () => {
-      // [KIT-107] If the selected result is appended, we will request one extra value than
-      // we need, creating an inconsistent UX. If the numberOfValues is kept the same (e.g. because
-      // we detect at an idle value), then the showLess button will momentarily flicker as the
-      // number of currentValues is greater than the original number of requested values.
-      // Instead, we replace an idle value, keeping the number of values the same.
+    it('when there are idle values, the search result pushes idle values down, removing the last value', () => {
       const valueA = buildMockFacetValueRequest({value: 'A'});
       const valueB = buildMockFacetValueRequest({value: 'B'});
 
       state[facetId]!.request.currentValues = [valueA, valueB];
+      state[facetId]!.request.numberOfValues = 2;
       dispatchFacetSearchResultAction();
 
       const {currentValues} = getFacetRequest();
-      expect(currentValues).toEqual([expectedSearchResultValue, valueB]);
+      expect(currentValues).toEqual([expectedSearchResultValue, valueA]);
     });
 
     it(`when there are only ${facetValueState} values, it adds the search result to the end`, () => {
       const activeValue = buildMockFacetValueRequest({
         state: facetValueState,
       });
-      state[facetId]!.request.currentValues = [activeValue];
+      const activeValue2 = buildMockFacetValueRequest({
+        state: facetValueState,
+      });
+      state[facetId]!.request.currentValues = [activeValue, activeValue2];
+      state[facetId]!.request.numberOfValues = 2;
       dispatchFacetSearchResultAction();
 
       const {currentValues} = getFacetRequest();
-      expect(currentValues).toEqual([activeValue, expectedSearchResultValue]);
+      expect(currentValues).toEqual([
+        activeValue,
+        activeValue2,
+        expectedSearchResultValue,
+      ]);
     });
   });
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -266,9 +266,17 @@ function insertNewValue(
     firstIdleIndex === -1 ? currentValues.length : firstIdleIndex;
 
   const valuesBefore = currentValues.slice(0, indexToInsertAt);
-  const valuesAfter = currentValues.slice(indexToInsertAt + 1);
+  const valuesAfter = currentValues.slice(indexToInsertAt);
 
   facetRequest.currentValues = [...valuesBefore, facetValue, ...valuesAfter];
+
+  if (firstIdleIndex > -1) {
+    facetRequest.currentValues = facetRequest.currentValues.slice(
+      0,
+      facetRequest.numberOfValues
+    );
+  }
+
   facetRequest.numberOfValues = facetRequest.currentValues.length;
 }
 

--- a/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/facets/facet-set/facet-set-slice.ts
@@ -265,16 +265,10 @@ function insertNewValue(
   const indexToInsertAt =
     firstIdleIndex === -1 ? currentValues.length : firstIdleIndex;
 
-  const valuesBefore = currentValues.slice(0, indexToInsertAt);
-  const valuesAfter = currentValues.slice(indexToInsertAt);
-
-  facetRequest.currentValues = [...valuesBefore, facetValue, ...valuesAfter];
+  facetRequest.currentValues.splice(indexToInsertAt, 0, facetValue);
 
   if (firstIdleIndex > -1) {
-    facetRequest.currentValues = facetRequest.currentValues.slice(
-      0,
-      facetRequest.numberOfValues
-    );
+    facetRequest.currentValues.pop();
   }
 
   facetRequest.numberOfValues = facetRequest.currentValues.length;


### PR DESCRIPTION
This PR ensures that when selecting a facet search value, the first idle value does not get replaced by it. Instead, the new value will be inserted before the first idle value, pushing each other values down, with the last one getting removed.

When there are no idle values the new value will get added after the last active value, as was the case before.

Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c98c22c5-464a-46dd-8088-b306954da919" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/afacf7c9-b566-4bca-b792-787b12422a68" />

After:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c98c22c5-464a-46dd-8088-b306954da919" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/9c8642dd-9e07-4d8e-98f6-d028a5e1e49e" />
