### PR TITLE
fix(atomic): ensure context root is declared when context is used

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -141,7 +141,7 @@ jobs:
     name: 'Run unit tests'
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/store.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/store.spec.ts
@@ -2,7 +2,7 @@ import {CommerceEngine, Selectors} from '@coveo/headless/commerce';
 import {describe, test, expect, vi} from 'vitest';
 import {createCommerceStore} from './store';
 
-vi.mocked('@coveo/headless/commerce');
+vi.mock('@coveo/headless/commerce', {spy: true});
 
 describe('CommerceStore', () => {
   test('should set and unset loading flags correctly', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.ts
@@ -10,7 +10,6 @@ import {
   SearchState,
   ProductListingState,
 } from '@coveo/headless/commerce';
-import {ContextRoot} from '@lit/context';
 import {html, CSSResultGroup, unsafeCSS, LitElement} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {guard} from 'lit/directives/guard.js';
@@ -62,12 +61,6 @@ export class AtomicCommerceSortDropdown
   @state() error!: Error;
 
   static styles: CSSResultGroup = [unsafeCSS(styles)];
-
-  constructor() {
-    super();
-    const contextRoot = new ContextRoot();
-    contextRoot.attach(document.body);
-  }
 
   public initialize() {
     if (this.bindings.interfaceElement.type === 'product-listing') {

--- a/packages/atomic/src/components/context/bindings-context.ts
+++ b/packages/atomic/src/components/context/bindings-context.ts
@@ -1,4 +1,9 @@
 import {AnyBindings} from '@/src/components';
-import {createContext} from '@lit/context';
+import {createContext, ContextRoot} from '@lit/context';
+
+if (typeof window !== 'undefined') {
+  const contextRoot = new ContextRoot();
+  contextRoot.attach(document.body);
+}
 
 export const bindingsContext = createContext<AnyBindings>(Symbol('bindings'));


### PR DESCRIPTION
If we don't, the consumer may shoot first, and their request may be lost to the wind