### PR TITLE
fix(headless): move facet display reg. tabs to the facet condition manager

### DIFF
--- a/packages/headless/src/controllers/core/facets/facet-conditions-manager/headless-facet-conditions-manager.test.ts
+++ b/packages/headless/src/controllers/core/facets/facet-conditions-manager/headless-facet-conditions-manager.test.ts
@@ -3,6 +3,7 @@ import {
   disableFacet,
   enableFacet,
 } from '../../../../features/facet-options/facet-options-actions.js';
+import {isFacetVisibleOnTab} from '../../../../features/facet-options/facet-options-utils.js';
 import {SearchAppState} from '../../../../state/search-app-state.js';
 import {buildMockCategoryFacetSlice} from '../../../../test/mock-category-facet-slice.js';
 import {buildMockCategoryFacetValueRequest} from '../../../../test/mock-category-facet-value-request.js';
@@ -26,6 +27,7 @@ import {
 } from './headless-facet-conditions-manager.js';
 
 vi.mock('../../../../features/facet-options/facet-options-actions');
+vi.mock('../../../../features/facet-options/facet-options-utils');
 
 describe('facet conditions manager', () => {
   let state: SearchAppState;
@@ -43,395 +45,835 @@ describe('facet conditions manager', () => {
     });
   });
 
