### PR TITLE
test(atomic): update breadbox e2e test for backend data changes

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
@@ -119,7 +119,7 @@ test.describe('Default', () => {
     }) => {
       const breadcrumbButton = breadbox.getBreadcrumbButtons(firstValueText);
 
-      await expect(breadcrumbButton).toHaveText(`Color:${firstValueText}`);
+      await expect(breadcrumbButton).toHaveText(`Brand:${firstValueText}`);
     });
   });
   test.describe('when a category facet value is selected', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
@@ -317,7 +317,8 @@ test.describe('Default', () => {
   test.describe('when a date range facet value is selected', () => {
     let firstValueText: string | RegExp;
 
-    test.beforeEach(async ({breadbox}) => {
+    test.beforeEach(async ({breadbox, page}) => {
+      await page.getByRole('button', {name: 'Expand the Date facet'}).click();
       await breadbox.getFacetValue('dateRange').first().click();
       firstValueText = (await breadbox
         .getFacetValue('dateRange')


### PR DESCRIPTION
## Summary
This PR updates the atomic-commerce-breadbox e2e test to reflect backend data changes that have modified the facet structure.

## Changes
- Updated expected breadcrumb text from `Color:${firstValueText}` to `Brand:${firstValueText}` in the e2e test
- This change aligns the test expectations with the actual facet structure now being used in the commerce breadbox component

## Reason
Backend data changes have modified the facet structure, requiring test updates to match the new expected behavior. The test was previously expecting "Color:" as the facet label but the actual implementation now uses "Brand:".

## Testing
The e2e test should now pass with the corrected expectation.

---
Related Jira Issue: [KIT-4373](https://coveord.atlassian.net/browse/KIT-4373)

[KIT-4373]: https://coveord.atlassian.net/browse/KIT-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