### PR TITLE
chore: add proper props for renderTextAreaClearButton

### DIFF
--- a/packages/atomic/src/components/common/search-box/text-area-clear-button.spec.ts
+++ b/packages/atomic/src/components/common/search-box/text-area-clear-button.spec.ts
@@ -13,12 +13,16 @@ describe('#renderTextAreaClearButton', () => {
     i18n = await createTestI18n();
   });
 
-  const renderComponent = async (ref?: Ref<HTMLTextAreaElement>) => {
+  const renderComponent = async (
+    ref?: Ref<HTMLTextAreaElement>,
+    onClick?: () => void
+  ) => {
     const element = await renderFunctionFixture(
       html`${renderTextAreaClearButton({
         props: {
           i18n,
           textAreaRef: ref ?? createRef<HTMLTextAreaElement>(),
+          onClick: onClick ?? (() => {}),
         },
       })}`
     );
@@ -54,6 +58,13 @@ describe('#renderTextAreaClearButton', () => {
     const {button} = await renderComponent(mockTextAreaRef);
     await userEvent.click(button!);
     expect(mockTextAreaRef.value?.focus).toHaveBeenCalled();
+  });
+
+  it('should trigger the onClick callback on click', async () => {
+    const onClick = vi.fn();
+    const {button} = await renderComponent(undefined, onClick);
+    await userEvent.click(button!);
+    expect(onClick).toHaveBeenCalled();
   });
 
   it('should have aria-label as "Clear" on the button', async () => {

--- a/packages/atomic/src/components/common/search-box/text-area-clear-button.ts
+++ b/packages/atomic/src/components/common/search-box/text-area-clear-button.ts
@@ -3,11 +3,12 @@ import {i18n} from 'i18next';
 import {html} from 'lit';
 import {Ref} from 'lit/directives/ref.js';
 import ClearSlim from '../../../images/clear-slim.svg';
-import {renderButton, ButtonProps} from '../button';
+import {renderButton} from '../button';
 
-interface Props extends Partial<ButtonProps> {
+interface Props {
   i18n: i18n;
   textAreaRef: Ref<HTMLTextAreaElement>;
+  onClick: () => void;
 }
 
 export const renderTextAreaClearButton: FunctionalComponent<Props> = ({


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4345

I dont like extending from a partial buttonProps as it can lead to forgotten props (happened in the submit button with `disabled`)
