### PR TITLE
fix(atomic): clear keyboard active descendant when search box input changes due to keypress

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
@@ -401,6 +401,68 @@ describe('AtomicCommerceSearchBox', () => {
 
       expect(suggestions()).toHaveLength(0);
     });
+
+    describe('when navigating suggestions with arrow keys', () => {
+      it('should call the #submit method on the search box controller when pressing Enter after clearing an active suggestion by typing', async () => {
+        const {element, textArea, suggestions} = await renderSearchBox();
+
+        submitMock.mockClear();
+
+        await userEvent.click(element);
+        expect(suggestions()).toHaveLength(3);
+
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.type(textArea, 'new text');
+        await userEvent.keyboard('{Enter}');
+
+        expect(submitMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call the #submit method on the search box controller when pressing Enter after clearing an active suggestion by using backspace', async () => {
+        const {element, textArea, suggestions} = await renderSearchBox({
+          searchBoxValue: 'test',
+        });
+
+        submitMock.mockClear();
+
+        await userEvent.click(element);
+        expect(suggestions()).toHaveLength(3);
+
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.type(textArea, '{Backspace}');
+        await userEvent.keyboard('{Enter}');
+
+        expect(submitMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call the #submit method on the search box controller when pressing Enter after clearing an active suggestion by typing space', async () => {
+        const {element, textArea, suggestions} = await renderSearchBox();
+
+        submitMock.mockClear();
+
+        await userEvent.click(element);
+        expect(suggestions()).toHaveLength(3);
+
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.type(textArea, ' ');
+        await userEvent.keyboard('{Enter}');
+
+        expect(submitMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('should call the #submit method on the search box controller when Enter is pressed without any active suggestion', async () => {
+        const {element, suggestions} = await renderSearchBox();
+
+        submitMock.mockClear();
+
+        await userEvent.click(element);
+        expect(suggestions()).toHaveLength(3);
+
+        await userEvent.keyboard('{Enter}');
+
+        expect(submitMock).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('when clicking the clear button', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
@@ -503,6 +503,11 @@ export class AtomicCommerceSearchBox
       case 'Tab':
         this.suggestionManager.clearSuggestions();
         break;
+      default:
+        if (this.suggestionManager.keyboardActiveDescendant) {
+          this.suggestionManager.updateKeyboardActiveDescendant();
+          this.suggestionManager.updateActiveDescendant();
+        }
     }
   }
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
@@ -506,8 +506,8 @@ export class AtomicCommerceSearchBox
       default:
         if (this.suggestionManager.keyboardActiveDescendant) {
           this.suggestionManager.updateKeyboardActiveDescendant();
-          this.suggestionManager.updateActiveDescendant();
         }
+        break;
     }
   }
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -479,8 +479,8 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
       default:
         if (this.suggestionManager.keyboardActiveDescendant) {
           this.suggestionManager.updateKeyboardActiveDescendant();
-          this.suggestionManager.updateActiveDescendant();
         }
+        break;
     }
   }
 

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.tsx
@@ -476,6 +476,11 @@ export class AtomicSearchBox implements InitializableComponent<Bindings> {
       case 'Tab':
         this.suggestionManager.clearSuggestions();
         break;
+      default:
+        if (this.suggestionManager.keyboardActiveDescendant) {
+          this.suggestionManager.updateKeyboardActiveDescendant();
+          this.suggestionManager.updateActiveDescendant();
+        }
     }
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4595

At the moment, if you select a suggestion through keyboard arrow navigation, submit a query, and then modify the search box input (e.g., by pressing backspace, or by entering characters and/or whitespaces in the input), pressing 'Enter' will not submit the query, because the `keyboardActiveDescendant` will still be set to the ID of the suggestion that was selected.

Clearing the keyboard active descendant fixes that.