### PR TITLE
fix(answerAPI): post feedback

### DIFF
--- a/packages/headless/src/api/knowledge/post-answer-evaluation.ts
+++ b/packages/headless/src/api/knowledge/post-answer-evaluation.ts
@@ -20,7 +20,15 @@ export interface AnswerEvaluationPOSTParams {
 
 export const answerEvaluation = answerSlice.injectEndpoints({
   endpoints: (builder) => ({
-    post: builder.mutation<void, AnswerEvaluationPOSTParams>({
+    /**
+     * Based on the RTKQuery documentation, the `query` method is typically utilized for GET requests,
+     * while the `mutation` method is designed for POST requests.
+     * However, in this instance,
+     * we hypothesize that the use of `mutation` is incompatible when paired with an empty response body and an 'application/json' content-type response header.
+     * This should be updated as soon as we can remove the content-type header from the response.
+     * @see https://redux-toolkit.js.org/rtk-query/usage/mutations#mutations
+     */
+    post: builder.query<void, AnswerEvaluationPOSTParams>({
       query: (body) => ({
         url: '/evaluations',
         method: 'POST',


### PR DESCRIPTION
# BugFix
## JIRA
https://coveord.atlassian.net/browse/SVCC-4958
## Scope
Submitting a CRGA feedback throws in the console. This has to be fixed
## Fix Context
The way [redux toolkit query](https://redux-toolkit.js.org/rtk-query/overview) handles mutations is unknown and not really documented

During the initial implementation, the implementer (me) wrongly assumed that a HTTP post had to be handled with a `builder.mutation`. Seems like its not the case. 
Using `builder.mutation` throws, while using `builder.query` doesn't throw. I couldn't find why by looking at the documentation or by debugging directly in the lib.
## How to test
Load the RGA demo and submit a feedback
[simplescreenrecorder-2025-05-01_11.46.46.webm](https://github.com/user-attachments/assets/b4857925-12b0-4c54-bc53-a47578aee786)


## Code coverage
I do not think we really have a way to test this.  
