### PR TITLE
fix(create-atomic): missing templating & update html template

### DIFF
--- a/packages/create-atomic-template/src/pages/index.html.hbs
+++ b/packages/create-atomic-template/src/pages/index.html.hbs
@@ -8,8 +8,8 @@
       If you wish to modify the page title, you should modify the `name` property defined in the coveo.deploy.json configuration file.
     -->
     <title>{{titleCase project}}</title>
-    <<link href="https://static.cloud.coveo.com/atomic/v3/themes/coveo.css" rel="stylesheet" />
-    <link href="/build/testingatomicwithcli.css" rel="stylesheet" />
+    <link href="https://static.cloud.coveo.com/atomic/v3/themes/coveo.css" rel="stylesheet" />
+    <link href="/build/{{project}}.css" rel="stylesheet" />
     <!-- 
       When using the Coveo CDN - Make sure you're using the same minor version as the packaged Atomic.
       E.g., if you have "@coveo/atomic@2.0.0" installed, use the "/atomic/v2.0.0/" path.
@@ -17,16 +17,13 @@
     
       <script type="module" src="https://static.cloud.coveo.com/atomic/vMAJOR.MINOR/atomic.esm.js"></script> 
     -->
-    <script type='module' src='/atomic/atomic.esm.js'></script>
     <!-- Custom Elements Lazy Loading -->
     <script type='module' src='/build/{{project}}.esm.js'></script>
     <!-- Global initialization script -->
     <script type='module' src='/build/index.esm.js'></script>
-    <!-- <script type="module">
-      /**
-       * To import modules from `@coveo/headless`, you need to do so from a TypeScript file and use npm specifier `@coveo/headless`.
-       */
-      import { buildSearchEngine } from "./headless/headless.esm.js";
+    <!--
+      To import modules from `@coveo/headless`, you need to do so from a TypeScript file and use npm specifier `@coveo/headless` (or one of its subpath exports when relevant).
+      import { buildSearchEngine } from "@coveo/headless";
     </script> -->
   </head>
   <body>

--- a/packages/create-atomic-template/stencil.config.ts
+++ b/packages/create-atomic-template/stencil.config.ts
@@ -8,7 +8,7 @@ import nodePolyfills from 'rollup-plugin-node-polyfills';
 // https://stenciljs.com/docs/config
 
 export const config: Config = {
-  namespace: 'testingatomicwithcli',
+  namespace: '{{project}}',
   globalStyle: 'src/style/index.css',
   taskQueue: 'async',
   outputTargets: [


### PR DESCRIPTION
This pull request updates the `create-atomic-template` package to ensure template placeholders are used when they should. The changes primarily focus on improving flexibility in project naming and styling.