### PR TITLE
chore: use fromJSON to coerce values

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -25,4 +25,4 @@ jobs:
     needs: approve
     with:
       version: ${{ github.event.inputs.version }}
-      debug: ${{ github.event.inputs.debug }}
+      debug: ${{ fromJSON(github.event.inputs.debug) }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -19,7 +19,7 @@ jobs:
     environment: 'Manual Release'
     steps:
       - run: exit 0
-      
+
   release:
     uses: ./.github/workflows/release.yml
     needs: approve


### PR DESCRIPTION
From what I understand from [GitHub Doc](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-data-type), we need to coerce all contextual values because they are passed along as "literals", thus losing their 'typing'.