### PR TITLE
test(insight): adds wait for results in refine modal tests

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-interface/e2e/atomic-insight-interface.e2e.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/e2e/atomic-insight-interface.e2e.ts
@@ -87,6 +87,10 @@ test.describe('Atomic Insight Panel', () => {
   });
 
   test.describe('refine modal', () => {
+    test.beforeEach(async ({insightInterface}) => {
+      await insightInterface.waitForResults();
+    });
+
     test('should open and close', async ({insightInterface}) => {
       await insightInterface.openRefineModal();
       await expect(insightInterface.insightRefineModal).toHaveAttribute(

--- a/packages/atomic/src/components/insight/atomic-insight-interface/e2e/page-object.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/e2e/page-object.ts
@@ -58,6 +58,10 @@ export class InsightInterfacePageObject extends BasePageObject<'atomic-insight-i
     return this.insightRefineModal.getByRole('button', {name: 'Close'});
   }
 
+  async waitForResults() {
+    await this.insightResults.first().waitFor({state: 'visible'});
+  }
+
   getTabByName(name: string) {
     return this.insightTabs.filter({
       hasText: name,


### PR DESCRIPTION
- Introduces a helper method to ensure results are visible before tests in the refine modal suite.
- Enhances test reliability by preventing race conditions during execution.

Without this, we may click the filter button _before_ the first search is completed and/or the interface is fully loaded.

https://coveord.atlassian.net/browse/SVCC-5059