### PR TITLE
chore(atomic): replace AriaLiveRegion decorator with a lit controller

### DIFF
--- a/packages/atomic/src/utils/accessibility-utils.spec.ts
+++ b/packages/atomic/src/utils/accessibility-utils.spec.ts
@@ -1,0 +1,71 @@
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {html, LitElement} from 'lit';
+import {customElement, state} from 'lit/decorators.js';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {AriaLiveRegionController} from './accessibility-utils';
+
+@customElement('stub-aria-live')
+class StubAriaLive extends LitElement {
+  @state() regions: {
+    [region: string]: {assertive: boolean; message: string};
+  } = {};
+
+  registerRegion = vi.fn();
+  updateMessage = vi.fn();
+  findAriaLiveListenerSpy = vi.fn().mockImplementation((event) => {
+    event.detail.element = this;
+  });
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener(
+      'atomic/accessibility/findAriaLive',
+      this.findAriaLiveListenerSpy
+    );
+  }
+}
+
+@customElement('test-element')
+class TestElement extends LitElement {
+  region = new AriaLiveRegionController(this, 'test-region', true);
+
+  render() {
+    this.region.message = 'Test message';
+
+    return html`<div>A test element</div>`;
+  }
+}
+
+describe('#AriaLiveRegionController', () => {
+  let testElement: TestElement;
+  let ariaLive: StubAriaLive;
+
+  beforeEach(async () => {
+    await fixture(
+      html`<stub-aria-live></stub-aria-live> <test-element></test-element>`
+    );
+    testElement = document.querySelector('test-element')! as TestElement;
+    ariaLive = document.querySelector('stub-aria-live')! as StubAriaLive;
+  });
+
+  it('should register the region when the host is updated', async () => {
+    expect(ariaLive.registerRegion).toHaveBeenCalledWith('test-region', true);
+  });
+
+  it('should dispatch a message to the aria live when setting the message', async () => {
+    expect(ariaLive.updateMessage).toHaveBeenCalledWith(
+      'test-region',
+      'Test message',
+      true
+    );
+  });
+
+  it('should update the message when the message is changed', async () => {
+    testElement.region.message = 'New message';
+    expect(ariaLive.updateMessage).toHaveBeenCalledWith(
+      'test-region',
+      'New message',
+      true
+    );
+  });
+});

--- a/packages/atomic/src/utils/accessibility-utils.ts
+++ b/packages/atomic/src/utils/accessibility-utils.ts
@@ -1,24 +1,57 @@
-// import {AnyBindings} from '../components/common/interface/bindings';
-// import {buildCustomEvent} from './event-utils';
-// import {InitializableComponent} from './initialization-utils';
-// import {defer} from './utils';
+import {ReactiveController, ReactiveControllerHost} from 'lit';
+import {buildCustomEvent} from './event-utils';
 
-// const findAriaLiveEventName = 'atomic/accessibility/findAriaLive';
-
-//TODO: Reimplement to fit Lit
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FindAriaLiveEventArgs {
-  // element?: HTMLAtomicAriaLiveElement;
+  element?: HTMLAtomicAriaLiveElement;
+}
+
+export class AriaLiveRegionController implements ReactiveController {
+  private host: ReactiveControllerHost;
+  private regionName: string;
+  private assertive: boolean;
+
+  constructor(
+    host: ReactiveControllerHost,
+    regionName: string,
+    assertive = false
+  ) {
+    this.host = host;
+    this.regionName = regionName;
+    this.assertive = assertive;
+
+    this.host.addController(this);
+  }
+
+  private getAriaLiveElement() {
+    const event = buildCustomEvent<FindAriaLiveEventArgs>(
+      'atomic/accessibility/findAriaLive',
+      {}
+    );
+    document.dispatchEvent(event);
+    const {element} = event.detail;
+    return element;
+  }
+
+  private dispatchMessage(message: string) {
+    this.getAriaLiveElement()?.updateMessage(
+      this.regionName,
+      message,
+      this.assertive
+    );
+  }
+
+  set message(msg: string) {
+    this.dispatchMessage(msg);
+  }
+
+  hostUpdate() {
+    this.getAriaLiveElement()?.registerRegion(this.regionName, this.assertive);
+  }
 }
 
 //TODO: Reimplement to fit Lit
-export function AriaLiveRegion(_regionName: string, _assertive = false) {}
-
-//TODO: Reimplement to fit Lit
 export class FocusTargetController {
-  //@ts-expect-error to implement
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public setTarget(el: HTMLElement) {}
+  public setTarget(_el: HTMLElement) {}
   public focusAfterSearch() {}
   public focusOnNextTarget() {}
   public async focus() {}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4143

## Before
```
 @AriaLiveRegion('search-box')
  protected searchBoxAriaMessage!: string;
```

## now

```
  protected searchBoxAriaMessage = new AriaLiveRegionController(
    this,
    'search-box'
  );
```
