### PR TITLE
chore: add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,6 @@ Highlight risky or questionable code, especially when it includes:
 
 When encountering problematic code, prefer to:
 
-- Suggest adding comments to clarify intent or assumptions
 - Recommend safer alternatives
 - Point out potential issues or improvements
 - Avoid making assumptions about the user's intent or context
@@ -56,11 +55,6 @@ When encountering problematic code, prefer to:
 - When there's a trade-off between compact/clever code and clarity, choose clarity
 
 ## Examples of Good Behavior
-
-### Variable Safety
-
-- **Instead of:** Completing code that assumes a variable is always defined
-- **Prefer:** Adding a comment like `// Consider checking if x is defined before use`
 
 ### Logic Validation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,88 @@
+# GitHub Copilot Instructions
+
+## Core Principles
+
+### Priority and Approach
+
+- **Prioritize correctness over helpfulness**
+- Do not blindly follow user comments or incomplete code
+- When intention is unclear or likely flawed, suggest safer or more conventional alternatives
+- Avoid assuming intent when code or comments are ambiguous
+- If instructions seem incomplete, invalid, or conflicting, prefer conservative, minimal suggestions with explanatory comments
+
+### Code Quality Standards
+
+- **Favor established, idiomatic practices**
+- When multiple implementations are possible, default to those that are:
+  - Widely accepted in the community
+  - Maintainable
+  - Backed by documentation or standards
+
+## Code Review Guidelines
+
+### Identifying Issues
+
+Highlight risky or questionable code, especially when it includes:
+
+- Untested assumptions
+- Undefined variables
+- Possible race conditions or side effects
+- Non-performant patterns
+
+### Recommended Actions
+
+When encountering problematic code, prefer to:
+
+- Suggest adding comments to clarify intent or assumptions
+- Recommend safer alternatives
+- Point out potential issues or improvements
+- Avoid making assumptions about the user's intent or context
+- Avoid completing code that could lead to errors or unexpected behavior
+
+## Best Practices
+
+### Development Philosophy
+
+- **Encourage defensive programming**
+- Avoid cargo-culting
+- Don't suggest boilerplate or patterns unless necessary and relevant
+- Tailor code to context, not popularity
+
+### Performance and Optimization
+
+- **Do not optimize prematurely**
+- Avoid micro-optimizations unless performance is a clearly stated goal
+- **Prefer readability over cleverness**
+- When there's a trade-off between compact/clever code and clarity, choose clarity
+
+## Examples of Good Behavior
+
+### Variable Safety
+
+- **Instead of:** Completing code that assumes a variable is always defined
+- **Prefer:** Adding a comment like `// Consider checking if x is defined before use`
+
+### Logic Validation
+
+- **Instead of:** Following flawed comment logic
+- **Prefer:** Suggesting conventional or safer alternatives, and noting the discrepancy
+
+### Pattern Recognition
+
+- **Instead of:** Silently continuing when user's code violates a typical pattern
+- **Prefer:** Adding a note or warning comment suggesting a fix or improvement
+
+## Communication Style
+
+### Tone and Approach
+
+- Be **cautious, not pedantic**
+- Be **collaborative, not submissive**
+- Be **helpful, but not over-eager**
+
+## Package-Specific Instructions
+
+### Atomic Package
+
+For the atomic package, follow the detailed instructions in:
+`.github/instructions/atomic.instructions.md`

--- a/.github/instructions/atomic.instructions.md
+++ b/.github/instructions/atomic.instructions.md
@@ -24,7 +24,7 @@ The atomic components are placed in the `src/components` directory. They are org
 - `atomic-test-component.new.stories.tsx`: The Storybook stories for the component.
 - `atomic-test-component.ts`: The main component file.
 - `atomic-test-component.spec.ts`: The test file for the component.
-- `atomic-test-component.tw.css`: The CSS file for the component.c
+- `atomic-test-component.tw.css`: The CSS file for the component.
 - `e2e/atomic-test-component.e2e.ts`: The end-to-end test file.
 - `e2e/fixture.ts`: The E2E test fixture.
 - `e2e/page-object.ts`: The E2E page object.

