### PR TITLE
feat(quantic): replaced sds styling hooks

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.css
@@ -1,5 +1,5 @@
 lightning-icon {
-  --sds-c-icon-color-foreground-default: white;
+  --slds-c-icon-color-foreground-default: var(--slds-g-color-brand-base-100, white);
 }
 .slds-visual-picker__figure {
   width: 9.6rem;
@@ -12,17 +12,12 @@ lightning-icon {
 }
 
 .loading-holder {
-  position: relative;
   width: 9.6rem;
   height: 2rem;
 }
 
 .slds-form-element__label {
   color: unset;
-}
-
-.slds-visual-picker {
-  overflow: hidden;
 }
 
 .row {

--- a/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticCaseClassification/quanticCaseClassification.html
@@ -9,7 +9,7 @@
         {label}
       </legend>
       <template if:true={loading}>
-        <div class="loading-holder slds-var-m-top_x-small">
+        <div class="loading-holder slds-is-relative slds-var-m-top_x-small">
           <lightning-spinner alternative-text={labels.loading} size="small"></lightning-spinner>
         </div>
       </template>
@@ -18,7 +18,7 @@
           <div class="row">
             <template if:false={hideSuggestions}>
               <template for:each={suggestions} for:item="suggestion">
-                <div key={suggestion.value} data-testid="case-classification-suggestion" class="case-classification-suggestion slds-visual-picker slds-visual-picker_medium slds-m-left_none slds-var-m-right_medium slds-var-m-top_x-small">
+                <div key={suggestion.value} data-testid="case-classification-suggestion" class="case-classification-suggestion slds-scrollable_none slds-visual-picker_medium slds-m-left_none slds-var-m-right_medium slds-var-m-top_x-small">
                   <input type="checkbox" checked={suggestion.checked} data-suggestion-id={suggestion.id}
                     onchange={handleSelectSuggestion} id={suggestion.value} value={suggestion.value} name="options" />
                   <label for={suggestion.value} title={suggestion.value}>
@@ -46,7 +46,7 @@
             </template>
             <template if:false={isMoreOptionsVisible}>
               <template for:each={filteredOptions} for:item="option">
-                <div key={option.value} data-testid="case-classification-option" class="case-classification-option slds-visual-picker slds-visual-picker_medium slds-m-left_none slds-var-m-right_medium slds-var-m-top_x-small">
+                <div key={option.value} data-testid="case-classification-option" class="case-classification-option slds-scrollable_none slds-visual-picker_medium slds-m-left_none slds-var-m-right_medium slds-var-m-top_x-small">
                   <input type="checkbox" checked={option.checked} onchange={handleSelectSuggestion} id={option.value}
                     value={option.value} name="options" />
                   <label for={option.value} title={option.value}>

--- a/packages/quantic/force-app/main/default/lwc/quanticResultActionStyles/quanticResultActionStyles.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultActionStyles/quanticResultActionStyles.css
@@ -1,7 +1,7 @@
 .result-action_white-container {
   background-color: white;
   display: inline-block;
-  border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+  border-radius: var(--slds-g-sizing-border-4, 0.25rem);
 }
 
 .result-action_button {
@@ -9,13 +9,19 @@
 }
 
 .result-action_first {
-  --sds-c-button-radius-border: 4px 0px 0px 4px;
+  border-top-left-radius: var(--slds-g-sizing-border-4, 4px);
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: var(--slds-g-sizing-border-4, 4px);
 }
 
 .result-action_middle {
-  --sds-c-button-radius-border: 0px;
+  border-radius: 0;
 }
 
 .result-action_last {
-  --sds-c-button-radius-border: 0px 4px 4px 0px;
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--slds-g-sizing-border-4, 4px);
+  border-bottom-left-radius: var(--slds-g-sizing-border-4, 4px);
+  border-bottom-right-radius: 0;
 }


### PR DESCRIPTION
[SFINT-6197](https://coveord.atlassian.net/browse/SFINT-6197)

This PR is part of the migration to SLDS 2 

## IN THIS PR:

- Replaced hooks that use the deprecated `sds` instead of `slds`
- Replaced some useless CSS for equivalent SLDS utility classes

