### PR TITLE
test(button): use button as guinea pig for 'standard' ut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24914,6 +24914,19 @@
         }
       }
     },
+    "node_modules/@vitest/browser/node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/browser/node_modules/@vitest/utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
@@ -25038,9 +25051,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
-      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25059,6 +25072,19 @@
       "dependencies": {
         "@vitest/utils": "3.1.1",
         "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -25096,6 +25122,19 @@
         "@vitest/pretty-format": "3.1.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -58255,6 +58294,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/spy": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
@@ -59981,6 +60033,7 @@
         "@types/postcss-import": "14.0.3",
         "@types/puppeteer": "7.0.4",
         "@vitest/browser": "3.1.1",
+        "@vitest/pretty-format": "3.1.2",
         "@whitespace/storybook-addon-html": "6.1.1",
         "axe-core": "4.10.2",
         "chalk": "5.4.1",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -118,6 +118,7 @@
     "@types/postcss-import": "14.0.3",
     "@types/puppeteer": "7.0.4",
     "@vitest/browser": "3.1.1",
+    "@vitest/pretty-format": "3.1.2",
     "@whitespace/storybook-addon-html": "6.1.1",
     "axe-core": "4.10.2",
     "chalk": "5.4.1",

--- a/packages/atomic/src/components/common/__snapshots__/button.spec.ts.snap
+++ b/packages/atomic/src/components/common/__snapshots__/button.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`button > matches known snaphsot 1`] = `
+exports[`button > matches known snapshot 1`] = `
 <button
   class="btn-primary"
 >

--- a/packages/atomic/src/components/common/__snapshots__/button.spec.ts.snap
+++ b/packages/atomic/src/components/common/__snapshots__/button.spec.ts.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`button > matches known snaphsot 1`] = `
+<button
+  class="btn-primary"
+>
+  
+      
+  <span
+    class="truncate"
+  >
+    Default test text
+  </span>
+  
+      
+  
+    
+</button>
+`;

