### PR TITLE
feat(headless SSR): augment request with x-forwarded-for header

### DIFF
--- a/packages/headless/src/app/commerce-ssr-engine/factories/static-state-factory.ts
+++ b/packages/headless/src/app/commerce-ssr-engine/factories/static-state-factory.ts
@@ -1,6 +1,7 @@
 import {UnknownAction} from '@reduxjs/toolkit';
 import {buildProductListing} from '../../../controllers/commerce/product-listing/headless-product-listing.js';
 import {buildSearch} from '../../../controllers/commerce/search/headless-search.js';
+import {augmentPreprocessRequestWithForwardedFor} from '../../ssr-engine/augment-preprocess-request.js';
 import {composeFunction} from '../../ssr-engine/common.js';
 import {createStaticState} from '../common.js';
 import {
@@ -38,6 +39,14 @@ export const fetchStaticStateFactory: <
           ...options,
         })(solutionType);
         const buildResult = await solutionTypeBuild(...params);
+
+        options.configuration.preprocessRequest =
+          augmentPreprocessRequestWithForwardedFor({
+            preprocessRequest: options.configuration.preprocessRequest,
+            navigatorContextProvider: options.navigatorContextProvider,
+            loggerOptions: options.loggerOptions,
+          });
+
         const staticStateBuild = await fetchStaticStateFactory(
           controllerDefinitions,
           options

--- a/packages/headless/src/app/navigator-context-provider.ts
+++ b/packages/headless/src/app/navigator-context-provider.ts
@@ -4,10 +4,12 @@
 export interface NavigatorContext {
   /**
    * The`X-Forwarded-For` header.
-   * This header is used to identify the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer.
+   * This header is used to identify the originating IP address of a client.
    * See [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+   *
+   * **Note:** This property is only relevant for Server-Side Rendering (SSR) use cases.
    */
-  forwardedFor: string | null;
+  forwardedFor?: string;
   /**
    * The URL of the page that referred the user to the current page.
    * See [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer)
@@ -45,7 +47,6 @@ export const defaultBrowserNavigatorContextProvider: BrowserNavigatorContextProv
     userAgent: navigator.userAgent,
     location: window.location.href,
     clientId,
-    forwardedFor: null,
   });
 
 export const defaultNodeJSNavigatorContextProvider: NavigatorContextProvider =
@@ -54,5 +55,4 @@ export const defaultNodeJSNavigatorContextProvider: NavigatorContextProvider =
     userAgent: null,
     location: null,
     clientId: '',
-    forwardedFor: null,
   });

--- a/packages/headless/src/app/navigator-context-provider.ts
+++ b/packages/headless/src/app/navigator-context-provider.ts
@@ -3,6 +3,12 @@
  */
 export interface NavigatorContext {
   /**
+   * The headers of the request, specifically the `X-Forwarded-For` header.
+   * This header is used to identify the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer.
+   * See [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+   */
+  forwardedFor: string | null;
+  /**
    * The URL of the page that referred the user to the current page.
    * See [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer)
    */
@@ -39,6 +45,7 @@ export const defaultBrowserNavigatorContextProvider: BrowserNavigatorContextProv
     userAgent: navigator.userAgent,
     location: window.location.href,
     clientId,
+    forwardedFor: null,
   });
 
 export const defaultNodeJSNavigatorContextProvider: NavigatorContextProvider =
@@ -47,4 +54,5 @@ export const defaultNodeJSNavigatorContextProvider: NavigatorContextProvider =
     userAgent: null,
     location: null,
     clientId: '',
+    forwardedFor: null,
   });

