### PR TITLE
chore(atomic): support @mapProperty decorator for CEM

### DIFF
--- a/packages/atomic/custom-elements-manifest.config.mjs
+++ b/packages/atomic/custom-elements-manifest.config.mjs
@@ -1,4 +1,4 @@
-import {cemPlugin} from './scripts/cem-plugin.mjs';
+import {cemPlugin, mapPropertyPlugin} from './scripts/cem-plugin.mjs';
 
 export default {
   /** Globs to analyze */
@@ -12,5 +12,5 @@ export default {
   ],
   stencil: true,
   litelement: true,
-  plugins: [cemPlugin()],
+  plugins: [cemPlugin(), mapPropertyPlugin()],
 };

--- a/packages/atomic/scripts/cem-plugin.mjs
+++ b/packages/atomic/scripts/cem-plugin.mjs
@@ -63,3 +63,56 @@ export const cemPlugin = () => ({
   // Runs for each module, after analyzing, all information about your module should now be available
   moduleLinkPhase,
 });
+
+function extractObjectLiteralOptions(arg, ts) {
+  const options = {};
+  if (arg && ts.isObjectLiteralExpression(arg)) {
+    for (const prop of arg.properties) {
+      if (ts.isPropertyAssignment(prop)) {
+        const key = prop.name.getText();
+        options[key] = prop.initializer.text ?? undefined;
+      }
+    }
+  }
+  return options;
+}
+
+/**
+ * CEM plugin to recognize @mapProperty decorator and emit the property as an attribute.
+ */
+function getDecoratorNameAndOptions(node, ts) {
+  let decoratorName = null;
+  let options = {};
+  if (ts.getDecorators) {
+    for (const decorator of ts.getDecorators(node) || []) {
+      const expr = decorator.expression;
+      if (ts.isCallExpression(expr)) {
+        decoratorName = expr.expression.getText();
+        options = extractObjectLiteralOptions(expr.arguments[0], ts);
+      } else {
+        decoratorName = expr.getText();
+      }
+    }
+  }
+  return {decoratorName, options};
+}
+
+export function mapPropertyPlugin() {
+  return {
+    name: 'map-property',
+    analyzePhase({ts, node, moduleDoc, context}) {
+      if (ts.isPropertyDeclaration(node)) {
+        const {decoratorName, options} = getDecoratorNameAndOptions(node, ts);
+        if (decoratorName === 'mapProperty') {
+          const propName = node.name.getText();
+          const attributeName = options.attributePrefix || propName;
+
+          moduleDoc.declarations[0].attributes.push({
+            name: attributeName,
+            fieldName: propName,
+          });
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
Add new Custom Elements Manifest (CEM) plugin, `mapPropertyPlugin`, to support the `@mapProperty` decorator.