### PR TITLE
chore(atomic): migrate query-correction/guard.tsx

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../utils/initialization-utils';
 import {AutoCorrection} from '../../common/query-correction/auto-correction';
 import {Correction} from '../../common/query-correction/correction';
-import {QueryCorrectionGuard} from '../../common/query-correction/guard';
+import {QueryCorrectionGuard} from '../../common/query-correction/stencil-guard';
 import {TriggerCorrection} from '../../common/query-correction/stencil-trigger-correction';
 import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 

--- a/packages/atomic/src/components/common/query-correction/stencil-guard.tsx
+++ b/packages/atomic/src/components/common/query-correction/stencil-guard.tsx
@@ -3,6 +3,8 @@ import {Fragment, FunctionalComponent, h} from '@stencil/core';
 interface QueryCorrectionGuardProps {
   hasCorrection: boolean;
 }
+
+// Just use a when directive for Lit. This is an unnecessary component in Lit's context.
 export const QueryCorrectionGuard: FunctionalComponent<
   QueryCorrectionGuardProps
 > = ({hasCorrection}, children) => {

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../utils/initialization-utils';
 import {AutoCorrection} from '../../common/query-correction/auto-correction';
 import {Correction} from '../../common/query-correction/correction';
-import {QueryCorrectionGuard} from '../../common/query-correction/guard';
+import {QueryCorrectionGuard} from '../../common/query-correction/stencil-guard';
 import {TriggerCorrection} from '../../common/query-correction/stencil-trigger-correction';
 import {Bindings} from '../atomic-search-interface/atomic-search-interface';
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4364

We should just use a when directive there. The guard is too simple.