### PR TITLE
chore: reenable deployment of major & minor directories

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -127,7 +127,7 @@
     {
       "id": "deploy-atomic-minor-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]",
         "source": "packages/atomic/cdn",
@@ -139,7 +139,7 @@
     {
       "id": "deploy-atomic-major-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]",
         "source": "packages/atomic/cdn",
@@ -163,7 +163,7 @@
     {
       "id": "deploy-atomic-major-storybook-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MAJOR_VERSION]/storybook",
         "source": "packages/atomic/dist-storybook",
@@ -175,7 +175,7 @@
     {
       "id": "deploy-atomic-minor-storybook-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic/v$[ATOMIC_MINOR_VERSION]/storybook",
         "source": "packages/atomic/dist-storybook",
@@ -211,7 +211,7 @@
     {
       "id": "deploy-atomic-react-minor-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic-react/v$[ATOMIC_REACT_MINOR_VERSION]",
         "source": "packages/atomic-react/dist",
@@ -223,7 +223,7 @@
     {
       "id": "deploy-atomic-react-major-to-s3-version",
       "s3": {
-        "disabled": true,
+        "disabled": $[IS_NIGHTLY],
         "bucket": "{terraform.infra.infra.bucket_binaries}",
         "directory": "proda/StaticCDN/atomic-react/v$[ATOMIC_REACT_MAJOR_VERSION]",
         "source": "packages/atomic-react/dist",


### PR DESCRIPTION
This reverts commit e35ccc371361c13b0bb1b2ba9f817a82120ad26e & reenable CDN deployment of Atomic.

KIT-4209