### PR TITLE
fix(headless commerce): ensure headless uses the same relay reference between engine and thunk

### DIFF
--- a/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
+++ b/packages/headless/src/app/case-assist-engine/case-assist-engine.test.ts
@@ -139,4 +139,12 @@ describe('buildCaseAssistEngine', () => {
       options.configuration.locale
     );
   });
+
+  it('should ensure that engine.relay is the same reference as thunk extra args relay', async () => {
+    const thunkRelay = await engine.dispatch(
+      (_dispatch, _getState, extra) => extra.relay
+    );
+
+    expect(thunkRelay).toBe(engine.relay);
+  });
 });

--- a/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.test.ts
@@ -129,4 +129,12 @@ describe('buildCommerceEngine', () => {
       [createCartKey(items[1])]: items[1],
     });
   });
+
+  it('should ensure that engine.relay is the same reference as thunk extra args relay', async () => {
+    const thunkRelay = await engine.dispatch(
+      (_dispatch, _getState, extra) => extra.relay
+    );
+
+    expect(thunkRelay).toBe(engine.relay);
+  });
 });

--- a/packages/headless/src/app/commerce-engine/commerce-engine.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine.ts
@@ -174,6 +174,10 @@ export function buildCommerceEngine(
   return redactEngine({
     ...engine,
 
+    get relay() {
+      return internalEngine.relay;
+    },
+
     get [stateKey]() {
       return internalEngine.state;
     },

--- a/packages/headless/src/app/insight-engine/insight-engine.test.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.test.ts
@@ -156,4 +156,12 @@ describe('buildInsightEngine', () => {
   it('exposes an #executeFirstSearch method', () => {
     expect(engine.executeFirstSearch).toBeTruthy();
   });
+
+  it('should ensure that engine.relay is the same reference as thunk extra args relay', async () => {
+    const thunkRelay = await engine.dispatch(
+      (_dispatch, _getState, extra) => extra.relay
+    );
+
+    expect(thunkRelay).toBe(engine.relay);
+  });
 });

--- a/packages/headless/src/app/recommendation-engine/recommendation-engine.test.ts
+++ b/packages/headless/src/app/recommendation-engine/recommendation-engine.test.ts
@@ -127,4 +127,12 @@ describe('buildRecommendationEngine', () => {
 
     expect(engine.state.configuration.search.locale).toBe(locale);
   });
+
+  it('should ensure that engine.relay is the same reference as thunk extra args relay', async () => {
+    const thunkRelay = await engine.dispatch(
+      (_dispatch, _getState, extra) => extra.relay
+    );
+
+    expect(thunkRelay).toBe(engine.relay);
+  });
 });

--- a/packages/headless/src/app/search-engine/search-engine.test.ts
+++ b/packages/headless/src/app/search-engine/search-engine.test.ts
@@ -185,5 +185,13 @@ describe('searchEngine', () => {
         expect(engine.state.configuration.search.apiBaseUrl).toBe(proxyBaseUrl);
       });
     });
+
+    it('should ensure that engine.relay is the same reference as thunk extra args relay', async () => {
+      const thunkRelay = await engine.dispatch(
+        (_dispatch, _getState, extra) => extra.relay
+      );
+
+      expect(thunkRelay).toBe(engine.relay);
+    });
   });
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4308

## Problem
The reference between engine.relay and the relay used in the `createAsyncThunk` actions was desynced in commerce because of the line in the commerce engine here: 

https://github.com/coveo/ui-kit/blob/9e01022db1d190ed5f8c13fd720b83886a32a3f9/packages/headless/src/app/commerce-engine/commerce-engine.ts#L138

This made it so when you modified relay via engine.relay.updateConfig, it would only change engine.relay and not extra.relay from the `createAsyncThunk` actions.

## Fix
return a getter for relay pointing to the original engine.

I added tests for other engines even though the bug only happened in commerce.
