### PR TITLE
fix(headless): fix ua events not firing with answer-api

### DIFF
--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -269,10 +269,14 @@ export const selectAnswerTriggerParams = createSelector(
   (state) => selectQuery(state)?.q,
   (state) => state.search.requestId,
   (state) => state.generatedAnswer.cannotAnswer,
-  (q, requestId, cannotAnswer) => ({
+  (state) => state.configuration.analytics.analyticsMode,
+  (state) => state.search.searchAction?.actionCause,
+  (q, requestId, cannotAnswer, analyticsMode, actionCause) => ({
     q,
     requestId,
     cannotAnswer,
+    analyticsMode,
+    actionCause,
   })
 );
 

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -336,13 +336,14 @@ export const constructAnswerQueryParams = (
   const context = selectContext(state);
 
   // For 'select' usage, exclude volatile analytics fields to match serializeQueryArgs behavior
-  const baseAnalyticsParams = fromAnalyticsStateToAnalyticsParams(
-    state.configuration.analytics,
-    navigatorContext,
-    {actionCause: selectSearchActionCause(state)}
-  );
-
-  const analyticsParams = usage === 'select' ? {} : (baseAnalyticsParams ?? {});
+  const analyticsParams =
+    usage === 'select'
+      ? {}
+      : fromAnalyticsStateToAnalyticsParams(
+          state.configuration.analytics,
+          navigatorContext,
+          {actionCause: selectSearchActionCause(state)}
+        );
 
   const searchHub = selectSearchHub(state);
   const pipeline = selectPipeline(state);

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api-state-mock.ts
@@ -1610,3 +1610,9 @@ export const expectedStreamAnswerAPIParamWithoutSearchAction = {
     actionCause: '',
   },
 };
+
+export const expectedStreamAnswerAPIParamForSelect = (() => {
+  const {analytics, ...expectedStreamAnswerAPIParamWithoutAnalytics} =
+    expectedStreamAnswerAPIParam;
+  return expectedStreamAnswerAPIParamWithoutAnalytics;
+})();

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -141,7 +141,7 @@ describe('#streamAnswerApi', () => {
       );
     });
 
-    it('should exclude volatile analytics fields when usage is select', () => {
+    it('should exclude analytics fields when usage is select', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMock as any,
         'select',
@@ -149,14 +149,7 @@ describe('#streamAnswerApi', () => {
       );
 
       // Verify that volatile fields (clientTimestamp, actionCause) are not present
-      expect(queryParams.analytics).toBeDefined();
-      expect(queryParams.analytics?.clientTimestamp).toBeUndefined();
-      expect(queryParams.analytics?.actionCause).toBeUndefined();
-
-      // Verify that other analytics fields are still present
-      expect(queryParams.analytics?.capture).toBeDefined();
-      expect(queryParams.analytics?.clientId).toBeDefined();
-      expect(queryParams.analytics?.originContext).toBeDefined();
+      expect(queryParams.analytics).toBeUndefined();
     });
 
     it('should include all analytics fields when usage is fetch', () => {

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../stream-answer-api.js';
 import {
   expectedStreamAnswerAPIParam,
+  expectedStreamAnswerAPIParamForSelect,
   expectedStreamAnswerAPIParamWithATabWithAnExpression,
   expectedStreamAnswerAPIParamWithoutAnyTab,
   expectedStreamAnswerAPIParamWithoutSearchAction,
@@ -51,13 +52,13 @@ describe('#streamAnswerApi', () => {
         buildMockNavigatorContextProvider()()
       );
 
-      expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
+      expect(queryParams).toEqual(expectedStreamAnswerAPIParamForSelect);
     });
 
     it('should merge tab expression in request constant query when expression is not a blank string', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithATabWithAnExpression as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
 
@@ -69,7 +70,7 @@ describe('#streamAnswerApi', () => {
     it('should not include tab info when there is NO tab', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithoutAnyTab as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
 
@@ -79,7 +80,7 @@ describe('#streamAnswerApi', () => {
     it('should merge filter expressions in request constant query when expression is selected', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithStaticFiltersSelected as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
 
@@ -91,7 +92,7 @@ describe('#streamAnswerApi', () => {
     it('should not include filter info when there is NO filter', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithoutAnyFilters as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
       expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
@@ -100,7 +101,7 @@ describe('#streamAnswerApi', () => {
     it('should not include non-selected filters and empty filters', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithNonValidFilters as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
       expect(queryParams).toEqual(expectedStreamAnswerAPIParam);
@@ -109,7 +110,7 @@ describe('#streamAnswerApi', () => {
     it('should merge multiple filter expressions and a tab expression', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithStaticFiltersAndTabExpression as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
       expect(queryParams).toEqual(
@@ -120,7 +121,7 @@ describe('#streamAnswerApi', () => {
     it('should not include advanced search queries when there are no advanced search queries', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithStaticFiltersAndTabExpressionWithEmptyCQ as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
       expect(queryParams).toEqual(
@@ -131,13 +132,47 @@ describe('#streamAnswerApi', () => {
     it('should accept an undefined SearchAction', () => {
       const queryParams = constructAnswerQueryParams(
         streamAnswerAPIStateMockWithoutSearchAction as any,
-        'select',
+        'fetch',
         buildMockNavigatorContextProvider()()
       );
 
       expect(queryParams).toEqual(
         expectedStreamAnswerAPIParamWithoutSearchAction
       );
+    });
+
+    it('should exclude volatile analytics fields when usage is select', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMock as any,
+        'select',
+        buildMockNavigatorContextProvider()()
+      );
+
+      // Verify that volatile fields (clientTimestamp, actionCause) are not present
+      expect(queryParams.analytics).toBeDefined();
+      expect(queryParams.analytics?.clientTimestamp).toBeUndefined();
+      expect(queryParams.analytics?.actionCause).toBeUndefined();
+
+      // Verify that other analytics fields are still present
+      expect(queryParams.analytics?.capture).toBeDefined();
+      expect(queryParams.analytics?.clientId).toBeDefined();
+      expect(queryParams.analytics?.originContext).toBeDefined();
+    });
+
+    it('should include all analytics fields when usage is fetch', () => {
+      const queryParams = constructAnswerQueryParams(
+        streamAnswerAPIStateMock as any,
+        'fetch',
+        buildMockNavigatorContextProvider()()
+      );
+
+      // Verify that all analytics fields are present including volatile ones
+      expect(queryParams.analytics).toBeDefined();
+      expect(queryParams.analytics?.clientTimestamp).toBeDefined();
+      expect(queryParams.analytics?.actionCause).toBeDefined();
+      expect(queryParams.analytics?.capture).toBeDefined();
+      expect(queryParams.analytics?.clientId).toBeDefined();
+      expect(queryParams.analytics?.originContext).toBeDefined();
     });
   });
 

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -59,7 +59,7 @@ vi.mock('../../../api/knowledge/stream-answer-api', async () => {
       actionCause: '',
     },
     {
-      q: 'this est une question in next mode without action cause',
+      q: 'this est une question in next mode with an action cause',
       requestId: '781',
       analyticsMode: 'next',
       actionCause: 'searchboxSubmit',

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -47,6 +47,23 @@ vi.mock('../../../api/knowledge/stream-answer-api', async () => {
     {q: 'this est une another question', requestId: '12'},
     {q: '', requestId: '34'},
     {q: 'this est une yet another question', requestId: '56'},
+    {
+      q: 'this est une question in legacy mode without action cause',
+      requestId: '78',
+      analyticsMode: 'legacy',
+    },
+    {
+      q: 'this est une question in next mode without action cause',
+      requestId: '7822',
+      analyticsMode: 'next',
+      actionCause: '',
+    },
+    {
+      q: 'this est une question in next mode without action cause',
+      requestId: '781',
+      analyticsMode: 'next',
+      actionCause: 'searchboxSubmit',
+    },
   ];
   return {
     ...originalStreamAnswerApi,
@@ -221,6 +238,18 @@ describe('knowledge-generated-answer', () => {
       // new request id, call
       listener();
       expect(triggerSearchRequest).toHaveBeenCalledTimes(2);
+
+      // new query, new request id, legacy mode, no action cause, call
+      listener();
+      expect(triggerSearchRequest).toHaveBeenCalledTimes(3);
+
+      // new query, new request id, next mode, no action cause, no call
+      listener();
+      expect(triggerSearchRequest).toHaveBeenCalledTimes(3);
+
+      // new query, new request id, next mode, with action cause, call
+      listener();
+      expect(triggerSearchRequest).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -112,7 +112,8 @@ const subscribeToSearchRequest = (
     if (
       triggerParams.q.length === 0 ||
       triggerParams.requestId.length === 0 ||
-      triggerParams.requestId === lastTriggerParams.requestId
+      triggerParams.requestId === lastTriggerParams.requestId ||
+      (triggerParams.analyticsMode === 'next' && !triggerParams.actionCause) // If analytics mode is next, we need to wait for the action cause to be set
     ) {
       return;
     }

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -1,4 +1,4 @@
-import {createAsyncThunk} from '@reduxjs/toolkit';
+import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
 import HistoryStore from '../../api/analytics/coveo.analytics/history-store.js';
 import {
   isErrorResponse,
@@ -106,6 +106,10 @@ interface TransitiveInsightSearchAction {
   next?: SearchAction;
 }
 
+export const updateSearchAction = createAction<SearchAction | undefined>(
+  'search/updateSearchAction'
+);
+
 export const executeSearch = createAsyncThunk<
   ExecuteSearchThunkReturn,
   TransitiveInsightSearchAction,
@@ -130,6 +134,9 @@ export const executeSearch = createAsyncThunk<
     const eventDescription = analyticsAction.next
       ? buildEventDescription(analyticsAction.next)
       : undefined;
+
+    config.dispatch(updateSearchAction(analyticsAction.next));
+
     const request = await buildInsightSearchRequest(state, eventDescription);
     const fetched = await processor.fetchFromAPI(request);
 

--- a/packages/headless/src/features/insight-search/insight-search-actions.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions.ts
@@ -1,4 +1,4 @@
-import {createAction, createAsyncThunk} from '@reduxjs/toolkit';
+import {createAsyncThunk} from '@reduxjs/toolkit';
 import HistoryStore from '../../api/analytics/coveo.analytics/history-store.js';
 import {
   isErrorResponse,
@@ -36,9 +36,10 @@ import type {
   FetchQuerySuggestionsActionCreatorPayload,
   FetchQuerySuggestionsThunkReturn,
 } from '../query-suggest/query-suggest-actions.js';
-import type {
-  ExecuteSearchThunkReturn,
-  SearchAction,
+import {
+  type ExecuteSearchThunkReturn,
+  type SearchAction,
+  updateSearchAction,
 } from '../search/search-actions.js';
 import {
   type MappedSearchRequest,
@@ -105,10 +106,6 @@ interface TransitiveInsightSearchAction {
   legacy: LegacyInsightAction;
   next?: SearchAction;
 }
-
-export const updateSearchAction = createAction<SearchAction | undefined>(
-  'search/updateSearchAction'
-);
 
 export const executeSearch = createAsyncThunk<
   ExecuteSearchThunkReturn,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SVCC-5272

## The bug 

When using the answer-api no ua events were sent for streamingEnd, like/dislike buttons or copy to clipboard action. This was because of the way we were retrieving the data from the answerAPI request from the state. Here is the step by step explanation of the origin of the bug:

1. In [generated-answer-analytics-actions](https://github.com/coveo/ui-kit/blob/65c2238aff401a813cff3ec5c116938c1dc1c716/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts#L353), we need to have the rgaID to be able to make the analytics call, but that `rgaID` is `undefined`
2. The reason it is `undefined` is because, when selecting the answer from the Redux Toolkit Query, we pass the `constructAnswerQueryParams(...)` to the selector. But there is a volatile value in the answer query payload; the clientTimestamp. 

Additionally, the fetch request also has access to the [engine.navigatorContext](https://github.com/coveo/ui-kit/blob/65c2238aff401a813cff3ec5c116938c1dc1c716/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts#L167) and passes it along to the answer API payload builder. That navigatorContext is then used to populate the analytics object. That navigatorObject is not available from the [selector](https://github.com/coveo/ui-kit/blob/65c2238aff401a813cff3ec5c116938c1dc1c716/packages/headless/src/features/generated-answer/generated-answer-selectors.ts#L19) used in the [analytics actions logger](https://github.com/coveo/ui-kit/blob/65c2238aff401a813cff3ec5c116938c1dc1c716/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts#L352).

(The navigatorContext looks like: 
```
{
    "referrer": "http://localhost:3333/examples/genqa.html",
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
    "location": "http://localhost:3333/examples/genqa.html#q=how%20to%20resolve%20netflix%20connection%20with%20tivo",
    "clientId": "2667c24d-449c-40ee-a9cd-2ea702b6fab8"
}
```
)
3. Since the body we pass to the select RTK query is not the same as the body that was serialized to the redux state, the select is unable to access any data and thus, the `rgaID` is null.

## The solution

When we are using RTK query to select (and not to fetch), we remove the analytics object from the selector body, and we also do the same thing for the [serializeQueryArgs method](https://github.com/coveo/ui-kit/blob/65c2238aff401a813cff3ec5c116938c1dc1c716/packages/headless/src/api/knowledge/stream-answer-api.ts#L201). This means that the key in the store does not contain any analytics, but since we don't need analytics in the select, it's not a problem.

## How to test

In genqa.html
1. Add an answer config ID:

```
          <atomic-generated-answer answer-configuration-id="fc581be0-6e61-4039-ab26-a3f2f52f308f">
          </atomic-generated-answer>
```
2.  Initialize in legacy mode:

```
      // Initialization
      await searchInterface.initialize({
        accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
        organizationId: 'searchuisamples',
        search: {
          pipeline: 'genqatest',
        },
        analytics: {analyticsMode: 'legacy'},
      });
```

Do some actions in the genQA tab, you should see the custom events be sent:

https://github.com/user-attachments/assets/78cad25f-6bc5-4af8-84b7-9001f1f7d8a9

