### PR TITLE
fix(headless): analytics body param not forwarded

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ To start Atomic & Headless simultaneously in development (recommended), run:
 npx nx run atomic:dev
 ```
 
+Add the `--stencil` switch if you are changing stencil files.
+
 To start a single project in development (for instance, the `quantic` package), run:
 
 ```sh

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @cspell/spellchecker */
 import {StateNeededByAnswerAPI} from '../stream-answer-api.js';
 
+const atomicVersion = '2.77.0';
+
 export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
   configuration: {
     organizationId: 'lbergeronsfdevt1z2624x',
@@ -24,7 +26,7 @@ export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
       trackingId: '',
       analyticsMode: 'next',
       source: {
-        '@coveo/atomic': '2.77.0',
+        '@coveo/atomic': atomicVersion,
       },
     },
     knowledge: {
@@ -34,7 +36,7 @@ export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
   insightConfiguration: {
     insightId: 'insight-id',
   },
-  version: '2.77.0',
+  version: atomicVersion,
   debug: false,
   pipeline: '',
   searchHub: 'jstpierre2 test - Woods test',
@@ -1442,6 +1444,15 @@ export const expectedStreamAnswerAPIParam = {
   numberOfResults: 10,
   firstResult: 0,
   tab: 'default',
+  analytics: {
+    capture: false,
+    clientId: '',
+    clientTimestamp: '2020-01-01T00:00:00.000Z',
+    documentLocation: '',
+    documentReferrer: '',
+    originContext: 'Search',
+    source: [`@coveo/atomic@${atomicVersion}`, '@coveo/headless@Test version'],
+  },
 };
 
 export const expectedStreamAnswerAPIParamWithATabWithAnExpression = {

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import {buildMockNavigatorContextProvider} from '../../../test/mock-navigator-context-provider.js';
 import {EventSourceMessage} from '../../../utils/fetch-event-source/parse';
 import {
   constructAnswerQueryParams,
@@ -26,27 +27,28 @@ describe('#streamAnswerApi', () => {
     it('returns the correct query params with fetch usage', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMock as any,
-        'fetch'
+        'fetch',
+        buildMockNavigatorContextProvider()()
       );
 
       expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
     });
 
     it('should create the right selector when usage is select', () => {
-      vi.useFakeTimers().setSystemTime(new Date('2024-01-01'));
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMock as any,
-        'select'
+        'select',
+        buildMockNavigatorContextProvider()()
       );
 
       expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
     });
 
     it('should merge tab expression in request constant query when expression is not a blank string', () => {
-      vi.useFakeTimers().setSystemTime(new Date('2024-01-01'));
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithATabWithAnExpression as any,
-        'select'
+        'select',
+        buildMockNavigatorContextProvider()()
       );
 
       expect(queryParams).toEqual(
@@ -55,10 +57,10 @@ describe('#streamAnswerApi', () => {
     });
 
     it('should not include tab info when there is NO tab', () => {
-      vi.useFakeTimers().setSystemTime(new Date('2024-01-01'));
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithoutAnyTab as any,
-        'select'
+        'select',
+        buildMockNavigatorContextProvider()()
       );
 
       expect(queryParams).toEqual(expectedStreamAnswerAPIParamWithoutAnyTab);

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -118,7 +118,7 @@ const subscribeToSearchRequest = (
 
     lastTriggerParams = triggerParams;
     engine.dispatch(resetAnswer());
-    engine.dispatch(fetchAnswer(state));
+    engine.dispatch(fetchAnswer(state, engine.navigatorContext));
   };
 
   engine.subscribe(strictListener);
@@ -160,7 +160,10 @@ export function buildAnswerApiGeneratedAnswer(
   return {
     ...controller,
     get state() {
-      const answerApiState = selectAnswer(engine.state).data;
+      const answerApiState = selectAnswer(
+        engine.state,
+        engine.navigatorContext
+      ).data;
       return {
         ...getState().generatedAnswer,
         answer: answerApiState?.answer,
@@ -178,7 +181,7 @@ export function buildAnswerApiGeneratedAnswer(
       };
     },
     retry() {
-      engine.dispatch(fetchAnswer(getState()));
+      engine.dispatch(fetchAnswer(getState(), engine.navigatorContext));
     },
     reset() {
       engine.dispatch(resetAnswer());
@@ -187,7 +190,8 @@ export function buildAnswerApiGeneratedAnswer(
       const args = parseEvaluationArguments({
         query: getState().query.q,
         feedback,
-        answerApiState: selectAnswer(engine.state).data!,
+        answerApiState: selectAnswer(engine.state, engine.navigatorContext)
+          .data!,
       });
       engine.dispatch(answerEvaluation.endpoints.post.initiate(args));
       engine.dispatch(sendGeneratedAnswerFeedback());


### PR DESCRIPTION
## Related Issue
[SVCC-5073](https://coveord.atlassian.net/browse/SVCC-5073) The `analytics` request body parameter is not forwarded to the Answer API's `generate` endpoint.

## Proposed Changes
* Adds the analytics data to the payload sent to /generate on the Answer API.
* Modify how RTK Query serializes our `getAnswer` endpoint to exclude serialization of the `clientTimestamp`. We're using that state in the key to the Redux store.

## Scope
Headless.

## TODO

Once this PR is approved, I'll have to backport the fix into V2.


[SVCC-5073]: https://coveord.atlassian.net/browse/SVCC-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