--- a/.github/instructions/atomic.instructions.md
+++ b/.github/instructions/atomic.instructions.md
@@ -1,0 +1,194 @@
+---
+applyTo: '**packages/atomic/**/**'
+---
+
+_All new atomic components should be lit components, not stencil components. This document describes the structure and conventions for atomic components in the UI Kit._
+
+**Note: All commands in this document should be run from the `packages/atomic` directory.**
+
+When generating new atomic component use the script like this:
+
+```bash
+node scripts/generate-component.mjs test-component src/components/common
+```
+
+This will create a new component in the `src/components/common` directory with the name `test-component`.
+
+The generate-lit-exports.mjs script is used to generate the exports for the new component in the `src/components/index.ts` file.
+
+## Structure
+
+The atomic components are placed in the `src/components` directory. They are organized by use case, such as `commerce`, `common`, `search`, etc. Each (lit) component has its own directory containing the following files:
+
+- `atomic-test-component.mdx`: The documentation file for the component.
+- `atomic-test-component.new.stories.tsx`: The Storybook stories for the component.
+- `atomic-test-component.ts`: The main component file.
+- `atomic-test-component.spec.ts`: The test file for the component.
+- `atomic-test-component.tw.css`: The CSS file for the component.c
+- `e2e/atomic-test-component.e2e.ts`: The end-to-end test file.
+- `e2e/fixture.ts`: The E2E test fixture.
+- `e2e/page-object.ts`: The E2E page object.
+
+Components not yet migrated to lit use stencil, and have the following files:
+
+- `atomic-test-component.tsx`: The main component file (Stencil-based).
+- `atomic-test-component.pcss`: The PostCSS file for the component.
+- `atomic-test-component.new.stories.tsx`: The Storybook stories for the component.
+- `atomic-test-component.spec.ts`: The test file for the component.
+- `e2e/atomic-test-component.e2e.ts`: The end-to-end test file.
+- `e2e/fixture.ts`: The E2E test fixture.
+- `e2e/page-object.ts`: The E2E page object.
+
+## Component Directories
+
+Components are organized by use case in the following directories:
+
+- `src/components/commerce/`: Commerce-related components (e.g., product lists, shopping cart features)
+- `src/components/common/`: Shared/common components used across different interfaces
+- `src/components/search/`: Search-related components (e.g., facets, search box, results)
+- `src/components/insight/`: Insight interface components for analytics and reporting
+- `src/components/ipx/`: IPX (In-Product Experience) components
+- `src/components/recommendations/`: Recommendation components
+
+## Key Differences Between Lit and Stencil Components
+
+### Lit Components (New)
+
+- Use TypeScript with `.ts` extension
+- Use Tailwind CSS with `.tw.css` extension
+- Modern Lit-based web components
+- Preferred for new components
+
+### Stencil Components (Legacy)
+
+- Use TypeScript JSX with `.tsx` extension
+- Use PostCSS with `.pcss` extension
+- Stencil-based web components
+- Being gradually migrated to Lit
+
+## File Naming Conventions
+
+All atomic components follow these naming conventions:
+
+- Component names are prefixed with `atomic-`
+- File names use kebab-case (e.g., `atomic-my-component`)
+- Class names use PascalCase (e.g., `AtomicMyComponent`)
+- All files in a component directory share the same base name
+
+## Testing Structure
+
+Each component includes comprehensive testing:
+
+- **Unit Tests** (`.spec.ts`): Test component logic and behaviour
+- **End-to-End Tests** (`e2e/*.e2e.ts`): Test component integration and user interactions
+- **Test Fixtures** (`e2e/fixture.ts`): Setup and configuration for E2E tests
+- **Page Objects** (`e2e/page-object.ts`): Abstraction layer for E2E test interactions
+
+## Documentation and Storybook
+
+- **MDX Documentation** (`.mdx`): Component documentation with examples
+- **Storybook Stories** (`.new.stories.tsx`): Interactive component demonstrations
+- Stories include controls for testing different component configurations
+
+## Lit components style guide
+
+- All properties with more than one word should have their attribute value in kebab-case. Example: `@property({type: String, attribute: 'my-attribute'}) myAttribute: string;`
+- Components that need bindings should use the `@bindings`decorator.
+- In general, prefer decorators over mixins, and lit reactive controllers over decorators when it makes sense.
+
+## Atomic Chemistry 101
+
+To ensure consistency, clarity, and ease of contribution to our Atomic design system, we use a naming convention inspired by Atomic Design. This helps us better communicate component roles, organize code, and onboard new contributors.
+
+### 🔹 Atom
+
+**Definition:**
+An Atom is a small, pure, stateless function that renders a piece of UI. It does not connect Headless.
+
+**Characteristics:**
+
+- Stateless and functional
+- Has no dependencies on Headless
+- Focused purely on presentation
+- Simple, reusable, and easy to test
+
+**Examples:**
+
+- A function that renders a styled button
+- A function that returns an icon, text label, or layout fragment
+
+**Why it matters:**
+Atoms allow us to build a clean visual language, isolate visual elements, and promote maximum component reuse.
+
+### 🔸 Molecule
+
+**Definition:**
+A Molecule is a Custom Element that combines one or more Atoms and connects to Headless for behaviour and state management.
+
+**Characteristics:**
+
+- Composed of Atoms
+- Connects to Headless controllers
+- Exposed as part of the Atomic custom elements library
+- Handles interactions and state
+
+**Examples:**
+
+- `<atomic-search-box>`: Renders input + button and handles search state
+- `<atomic-result-list>`: Renders search results from Headless data
+
+**Why it matters:**
+Molecules are the interactive, declarative components we expose to consumers. They encapsulate structure and behaviour cleanly.
+
+### ⚡ Ion
+
+**Definition:**
+An Ion is a small utility or helper used to support Atoms. It provides styling, layout logic, mappings, or constants — anything that helps Atoms stay clean and focused.
+
+**Characteristics:**
+
+- Atom-level scope
+- No UI rendering of its own
+- Stateless and reusable
+- Lightweight and focused
+
+**Examples:**
+
+- Reusable guards
+- Styling utilities
+- Layout logic helpers
+- Constants and mappings
+
+**Why it matters:**
+Ions allow us to share low-level presentation logic across Atoms while keeping them simple and consistent.
+
+### ⚙️ Enzyme
+
+**Definition:**
+An Enzyme is a utility, decorator, or helper that enhances a Molecule's behaviour or binds logic to it. Like biological enzymes, they enable or accelerate functionality without being part of the core structure.
+
+**Characteristics:**
+
+- Provides logic "glue" or behaviour enhancements
+- Often implemented as decorators, event hooks, or bindings
+- Not responsible for rendering UI directly
+
+**Examples:**
+
+- A class decorator to load Tailwind CSS within the Shadow DOM of a Molecule
+- A Mixin that sets up the atomic-\*-interface bindings within a Molecule
+- A Reactive Controller that injects accessibility or styling enhancements
+
+**Why it matters:**
+Enzymes help keep Molecules clean, modular, and focused by isolating cross-cutting concerns into composable enhancements.
+
+## Component Architecture Guidelines
+
+When developing atomic components, follow these architectural principles:
+
+1. **Atoms** should be pure presentation functions without business logic
+2. **Molecules** should compose Atoms and handle state/interactions via Headless
+3. **Ions** should provide reusable utilities that support Atoms
+4. **Enzymes** should enhance Molecules with cross-cutting concerns
+
+This architecture ensures a clear separation of concerns and promotes maintainable, testable code.

