### PR TITLE
chore: release workflow cron schedule

### DIFF
--- a/.github/workflows/cron-release.yml
+++ b/.github/workflows/cron-release.yml
@@ -1,0 +1,9 @@
+name: Scheduled Release
+on:
+  schedule:
+    # At 02:00 (UTC) Wednesday/ 21:00 (ETC) every Tuesday.
+    - cron: '0 2 * * 3'
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,25 @@
+name: Manual Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '⚠ be sure of yourself ⚠'
+        required: false
+        default: ''
+        type: string
+      debug:
+        description: 'Add DEBUG=* to the env if true'
+        type: boolean
+        default: false
+        required: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    environment: 'Manual Release'
+  release:
+    uses: ./.github/workflows/release.yml
+    needs: approve
+    with:
+      version: ${{ github.event.inputs.version }}
+      debug: ${{ github.event.inputs.debug }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Create release
 on:
   schedule:
-    # At 13:00 (UTC) every Wednesday.
-    - cron: '0 13 * * 3'
+    # At 02:00 (UTC) Wednesday/ 21:00 (ETC) every Tuesday.
+    - cron: '0 2 * * 3'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Create release
 on:
-  schedule:
-    # At 02:00 (UTC) Wednesday/ 21:00 (ETC) every Tuesday.
-    - cron: '0 2 * * 3'
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
         description: '⚠ be sure of yourself ⚠'
         required: false
         default: ''
+        type: string
       debug:
         description: 'Add DEBUG=* to the env if true'
         type: boolean


### PR DESCRIPTION
Adjusts the release workflow schedule to trigger at 02:00 UTC on Wednesdays, aligning with 21:00 ETC on Tuesdays for improved timing suitability.
