### PR TITLE
fix(atomic): fix atomic-recs-result-template rendering error

### DIFF
--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children-template/atomic-insight-result-children-template.tsx
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children-template/atomic-insight-result-children-template.tsx
@@ -62,9 +62,11 @@ export class AtomicInsightResultChildrenTemplate {
     string[]
   > = {};
 
-  public resultTemplateCommon: ResultTemplateCommon;
+  public resultTemplateCommon!: ResultTemplateCommon;
 
-  constructor() {
+  constructor() {}
+
+  connectedCallback() {
     this.resultTemplateCommon = new ResultTemplateCommon({
       host: this.host,
       setError: (err) => {

--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-template/atomic-insight-result-template.tsx
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-template/atomic-insight-result-template.tsx
@@ -18,7 +18,7 @@ import {
   shadow: true,
 })
 export class AtomicInsightResultTemplate {
-  private resultTemplateCommon: ResultTemplateCommon;
+  private resultTemplateCommon!: ResultTemplateCommon;
 
   @State() public error!: Error;
 
@@ -68,7 +68,9 @@ export class AtomicInsightResultTemplate {
     string[]
   > = {};
 
-  constructor() {
+  constructor() {}
+
+  connectedCallback() {
     this.resultTemplateCommon = new ResultTemplateCommon({
       host: this.host,
       setError: (err) => {

--- a/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
@@ -76,7 +76,7 @@ export class AtomicRecsResultTemplate {
 
   constructor() {}
 
-  public componentWillLoad() {
+  connectedCallback() {
     this.resultTemplateCommon = new ResultTemplateCommon({
       host: this.host,
       setError: (err) => {
@@ -85,7 +85,9 @@ export class AtomicRecsResultTemplate {
       validParents: ['atomic-recs-list', 'atomic-ipx-recs-list'],
       allowEmpty: true,
     });
+  }
 
+  public componentWillLoad() {
     this.conditions = makeDefinedConditions(this.ifDefined, this.ifNotDefined);
     this.resultTemplateCommon.matchConditions = makeMatchConditions(
       this.mustMatch,

--- a/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.tsx
@@ -24,7 +24,7 @@ import {
   shadow: true,
 })
 export class AtomicRecsResultTemplate {
-  private resultTemplateCommon: ResultTemplateCommon;
+  private resultTemplateCommon!: ResultTemplateCommon;
 
   @State() public error!: Error;
 
@@ -74,7 +74,9 @@ export class AtomicRecsResultTemplate {
     string[]
   > = {};
 
-  constructor() {
+  constructor() {}
+
+  public componentWillLoad() {
     this.resultTemplateCommon = new ResultTemplateCommon({
       host: this.host,
       setError: (err) => {
@@ -83,9 +85,7 @@ export class AtomicRecsResultTemplate {
       validParents: ['atomic-recs-list', 'atomic-ipx-recs-list'],
       allowEmpty: true,
     });
-  }
 
-  public componentWillLoad() {
     this.conditions = makeDefinedConditions(this.ifDefined, this.ifNotDefined);
     this.resultTemplateCommon.matchConditions = makeMatchConditions(
       this.mustMatch,

--- a/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
+++ b/packages/atomic/src/components/search/result-templates/atomic-result-children-template/atomic-result-children-template.tsx
@@ -49,9 +49,11 @@ export class AtomicResultChildrenTemplate {
     string[]
   > = {};
 
-  public resultTemplateCommon: ResultTemplateCommon;
+  public resultTemplateCommon!: ResultTemplateCommon;
 
-  constructor() {
+  constructor() {}
+
+  connectedCallback() {
     this.resultTemplateCommon = new ResultTemplateCommon({
       host: this.host,
       setError: (err) => {

--- a/packages/samples/angular/src/app/app-routing.module.ts
+++ b/packages/samples/angular/src/app/app-routing.module.ts
@@ -1,12 +1,17 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {AtomicAngularPageComponent} from './atomic-angular-page/atomic-angular-page.component';
+import {AtomicAngularRecommendationPageComponent} from './atomic-angular-recommendation-page/atomic-angular-recommendation-page.component';
 import {AtomicCommerceAngularPageComponent} from './atomic-commerce-angular-page/atomic-commerce-angular-page.component';
 
 const routes: Routes = [
   {
     path: 'atomic-angular',
     component: AtomicAngularPageComponent,
+  },
+  {
+    path: 'atomic-recommendation-angular',
+    component: AtomicAngularRecommendationPageComponent,
   },
   {
     path: 'atomic-commerce-angular',

--- a/packages/samples/angular/src/app/app.component.html
+++ b/packages/samples/angular/src/app/app.component.html
@@ -4,7 +4,12 @@
   <ul>
     <li>
       <a routerLink="/atomic-angular" routerLinkActive="active"
-        >Sample with Atomic Angular (&#64;coveo/atomic-angular)</a
+        >Sample search interface with Atomic Angular (&#64;coveo/atomic-angular)</a
+      >
+    </li>
+    <li>
+      <a routerLink="/atomic-recommendation-angular" routerLinkActive="active"
+        >Sample recommendation interface with Atomic Angular (&#64;coveo/atomic-angular)</a
       >
     </li>
     <li>

--- a/packages/samples/angular/src/app/app.module.ts
+++ b/packages/samples/angular/src/app/app.module.ts
@@ -4,6 +4,7 @@ import {AtomicAngularModule} from '@coveo/atomic-angular';
 import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
 import {AtomicAngularPageComponent} from './atomic-angular-page/atomic-angular-page.component';
+import {AtomicAngularRecommendationPageComponent} from './atomic-angular-recommendation-page/atomic-angular-recommendation-page.component';
 import {AtomicCommerceAngularPageComponent} from './atomic-commerce-angular-page/atomic-commerce-angular-page.component';
 import {FieldLabelComponent} from './field-label/field-label.component';
 import {FieldValueComponent} from './field-value/field-value.component';
@@ -13,6 +14,7 @@ import {LabelAndFieldValueComponent} from './label-and-field-value/label-and-fie
   declarations: [
     AppComponent,
     AtomicAngularPageComponent,
+    AtomicAngularRecommendationPageComponent,
     AtomicCommerceAngularPageComponent,
     FieldLabelComponent,
     FieldValueComponent,

--- a/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.css
+++ b/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.css
@@ -1,0 +1,45 @@
+div.result-root.with-sections.display-list.image-small atomic-result-section-visual {
+  height: 120px;
+}
+.rating-wrapper {
+  display: flex;
+  align-items: center;
+}
+.rating-wrapper span {
+  margin-left: 5px;
+  color: #8e959d;
+}
+
+.layout {
+  padding: 20px;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 30px;
+}
+
+.carousel {
+  grid-column: 1 / span 2;
+  --atomic-recs-number-of-columns: 3;
+}
+
+@media only screen and (max-width: 1600px) {
+  .tiles {
+    --atomic-recs-number-of-columns: 3;
+  }
+}
+
+@media only screen and (max-width: 1280px) {
+  .layout {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .tiles {
+    --atomic-recs-number-of-columns: 2;
+  }
+}
+
+@media only screen and (max-width: 720px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.html
+++ b/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.html
@@ -1,0 +1,56 @@
+<div class="layout">
+  <atomic-recs-interface
+    #recsInterface
+    class="carousel"
+    fields-to-include='["cat_rating_count"]'
+    language-assets-path="/lang"
+    icon-assets-path="/assets"
+  >
+    <atomic-recs-list
+      display="grid"
+      label="Recommendations"
+      number-of-recommendations="9"
+      number-of-recommendations-per-page="3"
+    >
+      <atomic-recs-result-template>
+        <template>
+          <style>
+            div.result-root.with-sections.display-list.image-small atomic-result-section-visual {
+              height: 120px;
+            }
+            .rating-wrapper {
+              display: flex;
+              align-items: center;
+            }
+            .rating-wrapper span {
+              margin-left: 5px;
+              color: #8e959d;
+            }
+          </style>
+          <atomic-result-section-visual>
+            <atomic-result-image field="ec_images" aria-hidden="true"></atomic-result-image>
+          </atomic-result-section-visual>
+          <atomic-result-section-title>
+            <atomic-result-link></atomic-result-link>
+          </atomic-result-section-title>
+          <atomic-result-section-title-metadata>
+            <div class="rating-wrapper">
+              <atomic-result-rating field="ec_rating"></atomic-result-rating>
+              <atomic-field-condition class="field" if-defined="ec_rating">
+                <span> <atomic-result-number field="cat_rating_count"></atomic-result-number> reviews </span>
+              </atomic-field-condition>
+            </div>
+          </atomic-result-section-title-metadata>
+          <atomic-result-section-emphasized>
+            <atomic-result-number field="ec_price">
+              <atomic-format-currency currency="USD"></atomic-format-currency>
+            </atomic-result-number>
+          </atomic-result-section-emphasized>
+          <atomic-result-section-excerpt
+            ><atomic-result-text field="excerpt"></atomic-result-text
+          ></atomic-result-section-excerpt>
+        </template>
+      </atomic-recs-result-template>
+    </atomic-recs-list>
+  </atomic-recs-interface>
+</div>

--- a/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.ts
+++ b/packages/samples/angular/src/app/atomic-angular-recommendation-page/atomic-angular-recommendation-page.component.ts
@@ -1,0 +1,60 @@
+import {AfterViewInit, Component, ViewChild} from '@angular/core';
+import {Result, Bindings, AtomicRecsInterface} from '@coveo/atomic-angular';
+
+@Component({
+  standalone: false,
+  selector: 'app-atomic-angular-recommendation-page',
+  templateUrl: './atomic-angular-recommendation-page.component.html',
+  styleUrls: ['./atomic-angular-recommendation-page.component.css'],
+})
+export class AtomicAngularRecommendationPageComponent implements AfterViewInit {
+  @ViewChild('recsInterface')
+  searchInterface!: AtomicRecsInterface;
+
+  constructor() {}
+  async ngAfterViewInit(): Promise<void> {
+    this.searchInterface
+      ?.initialize({
+        accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
+        organizationId: 'electronicscoveodemocomo0n2fu8v',
+        analytics: {
+          analyticsMode: 'legacy',
+        },
+      })
+      .then(() => {
+        this.searchInterface.getRecommendations();
+        this.searchInterface.i18n.addResourceBundle('en', 'translation', {
+          'no-ratings-available': 'No ratings available',
+        });
+      });
+  }
+
+  generateInstantResultsAriaLabel({i18n}: Bindings, result: Result) {
+    const information = [result.title];
+
+    if ('ec_rating' in result.raw) {
+      information.push(
+        i18n.t('stars', {
+          count: result.raw['ec_rating'] as number,
+          max: 5,
+        })
+      );
+    } else {
+      information.push(i18n.t('no-ratings-available'));
+    }
+
+    if ('ec_price' in result.raw) {
+      information.push(
+        (result.raw['ec_price'] as number).toLocaleString(
+          i18n.languages as string[],
+          {
+            style: 'currency',
+            currency: 'USD',
+          }
+        )
+      );
+    }
+
+    return information.join(', ');
+  }
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4224

The `atomic-recs-result-template` was throwing errors in Angular because its host element's parent wasn't defined when we were creating the `ResultTemplateCommon` instance in the constructor.

I applied the same fix to `atomic-recs-result-template` that was applied to `atomic-result-template` here: https://github.com/coveo/ui-kit/pull/5070/files#diff-869c29501cc46796f3035d2f9e0b3d564509824dd998c0c24d49efe4f2dd0423, i.e., creating he `ResultTemplateCommon` instance in the component's `connectedCallback` instead of in the constructor.

I also included a recommendation interface in the Angular sample.

For good measure, I preemptively applied the fix to other result template components that create `ResultTemplateCommon` instances (`atomic-insight-result-children-template`, `atomic-result-children-template`).

