### PR TITLE
chore(atomic): fix init issue for lit components when using initializeBindingsMixin

### DIFF
--- a/packages/atomic/src/utils/init-queue.ts
+++ b/packages/atomic/src/utils/init-queue.ts
@@ -68,3 +68,15 @@ export function queueEventForParent(
   }
   eventQueueMap.get(parent)!.push({event, element});
 }
+
+export function enqueueOrDispatchInitializationEvent(
+  parent: Element,
+  event: InitializeEvent,
+  element: Element
+) {
+  if (isParentReady(parent)) {
+    element.dispatchEvent(event);
+  } else {
+    queueEventForParent(parent, event, element);
+  }
+}

--- a/packages/atomic/src/utils/initialization-lit-stencil-common-utils.ts
+++ b/packages/atomic/src/utils/initialization-lit-stencil-common-utils.ts
@@ -1,6 +1,7 @@
 import type {AnyBindings} from '../components/common/interface/bindings';
 import {closest} from './dom-utils';
 import {buildCustomEvent} from './event-utils';
+import {enqueueOrDispatchInitializationEvent} from './init-queue';
 
 export function fetchBindings<SpecificBindings extends AnyBindings>(
   element: Element
@@ -10,16 +11,15 @@ export function fetchBindings<SpecificBindings extends AnyBindings>(
       initializeEventName,
       (bindings: unknown) => resolve(bindings as SpecificBindings)
     );
-    element.dispatchEvent(event);
-
-    if (!closest(element, initializableElements.join(', '))) {
+    const parent = closest(element, initializableElements.join(', '));
+    if (!parent) {
       reject(new MissingInterfaceParentError(element.nodeName.toLowerCase()));
+      return;
     }
+    enqueueOrDispatchInitializationEvent(parent, event, element);
   });
 }
-
 export type InitializeEventHandler = (bindings: AnyBindings) => void;
-
 export class MissingInterfaceParentError extends Error {
   constructor(elementName: string) {
     super(
@@ -29,7 +29,6 @@ export class MissingInterfaceParentError extends Error {
     );
   }
 }
-
 export const initializableElements = [
   'atomic-recs-interface',
   'atomic-search-interface',
@@ -39,5 +38,4 @@ export const initializableElements = [
   'atomic-insight-interface',
   'atomic-external',
 ];
-
 export const initializeEventName = 'atomic/initializeComponent';

--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -10,7 +10,7 @@ import {AnyBindings} from '../components/common/interface/bindings';
 import {Hidden} from '../components/common/stencil-hidden';
 import {Bindings} from '../components/search/atomic-search-interface/atomic-search-interface';
 import {buildCustomEvent} from './event-utils';
-import {isParentReady, queueEventForParent} from './init-queue';
+import {enqueueOrDispatchInitializationEvent} from './init-queue';
 import {
   MissingInterfaceParentError,
   InitializeEventHandler,
@@ -43,11 +43,7 @@ export function initializeBindings<
       return;
     }
 
-    if (isParentReady(parent)) {
-      element.dispatchEvent(event);
-    } else {
-      queueEventForParent(parent, event as InitializeEvent, element);
-    }
+    enqueueOrDispatchInitializationEvent(parent, event, element);
   });
 }
 
@@ -158,12 +154,11 @@ export function InitializeBindings<SpecificBindings extends AnyBindings>({
         );
         return;
       }
-
-      if (isParentReady(parent)) {
-        element.dispatchEvent(event);
-      } else {
-        queueEventForParent(parent, event as InitializeEvent, element);
-      }
+      enqueueOrDispatchInitializationEvent(
+        parent,
+        event as InitializeEvent,
+        element
+      );
       return componentWillLoad && componentWillLoad.call(this);
     };
 


### PR DESCRIPTION
This PR fixes an issue preventing initialization of lit components when using the initializeBindingsMixin mixin to retrieve bindings.
https://coveord.atlassian.net/browse/KIT-4161
