### PR TITLE
fix(answer): add context to /generate payload

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -6,6 +6,7 @@ import {
 } from '../../app/navigator-context-provider.js';
 import {selectAdvancedSearchQueries} from '../../features/advanced-search-queries/advanced-search-query-selectors.js';
 import {fromAnalyticsStateToAnalyticsParams} from '../../features/configuration/analytics-params.js';
+import {selectContext} from '../../features/context/context-selector.js';
 import {
   setAnswerContentFormat,
   setCannotAnswer,
@@ -327,6 +328,8 @@ export const constructAnswerQueryParams = (
 
   const {aq, cq, dq, lq} = buildAdvancedSearchQueryParams(state);
 
+  const context = selectContext(state);
+
   const searchHub = selectSearchHub(state);
   const pipeline = selectPipeline(state);
   const citationsFieldToInclude = selectFieldsToIncludeInCitation(state) ?? [];
@@ -341,6 +344,9 @@ export const constructAnswerQueryParams = (
     ...(cq && {cq}),
     ...(dq && {dq}),
     ...(lq && {lq}),
+    ...(context?.contextValues && {
+      context: context.contextValues,
+    }),
     pipelineRuleParameters: {
       mlGenerativeQuestionAnswering: {
         responseFormat: state.generatedAnswer.responseFormat,

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -205,6 +205,11 @@ export const streamAnswerAPIStateMock: StateNeededByAnswerAPI = {
       dq: '',
     },
   },
+  context: {
+    contextValues: {
+      testKey: 'testValue',
+    },
+  },
   querySuggest: {},
   querySet: {
     'atomic-search-box-ie7ah': 'what is the hardest wood',
@@ -1211,6 +1216,9 @@ export const expectedStreamAnswerAPIParam = {
   cq: 'cq-test-query',
   dq: 'dq-test-query',
   lq: 'lq-test-query',
+  context: {
+    testKey: 'testValue',
+  },
   pipelineRuleParameters: {
     mlGenerativeQuestionAnswering: {
       responseFormat: {

--- a/packages/headless/src/features/context/context-selector.ts
+++ b/packages/headless/src/features/context/context-selector.ts
@@ -1,0 +1,7 @@
+import {createSelector} from '@reduxjs/toolkit';
+import {ContextState} from './context-state.js';
+
+export const selectContext = createSelector(
+  (state: {context?: ContextState}) => state.context,
+  (context) => context
+);


### PR DESCRIPTION
We were missing the context in the payload of the /generate calls. This PR simply adds it from the state.

To test:

1. In genqa.html, add:
```
Line 22
<script async type="module">
      const {loadContextActions} = await (import.meta.env
        ? import('@coveo/headless')
        : import('http://localhost:3000/headless/v0.0.0/headless.esm.js'));

Line 39 (before execute first search):

      const engine = searchInterface.engine;
      const action = loadContextActions(engine).addContext({
        contextKey: 'userGroup',
        contextValue: 'sales',
      });
      engine.dispatch(action);

Line 128:
        <atomic-layout-section section="main">
          <atomic-generated-answer
            answer-configuration-id="fc581be0-6e61-4039-ab26-a3f2f52f308f"
          ></atomic-generated-answer>
```

Open genQa demo and do a search. You should see the context in the `/generate` endpoint:
<img width="2537" alt="image" src="https://github.com/user-attachments/assets/35edb2e6-6566-4267-ab09-aeea3aff3dff" />

