### PR TITLE
fix(shopify): get memoized fetch working in browsers

### DIFF
--- a/packages/shopify/src/utilities/app-proxy.ts
+++ b/packages/shopify/src/utilities/app-proxy.ts
@@ -1,20 +1,8 @@
 import {AppProxyOptions, CoveoShopifyOptions} from '../types';
 import {memoize} from './memoize';
 
-function getFetch(): typeof fetch {
-  // Browser environments
-  if (typeof fetch === 'function') {
-    return fetch;
-  }
-  // Node.js environments
-  if (typeof global !== 'undefined' && typeof global.fetch === 'function') {
-    return global.fetch;
-  }
-  throw new Error('Fetch API is not available in this environment.');
-}
-
 const memoizedFetch = memoize(
-  (...args: Parameters<typeof fetch>) => getFetch()(...args),
+  (...args: Parameters<typeof fetch>) => fetch(...args),
   (url: string) => url
 );
 


### PR DESCRIPTION
The `global` object isn't available in browsers, so `memoizedFetch` throws an error.
![Screenshot 2025-07-01 at 3 46 16 PM](https://github.com/user-attachments/assets/cfe34559-3769-4be7-bea2-157bad4e161d)
![Screenshot 2025-07-01 at 3 46 21 PM](https://github.com/user-attachments/assets/8bfd7b19-0c5f-4d7f-9a3b-8f2d8123ffd9)

https://coveord.atlassian.net/browse/LENS-3749