### PR TITLE
docs(atomic): document slot in no-items components

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -370,7 +370,7 @@ export namespace Components {
     interface AtomicCommerceLoadMoreProducts {
     }
     /**
-     * @alpha The `atomic-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
+     * @alpha The `atomic-commerce-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
      */
     interface AtomicCommerceNoProducts {
     }
@@ -3806,7 +3806,7 @@ declare global {
         new (): HTMLAtomicCommerceLoadMoreProductsElement;
     };
     /**
-     * @alpha The `atomic-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
+     * @alpha The `atomic-commerce-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
      */
     interface HTMLAtomicCommerceNoProductsElement extends Components.AtomicCommerceNoProducts, HTMLStencilElement {
     }
@@ -6177,7 +6177,7 @@ declare namespace LocalJSX {
     interface AtomicCommerceLoadMoreProducts {
     }
     /**
-     * @alpha The `atomic-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
+     * @alpha The `atomic-commerce-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
      */
     interface AtomicCommerceNoProducts {
     }
@@ -9534,7 +9534,7 @@ declare module "@stencil/core" {
              */
             "atomic-commerce-load-more-products": LocalJSX.AtomicCommerceLoadMoreProducts & JSXBase.HTMLAttributes<HTMLAtomicCommerceLoadMoreProductsElement>;
             /**
-             * @alpha The `atomic-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
+             * @alpha The `atomic-commerce-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
              */
             "atomic-commerce-no-products": LocalJSX.AtomicCommerceNoProducts & JSXBase.HTMLAttributes<HTMLAtomicCommerceNoProductsElement>;
             /**

--- a/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.tsx
@@ -23,7 +23,7 @@ import {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-int
 /**
  * @alpha
  *
- * The `atomic-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
+ * The `atomic-commerce-no-products` component displays search tips when there are no products. Any additional content slotted inside of its element will be displayed as well.
  *
  * @part no-results - The text indicating that no products were found for the search.
  * @part search-tips - The search tips to help the user correct the query.

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.tsx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.tsx
@@ -32,6 +32,8 @@ import {Bindings} from '../atomic-search-interface/atomic-search-interface';
  * @part search-tips - The search tips to help the user correct the query.
  * @part highlight - The highlighted query.
  * @part icon - The magnifying glass icon.
+ *
+ * @slot default - Any additional content slotted inside of its element will be displayed as well.
  */
 @Component({
   tag: 'atomic-no-results',


### PR DESCRIPTION
## Summary

This PR addresses KIT-4377 by documenting the undocumented slot in no-items components.

## Changes

- Added `@slot default` documentation to `atomic-no-results` component
- Fixed component name in JSDoc for `atomic-commerce-no-products` component (was incorrectly named `atomic-no-products`)
- Both components now properly document the default slot that allows additional content to be slotted inside

## Related

- Fixes KIT-4377
- Jira: https://coveord.atlassian.net/browse/KIT-4377

## Testing

- Documentation changes only, no functionality affected
- The slot was already working, this just adds proper documentation for it