### PR TITLE
fix(atomic, headless): let api clients handle 401 and 419 errors

### DIFF
--- a/packages/atomic/src/components/search/atomic-query-error/e2e/atomic-query-error.e2e.ts
+++ b/packages/atomic/src/components/search/atomic-query-error/e2e/atomic-query-error.e2e.ts
@@ -1,0 +1,35 @@
+import {test, expect} from './fixture';
+
+test.describe('AtomicQueryError', () => {
+  test('should be accessible', async ({makeAxeBuilder, queryError}) => {
+    await queryError.load();
+    await queryError.hydrated.waitFor();
+    const accessibilityResults = await makeAxeBuilder().analyze();
+    expect(accessibilityResults.violations).toEqual([]);
+  });
+
+  test.describe('when there is an invalid token', () => {
+    test('should display the component with the correct content', async ({
+      queryError,
+    }) => {
+      await queryError.load();
+
+      await expect(queryError.title).toBeVisible();
+      await expect(queryError.description).toBeVisible();
+      await expect(queryError.docLink).toBeVisible();
+    });
+  });
+
+  test.describe('when there is a 419 error', () => {
+    test('should display the component with the correct content', async ({
+      queryError,
+    }) => {
+      await queryError.with419Error();
+      await queryError.load();
+
+      await expect(queryError.title419).toBeVisible();
+      await expect(queryError.description419).toBeVisible();
+      await expect(queryError.infoButton).toBeVisible();
+    });
+  });
+});

--- a/packages/atomic/src/components/search/atomic-query-error/e2e/fixture.ts
+++ b/packages/atomic/src/components/search/atomic-query-error/e2e/fixture.ts
@@ -1,0 +1,16 @@
+import {AxeFixture, makeAxeBuilder} from '@/playwright-utils/base-fixture';
+import {test as base} from '@playwright/test';
+import {QueryErrorPageObject} from './page-object';
+
+type MyFixtures = {
+  queryError: QueryErrorPageObject;
+};
+
+export const test = base.extend<MyFixtures & AxeFixture>({
+  makeAxeBuilder,
+  queryError: async ({page}, use) => {
+    await use(new QueryErrorPageObject(page));
+  },
+});
+
+export {expect} from '@playwright/test';

--- a/packages/atomic/src/components/search/atomic-query-error/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-query-error/e2e/page-object.ts
@@ -1,0 +1,61 @@
+import {BasePageObject} from '@/playwright-utils/base-page-object';
+import {Page} from '@playwright/test';
+
+export class QueryErrorPageObject extends BasePageObject<'atomic-query-error'> {
+  constructor(page: Page) {
+    super(page, 'atomic-query-error');
+  }
+
+  get title() {
+    return this.page.getByText(
+      'Your organization searchuisamples cannot be accessed.',
+      {exact: true}
+    );
+  }
+
+  get description() {
+    return this.page.getByText('Ensure that the token is valid.', {
+      exact: true,
+    });
+  }
+
+  get docLink() {
+    return this.page.getByText('Coveo Online Help');
+  }
+
+  with419Error() {
+    return this.page.route(
+      'https://searchuisamples.org.coveo.com/rest/search/v2?organizationId=searchuisamples',
+      async (route, request) => {
+        if (request.method() === 'POST') {
+          await route.fulfill({
+            status: 419,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              message: 'Expired token',
+              statusCode: 419,
+              type: 'ExpiredTokenException',
+            }),
+          });
+        } else {
+          await route.continue();
+        }
+      }
+    );
+  }
+
+  get title419() {
+    return this.page.getByText('Something went wrong.', {exact: true});
+  }
+
+  get description419() {
+    return this.page.getByText(
+      'If the problem persists contact the administrator.',
+      {exact: true}
+    );
+  }
+
+  get infoButton() {
+    return this.page.getByRole('button', {name: 'Learn more'});
+  }
+}

--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -296,18 +296,6 @@ describe('PlatformClient call', () => {
     );
   });
 
-  it.each([401, 419])(
-    'when status is %d should return a TokenExpiredError',
-    async (status) => {
-      mockFetch.mockReturnValueOnce(
-        Promise.resolve(new Response(JSON.stringify({}), {status}))
-      );
-
-      const response = await platformCall();
-      expect(response).toBeInstanceOf(ExpiredTokenError);
-    }
-  );
-
   it('when status is 429 should try exponential backOff', async () => {
     mockFetch
       .mockReturnValueOnce(

--- a/packages/headless/src/api/platform-client.ts
+++ b/packages/headless/src/api/platform-client.ts
@@ -77,10 +77,6 @@ export class PlatformClient {
         },
       });
       switch (response.status) {
-        case 419:
-        case 401:
-          logger.info('Platform renewing token');
-          throw new ExpiredTokenError();
         case 404:
           throw new DisconnectedError(url, response.status);
         default:


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4455

We were throwing error for 401 and 419 cases and never catching them anywhere. This made it so the error never bubbled up to atomic. 

In this PR, we remove the handling of those cases in platform-client and we let api specific clients handle those cases. In SAPI, we have this [unwrapError](https://github.com/coveo/ui-kit/blob/6888a4ecab47477c4645e6d11e74eaeeaa1610de/packages/headless/src/api/search/search-api-client.ts#L94) function which takes care of the errors when they appear in the response. 

These are what SAPI returns so we can let unwrapError handle those : 
https://docs.coveo.com/en/56/build-a-search-ui/use-search-token-authentication#renew-expired-search-tokens

```
419 - Page Expired

{
  "message": "Expired token",
  "statusCode": 419,
  "type": "ExpiredTokenException"
}
```

```
400 - Bad Request

{
  "message": "The provided token is not a valid token.",
  "type": "InvalidToken"
}
```

There is not need to throw then and do some specific catching logic.
