### PR TITLE
Potential fix for code scanning alert no. 329: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -516,6 +516,8 @@ jobs:
     needs: should-e2e-atomic
     if: ${{ needs.should-e2e-atomic.outputs.changesOnlyInQuantic == 'false' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
Potential fix for [https://github.com/coveo/ui-kit/security/code-scanning/329](https://github.com/coveo/ui-kit/security/code-scanning/329)

To fix the issue, we will add a `permissions` block to the `e2e-atomic-insight-panel-test` job. Based on the steps in the job, it appears that only `contents: read` is required. This will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the job to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
