### PR TITLE
fix(atomic): add missing import in atom

### DIFF
--- a/packages/atomic/src/components/common/pager/pager-buttons.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.ts
@@ -1,3 +1,4 @@
+import '@/src/components/common/atomic-icon/atomic-icon';
 import {
   FunctionalComponent,
   FunctionalComponentWithChildren,


### PR DESCRIPTION
If we don't; the `atomic-icon` might be missing.