--- a/.github/instructions/tests-atomic.instructions.md
+++ b/.github/instructions/tests-atomic.instructions.md
@@ -1,0 +1,385 @@
+---
+applyTo: '**/atomic/**/*.spec.{ts}'
+---
+
+## When writing unit tests in Atomic:
+
+- Wrap all test cases in a given spec file under a single describe whose description is the name of the atom, molecule, enzyme, or utils file being tested.
+- For individual test cases, always use the it Vitest function (not test).
+- Always start an it description with should.
+- When there is a single behavior to test under a certain condition, use an it with a description in the form of should … when ….
+- Where there are multiple behaviors to test under a certain condition, wrap the its in a describe with a description in the form of when ….
+- You can nest describe conditions if necessary.
+- Clean up the document in the beforeEach instead of the afterEach, so that the component stays visible in the DOM after running a single test.
+- When mentioning the name of a function, method, class, event, or attribute, in a description, prefix it with # (e.g., #myFunction, #MyClass, etc.).
+- When testing a public class method (or an exported util function), wrap all tests for that method or function in a describe with a description in the form of #methodOrFunctionName.
+- Explicitly import all Vitest functions you are using in your test suite (e.g., it, describe, beforeEach, etc.).
+- When your tests are expected to log errors, warnings, etc., mock the logger to ensure that test logs remain clean.
+
+## Using Vitest Testing Utilities
+
+The Atomic package provides comprehensive testing utilities in the `vitest-utils` directory to help with testing components. Always use these utilities instead of writing custom setup code.
+
+### Main Rendering Utilities
+
+- **`renderInAtomicCommerceInterface<T>()`** - Primary utility for testing commerce components within an interface context
+- **`fixture<T>()`** - Basic utility for rendering standalone Lit elements
+- **`fixtureCleanup()`** - Cleanup utility (automatically called after each test)
+
+### Headless Mocking Utilities
+
+Use the `buildFake*` utilities from `vitest-utils/testing-helpers/fixtures/headless/commerce/` to mock headless controllers:
+
+- **`buildFakePager()`** - Mock pagination controller
+- **`buildFakeProductListing()`** - Mock product listing controller
+- **`buildFakeSearch()`** - Mock search controller
+- **`buildFakeInstantProducts()`** - Mock instant products controller
+- **`buildFakeSort()`** - Mock sort controller
+- And other `buildFake*` utilities as needed
+
+### Required Imports and Setup
+
+Always include these imports in your commerce component tests:
+
+```typescript
+import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
+import {buildFake*} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/*-controller';
+import {vi, describe, it, expect, beforeEach} from 'vitest';
+import {page} from '@vitest/browser/context';
+import {html} from 'lit';
+
+// Mock headless at the top level
+vi.mock('@coveo/headless/commerce', {spy: true});
+```
+
+### Creating Render Functions
+
+Create a reusable render function that sets up mocked dependencies:
+
+```typescript
+const renderComponent = async (options = {}) => {
+  const mockedController = vi
+    .fn()
+    .mockReturnValue(buildFakeController(options));
+  vi.mocked(buildHeadlessFunction).mockReturnValue(
+    buildFakeController({
+      implementation: {
+        subController: mockedController,
+      },
+    })
+  );
+
+  const {element} = await renderInAtomicCommerceInterface<ComponentType>({
+    template: html`<component-tag .prop=${options.prop}></component-tag>`,
+    selector: 'component-tag',
+    bindings: (bindings) => {
+      bindings.interfaceElement.type = 'product-listing';
+      bindings.store.onChange = vi.fn();
+      // Configure other bindings as needed
+      return bindings;
+    },
+  });
+
+  return element;
+};
+```
+
+### Using Page Locators
+
+Use page locators from `@vitest/browser/context` for element selection:
+
+```typescript
+const locators = {
+  button: page.getByRole('button'),
+  specificElement: page.getByLabelText('Label Text'),
+  parts: (element: ComponentType) => {
+    const qs = (part: string) =>
+      element.shadowRoot?.querySelector(`[part="${part}"]`);
+    return {
+      mainButton: qs('main-button'),
+      secondaryButton: qs('secondary-button'),
+    };
+  },
+};
+```
+
+### Component Test Structure
+
+Structure your component tests following this pattern:
+
+```typescript
+describe('atomic-component-name', () => {
+  // Setup render function here
+
+  it('should render with default props', async () => {
+    const element = await renderComponent();
+    expect(element).toBeDefined();
+  });
+
+  it('should handle prop changes when prop is updated', async () => {
+    const element = await renderComponent({prop: 'value'});
+    // Test implementation
+  });
+
+  describe('when specific condition occurs', () => {
+    beforeEach(async () => {
+      await renderComponent({specificState: true});
+    });
+
+    it('should behave correctly', async () => {
+      // Test implementation
+    });
+  });
+});
+```
+
+Atom example
+
+```typescript
+// my-atom.spec.ts
+import {describe, it} from 'vitest';
+
+describe('#renderMyAtom', () => {
+  it('should ...', () => {
+    /* ... */
+  });
+  it('should ... when ...', () => {
+    /* ... */
+  });
+  describe('when ...', () => {
+    it('should ...', () => {
+      /* ... */
+    });
+    it('should ...', () => {
+      /* ... */
+    });
+  });
+});
+```
+
+Molecule example
+
+```typescript
+// atomic-my-molecule.spec.ts
+import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
+import {buildFakeController} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/controller';
+import {buildHeadlessFunction} from '@coveo/headless/commerce';
+import {page} from '@vitest/browser/context';
+import {html} from 'lit';
+import {describe, it, vi, expect, beforeEach} from 'vitest';
+
+vi.mock('@coveo/headless/commerce', {spy: true});
+
+describe('atomic-my-molecule', () => {
+  const locators = {
+    mainButton: page.getByRole('button'),
+    specificElement: page.getByLabelText('Label'),
+  };
+
+  const renderMolecule = async (options = {}) => {
+    const mockedController = vi
+      .fn()
+      .mockReturnValue(buildFakeController(options));
+    vi.mocked(buildHeadlessFunction).mockReturnValue(
+      buildFakeController({
+        implementation: {
+          subController: mockedController,
+        },
+      })
+    );
+
+    const {element} = await renderInAtomicCommerceInterface<AtomicMyMolecule>({
+      template: html`<atomic-my-molecule></atomic-my-molecule>`,
+      selector: 'atomic-my-molecule',
+      bindings: (bindings) => {
+        bindings.interfaceElement.type = 'product-listing';
+        bindings.store.onChange = vi.fn();
+        return bindings;
+      },
+    });
+
+    return element;
+  };
+
+  it('should render correctly', async () => {
+    const element = await renderMolecule();
+    expect(element).toBeDefined();
+  });
+
+  it('should handle interaction when button is clicked', async () => {
+    await renderMolecule();
+    await locators.mainButton.click();
+    // Test expectations
+  });
+
+  describe('when specific state is active', () => {
+    beforeEach(async () => {
+      await renderMolecule({activeState: true});
+    });
+
+    it('should display correctly', async () => {
+      await expect.element(locators.specificElement).toBeVisible();
+    });
+  });
+
+  describe('#myPublicMethod', () => {
+    it('should perform action', async () => {
+      const element = await renderMolecule();
+      const result = element.myPublicMethod();
+      expect(result).toBe('expected');
+    });
+
+    it('should handle error when invalid input provided', async () => {
+      const element = await renderMolecule();
+      expect(() => element.myPublicMethod('invalid')).toThrow();
+    });
+
+    describe('when method has complex conditions', () => {
+      beforeEach(async () => {
+        await renderMolecule({complexState: true});
+      });
+
+      it('should handle complex case', async () => {
+        // Test implementation
+      });
+
+      it('should validate complex input', async () => {
+        // Test implementation
+      });
+    });
+  });
+});
+```
+
+Enzyme example
+
+```typescript
+// my-enzyme.spec.ts
+import {describe, it} from 'vitest';
+
+describe('#MyEnzymeClassName', () => {
+  it('should ...', () => {
+    /* ... */
+  });
+  it('should ... when ...', () => {
+    /* ... */
+  });
+  describe('when ...', () => {
+    it('should ...', () => {
+      /* ... */
+    });
+  });
+  describe('#myPublicMethod', () => {
+    it('should ...', () => {
+      /* ... */
+    });
+    it('should ... when ...', () => {
+      /* ... */
+    });
+    describe('when ...', () => {
+      it('should ...', () => {
+        /* ... */
+      });
+      it('should ...', () => {
+        /* ... */
+      });
+    });
+  });
+});
+```
+
+Utils file example
+
+```typescript
+// my-utils-file.spec.ts
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
+import {html} from 'lit';
+import {describe, it, vi, expect, beforeEach} from 'vitest';
+import {myUtilFunction1, myUtilFunction2} from './my-utils-file';
+
+// Mock external dependencies if needed
+vi.mock('external-library', () => ({
+  externalFunction: vi.fn(),
+}));
+
+describe('my-utils-file', () => {
+  describe('#myUtilFunction1', () => {
+    it('should return expected result', () => {
+      const result = myUtilFunction1('input');
+      expect(result).toBe('expected');
+    });
+
+    it('should handle edge case when input is empty', () => {
+      const result = myUtilFunction1('');
+      expect(result).toBe('default');
+    });
+
+    describe('when complex conditions are met', () => {
+      beforeEach(() => {
+        // Setup complex state
+        vi.mocked(externalFunction).mockReturnValue('mocked-value');
+      });
+
+      it('should process complex input correctly', () => {
+        const result = myUtilFunction1('complex-input');
+        expect(result).toContain('mocked-value');
+      });
+
+      it('should validate complex scenario', () => {
+        expect(() => myUtilFunction1('invalid-complex')).toThrow();
+      });
+    });
+  });
+
+  describe('#myUtilFunction2', () => {
+    it('should transform data correctly', () => {
+      const input = {prop: 'value'};
+      const result = myUtilFunction2(input);
+      expect(result).toEqual({prop: 'transformed-value'});
+    });
+
+    it('should handle async operation when promise is involved', async () => {
+      const promise = myUtilFunction2Async('input');
+      await expect(promise).resolves.toBe('async-result');
+    });
+
+    describe('when i18n is required', () => {
+      let i18n: i18n;
+
+      beforeEach(async () => {
+        i18n = await createTestI18n();
+      });
+
+      it('should use i18n correctly', () => {
+        const result = myUtilFunction2WithI18n('key', i18n);
+        expect(result).toBe('translated-value');
+      });
+
+      it('should fallback when translation missing', () => {
+        const result = myUtilFunction2WithI18n('missing-key', i18n);
+        expect(result).toBe('missing-key');
+      });
+    });
+  });
+});
+```
+
+### Important Guidelines
+
+- **Always mock headless at the top level** with `vi.mock('@coveo/headless/commerce', {spy: true})`
+- **Use `beforeEach` for setup, not `afterEach`** - the framework handles cleanup automatically
+- **Prefer `renderInAtomicCommerceInterface`** over `fixture` for commerce components to ensure proper context
+- **Mock logger when tests log errors/warnings** to keep test output clean
+- **Use page locators** from `@vitest/browser/context` for better test reliability
+- **Create reusable render functions** to avoid duplication and ensure consistent setup
+- **Use `buildFake*` utilities** instead of creating manual mocks for headless controllers
+
+To run the tests, use the following command:
+
+```bash
+npx vitest --config vitest.config.ts ./src/**/*.spec.ts --run
+```
+
+- Replace `./src/**/*.spec.ts` with the path to your test files
+- Run in the packages/atomic directory

