### PR TITLE
fix(atomic): ensure **all** custom-elements are scanned

### DIFF
--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -28,14 +28,17 @@ if (typeof window !== 'undefined') {
     const rootTagName =
       root instanceof Element ? root.tagName.toLowerCase() : '';
     const rootIsAtomicElement = rootTagName?.startsWith('atomic-');
-    const allAtomicElements = [
-      ...root.querySelectorAll(':not(:defined)'),
-    ].filter((el) => el.tagName.toLowerCase().startsWith('atomic-'));
-    const tags = allAtomicElements.map((el) => el.tagName.toLowerCase());
+    const allAtomicElements = [...root.querySelectorAll('*')].filter((el) =>
+      el.tagName.toLowerCase().startsWith('atomic-')
+    );
 
     // If the root element is an undefined Atomic component, add it to the list
-    if (rootIsAtomicElement && !customElements.get(rootTagName)) {
-      tags.push(rootTagName);
+    if (
+      rootIsAtomicElement &&
+      root instanceof Element &&
+      !customElements.get(rootTagName)
+    ) {
+      allAtomicElements.push(root);
     }
     if (rootIsAtomicElement) {
       const childTemplates = root.querySelectorAll('template');
@@ -50,14 +53,16 @@ if (typeof window !== 'undefined') {
         observer.observe(root.shadowRoot, {subtree: true, childList: true});
       }
     }
+    const litRegistrationPromises = [];
     for (const atomicElement of allAtomicElements) {
       const tagName = atomicElement.tagName.toLowerCase();
-      if (tagName in elementMap) {
+      if (tagName in elementMap && !customElements.get(tagName)) {
         // The element uses Lit already, we don't need to jam the lazy loader in the Shadow DOM.
+        litRegistrationPromises.push(register(tagName));
         continue;
       }
       if ('shadowRoot' in atomicElement && atomicElement.shadowRoot) {
-        discover(atomicElement.shadowRoot);
+        discover(atomicElement);
         continue;
       }
       if (atomicElement.classList.contains('hydrated')) {
@@ -66,11 +71,7 @@ if (typeof window !== 'undefined') {
       }
       observeStencilElementHydration(atomicElement);
     }
-    // Make the list unique
-    const tagsToRegister = [...new Set(tags)];
-    await Promise.allSettled(
-      tagsToRegister.map((tagName) => register(tagName))
-    );
+    await Promise.allSettled(litRegistrationPromises);
     customElements.upgrade(root);
   };
 


### PR DESCRIPTION
We need to go through all elements because Stencil lazy-loader eagerly define the element in the registry