### PR TITLE
chore: add missing props in renderSubmitButton

### DIFF
--- a/packages/atomic/src/components/common/search-box/submit-button.spec.ts
+++ b/packages/atomic/src/components/common/search-box/submit-button.spec.ts
@@ -18,6 +18,9 @@ describe('#renderSubmitButton', () => {
       html`${renderSubmitButton({
         props: {
           i18n,
+          disabled: false,
+          onClick: () => {},
+          title: 'search',
           ...additionalProps,
         },
       })}`
@@ -67,5 +70,25 @@ describe('#renderSubmitButton', () => {
   it('should have an svg icon on the atomic-icon', async () => {
     const {icon} = await renderComponent();
     expect(icon?.getAttribute('icon')).toContain('<svg');
+  });
+
+  it('should be disabled when the disabled prop is true', async () => {
+    const {button} = await renderComponent({disabled: true});
+    expect(button).toBeDisabled();
+  });
+
+  it('should trigger the onClick event when the button is clicked', async () => {
+    const onClick = vi.fn();
+    const {button} = await renderComponent({onClick});
+
+    await userEvent.click(button!);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should have the correct title attribute', async () => {
+    const title = 'Search';
+    const {button} = await renderComponent({title});
+    expect(button).toHaveAttribute('title', title);
   });
 });

--- a/packages/atomic/src/components/common/search-box/submit-button.ts
+++ b/packages/atomic/src/components/common/search-box/submit-button.ts
@@ -2,13 +2,17 @@ import {FunctionalComponent} from '@/src/utils/functional-component-utils';
 import {i18n} from 'i18next';
 import {html} from 'lit';
 import SearchSlimIcon from '../../../images/search-slim.svg';
-import {renderButton, ButtonProps} from '../button';
+import {renderButton} from '../button';
 
-interface Props extends Partial<ButtonProps> {
+interface Props {
   i18n: i18n;
+  disabled: boolean;
+  onClick: () => void;
+  title: string;
 }
 
 export const renderSubmitButton: FunctionalComponent<Props> = ({props}) => {
+  const {i18n, disabled, onClick, title} = props;
   return html`<div
     part="submit-button-wrapper"
     class="mr-2 flex items-center justify-center py-2"
@@ -18,10 +22,12 @@ export const renderSubmitButton: FunctionalComponent<Props> = ({props}) => {
         style: 'text-primary',
         class: 'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
         part: 'submit-button',
-        ariaLabel: props.i18n.t('search'),
+        ariaLabel: i18n.t('search'),
         onClick: () => {
-          props.onClick?.();
+          onClick?.();
         },
+        disabled,
+        title,
       },
     })(
       html`<atomic-icon


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4344

I dont like extending from a partial buttonProps as it can lead to forgotten props. `disabled` and `title` were forgotten since in stencil we were doing a destructuring `...otherProps
`