-  describe('with a single condition', () => {
-    const facetId = 'abc';
-    const parentFacetId = 'def';
-    let facetConditionsManager: FacetConditionsManager;
-    let condition: Mock;
-
-    function initCondition() {
-      state.facetSet[facetId] = buildMockFacetSlice();
-      state.facetOptions.facets[facetId] = buildFacetOptionsSlice();
-      facetConditionsManager = buildCoreFacetConditionsManager(engine, {
-        facetId: facetId,
-        conditions: [
-          {
-            parentFacetId,
-            condition: (condition = vi.fn(() => false)),
-          },
-        ],
-      });
-    }
-
-    it('subscribes', () => {
-      initCondition();
-      expect(engine.subscribe).toHaveBeenCalledTimes(1);
+  describe('when the facet is not impacted by a tab, or is "tabEnabled"', () => {
+    beforeEach(() => {
+      vi.mocked(isFacetVisibleOnTab).mockReturnValue(true);
     });
 
-    it('when stopWatching is called, unsubscribes', () => {
-      initCondition();
-      facetConditionsManager.stopWatching();
-      expect(engineUnsubscriber).toHaveBeenCalledTimes(1);
-    });
+    describe('with a single condition', () => {
+      const facetId = 'abc';
+      const parentFacetId = 'def';
+      let facetConditionsManager: FacetConditionsManager;
+      let condition: Mock;
 
-    describe('with a parent facet', () => {
-      beforeEach(() => {
-        state.facetSet[parentFacetId] = buildMockFacetSlice();
-        state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
-        initCondition();
-        state.facetSet[parentFacetId]!.request.currentValues = [
-          buildMockFacetValueRequest({
-            state: 'idle',
-            value: 'value a',
-          }),
-          buildMockFacetValueRequest({
-            state: 'selected',
-            value: 'value b',
-          }),
-        ];
-        engineListener();
-      });
-
-      it('calls condition with the correct values', () => {
-        expect(condition).toHaveBeenCalledWith(
-          state.facetSet[parentFacetId]!.request.currentValues
-        );
-      });
-    });
-
-    describe('with a parent category facet', () => {
-      beforeEach(() => {
-        state.categoryFacetSet[parentFacetId] = buildMockCategoryFacetSlice();
-        state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
-        initCondition();
-        state.categoryFacetSet[parentFacetId]!.request.currentValues = [
-          buildMockCategoryFacetValueRequest({
-            state: 'idle',
-            value: 'value a',
-          }),
-          buildMockCategoryFacetValueRequest({
-            state: 'selected',
-            value: 'value b',
-          }),
-        ];
-        engineListener();
-      });
-
-      it('calls condition with the correct values', () => {
-        expect(condition).toHaveBeenCalledWith(
-          state.categoryFacetSet[parentFacetId]!.request.currentValues
-        );
-      });
-    });
-
-    describe('with a parent numeric facet', () => {
-      beforeEach(() => {
-        state.numericFacetSet[parentFacetId] = buildMockNumericFacetSlice();
-        state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
-        initCondition();
-        state.numericFacetSet[parentFacetId]!.request.currentValues = [
-          buildMockNumericFacetValue({
-            state: 'idle',
-            start: 0,
-            end: 10,
-          }),
-          buildMockNumericFacetValue({
-            state: 'selected',
-            start: 10,
-            end: 20,
-          }),
-        ];
-        engineListener();
-      });
-
-      it('calls condition with the correct values', () => {
-        expect(condition).toHaveBeenCalledWith(
-          state.numericFacetSet[parentFacetId]!.request.currentValues
-        );
-      });
-    });
-
-    describe('with a parent date facet', () => {
-      beforeEach(() => {
-        state.dateFacetSet[parentFacetId] = buildMockDateFacetSlice();
-        state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
-        initCondition();
-        state.dateFacetSet[parentFacetId]!.request.currentValues = [
-          buildMockDateFacetValue({
-            state: 'idle',
-            start: '0',
-            end: '10',
-          }),
-          buildMockDateFacetValue({
-            state: 'selected',
-            start: '10',
-            end: '20',
-          }),
-        ];
-        engineListener();
-      });
-
-      it('calls condition with the correct values', () => {
-        expect(condition).toHaveBeenCalledWith(
-          state.dateFacetSet[parentFacetId]!.request.currentValues
-        );
-      });
-    });
-  });
-
-  describe('with two conditions', () => {
-    const dependentFacetId = 'abc';
-    const parentFacetAId = 'def';
-    const parentFacetBId = 'ghi';
-    function updateFacetValues(facetId: string, conditionMet: boolean) {
-      const values = state.facetSet[facetId]!.request.currentValues;
-      const valueState: FacetValueState = conditionMet ? 'selected' : 'idle';
-      if (values.length) {
-        values[0].value += 'a';
-        values[0].state = valueState;
-      } else {
-        values.push({value: 'a', state: valueState});
+      function initCondition() {
+        state.facetSet[facetId] = buildMockFacetSlice();
+        state.facetOptions.facets[facetId] = buildFacetOptionsSlice();
+        facetConditionsManager = buildCoreFacetConditionsManager(engine, {
+          facetId: facetId,
+          conditions: [
+            {
+              parentFacetId,
+              condition: (condition = vi.fn(() => false)),
+            },
+          ],
+        });
       }
-    }
 
-    function getConditionIsMet(facetId: string) {
-      return (
-        state.facetSet?.[facetId]!.request.currentValues?.[0]?.state ===
-        'selected'
-      );
-    }
-
-    function initFacet({
-      facetId,
-      enabled,
-      conditionMet,
-    }: {
-      facetId: string;
-      enabled: boolean;
-      conditionMet?: boolean;
-    }) {
-      state.facetOptions.facets[facetId] = buildFacetOptionsSlice({enabled});
-      state.facetSet[facetId] = buildMockFacetSlice({
-        request: buildMockFacetRequest({facetId}),
-      });
-      if (conditionMet) {
-        updateFacetValues(facetId, true);
-      }
-    }
-
-    function initConditions() {
-      buildCoreFacetConditionsManager(engine, {
-        facetId: dependentFacetId,
-        conditions: [
-          {
-            parentFacetId: parentFacetAId,
-            condition: vi.fn(() => getConditionIsMet(parentFacetAId)),
-          },
-          {
-            parentFacetId: parentFacetBId,
-            condition: vi.fn(() => getConditionIsMet(parentFacetBId)),
-          },
-        ],
-      });
-    }
-
-    describe('when facets are initialized before the conditions manager', () => {
-      it('when all facets are enabled and no condition is met, disables the facet', () => {
-        initFacet({facetId: dependentFacetId, enabled: true});
-        initFacet({
-          facetId: parentFacetAId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+      it('subscribes', () => {
+        initCondition();
+        expect(engine.subscribe).toHaveBeenCalledTimes(1);
       });
 
-      it('when all facets are enabled and one condition is met, does not dispatch any action', () => {
-        initFacet({facetId: dependentFacetId, enabled: true});
-        initFacet({facetId: parentFacetAId, enabled: true, conditionMet: true});
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(engine.dispatch).not.toHaveBeenCalled();
+      it('when stopWatching is called, unsubscribes', () => {
+        initCondition();
+        facetConditionsManager.stopWatching();
+        expect(engineUnsubscriber).toHaveBeenCalledTimes(1);
       });
 
-      it('when only the child facet is disabled and no condition is met, does not dispatch any action', () => {
-        initFacet({facetId: dependentFacetId, enabled: false});
-        initFacet({
-          facetId: parentFacetAId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(engine.dispatch).not.toHaveBeenCalled();
-      });
-
-      it('when only the child facet is disabled and one condition is met, enables the facet', () => {
-        initFacet({facetId: dependentFacetId, enabled: false});
-        initFacet({facetId: parentFacetAId, enabled: true, conditionMet: true});
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
-      });
-
-      it('when only facet B is enabled and condition A is met, does not dispatch any action', () => {
-        initFacet({facetId: dependentFacetId, enabled: false});
-        initFacet({
-          facetId: parentFacetAId,
-          enabled: false,
-          conditionMet: true,
-        });
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(engine.dispatch).not.toHaveBeenCalled();
-      });
-
-      it('when only facet A is enabled and condition A is met, enables the facet', () => {
-        initFacet({facetId: dependentFacetId, enabled: false});
-        initFacet({facetId: parentFacetAId, enabled: true, conditionMet: true});
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: false,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
-      });
-
-      it('when only facet A is disabled and condition A is met, disables the facet', () => {
-        initFacet({facetId: dependentFacetId, enabled: true});
-        initFacet({
-          facetId: parentFacetAId,
-          enabled: false,
-          conditionMet: true,
-        });
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: true,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
-      });
-
-      it('when only facet B is disabled and condition A is met, does not dispatch any action', () => {
-        initFacet({facetId: dependentFacetId, enabled: true});
-        initFacet({facetId: parentFacetAId, enabled: true, conditionMet: true});
-        initFacet({
-          facetId: parentFacetBId,
-          enabled: false,
-          conditionMet: false,
-        });
-        initConditions();
-        expect(engine.dispatch).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when facets are initialized after the conditions manager', () => {
-      beforeEach(() => {
-        initConditions();
-        engineListener();
-      });
-
-      it('does not dispatch any action', () => {
-        expect(engine.dispatch).not.toHaveBeenCalled();
-      });
-
-      describe('when the dependent facet is initialized and enabled', () => {
+      describe('with a parent facet', () => {
         beforeEach(() => {
+          state.facetSet[parentFacetId] = buildMockFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.facetSet[parentFacetId]!.request.currentValues = [
+            buildMockFacetValueRequest({
+              state: 'idle',
+              value: 'value a',
+            }),
+            buildMockFacetValueRequest({
+              state: 'selected',
+              value: 'value b',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.facetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent category facet', () => {
+        beforeEach(() => {
+          state.categoryFacetSet[parentFacetId] = buildMockCategoryFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.categoryFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockCategoryFacetValueRequest({
+              state: 'idle',
+              value: 'value a',
+            }),
+            buildMockCategoryFacetValueRequest({
+              state: 'selected',
+              value: 'value b',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.categoryFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent numeric facet', () => {
+        beforeEach(() => {
+          state.numericFacetSet[parentFacetId] = buildMockNumericFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.numericFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockNumericFacetValue({
+              state: 'idle',
+              start: 0,
+              end: 10,
+            }),
+            buildMockNumericFacetValue({
+              state: 'selected',
+              start: 10,
+              end: 20,
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.numericFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent date facet', () => {
+        beforeEach(() => {
+          state.dateFacetSet[parentFacetId] = buildMockDateFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.dateFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockDateFacetValue({
+              state: 'idle',
+              start: '0',
+              end: '10',
+            }),
+            buildMockDateFacetValue({
+              state: 'selected',
+              start: '10',
+              end: '20',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.dateFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+    });
+
+    describe('with two conditions', () => {
+      const dependentFacetId = 'abc';
+      const parentFacetAId = 'def';
+      const parentFacetBId = 'ghi';
+      function updateFacetValues(facetId: string, conditionMet: boolean) {
+        const values = state.facetSet[facetId]!.request.currentValues;
+        const valueState: FacetValueState = conditionMet ? 'selected' : 'idle';
+        if (values.length) {
+          values[0].value += 'a';
+          values[0].state = valueState;
+        } else {
+          values.push({value: 'a', state: valueState});
+        }
+      }
+
+      function getConditionIsMet(facetId: string) {
+        return (
+          state.facetSet?.[facetId]!.request.currentValues?.[0]?.state ===
+          'selected'
+        );
+      }
+
+      function initFacet({
+        facetId,
+        enabled,
+        conditionMet,
+      }: {
+        facetId: string;
+        enabled: boolean;
+        conditionMet?: boolean;
+      }) {
+        state.facetOptions.facets[facetId] = buildFacetOptionsSlice({enabled});
+        state.facetSet[facetId] = buildMockFacetSlice({
+          request: buildMockFacetRequest({facetId}),
+        });
+        if (conditionMet) {
+          updateFacetValues(facetId, true);
+        }
+      }
+
+      function initConditions() {
+        buildCoreFacetConditionsManager(engine, {
+          facetId: dependentFacetId,
+          conditions: [
+            {
+              parentFacetId: parentFacetAId,
+              condition: vi.fn(() => getConditionIsMet(parentFacetAId)),
+            },
+            {
+              parentFacetId: parentFacetBId,
+              condition: vi.fn(() => getConditionIsMet(parentFacetBId)),
+            },
+          ],
+        });
+      }
+
+      describe('when facets are initialized before the conditions manager', () => {
+        it('when all facets are enabled and no condition is met, disables the facet', () => {
           initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
         });
 
-        describe('and no parent is initialized', () => {
-          beforeEach(() => {
-            engineListener();
+        it('when all facets are enabled and one condition is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
           });
-
-          it('disables the facet', () => {
-            expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
           });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
         });
 
-        describe("and a parent is initialized but its condition isn't met", () => {
-          beforeEach(() => {
-            initFacet({
-              facetId: parentFacetAId,
-              enabled: true,
-              conditionMet: false,
-            });
-            engineListener();
+        it('when only the child facet is disabled and no condition is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: false,
           });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
 
-          it('disables the facet', () => {
-            expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        it('when only the child facet is disabled and one condition is met, enables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
           });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when only facet B is enabled and condition A is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: false,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('when only facet A is enabled and condition A is met, enables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: false,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when only facet A is disabled and condition A is met, disables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: false,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when only facet B is disabled and condition A is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: false,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
         });
       });
 
-      describe('when the dependent facet is initialized and disabled', () => {
+      describe('when facets are initialized after the conditions manager', () => {
         beforeEach(() => {
-          initFacet({facetId: dependentFacetId, enabled: false});
+          initConditions();
+          engineListener();
         });
 
-        describe('and a parent is initialized and its condition is met', () => {
-          beforeEach(() => {
-            initFacet({
-              facetId: parentFacetAId,
-              enabled: true,
-              conditionMet: true,
-            });
-            engineListener();
-          });
-
-          it('enables the facet', () => {
-            expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
-          });
+        it('does not dispatch any action', () => {
+          expect(engine.dispatch).not.toHaveBeenCalled();
         });
 
-        describe("and a parent is initialized and it condition isn't met", () => {
+        describe('when the dependent facet is initialized and enabled', () => {
           beforeEach(() => {
-            initFacet({
-              facetId: parentFacetAId,
-              enabled: true,
-              conditionMet: false,
-            });
-            engineListener();
+            initFacet({facetId: dependentFacetId, enabled: true});
           });
 
-          it('does not dispatch any action', () => {
-            expect(engine.dispatch).not.toHaveBeenCalled();
-          });
-
-          describe('then facet values are updated and the condition becomes met', () => {
+          describe('and no parent is initialized', () => {
             beforeEach(() => {
-              updateFacetValues(parentFacetAId, true);
+              engineListener();
+            });
+
+            it('disables the facet', () => {
+              expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+            });
+          });
+
+          describe("and a parent is initialized but its condition isn't met", () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: false,
+              });
+              engineListener();
+            });
+
+            it('disables the facet', () => {
+              expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+            });
+          });
+        });
+
+        describe('when the dependent facet is initialized and disabled', () => {
+          beforeEach(() => {
+            initFacet({facetId: dependentFacetId, enabled: false});
+          });
+
+          describe('and a parent is initialized and its condition is met', () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: true,
+              });
               engineListener();
             });
 
             it('enables the facet', () => {
               expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
+            });
+          });
+
+          describe("and a parent is initialized and it condition isn't met", () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: false,
+              });
+              engineListener();
+            });
+
+            it('does not dispatch any action', () => {
+              expect(engine.dispatch).not.toHaveBeenCalled();
+            });
+
+            describe('then facet values are updated and the condition becomes met', () => {
+              beforeEach(() => {
+                updateFacetValues(parentFacetAId, true);
+                engineListener();
+              });
+
+              it('enables the facet', () => {
+                expect(enableFacet).toHaveBeenCalledWith(dependentFacetId);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('when the facet is disabled by the tab', () => {
+    beforeEach(() => {
+      vi.mocked(isFacetVisibleOnTab).mockReturnValue(false);
+    });
+
+    describe('with a single condition', () => {
+      const facetId = 'abc';
+      const parentFacetId = 'def';
+      let facetConditionsManager: FacetConditionsManager;
+      let condition: Mock;
+
+      function initCondition() {
+        state.facetSet[facetId] = buildMockFacetSlice();
+        state.facetOptions.facets[facetId] = buildFacetOptionsSlice();
+        facetConditionsManager = buildCoreFacetConditionsManager(engine, {
+          facetId: facetId,
+          conditions: [
+            {
+              parentFacetId,
+              condition: (condition = vi.fn(() => false)),
+            },
+          ],
+        });
+      }
+
+      it('subscribes', () => {
+        initCondition();
+        expect(engine.subscribe).toHaveBeenCalledTimes(1);
+      });
+
+      it('when stopWatching is called, unsubscribes', () => {
+        initCondition();
+        facetConditionsManager.stopWatching();
+        expect(engineUnsubscriber).toHaveBeenCalledTimes(1);
+      });
+
+      describe('with a parent facet', () => {
+        beforeEach(() => {
+          state.facetSet[parentFacetId] = buildMockFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.facetSet[parentFacetId]!.request.currentValues = [
+            buildMockFacetValueRequest({
+              state: 'idle',
+              value: 'value a',
+            }),
+            buildMockFacetValueRequest({
+              state: 'selected',
+              value: 'value b',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.facetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent category facet', () => {
+        beforeEach(() => {
+          state.categoryFacetSet[parentFacetId] = buildMockCategoryFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.categoryFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockCategoryFacetValueRequest({
+              state: 'idle',
+              value: 'value a',
+            }),
+            buildMockCategoryFacetValueRequest({
+              state: 'selected',
+              value: 'value b',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.categoryFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent numeric facet', () => {
+        beforeEach(() => {
+          state.numericFacetSet[parentFacetId] = buildMockNumericFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.numericFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockNumericFacetValue({
+              state: 'idle',
+              start: 0,
+              end: 10,
+            }),
+            buildMockNumericFacetValue({
+              state: 'selected',
+              start: 10,
+              end: 20,
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.numericFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+
+      describe('with a parent date facet', () => {
+        beforeEach(() => {
+          state.dateFacetSet[parentFacetId] = buildMockDateFacetSlice();
+          state.facetOptions.facets[parentFacetId] = buildFacetOptionsSlice();
+          initCondition();
+          state.dateFacetSet[parentFacetId]!.request.currentValues = [
+            buildMockDateFacetValue({
+              state: 'idle',
+              start: '0',
+              end: '10',
+            }),
+            buildMockDateFacetValue({
+              state: 'selected',
+              start: '10',
+              end: '20',
+            }),
+          ];
+          engineListener();
+        });
+
+        it('calls condition with the correct values', () => {
+          expect(condition).toHaveBeenCalledWith(
+            state.dateFacetSet[parentFacetId]!.request.currentValues
+          );
+        });
+      });
+    });
+
+    describe('with two conditions', () => {
+      const dependentFacetId = 'abc';
+      const parentFacetAId = 'def';
+      const parentFacetBId = 'ghi';
+      function updateFacetValues(facetId: string, conditionMet: boolean) {
+        const values = state.facetSet[facetId]!.request.currentValues;
+        const valueState: FacetValueState = conditionMet ? 'selected' : 'idle';
+        if (values.length) {
+          values[0].value += 'a';
+          values[0].state = valueState;
+        } else {
+          values.push({value: 'a', state: valueState});
+        }
+      }
+
+      function getConditionIsMet(facetId: string) {
+        return (
+          state.facetSet?.[facetId]!.request.currentValues?.[0]?.state ===
+          'selected'
+        );
+      }
+
+      function initFacet({
+        facetId,
+        enabled,
+        conditionMet,
+      }: {
+        facetId: string;
+        enabled: boolean;
+        conditionMet?: boolean;
+      }) {
+        state.facetOptions.facets[facetId] = buildFacetOptionsSlice({enabled});
+        state.facetSet[facetId] = buildMockFacetSlice({
+          request: buildMockFacetRequest({facetId}),
+        });
+        if (conditionMet) {
+          updateFacetValues(facetId, true);
+        }
+      }
+
+      function initConditions() {
+        buildCoreFacetConditionsManager(engine, {
+          facetId: dependentFacetId,
+          conditions: [
+            {
+              parentFacetId: parentFacetAId,
+              condition: vi.fn(() => getConditionIsMet(parentFacetAId)),
+            },
+            {
+              parentFacetId: parentFacetBId,
+              condition: vi.fn(() => getConditionIsMet(parentFacetBId)),
+            },
+          ],
+        });
+      }
+
+      describe('when facets are initialized before the conditions manager', () => {
+        it('when all facets are enabled and no condition is met, disables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when all facets are enabled and one condition is met, disables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when only the child facet is disabled and no condition is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('when only the child facet is disabled and one condition is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('when only facet B is enabled and condition A is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: false,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('when only facet A is enabled and condition A is met, does not dispatch any action', () => {
+          initFacet({facetId: dependentFacetId, enabled: false});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: false,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        it('when only facet A is disabled and condition A is met, disables the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: false,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: true,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+
+        it('when only facet B is disabled and condition A is met, disable the facet', () => {
+          initFacet({facetId: dependentFacetId, enabled: true});
+          initFacet({
+            facetId: parentFacetAId,
+            enabled: true,
+            conditionMet: true,
+          });
+          initFacet({
+            facetId: parentFacetBId,
+            enabled: false,
+            conditionMet: false,
+          });
+          initConditions();
+          expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+        });
+      });
+
+      describe('when facets are initialized after the conditions manager', () => {
+        beforeEach(() => {
+          initConditions();
+          engineListener();
+        });
+
+        it('does not dispatch any action', () => {
+          expect(engine.dispatch).not.toHaveBeenCalled();
+        });
+
+        describe('when the dependent facet is initialized and enabled', () => {
+          beforeEach(() => {
+            initFacet({facetId: dependentFacetId, enabled: true});
+          });
+
+          describe('and no parent is initialized', () => {
+            beforeEach(() => {
+              engineListener();
+            });
+
+            it('disables the facet', () => {
+              expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+            });
+          });
+
+          describe("and a parent is initialized but its condition isn't met", () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: false,
+              });
+              engineListener();
+            });
+
+            it('disables the facet', () => {
+              expect(disableFacet).toHaveBeenCalledWith(dependentFacetId);
+            });
+          });
+        });
+
+        describe('when the dependent facet is initialized and disabled', () => {
+          beforeEach(() => {
+            initFacet({facetId: dependentFacetId, enabled: false});
+          });
+
+          describe('and a parent is initialized and its condition is met', () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: true,
+              });
+              engineListener();
+            });
+
+            it('does not dispatch any action', () => {
+              expect(engine.dispatch).not.toHaveBeenCalled();
+            });
+          });
+
+          describe("and a parent is initialized and it condition isn't met", () => {
+            beforeEach(() => {
+              initFacet({
+                facetId: parentFacetAId,
+                enabled: true,
+                conditionMet: false,
+              });
+              engineListener();
+            });
+
+            it('does not dispatch any action', () => {
+              expect(engine.dispatch).not.toHaveBeenCalled();
+            });
+
+            describe('then facet values are updated and the condition becomes met', () => {
+              beforeEach(() => {
+                updateFacetValues(parentFacetAId, true);
+                engineListener();
+              });
+
+              it('does not dispatch any action', () => {
+                expect(engine.dispatch).not.toHaveBeenCalled();
+              });
             });
           });
         });

--- a/packages/headless/src/features/facet-options/facet-options-slice.test.ts
+++ b/packages/headless/src/features/facet-options/facet-options-slice.test.ts
@@ -4,7 +4,6 @@ import {logSearchEvent} from '../analytics/analytics-actions.js';
 import {change} from '../history/history-actions.js';
 import {getHistoryInitialState} from '../history/history-state.js';
 import {executeSearch} from '../search/search-actions.js';
-import {updateActiveTab} from '../tab-set/tab-set-actions.js';
 import {updateFacetOptions} from './facet-options-actions.js';
 import {facetOptionsReducer} from './facet-options-slice.js';
 import {
@@ -40,72 +39,6 @@ describe('facet options slice', () => {
 
       expect(finalState.freezeFacetOrder).toBe(true);
     });
-  });
-
-  describe('update facet enabled state on updateActiveTab', () => {
-    const initialState = getFacetOptionsInitialState();
-    initialState.facets = {
-      notIncluded: {
-        enabled: true,
-        tabs: {
-          included: ['tab1'],
-          excluded: [],
-        },
-      },
-      included: {
-        enabled: false,
-        tabs: {
-          included: ['tab2'],
-          excluded: [],
-        },
-      },
-      notExcluded: {
-        enabled: true,
-        tabs: {
-          included: [],
-          excluded: ['tab1'],
-        },
-      },
-      excluded: {
-        enabled: true,
-        tabs: {
-          included: [],
-          excluded: ['tab2'],
-        },
-      },
-      notExcludedNotIncluded: {
-        enabled: true,
-        tabs: {
-          included: ['tab1'],
-          excluded: ['tab1'],
-        },
-      },
-      excludedAndIncluded: {
-        enabled: true,
-        tabs: {
-          included: ['tab2'],
-          excluded: ['tab2'],
-        },
-      },
-    };
-    const action = updateActiveTab('tab2');
-    const finalState = facetOptionsReducer(initialState, action);
-
-    const testCases: [string, boolean][] = [
-      ['notIncluded', false],
-      ['included', true],
-      ['notExcluded', true],
-      ['excluded', false],
-      ['notExcludedNotIncluded', false],
-      ['excludedAndIncluded', false],
-    ];
-
-    test.each(testCases)(
-      '%s facet should have enabled state %s',
-      (facet: string, expectedEnabled: boolean) => {
-        expect(finalState.facets[facet].enabled).toBe(expectedEnabled);
-      }
-    );
   });
 
   it('#executeSearch.fulfilled sets #freezeFacetOrder to false', () => {

--- a/packages/headless/src/features/facet-options/facet-options-slice.ts
+++ b/packages/headless/src/features/facet-options/facet-options-slice.ts
@@ -6,7 +6,6 @@ import {registerNumericFacet} from '../facets/range-facets/numeric-facet-set/num
 import {change} from '../history/history-actions.js';
 import {restoreSearchParameters} from '../search-parameters/search-parameter-actions.js';
 import {executeSearch} from '../search/search-actions.js';
-import {updateActiveTab} from '../tab-set/tab-set-actions.js';
 import {
   disableFacet,
   enableFacet,
@@ -17,7 +16,6 @@ import {
   getFacetOptionsInitialState,
   FacetOptionsState,
 } from './facet-options-state.js';
-import {isFacetIncludedOnTab} from './facet-options-utils.js';
 
 export const facetOptionsReducer = createReducer(
   getFacetOptionsInitialState(),
@@ -32,38 +30,29 @@ export const facetOptionsReducer = createReducer(
       .addCase(executeSearch.rejected, (state) => {
         state.freezeFacetOrder = false;
       })
-      .addCase(updateActiveTab, (state, action) => {
-        for (const facetId in state.facets) {
-          const facet = state.facets[facetId];
-
-          if (Object.keys({...facet.tabs}).length > 0) {
-            facet.enabled = isFacetIncludedOnTab(facet.tabs, action.payload);
-          }
-        }
-      })
       .addCase(
         change.fulfilled,
         (state, action) => action.payload?.facetOptions ?? state
       )
       .addCase(registerCategoryFacet, (state, action) => {
-        const {facetId, tabs, activeTab} = action.payload;
+        const {facetId, tabs} = action.payload;
 
-        handleRegisterFacetTabs(tabs, activeTab, state, facetId);
+        handleRegisterFacetTabs(tabs, state, facetId);
       })
       .addCase(registerFacet, (state, action) => {
-        const {facetId, tabs, activeTab} = action.payload;
+        const {facetId, tabs} = action.payload;
 
-        handleRegisterFacetTabs(tabs, activeTab, state, facetId);
+        handleRegisterFacetTabs(tabs, state, facetId);
       })
       .addCase(registerDateFacet, (state, action) => {
-        const {facetId, tabs, activeTab} = action.payload;
+        const {facetId, tabs} = action.payload;
 
-        handleRegisterFacetTabs(tabs, activeTab, state, facetId);
+        handleRegisterFacetTabs(tabs, state, facetId);
       })
       .addCase(registerNumericFacet, (state, action) => {
-        const {facetId, tabs, activeTab} = action.payload;
+        const {facetId, tabs} = action.payload;
 
-        handleRegisterFacetTabs(tabs, activeTab, state, facetId);
+        handleRegisterFacetTabs(tabs, state, facetId);
       })
       .addCase(enableFacet, (state, action) => {
         state.facets[action.payload].enabled = true;
@@ -72,16 +61,16 @@ export const facetOptionsReducer = createReducer(
         state.facets[action.payload].enabled = false;
       })
       .addCase(restoreSearchParameters, (state, action) => {
-        if (action.payload.tab) {
-          Object.entries(state.facets).forEach(([, facet]) => {
-            if (Object.keys(facet.tabs ?? {}).length > 0) {
-              facet.enabled = isFacetIncludedOnTab(
-                facet.tabs,
-                action.payload.tab
-              );
-            }
-          });
-        }
+        // if (action.payload.tab) {
+        //   Object.entries(state.facets).forEach(([, facet]) => {
+        //     if (Object.keys(facet.tabs ?? {}).length > 0) {
+        //       facet.enabled = isFacetVisibleOnTab(
+        //         facet.tabs,
+        //         action.payload.tab
+        //       );
+        //     }
+        //   });
+        // }
         [
           ...Object.keys(action.payload.f ?? {}),
           ...Object.keys(action.payload.fExcluded ?? {}),
@@ -100,7 +89,6 @@ export const facetOptionsReducer = createReducer(
 
 function handleRegisterFacetTabs(
   tabs: {included?: string[]; excluded?: string[]} | undefined,
-  activeTab: string | undefined,
   state: FacetOptionsState,
   facetId: string
 ) {
@@ -109,9 +97,9 @@ function handleRegisterFacetTabs(
     tabs: tabs ?? {},
   };
 
-  if (tabs && Object.keys(tabs).length > 0) {
-    newFacetState.enabled = isFacetIncludedOnTab(tabs, activeTab);
-  }
+  // if (tabs && Object.keys(tabs).length > 0) {
+  //   newFacetState.enabled = isFacetVisibleOnTab(tabs, activeTab);
+  // }
 
   state.facets[facetId] = newFacetState;
 }

--- a/packages/headless/src/features/facet-options/facet-options-utils.test.ts
+++ b/packages/headless/src/features/facet-options/facet-options-utils.test.ts
@@ -1,39 +1,39 @@
-import {isFacetIncludedOnTab} from './facet-options-utils.js';
+import {isFacetVisibleOnTab} from './facet-options-utils.js';
 
 describe('isFacetIncludedOnTab', () => {
   it('returns true when facetTabs or activeTab is undefined', () => {
-    expect(isFacetIncludedOnTab(undefined, 'tab1')).toBe(true);
-    expect(isFacetIncludedOnTab({excluded: ['tab2']}, undefined)).toBe(true);
-    expect(isFacetIncludedOnTab(undefined, undefined)).toBe(true);
+    expect(isFacetVisibleOnTab(undefined, 'tab1')).toBe(true);
+    expect(isFacetVisibleOnTab({excluded: ['tab2']}, undefined)).toBe(true);
+    expect(isFacetVisibleOnTab(undefined, undefined)).toBe(true);
   });
 
   it('returns false when activeTab is in facetTabs.excluded', () => {
     const facetTabs = {excluded: ['tab2', 'tab3']};
-    expect(isFacetIncludedOnTab(facetTabs, 'tab2')).toBe(false);
-    expect(isFacetIncludedOnTab(facetTabs, 'tab3')).toBe(false);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab2')).toBe(false);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab3')).toBe(false);
   });
 
   it('returns true when facetTabs.included is empty or activeTab is in facetTabs.included', () => {
     const facetTabs = {included: []};
-    expect(isFacetIncludedOnTab(facetTabs, 'tab1')).toBe(true);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab1')).toBe(true);
 
     const facetTabsWithIncluded = {included: ['tab1', 'tab2']};
-    expect(isFacetIncludedOnTab(facetTabsWithIncluded, 'tab1')).toBe(true);
-    expect(isFacetIncludedOnTab(facetTabsWithIncluded, 'tab2')).toBe(true);
+    expect(isFacetVisibleOnTab(facetTabsWithIncluded, 'tab1')).toBe(true);
+    expect(isFacetVisibleOnTab(facetTabsWithIncluded, 'tab2')).toBe(true);
   });
 
   it('returns false when activeTab is not in facetTabs.included', () => {
     const facetTabs = {included: ['tab1', 'tab2']};
-    expect(isFacetIncludedOnTab(facetTabs, 'tab3')).toBe(false);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab3')).toBe(false);
   });
 
   it('returns false when activeTab is in facetTabs.excluded and included', () => {
     const facetTabs = {included: ['tab1'], excluded: ['tab1']};
-    expect(isFacetIncludedOnTab(facetTabs, 'tab1')).toBe(false);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab1')).toBe(false);
   });
 
   it('returns false when activeTab is not in facetTabs.included and not in excluded', () => {
     const facetTabs = {included: ['tab1'], excluded: ['tab2']};
-    expect(isFacetIncludedOnTab(facetTabs, 'tab3')).toBe(false);
+    expect(isFacetVisibleOnTab(facetTabs, 'tab3')).toBe(false);
   });
 });

--- a/packages/headless/src/features/facet-options/facet-options-utils.ts
+++ b/packages/headless/src/features/facet-options/facet-options-utils.ts
@@ -1,4 +1,4 @@
-export const isFacetIncludedOnTab = (
+export const isFacetVisibleOnTab = (
   facetTabs: {excluded?: string[]; included?: string[]} | undefined,
   activeTab: string | undefined
 ) => {


### PR DESCRIPTION
This allows the logic to be properly handled at a single place

notably, this fix conflict between conditions and tabsIncluded/Excluded

KIT-4315

https://coveord.atlassian.net/browse/KIT-4315
