### PR TITLE
fix(headless-ssr-react): ensure provider's children are not remounted on hydration

### DIFF
--- a/packages/headless-react/.eslintrc.cjs
+++ b/packages/headless-react/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
         varsIgnorePattern: '^_',
       },
     ],
+    'testing-library/no-manual-cleanup': 'off',
   },
   ignorePatterns: ['dist/', '**/*.js'],
 };

--- a/packages/headless-react/project.json
+++ b/packages/headless-react/project.json
@@ -9,7 +9,7 @@
       "outputs": ["{projectRoot}/dist"],
       "cache": true,
       "options": {
-        "command": "tsc --project ./tsconfig.json",
+        "command": "tsc --project ./tsconfig.build.json",
         "cwd": "{projectRoot}"
       }
     }

--- a/packages/headless-react/src/client-utils.test.tsx
+++ b/packages/headless-react/src/client-utils.test.tsx
@@ -1,6 +1,6 @@
 import {renderHook} from '@testing-library/react';
 import {vi, expect, describe, test, it} from 'vitest';
-import {useSyncMemoizedStore} from './client-utils';
+import {useSyncMemoizedStore} from './client-utils.js';
 
 describe('useSyncMemoizedStore', () => {
   test('should return the initial snapshot', () => {

--- a/packages/headless-react/src/ssr-commerce/commerce-engine.test.tsx
+++ b/packages/headless-react/src/ssr-commerce/commerce-engine.test.tsx
@@ -10,7 +10,6 @@ import {
 import {act, render, renderHook, screen} from '@testing-library/react';
 import {randomUUID} from 'crypto';
 import {PropsWithChildren} from 'react';
-import React from 'react';
 import {
   vi,
   expect,
@@ -58,6 +57,7 @@ describe('Headless react SSR utils', () => {
       build,
       StaticStateProvider,
       HydratedStateProvider,
+      StateProvider,
       setNavigatorContextProvider,
     } = listingEngineDefinition;
 
@@ -68,6 +68,7 @@ describe('Headless react SSR utils', () => {
       useEngine,
       StaticStateProvider,
       HydratedStateProvider,
+      StateProvider,
       setNavigatorContextProvider,
     ];
 
@@ -119,6 +120,7 @@ describe('Headless react SSR utils', () => {
       listingEngineDefinition: {
         HydratedStateProvider,
         StaticStateProvider,
+        StateProvider,
         fetchStaticState,
         hydrateStaticState,
         setNavigatorContextProvider,
@@ -230,6 +232,32 @@ describe('Headless react SSR utils', () => {
       await checkRenderedProductList();
     });
 
+    test('should render with StateProvider using static state', async () => {
+      setNavigatorContextProvider(mockedNavigatorContextProvider);
+      const staticState = await fetchStaticState();
+      render(
+        <StateProvider controllers={staticState.controllers}>
+          <TestProductList />
+        </StateProvider>
+      );
+
+      await checkRenderedProductList();
+    });
+
+    test('should render with StateProvider using hydrated state', async () => {
+      setNavigatorContextProvider(mockedNavigatorContextProvider);
+      const staticState = await fetchStaticState();
+      const {engine, controllers} = await hydrateStaticState(staticState);
+
+      render(
+        <StateProvider engine={engine} controllers={controllers}>
+          <TestProductList />
+        </StateProvider>
+      );
+
+      await checkRenderedProductList();
+    });
+
     describe('hooks', () => {
       const {listingEngineDefinition} = engineDefinition;
       let staticState: InferStaticState<typeof listingEngineDefinition>;
@@ -260,6 +288,29 @@ describe('Headless react SSR utils', () => {
         );
       }
 
+      function stateProviderWrapperWithStaticState({
+        children,
+      }: PropsWithChildren) {
+        return (
+          <StateProvider controllers={staticState.controllers}>
+            {children}
+          </StateProvider>
+        );
+      }
+
+      function stateProviderWrapperWithHydratedState({
+        children,
+      }: PropsWithChildren) {
+        return (
+          <StateProvider
+            engine={hydratedState.engine}
+            controllers={hydratedState.controllers}
+          >
+            {children}
+          </StateProvider>
+        );
+      }
+
       describe('useEngine hook', () => {
         test('should throw error with no context', async () => {
           checkRenderError(
@@ -278,6 +329,20 @@ describe('Headless react SSR utils', () => {
         test('should return engine with hydrated state provider', async () => {
           const {result} = renderHook(() => useEngine(), {
             wrapper: hydratedStateProviderWrapper,
+          });
+          expect(result.current).toStrictEqual(hydratedState.engine);
+        });
+
+        test('should not return engine with StateProvider using static state', async () => {
+          const {result} = renderHook(() => useEngine(), {
+            wrapper: stateProviderWrapperWithStaticState,
+          });
+          expect(result.current).toBeUndefined();
+        });
+
+        test('should return engine with StateProvider using hydrated state', async () => {
+          const {result} = renderHook(() => useEngine(), {
+            wrapper: stateProviderWrapperWithHydratedState,
           });
           expect(result.current).toStrictEqual(hydratedState.engine);
         });
@@ -307,6 +372,39 @@ describe('Headless react SSR utils', () => {
           test('should update state when method is called', () => {
             const {result} = renderHook(() => useSearchBox(), {
               wrapper: hydratedStateProviderWrapper,
+            });
+            const initialState = result.current.state;
+            act(() => {
+              result.current.methods?.updateText('foo');
+            });
+
+            expect(initialState).not.toStrictEqual(result.current.state);
+            expect(result.current.state.value).toBe('foo');
+          });
+        });
+
+        describe('with StateProvider (static state)', () => {
+          test('should define state but not controller', () => {
+            const {result} = renderHook(() => useSearchBox(), {
+              wrapper: stateProviderWrapperWithStaticState,
+            });
+            expect(result.current.state).toBeDefined();
+            expect(result.current?.methods).toBeUndefined();
+          });
+        });
+
+        describe('with StateProvider (hydrated state)', () => {
+          test('should define both state and controller', () => {
+            const {result} = renderHook(() => useSearchBox(), {
+              wrapper: stateProviderWrapperWithHydratedState,
+            });
+            expect(result.current.state).toBeDefined();
+            expect(result.current?.methods).toBeDefined();
+          });
+
+          test('should update state when method is called', () => {
+            const {result} = renderHook(() => useSearchBox(), {
+              wrapper: stateProviderWrapperWithHydratedState,
             });
             const initialState = result.current.state;
             act(() => {

--- a/packages/headless-react/src/ssr-commerce/commerce-engine.tsx
+++ b/packages/headless-react/src/ssr-commerce/commerce-engine.tsx
@@ -14,6 +14,7 @@ import {
   buildControllerHooks,
   buildEngineHook,
   buildHydratedStateProvider,
+  buildStateProvider,
   buildStaticStateProvider,
 } from './common.js';
 import {
@@ -103,6 +104,11 @@ export function defineCommerceEngine<
         singletonContext as ListingContext,
         SolutionType.listing
       ),
+
+      StateProvider: buildStateProvider(
+        singletonContext as ListingContext,
+        SolutionType.listing
+      ),
     },
     searchEngineDefinition: {
       ...searchEngineDefinition,
@@ -111,6 +117,10 @@ export function defineCommerceEngine<
         SolutionType.search
       ),
       HydratedStateProvider: buildHydratedStateProvider(
+        singletonContext as SearchContext,
+        SolutionType.search
+      ),
+      StateProvider: buildStateProvider(
         singletonContext as SearchContext,
         SolutionType.search
       ),
@@ -125,6 +135,10 @@ export function defineCommerceEngine<
         singletonContext as StandaloneContext,
         SolutionType.standalone
       ),
+      StateProvider: buildStateProvider(
+        singletonContext as StandaloneContext,
+        SolutionType.standalone
+      ),
     },
     recommendationEngineDefinition: {
       ...recommendationEngineDefinition,
@@ -133,6 +147,10 @@ export function defineCommerceEngine<
         SolutionType.recommendation
       ),
       HydratedStateProvider: buildHydratedStateProvider(
+        singletonContext as RecommendationContext,
+        SolutionType.recommendation
+      ),
+      StateProvider: buildStateProvider(
         singletonContext as RecommendationContext,
         SolutionType.recommendation
       ),

--- a/packages/headless-react/src/ssr-commerce/common.test.tsx
+++ b/packages/headless-react/src/ssr-commerce/common.test.tsx
@@ -1,0 +1,343 @@
+import {
+  SolutionType,
+  CommerceEngine as SSRCommerceEngine,
+} from '@coveo/headless/ssr-commerce';
+import {render, cleanup, screen} from '@testing-library/react';
+import {Context, createContext} from 'react';
+import React from 'react';
+import {vi, expect, describe, test, afterEach} from 'vitest';
+import {
+  buildStateProvider,
+  buildStaticStateProvider,
+  buildHydratedStateProvider,
+} from './common.js';
+import {ContextState} from './types.js';
+
+type MockContext = ContextState<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+describe('SSR Commerce Common functions', () => {
+  const mockContext = createContext(
+    null
+  ) as unknown as Context<MockContext | null>;
+  const mockSingletonContext = {
+    get: () => mockContext,
+  };
+
+  const mockEngine = {
+    subscribe: vi.fn(),
+    dispatch: vi.fn(),
+  } as unknown as SSRCommerceEngine;
+
+  const mockControllers = {
+    searchBox: {
+      state: {value: 'test'},
+      subscribe: vi.fn(),
+      methods: {updateText: vi.fn()},
+    },
+  };
+
+  const mockStaticControllers = {
+    searchBox: {
+      state: {value: 'test'},
+    },
+  };
+
+  const mockSolutionType = SolutionType.listing;
+
+  function TestComponent() {
+    return <div data-testid="test-component">Test</div>;
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('buildStateProvider', () => {
+    const StateProvider = buildStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+
+    test('should render with static controllers only', () => {
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <TestComponent />
+        </StateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should render with both engine and controllers', () => {
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <TestComponent />
+        </StateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with engine when provided', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: mockEngine,
+        controllers: mockControllers,
+        solutionType: mockSolutionType,
+      });
+    });
+
+    test('should provide context value without engine when not provided', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: undefined,
+        controllers: mockStaticControllers,
+        solutionType: mockSolutionType,
+      });
+    });
+  });
+
+  describe('buildStaticStateProvider (deprecated)', () => {
+    const StaticStateProvider = buildStaticStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+
+    test('should render with static controllers', () => {
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <TestComponent />
+        </StaticStateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with controllers and solutionType', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <TestConsumer />
+        </StaticStateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        controllers: mockStaticControllers,
+        solutionType: mockSolutionType,
+      });
+    });
+  });
+
+  describe('buildHydratedStateProvider (deprecated)', () => {
+    const HydratedStateProvider = buildHydratedStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+
+    test('should render with engine and controllers', () => {
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <TestComponent />
+        </HydratedStateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with engine, controllers, and solutionType', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <TestConsumer />
+        </HydratedStateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: mockEngine,
+        controllers: mockControllers,
+        solutionType: mockSolutionType,
+      });
+    });
+  });
+
+  describe('StateProvider vs deprecated providers comparison', () => {
+    const StateProvider = buildStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+    const StaticStateProvider = buildStaticStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+    const HydratedStateProvider = buildHydratedStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+
+    test('StateProvider with static controllers should behave like StaticStateProvider', () => {
+      let stateProviderValue: MockContext | null = null;
+      let staticProviderValue: MockContext | null = null;
+
+      const StateConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        stateProviderValue = ctx;
+        return <div />;
+      };
+
+      const StaticConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        staticProviderValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <StateConsumer />
+        </StateProvider>
+      );
+
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <StaticConsumer />
+        </StaticStateProvider>
+      );
+
+      // StateProvider should include engine: undefined, while StaticStateProvider doesn't include engine at all
+      expect(stateProviderValue!.controllers).toEqual(
+        staticProviderValue!.controllers
+      );
+      expect(stateProviderValue!.solutionType).toEqual(
+        staticProviderValue!.solutionType
+      );
+      expect(stateProviderValue!.engine).toBeUndefined();
+      expect('engine' in staticProviderValue!).toBe(false);
+    });
+
+    test('StateProvider with hydrated state should behave like HydratedStateProvider', () => {
+      let stateProviderValue: MockContext | null = null;
+      let hydratedProviderValue: MockContext | null = null;
+
+      const StateConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        stateProviderValue = ctx;
+        return <div />;
+      };
+
+      const HydratedConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        hydratedProviderValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <StateConsumer />
+        </StateProvider>
+      );
+
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <HydratedConsumer />
+        </HydratedStateProvider>
+      );
+
+      expect(stateProviderValue).toEqual(hydratedProviderValue);
+    });
+  });
+
+  describe('isomorphic behavior', () => {
+    const StateProvider = buildStateProvider(
+      mockSingletonContext,
+      mockSolutionType
+    );
+
+    test('should work seamlessly when transitioning from static to hydrated state', () => {
+      const contextValues: (MockContext | null)[] = [];
+
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValues.push(ctx);
+        return <div />;
+      };
+
+      // First render with static state
+      const {rerender} = render(
+        <StateProvider controllers={mockStaticControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      // Re-render with hydrated state (simulating hydration)
+      rerender(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      expect(contextValues).toHaveLength(2);
+
+      // First render should have no engine
+      expect(contextValues[0]).toEqual({
+        engine: undefined,
+        controllers: mockStaticControllers,
+        solutionType: mockSolutionType,
+      });
+
+      // Second render should have engine
+      expect(contextValues[1]).toEqual({
+        engine: mockEngine,
+        controllers: mockControllers,
+        solutionType: mockSolutionType,
+      });
+    });
+  });
+});

--- a/packages/headless-react/src/ssr-commerce/common.tsx
+++ b/packages/headless-react/src/ssr-commerce/common.tsx
@@ -34,7 +34,7 @@ function isHydratedStateContext<
 >(
   ctx: ContextState<TControllers, TSolutionType>
 ): ctx is ContextHydratedState<TControllers, TSolutionType> {
-  return 'engine' in ctx;
+  return 'engine' in ctx && !!ctx.engine;
 }
 
 function buildControllerHook<
@@ -133,6 +133,10 @@ export function buildEngineHook<
   };
 }
 
+/**
+ * @deprecated use `buildStateProvider` instead.
+ * It is isomorphic and can be used for both static and hydrated state.
+ */
 export function buildStaticStateProvider<
   TControllers extends ControllerDefinitionsMap<Controller>,
   TSolutionType extends SolutionType,
@@ -156,6 +160,10 @@ export function buildStaticStateProvider<
   };
 }
 
+/**
+ * @deprecated use `buildStateProvider` instead.
+ * It is isomorphic and can be used for both static and hydrated state.
+ */
 export function buildHydratedStateProvider<
   TControllers extends ControllerDefinitionsMap<Controller>,
   TSolutionType extends SolutionType,
@@ -172,6 +180,37 @@ export function buildHydratedStateProvider<
   }: PropsWithChildren<{
     engine: SSRCommerceEngine;
     controllers: InferControllersMapFromDefinition<TControllers, TSolutionType>;
+  }>) => {
+    const {Provider} = singletonContext.get();
+    return (
+      <Provider value={{engine, controllers, solutionType}}>
+        {children}
+      </Provider>
+    );
+  };
+}
+
+export function buildStateProvider<
+  TControllers extends ControllerDefinitionsMap<Controller>,
+  TSolutionType extends SolutionType,
+>(
+  singletonContext: SingletonGetter<
+    Context<ContextState<TControllers, TSolutionType> | null>
+  >,
+  solutionType: TSolutionType
+) {
+  return ({
+    engine,
+    controllers,
+    children,
+  }: PropsWithChildren<{
+    engine?: SSRCommerceEngine;
+    controllers:
+      | InferControllersMapFromDefinition<TControllers, TSolutionType>
+      | InferControllerStaticStateMapFromDefinitionsWithSolutionType<
+          TControllers,
+          TSolutionType
+        >;
   }>) => {
     const {Provider} = singletonContext.get();
     return (

--- a/packages/headless-react/src/ssr-commerce/providers.tsx
+++ b/packages/headless-react/src/ssr-commerce/providers.tsx
@@ -139,32 +139,13 @@ export function buildProviderWithDefinition<
       });
     }, [staticState]);
 
-    if (hydratedState) {
-      return (
-        <definition.HydratedStateProvider
-          engine={hydratedState.engine}
-          controllers={hydratedState.controllers}
-        >
-          {children}
-        </definition.HydratedStateProvider>
-      );
-    }
-
-    const StaticStateProviderWithAnyControllers =
-      definition.StaticStateProvider as React.ComponentType<{
-        controllers: InferControllerStaticStateMapFromDefinitionsWithSolutionType<
-          ControllerDefinitionsMap<Controller>,
-          SolutionType
-        >;
-        children: React.ReactNode;
-      }>;
-
     return (
-      <StaticStateProviderWithAnyControllers
-        controllers={staticState.controllers}
+      <definition.StateProvider
+        engine={hydratedState?.engine}
+        controllers={hydratedState?.controllers || staticState.controllers}
       >
         {children}
-      </StaticStateProviderWithAnyControllers>
+      </definition.StateProvider>
     );
   };
 }

--- a/packages/headless-react/src/ssr-commerce/types.ts
+++ b/packages/headless-react/src/ssr-commerce/types.ts
@@ -33,9 +33,16 @@ export type ContextHydratedState<
 export type ContextState<
   TControllers extends ControllerDefinitionsMap<Controller>,
   TSolutionType extends SolutionType,
-> =
-  | ContextStaticState<TControllers, TSolutionType>
-  | ContextHydratedState<TControllers, TSolutionType>;
+> = {
+  engine?: SSRCommerceEngine;
+  controllers:
+    | InferControllersMapFromDefinition<TControllers, TSolutionType>
+    | InferControllerStaticStateMapFromDefinitionsWithSolutionType<
+        TControllers,
+        TSolutionType
+      >;
+  solutionType: TSolutionType;
+};
 
 export type ControllerHook<TController extends Controller> = () => {
   state: TController['state'];
@@ -55,6 +62,9 @@ export type ReactEngineDefinition<
   TEngineOptions,
   TSolutionType extends SolutionType,
 > = EngineDefinition<TControllers, TEngineOptions, TSolutionType> & {
+  /**
+   * @deprecated Use `StateProvider` instead.
+   */
   StaticStateProvider: FunctionComponent<
     PropsWithChildren<{
       controllers: InferControllerStaticStateMapFromDefinitionsWithSolutionType<
@@ -63,6 +73,9 @@ export type ReactEngineDefinition<
       >;
     }>
   >;
+  /**
+   * @deprecated Use `StateProvider` instead.
+   */
   HydratedStateProvider: FunctionComponent<
     PropsWithChildren<{
       engine: SSRCommerceEngine;
@@ -70,6 +83,17 @@ export type ReactEngineDefinition<
         TControllers,
         TSolutionType
       >;
+    }>
+  >;
+  StateProvider: FunctionComponent<
+    PropsWithChildren<{
+      engine?: SSRCommerceEngine;
+      controllers:
+        | InferControllersMapFromDefinition<TControllers, TSolutionType>
+        | InferControllerStaticStateMapFromDefinitionsWithSolutionType<
+            TControllers,
+            TSolutionType
+          >;
     }>
   >;
 };

--- a/packages/headless-react/src/ssr/common.test.tsx
+++ b/packages/headless-react/src/ssr/common.test.tsx
@@ -1,0 +1,267 @@
+import type {SearchEngine} from '@coveo/headless/ssr';
+import {render, cleanup, screen} from '@testing-library/react';
+import {Context, createContext} from 'react';
+import React from 'react';
+import {vi, expect, describe, test, afterEach} from 'vitest';
+import {
+  buildStateProvider,
+  buildStaticStateProvider,
+  buildHydratedStateProvider,
+} from './common.js';
+import {ContextState} from './types.js';
+
+type MockContext = ContextState<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+describe('SSR Common functions', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockContext = createContext(
+    null
+  ) as unknown as Context<MockContext | null>;
+  const mockSingletonContext = {
+    get: () => mockContext,
+  };
+
+  const mockEngine = {
+    state: {} as SearchEngine['state'],
+    subscribe: vi.fn(),
+    dispatch: vi.fn(),
+  } as unknown as SearchEngine;
+
+  const mockControllers = {
+    searchBox: {
+      state: {value: 'test'},
+      subscribe: vi.fn(),
+      methods: {updateText: vi.fn()},
+    },
+  };
+
+  const mockStaticControllers = {
+    searchBox: {
+      state: {value: 'test'},
+    },
+  };
+
+  function TestComponent() {
+    return <div data-testid="test-component">Test</div>;
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('buildStateProvider', () => {
+    const StateProvider = buildStateProvider(mockSingletonContext);
+
+    test('should render with static controllers only', () => {
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <TestComponent />
+        </StateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should render with both engine and controllers', () => {
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <TestComponent />
+        </StateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with engine when provided', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: mockEngine,
+        controllers: mockControllers,
+      });
+    });
+
+    test('should provide context value without engine when not provided', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <TestConsumer />
+        </StateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: undefined,
+        controllers: mockStaticControllers,
+      });
+    });
+  });
+
+  describe('buildStaticStateProvider (deprecated)', () => {
+    const StaticStateProvider = buildStaticStateProvider(mockSingletonContext);
+
+    test('should render with static controllers', () => {
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <TestComponent />
+        </StaticStateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with controllers only', () => {
+      let contextValue: MockContext | null = null;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <TestConsumer />
+        </StaticStateProvider>
+      );
+
+      expect(contextValue).toEqual({controllers: mockStaticControllers});
+    });
+  });
+
+  describe('buildHydratedStateProvider (deprecated)', () => {
+    const HydratedStateProvider =
+      buildHydratedStateProvider(mockSingletonContext);
+
+    test('should render with engine and controllers', () => {
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <TestComponent />
+        </HydratedStateProvider>
+      );
+
+      expect(screen.getByTestId('test-component')).toBeDefined();
+    });
+
+    test('should provide context value with engine and controllers', () => {
+      let contextValue: unknown;
+      const TestConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        contextValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <TestConsumer />
+        </HydratedStateProvider>
+      );
+
+      expect(contextValue).toEqual({
+        engine: mockEngine,
+        controllers: mockControllers,
+      });
+    });
+  });
+
+  describe('StateProvider vs deprecated providers comparison', () => {
+    const StateProvider = buildStateProvider(mockSingletonContext);
+    const StaticStateProvider = buildStaticStateProvider(mockSingletonContext);
+    const HydratedStateProvider =
+      buildHydratedStateProvider(mockSingletonContext);
+
+    test('StateProvider with static controllers should behave like StaticStateProvider', () => {
+      let stateProviderValue: MockContext | null = null;
+      let staticProviderValue: MockContext | null = null;
+
+      const StateConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        stateProviderValue = ctx;
+        return <div />;
+      };
+
+      const StaticConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        staticProviderValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider controllers={mockStaticControllers}>
+          <StateConsumer />
+        </StateProvider>
+      );
+
+      render(
+        <StaticStateProvider controllers={mockStaticControllers}>
+          <StaticConsumer />
+        </StaticStateProvider>
+      );
+
+      // StateProvider should include engine: undefined, while StaticStateProvider doesn't include engine at all
+      expect(stateProviderValue!.controllers).toEqual(
+        staticProviderValue!.controllers
+      );
+      expect('engine' in staticProviderValue!).toBe(false);
+    });
+
+    test('StateProvider with hydrated state should behave like HydratedStateProvider', () => {
+      let stateProviderValue: MockContext | null = null;
+      let hydratedProviderValue: MockContext | null = null;
+
+      const StateConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        stateProviderValue = ctx;
+        return <div />;
+      };
+
+      const HydratedConsumer = () => {
+        const ctx = React.useContext(mockContext);
+        hydratedProviderValue = ctx;
+        return <div />;
+      };
+
+      render(
+        <StateProvider engine={mockEngine} controllers={mockControllers}>
+          <StateConsumer />
+        </StateProvider>
+      );
+
+      render(
+        <HydratedStateProvider
+          engine={mockEngine}
+          controllers={mockControllers}
+        >
+          <HydratedConsumer />
+        </HydratedStateProvider>
+      );
+
+      expect(stateProviderValue).toEqual(hydratedProviderValue);
+    });
+  });
+});

