### PR TITLE
docs(atomic): remove parts from recent-queries documentation

### DIFF
--- a/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/commerce/search-box-suggestions/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.tsx
@@ -26,9 +26,6 @@ import {CommerceBindings as Bindings} from '../../atomic-commerce-interface/atom
 /**
  * The `atomic-commerce-search-box-recent-queries` component can be added as a child of an `atomic-commerce-search-box` component, allowing for the configuration of recent query suggestions.
  *
- * @part recent-query-title - The 'Recent queries' title.
- * @part recent-query-clear - The 'Clear' button for clearing recent queries.
- *
  * @alpha
  */
 @Component({

--- a/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
+++ b/packages/atomic/src/components/search/search-box-suggestions/atomic-search-box-recent-queries/atomic-search-box-recent-queries.tsx
@@ -25,9 +25,6 @@ import {Bindings} from '../../atomic-search-interface/atomic-search-interface';
 
 /**
  * The `atomic-search-box-recent-queries` component can be added as a child of an `atomic-search-box` component, allowing for the configuration of recent query suggestions.
- *
- * @part recent-query-title - The 'Recent queries' title.
- * @part recent-query-clear - The 'Clear' button for clearing recent queries    .
  */
 @Component({
   tag: 'atomic-search-box-recent-queries',


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4299

This does not work : 

```
    atomic-search-box-recent-queries::part(recent-query-title) {
      background-color: aqua;
    }
```


Because you must target the search-box instead of the actual recent queries component.

```
   atomic-search-box::part(recent-query-title) {
      background-color: aqua;
    }
```

It is confusing to have this part in the recent-queries documentation. It is already in the search boxes and is more complete there. (`recent-query-item` was missing for exemple)