### PR TITLE
chore(atomic): prefix functional components with `render`

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
@@ -20,13 +20,13 @@ import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import {createAppLoadedListener} from '../../common/interface/store';
 import {
-  pagerNextButton,
-  pagerPageButton,
-  pagerPageButtons,
-  pagerPreviousButton,
+  renderPagerNextButton,
+  renderPagerPageButton,
+  renderPageButtons,
+  renderPagerPreviousButton,
 } from '../../common/pager/pager-buttons';
-import {pagerGuard} from '../../common/pager/pager-guard';
-import {pagerNavigation} from '../../common/pager/pager-navigation';
+import {renderPagerGuard} from '../../common/pager/pager-guard';
+import {renderPagerNavigation} from '../../common/pager/pager-navigation';
 import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 import {getCurrentPagesRange} from './commerce-pager-utils';
 
@@ -121,18 +121,18 @@ export class AtomicCommercePager
       this.numberOfPages,
       this.pagerState.totalPages - 1
     );
-    return html`${pagerGuard({
+    return html`${renderPagerGuard({
       props: {
         hasItems: this.pagerState.totalPages > 1,
         isAppLoaded: this.isAppLoaded,
       },
     })(
-      html`${pagerNavigation({
+      html`${renderPagerNavigation({
         props: {
           i18n: this.bindings.i18n,
         },
       })(html`
-        ${pagerPreviousButton({
+        ${renderPagerPreviousButton({
           props: {
             icon: this.previousButtonIcon,
             disabled: this.pagerState.page === 0,
@@ -143,13 +143,13 @@ export class AtomicCommercePager
             },
           },
         })}
-        ${pagerPageButtons({
+        ${renderPageButtons({
           props: {
             i18n: this.bindings.i18n,
           },
         })(
           html`${pagesRange.map((pageNumber) =>
-            pagerPageButton({
+            renderPagerPageButton({
               props: {
                 isSelected: pageNumber === this.pagerState.page,
                 ariaLabel: this.bindings.i18n.t('page-number', {
@@ -168,7 +168,7 @@ export class AtomicCommercePager
             })
           )}`
         )}
-        ${pagerNextButton({
+        ${renderPagerNextButton({
           props: {
             icon: this.nextButtonIcon,
             disabled: this.pagerState.page + 1 >= this.pagerState.totalPages,

--- a/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
@@ -5,10 +5,10 @@ import {describe, test, beforeEach, afterEach, expect} from 'vitest';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import {
-  pagerNextButton,
-  pagerPageButton,
-  pagerPageButtons,
-  pagerPreviousButton,
+  renderPagerNextButton,
+  renderPagerPageButton,
+  renderPageButtons,
+  renderPagerPreviousButton,
 } from './pager-buttons';
 
 describe('pagerButtons', () => {
@@ -22,7 +22,7 @@ describe('pagerButtons', () => {
       document.body.appendChild(container);
 
       render(
-        html`${pagerPreviousButton({
+        html`${renderPagerPreviousButton({
           props: {
             i18n,
             icon: ArrowLeftIcon,
@@ -55,7 +55,7 @@ describe('pagerButtons', () => {
       container = document.createElement('div');
       document.body.appendChild(container);
       render(
-        html`${pagerNextButton({
+        html`${renderPagerNextButton({
           props: {
             i18n,
             icon: ArrowRightIcon,
@@ -95,7 +95,7 @@ describe('pagerButtons', () => {
 
     test('should render the button with the correct attributes', () => {
       render(
-        html`${pagerPageButton({
+        html`${renderPagerPageButton({
           props: {
             groupName: 'pager',
             page: 1,
@@ -115,7 +115,7 @@ describe('pagerButtons', () => {
 
     test('should render with the correct attributes when not selected', () => {
       render(
-        html`${pagerPageButton({
+        html`${renderPagerPageButton({
           props: {
             groupName: 'pager',
             page: 1,
@@ -133,7 +133,7 @@ describe('pagerButtons', () => {
 
     test('should render with the correct attributes when selected', () => {
       render(
-        html`${pagerPageButton({
+        html`${renderPagerPageButton({
           props: {
             groupName: 'pager',
             page: 1,
@@ -156,15 +156,15 @@ describe('pagerButtons', () => {
       container = document.createElement('div');
       document.body.appendChild(container);
       render(
-        html`${pagerPageButtons({
+        html`${renderPageButtons({
           props: {
             i18n,
           },
         })(
-          html`${pagerPageButton({
+          html`${renderPagerPageButton({
             props: {groupName: 'pager', page: 1, isSelected: true, text: '1'},
           })}
-          ${pagerPageButton({
+          ${renderPagerPageButton({
             props: {groupName: 'pager', page: 2, isSelected: false, text: '2'},
           })}`
         )}`,

--- a/packages/atomic/src/components/common/pager/pager-buttons.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.ts
@@ -6,7 +6,7 @@ import {
 import {i18n} from 'i18next';
 import {html} from 'lit';
 import {renderButton, ButtonProps} from '../button';
-import {radioButton, RadioButtonProps} from '../radio-button';
+import {renderRadioButton, RadioButtonProps} from '../radio-button';
 
 interface PagerNavigationButtonProps
   extends Omit<ButtonProps, 'style' | 'part' | 'class'> {
@@ -14,7 +14,7 @@ interface PagerNavigationButtonProps
   i18n: i18n;
 }
 
-export const pagerPreviousButton: FunctionalComponent<
+export const renderPagerPreviousButton: FunctionalComponent<
   PagerNavigationButtonProps
 > = ({props}) => {
   return renderButton({
@@ -34,7 +34,7 @@ export const pagerPreviousButton: FunctionalComponent<
   );
 };
 
-export const pagerNextButton: FunctionalComponent<
+export const renderPagerNextButton: FunctionalComponent<
   PagerNavigationButtonProps
 > = ({props}) => {
   return renderButton({
@@ -64,10 +64,10 @@ interface PagerPageButtonProps
   text: string;
 }
 
-export const pagerPageButton: FunctionalComponent<PagerPageButtonProps> = ({
-  props,
-}) => {
-  return radioButton({
+export const renderPagerPageButton: FunctionalComponent<
+  PagerPageButtonProps
+> = ({props}) => {
+  return renderRadioButton({
     props: {
       ...props,
       selectWhenFocused: false,
@@ -85,7 +85,7 @@ interface PagerPageButtonsProps {
   i18n: i18n;
 }
 
-export const pagerPageButtons: FunctionalComponentWithChildren<
+export const renderPageButtons: FunctionalComponentWithChildren<
   PagerPageButtonsProps
 > =
   ({props}) =>

--- a/packages/atomic/src/components/common/pager/pager-guard.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-guard.spec.ts
@@ -1,7 +1,7 @@
 import {displayIf} from '@/src/directives/display-if';
 import * as lit from 'lit';
 import {describe, test, expect, vi} from 'vitest';
-import {pagerGuard} from './pager-guard';
+import {renderPagerGuard} from './pager-guard';
 
 vi.mock('@/src/directives/display-if', () => ({
   displayIf: vi.fn(),
@@ -16,7 +16,7 @@ describe('pagerGuard', () => {
   const children = mockedLit.html`children`;
 
   test('should not render children when hasError is true', async () => {
-    pagerGuard({
+    renderPagerGuard({
       props: {hasError: true, isAppLoaded: true, hasItems: true},
     })(children);
 
@@ -24,7 +24,7 @@ describe('pagerGuard', () => {
   });
 
   test('should not render children when isAppLoaded is false', async () => {
-    pagerGuard({
+    renderPagerGuard({
       props: {hasError: false, isAppLoaded: false, hasItems: true},
     })(children);
 
@@ -32,7 +32,7 @@ describe('pagerGuard', () => {
   });
 
   test('should not render children when hasItems is false', async () => {
-    pagerGuard({
+    renderPagerGuard({
       props: {hasError: false, isAppLoaded: true, hasItems: false},
     })(children);
 
@@ -40,7 +40,7 @@ describe('pagerGuard', () => {
   });
 
   test('should render children when the condition is true', async () => {
-    pagerGuard({
+    renderPagerGuard({
       props: {hasError: false, isAppLoaded: true, hasItems: true},
     })(children);
 

--- a/packages/atomic/src/components/common/pager/pager-guard.ts
+++ b/packages/atomic/src/components/common/pager/pager-guard.ts
@@ -8,7 +8,7 @@ interface PagerGuardProps {
   hasItems: boolean;
 }
 
-export const pagerGuard: FunctionalComponentGuard<PagerGuardProps> =
+export const renderPagerGuard: FunctionalComponentGuard<PagerGuardProps> =
   ({props}) =>
   (children) => {
     const condition = !props.hasError && props.isAppLoaded && props.hasItems;

--- a/packages/atomic/src/components/common/pager/pager-navigation.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-navigation.spec.ts
@@ -2,7 +2,7 @@ import enTranslations from '@/dist/atomic/lang/en.json';
 import i18next, {i18n as I18n} from 'i18next';
 import {html, render} from 'lit';
 import {describe, test, beforeAll, expect} from 'vitest';
-import {pagerNavigation} from './pager-navigation';
+import {renderPagerNavigation} from './pager-navigation';
 
 describe('pagerNavigation', () => {
   let container: HTMLElement;
@@ -22,7 +22,7 @@ describe('pagerNavigation', () => {
     document.body.appendChild(container);
 
     render(
-      html`${pagerNavigation({props: {i18n}})(html`children`)}`,
+      html`${renderPagerNavigation({props: {i18n}})(html`children`)}`,
       container
     );
   });

--- a/packages/atomic/src/components/common/pager/pager-navigation.ts
+++ b/packages/atomic/src/components/common/pager/pager-navigation.ts
@@ -6,7 +6,7 @@ interface PagerNavigationProps {
   i18n: i18n;
 }
 
-export const pagerNavigation: FunctionalComponentWithChildren<
+export const renderPagerNavigation: FunctionalComponentWithChildren<
   PagerNavigationProps
 > =
   ({props}) =>

--- a/packages/atomic/src/components/common/radio-button.spec.ts
+++ b/packages/atomic/src/components/common/radio-button.spec.ts
@@ -2,7 +2,7 @@ import {createRipple} from '@/src/utils/ripple';
 import {fireEvent, within} from '@storybook/test';
 import {html, render} from 'lit';
 import {vi, describe, beforeEach, afterEach, it, expect} from 'vitest';
-import {radioButton, RadioButtonProps} from './radio-button';
+import {renderRadioButton, RadioButtonProps} from './radio-button';
 
 vi.mock('@/src/utils/ripple');
 
@@ -18,11 +18,11 @@ describe('radioButton', () => {
     document.body.removeChild(container);
   });
 
-  const renderRadioButton = (
+  const renderComponent = (
     props: Partial<RadioButtonProps>
   ): HTMLInputElement => {
     render(
-      html`${radioButton({props: {...props, groupName: 'test-group'}})}`,
+      html`${renderRadioButton({props: {...props, groupName: 'test-group'}})}`,
       container
     );
 
@@ -36,7 +36,7 @@ describe('radioButton', () => {
       ariaLabel: 'Test Radio Button',
     };
 
-    const input = renderRadioButton(props);
+    const input = renderComponent(props);
 
     expect(input).toBeInTheDocument();
     expect(input.name).toBe('test-group');
@@ -52,7 +52,7 @@ describe('radioButton', () => {
       onChecked,
     };
 
-    const input = renderRadioButton(props);
+    const input = renderComponent(props);
     await fireEvent.click(input);
 
     await expect(onChecked).toHaveBeenCalled();
@@ -68,9 +68,9 @@ describe('radioButton', () => {
     };
 
     render(
-      html`${radioButton({props: {...props, text: 'radio-1'}})}
-      ${radioButton({props: {...props, text: 'radio-2'}})}
-      ${radioButton({props: {...props, text: 'radio-3'}})}`,
+      html`${renderRadioButton({props: {...props, text: 'radio-1'}})}
+      ${renderRadioButton({props: {...props, text: 'radio-2'}})}
+      ${renderRadioButton({props: {...props, text: 'radio-3'}})}`,
       container
     );
 
@@ -94,7 +94,7 @@ describe('radioButton', () => {
       style: 'primary',
     };
 
-    const input = renderRadioButton(props);
+    const input = renderComponent(props);
     await fireEvent.mouseDown(input);
 
     await expect(mockedRipple).toHaveBeenCalledWith(expect.anything(), {
@@ -107,7 +107,7 @@ describe('radioButton', () => {
       class: 'test-class',
     };
 
-    const input = renderRadioButton(props);
+    const input = renderComponent(props);
     expect(input).toBeInTheDocument();
     expect(input.classList.contains('test-class')).toBe(true);
     expect(input.classList.contains('btn-radio')).toBe(true);
@@ -119,7 +119,7 @@ describe('radioButton', () => {
       part: 'test-part',
     };
 
-    const input = renderRadioButton(props);
+    const input = renderComponent(props);
     expect(input.getAttribute('part')).toBe('test-part');
   });
 
@@ -130,7 +130,7 @@ describe('radioButton', () => {
       ref,
     };
 
-    render(html`${radioButton({props})}`, container);
+    render(html`${renderRadioButton({props})}`, container);
 
     expect(ref).toHaveBeenCalled();
   });
@@ -140,7 +140,7 @@ describe('radioButton', () => {
       ariaCurrent: 'page',
     };
 
-    renderRadioButton(props);
+    renderComponent(props);
     expect(
       within(container).getByRole('radio', {current: 'page'})
     ).toBeInTheDocument();

--- a/packages/atomic/src/components/common/radio-button.ts
+++ b/packages/atomic/src/components/common/radio-button.ts
@@ -32,7 +32,9 @@ export interface RadioButtonProps {
   ref?: RefOrCallback;
 }
 
-export const radioButton: FunctionalComponent<RadioButtonProps> = ({props}) => {
+export const renderRadioButton: FunctionalComponent<RadioButtonProps> = ({
+  props,
+}) => {
   const classNames = {
     'btn-radio': true,
     selected: Boolean(props.checked),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4384

We decided on prefixing them so this PR just adds it to the missing ones
