### PR TITLE
ci: fix flakiness in headless-react

### DIFF
--- a/packages/headless-react/vitest.config.js
+++ b/packages/headless-react/vitest.config.js
@@ -5,4 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
   },
+  define: {
+    global: 'window',
+  },
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4466


This error here happens like 2% of the time. It seems commerce-engine.tsx is causing it by having some react process still run after the vitest environment teardown. After the teardown, the environment is no longer "jsdom", it is "node" so window is not defined. The last react processes throw an error which gets caught after the test environment gets torn down. We can fix it by just simply defining window here for this loose case.

https://github.com/coveo/ui-kit/actions/runs/16079036981/job/45380671867?pr=5578
