### PR TITLE
chore(atomic): remove VNode type from breadcrumb interface

### DIFF
--- a/packages/atomic/src/components/common/breadbox/breadcrumb-content.tsx
+++ b/packages/atomic/src/components/common/breadbox/breadcrumb-content.tsx
@@ -27,13 +27,9 @@ export const BreadcrumbContent: FunctionalComponent<BreadcrumbContentProps> = (
       </span>
       <span
         part="breadcrumb-value"
-        class={`ml-1 ${
-          props.breadcrumb.content
-            ? ''
-            : `max-w-[30ch] truncate ${props.breadcrumb.state}`
-        }`}
+        class={`ml-1 ${`max-w-[30ch] truncate ${props.breadcrumb.state}`}`}
       >
-        {props.breadcrumb.content ?? value}
+        {value}
       </span>
       <atomic-icon
         part="breadcrumb-clear"

--- a/packages/atomic/src/components/common/breadbox/breadcrumb-types.ts
+++ b/packages/atomic/src/components/common/breadbox/breadcrumb-types.ts
@@ -1,10 +1,7 @@
-import {VNode} from '@stencil/core';
-
 export interface Breadcrumb {
   facetId: string;
   label: string;
   formattedValue: string[];
   state?: 'idle' | 'selected' | 'excluded';
-  content?: VNode;
   deselect: () => void;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4259

This 'content' property was never used... Probably a relic of the past.