### PR TITLE
fix(atomic): remove title from search box submit button

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tsx
@@ -742,7 +742,6 @@ export class AtomicCommerceSearchBox
                 this.searchBox.submit();
                 this.suggestionManager.clearSuggestions();
               }}
-              title={searchLabel}
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,

--- a/packages/atomic/src/components/common/search-box/stencil-submit-button.tsx
+++ b/packages/atomic/src/components/common/search-box/stencil-submit-button.tsx
@@ -1,16 +1,18 @@
 import {FunctionalComponent, h} from '@stencil/core';
 import SearchSlimIcon from '../../../images/search-slim.svg';
 import {AnyBindings} from '../interface/bindings';
-import {Button, StencilButtonProps} from '../stencil-button';
+import {Button} from '../stencil-button';
 
-interface Props extends Partial<StencilButtonProps> {
+interface Props {
   bindings: AnyBindings;
+  disabled: boolean;
+  onClick: () => void;
 }
 
 export const SubmitButton: FunctionalComponent<Props> = ({
   bindings,
+  disabled,
   onClick,
-  ...defaultButtonProps
 }) => (
   <div
     part="submit-button-wrapper"
@@ -24,7 +26,7 @@ export const SubmitButton: FunctionalComponent<Props> = ({
       onClick={() => {
         onClick?.();
       }}
-      {...defaultButtonProps}
+      disabled={disabled}
     >
       <atomic-icon
         part="submit-icon"

--- a/packages/atomic/src/components/common/search-box/submit-button.spec.ts
+++ b/packages/atomic/src/components/common/search-box/submit-button.spec.ts
@@ -20,7 +20,6 @@ describe('#renderSubmitButton', () => {
           i18n,
           disabled: false,
           onClick: () => {},
-          title: 'search',
           ...additionalProps,
         },
       })}`
@@ -84,11 +83,5 @@ describe('#renderSubmitButton', () => {
     await userEvent.click(button!);
 
     expect(onClick).toHaveBeenCalled();
-  });
-
-  it('should have the correct title attribute', async () => {
-    const title = 'Search';
-    const {button} = await renderComponent({title});
-    expect(button).toHaveAttribute('title', title);
   });
 });

--- a/packages/atomic/src/components/common/search-box/submit-button.ts
+++ b/packages/atomic/src/components/common/search-box/submit-button.ts
@@ -8,11 +8,10 @@ interface Props {
   i18n: i18n;
   disabled: boolean;
   onClick: () => void;
-  title: string;
 }
 
 export const renderSubmitButton: FunctionalComponent<Props> = ({props}) => {
-  const {i18n, disabled, onClick, title} = props;
+  const {i18n, disabled, onClick} = props;
   return html`<div
     part="submit-button-wrapper"
     class="mr-2 flex items-center justify-center py-2"
@@ -27,7 +26,6 @@ export const renderSubmitButton: FunctionalComponent<Props> = ({props}) => {
           onClick?.();
         },
         disabled,
-        title,
       },
     })(
       html`<atomic-icon

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -733,7 +733,6 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
                 this.searchBox.submit();
                 this.suggestionManager.clearSuggestions();
               }}
-              title={searchLabel}
             />
             {this.renderSuggestions()}
           </SearchBoxWrapper>,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4238

## Before
When using a voice over, when navigating to the submit button on the search box, you heard : _"Search"_, _"Button"_, _"Search field with suggestions. Suggestions may be available under this field. To send, press Enter."_ 

The last part is wrong because suggestions are not available when navigating to the submit button. This is text that is meant to be read when focusing the `textarea`. This was found by @lvu285 during a qa check on query suggestions : https://github.com/coveo/ui-kit/pull/5205#issuecomment-2851475812

## After

By removing the title, the voice over now simply says : _"Search"_, _"Button"_ which is much clearer.
You now hear the third part only when focusing the textarea.