### PR TITLE
chore(atomic): atomic-product-multi-value-text font size override not applied correctly

### DIFF
--- a/packages/atomic/scripts/build.mjs
+++ b/packages/atomic/scripts/build.mjs
@@ -15,7 +15,7 @@ import {
 import resourceUrlTransformer from './asset-path-transformer.mjs';
 import {generateLitExports} from './generate-lit-exports.mjs';
 import pathTransformer from './path-transform.mjs';
-import {processCssFiles} from './process-css.mjs';
+import {processAllCss} from './process-css.mjs';
 import svgTransformer from './svg-transform.mjs';
 import versionTransformer from './version-transform.mjs';
 
@@ -119,7 +119,7 @@ function compileWithTransformer() {
 
   const exitCode = emitResult.emitSkipped || hasError ? 1 : 0;
   console.log(`Process exiting with code '${exitCode}'.`);
-  process.exit(exitCode);
+  return exitCode;
 }
 
 try {
@@ -132,11 +132,12 @@ try {
   console.log(chalk.blue('Generating Lit exports'));
   await generateLitExports();
 
-  console.log(chalk.blue('Starting CSS processing'));
-  await processCssFiles(srcDir, outDir);
-
   console.log(chalk.blue('Starting TypeScript compilation'));
-  compileWithTransformer();
+  const tsExitCode = compileWithTransformer();
+
+  await processAllCss(srcDir, outDir);
+
+  process.exit(tsExitCode);
 } catch (error) {
   console.error(chalk.red('Build failed:'), error);
   process.exit(1);

--- a/packages/atomic/scripts/process-css.mjs
+++ b/packages/atomic/scripts/process-css.mjs
@@ -140,12 +140,12 @@ export async function processCssFiles(srcDir, distDir) {
 function getAllJsFiles(dir) {
   let results = [];
   for (const name of readdirSync(dir)) {
-    const p = join(dir, name);
-    const stat = statSync(p);
+    const filePath = join(dir, name);
+    const stat = statSync(filePath);
     if (stat.isDirectory()) {
-      results = results.concat(getAllJsFiles(p));
-    } else if (stat.isFile() && p.endsWith('.js')) {
-      results.push(p);
+      results = results.concat(getAllJsFiles(filePath));
+    } else if (stat.isFile() && filePath.endsWith('.js')) {
+      results.push(filePath);
     }
   }
   return results;

--- a/packages/atomic/scripts/process-css.mjs
+++ b/packages/atomic/scripts/process-css.mjs
@@ -1,5 +1,11 @@
-import {mkdirSync, readdirSync, readFileSync, writeFileSync} from 'node:fs';
-import {dirname, join, relative} from 'node:path';
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {basename, dirname, join, relative} from 'node:path';
 import chalk from 'chalk';
 import * as lightningcss from 'lightningcss';
 import postcss from 'postcss';
@@ -85,11 +91,6 @@ async function convertCssToJs(srcPath, distPath, file) {
     const data = readFileSync(srcPath, 'utf8');
     const files = [file];
 
-    console.log(
-      chalk.blue('Processing:'),
-      chalk.green(`${srcPath} -> ${distPath}`)
-    );
-
     const imports = Array.from(data.matchAll(importMatcher)).flat();
     pushImports(srcPath, imports, files);
     const cleanedData = data.replace(importWholeLineMatcher, '');
@@ -98,9 +99,16 @@ async function convertCssToJs(srcPath, distPath, file) {
     const fileContent = generateFileContent(imports, result);
     const jsPath = `${distPath}.js`;
     writeFileSync(jsPath, fileContent);
-    console.log(chalk.blue('Successfully processed:'), chalk.green(jsPath));
+    console.log(
+      chalk.bgGreen('Successfully processed CSS file:'),
+      chalk.green(basename(srcPath))
+    );
   } catch (err) {
-    console.error(chalk.red(`Error processing file: ${srcPath}`), err);
+    console.error(
+      chalk.bgRed('Error processing file:'),
+      chalk.green(basename(srcPath)),
+      err
+    );
     throw err;
   }
 }
@@ -112,8 +120,8 @@ export async function processCssFiles(srcDir, distDir) {
       a.name.localeCompare(b.name)
     );
   } catch (err) {
-    console.error(chalk.red(`Error reading directory: ${srcDir}`), err);
-    return;
+    console.error(chalk.bgRed(`Error reading directory: ${srcDir}`), err);
+    throw err;
   }
   for (const entry of entries) {
     const srcPath = join(srcDir, entry.name);
@@ -127,4 +135,81 @@ export async function processCssFiles(srcDir, distDir) {
       await convertCssToJs(srcPath, distPath, entry);
     }
   }
+}
+
+function getAllJsFiles(dir) {
+  let results = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const stat = statSync(p);
+    if (stat.isDirectory()) {
+      results = results.concat(getAllJsFiles(p));
+    } else if (stat.isFile() && p.endsWith('.js')) {
+      results.push(p);
+    }
+  }
+  return results;
+}
+
+/**
+ * Process all inline css`...` tagged template blocks in JS files through PostCSS/Tailwind
+ */
+async function processInlineCss(distDir, srcDir) {
+  console.log(chalk.bold.blue('Post-processing inline CSS'));
+  const {plugins, options} = await postcssLoadConfig();
+  const files = getAllJsFiles(distDir);
+
+  for (const file of files) {
+    try {
+      let content = readFileSync(file, 'utf8');
+      const matches = [...content.matchAll(/css `([\s\S]*?)`/g)];
+      if (matches.length === 0) continue;
+
+      // Derive the original source file path for PostCSS resolution
+      const relativeFromDist = relative(distDir, file);
+      const originalSrcFile = join(
+        srcDir,
+        relativeFromDist.replace(/\.js$/, '.ts')
+      );
+
+      for (const match of matches) {
+        const fullMatch = match[0];
+        const rawCss = match[1];
+        const result = await postcss(plugins).process(rawCss, {
+          ...options,
+          from: originalSrcFile,
+        });
+
+        const minified = minifyCss(result, originalSrcFile);
+        const escaped = escapeBackslashes(minified);
+
+        content = content.split(fullMatch).join(`css\`${escaped}\``);
+      }
+
+      writeFileSync(file, content, 'utf8');
+      // Color only the file name green, keep directory uncolored
+      console.log(
+        chalk.bgGreen('Successfully processed inline CSS'),
+        chalk.green(basename(file))
+      );
+    } catch (err) {
+      // Color only the file name green in error path
+      console.error(
+        chalk.bgRed('Error processing inline CSS in file:'),
+        chalk.green(basename(file)),
+        err
+      );
+      throw err;
+    }
+  }
+}
+
+export async function processAllCss(srcDir, distDir) {
+  console.log(chalk.bold.blue('Starting CSS processing'));
+
+  await processCssFiles(srcDir, distDir);
+
+  await processInlineCss(distDir, srcDir);
+
+  console.log(chalk.bold.blue('CSS processing complete'));
 }

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
@@ -5,7 +5,7 @@ import {
   ProductTemplatesHelpers,
   type RegularFacetValue,
 } from '@coveo/headless/commerce';
-import {css, html, LitElement, nothing, type TemplateResult} from 'lit';
+import {html, LitElement, nothing, type TemplateResult} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings';
@@ -35,12 +35,6 @@ export class AtomicProductMultiValueText
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles = css`
-  @reference '../../../utils/tailwind.global.tw.css';
-  :host {
-    @apply set-font-size-sm;
-  }
-  `;
   @state()
   bindings!: CommerceBindings;
 
@@ -199,7 +193,7 @@ export class AtomicProductMultiValueText
     }
 
     return html`
-      <ul part="product-multi-value-text-list" class="m-0 flex list-none p-0">
+      <ul part="product-multi-value-text-list" class="m-0 flex list-none p-0 set-font-size-sm">
         ${this.renderListItems(this.sortedValues)}
       </ul>
     `;

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
@@ -36,27 +36,11 @@ export class AtomicProductMultiValueText
   implements InitializableComponent<CommerceBindings>
 {
   static styles = css`
+  @reference '../../../utils/tailwind.global.tw.css';
   :host {
-    > ul {
-      display: flex;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-  
-      li {
-        display: inline-block;
-      }
-
-      @apply set-font-size-sm;
-    }
+    @apply set-font-size-sm;
   }
-  
-  .separator {
-    &::before {
-      display: inline;
-      content: ",\00a0";
-    }
-  }`;
+  `;
   @state()
   bindings!: CommerceBindings;
 

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts
@@ -5,7 +5,7 @@ import {
   ProductTemplatesHelpers,
   type RegularFacetValue,
 } from '@coveo/headless/commerce';
-import {html, LitElement, nothing, type TemplateResult} from 'lit';
+import {css, html, LitElement, nothing, type TemplateResult} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings';
@@ -35,6 +35,28 @@ export class AtomicProductMultiValueText
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
+  static styles = css`
+  :host {
+    > ul {
+      display: flex;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+  
+      li {
+        display: inline-block;
+      }
+
+      @apply set-font-size-sm;
+    }
+  }
+  
+  .separator {
+    &::before {
+      display: inline;
+      content: ",\00a0";
+    }
+  }`;
   @state()
   bindings!: CommerceBindings;
 

--- a/packages/atomic/src/utils/tailwind.global.tw.css
+++ b/packages/atomic/src/utils/tailwind.global.tw.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @import "./tailwind-utilities/components.tw.css";
+@reference './tailwind-utilities/utilities.tw.css';
 @reference './coveo.tw.css';
 
 @layer base {


### PR DESCRIPTION
This PR fixes an issue where the base font size defined in tailwind.global.tw.css would take precedence over the font size `atomic-product-multi-value-text`, because it comes from a different component, atomic-product. Due to how constructed stylesheets get applied, we can't fix this by using css layers. Instead, we need to have the styles directly on the stylesheet of `atomic-product-multi-value-text`

This one is an interesting one, as it showcases how to migrate product template component styles from `template-system.pcss` to a component's stylesheet.

For most product template components, this change will be required first:
https://github.com/coveo/ui-kit/pull/5802/files#diff-913ab5c20cb2c3af53f6e5de776c7b0cd155ecfbae2b4fdf6e241cefee4c0a91

Then you can do something like:

```css
:host(.density-compact) {
  @apply text-sm;
}
:host(.density-normal) {
  @apply text-base;
}

```

Note that since `atomic-product-multi-value-text` has the same font size on all display modes/density settings, so we don't need to style differently based on those classes.

https://coveord.atlassian.net/browse/KIT-4676