### PR TITLE
chore: update MCP configuration with simplified GitHub integration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,29 +1,11 @@
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "github_token",
-      "description": "GitHub Personal Access Token",
-      "password": true
-    }
-  ],
   "servers": {
     "atlassian": {
       "url": "https://mcp.atlassian.com/v1/sse"
     },
     "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
-      }
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
     }
   }
 }


### PR DESCRIPTION
## Description
Update the MCP configuration to use the simplified GitHub integration setup with HTTP endpoint.

## Changes
- Removed Docker-based GitHub MCP server configuration
- Added simplified HTTP-based GitHub integration configuration
- Updated server URL to use the official GitHub Copilot MCP endpoint

## Related Issue
[KIT-4346](https://coveord.atlassian.net/browse/KIT-4346)

[KIT-4346]: https://coveord.atlassian.net/browse/KIT-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