### PR TITLE
test(quantic): Tests for QuanticSearchBoxSuggestionsList

### DIFF
--- a/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
@@ -31,7 +31,7 @@ export const SearchBoxSelectors: SearchBoxSelector = {
     ),
   clearRecentQueriesButton: () =>
     SearchBoxSelectors.get().find(
-      'c-quantic-search-box-input [data-cy="clear-recent-queries"]'
+      'c-quantic-search-box-input [data-testid="clear-recent-queries"]'
     ),
   querySuggestions: () =>
     SearchBoxSelectors.get().find(

--- a/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
@@ -16,10 +16,10 @@ export interface SearchBoxSelector extends ComponentSelector {
 export const SearchBoxSelectors: SearchBoxSelector = {
   get: () => cy.get(standaloneSearchBoxComponent),
   quanticSearchBoxInput: () =>
-    SearchBoxSelectors.get().find('[data-cy="quantic-search-box-input"]'),
+    SearchBoxSelectors.get().find('[data-testid="quantic-search-box-input"]'),
   input: (textarea = false) =>
     SearchBoxSelectors.get().find(
-      `c-quantic-search-box-input [data-cy="${textarea ? 'search-box-textarea' : 'search-box-input'}"]`
+      `c-quantic-search-box-input [data-testid="${textarea ? 'search-box-textarea' : 'search-box-input'}"]`
     ),
   suggestionList: () =>
     SearchBoxSelectors.get().find(

--- a/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/search-box/search-box-selectors.ts
@@ -31,18 +31,18 @@ export const SearchBoxSelectors: SearchBoxSelector = {
     ),
   clearRecentQueriesButton: () =>
     SearchBoxSelectors.get().find(
-      'c-quantic-search-box-input [data-testid="clear-recent-queries"]'
+      'c-quantic-search-box-input [data-testid="clear-recent-queries-button"]'
     ),
   querySuggestions: () =>
     SearchBoxSelectors.get().find(
-      'c-quantic-search-box-input [data-cy="suggestions-option"]'
+      'c-quantic-search-box-input [data-testid="suggestions-option"]'
     ),
   querySuggestionByIndex: (index: number) =>
     SearchBoxSelectors.querySuggestions().eq(index),
   querySuggestionContentByIndex: (index: number) =>
     SearchBoxSelectors.get()
       .find(
-        'c-quantic-search-box-input [data-cy="suggestions-option"] lightning-formatted-rich-text'
+        'c-quantic-search-box-input [data-testid="suggestions-option"] lightning-formatted-rich-text'
       )
       .eq(index),
 };

--- a/packages/quantic/cypress/e2e/default-2/standalone-search-box/standalone-search-box-selectors.ts
+++ b/packages/quantic/cypress/e2e/default-2/standalone-search-box/standalone-search-box-selectors.ts
@@ -15,13 +15,13 @@ export const StandaloneSearchBoxSelectors: StandaloneSearchBoxSelector = {
   get: () => cy.get(standaloneSearchBoxComponent),
   quanticSearchBoxInput: () =>
     StandaloneSearchBoxSelectors.get().find(
-      '[data-cy="quantic-search-box-input"]'
+      '[data-testid="quantic-search-box-input"]'
     ),
   input: (textarea = false) =>
     StandaloneSearchBoxSelectors.get().find(
       textarea
-        ? 'c-quantic-search-box-input [data-cy="search-box-textarea"]'
-        : 'c-quantic-search-box-input [data-cy="search-box-input"]'
+        ? 'c-quantic-search-box-input [data-testid="search-box-textarea"]'
+        : 'c-quantic-search-box-input [data-testid="search-box-input"]'
     ),
   suggestionList: () =>
     StandaloneSearchBoxSelectors.get().find(

--- a/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.html
+++ b/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.html
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <lightning-input
+      label={inputLabel}
+      value={inputValue}
+      data-testid="localstorage-input"
+      onchange={handleInputChange}
+    ></lightning-input>
+    <lightning-button
+      label="Set Value"
+      onclick={handleSetValue}
+      class="slds-var-m-top_small"
+      data-testid="localstorage-set-button"
+    ></lightning-button>
+
+    <lightning-button
+      label="Print Value"
+      onclick={handlePrintValue}
+      class="slds-var-m-top_small slds-var-m-left_small"
+      data-testid="localstorage-get-button"
+    ></lightning-button>
+
+    <p class="slds-var-m-top_medium" data-testid="localstorage-output">
+      {outputValue}
+    </p>
+  </div>
+</template>

--- a/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.js
+++ b/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.js
@@ -1,0 +1,28 @@
+import {api, LightningElement} from 'lwc';
+
+export default class ActionLocalStorage extends LightningElement {
+  @api storageKey;
+
+  inputValue = '';
+  outputValue = '';
+
+  handleInputChange(event) {
+    this.inputValue = event.target.value;
+  }
+
+  handleSetValue() {
+    if (this.storageKey) {
+      localStorage.setItem(this.storageKey, this.inputValue);
+    }
+  }
+
+  handlePrintValue() {
+    if (this.storageKey) {
+      this.outputValue = localStorage.getItem(this.storageKey) || '';
+    }
+  }
+
+  get inputLabel() {
+    return `Set value for key "${this.storageKey}":`;
+  }
+}

--- a/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.js-meta.xml
+++ b/packages/quantic/force-app/examples/main/lwc/actionLocalStorage/actionLocalStorage.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>52.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSearchBox/exampleQuanticSearchBox.html
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSearchBox/exampleQuanticSearchBox.html
@@ -6,6 +6,7 @@
   
     <div slot="configuration">
       <c-configurator options={options} ontryitnow={handleTryItNow}>
+         <c-action-local-storage slot="actions" storage-key={recentQueriesStorageKey}></c-action-local-storage>
       </c-configurator>
     </div>
 

--- a/packages/quantic/force-app/examples/main/lwc/exampleQuanticSearchBox/exampleQuanticSearchBox.js
+++ b/packages/quantic/force-app/examples/main/lwc/exampleQuanticSearchBox/exampleQuanticSearchBox.js
@@ -1,7 +1,12 @@
 import {LightningElement, track} from 'lwc';
 
+const DEFAULT_ENGINE_ID = 'quantic-search-box-engine';
+const RECENT_QUERIES_STORAGE_KEY_SUFFIX = '_quantic-recent-queries';
+
 export default class ExampleQuanticSearchBox extends LightningElement {
-  @track config = {};
+  @track config = {
+    engineId: DEFAULT_ENGINE_ID,
+  };
   isConfigured = false;
 
   pageTitle = 'Quantic Search Box';
@@ -12,7 +17,7 @@ export default class ExampleQuanticSearchBox extends LightningElement {
       attribute: 'engineId',
       label: 'Engine id',
       description: 'The ID of the engine instance the component registers to.',
-      defaultValue: 'quantic-search-box-engine',
+      defaultValue: DEFAULT_ENGINE_ID,
     },
     {
       attribute: 'useCase',
@@ -60,5 +65,9 @@ export default class ExampleQuanticSearchBox extends LightningElement {
   handleTryItNow(evt) {
     this.config = evt.detail;
     this.isConfigured = true;
+  }
+
+  get recentQueriesStorageKey() {
+    return `${this.config.engineId}${RECENT_QUERIES_STORAGE_KEY_SUFFIX}`;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/e2e/fixture.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/e2e/fixture.ts
@@ -35,8 +35,9 @@ export const testSearch = quanticBase.extend<QuanticPagerE2ESearchFixtures>({
   },
   pager: async ({page, options, configuration, search, urlHash}, use) => {
     await page.goto(urlHash ? `${pageUrl}#${urlHash}` : pageUrl);
+    const searchResponsePromise = search.waitForSearchResponse();
     configuration.configure(options);
-    await search.waitForSearchResponse();
+    await searchResponsePromise;
 
     await use(new PagerObject(page));
   },
@@ -54,8 +55,9 @@ export const testInsight = quanticBase.extend<QuanticPagerE2EInsightFixtures>({
     await page.goto(pageUrl);
     configuration.configure({...options, useCase: useCaseEnum.insight});
     await insightSetup.waitForInsightInterfaceInitialization();
+    const searchResponsePromise = search.waitForSearchResponse();
     await search.performSearch();
-    await search.waitForSearchResponse();
+    await searchResponsePromise;
     await use(new PagerObject(page));
   },
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticPager/e2e/quanticPager.e2e.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticPager/e2e/quanticPager.e2e.ts
@@ -18,11 +18,12 @@ useCaseTestCases.forEach((useCase) => {
         search,
       }) => {
         const searchResponsePromise = search.waitForSearchResponse();
+        const pagerNextUaAnalyticsPromise = pager.waitForPagerNextUaAnalytics();
         await pager.clickNextPageButton();
         const searchResponse = await searchResponsePromise;
         const {firstResult} = searchResponse.request().postDataJSON();
         expect(firstResult).toBe(numberOfResultsPerPage);
-        await pager.waitForPagerNextUaAnalytics();
+        await pagerNextUaAnalyticsPromise;
       });
     });
 
@@ -36,11 +37,13 @@ useCaseTestCases.forEach((useCase) => {
         await initialSearchResponsePromise;
 
         const searchResponsePromise = search.waitForSearchResponse();
+        const pagerPreviousUaAnalyticsPromise =
+          pager.waitForPagerPreviousUaAnalytics();
         await pager.clickPreviousPageButton();
         const searchResponse = await searchResponsePromise;
         const {firstResult} = searchResponse.request().postDataJSON();
         expect(firstResult).toBe(0);
-        await pager.waitForPagerPreviousUaAnalytics();
+        await pagerPreviousUaAnalyticsPromise;
       });
     });
 
@@ -51,11 +54,13 @@ useCaseTestCases.forEach((useCase) => {
       }) => {
         const examplePage = 3;
         const searchResponsePromise = search.waitForSearchResponse();
+        const pagerPageUaAnalyticsPromise =
+          pager.waitForPagerNumberUaAnalytics();
         await pager.clickPageNumberButton(examplePage);
         const searchResponse = await searchResponsePromise;
         const {firstResult} = searchResponse.request().postDataJSON();
         expect(firstResult).toBe(numberOfResultsPerPage * (examplePage - 1));
-        await pager.waitForPagerNumberUaAnalytics();
+        await pagerPageUaAnalyticsPromise;
       });
     });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/e2e/fixture.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/e2e/fixture.ts
@@ -35,6 +35,7 @@ export const testSearch =
       await page.goto(pageUrl);
       configuration.configure(options);
       await search.waitForSearchResponse();
+      await search.waitForSearchResultsVisible();
       await use(new ResultListObject(page));
     },
   });
