### PR TITLE
fix(atomic): fix "see all results" button deleting the query in the search box

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
@@ -444,6 +444,14 @@ describe('AtomicCommerceSearchBox', () => {
     });
   });
 
+  /**
+   * https://coveord.atlassian.net/browse/KIT-4468
+   * Write this test here when the atomic-suggestion-renderer is removed and when we can properly test the suggestions
+   */
+  describe.skip('when selecting a suggestion with the keyboard', () => {
+    it('should reset the aria-descendant on the search box', async () => {});
+  });
+
   it('should have the "suggestions-wrapper suggestions-single-list" part on the suggestions container', async () => {
     const {suggestionsContainer, textArea} = await renderSearchBox();
 

--- a/packages/atomic/src/components/common/suggestions/stencil-suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/stencil-suggestion-manager.ts
@@ -121,7 +121,6 @@ export class SuggestionManager<SearchBoxController> {
 
   public clickOnActiveElement() {
     this.activeDescendantElement?.click();
-    this.updateActiveDescendant();
   }
 
   public isRightPanelInFocus() {

--- a/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestion-manager.ts
@@ -121,7 +121,6 @@ export class SuggestionManager<SearchBoxController> {
 
   public clickOnActiveElement() {
     this.activeDescendantElement?.click();
-    this.updateActiveDescendant();
   }
 
   public isRightPanelInFocus() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4355

This fix removes a line that is meant to remove the activeDescendant and then to trigger an update to the search box. I am not sure why why removing it fixes the bug and keeps the removal of the activeDescendant when a suggestion is chosen.


## After

https://github.com/user-attachments/assets/225efa10-a3bc-4845-a077-4e6649d4fad6

