### PR TITLE
test(atomic): improve stability around suggestions/sb

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.new.stories.tsx
@@ -43,6 +43,7 @@ export const SearchBeforeInit: Story = {
     const commerceInterface = context.canvasElement.querySelector(
       'atomic-commerce-interface'
     );
+    await customElements.whenDefined('atomic-commerce-interface');
     await commerceInterface!.executeFirstRequest();
   },
 };

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
@@ -106,6 +106,9 @@ test.describe('default', () => {
     test.beforeEach(async ({searchBox, page}) => {
       await setRecentQueries(page, 4);
       await setSuggestions(page, 4);
+      // We reload to ensure we load the recent queries from local storage
+      await page.reload();
+      await searchBox.hydrated.waitFor();
       await searchBox.searchInput.waitFor({state: 'visible'});
       await searchBox.searchInput.click();
     });
@@ -435,8 +438,8 @@ test.describe('with minimum-query-length=4', () => {
       await expect(searchBox.searchSuggestions().first()).toBeVisible();
     });
 
-    test('should perform requests against the query suggest endpoint', () => {
-      expect(querySuggestionRequestPerformed).toBe(true);
+    test('should perform requests against the query suggest endpoint', async () => {
+      await expect.poll(() => querySuggestionRequestPerformed).toBe(true);
     });
   });
 });

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
@@ -33,7 +33,8 @@ export const WithTranslations: Story = {
     const commerceInterface =
       await canvas.findByTestId<AtomicCommerceInterface>('root-interface');
 
-    await context.step('Load translations', () => {
+    await context.step('Load translations', async () => {
+      await customElements.whenDefined('atomic-commerce-interface');
       commerceInterface.i18n.addResourceBundle('en', 'translation', {
         // "translation-key": "A single product"
         [context.args['attributes-value']]: context.args.translationValue,

--- a/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
@@ -1,7 +1,7 @@
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
-import {renderComponent} from '@/storybook-utils/common/render-component';
+import {renderComponentWithoutCodeRoot} from '@/storybook-utils/common/render-component';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
 import {html} from 'lit';
 
@@ -17,7 +17,7 @@ const meta: Meta = {
   title:
     'Atomic-Commerce/Interface Components/atomic-commerce-search-box-instant-products',
   id: 'atomic-commerce-search-box-instant-products',
-  render: renderComponent,
+  render: renderComponentWithoutCodeRoot,
   decorators: [commerceSearchBoxDecorator, commerceInterfaceDecorator],
   parameters,
   play,

--- a/packages/atomic/src/components/common/suggestions/suggestions-common.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestions-common.ts
@@ -1,4 +1,6 @@
 import {VNode} from '@stencil/core';
+import {HTMLStencilElement} from '@stencil/core/internal';
+import type {LitElement} from 'lit';
 import {buildCustomEvent} from '../../../utils/event-utils';
 import {closest} from '../../../utils/stencil-utils';
 import {AnyBindings} from '../interface/bindings';
@@ -142,6 +144,28 @@ export type SearchBoxSuggestionsBindings<
   getSuggestionElements(): SearchBoxSuggestionElement[];
 };
 
+const isLitElementLoosely = (candidate: unknown): candidate is LitElement =>
+  'updateComplete' in (candidate as LitElement) &&
+  (candidate as LitElement)['updateComplete'] instanceof Promise;
+
+const dispatchSearchBoxSuggestionsEventEventually = async <
+  SearchBoxController,
+  Bindings = AnyBindings,
+>(
+  interfaceElement: Element,
+  element: HTMLElement,
+  event: SearchBoxSuggestionsEvent<SearchBoxController, Bindings>
+) => {
+  if (isLitElementLoosely(interfaceElement)) {
+    await interfaceElement.updateComplete;
+  } else if ('componentOnReady' in interfaceElement) {
+    await (interfaceElement as HTMLStencilElement).componentOnReady();
+  }
+  element.dispatchEvent(
+    buildCustomEvent('atomic/searchBoxSuggestion/register', event)
+  );
+};
+
 /**
  * Dispatches an event which retrieves the `SearchBoxSuggestionsBindings` on a configured parent search box.
  * @param event Event sent from the registered query suggestions to the parent search box.
@@ -154,17 +178,15 @@ export const dispatchSearchBoxSuggestionsEvent = <
   event: SearchBoxSuggestionsEvent<SearchBoxController, Bindings>,
   element: HTMLElement
 ) => {
-  element.dispatchEvent(
-    buildCustomEvent('atomic/searchBoxSuggestion/register', event)
-  );
-
-  if (!closest(element, searchBoxElements.join(', '))) {
+  const interfaceElement = closest(element, searchBoxElements.join(', '));
+  if (!interfaceElement) {
     throw new Error(
       `The "${element.nodeName.toLowerCase()}" component was not handled, as it is not a child of the following elements: ${searchBoxElements.join(
         ', '
       )}`
     );
   }
+  dispatchSearchBoxSuggestionsEventEventually(interfaceElement, element, event);
 };
 
 export function elementHasNoQuery(el: SearchBoxSuggestionElement) {

--- a/packages/atomic/storybook-utils/commerce/commerce-search-box-wrapper.tsx
+++ b/packages/atomic/storybook-utils/commerce/commerce-search-box-wrapper.tsx
@@ -7,7 +7,7 @@ export const wrapInCommerceSearchBox = (
   decorator: Decorator;
 } => ({
   decorator: (story) => html`
-    <atomic-commerce-search-box id="code-root">
+    <atomic-commerce-search-box suggestion-timeout="5000" id="code-root">
       ${extra} ${story()}
     </atomic-commerce-search-box>
   `,


### PR DESCRIPTION
Reuse the mechanism from `children-update-complete-mixin.ts` to ensure the listener is registered before shooting the event.