### PR TITLE
chore(headless-react, headless-commerce-ssr): persist recent queries in headless react samples

### DIFF
--- a/packages/samples/headless-commerce-ssr-remix/app/components/parameter-manager.tsx
+++ b/packages/samples/headless-commerce-ssr-remix/app/components/parameter-manager.tsx
@@ -1,3 +1,4 @@
+import {usePersistQuery} from '@/app/hooks/use-recent-queries';
 import {useParameterManager} from '@/lib/commerce-engine';
 import {buildParameterSerializer} from '@coveo/headless-react/ssr-commerce';
 import {useSearchParams} from '@remix-run/react';
@@ -11,6 +12,10 @@ export default function ParameterManager({url}: {url: string | null}) {
   const initialUrl = useMemo(() => new URL(url ?? ''), [url]);
   const previousUrl = useRef(initialUrl.href);
   const [searchParams] = useSearchParams();
+
+  // Sync the `q` parameter with recent queries in localStorage
+  const query = searchParams.get('q');
+  usePersistQuery(query);
 
   /**
    * When the URL fragment changes, this effect deserializes it and synchronizes it into the

--- a/packages/samples/headless-commerce-ssr-remix/app/components/search-box.tsx
+++ b/packages/samples/headless-commerce-ssr-remix/app/components/search-box.tsx
@@ -1,3 +1,4 @@
+import {useInitializeRecentQueries} from '@/app/hooks/use-recent-queries';
 import {
   useInstantProducts,
   useRecentQueriesList,
@@ -9,12 +10,16 @@ import RecentQueries from './recent-queries';
 
 export default function SearchBox() {
   const {state, methods} = useSearchBox();
-  const {state: recentQueriesState} = useRecentQueriesList();
+  const {state: recentQueriesState, methods: recentQueriesController} =
+    useRecentQueriesList();
   const {state: instantProductsState, methods: instantProductsController} =
     useInstantProducts();
 
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isSelectingSuggestion, setIsSelectingSuggestion] = useState(false);
+
+  // Sync recent queries from localStorage when the component loads
+  useInitializeRecentQueries(recentQueriesController?.updateRecentQueries);
 
   const onSearchBoxInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsSelectingSuggestion(true);

--- a/packages/samples/headless-commerce-ssr-remix/app/hooks/use-recent-queries.ts
+++ b/packages/samples/headless-commerce-ssr-remix/app/hooks/use-recent-queries.ts
@@ -1,0 +1,42 @@
+import {useEffect} from 'react';
+
+const recentQueriesKeyStorageKey = 'commerce-recent-queries';
+
+function getStoredRecentQueries(): string[] {
+  const storedQueries = localStorage.getItem(recentQueriesKeyStorageKey);
+  if (storedQueries) {
+    try {
+      return JSON.parse(storedQueries);
+    } catch (error) {
+      console.error('Failed to parse recent queries from localStorage:', error);
+    }
+  }
+  return [];
+}
+
+function saveRecentQueries(queries: string[]) {
+  localStorage.setItem(recentQueriesKeyStorageKey, JSON.stringify(queries));
+}
+
+export function useInitializeRecentQueries(
+  updateRecentQueries?: (queries: string[]) => void
+) {
+  useEffect(() => {
+    const queries = getStoredRecentQueries();
+    if (updateRecentQueries && queries.length > 0) {
+      updateRecentQueries(queries);
+    }
+  }, [updateRecentQueries]);
+}
+
+export function usePersistQuery(query: string | null) {
+  useEffect(() => {
+    if (!query || query.trim() === '') {
+      return;
+    }
+
+    const queries = getStoredRecentQueries();
+    queries.unshift(query);
+    saveRecentQueries(queries);
+  }, [query]);
+}

--- a/packages/samples/headless-react/src/components/recent-queries/recent-queries.class.tsx
+++ b/packages/samples/headless-react/src/components/recent-queries/recent-queries.class.tsx
@@ -13,22 +13,39 @@ export class RecentQueriesList extends Component<
   RecentQueriesState
 > {
   static contextType = AppContext;
-  context!: ContextType<typeof AppContext>;
+  declare context: ContextType<typeof AppContext>;
 
   private controller!: HeadlessRecentQueriesList;
   private unsubscribe: Unsubscribe = () => {};
 
   componentDidMount() {
+    const initialState = {queries: this.retrieveLocalStorage()};
     this.controller = buildRecentQueriesList(this.context.engine!, {
       options: this.props,
+      initialState,
     });
     this.updateState();
 
-    this.unsubscribe = this.controller.subscribe(() => this.updateState());
+    this.unsubscribe = this.controller.subscribe(() => {
+      this.updateState();
+      this.updateLocalStorage();
+    });
   }
 
   componentWillUnmount() {
     this.unsubscribe();
+  }
+
+  private retrieveLocalStorage() {
+    const storedQueries = localStorage.getItem('recentQueries');
+    return storedQueries ? JSON.parse(storedQueries) : [];
+  }
+
+  private updateLocalStorage() {
+    localStorage.setItem(
+      'recentQueries',
+      JSON.stringify(this.controller.state.queries)
+    );
   }
 
   private updateState() {

--- a/packages/samples/headless-react/src/components/recent-queries/recent-queries.class.tsx
+++ b/packages/samples/headless-react/src/components/recent-queries/recent-queries.class.tsx
@@ -13,7 +13,7 @@ export class RecentQueriesList extends Component<
   RecentQueriesState
 > {
   static contextType = AppContext;
-  declare context: ContextType<typeof AppContext>;
+  context: ContextType<typeof AppContext> = undefined!;
 
   private controller!: HeadlessRecentQueriesList;
   private unsubscribe: Unsubscribe = () => {};

--- a/packages/samples/headless-react/src/components/recent-queries/recent-queries.fn.tsx
+++ b/packages/samples/headless-react/src/components/recent-queries/recent-queries.fn.tsx
@@ -11,7 +11,31 @@ export const RecentQueriesList: React.FunctionComponent<RecentQueriesProps> = (
   const {controller} = props;
   const [state, setState] = useState(controller.state);
 
-  useEffect(() => controller.subscribe(() => setState(controller.state)), []);
+  useEffect(() => {
+    const storedQueries = retrieveLocalStorage();
+    if (storedQueries.length) {
+      controller.state.queries = storedQueries;
+    }
+
+    const unsubscribe = controller.subscribe(() => {
+      setState(controller.state);
+      updateLocalStorage();
+    });
+
+    return () => unsubscribe();
+  }, [controller]);
+
+  const retrieveLocalStorage = () => {
+    const storedQueries = localStorage.getItem('recentQueries');
+    return storedQueries ? JSON.parse(storedQueries) : [];
+  };
+
+  const updateLocalStorage = () => {
+    localStorage.setItem(
+      'recentQueries',
+      JSON.stringify(controller.state.queries)
+    );
+  };
 
   return (
     <div>

--- a/packages/samples/headless-ssr-commerce-nextjs/components/recent-queries.tsx
+++ b/packages/samples/headless-ssr-commerce-nextjs/components/recent-queries.tsx
@@ -1,12 +1,8 @@
-import {useInitializeRecentQueries} from '@/hooks/use-recent-queries';
 import {useInstantProducts, useRecentQueriesList} from '@/lib/commerce-engine';
 
 export default function RecentQueries() {
   const {state, methods} = useRecentQueriesList();
   const {methods: instantProductsController} = useInstantProducts();
-
-  // Sync recent queries from localStorage when the component loads
-  useInitializeRecentQueries(methods?.updateRecentQueries);
 
   return (
     <div>

--- a/packages/samples/headless-ssr-commerce-nextjs/components/search-box.tsx
+++ b/packages/samples/headless-ssr-commerce-nextjs/components/search-box.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {useInitializeRecentQueries} from '@/hooks/use-recent-queries';
 import {
   useInstantProducts,
   useRecentQueriesList,
@@ -11,12 +12,16 @@ import RecentQueries from './recent-queries';
 
 export default function SearchBox() {
   const {state, methods} = useSearchBox();
-  const {state: recentQueriesState} = useRecentQueriesList();
+  const {state: recentQueriesState, methods: recentQueriesController} =
+    useRecentQueriesList();
   const {state: instantProductsState, methods: instantProductsController} =
     useInstantProducts();
 
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isSelectingSuggestion, setIsSelectingSuggestion] = useState(false);
+
+  // Sync recent queries from localStorage when the component loads
+  useInitializeRecentQueries(recentQueriesController?.updateRecentQueries);
 
   const onSearchBoxInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsSelectingSuggestion(true);

--- a/packages/samples/headless-ssr-commerce-nextjs/hooks/use-recent-queries.ts
+++ b/packages/samples/headless-ssr-commerce-nextjs/hooks/use-recent-queries.ts
@@ -23,7 +23,7 @@ export function useInitializeRecentQueries(
 ) {
   useEffect(() => {
     const queries = getStoredRecentQueries();
-    if (updateRecentQueries) {
+    if (updateRecentQueries && queries.length > 0) {
       updateRecentQueries(queries);
     }
   }, [updateRecentQueries]);


### PR DESCRIPTION
This PR adds recent queries persistence to the headless-commerce-ssr-remix, headless-react and headless-commerce-ssr samples.

https://coveord.atlassian.net/browse/KIT-4136
