### PR TITLE
chore(headless): deprecate restoreTab action (KIT-4398)

### DIFF
--- a/packages/headless/CHANGELOG.md
+++ b/packages/headless/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <small>3.26.2 (2025-06-24)</small>
+
+- chore(headless): deprecate `restoreTab` action (KIT-4398) - will be removed in V4
+
 ## <small>3.26.1 (2025-06-18)</small>
 
 - chore(deps): update vite to v3.2.3 j:kit-282 (#5475) ([32f2b2e](https://github.com/coveo/ui-kit/commits/32f2b2e)), closes [#5475](https://github.com/coveo/ui-kit/issues/5475)

--- a/packages/headless/src/features/search-parameters/search-parameter-actions-loader.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions-loader.ts
@@ -36,6 +36,7 @@ export interface SearchParameterActionCreators {
    *
    * @param payload - The action creator payload.
    * @returns A dispatchable action.
+   * @deprecated This action will be removed in V4. Use alternative tab management methods instead.
    */
   restoreTab(payload: string): PayloadAction<string>;
 }

--- a/packages/headless/src/features/search-parameters/search-parameter-actions.ts
+++ b/packages/headless/src/features/search-parameters/search-parameter-actions.ts
@@ -87,7 +87,7 @@ export interface SearchParameters {
 
   /**
    * The active tab id.
-   * @deprecated Restoring the tab with the restoreSearchParameters action can cause components to be visible/hidden on the wrong tab. Instead, first restore the tab using the `restoreTab` action, then the rest of the parameters with the restoreSearchParameters action.
+   * @deprecated Restoring the tab with the restoreSearchParameters action can cause components to be visible/hidden on the wrong tab. The `restoreTab` action is also deprecated and will be removed in V4. Use alternative tab management methods instead.
    */
   tab?: string;
 
@@ -108,6 +108,10 @@ export const restoreSearchParameters = createAction(
     validatePayload(payload, searchParametersDefinition)
 );
 
+/**
+ * Restores a tab from the search parameters.
+ * @deprecated This action will be removed in V4. Use alternative tab management methods instead.
+ */
 export const restoreTab = createAction(
   'searchParameters/restoreTab',
   (payload: TabId) => validatePayload(payload, requiredNonEmptyString)


### PR DESCRIPTION
## Summary

This PR deprecates the `restoreTab` action in the headless library as part of KIT-4398. The action will be removed in V4.

## Changes

- Added `@deprecated` JSDoc comment to the `restoreTab` action indicating it will be removed in V4
- Updated the deprecation comment for the `restoreTab` action in the search parameter actions loader
- Updated the existing deprecation comment for the `tab` property in `SearchParameters` interface to mention that `restoreTab` is also deprecated
- Added changelog entry for the deprecation

## Impact

- Developers using the `restoreTab` action will see deprecation warnings in their IDEs and documentation
- The action will continue to work as expected until V4
- Users should migrate to alternative tab management methods before V4

## Testing

- No functional changes were made, only deprecation warnings added
- Existing tests continue to pass
- The action remains fully functional

## Ticket

Fixes: KIT-4398