--- a/packages/atomic/src/components/common/button.spec.ts
+++ b/packages/atomic/src/components/common/button.spec.ts
@@ -21,9 +21,13 @@ describe('button', () => {
   };
 
   it('should render a button in the document', async () => {
-    const props = {};
-    const button = await renderButton(props);
+    const button = await renderButton();
     expect(button).toBeInTheDocument();
+  });
+
+  it('matches known snapshot', async () => {
+    const button = await renderButton();
+    expect(button).toMatchSnapshot();
   });
 
   it('should render a button with the correct style', async () => {
@@ -42,7 +46,6 @@ describe('button', () => {
     };
 
     const button = await renderButton(props);
-
     expect(button.querySelector('span')).toHaveTextContent('Click me');
   });
 

--- a/packages/atomic/src/components/common/button.spec.ts
+++ b/packages/atomic/src/components/common/button.spec.ts
@@ -1,70 +1,57 @@
 import {createRipple} from '@/src/utils/ripple';
-import {fireEvent, within} from '@storybook/test';
-import {html, nothing, render} from 'lit';
-import {vi} from 'vitest';
-import {button, ButtonProps} from './button';
+import {fixture} from '@/vitest-utils/testing-helpers/fixture.js';
+import {userEvent} from '@vitest/browser/context';
+import {html, nothing} from 'lit';
+import {vi, expect, describe, it} from 'vitest';
+import {button, ButtonProps} from './button.js';
 
-vi.mock('@/src/utils/ripple', () => ({
-  createRipple: vi.fn(),
-}));
+vi.mock('@/src/utils/ripple', {spy: true});
 
 describe('button', () => {
-  let container: HTMLElement;
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
-
-  afterEach(() => {
-    document.body.removeChild(container);
-  });
-
-  const renderButton = (props: Partial<ButtonProps>): HTMLButtonElement => {
-    render(
+  const renderButton = async (props: Partial<ButtonProps> = {}) => {
+    return fixture(
       html`${button({
         props: {
+          text: 'Default test text',
           ...props,
           style: props.style ?? 'primary',
         },
-      })(nothing)}`,
-      container
+      })(nothing)}`
     );
-    return within(container).getByRole('button') as HTMLButtonElement;
   };
 
-  it('should render a button in the document', () => {
+  it('should render a button in the document', async () => {
     const props = {};
-    const button = renderButton(props);
+    const button = await renderButton(props);
     expect(button).toBeInTheDocument();
   });
 
-  it('should render a button with the correct style', () => {
+  it('should render a button with the correct style', async () => {
     const props: Partial<ButtonProps> = {
       style: 'outline-error',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button).toHaveClass('btn-outline-error');
   });
 
-  it('should render a button with the correct text', () => {
+  it('should render a button with the correct text', async () => {
     const props = {
       text: 'Click me',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
-    expect(button.querySelector('span')?.textContent).toBe('Click me');
+    expect(button.querySelector('span')).toHaveTextContent('Click me');
   });
 
-  it('should wrap the button text with a truncate class', () => {
+  it('should wrap the button text with a truncate class', async () => {
     const props = {
       text: 'Click me',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.querySelector('span')).toHaveClass('truncate');
   });
@@ -75,109 +62,110 @@ describe('button', () => {
       onClick: handleClick,
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
-    await fireEvent.click(button);
+    await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('should apply disabled attribute', () => {
+  it('should apply disabled attribute', async () => {
     const props = {
       disabled: true,
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.hasAttribute('disabled')).toBe(true);
   });
 
-  it('should apply aria attributes', () => {
+  it('should apply aria attributes', async () => {
     const props: Partial<ButtonProps> = {
       ariaLabel: 'button',
       ariaPressed: 'true',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('aria-label')).toBe('button');
     expect(button.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('should apply custom class', () => {
+  it('should apply custom class', async () => {
     const props = {
       class: 'custom-class',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button).toHaveClass('custom-class');
     expect(button).toHaveClass('btn-primary');
   });
 
-  it('should apply part attribute', () => {
+  it('should apply part attribute', async () => {
     const props = {
       part: 'button-part',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('part')).toBe('button-part');
   });
 
-  it('should apply title attribute', () => {
+  it('should apply title attribute', async () => {
     const props = {
       title: 'Button Title',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('title')).toBe('Button Title');
   });
 
-  it('should apply tabindex attribute', () => {
+  it('should apply tabindex attribute', async () => {
     const props = {
       tabIndex: 1,
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('tabindex')).toBe('1');
   });
 
-  it('should apply role attribute', () => {
+  it('should apply role attribute', async () => {
     const props: Partial<ButtonProps> = {
       role: 'button',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('role')).toBe('button');
   });
 
-  it('should call onMouseDown when the mousedown event is fired on the button', async () => {
-    const props: Partial<ButtonProps> = {};
-    const button = renderButton(props);
-    await fireEvent.mouseDown(button);
-    expect(createRipple).toHaveBeenCalled();
+  it('should create a ripple when clicked', async () => {
+    const button = await renderButton();
+
+    await userEvent.click(button);
+
+    expect(createRipple).toBeCalled();
   });
 
-  it('should apply form attribute', () => {
+  it('should apply form attribute', async () => {
     const props = {
       form: 'form-id',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('form')).toBe('form-id');
   });
 
-  it('should apply type attribute', () => {
+  it('should apply type attribute', async () => {
     const props: Partial<ButtonProps> = {
       type: 'submit',
     };
 
-    const button = renderButton(props);
+    const button = await renderButton(props);
 
     expect(button.getAttribute('type')).toBe('submit');
   });

--- a/packages/atomic/vitest-utils/lit-serializer.ts
+++ b/packages/atomic/vitest-utils/lit-serializer.ts
@@ -1,0 +1,28 @@
+import {plugins} from '@vitest/pretty-format';
+import {SnapshotSerializer} from 'vitest';
+
+export default {
+  test: (val: unknown) => val instanceof HTMLElement,
+  serialize(val, config, indentation, depth, refs, printer) {
+    const clone = val.cloneNode(true) as HTMLElement;
+    const walker = document.createTreeWalker(clone);
+    const comments: Comment[] = [];
+    do {
+      if (walker.currentNode.nodeType === Node.COMMENT_NODE) {
+        comments.push(walker.currentNode as Comment);
+      }
+    } while (walker.nextNode());
+
+    for (const comment of comments) {
+      comment.parentNode?.removeChild(comment);
+    }
+    return plugins.DOMElement.serialize(
+      clone,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer
+    );
+  },
+} satisfies SnapshotSerializer;

--- a/packages/atomic/vitest.config.ts
+++ b/packages/atomic/vitest.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       'src/**/search-layout.spec.ts',
     ],
     restoreMocks: true,
+    snapshotSerializers: ['vitest-utils/lit-serializer.ts'],
     setupFiles: ['./vitest-utils/setup.ts'],
     globals: true,
     deps: {


### PR DESCRIPTION
To not merge; goal's to dissect the PR to write up some tests for Functional Components/Atoms

Although **to merge** in this PR:
 - Snapshot serializer for Lit --> Allow stable serialization of DOMElement (not tested with ShadowDOM, ⚠️ )
 - Scrap' Storybook utils outta here
 - Use click instead of "mousedown"; best practices [^1] (and the frameworks we uses behind the scene) push us to use "human-like" interaction, and click is more than close enough; testing whether a user start clicking on the button, then moving their mice out the button is quite zealous.
 
 [^1]: https://testing-library.com/docs/guide-events/#interactions-vs-events