### PR TITLE
fix: support static filters search params

### DIFF
--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1103,6 +1103,98 @@ export const streamAnswerAPIStateMockWithoutAnyTab: StateNeededByAnswerAPI = {
   },
 };
 
+export const streamAnswerAPIStateMockWithStaticFiltersSelected: StateNeededByAnswerAPI =
+  {
+    ...streamAnswerAPIStateMock,
+    staticFilterSet: {
+      youtube: {
+        id: 'test-static-filter',
+        values: [
+          {
+            caption: 'youtube',
+            expression: '@filetype=="youtubevideo"',
+            state: 'selected',
+          },
+        ],
+      },
+    },
+  };
+
+export const streamAnswerAPIStateMockWithNonValidFilters: StateNeededByAnswerAPI =
+  {
+    ...streamAnswerAPIStateMock,
+    staticFilterSet: {
+      idle: {
+        id: 'test-idle-filter',
+        values: [
+          {
+            caption: 'idle',
+            expression: '@filetype=="youtubevideo"',
+            state: 'idle',
+          },
+        ],
+      },
+      exlcuded: {
+        id: 'test-excluded-filter',
+        values: [
+          {
+            caption: 'excluded',
+            expression: '@filetype=="youtubevideo"',
+            state: 'excluded',
+          },
+        ],
+      },
+      empty: {
+        id: 'test-empty-filter',
+        values: [
+          {
+            caption: 'empty',
+            expression: '', // empty expression
+            state: 'selected',
+          },
+        ],
+      },
+    },
+  };
+
+export const streamAnswerAPIStateMockWithoutAnyFilters: StateNeededByAnswerAPI =
+  {
+    ...streamAnswerAPIStateMock,
+    staticFilterSet: {},
+  };
+
+export const streamAnswerAPIStateMockWithStaticFiltersAndTabExpression: StateNeededByAnswerAPI =
+  {
+    ...streamAnswerAPIStateMockWithATabWithAnExpression,
+    staticFilterSet: {
+      firstFilter: {
+        id: 'test-static-filter-1',
+        values: [
+          {
+            caption: 'youtube',
+            expression: '@filetype=="youtubevideo"',
+            state: 'selected',
+          },
+          {
+            caption: 'dropbox',
+            expression: '@filetype=="dropbox"',
+            state: 'selected',
+          },
+        ],
+      },
+      secondFilter: {
+        id: 'test-static-filter-2',
+        values: [
+          {
+            caption: 'html',
+            expression: '@filetype=="tsx"',
+            state: 'selected',
+          },
+        ],
+      },
+    },
+  };
+
 export const expectedStreamAnswerAPIParam = {
   q: 'what is the hardest wood',
   aq: 'aq-test-query',
@@ -1464,4 +1556,14 @@ export const expectedStreamAnswerAPIParamWithATabWithAnExpression = {
 export const expectedStreamAnswerAPIParamWithoutAnyTab = {
   ...expectedStreamAnswerAPIParam,
   tab: '',
+};
+
+export const expectedStreamAnswerAPIParamWithStaticFiltersSelected = {
+  ...expectedStreamAnswerAPIParam,
+  cq: '@filetype=="youtubevideo" AND cq-test-query',
+};
+
+export const expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpression = {
+  ...expectedStreamAnswerAPIParam,
+  cq: '@fileType=html AND (@filetype=="youtubevideo" OR @filetype=="dropbox") AND @filetype=="tsx" AND cq-test-query',
 };

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -10,9 +10,15 @@ import {
   expectedStreamAnswerAPIParam,
   expectedStreamAnswerAPIParamWithATabWithAnExpression,
   expectedStreamAnswerAPIParamWithoutAnyTab,
+  expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpression,
+  expectedStreamAnswerAPIParamWithStaticFiltersSelected,
   streamAnswerAPIStateMock,
   streamAnswerAPIStateMockWithATabWithAnExpression,
+  streamAnswerAPIStateMockWithoutAnyFilters,
   streamAnswerAPIStateMockWithoutAnyTab,
+  streamAnswerAPIStateMockWithNonValidFilters,
+  streamAnswerAPIStateMockWithStaticFiltersAndTabExpression,
+  streamAnswerAPIStateMockWithStaticFiltersSelected,
 } from './stream-answer-api-state-mock.js';
 
 describe('#streamAnswerApi', () => {
@@ -64,6 +70,47 @@ describe('#streamAnswerApi', () => {
       );
 
       expect(queryParams).toEqual(expectedStreamAnswerAPIParamWithoutAnyTab);
+    });
+
+    it('should merge filter expressions in request constant query when expression is selected', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMockWithStaticFiltersSelected as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+
+      expect(queryParams).toEqual(
+        expectedStreamAnswerAPIParamWithStaticFiltersSelected
+      );
+    });
+
+    it('should not include filter info when there is NO filter', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMockWithoutAnyFilters as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+      expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
+    });
+
+    it('should not include non-selected filters and empty filters', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMockWithNonValidFilters as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+      expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
+    });
+
+    it('should merge multiple filter expressions and a tab expression', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMockWithStaticFiltersAndTabExpression as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+      expect(queryParams).toEqual(
+        expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpression
+      );
     });
   });
 

