### PR TITLE
fix(atomic): prevent double "clear recent queries" button

### DIFF
--- a/packages/atomic/src/components/common/suggestions/stencil-suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/stencil-suggestion-manager.ts
@@ -421,13 +421,10 @@ export class SuggestionManager<SearchBoxController> {
     const filterOnDuplicate = new Set();
 
     const out = suggestionElements.filter((suggestionElement) => {
-      if (isNullOrUndefined(suggestionElement.query)) {
-        return true;
-      }
-      if (filterOnDuplicate.has(suggestionElement.query)) {
+      if (filterOnDuplicate.has(suggestionElement.key)) {
         return false;
       } else {
-        filterOnDuplicate.add(suggestionElement.query);
+        filterOnDuplicate.add(suggestionElement.key);
         return true;
       }
     });

--- a/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
@@ -422,13 +422,10 @@ export class SuggestionManager<SearchBoxController> {
     const filterOnDuplicate = new Set();
 
     const out = suggestionElements.filter((suggestionElement) => {
-      if (isNullOrUndefined(suggestionElement.query)) {
-        return true;
-      }
-      if (filterOnDuplicate.has(suggestionElement.query)) {
+      if (filterOnDuplicate.has(suggestionElement.key)) {
         return false;
       } else {
-        filterOnDuplicate.add(suggestionElement.query);
+        filterOnDuplicate.add(suggestionElement.key);
         return true;
       }
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4302

See the jira for the visualisation of the bug. Was only able to reproduce it in storybook.

This happened because of this code here that currently sometimes renders twice a query-suggestions or a recent-queries.
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/467deef8-d6ad-4ed2-ba94-1df37a428bd2" />


We already have code that filter out the duplicates in that case but it filters out based on the query. The recent query clear button does not have a query attached so it always stayed in the suggestions. 

The fix is to filter them out based on the key. 

I don't think this would happen with the Lit search box since the code above is different but it is still better to filter out based on the key so I will fix it now. 
