### PR TITLE
fix(headless): preserve selected state for filter ranges after restore

### DIFF
--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-reducers.test.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-reducers.test.ts
@@ -236,7 +236,7 @@ describe('range facet reducers', () => {
       expect(value.state).toBe('selected');
     });
 
-    it('when a request #currentValues range is not found in the payload, it unselects it', () => {
+    it('when a request #currentValues range is not found in the payload, it does not unselect it', () => {
       const value = buildMockNumericFacetValue({
         start: 0,
         end: 10,
@@ -251,7 +251,7 @@ describe('range facet reducers', () => {
       const nf = {};
 
       handleRangeFacetSearchParameterRestoration(state, nf);
-      expect(value.state).toBe('idle');
+      expect(value.state).toBe('selected');
     });
 
     it('when a range in the payload is not found, it adds it to #currentValues', () => {

--- a/packages/headless/src/features/facets/range-facets/generic/range-facet-reducers.ts
+++ b/packages/headless/src/features/facets/range-facets/generic/range-facet-reducers.ts
@@ -124,7 +124,9 @@ export function handleRangeFacetSearchParameterRestoration<
 
     request.currentValues.forEach((range: Range) => {
       const found = !!findRange(rangesToSelect, range);
-      range.state = found ? 'selected' : 'idle';
+      if (found) {
+        range.state = 'selected';
+      }
       return range;
     });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4196

The url parameters should not make every range value "idle". It should just put the values from the url as "selected". It should not touch values that are not present in the url.

Fix #5234 