--- a/packages/headless-react/src/ssr/common.tsx
+++ b/packages/headless-react/src/ssr/common.tsx
@@ -29,7 +29,7 @@ function isHydratedStateContext<
 >(
   ctx: ContextState<TEngine, TControllers>
 ): ctx is ContextHydratedState<TEngine, TControllers> {
-  return 'engine' in ctx;
+  return 'engine' in ctx && !!ctx.engine;
 }
 
 function buildControllerHook<
@@ -108,6 +108,10 @@ export function buildEngineHook<
   };
 }
 
+/**
+ * @deprecated use `buildStateProvider` instead.
+ * It is isomorphic and can be used for both static and hydrated state.
+ */
 export function buildStaticStateProvider<
   TEngine extends CoreEngine,
   TControllers extends ControllerDefinitionsMap<TEngine, Controller>,
@@ -127,6 +131,10 @@ export function buildStaticStateProvider<
   };
 }
 
+/**
+ * @deprecated use `buildStateProvider` instead.
+ * It is isomorphic and can be used for both static and hydrated state.
+ */
 export function buildHydratedStateProvider<
   TEngine extends CoreEngine,
   TControllers extends ControllerDefinitionsMap<TEngine, Controller>,
@@ -142,6 +150,29 @@ export function buildHydratedStateProvider<
   }: PropsWithChildren<{
     engine: TEngine;
     controllers: InferControllersMapFromDefinition<TControllers>;
+  }>) => {
+    const {Provider} = singletonContext.get();
+    return <Provider value={{engine, controllers}}>{children}</Provider>;
+  };
+}
+
+export function buildStateProvider<
+  TEngine extends CoreEngine,
+  TControllers extends ControllerDefinitionsMap<TEngine, Controller>,
+>(
+  singletonContext: SingletonGetter<
+    Context<ContextState<TEngine, TControllers> | null>
+  >
+) {
+  return ({
+    engine,
+    controllers,
+    children,
+  }: PropsWithChildren<{
+    engine?: TEngine;
+    controllers:
+      | InferControllersMapFromDefinition<TControllers>
+      | InferControllerStaticStateMapFromDefinitions<TControllers>;
   }>) => {
     const {Provider} = singletonContext.get();
     return <Provider value={{engine, controllers}}>{children}</Provider>;

--- a/packages/headless-react/src/ssr/search-engine.tsx
+++ b/packages/headless-react/src/ssr/search-engine.tsx
@@ -13,6 +13,7 @@ import {
   buildControllerHooks,
   buildEngineHook,
   buildHydratedStateProvider,
+  buildStateProvider,
   buildStaticStateProvider,
 } from './common.js';
 import {ContextState, ReactEngineDefinition} from './types.js';
@@ -44,7 +45,14 @@ export function defineSearchEngine<
     ...defineBaseSearchEngine({...options}),
     useEngine: buildEngineHook(singletonContext),
     controllers: buildControllerHooks(singletonContext, options.controllers),
+    /**
+     * @deprecated Use `StateProvider` instead.
+     */
     StaticStateProvider: buildStaticStateProvider(singletonContext),
+    /**
+     * @deprecated Use `HydratedStateProvider` instead.
+     */
     HydratedStateProvider: buildHydratedStateProvider(singletonContext),
+    StateProvider: buildStateProvider(singletonContext),
   };
 }