--- a/packages/headless/src/features/search/search-request.ts
+++ b/packages/headless/src/features/search/search-request.ts
@@ -12,6 +12,7 @@ import {RangeFacetSetState} from '../facets/range-facets/generic/interfaces/rang
 import {maximumNumberOfResultsFromIndex} from '../pagination/pagination-constants.js';
 import {buildSearchAndFoldingLoadCollectionRequest as legacyBuildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/legacy/search-and-folding-request.js';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../search-and-folding/search-and-folding-request.js';
+import {selectStaticFilterExpressions} from '../static-filter-set/static-filter-set-selectors.js';
 import {mapSearchRequest} from './search-mappings.js';
 
 type StateNeededBySearchRequest = ConfigurationSection &
@@ -182,21 +183,9 @@ function buildConstantQuery(state: StateNeededBySearchRequest) {
     (tab) => tab.isActive
   );
   const tabExpression = activeTab?.expression.trim() || '';
-  const filterExpressions = getStaticFilterExpressions(state);
+  const filterExpressions = selectStaticFilterExpressions(state);
 
   return [cq, tabExpression, ...filterExpressions]
     .filter((expression) => !!expression)
     .join(' AND ');
-}
-
-function getStaticFilterExpressions(state: StateNeededBySearchRequest) {
-  const filters = Object.values(state.staticFilterSet || {});
-  return filters.map((filter) => {
-    const selected = filter.values.filter(
-      (value) => value.state === 'selected' && !!value.expression.trim()
-    );
-
-    const expression = selected.map((value) => value.expression).join(' OR ');
-    return selected.length > 1 ? `(${expression})` : expression;
-  });
 }

--- a/packages/headless/src/features/static-filter-set/static-filter-set-selectors.test.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-selectors.test.ts
@@ -1,0 +1,131 @@
+import {StaticFilterSection} from '../../state/state-sections.js';
+import {selectStaticFilterExpressions} from './static-filter-set-selectors.js';
+
+describe('static filter set expressions', () => {
+  describe('getStaticFilterExpressions', () => {
+    it('returns an empty array when there are no static filters', () => {
+      const state = {
+        staticFilterSet: {},
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when state is undefined', () => {
+      const state = {
+        staticFilterSet: undefined,
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual([]);
+    });
+
+    it('returns an array with a single selected filter expressions', () => {
+      const state: StaticFilterSection = {
+        staticFilterSet: {
+          youtube: {
+            id: 'test-static-filter',
+            values: [
+              {
+                caption: 'youtube',
+                expression: '@filetype=="youtubevideo"',
+                state: 'selected',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual(['@filetype=="youtubevideo"']);
+    });
+
+    it('only returns selected filter expressions', () => {
+      const state: StaticFilterSection = {
+        staticFilterSet: {
+          filters: {
+            id: 'test-static-filter',
+            values: [
+              {
+                caption: 'idle-filter',
+                expression: '@filetype=="idle"',
+                state: 'idle',
+              },
+              {
+                caption: 'selected-filter',
+                expression: '@filetype=="selected"',
+                state: 'selected',
+              },
+              {
+                caption: 'excluded-filter',
+                expression: '@filetype=="excluded"',
+                state: 'excluded',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual(['@filetype=="selected"']);
+    });
+
+    it('concatenates multiple values with OR for a single filter', () => {
+      const state: StaticFilterSection = {
+        staticFilterSet: {
+          dropbox: {
+            id: 'test-static-filter',
+            values: [
+              {
+                caption: 'dropbox',
+                expression: '@filetype=="pdf"',
+                state: 'selected',
+              },
+              {
+                caption: 'youtube',
+                expression: '@filetype=="youtubevideo"',
+                state: 'selected',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual([
+        '(@filetype=="pdf" OR @filetype=="youtubevideo")',
+      ]);
+    });
+
+    it('returns an array with multiple different selected filter expressions', () => {
+      const state: StaticFilterSection = {
+        staticFilterSet: {
+          youtube: {
+            id: 'test-static-filter',
+            values: [
+              {
+                caption: 'youtube',
+                expression: '@filetype=="youtubevideo"',
+                state: 'selected',
+              },
+            ],
+          },
+          dropbox: {
+            id: 'test-static-filter',
+            values: [
+              {
+                caption: 'dropbox',
+                expression: '@filetype=="pdf"',
+                state: 'selected',
+              },
+            ],
+          },
+        },
+      };
+
+      const result = selectStaticFilterExpressions(state);
+      expect(result).toEqual(['@filetype=="youtubevideo"', '@filetype=="pdf"']);
+    });
+  });
+});

--- a/packages/headless/src/features/static-filter-set/static-filter-set-selectors.ts
+++ b/packages/headless/src/features/static-filter-set/static-filter-set-selectors.ts
@@ -1,0 +1,22 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {StaticFilterSection} from '../../state/state-sections.js';
+
+/**
+ * Given a static filter state, returns an array of selected filter expressions.
+ * @param state The static filter state that contains the static filter set.
+ * @returns An array of filter expressions.
+ */
+export const selectStaticFilterExpressions = createSelector(
+  (state: Partial<StaticFilterSection>) => state.staticFilterSet,
+  (staticFilterSet) => {
+    const filters = Object.values(staticFilterSet || {});
+    return filters.map((filter) => {
+      const selected = filter.values.filter(
+        (value) => value.state === 'selected' && !!value.expression.trim()
+      );
+
+      const expression = selected.map((value) => value.expression).join(' OR ');
+      return selected.length > 1 ? `(${expression})` : expression;
+    });
+  }
+);


### PR DESCRIPTION
## Related Issue
[SVCC-5083](https://coveord.atlassian.net/browse/SVCC-5083) 
During the review of another PR it was found we were missing support for static filters when we call the answer API.

## Proposed Changes
- Support for static filters in Advanced Search Query Parameters
- Extract `getStaticFilterExpressions` to separate file in /features
- Replace use in `search-request`. I did not replace the use in`legacy`, not sure if we should modify/update legacy since it's legacy
- Add tests for `getStaticFilterExpressions`

## How to test

Run `npx nx run headless:test`

## Scope
Headless.


[SVCC-5083]: https://coveord.atlassian.net/browse/SVCC-5083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