### PR TITLE
test(atomic): remove `globals: true` in vitest config

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/analytics-config.spec.ts
@@ -2,6 +2,7 @@ import {
   CommerceEngineConfiguration,
   getSampleCommerceEngineConfiguration,
 } from '@coveo/headless/commerce';
+import {describe, expect, it} from 'vitest';
 import {getAnalyticsConfig} from './analytics-config';
 
 describe('getAnalyticsConfig', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
@@ -16,7 +16,15 @@ import {html} from 'lit';
 import {LitElement} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {within} from 'shadow-dom-testing-library';
-import {describe, test, expect, vi, MockInstance} from 'vitest';
+import {
+  describe,
+  test,
+  expect,
+  vi,
+  MockInstance,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import {stateKey} from '../../../../../headless/src/app/state-key';
 import {
   AtomicCommerceInterface,

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.spec.ts
@@ -10,7 +10,7 @@ import {
 import {page} from '@vitest/browser/context';
 import {html} from 'lit';
 import {ifDefined} from 'lit/directives/if-defined.js';
-import {describe, vi, expect, MockInstance} from 'vitest';
+import {describe, vi, expect, MockInstance, test, beforeEach} from 'vitest';
 import {AtomicCommercePager} from './atomic-commerce-pager';
 import './atomic-commerce-pager';
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.spec.ts
@@ -7,7 +7,7 @@ import {buildProductListing, buildSearch} from '@coveo/headless/commerce';
 import {page} from '@vitest/browser/context';
 import '@vitest/browser/matchers.d.ts';
 import {html} from 'lit';
-import {beforeEach, expect, vi} from 'vitest';
+import {beforeEach, expect, vi, describe, it} from 'vitest';
 import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 import {AtomicCommerceSortDropdown} from './atomic-commerce-sort-dropdown';
 import './atomic-commerce-sort-dropdown';

--- a/packages/atomic/src/components/commerce/sort/option.spec.ts
+++ b/packages/atomic/src/components/commerce/sort/option.spec.ts
@@ -1,7 +1,7 @@
 import {renderSortOption as renderCommonSortOption} from '@/src/components/common/sort/option';
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {SortBy, SortCriterion} from '@coveo/headless/commerce';
-import {vi} from 'vitest';
+import {vi, describe, beforeAll, it, expect} from 'vitest';
 import {
   CommerceSortOptionProps,
   renderCommerceSortOption,

--- a/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.spec.ts
+++ b/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.spec.ts
@@ -1,6 +1,6 @@
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
 import {html} from 'lit';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import './atomic-component-error';
 import {AtomicComponentError} from './atomic-component-error';
 

--- a/packages/atomic/src/components/common/atomic-icon/atomic-icon.spec.ts
+++ b/packages/atomic/src/components/common/atomic-icon/atomic-icon.spec.ts
@@ -4,7 +4,7 @@ import {page} from '@vitest/browser/context';
 import '@vitest/browser/matchers.d.ts';
 import DOMPurify from 'dompurify';
 import {html} from 'lit';
-import {expect, MockInstance, vi} from 'vitest';
+import {expect, MockInstance, vi, describe, beforeEach, it} from 'vitest';
 import './atomic-icon';
 import {AtomicIcon} from './atomic-icon';
 

--- a/packages/atomic/src/components/common/button.spec.ts
+++ b/packages/atomic/src/components/common/button.spec.ts
@@ -1,7 +1,7 @@
 import {createRipple} from '@/src/utils/ripple';
 import {fireEvent, within} from '@storybook/test';
 import {html, nothing, render} from 'lit';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {renderButton as button, ButtonProps} from './button';
 
 vi.mock('@/src/utils/ripple', () => ({

--- a/packages/atomic/src/components/common/checkbox.spec.ts
+++ b/packages/atomic/src/components/common/checkbox.spec.ts
@@ -1,6 +1,6 @@
 import {fireEvent, within} from '@storybook/test';
 import {html, render} from 'lit';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {checkbox, CheckboxProps} from './checkbox';
 
 describe('checkbox', () => {

--- a/packages/atomic/src/components/common/facets/facet-common.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.spec.ts
@@ -1,4 +1,5 @@
 import {NumericFacetValue, SearchStatusState} from '@coveo/headless';
+import {describe, expect, it} from 'vitest';
 import {shouldDisplayInputForFacetRange} from './facet-common';
 
 describe('facet common', () => {

--- a/packages/atomic/src/components/common/facets/facet-search/facet-search-utils.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-search/facet-search-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {highlightSearchResult} from './facet-search-utils';
 
 describe('#highlightSearchResult', () => {

--- a/packages/atomic/src/components/common/facets/facet-values-group/facet-values-group.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-values-group/facet-values-group.spec.ts
@@ -1,7 +1,15 @@
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {html} from 'lit';
-import {MockedFunction, vi} from 'vitest';
+import {
+  MockedFunction,
+  vi,
+  describe,
+  beforeAll,
+  beforeEach,
+  it,
+  expect,
+} from 'vitest';
 import {renderFieldsetGroup as renderCommonFieldsetGroup} from '../../fieldset-group';
 import {renderFacetValuesGroup} from './facet-values-group';
 import {FacetValuesGroupProps} from './stencil-facet-values-group';

--- a/packages/atomic/src/components/common/fieldset-group.spec.ts
+++ b/packages/atomic/src/components/common/fieldset-group.spec.ts
@@ -1,6 +1,7 @@
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {page} from '@vitest/browser/context';
 import {html} from 'lit';
+import {describe, it, expect} from 'vitest';
 import {GroupProps, renderFieldsetGroup} from './fieldset-group';
 
 describe('renderFieldsetGroup', () => {

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {transformMarkdownToHtml} from './markdown-utils.js';
 
 describe('markdownUtils', () => {

--- a/packages/atomic/src/components/common/heading.spec.ts
+++ b/packages/atomic/src/components/common/heading.spec.ts
@@ -1,5 +1,6 @@
 import {within} from '@storybook/test';
 import {html, render} from 'lit';
+import {describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {heading, HeadingProps} from './heading';
 
 describe('heading', () => {

--- a/packages/atomic/src/components/common/load-more/button.spec.ts
+++ b/packages/atomic/src/components/common/load-more/button.spec.ts
@@ -1,6 +1,7 @@
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {i18n as I18n} from 'i18next';
 import {html, render} from 'lit';
+import {describe, beforeAll, beforeEach, afterEach, test, expect} from 'vitest';
 import {loadMoreButton} from './button';
 
 describe('loadMoreButton', () => {

--- a/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
@@ -1,7 +1,7 @@
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {i18n as I18n} from 'i18next';
 import {html, render} from 'lit';
-import {describe, test} from 'vitest';
+import {describe, test, beforeEach, afterEach, expect} from 'vitest';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import {

--- a/packages/atomic/src/components/common/radio-button.spec.ts
+++ b/packages/atomic/src/components/common/radio-button.spec.ts
@@ -1,6 +1,6 @@
 import {fireEvent, within} from '@storybook/test';
 import {html, render} from 'lit';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {createRipple} from '../../utils/ripple';
 import {radioButton, RadioButtonProps} from './radio-button';
 

--- a/packages/atomic/src/components/common/sort/label.spec.ts
+++ b/packages/atomic/src/components/common/sort/label.spec.ts
@@ -2,7 +2,7 @@ import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import '@vitest/browser/matchers.d.ts';
 import {html} from 'lit';
-import {expect} from 'vitest';
+import {expect, describe, beforeAll, it} from 'vitest';
 import {renderSortLabel, SortLabelProps} from './label';
 
 describe('renderSortLabel', () => {

--- a/packages/atomic/src/components/common/sort/option.spec.ts
+++ b/packages/atomic/src/components/common/sort/option.spec.ts
@@ -3,7 +3,7 @@ import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {page} from '@vitest/browser/context';
 import '@vitest/browser/matchers.d.ts';
 import {html} from 'lit';
-import {expect} from 'vitest';
+import {expect, describe, beforeAll, it} from 'vitest';
 import {renderSortOption, SortOptionProps} from './option';
 
 describe('renderSortOption', () => {

--- a/packages/atomic/src/components/common/sort/select.spec.ts
+++ b/packages/atomic/src/components/common/sort/select.spec.ts
@@ -3,7 +3,7 @@ import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {page} from '@vitest/browser/context';
 import '@vitest/browser/matchers.d.ts';
 import {html, TemplateResult} from 'lit';
-import {expect, vi} from 'vitest';
+import {expect, vi, describe, beforeAll, it} from 'vitest';
 import {renderSortSelect, SortSelectProps} from './select';
 
 describe('renderSortSelect', () => {

--- a/packages/atomic/src/components/common/sort/sort-guard.spec.ts
+++ b/packages/atomic/src/components/common/sort/sort-guard.spec.ts
@@ -1,6 +1,6 @@
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {html, nothing, noChange, TemplateResult} from 'lit';
-import {expect, vi} from 'vitest';
+import {expect, vi, describe, it} from 'vitest';
 import {sortGuard} from './sort-guard';
 
 describe('sortGuard', () => {

--- a/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/analytics-config.spec.ts
@@ -3,7 +3,7 @@ import {
   getSampleSearchEngineConfiguration,
   SearchEngineConfiguration,
 } from '@coveo/headless';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {getAnalyticsConfig} from './analytics-config';
 import {createSearchStore} from './store';
 

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-icon/atomic-result-icon.spec.ts
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-icon/atomic-result-icon.spec.ts
@@ -1,3 +1,5 @@
+import {describe, it} from 'vitest';
+
 describe('AtomicResultIcon', () => {
   describe('when not used inside a result template', () => {
     it.todo('should remove itself');

--- a/packages/atomic/src/decorators/bind-state.spec.ts
+++ b/packages/atomic/src/decorators/bind-state.spec.ts
@@ -1,7 +1,7 @@
 import {type Controller} from '@coveo/headless';
 import {LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import type {Bindings} from '../components/search/atomic-search-interface/interfaces';
 import {bindStateToController} from './bind-state';
 import type {InitializableComponent} from './types';

--- a/packages/atomic/src/decorators/binding-guard.spec.ts
+++ b/packages/atomic/src/decorators/binding-guard.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '@coveo/headless';
 import {LitElement, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import type {Bindings} from '../components/search/atomic-search-interface/interfaces';
 import {bindingGuard} from './binding-guard';
 

--- a/packages/atomic/src/decorators/bindings.spec.ts
+++ b/packages/atomic/src/decorators/bindings.spec.ts
@@ -2,7 +2,7 @@ import {provide} from '@lit/context';
 import i18next from 'i18next';
 import {LitElement, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {bindingsContext} from '../components/context/bindings-context';
 import type {Bindings} from '../components/search/atomic-search-interface/interfaces';
 import {bindings} from './bindings';

--- a/packages/atomic/src/decorators/error-guard.spec.ts
+++ b/packages/atomic/src/decorators/error-guard.spec.ts
@@ -1,7 +1,7 @@
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
 import {LitElement, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {errorGuard} from './error-guard';
 
 describe('@errorGuard decorator', () => {

--- a/packages/atomic/src/decorators/light-dom.spec.ts
+++ b/packages/atomic/src/decorators/light-dom.spec.ts
@@ -1,5 +1,6 @@
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
 import {html, LitElement, unsafeCSS} from 'lit';
+import {describe, beforeEach, it, expect} from 'vitest';
 import {injectStylesForNoShadowDOM} from './light-dom';
 
 describe('injectStylesForNoShadowDOM', () => {

--- a/packages/atomic/src/decorators/watch.spec.ts
+++ b/packages/atomic/src/decorators/watch.spec.ts
@@ -1,6 +1,6 @@
 import {LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {watch} from './watch.js';
 
 @customElement('test-element')

--- a/packages/atomic/src/decorators/with-tailwind-styles.spec.ts
+++ b/packages/atomic/src/decorators/with-tailwind-styles.spec.ts
@@ -3,6 +3,7 @@ import utilities from '@/src/utils/tailwind-utilities/utilities.tw.css';
 import globalStyles from '@/src/utils/tailwind.global.tw.css';
 import {CSSResult, CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {withTailwindStyles} from './with-tailwind-styles';
 
 const componentStyles = `

--- a/packages/atomic/src/directives/display-if.spec.ts
+++ b/packages/atomic/src/directives/display-if.spec.ts
@@ -1,6 +1,6 @@
 import {html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {describe, beforeEach, test, expect} from 'vitest';
+import {describe, beforeEach, afterEach, test, expect} from 'vitest';
 import {displayIf} from './display-if';
 
 describe('displayIf', () => {

--- a/packages/atomic/src/directives/localized-string.spec.ts
+++ b/packages/atomic/src/directives/localized-string.spec.ts
@@ -1,5 +1,6 @@
 import i18next, {i18n as I18n} from 'i18next';
 import {html, render} from 'lit';
+import {describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {localizedString, LocalizedStringProps} from './localized-string';
 
 describe('localizedString', () => {

--- a/packages/atomic/src/directives/multi-class-map.spec.ts
+++ b/packages/atomic/src/directives/multi-class-map.spec.ts
@@ -1,4 +1,5 @@
 import {html, render} from 'lit';
+import {describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {multiClassMap, tw} from './multi-class-map';
 
 describe('MultiClassMapDirective', () => {

--- a/packages/atomic/src/mixins/bindings-mixin.spec.ts
+++ b/packages/atomic/src/mixins/bindings-mixin.spec.ts
@@ -1,7 +1,16 @@
 import i18next from 'i18next';
 import {LitElement, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {Mock, vi} from 'vitest';
+import {
+  Mock,
+  vi,
+  describe,
+  beforeEach,
+  afterEach,
+  it,
+  test,
+  expect,
+} from 'vitest';
 import type {Bindings} from '../components/search/atomic-search-interface/interfaces';
 import {InitializableComponent} from '../decorators/types';
 import {fetchBindings} from '../utils/initialization-lit-stencil-common-utils';

--- a/packages/atomic/src/mixins/children-update-complete-mixin.spec.ts
+++ b/packages/atomic/src/mixins/children-update-complete-mixin.spec.ts
@@ -1,6 +1,6 @@
 import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {vi} from 'vitest';
+import {describe, beforeEach, afterEach, it, expect, vi} from 'vitest';
 import {ChildrenUpdateCompleteMixin} from './children-update-complete-mixin';
 
 type StencilTestElement = HTMLElement & {

--- a/packages/atomic/src/utils/debounce-utils.spec.ts
+++ b/packages/atomic/src/utils/debounce-utils.spec.ts
@@ -1,4 +1,4 @@
-import {vi} from 'vitest';
+import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
 import {buildDebouncedQueue, DebouncedQueue} from './debounce-utils';
 
 describe('buildDebouncedQueue', () => {

--- a/packages/atomic/src/utils/event-utils.spec.ts
+++ b/packages/atomic/src/utils/event-utils.spec.ts
@@ -1,4 +1,4 @@
-import {vi} from 'vitest';
+import {vi, describe, it, expect} from 'vitest';
 import {listenOnce} from './event-utils';
 
 describe('listenOnce', () => {

--- a/packages/atomic/src/utils/init-queue.spec.ts
+++ b/packages/atomic/src/utils/init-queue.spec.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {
   markParentAsReady,
   isParentReady,

--- a/packages/atomic/src/utils/initialization-lit-stencil-common-utils.spec.ts
+++ b/packages/atomic/src/utils/initialization-lit-stencil-common-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {
   fetchBindings,
   MissingInterfaceParentError,

--- a/packages/atomic/src/utils/local-storage-utils.spec.ts
+++ b/packages/atomic/src/utils/local-storage-utils.spec.ts
@@ -2,7 +2,7 @@ import {
   buildSearchEngine,
   getSampleSearchEngineConfiguration,
 } from '@coveo/headless';
-import {vi} from 'vitest';
+import {describe, beforeEach, it, expect, vi} from 'vitest';
 import {SafeStorage, StorageItems} from './local-storage-utils';
 
 describe('Safe local storage', () => {

--- a/packages/atomic/src/utils/props-utils.spec.ts
+++ b/packages/atomic/src/utils/props-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {mapAttributesToProp} from './props-utils';
 
 describe('mapAttributesToProp', () => {

--- a/packages/atomic/src/utils/result-utils.spec.ts
+++ b/packages/atomic/src/utils/result-utils.spec.ts
@@ -4,7 +4,7 @@ import {
   Raw,
   Result,
 } from '@coveo/headless';
-import {vi} from 'vitest';
+import {vi, describe, it, expect} from 'vitest';
 import {Bindings} from '../components/search/atomic-search-interface/atomic-search-interface';
 import {buildStringTemplateFromResult} from './result-utils';
 

--- a/packages/atomic/src/utils/set.spec.ts
+++ b/packages/atomic/src/utils/set.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {intersection} from './set';
 
 describe('intersection', () => {

--- a/packages/atomic/src/utils/string-utils.spec.ts
+++ b/packages/atomic/src/utils/string-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {encodeForDomAttribute} from './string-utils';
 
 describe('encodeForDomAttribute', () => {

--- a/packages/atomic/src/utils/tab-utils.spec.ts
+++ b/packages/atomic/src/utils/tab-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, beforeEach, it, expect, test} from 'vitest';
 import {shouldDisplayOnCurrentTab} from './tab-utils';
 
 describe('tab-utils', () => {

--- a/packages/atomic/src/utils/utils.spec.ts
+++ b/packages/atomic/src/utils/utils.spec.ts
@@ -1,4 +1,4 @@
-import {vi} from 'vitest';
+import {vi, describe, it, expect} from 'vitest';
 import {
   once,
   camelToKebab,

--- a/packages/atomic/src/utils/xss-utils.spec.ts
+++ b/packages/atomic/src/utils/xss-utils.spec.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {filterProtocol} from './xss-utils';
 
 describe('filterProtocol', () => {

--- a/packages/atomic/vitest.config.ts
+++ b/packages/atomic/vitest.config.ts
@@ -79,7 +79,6 @@ export default defineConfig({
     ],
     restoreMocks: true,
     setupFiles: ['./vitest-utils/setup.ts'],
-    globals: true,
     deps: {
       moduleDirectories: ['node_modules', path.resolve('../../packages')],
     },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4172

We should add this to make sure we properly import the test functions from vitest.

without the imports, it creates annoying IDE issues.
with `globals: true,` we always forget to import them
