### PR TITLE
ci: enable back flaky test

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/e2e/atomic-product-multi-value-text.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/e2e/atomic-product-multi-value-text.e2e.ts
@@ -102,9 +102,7 @@ test.describe('with max-values-to-display set to total number of values (6)', ()
     await expect(productMultiValueText.separators).toHaveCount(5);
   });
 
-  //TODO: Address in KIT-4278 -
-  // *might be fixed with the await added in this PR
-  test.skip('should not render an indicator that more values are available', async ({
+  test('should not render an indicator that more values are available', async ({
     productMultiValueText,
   }) => {
     await expect(productMultiValueText.moreValuesIndicator()).not.toBeVisible();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4278

It was actually probably fixed in a previous PR when `await` was added to the floating isVisible() promise.