### PR TITLE
chore(atomic): add commerce-layout mixin

### DIFF
--- a/packages/atomic/src/decorators/light-dom.spec.ts
+++ b/packages/atomic/src/decorators/light-dom.spec.ts
@@ -1,10 +1,25 @@
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
-import {html, LitElement, unsafeCSS} from 'lit';
+import {css, html, LitElement, unsafeCSS} from 'lit';
 import {describe, beforeEach, it, expect} from 'vitest';
 import {injectStylesForNoShadowDOM} from './light-dom';
 
 describe('injectStylesForNoShadowDOM', () => {
   const styles = 'body { background-color: red; }';
+
+  @injectStylesForNoShadowDOM
+  class ComplexStyledElement extends LitElement {
+    static styles = [
+      unsafeCSS(styles),
+      unsafeCSS(css`
+        div {
+          color: blue;
+        }
+      `),
+    ];
+    render() {
+      return html`<div>children element</div>`;
+    }
+  }
 
   @injectStylesForNoShadowDOM
   class StyledElement extends LitElement {
@@ -45,6 +60,7 @@ describe('injectStylesForNoShadowDOM', () => {
   customElements.define('light-dom-parent-element', LightDomParentElement);
   customElements.define('shadow-dom-parent-element', ShadownDomParentElement);
   customElements.define('styled-element', StyledElement);
+  customElements.define('complex-styled-element', ComplexStyledElement);
   customElements.define('unstyled-element', UnstyledElement);
 
   describe('when the element added in a shadow dom does not contain style', () => {
@@ -92,6 +108,24 @@ describe('injectStylesForNoShadowDOM', () => {
       const styleElement = document?.adoptedStyleSheets || [];
 
       expect(styleElement).toHaveLength(0);
+    });
+  });
+
+  describe('when the element has an array of styles', () => {
+    beforeEach(async () => {
+      await fixture(html`
+        <shadow-dom-parent-element>
+          <complex-styled-element></complex-styled-element>
+        </shadow-dom-parent-element>
+      `);
+    });
+
+    it('should have added 2 stylesheets', async () => {
+      const styleElement =
+        document.querySelector('shadow-dom-parent-element')?.shadowRoot
+          ?.adoptedStyleSheets || [];
+
+      expect(styleElement).toHaveLength(2);
     });
   });
 

--- a/packages/atomic/src/decorators/light-dom.ts
+++ b/packages/atomic/src/decorators/light-dom.ts
@@ -2,7 +2,7 @@ import {CSSResult} from 'lit';
 
 export const injectStylesForNoShadowDOM = <
   T extends {
-    styles: CSSResult;
+    styles: CSSResult | CSSResult[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     new (...args: any[]): any;
   },
@@ -21,16 +21,17 @@ export const injectStylesForNoShadowDOM = <
 
     injectStyles() {
       const parent = this.getRootNode();
-      const styleSheet = Base.styles?.styleSheet;
+      const styles = Array.isArray(Base.styles) ? Base.styles : [Base.styles];
       const isDocumentOrShadowRoot =
         parent instanceof Document || parent instanceof ShadowRoot;
 
-      if (
-        styleSheet &&
-        isDocumentOrShadowRoot &&
-        !parent.adoptedStyleSheets.includes(styleSheet)
-      ) {
-        parent.adoptedStyleSheets.push(styleSheet);
+      if (isDocumentOrShadowRoot) {
+        for (const style of styles) {
+          const styleSheet = style?.styleSheet;
+          if (styleSheet && !parent.adoptedStyleSheets.includes(styleSheet)) {
+            parent.adoptedStyleSheets.push(styleSheet);
+          }
+        }
       }
     }
   };

--- a/packages/atomic/src/mixins/bindings-mixin.ts
+++ b/packages/atomic/src/mixins/bindings-mixin.ts
@@ -7,6 +7,7 @@ import type {
 import type {AnyBindings} from '../components/common/interface/bindings';
 import {InitializableComponent} from '../decorators/types';
 import {fetchBindings} from '../utils/initialization-lit-stencil-common-utils';
+import {Constructor} from './mixin-common';
 
 function initializeBindings<
   SpecificBindings extends AnyBindings,
@@ -76,9 +77,6 @@ export class BindingController implements ReactiveController {
     this.unsubscribeLanguage();
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Constructor<T = {}> = new (...args: any[]) => T;
 
 /**
  * Mixin that initializes bindings for a Lit component.

--- a/packages/atomic/src/mixins/children-update-complete-mixin.ts
+++ b/packages/atomic/src/mixins/children-update-complete-mixin.ts
@@ -1,8 +1,6 @@
 import {HTMLStencilElement} from '@stencil/core/internal';
 import {LitElement} from 'lit';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Constructor<T = {}> = new (...args: any[]) => T;
+import {Constructor} from './mixin-common';
 
 export const ChildrenUpdateCompleteMixin = <T extends Constructor<LitElement>>(
   superClass: T

--- a/packages/atomic/src/mixins/commerce-layout-mixin.spec.ts
+++ b/packages/atomic/src/mixins/commerce-layout-mixin.spec.ts
@@ -1,0 +1,71 @@
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {LitElement, unsafeCSS, html, CSSResult} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
+import {describe, it, expect, vi} from 'vitest';
+import {buildCommerceLayout} from '../components/commerce/atomic-commerce-layout/commerce-layout';
+import {DEFAULT_MOBILE_BREAKPOINT} from '../utils/replace-breakpoint';
+import {CommerceLayoutMixin} from './commerce-layout-mixin';
+
+vi.mock('../components/commerce/atomic-commerce-layout/commerce-layout', {
+  spy: true,
+});
+
+const dummyCss = '.foo { color: red; }';
+
+@customElement('test-commerce-layout')
+class TestElement extends CommerceLayoutMixin(LitElement, unsafeCSS(dummyCss)) {
+  @property({type: String, reflect: true, attribute: 'mobile-breakpoint'})
+  mobileBreakpoint: string = DEFAULT_MOBILE_BREAKPOINT;
+}
+
+const setupElement = async (props?: {breakpoint?: string}) => {
+  const element = (await fixture(
+    html`<test-commerce-layout
+      mobile-breakpoint="${ifDefined(props?.breakpoint)}"
+    ></test-commerce-layout>`
+  )) as TestElement;
+  return element;
+};
+
+describe('CommerceLayoutMixin', () => {
+  it('should call #mockBuildCommerceLayout with default mobileBreakpoint', async () => {
+    const element = await setupElement();
+    const mockBuildCommerceLayout = vi.mocked(buildCommerceLayout);
+    expect(mockBuildCommerceLayout).toHaveBeenCalledWith(
+      element,
+      DEFAULT_MOBILE_BREAKPOINT
+    );
+  });
+
+  it('should call #mockBuildCommerceLayout with specified mobileBreakpoint', async () => {
+    const element = await setupElement({breakpoint: '600px'});
+    const mockBuildCommerceLayout = vi.mocked(buildCommerceLayout);
+    expect(mockBuildCommerceLayout).toHaveBeenCalledWith(element, '600px');
+  });
+
+  it('should set a random id if not present', async () => {
+    const element = await setupElement();
+    expect(element.id).toMatch(/^atomic-commerce-layout-/);
+  });
+
+  it('should only have one CSS style in the component style array (control test)', async () => {
+    @customElement('baseline-element')
+    class BaselineElement extends LitElement {
+      static styles = [unsafeCSS(dummyCss)];
+    }
+    const element = (await fixture(
+      html`<baseline-element></baseline-element>`
+    )) as BaselineElement;
+    const stylesArr = (element.constructor as typeof TestElement)
+      .styles! as CSSResult[];
+    expect(stylesArr.length).toBe(1);
+  });
+
+  it('should add dynamic layout CSS to styles on connectedCallback', async () => {
+    const element = await setupElement();
+    const stylesArr = (element.constructor as typeof TestElement)
+      .styles! as CSSResult[];
+    expect(stylesArr.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/atomic/src/mixins/commerce-layout-mixin.ts
+++ b/packages/atomic/src/mixins/commerce-layout-mixin.ts
@@ -1,0 +1,36 @@
+import {CSSResult, LitElement, unsafeCSS} from 'lit';
+import {buildCommerceLayout} from '../components/commerce/atomic-commerce-layout/commerce-layout';
+import {injectStylesForNoShadowDOM} from '../decorators/light-dom';
+import {DEFAULT_MOBILE_BREAKPOINT} from '../utils/replace-breakpoint';
+import {randomID} from '../utils/utils';
+import {Constructor} from './mixin-common';
+
+export const CommerceLayoutMixin = <T extends Constructor<LitElement>>(
+  superClass: T,
+  cssResult: CSSResult
+) => {
+  @injectStylesForNoShadowDOM
+  class CommerceLayoutMixinClass extends superClass {
+    protected mobileBreakpoint: string = DEFAULT_MOBILE_BREAKPOINT;
+
+    static styles = [cssResult];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      super(...args);
+      if (!this.id) {
+        this.id = randomID('atomic-commerce-layout-');
+      }
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+      const layout = unsafeCSS(
+        buildCommerceLayout(this, this.mobileBreakpoint)
+      );
+      CommerceLayoutMixinClass.styles.unshift(layout);
+    }
+  }
+
+  return CommerceLayoutMixinClass as T;
+};

--- a/packages/atomic/src/mixins/mixin-common.ts
+++ b/packages/atomic/src/mixins/mixin-common.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Constructor<T = {}> = new (...args: any[]) => T;


### PR DESCRIPTION
Added the `CommerceLayoutMixin` for Lit components, which automatically injects dynamic layout styles and manages the layout breakpoint. 

Instead of manually injecting styles and IDs in lifecycle hooks, components can now simply extend the mixin:

The mixin handles:
- Unique ID assignment
- Dynamic and static style injection
- Consistent mobileBreakpoint management

This results in cleaner, more reusable, and more maintainable layout components.

### Before
```tsx
export class MyElement implements InitializableComponent<Bindings> {
  @InitializeBindings() public bindings!: Bindings;

  public componentDidLoad() {
    const id = this.host.id || randomID('atomic-commerce-layout-');
    this.host.id = id;

    const styleSheet = new CSSStyleSheet();
    styleSheet.replaceSync(
      buildCommerceLayout(this.host, this.mobileBreakpoint)
    );
    this.bindings.addAdoptedStyleSheets(styleSheet);
  }

 // ...
}
```

### Now
```ts
@customElement('my-element')
class MyElement extends CommerceLayoutMixin(LitElement, unsafeCSS(css`...`)) {
  // ...
}
```


https://coveord.atlassian.net/browse/KIT-4334