### PR TITLE
fix(headless): ensure cq is defined before appending it to expressions

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -306,7 +306,7 @@ const buildAdvancedSearchQueryParams = (state: StateNeededByAnswerAPI) => {
   };
 
   if (expressions.length) {
-    mergedAdvancedSearchQueryParams.cq = `${expressions} AND ${advancedSearchQueryParams.cq}`;
+    mergedAdvancedSearchQueryParams.cq = `${expressions}`;
   }
 
   return mergedAdvancedSearchQueryParams;
@@ -315,8 +315,9 @@ const buildAdvancedSearchQueryParams = (state: StateNeededByAnswerAPI) => {
 const buildExpressionList = (state: StateNeededByAnswerAPI) => {
   const activeTabExpression = selectActiveTabExpression(state.tabSet);
   const filterExpressions = selectStaticFilterExpressions(state);
+  const {cq} = selectAdvancedSearchQueries(state);
 
-  return [activeTabExpression, ...filterExpressions]
+  return [activeTabExpression, ...filterExpressions, cq]
     .filter((expression) => !!expression)
     .join(' AND ');
 };

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -299,15 +299,15 @@ const getNumberOfResultsWithinIndexLimit = (state: StateNeededByAnswerAPI) => {
 
 const buildAdvancedSearchQueryParams = (state: StateNeededByAnswerAPI) => {
   const advancedSearchQueryParams = selectAdvancedSearchQueries(state);
-  const expressions = buildExpressionList(state);
+  const mergedCq = mergeAdvancedCQParams(state);
 
   return {
     ...advancedSearchQueryParams,
-    ...(expressions.length && {cq: expressions}),
+    ...(mergedCq && {cq: mergedCq}),
   };
 };
 
-const buildExpressionList = (state: StateNeededByAnswerAPI) => {
+const mergeAdvancedCQParams = (state: StateNeededByAnswerAPI) => {
   const activeTabExpression = selectActiveTabExpression(state.tabSet);
   const filterExpressions = selectStaticFilterExpressions(state);
   const {cq} = selectAdvancedSearchQueries(state);

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -301,15 +301,10 @@ const buildAdvancedSearchQueryParams = (state: StateNeededByAnswerAPI) => {
   const advancedSearchQueryParams = selectAdvancedSearchQueries(state);
   const expressions = buildExpressionList(state);
 
-  const mergedAdvancedSearchQueryParams = {
+  return {
     ...advancedSearchQueryParams,
+    ...(expressions.length && {cq: expressions}),
   };
-
-  if (expressions.length) {
-    mergedAdvancedSearchQueryParams.cq = `${expressions}`;
-  }
-
-  return mergedAdvancedSearchQueryParams;
 };
 
 const buildExpressionList = (state: StateNeededByAnswerAPI) => {

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1195,6 +1195,15 @@ export const streamAnswerAPIStateMockWithStaticFiltersAndTabExpression: StateNee
     },
   };
 
+export const streamAnswerAPIStateMockWithStaticFiltersAndTabExpressionWithEmptyCQ =
+  {
+    ...streamAnswerAPIStateMockWithStaticFiltersAndTabExpression,
+    advancedSearchQueries: {
+      ...streamAnswerAPIStateMockWithStaticFiltersAndTabExpression.advancedSearchQueries,
+      cq: '',
+    },
+  };
+
 export const expectedStreamAnswerAPIParam = {
   q: 'what is the hardest wood',
   aq: 'aq-test-query',
@@ -1567,3 +1576,9 @@ export const expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpression = {
   ...expectedStreamAnswerAPIParam,
   cq: '@fileType=html AND (@filetype=="youtubevideo" OR @filetype=="dropbox") AND @filetype=="tsx" AND cq-test-query',
 };
+
+export const expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpressionWithoutAdvancedCQ =
+  {
+    ...expectedStreamAnswerAPIParam,
+    cq: '@fileType=html AND (@filetype=="youtubevideo" OR @filetype=="dropbox") AND @filetype=="tsx"',
+  };

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -19,6 +19,8 @@ import {
   streamAnswerAPIStateMockWithNonValidFilters,
   streamAnswerAPIStateMockWithStaticFiltersAndTabExpression,
   streamAnswerAPIStateMockWithStaticFiltersSelected,
+  streamAnswerAPIStateMockWithStaticFiltersAndTabExpressionWithEmptyCQ,
+  expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpressionWithoutAdvancedCQ,
 } from './stream-answer-api-state-mock.js';
 
 describe('#streamAnswerApi', () => {
@@ -110,6 +112,16 @@ describe('#streamAnswerApi', () => {
       );
       expect(queryParams).toEqual(
         expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpression
+      );
+    });
+    it('should not include advanced search queries when there are no advanced search queries', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMockWithStaticFiltersAndTabExpressionWithEmptyCQ as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+      expect(queryParams).toEqual(
+        expectedStreamAnswerAPIParamWithStaticFiltersAndTabExpressionWithoutAdvancedCQ
       );
     });
   });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-5134
Fixes an issue where undefined would be appended to `cq` when `cq` was empty in `loadAdvancedSearchQueryActions`.

Before:

![image](https://github.com/user-attachments/assets/2f944197-e6f2-4b97-af6e-d36e51866019)

After:

![image](https://github.com/user-attachments/assets/505e2523-a929-4836-9866-b468b44e2aec)


To test:

in `tabs.html`, add advanced queries actions:
```
    <script type="module">
      import {loadAdvancedSearchQueryActions} from 'https://static.cloud.coveo.com/atomic/v1/headless/headless.esm.js';
...
        const advQueriesActions = loadAdvancedSearchQueryActions(searchInterface.engine);
        searchInterface.engine?.dispatch(
          advQueriesActions.updateAdvancedSearchQueries({
            aq: '@fileType=html',
            cq: '',
            dq: '',
            lq: '',
          })
        );
```
Also add an `<atomic-generated-answer>` component on line 225 of the same file:

```
          <atomic-generated-answer
            answer-configuration-id="fc581be0-6e61-4039-ab26-a3f2f52f308f"
          ></atomic-generated-answer>
```

Then open tabs.html in the demo page, click on the `videos` tab and then do a search. You will see that `cq` will be correctly defined