### PR TITLE
fix(atomic): always add fileType to the list of fieldsToIncludeInCitations

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -679,7 +679,7 @@ export namespace Components {
         /**
           * A list of fields to include with the citations used to generate the answer.
          */
-        "fieldsToIncludeInCitations": string;
+        "fieldsToIncludeInCitations"?: string;
         /**
           * The maximum height (in rem units) of the answer when collapsed.
          */
@@ -823,7 +823,7 @@ export namespace Components {
         /**
           * A list of fields to include with the citations used to generate the answer.
          */
-        "fieldsToIncludeInCitations": string;
+        "fieldsToIncludeInCitations"?: string;
         /**
           * The maximum height (in rem units) of the answer when collapsed.
          */

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
@@ -73,7 +73,7 @@ export class AtomicInsightGeneratedAnswer
   private readonly DEFAULT_COLLAPSED_HEIGHT = 16;
   private readonly MAX_COLLAPSED_HEIGHT = 32;
   private readonly MIN_COLLAPSED_HEIGHT = 9;
-  private readonly DEFAULT_FIELDS_TO_INCLUDE_IN_CITATIONS = 'filetype';
+  private readonly REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS = ['filetype'];
 
   @BindStateToController('generatedAnswer', {
     onUpdateCallbackMethod: 'onGeneratedAnswerStateUpdate',
@@ -123,8 +123,7 @@ export class AtomicInsightGeneratedAnswer
   /**
    * A list of fields to include with the citations used to generate the answer.
    */
-  @Prop() fieldsToIncludeInCitations =
-    this.DEFAULT_FIELDS_TO_INCLUDE_IN_CITATIONS;
+  @Prop() fieldsToIncludeInCitations?: string;
 
   @AriaLiveRegion('generated-answer')
   protected ariaMessage!: string;
@@ -258,10 +257,11 @@ export class AtomicInsightGeneratedAnswer
   }
 
   private getCitationFields() {
-    return this.fieldsToIncludeInCitations
-      ?.split(',')
+    return (this.fieldsToIncludeInCitations ?? '')
+      .split(',')
       .map((field) => field.trim())
-      .filter((field) => field.length > 0);
+      .filter((field) => field.length > 0)
+      .concat(this.REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS)
   }
 
   private validateMaxCollapsedHeight(): number {

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -76,7 +76,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   private readonly DEFAULT_COLLAPSED_HEIGHT = 16;
   private readonly MAX_COLLAPSED_HEIGHT = 32;
   private readonly MIN_COLLAPSED_HEIGHT = 9;
-  private readonly DEFAULT_FIELDS_TO_INCLUDE_IN_CITATIONS = 'filetype';
+  private readonly REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS = ['filetype'];
 
   @BindStateToController('generatedAnswer', {
     onUpdateCallbackMethod: 'onGeneratedAnswerStateUpdate',
@@ -131,8 +131,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   /**
    * A list of fields to include with the citations used to generate the answer.
    */
-  @Prop() fieldsToIncludeInCitations =
-    this.DEFAULT_FIELDS_TO_INCLUDE_IN_CITATIONS;
+  @Prop() fieldsToIncludeInCitations?: string;
 
   /**
    * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.
@@ -301,10 +300,11 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
   }
 
   private getCitationFields() {
-    return this.fieldsToIncludeInCitations
-      ?.split(',')
+    return (this.fieldsToIncludeInCitations ?? '')
+      .split(',')
       .map((field) => field.trim())
-      .filter((field) => field.length > 0);
+      .filter((field) => field.length > 0)
+      .concat(this.REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS)
   }
 
   private validateMaxCollapsedHeight(): number {


### PR DESCRIPTION
## Issue

When you set a custom `fields-to-include-in-citations` value in the `atomic-generated-answer` and `atomic-insight-generated-answer` components, the call to the backend does not include the required fields for citation anchoring to work (`filetype`).

## Change

In this PR, I edit the logic in order to always add a list of required fields to `fieldsToIncludeInCitations`, even when customers set a custom value.

## How to test


https://github.com/user-attachments/assets/46ade44f-0ee4-4a30-a1d7-b65b9b6f593f



This change was tested locally by modifying the `genqa.html` file.

Line 27:
```
await searchInterface.initialize({
        accessToken: '{access-token}',
        organizationId: 'lbergeronsfdevt1z2624x',
        environment:'dev',
        search: {
          pipeline: 'LBergeron RGA Wood',
        },
      }); 
```
Line 119:
```
 <atomic-generated-answer fields-to-include-in-citations="allo, bye"></atomic-generated-answer>
```
[SVCC-5273](https://coveord.atlassian.net/browse/SVCC-5273)

[SVCC-5273]: https://coveord.atlassian.net/browse/SVCC-5273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