### PR TITLE
chore(ci): change create-atomic release process from cli to ui-kit

### DIFF
--- a/packages/create-atomic-template/package.json
+++ b/packages/create-atomic-template/package.json
@@ -4,7 +4,6 @@
   "version": "1.41.1",
   "private": true,
   "scripts": {
-    "release:phase1": "npx -p=@coveord/release npm-publish",
     "lint": "prettier --check . && eslint ."
   },
   "dependencies": {

--- a/packages/create-atomic-template/project.json
+++ b/packages/create-atomic-template/project.json
@@ -1,19 +1,4 @@
 {
   "name": "create-atomic-template",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "library",
-  "targets": {
-    "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "exit 0"
-      }
-    },
-    "test": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "exit 0"
-      }
-    }
-  }
+  "$schema": "../../node_modules/nx/schemas/project-schema.json"
 }

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -12,8 +12,7 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node ./index.mjs",
-    "build": "tsc -p tsconfig.json",
-    "prepublishOnly": "rimraf template && npm run build && node ./scripts/preparePackageJsonTemplate.mjs",
+    "build:ts": "tsc -p tsconfig.json",
     "lint": "prettier --check . && eslint .",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -15,7 +15,7 @@
     "build": "tsc -p tsconfig.json",
     "prepublishOnly": "rimraf template && npm run build && node ./scripts/preparePackageJsonTemplate.mjs",
     "lint": "prettier --check . && eslint .",
-    "release:phase1": "npx -p=@coveord/release npm-publish"
+    "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },
   "keywords": [
     "coveo",

--- a/packages/create-atomic/project.json
+++ b/packages/create-atomic/project.json
@@ -1,7 +1,18 @@
 {
   "name": "create-atomic",
-  "root": "packages/ui/atomic/create-atomic",
-  "sourceRoot": "packages/ui/atomic/create-atomic/src",
-  "projectType": "application",
-  "implicitDependencies": ["create-atomic-template"]
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "release:phase1": {},
+    "release:phase3": {},
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/lib"],
+      "cache": true,
+      "options": {
+        "commands": ["npm run build"],
+        "parallel": true,
+        "cwd": "{projectRoot}"
+      }
+    }
+  }
 }

--- a/packages/create-atomic/project.json
+++ b/packages/create-atomic/project.json
@@ -7,11 +7,15 @@
     "release:phase3": {},
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{projectRoot}/lib"],
+      "outputs": ["{projectRoot}/lib", "{projectRoot}/template"],
       "cache": true,
       "options": {
-        "commands": ["npm run build"],
-        "parallel": true,
+        "commands": [
+          "rimraf template",
+          "npm run build:ts",
+          "node ./scripts/preparePackageJsonTemplate.mjs"
+        ],
+        "parallel": false,
         "cwd": "{projectRoot}"
       }
     }

--- a/packages/create-atomic/project.json
+++ b/packages/create-atomic/project.json
@@ -1,6 +1,7 @@
 {
   "name": "create-atomic",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "implicitDependencies": ["create-atomic-template"],
   "targets": {
     "release:phase1": {},
     "release:phase3": {},


### PR DESCRIPTION
Scripts were still using "CLI" release process references. This address that.

https://coveord.atlassian.net/browse/KIT-4543