### PR TITLE
docs(atomic): better spacing for search box suggestions storybook doc

### DIFF
--- a/.github/workflows/prbot.yml
+++ b/.github/workflows/prbot.yml
@@ -261,7 +261,7 @@ jobs:
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: prepare-playwright-atomic
-    if: ${{ success() && !contains(needs.*.result, 'skipped') }}
+    if: ${{ needs.prepare-playwright-atomic.outputs.shardIndex != '[0]' && needs.prepare-playwright-atomic.outputs.shardTotal != '[0]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
@@ -1,7 +1,7 @@
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
-import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {renderComponentWithoutCodeRoot} from '@/storybook-utils/common/render-component';
+import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {userEvent} from '@storybook/test';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
 import {html} from 'lit';

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
@@ -1,7 +1,7 @@
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
-import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {renderComponent} from '@/storybook-utils/common/render-component';
+import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {userEvent} from '@storybook/test';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
 import {within} from 'shadow-dom-testing-library';

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
@@ -1,7 +1,7 @@
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
-import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {renderComponent} from '@/storybook-utils/common/render-component';
+import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {userEvent} from '@storybook/test';
 import type {Meta, StoryObj as Story} from '@storybook/web-components';
 import {within} from 'shadow-dom-testing-library';

--- a/packages/atomic/storybook-utils/common/search-box-suggestions-parameters.ts
+++ b/packages/atomic/storybook-utils/common/search-box-suggestions-parameters.ts
@@ -1,0 +1,13 @@
+import {Parameters} from '@storybook/web-components';
+import {parameters as commonParameters} from './common-meta-parameters.js';
+
+export const parameters: Parameters = {
+  ...commonParameters,
+  docs: {
+    ...commonParameters.docs,
+    story: {
+      ...commonParameters.docs?.story,
+      height: '400px',
+    },
+  },
+};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4298

so it has more space

## Before
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/ec4642f0-74ec-4202-90f5-dae91e9a6edc" />


## After
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/ce49d1fe-e699-4398-8ee0-2274be8b7fb2" />

