### PR TITLE
ci(create-atomic): fix release phase 1 for new create-atomic packages

### DIFF
--- a/packages/create-atomic-component-project/package.json
+++ b/packages/create-atomic-component-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coveo/create-atomic-component-project",
-  "version": "1.3.0",
+  "version": "1.2.16",
   "description": "Initialize a Coveo Atomic Library Project",
   "type": "module",
   "main": "index.js",

--- a/packages/create-atomic-component-project/package.json
+++ b/packages/create-atomic-component-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coveo/create-atomic-component-project",
-  "version": "1.2.16",
+  "version": "1.3.0",
   "description": "Initialize a Coveo Atomic Library Project",
   "type": "module",
   "main": "index.js",
@@ -12,6 +12,7 @@
     "template/.gitignore"
   ],
   "scripts": {
+    "build": "nx build",
     "publish:npm": "npm run-script -w=@coveo/ci npm-publish",
     "publish:bump": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"

--- a/packages/create-atomic-component-project/project.json
+++ b/packages/create-atomic-component-project/project.json
@@ -5,6 +5,9 @@
   "projectType": "application",
   "implicitDependencies": ["create-atomic-component-project-template"],
   "targets": {
+    "build": {
+      "executor": "nx:noop"
+    },
     "release:phase1": {},
     "release:phase3": {}
   }

--- a/packages/create-atomic-component/package.json
+++ b/packages/create-atomic-component/package.json
@@ -12,6 +12,7 @@
     "template/.gitignore"
   ],
   "scripts": {
+    "build": "nx build",
     "publish:npm": "npm run-script -w=@coveo/ci npm-publish",
     "publish:bump": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"

--- a/packages/create-atomic-component/project.json
+++ b/packages/create-atomic-component/project.json
@@ -5,6 +5,9 @@
   "projectType": "application",
   "implicitDependencies": ["create-atomic-component-template"],
   "targets": {
+    "build": {
+      "executor": "nx:noop"
+    },
     "release:phase1": {},
     "release:phase3": {}
   }


### PR DESCRIPTION
The release:phase:1 scripts require a build script, no matter what it seems.

Just added a noop executor in this case

KIT-4508
