### PR TITLE
chore(atomic): remove "results" part from query-summary components

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.tsx
@@ -23,7 +23,6 @@ import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-int
  * The `atomic-commerce-query-summary` component displays information about the current range of results and the request duration (e.g., "Results 1-10 of 123 in 0.47 seconds").
  *
  * @part container - The container for the whole summary.
- * @part results - The container for the results.
  * @part highlight - The summary highlights.
  * @part query - The summary highlighted query.
  * @part placeholder - The query summary placeholder used while the search interface is initializing.

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.tsx
@@ -20,7 +20,6 @@ import {Bindings} from '../atomic-search-interface/atomic-search-interface';
  * The `atomic-query-summary` component displays information about the current range of results and the request duration (e.g., "Results 1-10 of 123 in 0.47 seconds").
  *
  * @part container - The container for the whole summary.
- * @part results - The container for the results.
  * @part duration - The container for the duration.
  * @part highlight - The summary highlights.
  * @part query - The summary highlighted query.


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4358

It's a mistake, there is no "results" part in this component.
