### PR TITLE
fix(headless): missing actionCause analytics

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -4,6 +4,7 @@ import {
   NavigatorContext,
 } from '../../app/navigator-context-provider.js';
 import {selectAdvancedSearchQueries} from '../../features/advanced-search-queries/advanced-search-query-selectors.js';
+import {SearchPageEvents} from '../../features/analytics/search-action-cause.js';
 import {fromAnalyticsStateToAnalyticsParams} from '../../features/configuration/analytics-params.js';
 import {
   setAnswerContentFormat,
@@ -378,7 +379,10 @@ export const constructAnswerQueryParams = (
     tab: selectActiveTab(state.tabSet),
     ...fromAnalyticsStateToAnalyticsParams(
       state.configuration.analytics,
-      navigatorContext
+      navigatorContext,
+      {
+        actionCause: SearchPageEvents.searchboxSubmit,
+      }
     ),
   };
 };

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1537,6 +1537,7 @@ export const expectedStreamAnswerAPIParam = {
   firstResult: 0,
   tab: 'default',
   analytics: {
+    actionCause: 'searchboxSubmit',
     capture: false,
     clientId: '',
     clientTimestamp: '2020-01-01T00:00:00.000Z',

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {buildMockNavigatorContextProvider} from '../../../test/mock-navigator-context-provider.js';
-import {EventSourceMessage} from '../../../utils/fetch-event-source/parse';
+import {EventSourceMessage} from '../../../utils/fetch-event-source/parse.js';
 import {
   constructAnswerQueryParams,
   GeneratedAnswerStream,


### PR DESCRIPTION
Adds the missing `actionCause` property to the analytics section sent when calling the /generate endpoint.

[SVCC-5132
](https://coveord.atlassian.net/browse/SVCC-5132)

---

Following a bug report where the `actionCause` is missing from calls.

Note that right now, since this is only used when calling the /generate endpoint which is triggered by submitting to the search box, that's the event we're sending.

In the rest of the solution, it's either using specific events like this from `SearchPageEvents` or taking the event description from an event description object. We don't have the event description easily accessible right now, but if in the future we also use this endpoint for other event types, we'll have to take this into account.