### PR TITLE
feat(headless): add support for custom relay environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6137,34 +6137,11 @@
       "resolved": "packages/quantic",
       "link": true
     },
-    "node_modules/@coveo/relay": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@coveo/relay/-/relay-1.1.1.tgz",
-      "integrity": "sha512-Z23drivB3O25KiruSKmln37JuAh0RukUcyPMeGeAL5oY6cjXsXgQLsgx+mrx2hRb0lRaF5zxTCMpXrTFW1oFfA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coveo/explorer-messenger": "^0.4.1",
-        "uuid": "^11.0.0"
-      }
-    },
     "node_modules/@coveo/relay-event-types": {
       "version": "14.3.3",
       "resolved": "https://registry.npmjs.org/@coveo/relay-event-types/-/relay-event-types-14.3.3.tgz",
       "integrity": "sha512-leZEw0XfOZtuNRJk76ba/ULwy3ei0lnJGtZlE9VORlLm5mBdRj7VtimmL210GRDT1bxJPakuCddQkQms9FQykw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@coveo/relay/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/@coveo/semantic-monorepo-tools": {
       "version": "2.6.2",
@@ -61990,7 +61967,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "1.0.14",
-        "@coveo/relay": "1.1.1",
+        "@coveo/relay": "1.2.0",
         "@coveo/relay-event-types": "14.3.3",
         "@reduxjs/toolkit": "2.6.0",
         "abortcontroller-polyfill": "1.7.8",
@@ -62350,6 +62327,16 @@
         "semver": "bin/semver.js"
       }
     },
+    "packages/headless/node_modules/@coveo/relay": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@coveo/relay/-/relay-1.2.0.tgz",
+      "integrity": "sha512-sT49PwghsJ3UaCjujeDfejXV9bk5p7a6Ni5c/0Ulbh0E8wsvyljrqzMFgo6Mnw/pt+uglVhNUthCq9ySS5kG4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@coveo/explorer-messenger": "^0.4.1",
+        "uuid": "^11.0.0"
+      }
+    },
     "packages/headless/node_modules/fast-equals": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
@@ -62357,6 +62344,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "packages/headless/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/quantic": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -161,7 +161,7 @@
   },
   "dependencies": {
     "@coveo/bueno": "1.0.14",
-    "@coveo/relay": "1.1.1",
+    "@coveo/relay": "1.2.0",
     "@coveo/relay-event-types": "14.3.3",
     "@reduxjs/toolkit": "2.6.0",
     "abortcontroller-polyfill": "1.7.8",


### PR DESCRIPTION
Relay support custom environments (see https://github.com/coveo-platform/relay/pull/158), enabling it to work in non browser environments. Headless currently does not support this option. This PR adds support for custom relay environments through headless, enabling relay to work correctly in non browser environments.

In particular this option will be used by the shopify package in order to support hydrogen style implementations.

We will utilise the `generateUUID` option, to enable us to properly generate a client id for shopify visitors, rather than dropping a cookie, which will only work in the browser.

UPDATE:

Rather than adding an additional option, we will try to update relay after initialization. This is to avoid making the headless arguments more complicated since they already have a custom environment concept, but it is incompatible. We can revisit in the next major version