### PR TITLE
ci: properly fix flakiness in atomic-react tests

### DIFF
--- a/packages/samples/atomic-react/tests/smoke.spec.ts
+++ b/packages/samples/atomic-react/tests/smoke.spec.ts
@@ -11,6 +11,11 @@ test.describe('smoke test', () => {
     const searchBox = page.locator('atomic-search-box');
     await expect(searchBox).toBeVisible();
 
+    const querySummary = page.locator('atomic-query-summary');
+
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
     const textarea = searchBox.locator('textarea[part="textarea"]');
     await textarea.fill('test');
     await textarea.press('Enter');
@@ -20,7 +25,6 @@ test.describe('smoke test', () => {
     await expect(facet).toBeVisible();
 
     // Verify query summary
-    const querySummary = page.locator('atomic-query-summary');
     await expect(querySummary).toBeVisible();
 
     const summaryContainer = querySummary.locator('div[part="container"]');
@@ -49,13 +53,17 @@ test.describe('smoke test', () => {
     const searchBox = page.locator('atomic-commerce-search-box');
     await expect(searchBox).toBeVisible();
 
+    const querySummary = page.locator('atomic-commerce-query-summary');
+
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
     // Perform a search query
     const textarea = searchBox.locator('textarea[part="textarea"]');
     await textarea.fill('shoe');
     await textarea.press('Enter');
 
     // Verify query summary
-    const querySummary = page.locator('atomic-commerce-query-summary');
     await expect(querySummary).toBeVisible();
 
     const summaryContainer = querySummary.locator('div[part="container"]');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4465

I was able to reproduce the flakiness locally and it gets fixed by waiting for the query summary to be rendered before doing the query.