### PR TITLE
fix(quantic): wrong event name used in resultSendAsEmail

### DIFF
--- a/packages/quantic/force-app/solutionExamples/main/lwc/resultSendAsEmail/resultSendAsEmail.js
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/resultSendAsEmail/resultSendAsEmail.js
@@ -51,7 +51,7 @@ export default class ResultSendAsEmail extends LightningElement {
     '<a href="${clickUri}">${title}</a><br/><br/><quote>${excerpt}</quote>';
 
   iconName = 'utility:email';
-  eventName = 'insightpanel__posttofeed';
+  eventName = 'insightpanel__sendasemail';
   insertType = 'replace';
 
   /** @type {boolean} */


### PR DESCRIPTION
### SFINT-6226

Wrong event name used in resultSendAsEmail