--- a/packages/headless/src/app/navigator-context-provider.ts
+++ b/packages/headless/src/app/navigator-context-provider.ts
@@ -3,7 +3,7 @@
  */
 export interface NavigatorContext {
   /**
-   * The headers of the request, specifically the `X-Forwarded-For` header.
+   * The`X-Forwarded-For` header.
    * This header is used to identify the originating IP address of a client connecting to a web server through an HTTP proxy or load balancer.
    * See [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
    */

--- a/packages/headless/src/app/search-engine/search-engine.ssr.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ssr.ts
@@ -7,6 +7,7 @@ import {LegacySearchAction} from '../../features/analytics/analytics-utils.js';
 import {createWaitForActionMiddleware} from '../../utils/utils.js';
 import {buildLogger} from '../logger.js';
 import {NavigatorContextProvider} from '../navigator-context-provider.js';
+import {augmentPreprocessRequestWithForwardedFor} from '../ssr-engine/augment-preprocess-request.js';
 import {
   buildControllerDefinitions,
   composeFunction,
@@ -163,6 +164,14 @@ export function defineSearchEngine<
       const staticState = await fetchStaticState.fromBuildResult({
         buildResult,
       });
+
+      options.configuration.preprocessRequest =
+        augmentPreprocessRequestWithForwardedFor({
+          preprocessRequest: options.configuration.preprocessRequest,
+          navigatorContextProvider: options.navigatorContextProvider,
+          loggerOptions: options.loggerOptions,
+        });
+
       return staticState;
     },
     {

--- a/packages/headless/src/app/ssr-engine/augment-preprocess-request.test.ts
+++ b/packages/headless/src/app/ssr-engine/augment-preprocess-request.test.ts
@@ -1,0 +1,93 @@
+import {Logger} from 'pino';
+import {describe, it, expect, vi} from 'vitest';
+import {
+  PlatformRequestOptions,
+  PreprocessRequest,
+} from '../../api/preprocess-request.js';
+import * as loggerModule from '../logger.js';
+import {NavigatorContextProvider} from '../navigator-context-provider.js';
+import {
+  augmentPreprocessRequestWithForwardedFor,
+  AugmentPreprocessRequestOptions,
+} from './augment-preprocess-request.js';
+
+function buildMockRequest(
+  headers: Record<string, string> = {}
+): PlatformRequestOptions {
+  return {
+    url: 'https://example.com',
+    headers,
+    method: 'GET',
+  };
+}
+
+describe('#augmentPreprocessRequestWithForwardedFor', () => {
+  it('should inject x-forwarded-for header if provided by navigatorContextProvider', async () => {
+    const options: AugmentPreprocessRequestOptions = {
+      navigatorContextProvider: (() => ({
+        forwardedFor: '1.2.3.4',
+      })) as NavigatorContextProvider,
+    };
+    const augmented = augmentPreprocessRequestWithForwardedFor(options);
+    const request = buildMockRequest();
+    const result = await augmented(request, 'searchApiFetch');
+
+    const headers = new Headers(result.headers);
+    expect(headers.get('x-forwarded-for')).toBe('1.2.3.4');
+  });
+
+  it('should log a warning if forwardedFor is missing', async () => {
+    const loggerWarn = vi.fn();
+    vi.spyOn(loggerModule, 'buildLogger').mockReturnValue({
+      warn: loggerWarn,
+    } as unknown as Logger);
+
+    const options: AugmentPreprocessRequestOptions = {
+      navigatorContextProvider: (() => ({})) as NavigatorContextProvider,
+      loggerOptions: {level: 'warn'},
+    };
+
+    const augmented = augmentPreprocessRequestWithForwardedFor(options);
+    const request = buildMockRequest();
+    await augmented(request, 'searchApiFetch');
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to set x-forwarded-for header')
+    );
+  });
+
+  it('should call the original preprocessRequest if provided', async () => {
+    const original: PreprocessRequest = vi.fn(async (req) => {
+      req.headers.set('x-custom', 'foo');
+      return req;
+    });
+    const options: AugmentPreprocessRequestOptions = {
+      preprocessRequest: original,
+      navigatorContextProvider: (() => ({
+        forwardedFor: '5.6.7.8',
+      })) as NavigatorContextProvider,
+    };
+    const augmented = augmentPreprocessRequestWithForwardedFor(options);
+    const request = buildMockRequest();
+    const result = await augmented(request, 'searchApiFetch');
+    const headers = new Headers(result.headers);
+
+    expect(headers.get('x-forwarded-for')).toBe('5.6.7.8');
+    expect(headers.get('x-custom')).toBe('foo');
+    expect(original).toHaveBeenCalled();
+  });
+
+  it('should return the request if no original preprocessRequest is provided', async () => {
+    const options: AugmentPreprocessRequestOptions = {
+      navigatorContextProvider: (() => ({
+        forwardedFor: '9.9.9.9',
+      })) as NavigatorContextProvider,
+    };
+    const augmented = augmentPreprocessRequestWithForwardedFor(options);
+    const request = buildMockRequest();
+    const result = await augmented(request, 'searchApiFetch');
+
+    const headers = new Headers(result.headers);
+    expect(headers.get('x-forwarded-for')).toBe('9.9.9.9');
+  });
+});

--- a/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
+++ b/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
@@ -1,0 +1,41 @@
+import {
+  PlatformClientOrigin,
+  PlatformRequestOptions,
+  PreprocessRequest,
+  RequestMetadata,
+} from '../../api/preprocess-request.js';
+import {buildLogger, LoggerOptions} from '../logger.js';
+import {NavigatorContextProvider} from '../navigator-context-provider.js';
+
+export interface AugmentPreprocessRequestOptions {
+  preprocessRequest?: PreprocessRequest;
+  navigatorContextProvider?: NavigatorContextProvider;
+  loggerOptions?: LoggerOptions;
+}
+
+export function augmentPreprocessRequestWithForwardedFor(
+  options: AugmentPreprocessRequestOptions
+) {
+  const originalPreprocessRequest = options.preprocessRequest;
+  return async (
+    request: PlatformRequestOptions,
+    clientOrigin: PlatformClientOrigin,
+    metadata?: RequestMetadata
+  ) => {
+    const headers = new Headers(request.headers);
+    const forwardedFor = options.navigatorContextProvider?.()?.forwardedFor;
+    if (forwardedFor) {
+      headers.set('x-forwarded-for', forwardedFor as string);
+    } else {
+      const logger = buildLogger(options.loggerOptions);
+      logger.warn(
+        '[WARNING] Unable to set x-forwarded-for header. Make sure to set the navigator context provider.'
+      );
+    }
+    request.headers = headers;
+    if (originalPreprocessRequest) {
+      return originalPreprocessRequest(request, clientOrigin, metadata);
+    }
+    return request;
+  };
+}

--- a/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
+++ b/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
@@ -29,7 +29,7 @@ export function augmentPreprocessRequestWithForwardedFor(
     } else {
       const logger = buildLogger(options.loggerOptions);
       logger.warn(
-        '[WARNING] Unable to set x-forwarded-for header. Make sure to set the 'forwardedFor' property in the navigator context provider.'
+        "[WARNING] Unable to set x-forwarded-for header. Make sure to set the 'forwardedFor' property in the navigator context provider."
       );
     }
     request.headers = headers;

--- a/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
+++ b/packages/headless/src/app/ssr-engine/augment-preprocess-request.ts
@@ -29,7 +29,7 @@ export function augmentPreprocessRequestWithForwardedFor(
     } else {
       const logger = buildLogger(options.loggerOptions);
       logger.warn(
-        '[WARNING] Unable to set x-forwarded-for header. Make sure to set the navigator context provider.'
+        '[WARNING] Unable to set x-forwarded-for header. Make sure to set the 'forwardedFor' property in the navigator context provider.'
       );
     }
     request.headers = headers;

--- a/packages/headless/src/test/mock-navigator-context-provider.ts
+++ b/packages/headless/src/test/mock-navigator-context-provider.ts
@@ -12,6 +12,5 @@ export const buildMockNavigatorContextProvider = (
     location: context?.location || '',
     clientId: context?.clientId || '',
     capture: context?.capture,
-    forwardedFor: context?.forwardedFor || null,
   });
 };