@@ -57,6 +58,7 @@ export const testInsight =
       await insightSetup.waitForInsightInterfaceInitialization();
       await search.performSearch();
       await search.waitForSearchResponse();
+      await search.waitForSearchResultsVisible();
       await use(new ResultListObject(page));
     },
   });

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -28,8 +28,8 @@ const defaultOptions = {
 };
 
 const selectors = {
-  searchBoxInput: '[data-cy="search-box-input"]',
-  searchBoxTextArea: '[data-cy="search-box-textarea"]',
+  searchBoxInput: '[data-testid="search-box-input"]',
+  searchBoxTextArea: '[data-testid="search-box-textarea"]',
   searchBoxSubmitBtn: '.searchbox__submit-button',
   searchBoxClearIcon: '.searchbox__clear-button',
   searchBoxSuggestionsList: 'c-quantic-search-box-suggestions-list',
@@ -39,7 +39,7 @@ const selectors = {
   searchBoxSearchIcon: '.searchbox__search-icon',
   suggestionOption: '[data-cy="suggestions-option"]',
   suggestionOptionText: '[data-cy="suggestions-option-text"]',
-  clearRecentQueryButton: '[data-testid="clear-recent-queries"]',
+  clearRecentQueryButton: '[data-testid="clear-recent-queries-button"]',
 };
 
 function setupEventListeners(element) {
@@ -195,7 +195,7 @@ describe('c-quantic-search-box-input', () => {
 
       describe('when the suggestions list is not empty', () => {
         describe('when only query suggestions are displayed', () => {
-          it('should display the suggestions in the suggestions list', async () => {
+          it('should pass the suggestions to the suggestions list', async () => {
             const expectedSuggestionsLabelValues = [
               ...mockSuggestions.map((suggestion) => suggestion.rawValue),
             ];

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/__tests__/quanticSearchBoxInput.test.js
@@ -39,7 +39,7 @@ const selectors = {
   searchBoxSearchIcon: '.searchbox__search-icon',
   suggestionOption: '[data-cy="suggestions-option"]',
   suggestionOptionText: '[data-cy="suggestions-option-text"]',
-  clearRecentQueryButton: '[data-cy="clear-recent-queries"]',
+  clearRecentQueryButton: '[data-testid="clear-recent-queries"]',
 };
 
 function setupEventListeners(element) {

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/defaultSearchBoxInput.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/defaultSearchBoxInput.html
@@ -31,7 +31,7 @@
                 aria-expanded={shouldDisplaySuggestions}
                 aria-haspopup="listbox"
                 aria-autocomplete="list"
-                data-cy="search-box-input"
+                data-testid="search-box-input"
                 data-value={inputValue}
               />
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/templates/expandableSearchBoxInput.html
@@ -35,7 +35,7 @@
                 aria-autocomplete="list"
                 aria-haspopup="listbox"
                 style="white-space: nowrap"
-                data-cy="search-box-textarea"
+                data-testid="search-box-textarea"
                 data-value={inputValue}
               >
               </textarea>

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
@@ -342,8 +342,8 @@ describe('c-quantic-search-box-suggestions-list', () => {
       expect(clearButton.querySelector(selectors.lightningIcon)).toBeNull();
       expect(clearButton.textContent).toContain(labels.recentQueries);
       const recentQueryOption = options.item(1);
-      expect(recentQueryOption.querySelector(selectors.richText).value).toBe(
-        'test recent query'
+      expect(recentQueryOption.querySelector(selectors.richText).value).toEqual(
+        expect.stringContaining('<strong>test</strong> recent query')
       );
     });
 
@@ -357,9 +357,9 @@ describe('c-quantic-search-box-suggestions-list', () => {
       const options = element.shadowRoot.querySelectorAll(selectors.option);
       // Skip the first option (clear button)
       const recentQueryOption = options.item(1);
-      expect(
-        recentQueryOption.querySelector(selectors.richText).value
-      ).toContain('<strong>test</strong>');
+      expect(recentQueryOption.querySelector(selectors.richText).value).toEqual(
+        expect.stringContaining('<strong>test</strong>')
+      );
     });
   });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
@@ -1,0 +1,479 @@
+/* eslint-disable no-import-assign */
+import QuanticSearchBoxSuggestionsList from 'c/quanticSearchBoxSuggestionsList';
+// import * as mockHeadlessLoader from 'c/quanticHeadlessLoader';
+import {cleanup, buildCreateTestComponent, flushPromises} from 'c/testUtils';
+
+const labels = {
+  clear: 'Clear',
+  recentQueries: 'Recent queries',
+};
+
+jest.mock(
+  '@salesforce/label/c.quantic_Clear',
+  () => ({default: labels.clear}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_QuerySuggestionAriaLabel',
+  () => ({default: 'Query suggestion'}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_RecentQueries',
+  () => ({default: labels.recentQueries}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_RecentQueryAriaLabel',
+  () => ({default: 'Recent query'}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_SuggestionFound',
+  () => ({default: '{{0}} suggestion found'}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_SuggestionFound_Plural',
+  () => ({default: '{{0}} suggestions found'}),
+  {
+    virtual: true,
+  }
+);
+jest.mock(
+  '@salesforce/label/c.quantic_SuggestionNotFound',
+  () => ({default: 'No suggestions found'}),
+  {
+    virtual: true,
+  }
+);
+
+jest.mock('c/quanticUtils', () => ({
+  AriaLiveRegion: jest.fn(() => ({
+    dispatchMessage: jest.fn(),
+  })),
+  I18nUtils: {
+    format: jest.fn((template, ...args) => {
+      return template.replace(
+        /\{\{(\d+)\}\}/g,
+        (match, index) => args[index] || match
+      );
+    }),
+    getLabelNameWithCount: jest.fn((baseName, count) => {
+      return count === 1 ? baseName : `${baseName}_plural`;
+    }),
+  },
+  RecentQueryUtils: {
+    formatRecentQuery: jest.fn((query, currentQuery) => {
+      if (!currentQuery) return query;
+      const lowerQuery = query.toLowerCase();
+      const lowerCurrentQuery = currentQuery.toLowerCase();
+      const index = lowerQuery.indexOf(lowerCurrentQuery);
+      if (index === 0) {
+        return `<strong>${query.substring(0, currentQuery.length)}</strong>${query.substring(currentQuery.length)}`;
+      }
+      return query;
+    }),
+  },
+}));
+
+const defaultOptions = {
+  maxNumberOfSuggestions: 7,
+};
+
+const selectors = {
+  listbox: '[role="listbox"]',
+  option: 'li[role="option"]',
+  richText: 'lightning-formatted-rich-text',
+  lightningIcon: 'lightning-icon',
+  clearButton: '[data-testid="clear-recent-queries"]',
+  suggestionOption: '[data-testid="suggestion-option"]',
+  recentQueryOption: '[data-testid="recent-query-option"]',
+};
+
+const mockSuggestions = [
+  {key: 1, value: 'test query 1', rawValue: 'test query 1'},
+  {key: 2, value: 'test query 2', rawValue: 'test query 2'},
+  {key: 3, value: 'another suggestion', rawValue: 'another suggestion'},
+];
+
+const mockRecentQueries = [
+  'recent query 1',
+  'recent query 2',
+  'test recent query',
+];
+
+const createTestComponent = buildCreateTestComponent(
+  QuanticSearchBoxSuggestionsList,
+  'c-quantic-search-box-suggestions-list',
+  defaultOptions
+);
+
+describe('c-quantic-search-box-suggestions-list', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('suggestion list rendering', () => {
+    describe('when no suggestions or recent queries are provided', () => {
+      it('should render an empty list', async () => {
+        const element = createTestComponent();
+        await flushPromises();
+
+        const listbox = element.shadowRoot.querySelector(selectors.listbox);
+        expect(listbox).toBeTruthy();
+        expect(listbox.children.length).toBe(0);
+      });
+    });
+
+    describe('when suggestions are provided', () => {
+      it('should render suggestions as options', async () => {
+        const element = createTestComponent({
+          suggestions: mockSuggestions,
+        });
+        await flushPromises();
+
+        const options = element.shadowRoot.querySelectorAll(selectors.option);
+        expect(options.length).toBe(mockSuggestions.length);
+        // Where there's only suggestions, we don't render a clear recent queries button.
+        expect(
+          element.shadowRoot.querySelector(selectors.clearButton)
+        ).toBeNull();
+        options.forEach((option, index) => {
+          const lightningRichText = option.querySelector(selectors.richText);
+          expect(lightningRichText.value).toBe(mockSuggestions[index].value);
+          expect(lightningRichText.title).toBe(mockSuggestions[index].rawValue);
+          expect(option.querySelector(selectors.lightningIcon).iconName).toBe(
+            'utility:search'
+          );
+        });
+      });
+
+      it('should handle a non-array suggestions input', async () => {
+        const element = createTestComponent();
+        element.suggestions = 'foo';
+        await flushPromises();
+
+        const options = element.shadowRoot.querySelectorAll(selectors.option);
+        expect(options.length).toBe(0); // Should not render any options
+      });
+    });
+
+    describe('when recent queries are provided', () => {
+      it('should render recent queries as options', async () => {
+        const element = createTestComponent({
+          recentQueries: mockRecentQueries,
+        });
+        await flushPromises();
+
+        const options = element.shadowRoot.querySelectorAll(selectors.option);
+        // Should include clear button + recent queries
+        expect(options.length).toBe(mockRecentQueries.length + 1);
+        const clearButton = options.item(0);
+        expect(clearButton.querySelector(selectors.lightningIcon)).toBeNull();
+        expect(clearButton.textContent).toContain(labels.recentQueries);
+        // Skip the first option (clear button) and check the rest
+        Array.from(options)
+          .slice(1)
+          .forEach((option, index) => {
+            const lightningRichText = option.querySelector(selectors.richText);
+            expect(lightningRichText.value).toBe(mockRecentQueries[index]);
+            expect(lightningRichText.title).toBe(mockRecentQueries[index]);
+            expect(option.querySelector(selectors.lightningIcon).iconName).toBe(
+              'utility:clock'
+            );
+          });
+      });
+
+      it('should handle a non-array recent queries input', async () => {
+        const element = createTestComponent();
+        element.recentQueries = 'foo';
+        await flushPromises();
+
+        const options = element.shadowRoot.querySelectorAll(selectors.option);
+        expect(options.length).toBe(0); // Should not render any options
+      });
+    });
+
+    describe('when both suggestions and recent queries are provided and query is empty', () => {
+      it('should render suggestions and recent queries as options', async () => {
+        const mockSuggestionListOptions = [
+          ...mockRecentQueries.map((query) => ({
+            value: query,
+            rawValue: query,
+            isRecentQuery: true,
+          })),
+          ...mockSuggestions.map((suggestion) => ({
+            value: suggestion.value,
+            rawValue: suggestion.rawValue,
+            isRecentQuery: false,
+          })),
+        ];
+        const element = createTestComponent({
+          suggestions: mockSuggestions,
+          recentQueries: mockRecentQueries,
+        });
+        await flushPromises();
+
+        const options = element.shadowRoot.querySelectorAll(selectors.option);
+        // Should include clear button + recent queries
+        expect(options.length).toBe(
+          mockSuggestions.length + mockRecentQueries.length + 1
+        );
+        // First option should be the clear button
+        const clearButton = options.item(0);
+        expect(clearButton.querySelector(selectors.lightningIcon)).toBeNull();
+        expect(clearButton.textContent).toContain(labels.recentQueries);
+        // Skip the first option (clear button) and check the rest
+        Array.from(options)
+          .slice(1)
+          .forEach((option, index) => {
+            const lightningRichText = option.querySelector(selectors.richText);
+            expect(lightningRichText.value).toBe(
+              mockSuggestionListOptions[index].value
+            );
+            expect(lightningRichText.title).toBe(
+              mockSuggestionListOptions[index].rawValue
+            );
+            const expectedIcon = mockSuggestionListOptions[index].isRecentQuery
+              ? 'utility:clock'
+              : 'utility:search';
+            expect(option.querySelector(selectors.lightningIcon).iconName).toBe(
+              expectedIcon
+            );
+          });
+      });
+    });
+  });
+
+  describe('query property', () => {
+    it('should filter recent queries based on current query', async () => {
+      const element = createTestComponent({
+        recentQueries: mockRecentQueries,
+        query: 'test',
+      });
+      await flushPromises();
+
+      // Should only show recent queries that start with 'test'
+      const options = element.shadowRoot.querySelectorAll(selectors.option);
+      // Clear button + filtered recent queries
+      expect(options.length).toBe(2); // clear button + 'test recent query'
+      // The first option should be the clear button
+      const clearButton = options.item(0);
+      expect(clearButton.querySelector(selectors.lightningIcon)).toBeNull();
+      expect(clearButton.textContent).toContain(labels.recentQueries);
+    });
+
+    it('should bold the current query in recent queries', async () => {
+      const element = createTestComponent({
+        recentQueries: mockRecentQueries,
+        query: 'test',
+      });
+      await flushPromises();
+
+      const options = element.shadowRoot.querySelectorAll(selectors.option);
+      // Skip the first option (clear button)
+      const recentQueryOption = options.item(1);
+      expect(
+        recentQueryOption.querySelector(selectors.richText).value
+      ).toContain('<strong>test</strong>');
+    });
+  });
+
+  describe('maxNumberOfSuggestions property', () => {
+    it('should limit the number of suggestions displayed', async () => {
+      const manySuggestions = Array.from({length: 15}, (_, i) => ({
+        key: i,
+        value: `suggestion ${i}`,
+        rawValue: `suggestion ${i}`,
+      }));
+
+      const element = createTestComponent({
+        suggestions: manySuggestions,
+        maxNumberOfSuggestions: 5,
+      });
+      await flushPromises();
+
+      const options = element.shadowRoot.querySelectorAll(selectors.option);
+      expect(options.length).toBe(5);
+    });
+  });
+
+  describe('selection navigation', () => {
+    beforeEach(() => {
+      // Mock the querySelector and getAttribute methods for navigation
+      global.Element.prototype.getAttribute = jest
+        .fn()
+        .mockReturnValue('test-id');
+    });
+
+    it('should move selection down correctly', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      const result = element.selectionDown();
+      expect(result).toEqual({
+        id: 'test-id',
+        value: mockSuggestions[0].rawValue,
+      });
+    });
+
+    it('should move selection up correctly', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      // Move down first, then up
+      element.selectionDown();
+      const result = element.selectionUp();
+      expect(result).toEqual({
+        id: 'test-id',
+        value: mockSuggestions[mockSuggestions.length - 1].rawValue,
+      });
+    });
+
+    it('should wrap around when moving past the end', async () => {
+      const element = createTestComponent({
+        suggestions: [mockSuggestions[0]], // Only one suggestion
+      });
+      await flushPromises();
+
+      element.selectionDown(); // Select first
+      const result = element.selectionDown(); // Should wrap to first again
+      expect(result).toEqual({
+        id: 'test-id',
+        value: mockSuggestions[0].rawValue,
+      });
+    });
+  });
+
+  describe('getCurrentSelectedValue method', () => {
+    it('should return null when no selection is made', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      const result = element.getCurrentSelectedValue();
+      expect(result).toBeNull();
+    });
+
+    it('should return selected value when selection is made', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      element.selectionDown(); // Select first suggestion
+      const result = element.getCurrentSelectedValue();
+      expect(result).toEqual({
+        value: mockSuggestions[0].rawValue,
+        isClearRecentQueryButton: false,
+        isRecentQuery: false,
+      });
+    });
+  });
+
+  describe('event handling', () => {
+    it('should dispatch quantic__selection event when suggestion is selected', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      const mockEventHandler = jest.fn();
+      element.addEventListener('quantic__selection', mockEventHandler);
+
+      // Simulate clicking on first suggestion
+      const firstOption = element.shadowRoot.querySelector(selectors.option);
+      if (firstOption) {
+        firstOption.click();
+      }
+
+      expect(mockEventHandler).toHaveBeenCalled();
+    });
+
+    it('should dispatch quantic__suggestionlistrender event on render', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+      });
+
+      const mockEventHandler = jest.fn();
+      element.addEventListener(
+        'quantic__suggestionlistrender',
+        mockEventHandler
+      );
+
+      await flushPromises();
+
+      expect(mockEventHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should announce suggestions with aria live region', async () => {
+      const mockAriaLiveRegion = require('c/quanticUtils').AriaLiveRegion();
+
+      createTestComponent({
+        suggestions: mockSuggestions,
+      });
+      await flushPromises();
+
+      expect(mockAriaLiveRegion.dispatchMessage).toHaveBeenCalled();
+    });
+
+    it('should announce when no suggestions are found', async () => {
+      const mockAriaLiveRegion = require('c/quanticUtils').AriaLiveRegion();
+
+      createTestComponent({
+        suggestions: [],
+      });
+      await flushPromises();
+
+      expect(mockAriaLiveRegion.dispatchMessage).toHaveBeenCalledWith(
+        'No suggestions found'
+      );
+    });
+  });
+
+  describe('mixed suggestions and recent queries', () => {
+    it('should display both suggestions and recent queries without duplicates', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+        recentQueries: mockRecentQueries,
+        query: 'test',
+      });
+      await flushPromises();
+
+      const options = element.shadowRoot.querySelectorAll(selectors.option);
+      // Should have clear button + recent queries + non-duplicate suggestions
+      expect(options.length).toBeGreaterThan(0);
+    });
+
+    it('should prioritize recent queries over suggestions', async () => {
+      const element = createTestComponent({
+        suggestions: mockSuggestions,
+        recentQueries: ['test query 1'], // Same as first suggestion
+        query: 'test',
+      });
+      await flushPromises();
+
+      // Recent query should appear, suggestion should be filtered out to avoid duplicate
+      const options = element.shadowRoot.querySelectorAll(selectors.option);
+      expect(options.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/__tests__/quanticSearchBoxSuggestionsList.test.js
@@ -100,7 +100,7 @@ const selectors = {
   option: 'li[role="option"]',
   richText: 'lightning-formatted-rich-text',
   lightningIcon: 'lightning-icon',
-  clearButton: '[data-testid="clear-recent-queries"]',
+  clearButton: '[data-testid="clear-recent-queries-button"]',
   suggestionOption: '[data-testid="suggestion-option"]',
   recentQueryOption: '[data-testid="recent-query-option"]',
 };

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
@@ -37,6 +37,7 @@ type QuanticSearchBoxSuggestionsListE2eInsightFixtures =
 
 export const testSearch =
   quanticBase.extend<QuanticSearchBoxSuggestionsListE2ESearchFixtures>({
+    pageUrl: searchBoxSuggestionsListUrl,
     options: {},
     analyticsMode: AnalyticsModeEnum.legacy,
     recentQueries: [],
@@ -71,6 +72,7 @@ export const testSearch =
 
 export const testInsight =
   quanticBase.extend<QuanticSearchBoxSuggestionsListE2eInsightFixtures>({
+    pageUrl: searchBoxSuggestionsListUrl,
     options: {},
     analyticsMode: AnalyticsModeEnum.legacy,
     recentQueries: [],

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
@@ -10,6 +10,7 @@ import {
 import {InsightSetupObject} from '../../../../../../playwright/page-object/insightSetupObject';
 import {useCaseEnum} from '../../../../../../playwright/utils/useCase';
 import {QuerySuggestObject} from '../../../../../../playwright/page-object/querySuggestObject';
+import {AnalyticsModeEnum} from '../../../../../../playwright/utils/analyticsMode';
 
 const searchBoxSuggestionsListUrl = 's/quantic-search-box';
 
@@ -37,6 +38,7 @@ type QuanticSearchBoxSuggestionsListE2eInsightFixtures =
 export const testSearch =
   quanticBase.extend<QuanticSearchBoxSuggestionsListE2ESearchFixtures>({
     options: {},
+    analyticsMode: AnalyticsModeEnum.legacy,
     recentQueries: [],
     search: async ({page}, use) => {
       await use(new SearchObject(page, searchRequestRegex));
@@ -45,7 +47,15 @@ export const testSearch =
       await use(new QuerySuggestObject(page, querySuggestRegex));
     },
     searchBoxSuggestionsList: async (
-      {page, options, configuration, search, querySuggest, recentQueries},
+      {
+        page,
+        options,
+        configuration,
+        search,
+        analytics,
+        querySuggest,
+        recentQueries,
+      },
       use
     ) => {
       await page.goto(searchBoxSuggestionsListUrl);
@@ -55,13 +65,14 @@ export const testSearch =
 
       configuration.configure(options);
       await search.waitForSearchResponse();
-      await use(new SearchBoxSuggestionsListObject(page));
+      await use(new SearchBoxSuggestionsListObject(page, analytics));
     },
   });
 
 export const testInsight =
   quanticBase.extend<QuanticSearchBoxSuggestionsListE2eInsightFixtures>({
     options: {},
+    analyticsMode: AnalyticsModeEnum.legacy,
     recentQueries: [],
     search: async ({page}, use) => {
       await use(new SearchObject(page, insightSearchRequestRegex));
@@ -73,7 +84,15 @@ export const testInsight =
       await use(new InsightSetupObject(page));
     },
     searchBoxSuggestionsList: async (
-      {page, options, configuration, insightSetup, querySuggest, recentQueries},
+      {
+        page,
+        options,
+        configuration,
+        insightSetup,
+        querySuggest,
+        analytics,
+        recentQueries,
+      },
       use
     ) => {
       await page.goto(searchBoxSuggestionsListUrl);
@@ -82,7 +101,7 @@ export const testInsight =
       }
       configuration.configure({...options, useCase: useCaseEnum.insight});
       await insightSetup.waitForInsightInterfaceInitialization();
-      await use(new SearchBoxSuggestionsListObject(page));
+      await use(new SearchBoxSuggestionsListObject(page, analytics));
     },
   });
 

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/fixture.ts
@@ -1,0 +1,89 @@
+import {SearchBoxSuggestionsListObject} from './pageObject';
+import {quanticBase} from '../../../../../../playwright/fixtures/baseFixture';
+import {SearchObject} from '../../../../../../playwright/page-object/searchObject';
+import {
+  searchRequestRegex,
+  insightSearchRequestRegex,
+  querySuggestRegex,
+  insightQuerySuggestRegex,
+} from '../../../../../../playwright/utils/requests';
+import {InsightSetupObject} from '../../../../../../playwright/page-object/insightSetupObject';
+import {useCaseEnum} from '../../../../../../playwright/utils/useCase';
+import {QuerySuggestObject} from '../../../../../../playwright/page-object/querySuggestObject';
+
+const searchBoxSuggestionsListUrl = 's/quantic-search-box';
+
+interface SearchBoxSuggestionsListOptions {
+  engineId?: string;
+  maxNumberOfSuggestions: number;
+}
+
+type QuanticSearchBoxSuggestionsListE2EFixtures = {
+  recentQueries: string[];
+  searchBoxSuggestionsList: SearchBoxSuggestionsListObject;
+  search: SearchObject;
+  querySuggest: QuerySuggestObject;
+  options: Partial<SearchBoxSuggestionsListOptions>;
+};
+
+type QuanticSearchBoxSuggestionsListE2ESearchFixtures =
+  QuanticSearchBoxSuggestionsListE2EFixtures;
+
+type QuanticSearchBoxSuggestionsListE2eInsightFixtures =
+  QuanticSearchBoxSuggestionsListE2ESearchFixtures & {
+    insightSetup: InsightSetupObject;
+  };
+
+export const testSearch =
+  quanticBase.extend<QuanticSearchBoxSuggestionsListE2ESearchFixtures>({
+    options: {},
+    recentQueries: [],
+    search: async ({page}, use) => {
+      await use(new SearchObject(page, searchRequestRegex));
+    },
+    querySuggest: async ({page}, use) => {
+      await use(new QuerySuggestObject(page, querySuggestRegex));
+    },
+    searchBoxSuggestionsList: async (
+      {page, options, configuration, search, querySuggest, recentQueries},
+      use
+    ) => {
+      await page.goto(searchBoxSuggestionsListUrl);
+      if (recentQueries.length > 0) {
+        await querySuggest.setRecentQueries(recentQueries);
+      }
+
+      configuration.configure(options);
+      await search.waitForSearchResponse();
+      await use(new SearchBoxSuggestionsListObject(page));
+    },
+  });
+
+export const testInsight =
+  quanticBase.extend<QuanticSearchBoxSuggestionsListE2eInsightFixtures>({
+    options: {},
+    recentQueries: [],
+    search: async ({page}, use) => {
+      await use(new SearchObject(page, insightSearchRequestRegex));
+    },
+    querySuggest: async ({page}, use) => {
+      await use(new QuerySuggestObject(page, insightQuerySuggestRegex));
+    },
+    insightSetup: async ({page}, use) => {
+      await use(new InsightSetupObject(page));
+    },
+    searchBoxSuggestionsList: async (
+      {page, options, configuration, insightSetup, querySuggest, recentQueries},
+      use
+    ) => {
+      await page.goto(searchBoxSuggestionsListUrl);
+      if (recentQueries.length > 0) {
+        await querySuggest.setRecentQueries(recentQueries);
+      }
+      configuration.configure({...options, useCase: useCaseEnum.insight});
+      await insightSetup.waitForInsightInterfaceInitialization();
+      await use(new SearchBoxSuggestionsListObject(page));
+    },
+  });
+
+export {expect} from '@playwright/test';

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/pageObject.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/pageObject.ts
@@ -1,0 +1,143 @@
+import type {Locator, Page, Request} from '@playwright/test';
+import {
+  isUaCustomEvent,
+  isUaSearchEvent,
+} from '../../../../../../playwright/utils/requests';
+
+export class SearchBoxSuggestionsListObject {
+  constructor(public page: Page) {
+    this.page = page;
+  }
+
+  get searchBoxSuggestionsList(): Locator {
+    return this.page.locator('c-quantic-search-box-suggestions-list');
+  }
+
+  get searchBoxInput(): Locator {
+    return this.page.getByTestId('search-box-input');
+  }
+
+  get suggestionsList(): Locator {
+    return this.searchBoxSuggestionsList.getByRole('listbox');
+  }
+
+  get firstSuggestion(): Locator {
+    return this.suggestionsList.getByRole('option').first();
+  }
+
+  get suggestionCount(): Promise<number> {
+    return this.suggestionsList.getByRole('option').count();
+  }
+
+  get clearRecentQueriesButton(): Locator {
+    return this.page.getByTestId('clear-recent-queries-button');
+  }
+
+  getSuggestionAtIndex(index: number): Locator {
+    return this.suggestionsList.getByRole('option').nth(index);
+  }
+
+  getSuggestionByText(text: string): Locator {
+    return this.suggestionsList.getByRole('option').filter({
+      hasText: text,
+    });
+  }
+
+  async focusOutsideSearchBox(): Promise<void> {
+    await this.page.locator('body').click();
+  }
+
+  async waitForQuerySuggestSearchAnalytics(
+    expectedFields: Record<string, any>
+  ): Promise<Request> {
+    return this.waitForSearchAnalytics(
+      'omniboxAnalytics',
+      (data: Record<string, any>) => {
+        return Object.keys(expectedFields).every(
+          (key) => data?.[key] === expectedFields[key]
+        );
+      }
+    );
+  }
+
+  async waitForRecentQuerySearchAnalytics(
+    expectedFields: Record<string, any>
+  ): Promise<Request> {
+    return this.waitForSearchAnalytics(
+      'recentQueriesClick',
+      (data: Record<string, any>) => {
+        return Object.keys(expectedFields).every(
+          (key) => data?.[key] === expectedFields[key]
+        );
+      }
+    );
+  }
+
+  async waitForClearRecentQueriesAnalytics(
+    expectedFields: Record<string, any>
+  ): Promise<Request> {
+    return this.waitForCustomUARequest(
+      'recentQueries',
+      'clearRecentQueries',
+      (data: Record<string, any>) => {
+        return Object.keys(expectedFields).every(
+          (key) => data?.[key] === expectedFields[key]
+        );
+      }
+    );
+  }
+
+  async waitForSearchAnalytics(
+    actionCause: string,
+    customChecker?: Function
+  ): Promise<Request> {
+    const uaRequest = this.page.waitForRequest((request) => {
+      if (isUaSearchEvent(request)) {
+        const requestBody = request.postDataJSON?.();
+
+        const expectedFields: Record<string, any> = {
+          actionCause: actionCause,
+        };
+
+        const matchesExpectedFields = Object.keys(expectedFields).every(
+          (key) => requestBody?.[key] === expectedFields[key]
+        );
+
+        return (
+          matchesExpectedFields &&
+          (customChecker ? customChecker(requestBody) : true)
+        );
+      }
+      return false;
+    });
+    return uaRequest;
+  }
+
+  async waitForCustomUARequest(
+    eventType: string,
+    eventValue: string,
+    customChecker?: Function
+  ): Promise<Request> {
+    const uaRequest = this.page.waitForRequest((request) => {
+      if (isUaCustomEvent(request)) {
+        const requestBody = request.postDataJSON?.();
+
+        const expectedFields: Record<string, any> = {
+          eventType,
+          eventValue,
+        };
+
+        const matchesExpectedFields = Object.keys(expectedFields).every(
+          (key) => requestBody?.[key] === expectedFields[key]
+        );
+
+        return (
+          matchesExpectedFields &&
+          (customChecker ? customChecker(requestBody) : true)
+        );
+      }
+      return false;
+    });
+    return uaRequest;
+  }
+}

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
@@ -3,6 +3,10 @@ import {
   useCaseTestCases,
   useCaseEnum,
 } from '../../../../../../playwright/utils/useCase';
+import {
+  AnalyticsModeEnum,
+  analyticsModeTest,
+} from '../../../../../../playwright/utils/analyticsMode';
 
 const fixtures = {
   search: testSearch,
@@ -15,72 +19,36 @@ const mockRecentQueries = [
   'recent query 3',
 ];
 
+// The events tested by these tests are only legacy analytics events.
+// There's no need to test the next analytics mode for this test suite.
+const supportedAnalyticsModes = analyticsModeTest.filter(
+  (analyticsProtocol) => analyticsProtocol.mode === AnalyticsModeEnum.legacy
+);
+
 useCaseTestCases.forEach((useCase) => {
   let test = fixtures[useCase.value];
   test.describe(`quantic search box suggestions list ${useCase.label}`, () => {
-    test.describe('search box input interactions', () => {
-      test('should request query suggestions on input focus', async ({
-        searchBoxSuggestionsList,
-        querySuggest,
-      }) => {
-        const querySuggestRequestPromise =
-          querySuggest.waitForQuerySuggestRequest();
-        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-        await searchBoxInput.focus();
-        await querySuggestRequestPromise;
-      });
+    supportedAnalyticsModes.forEach((analytics) => {
+      test.describe(analytics.label, () => {
+        test.use({
+          analyticsMode: analytics.mode,
+        });
 
-      test('should display suggestions on input focus', async ({
-        searchBoxSuggestionsList,
-        querySuggest,
-      }) => {
-        const mockQuerySuggestions = [
-          'Suggestion 1',
-          'Suggestion 2',
-          'Suggestion 3',
-        ];
-        querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
-        const querySuggestResponsePromise =
-          querySuggest.waitForQuerySuggestResponse();
-        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-        await searchBoxInput.focus();
-        await querySuggestResponsePromise;
-
-        const suggestionsList = searchBoxSuggestionsList.suggestionsList;
-        test.expect(await suggestionsList.isVisible()).toBeTruthy();
-        const suggestionCount = await searchBoxSuggestionsList.suggestionCount;
-        test.expect(suggestionCount).toBe(mockQuerySuggestions.length);
-      });
-
-      test('should hide suggestions on input blur', async ({
-        searchBoxSuggestionsList,
-        querySuggest,
-      }) => {
-        const mockQuerySuggestions = [
-          'Suggestion 1',
-          'Suggestion 2',
-          'Suggestion 3',
-        ];
-        querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
-        const querySuggestResponsePromise =
-          querySuggest.waitForQuerySuggestResponse();
-        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-        await searchBoxInput.focus();
-        await querySuggestResponsePromise;
-
-        const suggestionsList = searchBoxSuggestionsList.suggestionsList;
-        test.expect(await suggestionsList.isVisible()).toBeTruthy();
-
-        await searchBoxSuggestionsList.focusOutsideSearchBox();
-        test.expect(await suggestionsList.isVisible()).toBeFalsy();
-      });
-
-      test.describe('using the mouse', () => {
-        test.describe('when clicking on a suggestion', () => {
-          test('should send a search request and analytics with the suggestion as query', async ({
+        test.describe('search box input interactions', () => {
+          test('should request query suggestions on input focus', async ({
             searchBoxSuggestionsList,
             querySuggest,
-            search,
+          }) => {
+            const querySuggestRequestPromise =
+              querySuggest.waitForQuerySuggestRequest();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestRequestPromise;
+          });
+
+          test('should display suggestions on input focus', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
           }) => {
             const mockQuerySuggestions = [
               'Suggestion 1',
@@ -94,94 +62,16 @@ useCaseTestCases.forEach((useCase) => {
             await searchBoxInput.focus();
             await querySuggestResponsePromise;
 
-            const searchAnalyticsPromise =
-              searchBoxSuggestionsList.waitForQuerySuggestSearchAnalytics({
-                queryText: mockQuerySuggestions[0],
-              });
-            const searchRequestPromise = search.waitForSearchRequest();
-            const firstSuggestion = searchBoxSuggestionsList.firstSuggestion;
-            await firstSuggestion.click();
-            const requestBody = (await searchRequestPromise).postDataJSON();
-            test.expect(requestBody.q).toBe(mockQuerySuggestions[0]);
-            await searchAnalyticsPromise;
+            const suggestionsList = searchBoxSuggestionsList.suggestionsList;
+            test.expect(await suggestionsList.isVisible()).toBeTruthy();
+            const suggestionCount =
+              await searchBoxSuggestionsList.suggestionCount;
+            test.expect(suggestionCount).toBe(mockQuerySuggestions.length);
           });
-        });
 
-        test.describe('when clicking on a recent query', () => {
-          test.skip(
-            useCase.value === useCaseEnum.insight,
-            'Recent queries are not available in Insight use case'
-          );
-          test.use({
-            recentQueries: mockRecentQueries,
-          });
-          test('should send a search request and analytics with the recent query as query', async ({
+          test('should hide suggestions on input blur', async ({
             searchBoxSuggestionsList,
             querySuggest,
-            search,
-          }) => {
-            const querySuggestResponsePromise =
-              querySuggest.waitForQuerySuggestResponse();
-            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-            await searchBoxInput.focus();
-            await querySuggestResponsePromise;
-
-            const searchAnalyticsPromise =
-              searchBoxSuggestionsList.waitForRecentQuerySearchAnalytics({
-                queryText: mockRecentQueries[0],
-              });
-            const searchRequestPromise = search.waitForSearchRequest();
-            const secondSuggestion =
-              searchBoxSuggestionsList.getSuggestionAtIndex(1); // The first item is the clear recent queries button.
-            await secondSuggestion.click();
-            const searchRequestBody = (
-              await searchRequestPromise
-            ).postDataJSON();
-            test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
-            test
-              .expect(searchRequestBody?.analytics?.actionCause)
-              .toBe('recentQueriesClick');
-            await searchAnalyticsPromise;
-          });
-        });
-
-        test.describe('when clicking on the clear recent queries button', () => {
-          test.skip(
-            useCase.value === useCaseEnum.insight,
-            'Recent queries are not available in Insight use case'
-          );
-          test.use({
-            recentQueries: mockRecentQueries,
-          });
-          test('should clear recent queries and send analytics', async ({
-            searchBoxSuggestionsList,
-            querySuggest,
-          }) => {
-            const querySuggestResponsePromise =
-              querySuggest.waitForQuerySuggestResponse();
-            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-            await searchBoxInput.focus();
-            await querySuggestResponsePromise;
-
-            const clearRecentQueriesAnalyticsPromise =
-              searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
-            const firstSuggestion =
-              searchBoxSuggestionsList.getSuggestionAtIndex(0); // The first item is the clear recent queries button.
-            await firstSuggestion.click();
-            await clearRecentQueriesAnalyticsPromise;
-            const recentQueriesFromLocalStorage =
-              await querySuggest.getRecentQueriesFromLocalStorage();
-            test.expect(recentQueriesFromLocalStorage).toEqual([]);
-          });
-        });
-      });
-
-      test.describe('when using the keyboard', () => {
-        test.describe('when selecting a suggestion', () => {
-          test('should send a search request and analytics with the suggestion as query', async ({
-            searchBoxSuggestionsList,
-            querySuggest,
-            search,
           }) => {
             const mockQuerySuggestions = [
               'Suggestion 1',
@@ -195,86 +85,223 @@ useCaseTestCases.forEach((useCase) => {
             await searchBoxInput.focus();
             await querySuggestResponsePromise;
 
-            const searchAnalyticsPromise =
-              searchBoxSuggestionsList.waitForQuerySuggestSearchAnalytics({
-                queryText: mockQuerySuggestions[1],
-              });
-            const searchRequestPromise = search.waitForSearchRequest();
-            // Navigate to the second suggestion using keyboard
-            await searchBoxInput.press('ArrowDown');
-            await searchBoxInput.press('ArrowDown');
-            await searchBoxInput.press('Enter');
-            const requestBody = (await searchRequestPromise).postDataJSON();
-            test.expect(requestBody.q).toBe(mockQuerySuggestions[1]);
-            await searchAnalyticsPromise;
+            const suggestionsList = searchBoxSuggestionsList.suggestionsList;
+            test.expect(await suggestionsList.isVisible()).toBeTruthy();
+
+            await searchBoxSuggestionsList.focusOutsideSearchBox();
+            test.expect(await suggestionsList.isVisible()).toBeFalsy();
           });
         });
 
-        test.describe('when selecting a recent query', () => {
-          test.skip(
-            useCase.value === useCaseEnum.insight,
-            'Recent queries are not available in Insight use case'
-          );
-          test.use({
-            recentQueries: mockRecentQueries,
-          });
-          test('should send a search request and analytics with the recent as query', async ({
-            searchBoxSuggestionsList,
-            querySuggest,
-            search,
-          }) => {
-            const querySuggestResponsePromise =
-              querySuggest.waitForQuerySuggestResponse();
-            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-            await searchBoxInput.focus();
-            await querySuggestResponsePromise;
+        test.describe('using the mouse', () => {
+          test.describe('when clicking on a suggestion', () => {
+            test('should send a search request and analytics with the suggestion as query', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+              search,
+            }) => {
+              const mockQuerySuggestions = [
+                'Suggestion 1',
+                'Suggestion 2',
+                'Suggestion 3',
+              ];
+              querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
 
-            const searchAnalyticsPromise =
-              searchBoxSuggestionsList.waitForRecentQuerySearchAnalytics({
-                queryText: mockRecentQueries[0],
-              });
-            const searchRequestPromise = search.waitForSearchRequest();
-            // Navigate to the second suggestion using keyboard
-            await searchBoxInput.press('ArrowDown');
-            await searchBoxInput.press('ArrowDown');
-            await searchBoxInput.press('Enter');
-            const searchRequestBody = (
-              await searchRequestPromise
-            ).postDataJSON();
-            test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
-            test
-              .expect(searchRequestBody?.analytics?.actionCause)
-              .toBe('recentQueriesClick');
-            await searchAnalyticsPromise;
+              const searchAnalyticsPromise =
+                searchBoxSuggestionsList.waitForQuerySuggestSearchLegacyAnalytics(
+                  {
+                    queryText: mockQuerySuggestions[0],
+                  }
+                );
+              const searchRequestPromise = search.waitForSearchRequest();
+              const firstSuggestion = searchBoxSuggestionsList.firstSuggestion;
+              await firstSuggestion.click();
+              const requestBody = (await searchRequestPromise).postDataJSON();
+              test.expect(requestBody.q).toBe(mockQuerySuggestions[0]);
+              await searchAnalyticsPromise;
+            });
+          });
+
+          test.describe('when clicking on a recent query', () => {
+            test.skip(
+              useCase.value === useCaseEnum.insight,
+              'Recent queries are not available in Insight use case'
+            );
+            test.use({
+              recentQueries: mockRecentQueries,
+            });
+            test('should send a search request and analytics with the recent query as query', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+              search,
+            }) => {
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
+
+              const searchAnalyticsPromise =
+                searchBoxSuggestionsList.waitForRecentQuerySearchLegacyAnalytics(
+                  {
+                    queryText: mockRecentQueries[0],
+                  }
+                );
+              const searchRequestPromise = search.waitForSearchRequest();
+              const secondSuggestion =
+                searchBoxSuggestionsList.getSuggestionAtIndex(1); // The first item is the clear recent queries button.
+              await secondSuggestion.click();
+              const searchRequestBody = (
+                await searchRequestPromise
+              ).postDataJSON();
+              test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
+              test
+                .expect(searchRequestBody?.analytics?.actionCause)
+                .toBe('recentQueriesClick');
+              await searchAnalyticsPromise;
+            });
+          });
+
+          test.describe('when clicking on the clear recent queries button', () => {
+            test.skip(
+              useCase.value === useCaseEnum.insight,
+              'Recent queries are not available in Insight use case'
+            );
+            test.use({
+              recentQueries: mockRecentQueries,
+            });
+            test('should clear recent queries and send analytics', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+            }) => {
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
+
+              const clearRecentQueriesAnalyticsPromise =
+                searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
+              const firstSuggestion =
+                searchBoxSuggestionsList.getSuggestionAtIndex(0); // The first item is the clear recent queries button.
+              await firstSuggestion.click();
+              await clearRecentQueriesAnalyticsPromise;
+              const recentQueriesFromLocalStorage =
+                await querySuggest.getRecentQueriesFromLocalStorage();
+              test.expect(recentQueriesFromLocalStorage).toEqual([]);
+            });
           });
         });
 
-        test.describe('when selecting the clear recent queries button', () => {
-          test.skip(
-            useCase.value === useCaseEnum.insight,
-            'Recent queries are not available in Insight use case'
-          );
-          test.use({
-            recentQueries: mockRecentQueries,
-          });
-          test('should clear recent queries and send analytics', async ({
-            searchBoxSuggestionsList,
-            querySuggest,
-          }) => {
-            const querySuggestResponsePromise =
-              querySuggest.waitForQuerySuggestResponse();
-            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-            await searchBoxInput.focus();
-            await querySuggestResponsePromise;
+        test.describe('when using the keyboard', () => {
+          test.describe('when selecting a suggestion', () => {
+            test('should send a search request and analytics with the suggestion as query', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+              search,
+            }) => {
+              const mockQuerySuggestions = [
+                'Suggestion 1',
+                'Suggestion 2',
+                'Suggestion 3',
+              ];
+              querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
 
-            const clearRecentQueriesAnalyticsPromise =
-              searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
-            await searchBoxInput.press('ArrowDown');
-            await searchBoxInput.press('Enter');
-            await clearRecentQueriesAnalyticsPromise;
-            const recentQueriesFromLocalStorage =
-              await querySuggest.getRecentQueriesFromLocalStorage();
-            test.expect(recentQueriesFromLocalStorage).toEqual([]);
+              const searchAnalyticsPromise =
+                searchBoxSuggestionsList.waitForQuerySuggestSearchLegacyAnalytics(
+                  {
+                    queryText: mockQuerySuggestions[1],
+                  }
+                );
+              const searchRequestPromise = search.waitForSearchRequest();
+              // Navigate to the second suggestion using keyboard
+              await searchBoxInput.press('ArrowDown');
+              await searchBoxInput.press('ArrowDown');
+              await searchBoxInput.press('Enter');
+              const requestBody = (await searchRequestPromise).postDataJSON();
+              test.expect(requestBody.q).toBe(mockQuerySuggestions[1]);
+              await searchAnalyticsPromise;
+            });
+          });
+
+          test.describe('when selecting a recent query', () => {
+            test.skip(
+              useCase.value === useCaseEnum.insight,
+              'Recent queries are not available in Insight use case'
+            );
+            test.use({
+              recentQueries: mockRecentQueries,
+            });
+            test('should send a search request and analytics with the recent as query', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+              search,
+            }) => {
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
+
+              const searchAnalyticsPromise =
+                searchBoxSuggestionsList.waitForRecentQuerySearchLegacyAnalytics(
+                  {
+                    queryText: mockRecentQueries[0],
+                  }
+                );
+              const searchRequestPromise = search.waitForSearchRequest();
+              // Navigate to the second suggestion using keyboard
+              await searchBoxInput.press('ArrowDown');
+              await searchBoxInput.press('ArrowDown');
+              await searchBoxInput.press('Enter');
+              const searchRequestBody = (
+                await searchRequestPromise
+              ).postDataJSON();
+              test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
+              test
+                .expect(searchRequestBody?.analytics?.actionCause)
+                .toBe('recentQueriesClick');
+              await searchAnalyticsPromise;
+            });
+          });
+
+          test.describe('when selecting the clear recent queries button', () => {
+            test.skip(
+              useCase.value === useCaseEnum.insight,
+              'Recent queries are not available in Insight use case'
+            );
+            test.use({
+              recentQueries: mockRecentQueries,
+            });
+            test('should clear recent queries and send analytics', async ({
+              searchBoxSuggestionsList,
+              querySuggest,
+            }) => {
+              const querySuggestResponsePromise =
+                querySuggest.waitForQuerySuggestResponse();
+              const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+              await searchBoxInput.focus();
+              await querySuggestResponsePromise;
+
+              const clearRecentQueriesAnalyticsPromise =
+                searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
+              await searchBoxInput.press('ArrowDown');
+              await searchBoxInput.press('Enter');
+              await clearRecentQueriesAnalyticsPromise;
+              const recentQueriesFromLocalStorage =
+                await querySuggest.getRecentQueriesFromLocalStorage();
+              test.expect(recentQueriesFromLocalStorage).toEqual([]);
+            });
           });
         });
       });

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
@@ -1,0 +1,283 @@
+import {testSearch, testInsight} from './fixture';
+import {
+  useCaseTestCases,
+  useCaseEnum,
+} from '../../../../../../playwright/utils/useCase';
+
+const fixtures = {
+  search: testSearch,
+  insight: testInsight,
+};
+
+const mockRecentQueries = [
+  'recent query 1',
+  'recent query 2',
+  'recent query 3',
+];
+
+useCaseTestCases.forEach((useCase) => {
+  let test = fixtures[useCase.value];
+  test.describe(`quantic search box suggestions list ${useCase.label}`, () => {
+    test.describe('search box input interactions', () => {
+      test('should request query suggestions on input focus', async ({
+        searchBoxSuggestionsList,
+        querySuggest,
+      }) => {
+        const querySuggestRequestPromise =
+          querySuggest.waitForQuerySuggestRequest();
+        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+        await searchBoxInput.focus();
+        await querySuggestRequestPromise;
+      });
+
+      test('should display suggestions on input focus', async ({
+        searchBoxSuggestionsList,
+        querySuggest,
+      }) => {
+        const mockQuerySuggestions = [
+          'Suggestion 1',
+          'Suggestion 2',
+          'Suggestion 3',
+        ];
+        querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+        const querySuggestResponsePromise =
+          querySuggest.waitForQuerySuggestResponse();
+        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+        await searchBoxInput.focus();
+        await querySuggestResponsePromise;
+
+        const suggestionsList = searchBoxSuggestionsList.suggestionsList;
+        test.expect(await suggestionsList.isVisible()).toBeTruthy();
+        const suggestionCount = await searchBoxSuggestionsList.suggestionCount;
+        test.expect(suggestionCount).toBe(mockQuerySuggestions.length);
+      });
+
+      test('should hide suggestions on input blur', async ({
+        searchBoxSuggestionsList,
+        querySuggest,
+      }) => {
+        const mockQuerySuggestions = [
+          'Suggestion 1',
+          'Suggestion 2',
+          'Suggestion 3',
+        ];
+        querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+        const querySuggestResponsePromise =
+          querySuggest.waitForQuerySuggestResponse();
+        const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+        await searchBoxInput.focus();
+        await querySuggestResponsePromise;
+
+        const suggestionsList = searchBoxSuggestionsList.suggestionsList;
+        test.expect(await suggestionsList.isVisible()).toBeTruthy();
+
+        await searchBoxSuggestionsList.focusOutsideSearchBox();
+        test.expect(await suggestionsList.isVisible()).toBeFalsy();
+      });
+
+      test.describe('using the mouse', () => {
+        test.describe('when clicking on a suggestion', () => {
+          test('should send a search request and analytics with the suggestion as query', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+            search,
+          }) => {
+            const mockQuerySuggestions = [
+              'Suggestion 1',
+              'Suggestion 2',
+              'Suggestion 3',
+            ];
+            querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const searchAnalyticsPromise =
+              searchBoxSuggestionsList.waitForQuerySuggestSearchAnalytics({
+                queryText: mockQuerySuggestions[0],
+              });
+            const searchRequestPromise = search.waitForSearchRequest();
+            const firstSuggestion = searchBoxSuggestionsList.firstSuggestion;
+            await firstSuggestion.click();
+            const requestBody = (await searchRequestPromise).postDataJSON();
+            test.expect(requestBody.q).toBe(mockQuerySuggestions[0]);
+            await searchAnalyticsPromise;
+          });
+        });
+
+        test.describe('when clicking on a recent query', () => {
+          test.skip(
+            useCase.value === useCaseEnum.insight,
+            'Recent queries are not available in Insight use case'
+          );
+          test.use({
+            recentQueries: mockRecentQueries,
+          });
+          test('should send a search request and analytics with the recent query as query', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+            search,
+          }) => {
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const searchAnalyticsPromise =
+              searchBoxSuggestionsList.waitForRecentQuerySearchAnalytics({
+                queryText: mockRecentQueries[0],
+              });
+            const searchRequestPromise = search.waitForSearchRequest();
+            const secondSuggestion =
+              searchBoxSuggestionsList.getSuggestionAtIndex(1); // The first item is the clear recent queries button.
+            await secondSuggestion.click();
+            const searchRequestBody = (
+              await searchRequestPromise
+            ).postDataJSON();
+            test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
+            test
+              .expect(searchRequestBody?.analytics?.actionCause)
+              .toBe('recentQueriesClick');
+            await searchAnalyticsPromise;
+          });
+        });
+
+        test.describe('when clicking on the clear recent queries button', () => {
+          test.skip(
+            useCase.value === useCaseEnum.insight,
+            'Recent queries are not available in Insight use case'
+          );
+          test.use({
+            recentQueries: mockRecentQueries,
+          });
+          test('should clear recent queries and send analytics', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+          }) => {
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const clearRecentQueriesAnalyticsPromise =
+              searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
+            const firstSuggestion =
+              searchBoxSuggestionsList.getSuggestionAtIndex(0); // The first item is the clear recent queries button.
+            await firstSuggestion.click();
+            await clearRecentQueriesAnalyticsPromise;
+            const recentQueriesFromLocalStorage =
+              await querySuggest.getRecentQueriesFromLocalStorage();
+            test.expect(recentQueriesFromLocalStorage).toEqual([]);
+          });
+        });
+      });
+
+      test.describe('when using the keyboard', () => {
+        test.describe('when selecting a suggestion', () => {
+          test('should send a search request and analytics with the suggestion as query', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+            search,
+          }) => {
+            const mockQuerySuggestions = [
+              'Suggestion 1',
+              'Suggestion 2',
+              'Suggestion 3',
+            ];
+            querySuggest.mockQuerySuggestResponse(mockQuerySuggestions);
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const searchAnalyticsPromise =
+              searchBoxSuggestionsList.waitForQuerySuggestSearchAnalytics({
+                queryText: mockQuerySuggestions[1],
+              });
+            const searchRequestPromise = search.waitForSearchRequest();
+            // Navigate to the second suggestion using keyboard
+            await searchBoxInput.press('ArrowDown');
+            await searchBoxInput.press('ArrowDown');
+            await searchBoxInput.press('Enter');
+            const requestBody = (await searchRequestPromise).postDataJSON();
+            test.expect(requestBody.q).toBe(mockQuerySuggestions[1]);
+            await searchAnalyticsPromise;
+          });
+        });
+
+        test.describe('when selecting a recent query', () => {
+          test.skip(
+            useCase.value === useCaseEnum.insight,
+            'Recent queries are not available in Insight use case'
+          );
+          test.use({
+            recentQueries: mockRecentQueries,
+          });
+          test('should send a search request and analytics with the recent as query', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+            search,
+          }) => {
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const searchAnalyticsPromise =
+              searchBoxSuggestionsList.waitForRecentQuerySearchAnalytics({
+                queryText: mockRecentQueries[0],
+              });
+            const searchRequestPromise = search.waitForSearchRequest();
+            // Navigate to the second suggestion using keyboard
+            await searchBoxInput.press('ArrowDown');
+            await searchBoxInput.press('ArrowDown');
+            await searchBoxInput.press('Enter');
+            const searchRequestBody = (
+              await searchRequestPromise
+            ).postDataJSON();
+            test.expect(searchRequestBody.q).toBe(mockRecentQueries[0]);
+            test
+              .expect(searchRequestBody?.analytics?.actionCause)
+              .toBe('recentQueriesClick');
+            await searchAnalyticsPromise;
+          });
+        });
+
+        test.describe('when selecting the clear recent queries button', () => {
+          test.skip(
+            useCase.value === useCaseEnum.insight,
+            'Recent queries are not available in Insight use case'
+          );
+          test.use({
+            recentQueries: mockRecentQueries,
+          });
+          test('should clear recent queries and send analytics', async ({
+            searchBoxSuggestionsList,
+            querySuggest,
+          }) => {
+            const querySuggestResponsePromise =
+              querySuggest.waitForQuerySuggestResponse();
+            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
+            await searchBoxInput.focus();
+            await querySuggestResponsePromise;
+
+            const clearRecentQueriesAnalyticsPromise =
+              searchBoxSuggestionsList.waitForClearRecentQueriesAnalytics({});
+            await searchBoxInput.press('ArrowDown');
+            await searchBoxInput.press('Enter');
+            await clearRecentQueriesAnalyticsPromise;
+            const recentQueriesFromLocalStorage =
+              await querySuggest.getRecentQueriesFromLocalStorage();
+            test.expect(recentQueriesFromLocalStorage).toEqual([]);
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/e2e/quanticSearchBoxSuggestionsList.e2e.ts
@@ -35,17 +35,6 @@ useCaseTestCases.forEach((useCase) => {
         });
 
         test.describe('search box input interactions', () => {
-          test('should request query suggestions on input focus', async ({
-            searchBoxSuggestionsList,
-            querySuggest,
-          }) => {
-            const querySuggestRequestPromise =
-              querySuggest.waitForQuerySuggestRequest();
-            const searchBoxInput = searchBoxSuggestionsList.searchBoxInput;
-            await searchBoxInput.focus();
-            await querySuggestRequestPromise;
-          });
-
           test('should display suggestions on input focus', async ({
             searchBoxSuggestionsList,
             querySuggest,

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
@@ -14,7 +14,7 @@
             key={option.key}
             onmousedown={option.onClick}
             tabindex="-1"
-            data-testid="clear-recent-queries"
+            data-testid="clear-recent-queries-button"
             role="option"
             class="slds-listbox__item"
             aria-selected={option.isSelected}
@@ -33,7 +33,7 @@
             key={option.key}
             onmousedown={option.onClick}
             tabindex="-1"
-            data-cy="suggestions-option"
+            data-testid="suggestions-option"
             role="option"
             class="slds-listbox__item"
             data-rawvalue={option.rawValue}

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.html
@@ -1,37 +1,66 @@
 <template>
-    <div class={listboxCssClass}>
-        <ul id="listbox-id" data-cy="suggestion-list" class="slds-listbox slds-listbox_vertical" tabindex="-1"
-            role="listbox">
-            <template for:each={allOptions} for:item="option">
-                <template lwc:if={option.isClearRecentQueryButton}>
-                    <li id={option.id} key={option.key} onmousedown={option.onClick} tabindex="-1"
-                        data-cy="clear-recent-queries" role="option" class="slds-listbox__item"
-                        aria-selected={option.isSelected}>
-                        <div class={clearRecentQueriesOptionCSSClass} data-role="option">
-                            <span class="slds-media__body slds-text-title_bold">
-                                {labels.recentQueries}
-                            </span>
-                            <span class="slds-text-color_weak">{labels.clear}</span>
-                        </div>
-                    </li>
-                </template>
-                <template lwc:else>
-                    <li id={option.id} key={option.key} onmousedown={option.onClick} tabindex="-1"
-                        data-cy="suggestions-option" role="option" class="slds-listbox__item"
-                        data-rawvalue={option.rawValue} aria-selected={option.isSelected}>
-                        <div class={option.containerCSSClass}>
-                            <span class="slds-media__figure slds-listbox__option-icon suggestion-option__icon">
-                                <lightning-icon icon-name={option.icon} size="xx-small"
-                                    alternative-text={option.iconTitle}></lightning-icon>
-                            </span>
-                            <span class="slds-media__body slds-grid">
-                                <lightning-formatted-rich-text class="slds-truncate" data-cy="suggestions-option-text"
-                                    value={option.value} title={option.rawValue}></lightning-formatted-rich-text>
-                            </span>
-                        </div>
-                    </li>
-                </template>
-            </template>
-        </ul>
-    </div>
+  <div class={listboxCssClass}>
+    <ul
+      id="listbox-id"
+      data-cy="suggestion-list"
+      class="slds-listbox slds-listbox_vertical"
+      tabindex="-1"
+      role="listbox"
+    >
+      <template for:each={allOptions} for:item="option">
+        <template lwc:if={option.isClearRecentQueryButton}>
+          <li
+            id={option.id}
+            key={option.key}
+            onmousedown={option.onClick}
+            tabindex="-1"
+            data-testid="clear-recent-queries"
+            role="option"
+            class="slds-listbox__item"
+            aria-selected={option.isSelected}
+          >
+            <div class={clearRecentQueriesOptionCSSClass} data-role="option">
+              <span class="slds-media__body slds-text-title_bold">
+                {labels.recentQueries}
+              </span>
+              <span class="slds-text-color_weak">{labels.clear}</span>
+            </div>
+          </li>
+        </template>
+        <template lwc:else>
+          <li
+            id={option.id}
+            key={option.key}
+            onmousedown={option.onClick}
+            tabindex="-1"
+            data-cy="suggestions-option"
+            role="option"
+            class="slds-listbox__item"
+            data-rawvalue={option.rawValue}
+            aria-selected={option.isSelected}
+          >
+            <div class={option.containerCSSClass}>
+              <span
+                class="slds-media__figure slds-listbox__option-icon suggestion-option__icon"
+              >
+                <lightning-icon
+                  icon-name={option.icon}
+                  size="xx-small"
+                  alternative-text={option.iconTitle}
+                ></lightning-icon>
+              </span>
+              <span class="slds-media__body slds-grid">
+                <lightning-formatted-rich-text
+                  class="slds-truncate"
+                  data-cy="suggestions-option-text"
+                  value={option.value}
+                  title={option.rawValue}
+                ></lightning-formatted-rich-text>
+              </span>
+            </div>
+          </li>
+        </template>
+      </template>
+    </ul>
+  </div>
 </template>

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js
@@ -259,6 +259,8 @@ export default class QuanticSearchBoxSuggestionsList extends LightningElement {
       iconTitle: suggestion.isRecentQuery
         ? this.labels.recentQueryAriaLabel
         : this.labels.querySuggestionAriaLabel,
+      isClearRecentQueryButton: false,
+      isRecentQuery: !!suggestion.isRecentQuery,
       onClick: (event) => {
         this.handleSelection(event, optionIndex);
       },

--- a/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/templates/standaloneSearchBox.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticStandaloneSearchBox/templates/standaloneSearchBox.html
@@ -13,7 +13,7 @@
         without-submit-button={withoutSubmitButton}
         placeholder={placeholder}
         suggestions={suggestions}
-        data-cy="quantic-search-box-input"
+        data-testid="quantic-search-box-input"
       ></c-quantic-search-box-input>
     </c-quantic-search-interface>
   </template>

--- a/packages/quantic/playwright/page-object/analytics.ts
+++ b/packages/quantic/playwright/page-object/analytics.ts
@@ -87,10 +87,8 @@ export class AnalyticsObject {
       if (isUaSearchEvent(request)) {
         const event = request.postDataJSON?.();
         return (
-          (event?.actionCause === actionCause &&
-            additionalMatch &&
-            additionalMatch(event)) ||
-          false
+          event?.actionCause === actionCause &&
+          (additionalMatch ? additionalMatch(event) === true : true)
         );
       }
       return false;

--- a/packages/quantic/playwright/page-object/analytics.ts
+++ b/packages/quantic/playwright/page-object/analytics.ts
@@ -4,6 +4,7 @@ import {
   isEventProtocol,
   isUaClickEvent,
   isUaCustomEvent,
+  isUaSearchEvent,
 } from '../utils/requests';
 import {AnalyticsMode} from '../utils/analyticsMode';
 
@@ -68,6 +69,29 @@ export class AnalyticsObject {
         if (additionalMatch && !additionalMatch(event)) return false;
 
         return true;
+      }
+      return false;
+    });
+    return uaRequest;
+  }
+
+  async waitForSearchUaAnalytics(
+    actionCause: string,
+    additionalMatch?: (event: {
+      actionCause: string;
+      customData?: Record<string, string>;
+      [key: string]: unknown;
+    }) => boolean
+  ): Promise<Request> {
+    const uaRequest = this.page.waitForRequest((request) => {
+      if (isUaSearchEvent(request)) {
+        const event = request.postDataJSON?.();
+        return (
+          (event?.actionCause === actionCause &&
+            additionalMatch &&
+            additionalMatch(event)) ||
+          false
+        );
       }
       return false;
     });

--- a/packages/quantic/playwright/page-object/querySuggestObject.ts
+++ b/packages/quantic/playwright/page-object/querySuggestObject.ts
@@ -1,0 +1,58 @@
+import {Page, Request, Response} from '@playwright/test';
+
+export class QuerySuggestObject {
+  constructor(
+    protected page: Page,
+    protected querySuggestRequestRegex: RegExp
+  ) {
+    this.page = page;
+    this.querySuggestRequestRegex = querySuggestRequestRegex;
+  }
+
+  async setRecentQueries(queries: string[]): Promise<void> {
+    await this.page
+      .getByTestId('localstorage-input')
+      .locator('input')
+      .fill(JSON.stringify(queries));
+    await this.page.getByTestId('localstorage-set-button').click();
+  }
+
+  async getRecentQueriesFromLocalStorage(): Promise<string[]> {
+    await this.page.getByTestId('localstorage-input').locator('input').fill('');
+    await this.page.getByTestId('localstorage-get-button').click();
+    const content = await this.page
+      .getByTestId('localstorage-output')
+      .textContent();
+    return content ? JSON.parse(content) : [];
+  }
+
+  async waitForQuerySuggestRequest(): Promise<Request> {
+    return this.page.waitForRequest(this.querySuggestRequestRegex);
+  }
+
+  async waitForQuerySuggestResponse(): Promise<Response> {
+    return this.page.waitForResponse(this.querySuggestRequestRegex);
+  }
+
+  async mockQuerySuggestResponse(suggestions: string[]) {
+    await this.page.route(this.querySuggestRequestRegex, async (route) => {
+      const apiResponse = await this.page.request.fetch(route.request());
+      const originalBody = await apiResponse.json();
+      const modifiedBody = {
+        ...originalBody,
+        completions: suggestions.map((suggestion) => ({
+          expression: suggestion,
+          highlighted: `[${suggestion}]`,
+          executableConfidence: 1,
+          objectId: `suggestion-${suggestion}`,
+          score: 42,
+        })),
+      };
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(modifiedBody),
+      });
+    });
+  }
+}

--- a/packages/quantic/playwright/page-object/searchObject.ts
+++ b/packages/quantic/playwright/page-object/searchObject.ts
@@ -1,5 +1,12 @@
 import {Page, Locator, Response, Request} from '@playwright/test';
 
+const selectors = {
+  searchResults: 'c-quantic-result',
+  performSearchButton: 'c-action-perform-search button',
+  performSearchInput: 'c-action-perform-search input',
+  performRecommendationSearchButton: 'c-action-get-recommendations button',
+};
+
 export class SearchObject {
   constructor(
     protected page: Page,
@@ -10,11 +17,11 @@ export class SearchObject {
   }
 
   get performSearchButton(): Locator {
-    return this.page.locator('c-action-perform-search button');
+    return this.page.locator(selectors.performSearchButton);
   }
 
   get searchInput(): Locator {
-    return this.page.locator('c-action-perform-search input');
+    return this.page.locator(selectors.performSearchInput);
   }
 
   async fillSearchInput(query: string): Promise<void> {
@@ -34,12 +41,18 @@ export class SearchObject {
     return this.page.waitForResponse(this.searchRequestRegex);
   }
 
+  async waitForSearchResultsVisible(): Promise<void> {
+    await this.page.waitForSelector(selectors.searchResults, {
+      state: 'visible',
+    });
+  }
+
   async waitForSearchRequest(): Promise<Request> {
     return this.page.waitForRequest(this.searchRequestRegex);
   }
 
   get performRecommendationSearchButton(): Locator {
-    return this.page.locator('c-action-get-recommendations button');
+    return this.page.locator(selectors.performRecommendationSearchButton);
   }
 
   async performRecommendationSearch(): Promise<void> {

--- a/packages/quantic/playwright/utils/requests.ts
+++ b/packages/quantic/playwright/utils/requests.ts
@@ -8,6 +8,10 @@ export const classifyRequestRegex =
 export const documentsSuggestRequestRegex =
   /\/rest\/organizations\/.*\/caseassists\/.*\/documents\/suggest/;
 export const facetRequestRegex = /\/rest\/search\/v2\/facet\?organizationId=.*/;
+export const querySuggestRegex =
+  /\/rest\/search\/v2\/querySuggest\?organizationId=.*/;
+export const insightQuerySuggestRegex =
+  /\/rest\/organizations\/.*\/insight\/v1\/configs\/.*\/querysuggest/;
 
 export const analyticsSearchesUrlRegex =
   /\/rest(\/ua)?\/v15\/analytics\/search(es)?/;


### PR DESCRIPTION
## [SFINT-5645]

- Added unit tests for the QuanticSearchBoxSuggestionsList
- Added e2e tests for the QuanticSearchBoxSuggestionsList (leveraging the exampleSearchbox page)
- Created a new ActionLocalStorage LWC to be used in tests to read/set a value in the localStorage, this allows us to correctly handle the localStorage even between the different versions of LockerService and Lightning Web Security.
- Created a new QuerySuggestObject to use in tests to intercept and mock calls to the /querysuggest API.
- Updated some other tests that were testing the same stuff I was adding, 
    - for example, modified the QuanticSearchboxInput tests to remove the tests that were testing the rendering of querySuggestions, to instead test that the right data is passed to the QuanticSearchBoxSuggestionsList component.

[SFINT-5645]: https://coveord.atlassian.net/browse/SFINT-5645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Unit tests

![image](https://github.com/user-attachments/assets/407a7029-d2f9-4043-8448-5874bc13c04c)
c

### E2E tests

![image](https://github.com/user-attachments/assets/e863ba0e-dd18-4559-87e2-7842bc0b5618)

> I am unsure about some of those e2e tests, if they are worth keeping.
> For example the input focus/blur,
> I am also questioning the worth of the tests that checks that we send a search request with the right query when selecting a value in the suggestions, that's pretty much covered across unit tests of the component and also Headless unit tests.

For the tests that are skipped, this is because the Insight use-case doesn't support the recent queries.

### Component to handle the local storage

- Has an option to specify a key for the localstorage and will display its key as the label for the input.
- There's a button to set the value
- There's a button to read and print the value so you can test *after* making modifications the resulting localstorage.

![image](https://github.com/user-attachments/assets/599ea629-af95-4ab9-9354-06c7799d7d7d)
