### PR TITLE
chore: skip flaky test in cypress search box

### DIFF
--- a/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
+++ b/packages/atomic/cypress/e2e/search-box/search-box.cypress.ts
@@ -520,7 +520,7 @@ describe('Search Box Test Suites', () => {
         .and('contain', 'active-suggestion');
     });
 
-    it('should collapse suggestions when clicking on the search button', () => {
+    it.skip('should collapse suggestions when clicking on the search button', () => {
       SearchBoxSelectors.textArea().focus();
       SearchBoxSelectors.querySuggestions().should('exist');
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4269

Happened twice already so we should skip it for now. KIT-4270 will address this.