### PR TITLE
fix(atomic): move exclusion button out of aria-hidden label to restore accessibility

### DIFF
--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.ts
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/facet-value-checkbox.ts
@@ -85,23 +85,24 @@ export const renderFacetValueCheckbox: FunctionalComponentWithChildren<
     return html`
       ${keyed(
         props.displayValue,
-        html`<li class="relative flex items-center">
+        html`<li class="group relative flex items-center">
           ${renderCheckbox()}
           <label
             ${ref((ref) => (labelRef = ref as HTMLLabelElement))}
             .htmlFor=${id}
             part="value-checkbox-label"
-            class="group items-center"
+            class="items-center"
             @mousedown=${(e: MouseEvent) => createRipple(e, {color: 'neutral'})}
             aria-hidden="true"
           >
-            ${children} ${renderExclusion()}
+            ${children}
             <span part="value-count" class="value-count">
               ${props.i18n.t('between-parentheses', {
                 text: count,
               })}
             </span>
           </label>
+          ${renderExclusion()}
         </li>`
       )}
     `;

--- a/packages/atomic/src/components/common/facets/facet-value-checkbox/stencil-facet-value-checkbox.tsx
+++ b/packages/atomic/src/components/common/facets/facet-value-checkbox/stencil-facet-value-checkbox.tsx
@@ -67,24 +67,24 @@ export const FacetValueCheckbox: FunctionalComponent<
   };
 
   return (
-    <li key={props.displayValue} class="relative flex items-center">
+    <li key={props.displayValue} class="group relative flex items-center">
       {renderCheckbox()}
       <label
         ref={(ref) => (labelRef = ref!)}
         htmlFor={id}
         part="value-checkbox-label"
-        class="group items-center"
+        class="items-center"
         onMouseDown={(e) => createRipple(e, {color: 'neutral'})}
         aria-hidden="true"
       >
         {children}
-        {renderExclusion()}
         <span part="value-count" class="value-count">
           {props.i18n.t('between-parentheses', {
             text: count,
           })}
         </span>
       </label>
+      {renderExclusion()}
     </li>
   );
 };

--- a/packages/atomic/src/components/common/facets/facet-value-exclude/facet-value-exclude.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-value-exclude/facet-value-exclude.spec.ts
@@ -1,75 +1,50 @@
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
-import {page} from '@vitest/browser/context';
-import '@vitest/browser/matchers.d.ts';
+import {userEvent} from '@vitest/browser/context';
 import {html} from 'lit';
 import {expect, vi, describe, it} from 'vitest';
 import {renderFacetValueExclude, ExcludeProps} from './facet-value-exclude';
 
 const setupElement = async (props: Partial<ExcludeProps> = {}) => {
-  const defaultProps: ExcludeProps = {
-    onClick: vi.fn(),
-    ...props,
-  };
-  return await renderFunctionFixture(
-    html`${renderFacetValueExclude({props: defaultProps})}`
+  const element = await renderFunctionFixture(
+    html`${renderFacetValueExclude({
+      props: {
+        onClick: vi.fn(),
+        ...props,
+      },
+    })}`
   );
-};
+  const button = element.querySelector('button');
+  button!.style.visibility = 'visible';
 
-const locators = {
-  get button() {
-    return page.getByRole('button');
-  },
-  icon(element: HTMLElement) {
-    return element.querySelector('atomic-icon');
-  },
+  return {
+    element,
+    button,
+    icon: element.querySelector('atomic-icon'),
+  };
 };
 
 describe('renderFacetValueExclude', () => {
   it('renders the button and icon', async () => {
-    const element = await setupElement();
-    const {button} = locators;
-    const icon = locators.icon(element);
-    await expect(button).toBeInTheDocument();
-    await expect(icon).toBeInTheDocument();
+    const {button, icon} = await setupElement();
+    expect(button).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
   });
 
   it('applies the correct part attributes', async () => {
-    await setupElement({class: 'custom-class'});
-    const {button} = locators;
+    const {button} = await setupElement();
     expect(button).toHaveAttribute('part', 'value-exclude-button');
-    expect(button).toHaveClass('custom-class');
   });
 
   it('sets aria-label and value attributes from props', async () => {
-    await setupElement({ariaLabel: 'Exclude', text: 'foo'});
-    const {button} = locators;
+    const {button} = await setupElement({ariaLabel: 'Exclude'});
+
     expect(button).toHaveAttribute('aria-label', 'Exclude');
-    expect(button).toHaveAttribute('value', 'foo');
   });
 
   it('calls onClick when button is clicked', async () => {
     const onClick = vi.fn();
-    await setupElement({onClick});
-    const {button} = locators;
-    await button.click();
+    const {button} = await setupElement({onClick});
+    await userEvent.click(button!);
     expect(onClick).toHaveBeenCalled();
-  });
-
-  it('calls onMouseEnter when mouse enters button', async () => {
-    const onMouseEnter = vi.fn();
-    await setupElement({onMouseEnter});
-    const {button} = locators;
-    button.element().dispatchEvent(new MouseEvent('mouseenter'));
-    expect(onMouseEnter).toHaveBeenCalled();
-  });
-
-  it('forwards ref if provided', async () => {
-    let refElement: Element | undefined;
-    const ref = (el?: Element) => {
-      refElement = el;
-    };
-    await setupElement({ref});
-    expect(refElement).not.toBeNull();
-    expect(refElement?.tagName).toBe('BUTTON');
   });
 });

--- a/packages/atomic/src/components/common/facets/facet-value-exclude/facet-value-exclude.ts
+++ b/packages/atomic/src/components/common/facets/facet-value-exclude/facet-value-exclude.ts
@@ -1,47 +1,26 @@
-import {multiClassMap} from '@/src/directives/multi-class-map';
 import {FunctionalComponent} from '@/src/utils/functional-component-utils';
 import {html} from 'lit';
 import {ifDefined} from 'lit/directives/if-defined.js';
-import {keyed} from 'lit/directives/keyed.js';
-import {ref, RefOrCallback} from 'lit/directives/ref.js';
 import Tick from '../../../../images/clear.svg';
 import '../../atomic-icon/atomic-icon';
 
 export interface ExcludeProps {
   onClick(): void;
-  key?: string | number;
-  class?: string;
-  text?: string;
   ariaLabel?: string;
-  ref?: RefOrCallback;
-  onMouseEnter?(evt: MouseEvent): void;
 }
 
 export const renderFacetValueExclude: FunctionalComponent<ExcludeProps> = ({
   props,
 }) => {
-  const baseClassNames = 'value-exclude-button peer order-last flex ml-auto';
-
-  const classNames = {
-    [baseClassNames]: true,
-    [props.class ?? '']: Boolean(props.class),
-  };
-
-  return html` ${keyed(
-    props.key ?? '',
-    html`<button
-      class=${multiClassMap(classNames)}
-      part="value-exclude-button"
-      ${ref(props.ref)}
-      aria-label=${ifDefined(props.ariaLabel ?? props.text)}
-      value=${ifDefined(props.text)}
-      @click=${() => props.onClick?.()}
-      @mouseenter=${(e: MouseEvent) => props.onMouseEnter?.(e)}
-    >
-      <atomic-icon
-        class="bg-neutral hover:bg-error invisible order-last w-4 rounded p-1 group-hover:visible hover:fill-white"
-        icon=${Tick}
-      ></atomic-icon>
-    </button>`
-  )}`;
+  return html`<button
+    class="value-exclude-button peer invisible absolute right-2 z-1 order-last ml-auto flex group-hover:visible"
+    part="value-exclude-button"
+    aria-label=${ifDefined(props.ariaLabel)}
+    @click=${() => props.onClick?.()}
+  >
+    <atomic-icon
+      class="bg-neutral hover:bg-error order-last w-4 rounded p-1 hover:fill-white"
+      icon=${Tick}
+    ></atomic-icon>
+  </button> `;
 };

--- a/packages/atomic/src/components/common/facets/facet-value-exclude/stencil-facet-value-exclude.tsx
+++ b/packages/atomic/src/components/common/facets/facet-value-exclude/stencil-facet-value-exclude.tsx
@@ -3,45 +3,19 @@ import Tick from '../../../../images/clear.svg';
 
 export interface ExcludeProps {
   onClick(): void;
-  key?: string | number;
-  class?: string;
-  text?: string;
   ariaLabel?: string;
-  ref?(element?: HTMLElement): void;
-  onMouseEnter?(evt: MouseEvent): void;
 }
 
 export const FacetValueExclude: FunctionalComponent<ExcludeProps> = (props) => {
-  const classNames = [
-    'value-exclude-button',
-    'peer',
-    'order-last',
-    'flex',
-    'ml-auto',
-  ];
-  if (props.class) {
-    classNames.push(props.class);
-  }
-
-  const attributes = {
-    class: classNames.join(' '),
-    part: 'value-exclude-button',
-    ref: props.ref,
-    key: props.key,
-    'aria-label': props.ariaLabel ?? props.text,
-    value: props.text,
-  };
-
   return (
     <button
-      {...attributes}
+      part="value-exclude-button"
+      aria-label={props.ariaLabel}
+      class="value-exclude-button peer invisible absolute right-2 z-1 order-last ml-auto flex group-hover:visible"
       onClick={() => props.onClick?.()}
-      onMouseEnter={(e) => props.onMouseEnter?.(e)}
     >
       <atomic-icon
-        class={
-          'bg-neutral hover:bg-error invisible order-last w-4 rounded p-1 group-hover:visible hover:fill-white'
-        }
+        class="bg-neutral hover:bg-error order-last w-4 rounded p-1 hover:fill-white"
         icon={Tick}
       ></atomic-icon>
     </button>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4173

For better accessibility.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden
> aria-hidden="true" should not be used on elements that can receive focus. Additionally, since this attribute is inherited by an element's children, it should not be added onto the parent or ancestor of a focusable element.


- Also refactored the two test files affected since there was an unnecessary amount of lines
- Also removed a bunch of unused props from facetValueExclude