### PR TITLE
fix: disable flaky test in atomic-commerce-search-box-recent-queries

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts
@@ -26,7 +26,7 @@ test.describe('AtomicCommerceSearchBoxRecentQueries', () => {
     ).not.toBeVisible();
   });
 
-  test('when clicking clear recent queries, it should clear the recent queries', async ({
+  test.skip('when clicking clear recent queries, it should clear the recent queries', async ({
     commerceSearchBoxRecentQueries,
   }) => {
     await commerceSearchBoxRecentQueries.clearButton.click();


### PR DESCRIPTION
This PR disables the flaky test `when clicking clear recent queries, it should clear the recent queries` in the `AtomicCommerceSearchBoxRecentQueries` e2e test suite.

**What was changed:**
- Added `.skip` to the test at line 29 in `packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts`

**Why:**
This test was causing intermittent failures in the CI pipeline and needs to be temporarily disabled until it can be investigated and fixed.

**Test path:**
`src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts:29:3 › AtomicCommerceSearchBoxRecentQueries › when clicking clear recent queries, it should clear the recent queries`