--- a/packages/headless-react/src/ssr/search-engine.tsx
+++ b/packages/headless-react/src/ssr/search-engine.tsx
@@ -50,7 +50,7 @@ export function defineSearchEngine<
      */
     StaticStateProvider: buildStaticStateProvider(singletonContext),
     /**
-     * @deprecated Use `HydratedStateProvider` instead.
+     * @deprecated Use `StateProvider` instead.
      */
     HydratedStateProvider: buildHydratedStateProvider(singletonContext),
     StateProvider: buildStateProvider(singletonContext),

--- a/packages/headless-react/src/ssr/types.ts
+++ b/packages/headless-react/src/ssr/types.ts
@@ -49,15 +49,29 @@ export type ReactEngineDefinition<
 > = EngineDefinition<TEngine, TControllers, TEngineOptions> & {
   controllers: InferControllerHooksMapFromDefinition<TControllers>;
   useEngine(): TEngine | undefined;
+  /**
+   * @deprecated Use `StateProvider` instead.
+   */
   StaticStateProvider: FunctionComponent<
     PropsWithChildren<{
       controllers: InferControllerStaticStateMapFromDefinitions<TControllers>;
     }>
   >;
+  /**
+   * @deprecated Use `StateProvider` instead.
+   */
   HydratedStateProvider: FunctionComponent<
     PropsWithChildren<{
       engine: TEngine;
       controllers: InferControllersMapFromDefinition<TControllers>;
+    }>
+  >;
+  StateProvider: FunctionComponent<
+    PropsWithChildren<{
+      engine?: TEngine;
+      controllers:
+        | InferControllersMapFromDefinition<TControllers>
+        | InferControllerStaticStateMapFromDefinitions<TControllers>;
     }>
   >;
 };

--- a/packages/headless-react/tsconfig.build.json
+++ b/packages/headless-react/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/headless-react/tsconfig.json
+++ b/packages/headless-react/tsconfig.json
@@ -23,6 +23,5 @@
     "lib": ["dom", "ES2023"],
     "types": ["vitest/globals"]
   },
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
The current provider has a fundamental flaw: When we change the parent element where the children are rendered, the children are remounted.

To solve this, I mashed up the static & hydrated provider together essentially.
And while at it, I reckon we should deprecate the hydrated & static because they alone are a bit useless IMO compared to the "isomorphic" one.