### PR TITLE
chore(atomic): remove style management from bindings

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
@@ -116,18 +116,6 @@ export class TestElement
   public bindings: CommerceBindings = {} as CommerceBindings;
   @state() public error!: Error;
 
-  // TODO: KIT-4333: do not add stylesheet in the bindings
-  // use @injectStylesForNoShadowDOM instead
-  public addStyles(styles: string | CSSStyleSheet) {
-    if (typeof styles === 'string') {
-      const styleSheet = new CSSStyleSheet();
-      styleSheet.replaceSync(styles);
-      this.bindings.addAdoptedStyleSheets(styleSheet);
-    } else if (styles instanceof CSSStyleSheet) {
-      this.bindings.addAdoptedStyleSheets(styles);
-    }
-  }
-
   public initialized = false;
 
   public render() {
@@ -258,20 +246,6 @@ describe('AtomicCommerceInterface', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         `Could not find the scroll container with the selector "${element.scrollContainer}". This will prevent UX interactions that require a scroll from working correctly. Please review the CSS selector in the scrollContainer option`
       );
-    });
-
-    test('should add a stylesheet to adoptedStyleSheets', async () => {
-      const styles = 'body { background-color: red; }';
-      childElement.addStyles(styles);
-
-      const parent = element.getRootNode();
-
-      if (parent instanceof Document || parent instanceof ShadowRoot) {
-        const styleSheet = parent.adoptedStyleSheets.find((sheet) =>
-          sheet.cssRules[0]?.cssText.includes(styles)
-        );
-        expect(styleSheet).toBeDefined();
-      }
     });
 
     describe('when properties changes', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
@@ -29,10 +29,7 @@ import i18next, {i18n} from 'i18next';
 import {CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ChildrenUpdateCompleteMixin} from '../../../mixins/children-update-complete-mixin';
-import {
-  AdoptedStylesBindings,
-  CommonBindings,
-} from '../../common/interface/bindings';
+import {CommonBindings} from '../../common/interface/bindings';
 import {
   BaseAtomicInterface,
   CommonAtomicInterfaceHelper,
@@ -56,8 +53,7 @@ export type CommerceBindings = CommonBindings<
   CommerceEngine,
   CommerceStore,
   AtomicCommerceInterface
-> &
-  AdoptedStylesBindings;
+>;
 
 const FirstRequestExecutedFlag = 'firstRequestExecuted';
 
@@ -352,21 +348,6 @@ export class AtomicCommerceInterface
       i18n: this.i18n,
       store: this.store,
       interfaceElement: this as AtomicCommerceInterface,
-      addAdoptedStyleSheets: (stylesheet) => {
-        // TODO: KIT-4333: remove and only keep decorator
-        const parent = this.getRootNode();
-        const styleSheet = stylesheet;
-        const isDocumentOrShadowRoot =
-          parent instanceof Document || parent instanceof ShadowRoot;
-
-        if (
-          styleSheet &&
-          isDocumentOrShadowRoot &&
-          !parent.adoptedStyleSheets.includes(styleSheet)
-        ) {
-          parent.adoptedStyleSheets.push(styleSheet);
-        }
-      },
     };
   }
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.tsx
@@ -206,7 +206,6 @@ export class AtomicCommerceRecommendationInterface
       i18n: this.i18n,
       store: this.store,
       interfaceElement: this.host,
-      // TODO: KIT-4333: remove this and use injectStylesForNoShadowDOM decorator instead
       addAdoptedStyleSheets: (stylesheet) => {
         const parent = this.host.getRootNode();
         const styleSheet = stylesheet;

--- a/packages/atomic/src/components/common/interface/bindings.ts
+++ b/packages/atomic/src/components/common/interface/bindings.ts
@@ -50,8 +50,14 @@ export interface NonceBindings {
   createScriptElement: () => HTMLScriptElement;
 }
 
+/**
+ * @deprecated
+ * If used to inject style on a component with no shadow DOM, use `@injectStylesForNoShadowDOM` decorator on Lit component.
+ * If used to inject a styled layout, consider using `CommerceLayoutMixin` instead.
+ */
 export interface AdoptedStylesBindings {
   /**
+   * @deprecated
    * An array of adopted stylesheets to be used in the shadow DOM.
    */
   addAdoptedStyleSheets: (stylesheet: CSSStyleSheet) => void;

--- a/packages/atomic/src/decorators/light-dom.ts
+++ b/packages/atomic/src/decorators/light-dom.ts
@@ -1,5 +1,21 @@
 import {CSSResult} from 'lit';
 
+/**
+ * Decorator to inject styles into components that do not use Shadow DOM.
+ *
+ * This decorator is intended for LitElement-based components that render in the light DOM (i.e., without a shadow root).
+ * It ensures that the component's styles (provided as static `styles` property) are injected into the document or shadow root using `adoptedStyleSheets`.
+ *
+ * Usage:
+ *   @injectStylesForNoShadowDOM
+ *   class MyComponent extends LitElement { ... }
+ *
+ * - Ensures styles are applied even when Shadow DOM is not used.
+ * - Prevents duplicate style injection by checking for existing style sheets.
+ * - Calls the original `connectedCallback` and `createRenderRoot` methods.
+ *
+ * @template T - A LitElement constructor with a static `styles` property.
+ */
 export const injectStylesForNoShadowDOM = <
   T extends {
     styles: CSSResult | CSSResult[];


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4333

Bindings should not be responsible for styling the component