### PR TITLE
chore(atomic,quantic): move tests scripts orchestrations to nx

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -49,10 +49,10 @@
   "scripts": {
     "clean": "rimraf -rf dist/* dist-storybook/* www/* docs/* playwright-report/*",
     "build": "nx build",
-    "build:locales": "npx nx build:locales atomic",
+    "build:locales": "nx build:locales atomic",
     "start": "nx dev atomic",
     "prod": "npx serve www -l 3333 --no-request-logging",
-    "test": "vitest --run && npm run build:locales && stencil test --spec -- src/utils/initialization-utils.spec.ts src/components/search/atomic-layout/search-layout.spec.ts",
+    "test": "nx test atomic",
     "test:watch": "vitest",
     "e2e": "cypress run --browser chrome",
     "e2e:firefox": "cypress run --browser firefox",

--- a/packages/atomic/project.json
+++ b/packages/atomic/project.json
@@ -120,6 +120,25 @@
           }
         }
       }
+    },
+    "test": {
+      "executor": "nx:noop",
+      "dependsOn": ["test:stencil", "test:lit"]
+    },
+    "test:stencil": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build:locales"],
+      "options": {
+        "command": "stencil test --spec -- src/utils/initialization-utils.spec.ts src/components/search/atomic-layout/search-layout.spec.ts",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test:lit": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "vitest --run",
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/coveo/ui-kit.git"
   },
   "scripts": {
-    "test": "npm run babel:headless && npm run build:staticresources && npm run lint:check:tests && npm run validate:types && npm run test:unit",
+    "test": "nx test quantic",
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
     "lint:fix": "npm run lint:fix:js",
     "lint:fix:js": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --write",

--- a/packages/quantic/project.json
+++ b/packages/quantic/project.json
@@ -40,6 +40,20 @@
       "options": {
         "script": "promote:sfdx:ci"
       }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/coverage"],
+      "dependsOn": ["build"],
+      "options": {
+        "commands": [
+          "npm run lint:check:tests",
+          "npm run validate:types",
+          "npm run test:unit"
+        ],
+        "parallel": true,
+        "cwd": "{projectRoot}"
+      }
     }
   }
 }


### PR DESCRIPTION
Move the tests orchestration to `nx`, this allow to ensure tasks are parallelized when they could, and that their dependencies runs when they should

This should help with `ENOENT: no such file or directory, open '../../node_modules/@coveo/headless/dist/quantic/headless.js` error that happens in UT.