### PR TITLE
chore: make search team own the package json of shopify package for renovate update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,3 +31,4 @@
 # Owners of the Shopify headless package
 
 /packages/shopify/ @coveo/shopify
+/packages/shopify/package.json @coveo/shopify @coveo/search


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4271

[This](https://github.com/coveo/ui-kit/pull/5363
) PR is blocked by this and we already do this for quantic. Should we do this for the shopify package as well ? 
