### PR TITLE
fix(atomic): make customElements registering more robust

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/atomic-stencil-lit-migration.md
@@ -57,5 +57,6 @@ _The `[component-name]` component is designed to [brief description of the compo
 - [ ] 🦥 Slotted Content, public methods and properties are documented
 - [ ] 🔄 The component outputs the same Angular output as before with Stencil
 - [ ] 🏷️ The component declares the component type in the HTMLElementTagNameMap
+- [ ] ✅ The component uses the atomicElement decorator instead of Lit’s customElement decorator
 
 https://coveord.atlassian.net/browse/KIT-[____]

--- a/packages/atomic/scripts/generate-component-templates/component.ts.hbs
+++ b/packages/atomic/scripts/generate-component-templates/component.ts.hbs
@@ -1,12 +1,13 @@
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import {CSSResultGroup, html, unsafeCSS} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {property} from 'lit/decorators.js';
 import styles from './{{name}}.tw.css';
+import {atomicElement} from '@/src/decorators/safe-custom-elements';
 
 /**
 * The {{name}} is a component that does something.
 */
-@customElement('{{name}}')
+@atomicElement('{{name}}')
 @withTailwindStyles
 export class {{namePascalCase}} extends LitElement {
   static styles: CSSResultGroup = [

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
@@ -1,3 +1,4 @@
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {watch} from '@/src/decorators/watch';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import {markParentAsReady} from '@/src/utils/init-queue';
@@ -27,7 +28,7 @@ import {
 import {provide} from '@lit/context';
 import i18next, {i18n} from 'i18next';
 import {CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {property, state} from 'lit/decorators.js';
 import {ChildrenUpdateCompleteMixin} from '../../../mixins/children-update-complete-mixin';
 import {
   AdoptedStylesBindings,
@@ -70,7 +71,7 @@ const FirstRequestExecutedFlag = 'firstRequestExecuted';
  *
  * @slot default - The default slot where you can add child components to the search box.
  */
-@customElement('atomic-commerce-interface')
+@atomicElement('atomic-commerce-interface')
 @withTailwindStyles
 export class AtomicCommerceInterface
   extends ChildrenUpdateCompleteMixin(LitElement)

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
@@ -1,3 +1,4 @@
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {bindStateToController} from '@/src/decorators/bind-state';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings';
@@ -15,7 +16,7 @@ import {
   Search,
 } from '@coveo/headless/commerce';
 import {html, LitElement} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {property, state} from 'lit/decorators.js';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import {createAppLoadedListener} from '../../common/interface/store';
@@ -45,7 +46,7 @@ import {getCurrentPagesRange} from './commerce-pager-utils';
  * @event atomic/scrollToTop - Emitted when the user clicks the next or previous button, or a page button.
  * @alpha
  */
-@customElement('atomic-commerce-pager')
+@atomicElement('atomic-commerce-pager')
 @bindings()
 @withTailwindStyles
 export class AtomicCommercePager

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.ts
@@ -8,6 +8,7 @@ import {
   SearchBoxSuggestions,
   SearchBoxSuggestionsBindings,
 } from '@/src/components/common/suggestions/suggestions-common';
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {errorGuard} from '@/src/decorators/error-guard';
 import {InitializableComponent} from '@/src/decorators/types';
 import {
@@ -17,7 +18,7 @@ import {
   Suggestion,
 } from '@coveo/headless/commerce';
 import {html, LitElement, nothing} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {property, state} from 'lit/decorators.js';
 import SearchIcon from '../../../images/search.svg';
 import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 
@@ -25,7 +26,7 @@ import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-int
  * The `atomic-commerce-search-box-query-suggestions` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of query suggestion behavior.
  * @alpha
  */
-@customElement('atomic-commerce-search-box-query-suggestions')
+@atomicElement('atomic-commerce-search-box-query-suggestions')
 export class AtomicCommerceSearchBoxQuerySuggestions
   extends LitElement
   implements InitializableComponent<CommerceBindings>

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.ts
@@ -1,3 +1,4 @@
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {bindings} from '@/src/decorators/bindings';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
 import {
@@ -11,7 +12,7 @@ import {
   ProductListingState,
 } from '@coveo/headless/commerce';
 import {html, CSSResultGroup, unsafeCSS, LitElement} from 'lit';
-import {customElement, state} from 'lit/decorators.js';
+import {state} from 'lit/decorators.js';
 import {guard} from 'lit/directives/guard.js';
 import {map} from 'lit/directives/map.js';
 import {bindStateToController} from '../../../decorators/bind-state';
@@ -37,7 +38,7 @@ import styles from './atomic-commerce-sort-dropdown.tw.css';
  *
  * @alpha
  */
-@customElement('atomic-commerce-sort-dropdown')
+@atomicElement('atomic-commerce-sort-dropdown')
 @bindings()
 @withTailwindStyles
 export class AtomicCommerceSortDropdown

--- a/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.ts
+++ b/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.ts
@@ -1,11 +1,12 @@
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
 import {html, LitElement} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {property} from 'lit/decorators.js';
 
 /**
  * The `atomic-component-error` component is used by other components to render and log errors.
  */
-@customElement('atomic-component-error')
+@atomicElement('atomic-component-error')
 @withTailwindStyles
 export class AtomicComponentError extends LitElement {
   @property({type: Object}) element!: HTMLElement;

--- a/packages/atomic/src/components/common/atomic-icon/atomic-icon.ts
+++ b/packages/atomic/src/components/common/atomic-icon/atomic-icon.ts
@@ -1,3 +1,4 @@
+import {atomicElement} from '@/src/decorators/atomic-element';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {errorGuard} from '@/src/decorators/error-guard';
 import {injectStylesForNoShadowDOM} from '@/src/decorators/light-dom';
@@ -7,7 +8,7 @@ import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {parseAssetURL} from '@/src/utils/utils';
 import DOMPurify from 'dompurify';
 import {LitElement, svg, unsafeCSS} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {property, state} from 'lit/decorators.js';
 import {guard} from 'lit/directives/guard.js';
 import {unsafeSVG} from 'lit/directives/unsafe-svg.js';
 import {AnyBindings} from '../interface/bindings';
@@ -36,7 +37,7 @@ class IconFetchError extends Error {
  *
  * This component can display an icon from those available in the Atomic package, from a specific location, or as an inline SVG element.
  */
-@customElement('atomic-icon')
+@atomicElement('atomic-icon')
 @injectStylesForNoShadowDOM
 export class AtomicIcon
   extends InitializeBindingsMixin(LitElement)

--- a/packages/atomic/src/decorators/atomic-element.spec.ts
+++ b/packages/atomic/src/decorators/atomic-element.spec.ts
@@ -1,0 +1,20 @@
+import {describe, it, expect} from 'vitest';
+import {atomicElement} from './atomic-element';
+
+describe('#atomicElement', () => {
+  const tagName = 'test-element';
+  class TestElement extends HTMLElement {}
+
+  it('should define a custom element if not already defined', () => {
+    atomicElement(tagName)(TestElement);
+    expect(customElements.get(tagName)).toBe(TestElement);
+  });
+
+  it('should not redefine a custom element if already defined', () => {
+    class SecondElement extends HTMLElement {}
+    expect(customElements.get(tagName)).toBe(TestElement);
+
+    atomicElement(tagName)(SecondElement);
+    expect(customElements.get(tagName)).toBe(TestElement);
+  });
+});

--- a/packages/atomic/src/decorators/atomic-element.ts
+++ b/packages/atomic/src/decorators/atomic-element.ts
@@ -1,0 +1,34 @@
+import {Constructor} from './base';
+
+/**
+ * Allow for custom element classes with private constructors
+ */
+type CustomElementClass = Omit<typeof HTMLElement, 'new'>;
+
+export type CustomElementDecorator = {
+  (target: CustomElementClass): void;
+};
+
+/**
+ * Class decorator factory that defines the decorated class as a custom element.
+ *
+ * Replaces the `@customElement` decorator from Lit with a implementation that
+ * checks if the custom element is already defined before defining it.
+ *
+ * ```js
+ * @atomicElement('my-element')
+ * class MyElement extends LitElement {
+ *   render() {
+ *     return html``;
+ *   }
+ * }
+ * ```
+ * @param tagName The tag name of the atomic element to define.
+ */
+export const atomicElement =
+  (tagName: string): CustomElementDecorator =>
+  (classOrTarget: CustomElementClass | Constructor<HTMLElement>) => {
+    if (!customElements.get(tagName)) {
+      customElements.define(tagName, classOrTarget as CustomElementConstructor);
+    }
+  };

--- a/packages/atomic/src/decorators/base.ts
+++ b/packages/atomic/src/decorators/base.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Constructor<T = {}> = new (...args: any[]) => T;

--- a/packages/atomic/src/decorators/bindings.ts
+++ b/packages/atomic/src/decorators/bindings.ts
@@ -13,7 +13,7 @@ import {InitializableComponent} from './types';
  * import {bindings} from './decorators/bindings';
  * import {InitializableComponent} from './decorators/types';
  *
- * @customElement('test-element')
+ * @atomicElement('test-element')
  * @bindings()
  * export class TestElement extends LitElement implements InitializableComponent<Bindings> {
  *

--- a/packages/atomic/src/mixins/bindings-mixin.ts
+++ b/packages/atomic/src/mixins/bindings-mixin.ts
@@ -5,6 +5,7 @@ import type {
   ReactiveElement,
 } from 'lit';
 import type {AnyBindings} from '../components/common/interface/bindings';
+import {Constructor} from '../decorators/base';
 import {InitializableComponent} from '../decorators/types';
 import {fetchBindings} from '../utils/initialization-lit-stencil-common-utils';
 
@@ -76,9 +77,6 @@ export class BindingController implements ReactiveController {
     this.unsubscribeLanguage();
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Constructor<T = {}> = new (...args: any[]) => T;
 
 /**
  * Mixin that initializes bindings for a Lit component.

--- a/packages/atomic/src/mixins/children-update-complete-mixin.ts
+++ b/packages/atomic/src/mixins/children-update-complete-mixin.ts
@@ -1,8 +1,6 @@
 import {HTMLStencilElement} from '@stencil/core/internal';
 import {LitElement} from 'lit';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Constructor<T = {}> = new (...args: any[]) => T;
+import {Constructor} from '../decorators/base';
 
 export const ChildrenUpdateCompleteMixin = <T extends Constructor<LitElement>>(
   superClass: T


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4274

A client is having issues here with a special nextjs setup : https://coveord.atlassian.net/browse/KIT-4266

I propose to have our own more robust customElement decorator for these cases to never happen.

More info to read about this in this thread : https://github.com/lit/lit/issues/4455