### PR TITLE
fix(atomic): ensure correct path for locales

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
@@ -160,7 +160,7 @@ export class AtomicCommerceInterface
    *
    */
   @property({type: String, attribute: 'language-assets-path', reflect: true})
-  languageAssetsPath = '/lang';
+  languageAssetsPath = './lang';
 
   /**
    * The icon assets path. By default, this will be a relative URL pointing to `./assets`.
@@ -169,7 +169,7 @@ export class AtomicCommerceInterface
    *
    */
   @property({type: String, attribute: 'icon-assets-path', reflect: true})
-  iconAssetsPath = '/assets';
+  iconAssetsPath = './assets';
 
   private i18Initialized: Promise<void>;
 

--- a/packages/atomic/src/components/common/interface/i18n-stencil.ts
+++ b/packages/atomic/src/components/common/interface/i18n-stencil.ts
@@ -1,9 +1,9 @@
-import {getAssetPath} from '@/src/utils/utils';
+import {getAssetPath} from '@/src/utils/stencil-utils';
 import DOMPurify from 'dompurify';
 import Backend, {HttpBackendOptions} from 'i18next-http-backend';
 import availableLocales from '../../../generated/availableLocales.json';
 import {AnyEngineType} from './bindings';
-import {BaseAtomicInterface} from './interface-common';
+import {StencilBaseAtomicInterface} from './interface-common-stencil';
 
 export const i18nTranslationNamespace = 'translation';
 
@@ -12,7 +12,7 @@ function isI18nLocaleAvailable(locale: string) {
 }
 
 export function i18nBackendOptions(
-  atomicInterface: BaseAtomicInterface<AnyEngineType>
+  atomicInterface: StencilBaseAtomicInterface<AnyEngineType>
 ): HttpBackendOptions {
   return {
     loadPath: `${getAssetPath(
@@ -51,7 +51,9 @@ export function i18nBackendOptions(
   };
 }
 
-export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
+export function init18n(
+  atomicInterface: StencilBaseAtomicInterface<AnyEngineType>
+) {
   return atomicInterface.i18n.use(Backend).init({
     debug: atomicInterface.logLevel === 'debug',
     lng: atomicInterface.language,

--- a/packages/atomic/src/components/common/interface/interface-common-stencil.tsx
+++ b/packages/atomic/src/components/common/interface/interface-common-stencil.tsx
@@ -6,8 +6,8 @@ import {ComponentInterface, h} from '@stencil/core';
 import {i18n, TFunction} from 'i18next';
 import Backend from 'i18next-http-backend';
 import {AnyBindings, AnyEngineType} from './bindings';
-import {i18nBackendOptions, i18nTranslationNamespace} from './i18n';
-import {init18n} from './i18n';
+import {i18nBackendOptions, i18nTranslationNamespace} from './i18n-stencil';
+import {init18n} from './i18n-stencil';
 
 export interface StencilBaseAtomicInterface<EngineType extends AnyEngineType>
   extends ComponentInterface {

--- a/packages/atomic/src/components/common/interface/interface-common.ts
+++ b/packages/atomic/src/components/common/interface/interface-common.ts
@@ -6,8 +6,8 @@ import {html} from 'lit';
 import {loadDayjsLocale} from '../../../utils/dayjs-locales.js';
 import '../atomic-component-error/atomic-component-error.js';
 import {AnyBindings, AnyEngineType} from './bindings.js';
-import {i18nBackendOptions, i18nTranslationNamespace} from './i18n.js';
 import {init18n} from './i18n.js';
+import {i18nBackendOptions, i18nTranslationNamespace} from './i18n.js';
 
 export type InitializeEventHandler = (bindings: AnyBindings) => void;
 export type InitializeEvent = CustomEvent<InitializeEventHandler>;


### PR DESCRIPTION
This PR fixes an issue with Lit component interfaces where the wrong path would be used to retrieve the language assets, for example with the CDN build of atomic.

https://coveord.atlassian.net/browse/KIT-4186