### PR TITLE
docs(headless,atomic): link updates

### DIFF
--- a/packages/headless/src/controllers/core/facets/range-facet/date-facet/headless-date-facet-options.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/date-facet/headless-date-facet-options.ts
@@ -45,7 +45,7 @@ export interface DateFacetOptions {
   /**
    * Whether the index should automatically create range values.
    *
-   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1982/#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
+   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1833#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
    */
   generateAutomaticRanges: boolean;
 

--- a/packages/headless/src/controllers/core/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
+++ b/packages/headless/src/controllers/core/facets/range-facet/numeric-facet/headless-numeric-facet-options.ts
@@ -53,7 +53,7 @@ export interface NumericFacetOptions {
   /**
    * Whether the index should automatically create range values.
    *
-   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1982/#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
+   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1833#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
    */
   generateAutomaticRanges: boolean;
 

--- a/packages/headless/src/controllers/dictionary-field-context/headless-dictionary-field-context.ts
+++ b/packages/headless/src/controllers/dictionary-field-context/headless-dictionary-field-context.ts
@@ -16,7 +16,7 @@ import {
 export type {DictionaryFieldContextPayload};
 
 /**
- * The `DictionaryFieldContext` controller allows specifying which [dictionary field](https://docs.coveo.com/en/2036/index-content/about-fields#dictionary-fields) keys to retrieve.
+ * The `DictionaryFieldContext` controller allows specifying which [dictionary field](https://docs.coveo.com/en/2036/) keys to retrieve.
  *
  * Example: [dictionary-field-context.fn.ts](https://github.com/coveo/ui-kit/blob/master/packages/samples/headless-react/src/components/dictionary-field-context/dictionary-field-context.fn.ts)
  *

--- a/packages/headless/src/features/dictionary-field-context/dictionary-field-context-state.ts
+++ b/packages/headless/src/features/dictionary-field-context/dictionary-field-context-state.ts
@@ -1,7 +1,7 @@
 export type DictionaryFieldContextPayload = Record<string, string>;
 export type DictionaryFieldContextState = {
   /**
-   * Holds the [dictionary field context](https://docs.coveo.com/en/2036/index-content/about-fields#dictionary-fields) information.
+   * Holds the [dictionary field context](https://docs.coveo.com/en/2036/) information.
    */
   contextValues: DictionaryFieldContextPayload;
 };

--- a/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/date-facet-set/date-facet-actions.ts
@@ -54,7 +54,7 @@ export interface RegisterDateFacetActionCreatorPayload {
   /**
    * Whether the index should automatically create range values.
    *
-   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1982/#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
+   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1833#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
    */
   generateAutomaticRanges: boolean;
 

--- a/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
+++ b/packages/headless/src/features/facets/range-facets/numeric-facet-set/numeric-facet-actions.ts
@@ -48,7 +48,7 @@ export interface RegisterNumericFacetActionCreatorPayload {
   /**
    * Whether the index should automatically create range values.
    *
-   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1982/#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
+   * Tip: If you set this parameter to true, you should ensure that the ['Use cache for numeric queries' option](https://docs.coveo.com/en/1833#use-cache-for-numeric-queries) is enabled for this facet's field in your index in order to speed up automatic range evaluation.
    */
   generateAutomaticRanges: boolean;
 

--- a/packages/headless/src/state/state-sections.ts
+++ b/packages/headless/src/state/state-sections.ts
@@ -149,7 +149,7 @@ export interface ContextSection {
 
 export interface DictionaryFieldContextSection {
   /**
-   * Holds the [dictionary field context](https://docs.coveo.com/en/2036/index-content/about-fields#dictionary-fields) information.
+   * Holds the [dictionary field context](https://docs.coveo.com/en/2036/) information.
    */
   dictionaryFieldContext: DictionaryFieldContextState;
 }


### PR DESCRIPTION
[DOC-17007](https://coveord.atlassian.net/browse/DOC-17007)

A few field pages are changing on docs.coveo.com and it will affect links.
To be merged after https://github.com/coveo/doc_jekyll-public-site/pull/13160

[DOC-17007]: https://coveord.atlassian.net/browse/DOC-17007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