### PR TITLE
chore: add support for using copilot prompts/instructions from atomic

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -1,4 +1,6 @@
-# GitHub Copilot Instructions
+---
+applyTo: '**'
+---
 
 ## Core Principles
 

--- a/packages/atomic/.gitignore
+++ b/packages/atomic/.gitignore
@@ -16,7 +16,8 @@ log.txt
 
 .stencil/
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .sass-cache/
 .versions/
 node_modules/
@@ -32,7 +33,6 @@ src/components/search/atomic-search-interface/lang/
 src/generated
 
 cypress/screenshots/*
-
 
 /test-results/
 /playwright-report/

--- a/packages/atomic/.vscode/settings.json
+++ b/packages/atomic/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "chat.promptFilesLocations": {
+    "../../.github/prompts": true
+  },
+  "chat.instructionsFilesLocations": {
+    "../../.github/instructions": true
+  }
+}


### PR DESCRIPTION
Right now, it is not possible to use copilot prompts/instructions if you open a specific package, for example atomic, instead of the full ui-kit repo.

With workspace settings inside a package, it is possible to set custom paths to the prompts/instructions files

This PR adds this to the atomic package only. We can add the same file to other packages later if needed. 

https://coveord.atlassian.net/browse/KIT-4436