--- a/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
+++ b/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
@@ -193,9 +193,9 @@ it('should throw error when required prop is missing', async () => {
 ```typescript
 it('should handle click when button is pressed', async () => {
   await renderComponent();
-  const button = locators.button;
+  const button = locators.mainButton;
 
-  await button.click();
+  await mainButton.click();
 
   // Verify the result
   await expect.element(page.getByText('Expected Result')).toBeVisible();

--- a/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
+++ b/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
@@ -67,15 +67,6 @@ describe('atomic-commerce-component', () => {
   const locators = {
     mainButton: page.getByRole('button'),
     specificElement: page.getByLabelText('Label Text'),
-    // Use parts for shadow DOM elements
-    parts: (element: AtomicCommerceComponent) => {
-      const qs = (part: string) =>
-        element.shadowRoot?.querySelector(`[part="${part}"]`);
-      return {
-        mainButton: qs('main-button'),
-        secondaryButton: qs('secondary-button'),
-      };
-    },
   };
 
   const renderComponent = async (options = {}) => {
@@ -103,7 +94,20 @@ describe('atomic-commerce-component', () => {
         },
       });
 
-    return element;
+    return {
+      element,
+      locators: {
+        get mainButton() {
+          return page.getByRole('button');
+        },
+        get specificElement() {
+          return page.getByRole('bla');
+        },
+        get boom() {
+          return element.shadowRoot?.querySelector('div[part="sds"]');
+        },
+      },
+    };
   };
 
   // Test cases here

--- a/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
+++ b/.github/prompts/add-vitest-test-atomic-lit-component.prompt.md
@@ -1,0 +1,275 @@
+---
+mode: 'agent'
+tools: ['codebase', 'terminalLastCommand', 'testFailure', 'problems']
+description: 'Add comprehensive Vitest unit tests to Atomic Lit components following established patterns'
+---
+
+# Add Vitest Tests to Atomic Lit Components
+
+Your goal is to create comprehensive Vitest unit tests for an existing Atomic Lit component following the established patterns and conventions in the UI Kit project.
+
+**Note: All commands in this guide should be run from the `packages/atomic` directory.**
+
+## Task Overview
+
+You will be asked to add unit tests for a specific Atomic Lit component. Follow the guidelines from the [atomic testing instructions](../instructions/tests-atomic.instructions.md) and create a complete test suite that covers all component functionality.
+
+## Steps to Create Tests
+
+Ask for the component name if not provided, then follow these steps:
+
+### 1. Analyze the Component
+
+First, examine the component file to understand:
+
+- Component type (simple display, commerce component, complex interactive)
+- Props and their types
+- Public methods
+- State management
+- Dependencies on headless controllers
+- Error handling requirements
+- What will be rendered in Shadow DOM versus Light DOM (Tests locators should be aware of this)
+
+### 2. Create Test File Structure
+
+Create a test file named `{component-name}.spec.ts` in the same directory as the component.
+
+### 3. Set Up Required Imports
+
+```typescript
+import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
+import {buildFake[Controller]} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/[controller]';
+import {build[HeadlessFunction]} from '@coveo/headless/commerce';
+import {page} from '@vitest/browser/context';
+import {html} from 'lit';
+import {describe, it, vi, expect, beforeEach} from 'vitest';
+import {Atomic[ComponentName]} from './atomic-[component-name]';
+
+// Mock headless at the top level
+vi.mock('@coveo/headless/commerce', {spy: true});
+```
+
+### 4. Create Test Suite Structure
+
+Follow this naming pattern:
+
+- Main describe: component tag name (e.g., `'atomic-commerce-text'`)
+- Method describes: `#methodName` (e.g., `'#initialize'`)
+- Condition describes: `'when [condition]'` (e.g., `'when value is provided'`)
+- Test cases: Always start with "should" (e.g., `'should render correctly'`)
+
+### 5. Implement Test Patterns Based on Component Type
+
+#### A. Commerce Components (Most Common)
+
+```typescript
+describe('atomic-commerce-component', () => {
+  const locators = {
+    mainButton: page.getByRole('button'),
+    specificElement: page.getByLabelText('Label Text'),
+    // Use parts for shadow DOM elements
+    parts: (element: AtomicCommerceComponent) => {
+      const qs = (part: string) =>
+        element.shadowRoot?.querySelector(`[part="${part}"]`);
+      return {
+        mainButton: qs('main-button'),
+        secondaryButton: qs('secondary-button'),
+      };
+    },
+  };
+
+  const renderComponent = async (options = {}) => {
+    const mockedController = vi
+      .fn()
+      .mockReturnValue(buildFakeController(options));
+    vi.mocked(buildHeadlessFunction).mockReturnValue(
+      buildFakeController({
+        implementation: {
+          subController: mockedController,
+        },
+      })
+    );
+
+    const {element} =
+      await renderInAtomicCommerceInterface<AtomicCommerceComponent>({
+        template: html`<atomic-commerce-component
+          .prop=${options.prop}
+        ></atomic-commerce-component>`,
+        selector: 'atomic-commerce-component',
+        bindings: (bindings) => {
+          bindings.interfaceElement.type = 'product-listing';
+          bindings.store.onChange = vi.fn();
+          return bindings;
+        },
+      });
+
+    return element;
+  };
+
+  // Test cases here
+});
+```
+
+#### B. Simple Components (Text, Display-only)
+
+```typescript
+describe('atomic-simple-component', () => {
+  const renderComponent = async (props = {}) => {
+    const {element} =
+      await renderInAtomicCommerceInterface<AtomicSimpleComponent>({
+        template: html`<atomic-simple-component
+          .value=${props.value}
+          .count=${props.count}
+        ></atomic-simple-component>`,
+        selector: 'atomic-simple-component',
+        bindings: (bindings) => {
+          bindings.interfaceElement.type = 'product-listing';
+          return bindings;
+        },
+      });
+
+    return element;
+  };
+
+  // Test cases here
+});
+```
+
+### 6. Implement Essential Test Cases
+
+Create tests for:
+
+1. **Basic rendering** - Component creates and renders correctly
+2. **Prop validation** - All public properties work as expected
+3. **User interactions** - Click handlers, form inputs, etc.
+4. **State management** - Internal state changes
+5. **Error conditions** - Missing required props, invalid inputs
+6. **Public methods** - All exported functions work correctly
+
+### 7. Run Tests to Verify
+
+```bash
+npx vitest --config vitest.config.ts ./src/components/path/component.spec.ts --run
+```
+
+## Test Implementation Examples
+
+### Basic Test Structure
+
+```typescript
+it('should render with default props', async () => {
+  const element = await renderComponent();
+  expect(element).toBeDefined();
+});
+
+it('should handle prop changes when prop is updated', async () => {
+  const element = await renderComponent({prop: 'value'});
+  // Test implementation
+});
+
+describe('when specific condition occurs', () => {
+  beforeEach(async () => {
+    await renderComponent({specificState: true});
+  });
+
+  it('should behave correctly', async () => {
+    // Test implementation
+  });
+});
+```
+
+### Error Handling Tests
+
+```typescript
+it('should throw error when required prop is missing', async () => {
+  const element = await renderComponent();
+  expect(element.error).toBeDefined();
+  expect(element.error.message).toContain('must be defined');
+});
+```
+
+### User Interaction Tests
+
+```typescript
+it('should handle click when button is pressed', async () => {
+  await renderComponent();
+  const button = locators.button;
+
+  await button.click();
+
+  // Verify the result
+  await expect.element(page.getByText('Expected Result')).toBeVisible();
+});
+```
+
+### Public Method Tests
+
+```typescript
+describe('#publicMethod', () => {
+  it('should return expected result', async () => {
+    const element = await renderComponent();
+    const result = element.publicMethod('input');
+    expect(result).toBe('expected');
+  });
+
+  it('should handle error when invalid input provided', async () => {
+    const element = await renderComponent();
+    expect(() => element.publicMethod('invalid')).toThrow();
+  });
+});
+```
+
+## Important Guidelines
+
+### Mock Setup Order
+
+⚠️ **Always mock headless before importing component**:
+
+```typescript
+// ✅ Correct
+vi.mock('@coveo/headless/commerce', {spy: true});
+import {AtomicComponent} from './atomic-component';
+
+// ❌ Incorrect
+import {AtomicComponent} from './atomic-component';
+vi.mock('@coveo/headless/commerce', {spy: true});
+```
+
+### Test Naming
+
+- **Component level**: Use component tag name (`'atomic-commerce-text'`)
+- **Method level**: Use `#methodName` (`'#initialize'`)
+- **Condition level**: Use `'when [condition]'` (`'when value is provided'`)
+- **Test cases**: Always start with "should" (`'should render correctly'`)
+
+### Use beforeEach for Setup
+
+```typescript
+// ✅ Correct: Use beforeEach for setup
+describe('when condition occurs', () => {
+  beforeEach(async () => {
+    await renderComponent({specificState: true});
+  });
+
+  it('should behave correctly', async () => {
+    // Test implementation
+  });
+});
+```
+
+## Completion Checklist
+
+After creating the test file:
+
+- [ ] All imports are correctly set up
+- [ ] Headless mocking is configured properly
+- [ ] Component render function works
+- [ ] Basic rendering test passes
+- [ ] All public props are tested
+- [ ] All public methods are tested
+- [ ] Error conditions are tested
+- [ ] User interactions are tested (if applicable)
+- [ ] Tests follow naming conventions
+- [ ] Tests run successfully without errors
+
+Ask me for the component name if not provided, then proceed to analyze the component and create comprehensive tests following these patterns.

--- a/.github/prompts/migrate-stencil-to-lit.prompt.md
+++ b/.github/prompts/migrate-stencil-to-lit.prompt.md
@@ -1,0 +1,265 @@
+---
+mode: 'agent'
+description: 'Migrate an atomic Stencil component to Lit with functional components/utils migration'
+---
+
+# Migrate Stencil Component to Lit
+
+Your goal is to migrate an existing atomic Stencil component to a modern Lit-based component while preserving all functionality and maintaining the project's coding standards.
+
+**Note: All commands in this migration should be run from the `packages/atomic` directory.**
+
+## Migration Requirements
+
+Follow the guidelines from [atomic component instructions](../instructions/atomic.instructions.md) for proper structure and conventions.
+
+### 1. Generate New Lit Component Structure
+
+Use the generate-component.mjs script to create the new Lit component structure:
+
+```bash
+node scripts/generate-component.mjs ${input:componentName} ${input:componentDirectory:src/components/common}
+```
+
+Ask for the component name (without `atomic-` prefix) and target directory if not provided.
+
+### 2. File Migration Map
+
+Migrate files according to this mapping:
+
+**From Stencil format:**
+
+- `atomic-{name}.tsx` → `atomic-{name}.ts` (main component)
+- `atomic-{name}.pcss` → `atomic-{name}.tw.css` (styles)
+- Keep unchanged: `.spec.ts`, `.new.stories.tsx`, `.mdx`, `e2e/` files
+
+### 3. Component Code Migration
+
+**Convert Stencil syntax to Lit:**
+
+- Replace `@Component` decorator with Lit `@customElement`
+- Convert JSX templates to Lit `html` template literals
+- Replace `@Prop()` with `@property()`
+- Replace `@State()` with `@state()`
+- Replace `@Event()` with custom event dispatching
+- Replace `@Listen()` with appropriate event listeners
+- Convert lifecycle methods (componentWillLoad → willUpdate, etc.)
+- Replace CSS classes with Tailwind CSS utilities
+
+**Style Migration:**
+
+- Convert PostCSS (`.pcss`) to Tailwind CSS (`.tw.css`)
+- Replace CSS custom properties with Tailwind utilities where possible
+- Maintain design system consistency
+
+### 4. Common Migration Pitfalls and Corrections
+
+**❌ Incorrect InitializableComponent usage:**
+
+```typescript
+// DON'T: Using wrong import or implementation
+import {InitializableComponent} from 'somewhere/else';
+```
+
+**✅ Correct InitializableComponent usage:**
+
+```typescript
+import {InitializableComponent} from '@/src/decorators/types';
+
+export class AtomicCommercePager
+  extends LitElement
+  implements InitializableComponent<CommerceBindings>
+```
+
+**❌ Missing bindings decorator/mixin:**
+
+```typescript
+// DON'T: Forget to add bindings decorator
+@customElement('atomic-commerce-pager')
+export class AtomicCommercePager extends LitElement
+```
+
+**✅ Correct bindings setup:**
+
+```typescript
+import {bindings} from '@/src/decorators/bindings';
+
+@customElement('atomic-commerce-pager')
+@bindings()
+@withTailwindStyles
+export class AtomicCommercePager
+  extends LitElement
+  implements InitializableComponent<CommerceBindings>
+{
+  @state()
+  bindings!: CommerceBindings;
+  // ...
+}
+```
+
+**❌ Removing global type declaration:**
+
+```typescript
+// DON'T: Remove this declaration even if there are errors
+// export class AtomicCommercePager extends LitElement { }
+// (missing global declaration)
+```
+
+**✅ Keep global type declaration:**
+
+```typescript
+declare global {
+  interface HTMLElementTagNameMap {
+    'atomic-commerce-pager': AtomicCommercePager;
+  }
+}
+```
+
+_Note: TypeScript errors are normal until rebuilding atomic package_
+
+**❌ Missing CSS file references:**
+
+```css
+/* DON'T: Forget to include required Tailwind utilities */
+/* Missing @reference for custom utils */
+```
+
+**✅ Include all required CSS references:**
+
+```css
+@reference '../../../utils/coveo.tw.css';
+/* Include this if component uses custom Tailwind utilities */
+```
+
+**❌ Incorrect functional component method naming:**
+
+```typescript
+// DON'T: Use non-render prefixed methods
+private pagerButton() { }
+private buttonElement() { }
+```
+
+**✅ Correct functional component method naming:**
+
+```typescript
+// DO: All FC methods must start with 'render'
+private renderPagerButton() { }
+private renderButtonElement() { }
+```
+
+**❌ Wrong bindStateToController import:**
+
+```typescript
+// DON'T: Use old utility import
+import {BindStateToController} from '@/src/utils/initialization-utils';
+```
+
+**✅ Correct bindStateToController import:**
+
+```typescript
+// DO: Use the decorator version
+import {bindStateToController} from '@/src/decorators/bind-state';
+```
+
+### 5. Functional Components/Utils Migration
+
+**For any functional components or utilities used by the component:**
+
+1. **Create Lit versions:**
+
+   - Migrate the functional logic to work with Lit (functional components are always in separate files, never inline them in the main component)
+   - Update imports and usage in the main component
+   - Follow Lit patterns and best practices
+   - Make sure to use the correct FunctionalComponentX type for each component
+
+2. **Preserve Stencil versions:**
+
+   - Rename original files with `stencil-` prefix
+   - Example: `utils/helper.ts` → `utils/stencil-helper.ts`
+   - **Update ALL Stencil components across ALL use cases** (commerce, search, headless, etc.) that import these utilities to use the prefixed versions
+   - Search the entire codebase for imports of the renamed utilities
+
+3. **Update import statements:**
+   - Ensure the new Lit component uses the new Lit-compatible versions
+   - **Search across all packages and use cases** for any imports that need updating
+   - Verify no circular dependencies are introduced
+   - Use global search to find all references: `grep -r "import.*helper" packages/` (replace with actual utility name)
+
+### 6. Testing Migration
+
+**Update test files:**
+
+- Adapt unit tests (`.spec.ts`) for Lit component testing patterns
+- Update any component-specific test utilities
+- Ensure E2E tests continue to work with the new component structure
+
+### 7. Documentation Updates
+
+**Update component documentation:**
+
+- Review and update `.mdx` documentation file
+- Update Storybook stories (`.new.stories.tsx`) for Lit component
+- Ensure all examples work with the new implementation
+
+### 8. Export Management
+
+After migration, run the generate-lit-exports.mjs script:
+
+```bash
+node scripts/generate-lit-exports.mjs
+```
+
+This updates the exports in `src/components/index.ts` for the new Lit component.
+
+### 9. Validation Steps
+
+**Before completing the migration:**
+
+1. **Build verification:**
+
+   - Ensure the component builds without errors
+   - Run TypeScript checks
+   - Verify Storybook stories render correctly
+
+2. **Functionality testing:**
+
+   - Run unit tests: `npm test -- atomic-{name}.spec.ts`
+   - Run E2E tests if available
+   - Manual testing in Storybook
+
+3. **Integration verification:**
+   - Check that dependent components still work
+   - Verify the component works in sample applications
+   - Ensure accessibility features are preserved
+
+## Migration Checklist
+
+- [ ] Generate new Lit component structure using generate-component.mjs
+- [ ] Migrate main component from .tsx to .ts
+- [ ] Convert PostCSS styles to Tailwind CSS
+- [ ] **Verify correct InitializableComponent import and implementation**
+- [ ] **Add @bindings() decorator and bindings state property**
+- [ ] **Keep global HTMLElementTagNameMap declaration (ignore TS errors until rebuild)**
+- [ ] **Include all required CSS references (e.g., @reference '../../../utils/coveo.tw.css')**
+- [ ] **Ensure functional component methods start with 'render' prefix**
+- [ ] **Use correct bindStateToController import from decorators**
+- [ ] Migrate functional components/utils with stencil- prefixing
+- [ ] **Update ALL imports across ALL use cases (commerce, search, headless, etc.) when renaming utilities**
+- [ ] **Verify no broken imports remain in any package using global search**
+- [ ] Update unit tests for Lit patterns
+- [ ] Update Storybook stories
+- [ ] Update documentation (.mdx)
+- [ ] Run generate-lit-exports.mjs
+- [ ] Verify build passes
+- [ ] Verify all tests pass
+- [ ] Manual testing in Storybook
+- [ ] Check integration with dependent components
+
+## Important Notes
+
+- **Preserve backward compatibility:** Ensure the new Lit component provides the same API and behavior
+- **Maintain accessibility:** All ARIA attributes and keyboard navigation should be preserved
+- **Follow conventions:** Use the established patterns from other Lit components in the codebase
+- **Test thoroughly:** Both automated and manual testing are crucial for a successful migration
+
+Ask me for the component name and directory if not provided, then proceed with the migration following these steps systematically.


### PR DESCRIPTION
This PR includes instructions/prompts for github copilot. It ensures that code generated by copilot follows our best practices for Atomic more accurately. It also includes two custom prompt examples:

## migrate-stencil-to-lit.prompt.md
Can be used to do the initial work for the migration of a component from stencil to lit.

## add-vitest-test-atomic-lit-component.prompt.md
This one works, but needs improvement. Depending on the component, this prompt can generate a good starting point. 

https://coveord.atlassian.net/browse/KIT-4100