### PR TITLE
chore(atomic): make atomic-product-text light dom

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -3010,7 +3010,7 @@ export declare interface AtomicProductTemplate extends LitAtomicProductTemplate 
 
 @ProxyCmp({
   inputs: ['field', 'shouldHighlight', 'default'],
-  methods: ['initialize', 'initBindings'],
+  methods: ['initialize'],
   defineCustomElementFn: () => {customElements.get('atomic-product-text') || customElements.define('atomic-product-text', LitAtomicProductText);}
 })
 @Component({

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.spec.ts
@@ -16,7 +16,7 @@ describe('atomic-product-text', () => {
 
   const locators = {
     getCommerceText: (element: AtomicProductText) =>
-      element.shadowRoot?.querySelector('atomic-commerce-text'),
+      element?.querySelector('atomic-commerce-text'),
   };
 
   beforeEach(async () => {
@@ -93,7 +93,7 @@ describe('atomic-product-text', () => {
     const commerceText = locators.getCommerceText(element);
     expect(element).toBeDefined();
     expect(commerceText).toBeNull();
-    expect(element).toBeEmptyDOMElement();
+    expect(element.textContent?.trim()).toBe('');
   });
 
   describe('when field has value', () => {
@@ -169,7 +169,7 @@ describe('atomic-product-text', () => {
 
       expect(commerceText).toBeNull();
       expect(element).toBeDefined();
-      expect(element).toBeEmptyDOMElement();
+      expect(element.textContent?.trim()).toBe('');
     });
   });
 
@@ -179,9 +179,7 @@ describe('atomic-product-text', () => {
         product: null as unknown as Product,
       });
 
-      const errorComponent = element?.shadowRoot?.querySelector(
-        'atomic-component-error'
-      );
+      const errorComponent = element?.querySelector('atomic-component-error');
       expect(errorComponent).toBeDefined();
     });
 
@@ -190,9 +188,7 @@ describe('atomic-product-text', () => {
         product: undefined as unknown as Product,
       });
 
-      const errorComponent = element?.shadowRoot?.querySelector(
-        'atomic-component-error'
-      );
+      const errorComponent = element?.querySelector('atomic-component-error');
       expect(errorComponent).toBeDefined();
     });
   });
@@ -269,9 +265,7 @@ describe('atomic-product-text', () => {
       const commerceText = locators.getCommerceText(element);
       expect(commerceText).toBeNull();
 
-      expect(element.shadowRoot?.innerHTML).not.toContain(
-        '<atomic-commerce-text'
-      );
+      expect(element.innerHTML).not.toContain('<atomic-commerce-text');
     });
 
     it('should render highlights for #excerpt field with highlight keywords', async () => {
@@ -294,9 +288,7 @@ describe('atomic-product-text', () => {
       const commerceText = locators.getCommerceText(element);
       expect(commerceText).toBeNull();
 
-      expect(element.shadowRoot?.innerHTML).not.toContain(
-        '<atomic-commerce-text'
-      );
+      expect(element.innerHTML).not.toContain('<atomic-commerce-text');
     });
 
     it('should render plain text when #field is not supported for highlighting', async () => {
@@ -462,7 +454,7 @@ describe('atomic-product-text', () => {
 
     expect(element).toBeDefined();
     expect(commerceText).toBeNull();
-    expect(element).toBeEmptyDOMElement();
+    expect(element.textContent?.trim()).toBe('');
   });
 
   it('should display nothing for boolean #field values', async () => {
@@ -479,7 +471,7 @@ describe('atomic-product-text', () => {
 
     expect(element).toBeDefined();
     expect(commerceText).toBeNull();
-    expect(element).toBeEmptyDOMElement();
+    expect(element.textContent?.trim()).toBe('');
   });
 
   it('should handle special characters in #field values', async () => {

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
@@ -3,14 +3,14 @@ import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard';
+import {injectStylesForNoShadowDOM} from '@/src/decorators/light-dom';
 import {InitializableComponent} from '@/src/decorators/types';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {
   Product,
   ProductTemplatesHelpers,
   HighlightUtils,
 } from '@coveo/headless/commerce';
-import {LitElement, html, nothing} from 'lit';
+import {LitElement, html, nothing, css} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {getFieldValueCaption} from '../../../utils/field-utils';
@@ -23,12 +23,14 @@ import {getStringValueFromProductOrNull} from '../product-template-component-uti
 /**
  * The `atomic-product-text` component renders the value of a string field for a given product.
  */
-@bindings()
 @customElement('atomic-product-text')
+@bindings()
+@injectStylesForNoShadowDOM
 export class AtomicProductText
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
+  static styles = css``;
   /**
    * The string field whose value the component should render.
    * The component will look for the specified field in the product's properties first, and then in the product's `additionalFields` property.

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
@@ -9,7 +9,7 @@ import {
   ProductTemplatesHelpers,
   HighlightUtils,
 } from '@coveo/headless/commerce';
-import {LitElement, html, nothing, css} from 'lit';
+import {LitElement, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {getFieldValueCaption} from '../../../utils/field-utils';

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.ts
@@ -3,7 +3,6 @@ import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard';
-import {injectStylesForNoShadowDOM} from '@/src/decorators/light-dom';
 import {InitializableComponent} from '@/src/decorators/types';
 import {
   Product,
@@ -25,12 +24,10 @@ import {getStringValueFromProductOrNull} from '../product-template-component-uti
  */
 @customElement('atomic-product-text')
 @bindings()
-@injectStylesForNoShadowDOM
 export class AtomicProductText
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles = css``;
   /**
    * The string field whose value the component should render.
    * The component will look for the specified field in the product's properties first, and then in the product's `additionalFields` property.
@@ -60,6 +57,10 @@ export class AtomicProductText
   @state() public bindings!: CommerceBindings;
 
   @state() public error!: Error;
+
+  protected createRenderRoot() {
+    return this;
+  }
 
   initialize() {
     if (!this.product && this.productController.item) {


### PR DESCRIPTION
This PR disables shadow DOM for atomic-product-text, as it was with the stencil version. Shadow DOM was causing styling issues when using atomic-product-text inside of atomic-product-link.

https://coveord.atlassian.net/browse/KIT-4492
