### PR TITLE
feat(shopify): export constants in utils package

### DIFF
--- a/packages/shopify/src/utilities/index.test.ts
+++ b/packages/shopify/src/utilities/index.test.ts
@@ -1,0 +1,16 @@
+import {it, expect} from 'vitest';
+import {
+  fetchAppProxyConfig,
+  SHOPIFY_COOKIE_KEY,
+  COVEO_SHOPIFY_CONFIG_KEY,
+  getShopifyCookie,
+  getClientId,
+} from './index';
+
+it('should export the correct types', () => {
+  expect(fetchAppProxyConfig).toBeDefined();
+  expect(getShopifyCookie).toBeDefined();
+  expect(getClientId).toBeDefined();
+  expect(SHOPIFY_COOKIE_KEY).toBeDefined();
+  expect(COVEO_SHOPIFY_CONFIG_KEY).toBeDefined();
+});

--- a/packages/shopify/src/utilities/index.ts
+++ b/packages/shopify/src/utilities/index.ts
@@ -1,3 +1,4 @@
 export {getClientId} from './clientid';
 export {getShopifyCookie} from './shopify';
 export {fetchAppProxyConfig} from './app-proxy';
+export * from '../constants';


### PR DESCRIPTION
We would like to use the constants exported by the shopify package without importing the whole commerce module. This is to reduce the size of the webpixel package. 