--- a/packages/headless/src/test/mock-navigator-context-provider.ts
+++ b/packages/headless/src/test/mock-navigator-context-provider.ts
@@ -12,5 +12,6 @@ export const buildMockNavigatorContextProvider = (
     location: context?.location || '',
     clientId: context?.clientId || '',
     capture: context?.capture,
+    forwardedFor: context?.forwardedFor || null,
   });
 };

--- a/packages/samples/headless-commerce-ssr-remix/lib/navigator-context.ts
+++ b/packages/samples/headless-commerce-ssr-remix/lib/navigator-context.ts
@@ -12,5 +12,6 @@ export const getNavigatorContext = async (
     userAgent: request.headers.get('User-Agent') ?? '',
     location: request.url,
     capture: capture && clientId !== '',
+    forwardedFor: request.headers.get('x-forwarded-for') ?? '',
   };
 };

--- a/packages/samples/headless-ssr-commerce-nextjs/lib/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr-commerce-nextjs/lib/navigatorContextProvider.ts
@@ -50,6 +50,11 @@ export class NextJsNavigatorContext implements NavigatorContext {
     return clientId!;
   }
 
+  /**
+   * Retrieves the forwarded-for header, which may contain the original IP address
+   * of the client making the request.
+   * @returns The forwarded-for IP address if available, otherwise an empty string.
+   */
   get forwardedFor() {
     return (
       this.headers.get('x-forwarded-for') ||

--- a/packages/samples/headless-ssr-commerce-nextjs/lib/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr-commerce-nextjs/lib/navigatorContextProvider.ts
@@ -50,6 +50,14 @@ export class NextJsNavigatorContext implements NavigatorContext {
     return clientId!;
   }
 
+  get forwardedFor() {
+    return (
+      this.headers.get('x-forwarded-for') ||
+      this.headers.get('x-forwarded-host') ||
+      ''
+    );
+  }
+
   /**
    * Marshals the navigation context into a format that can be used by Coveo's headless library.
    * @returns An object containing clientId, location, referrer, and userAgent properties.
@@ -60,6 +68,7 @@ export class NextJsNavigatorContext implements NavigatorContext {
       location: this.location,
       referrer: this.referrer,
       userAgent: this.userAgent,
+      forwardedFor: this.forwardedFor,
     };
   }
 }

--- a/packages/samples/headless-ssr/app-router/src/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr/app-router/src/navigatorContextProvider.ts
@@ -28,12 +28,21 @@ export class NextJsAppRouterNavigatorContext implements NavigatorContext {
     return clientId || crypto.randomUUID();
   }
 
+  get forwardedFor() {
+    return (
+      this.headers.get('x-forwarded-for') ||
+      this.headers.get('x-forwarded-host') ||
+      ''
+    );
+  }
+
   get marshal(): NavigatorContext {
     return {
       clientId: this.clientId,
       location: this.location,
       referrer: this.referrer,
       userAgent: this.userAgent,
+      forwardedFor: this.forwardedFor,
     };
   }
 }

--- a/packages/samples/headless-ssr/common/lib/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr/common/lib/navigatorContextProvider.ts
@@ -28,12 +28,21 @@ export class NextJsNavigatorContext implements NavigatorContext {
     return clientId || crypto.randomUUID();
   }
 
+  get forwardedFor() {
+    return (
+      this.headers.get('x-forwarded-for') ||
+      this.headers.get('x-forwarded-host') ||
+      ''
+    );
+  }
+
   get marshal(): NavigatorContext {
     return {
       clientId: this.clientId,
       location: this.location,
       referrer: this.referrer,
       userAgent: this.userAgent,
+      forwardedFor: this.forwardedFor,
     };
   }
 }

--- a/packages/samples/headless-ssr/pages-router/src/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr/pages-router/src/navigatorContextProvider.ts
@@ -41,12 +41,22 @@ export class NextJsPagesRouterNavigatorContext implements NavigatorContext {
     return clientId || crypto.randomUUID();
   }
 
+  get forwardedFor() {
+    const forwardedForHeader =
+      this.headers['x-forwarded-for'] || this.headers['x-forwarded-host'];
+    const forwardedFor = Array.isArray(forwardedForHeader)
+      ? forwardedForHeader[0]
+      : forwardedForHeader;
+    return forwardedFor ?? null;
+  }
+
   get marshal(): NavigatorContext {
     return {
       clientId: this.clientId,
       location: this.location,
       referrer: this.referrer,
       userAgent: this.userAgent,
+      forwardedFor: this.forwardedFor,
     };
   }
 }

--- a/packages/samples/headless-ssr/pages-router/src/navigatorContextProvider.ts
+++ b/packages/samples/headless-ssr/pages-router/src/navigatorContextProvider.ts
@@ -47,7 +47,7 @@ export class NextJsPagesRouterNavigatorContext implements NavigatorContext {
     const forwardedFor = Array.isArray(forwardedForHeader)
       ? forwardedForHeader[0]
       : forwardedForHeader;
-    return forwardedFor ?? null;
+    return forwardedFor;
   }
 
   get marshal(): NavigatorContext {


### PR DESCRIPTION
Updates `NavigatorContext` to include a `forwardedFor` field so the X-Forwarded-For header can be automatically injected at `preprocessRequest`.

⸻

https://coveord.atlassian.net/browse/KIT-4294
