### PR TITLE
fix(quantic): updated section to create scratch org in the readme

### DIFF
--- a/packages/quantic/README.md
+++ b/packages/quantic/README.md
@@ -50,9 +50,9 @@ Optionally install the [VSCode Salesforce Extension Pack](https://marketplace.vi
 
 This command will create two scratch orgs for you:
 
-- One with Lightning Web Security (LWS) enabled.
+- One with Lightning Web Security (LWS) enabled. (Alias: `Quantic__LWS_enabled`)
 
-- One with LWS disabled.
+- One with LWS disabled, Locker Service enabled. (Alias: `Quantic__LWS_disabled`)
 
 Each scratch org will include:
 


### PR DESCRIPTION
## SFINT-6146

The command `npm run scratch:dev` is mentioned in the readme while it’s not present in the package.json file of quantic, we should update and fix the readme accordingly.

I updated the readme by mentioning the command `npm run setup:examples` which is now the command that takes care of building two scratch orgs with/without LWS with everything ready:
- All Quantic components.
- All Quantic Playground examples.
- All Solution Examples.