### PR TITLE
feat(lint): enable biome noFloatingPromises rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -94,7 +94,11 @@
   },
   "linter": {
     "enabled": true,
-    "rules": {"recommended": false, "style": {"useBlockStatements": "off"}},
+    "rules": {
+      "recommended": false,
+      "style": {"useBlockStatements": "off"},
+      "nursery": {"noFloatingPromises": "warn"}
+    },
     "includes": [
       "**",
       "!**/packages/quantic/**/*",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3614


<img width="1529" alt="noFloatingPromises" src="https://github.com/user-attachments/assets/b86fad5f-42f9-4fd9-9098-fbeb9f7a257a" />

## Enable noFloatingPromises rule in Biome
Enables the noFloatingPromises rule as a warning to catch potential issues with unhandled promises in the codebase.
This will help identify places where promises are created but not properly handled (not awaited, returned, or caught), which can lead to silent failures and hard-to-debug issues.