### PR TITLE
chore(mcp): add Confluence & GitHub MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 .idea
 node_modules
 npm-debug.log
-.vscode/*
 .ds_store
 dist
 .size-snapshot.json
 reports/*.xml
-!.vscode/extensions.json
 .dccache
 sarifs
 **.cy.ts.mp4
@@ -19,3 +17,8 @@ topology.json
 .git-message
 packages/atomic/custom-elements.json
 .nx
+
+# .vscode
+.vscode/*
+!.vscode/extensions.json
+!.vscode/mcp.json

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,29 @@
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "github_token",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "atlassian": {
+      "url": "https://mcp.atlassian.com/v1/sse"
+    },
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add minimal setup for the commonly used MCP Server @coveo.

- `github`: from github.com/github/github-mcp-server. 🤞 A Remote MCP Server to replace/simplify the whole thing.
- `atlassian`: official (beta) remote mcp from Atlassian.

> !NOTE:
> Requires VSCode 1.101+ for Atlassian for proper OAuth handshake support