### PR TITLE
fix(atomic): ensure component styles dont break when using @import rules

### DIFF
--- a/packages/atomic/scripts/process-css.mjs
+++ b/packages/atomic/scripts/process-css.mjs
@@ -42,7 +42,7 @@ function generateFileContent(imports, result) {
   if (imports.length === 0) {
     return dedent`
     ${cssJs}
-    export default [css];
+    export default css;
     `;
   }
 
@@ -58,7 +58,7 @@ function generateFileContent(imports, result) {
       .map((_, index) => `...dep${index}`)
       .concat('css')
       .join(', ')}];
-    export default allCss;
+    export default allCss.join('');
     `;
 
   return dedent`


### PR DESCRIPTION
This PR changes the CSS processing script to ensure that the generated .css.js files always export all their stylesheets as a single string. When using @import rules in a stylesheet, the styles would instead be returned as an array of strings which [unsafeCSS](https://lit.dev/docs/api/styles/#unsafeCSS) can't handle.

https://coveord.atlassian.net/browse/KIT-4659
