### PR TITLE
fix(atomic): restore smart-snippets styling to pre-Tailwind v4 appearance

### DIFF
--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-answer/atomic-smart-snippet-answer.pcss
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-answer/atomic-smart-snippet-answer.pcss
@@ -10,3 +10,12 @@
     }
   }
 }
+
+ul,
+ol {
+  @apply mb-4 list-outside list-decimal pl-10;
+}
+
+a {
+  @apply text-primary underline;
+}

--- a/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-answer/atomic-smart-snippet-answer.pcss
+++ b/packages/atomic/src/components/common/smart-snippets/atomic-smart-snippet-answer/atomic-smart-snippet-answer.pcss
@@ -11,6 +11,10 @@
   }
 }
 
+p {
+  @apply mt-4 mb-4;
+}
+
 ul,
 ol {
   @apply mb-4 list-outside list-decimal pl-10;


### PR DESCRIPTION


https://coveord.atlassian.net/browse/KIT-4276

## before tailwind v4
<img width="939" alt="image" src="https://github.com/user-attachments/assets/b730a3b5-5d97-42a2-b773-af527c2085c3" />

## after tailwind v4
<img width="940" alt="image" src="https://github.com/user-attachments/assets/94dca6e2-4352-42d9-9edd-a45fdadfd06f" />

## now
<img width="935" alt="image" src="https://github.com/user-attachments/assets/b4cba5b2-3246-476e-9d34-93352f8b3c77" />


