### PR TITLE
fix(headless): send action cause in legacy analytics mode

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -270,7 +270,12 @@ export const answerApi = answerSlice.injectEndpoints({
 export const selectAnswerTriggerParams = createSelector(
   (state) => selectQuery(state)?.q,
   (state) => state.search.requestId,
-  (q, requestId) => ({q, requestId})
+  (state) => state.generatedAnswer.cannotAnswer,
+  (q, requestId, cannotAnswer) => ({
+    q,
+    requestId,
+    cannotAnswer,
+  })
 );
 
 let generateFacetParams: Record<string, ReturnType<typeof getFacets>> = {};

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -105,15 +105,14 @@ const subscribeToSearchRequest = (
       lastTriggerParams = triggerParams;
     }
 
-    if (triggerParams.q.length === 0 && !!state.generatedAnswer.cannotAnswer) {
+    if (triggerParams.q.length === 0 && !!triggerParams.cannotAnswer) {
       engine.dispatch(setCannotAnswer(false));
     }
 
     if (
       triggerParams.q.length === 0 ||
       triggerParams.requestId.length === 0 ||
-      triggerParams.requestId === lastTriggerParams.requestId ||
-      !state.search?.searchAction?.actionCause
+      triggerParams.requestId === lastTriggerParams.requestId
     ) {
       return;
     }

--- a/packages/headless/src/features/search/legacy/search-actions.ts
+++ b/packages/headless/src/features/search/legacy/search-actions.ts
@@ -336,11 +336,13 @@ export async function legacyExecuteSearch(
     logger,
   });
 
-  config.dispatch(
-    updateSearchAction({
-      actionCause: eventDescription?.actionCause || 'default',
-    })
-  );
+  if (eventDescription?.actionCause) {
+    config.dispatch(
+      updateSearchAction({
+        actionCause: eventDescription.actionCause,
+      })
+    );
+  }
 
   const request = await buildSearchRequest(state, eventDescription);
 

--- a/packages/headless/src/features/search/legacy/search-actions.ts
+++ b/packages/headless/src/features/search/legacy/search-actions.ts
@@ -31,6 +31,7 @@ import {
   UpdateQueryActionCreatorPayload,
 } from '../../query/query-actions.js';
 import {buildSearchAndFoldingLoadCollectionRequest} from '../../search-and-folding/legacy/search-and-folding-request.js';
+import {updateSearchAction} from '../search-actions.js';
 import {logFetchMoreResults} from '../search-analytics-actions.js';
 import {MappedSearchRequest, mapSearchRequest} from '../search-mappings.js';
 import {
@@ -334,6 +335,12 @@ export async function legacyExecuteSearch(
     preprocessRequest,
     logger,
   });
+
+  config.dispatch(
+    updateSearchAction({
+      actionCause: eventDescription?.actionCause || 'default',
+    })
+  );
 
   const request = await buildSearchRequest(state, eventDescription);
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-5218
### The bug

No call was ever sent to the /generate endpoint of the answer API when analytics were set to legacy mode

### The cause

In the [search-actions controller](https://github.com/coveo/ui-kit/blob/fix/SVCC-5218/packages/headless/src/features/search/search-actions.ts#L118), when we are in legacy mode, we use the legacy execute search and we thus skip the setting of the action cause in the new [execute search controller](https://github.com/coveo/ui-kit/blob/fix/SVCC-5218/packages/headless/src/features/search/search-actions.ts#L126).  Since we were waiting for the actionCause to be in the store before dispatching the /generate call,  we never sent any calls.

### The solution

In the legacy execute search, dispatch an update of the actionCause in the state. 
Note that we don't wait for the actionCause to be defined in the answer api listener anymore. This is because the actionCause could theoretically be undefined when using the legacy analytics (even though it _should_ never happen)

### To test 
In genqa.html
1. Add an answer config ID:

```
          <atomic-generated-answer answer-configuration-id="fc581be0-6e61-4039-ab26-a3f2f52f308f">
          </atomic-generated-answer>
```
2.  Initialize in legacy mode:

```
      // Initialization
      await searchInterface.initialize({
        accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
        organizationId: 'searchuisamples',
        search: {
          pipeline: 'genqatest',
        },
        analytics: {analyticsMode: 'legacy'},
      });
```

genQA should be working and the /generate POST should contain an analytics -> actionCause