### PR TITLE
fix(headless): align logic for setting category facet previousState with expectations from RFC

### DIFF
--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.test.ts
@@ -442,6 +442,7 @@ describe('category facet slice', () => {
           {
             value: selection.value,
             state: 'selected',
+            previousState: 'idle',
             children: [],
             retrieveChildren: true,
             retrieveCount,
@@ -465,6 +466,7 @@ describe('category facet slice', () => {
         const child = buildMockCategoryFacetValueRequest({
           value: 'B',
           state: 'selected',
+          previousState: 'idle',
           retrieveChildren: true,
           retrieveCount,
         });
@@ -529,6 +531,7 @@ describe('category facet slice', () => {
             retrieveChildren: true,
             retrieveCount,
             state: 'selected',
+            previousState: 'idle',
           });
 
           const children =
@@ -550,11 +553,11 @@ describe('category facet slice', () => {
           ).toBe(false);
         });
 
-        it('sets the parent previousState to the previous state value', () => {
+        it('sets the parent previousState to undefined', () => {
           const finalState = categoryFacetSetReducer(state, action);
           expect(
             finalState[facetId]?.request.currentValues[0].previousState
-          ).toBe('selected');
+          ).toBeUndefined();
         });
       });
 
@@ -577,6 +580,7 @@ describe('category facet slice', () => {
           const child = buildMockCategoryFacetValueRequest({
             value: 'B',
             state: 'selected',
+            previousState: 'idle',
             retrieveChildren: true,
             retrieveCount,
           });
@@ -626,6 +630,7 @@ describe('category facet slice', () => {
           retrieveChildren: true,
           retrieveCount,
           state: 'selected',
+          previousState: 'idle',
         });
 
         expect(

--- a/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
+++ b/packages/headless/src/features/facets/category-facet-set/category-facet-set-slice.ts
@@ -104,8 +104,8 @@ export const categoryFacetSetReducer = createReducer(
           const lastSelectedParent = children[0];
 
           lastSelectedParent.retrieveChildren = true;
-          lastSelectedParent.previousState = lastSelectedParent.state;
           lastSelectedParent.state = 'selected';
+          lastSelectedParent.previousState = 'idle';
           lastSelectedParent.children = [];
           return;
         }
@@ -115,6 +115,7 @@ export const categoryFacetSetReducer = createReducer(
           retrieveCount
         );
         newParent.state = 'selected';
+        newParent.previousState = 'idle';
         children.push(newParent);
         request.numberOfValues = 1;
       })
@@ -204,7 +205,7 @@ function ensurePathAndReturnChildren(
     }
 
     parent.retrieveChildren = false;
-    parent.previousState = parent.state !== 'idle' ? parent.state : undefined;
+    parent.previousState = undefined;
     parent.state = 'idle';
     children = parent.children;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4608

We now set `previousState: 'idle'` on the currently selected value (and set it to undefined on its parent value if necessary) when toggling selection in a category facet.
