### PR TITLE
fix(AtomicGeneratedAnswer): disable citation anchoring

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -543,9 +543,9 @@ export namespace Components {
         "collapsible"?: boolean;
         /**
           * Option to disable citation anchoring.
-          * @default false
+          * @default 'false'
          */
-        "disableCitationAnchoring"?: boolean;
+        "disableCitationAnchoring"?: string;
         /**
           * A list of fields to include with the citations used to generate the answer.
          */
@@ -692,9 +692,9 @@ export namespace Components {
         "collapsible"?: boolean;
         /**
           * Option to disable citation anchoring.
-          * @default false
+          * @default 'false'
          */
-        "disableCitationAnchoring"?: boolean;
+        "disableCitationAnchoring"?: string;
         /**
           * A list of fields to include with the citations used to generate the answer.
          */
@@ -5181,9 +5181,9 @@ declare namespace LocalJSX {
         "collapsible"?: boolean;
         /**
           * Option to disable citation anchoring.
-          * @default false
+          * @default 'false'
          */
-        "disableCitationAnchoring"?: boolean;
+        "disableCitationAnchoring"?: string;
         /**
           * A list of fields to include with the citations used to generate the answer.
          */
@@ -5327,9 +5327,9 @@ declare namespace LocalJSX {
         "collapsible"?: boolean;
         /**
           * Option to disable citation anchoring.
-          * @default false
+          * @default 'false'
          */
-        "disableCitationAnchoring"?: boolean;
+        "disableCitationAnchoring"?: string;
         /**
           * A list of fields to include with the citations used to generate the answer.
          */

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.spec.ts
@@ -1,0 +1,324 @@
+import {Schema} from '@coveo/bueno';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {GeneratedAnswerCommon} from './generated-answer-common';
+
+describe('GeneratedAnswerCommon', () => {
+  let mockProps: {
+    host: HTMLElement;
+    withToggle?: boolean;
+    collapsible?: boolean;
+    disableCitationAnchoring?: boolean;
+    getGeneratedAnswer: ReturnType<typeof vi.fn>;
+    getGeneratedAnswerState: ReturnType<typeof vi.fn>;
+    getSearchStatusState: ReturnType<typeof vi.fn>;
+    getBindings: ReturnType<typeof vi.fn>;
+    getCopied: ReturnType<typeof vi.fn>;
+    setCopied: ReturnType<typeof vi.fn>;
+    getCopyError: ReturnType<typeof vi.fn>;
+    setCopyError: ReturnType<typeof vi.fn>;
+    setAriaMessage: ReturnType<typeof vi.fn>;
+    buildInteractiveCitation: ReturnType<typeof vi.fn>;
+  };
+  let mockHost: HTMLElement;
+  let generatedAnswerCommon: GeneratedAnswerCommon;
+
+  beforeEach(() => {
+    mockHost = document.createElement('div');
+
+    mockProps = {
+      host: mockHost,
+      withToggle: true,
+      collapsible: true,
+      disableCitationAnchoring: false,
+      getGeneratedAnswer: vi.fn().mockReturnValue({
+        state: {isVisible: true},
+        logCopyToClipboard: vi.fn(),
+        show: vi.fn(),
+        hide: vi.fn(),
+        expand: vi.fn(),
+        collapse: vi.fn(),
+        retry: vi.fn(),
+        like: vi.fn(),
+        dislike: vi.fn(),
+      }),
+      getGeneratedAnswerState: vi.fn().mockReturnValue({
+        isVisible: true,
+        isStreaming: false,
+        answer: 'Test answer',
+        citations: [],
+        error: null,
+        expanded: true,
+      }),
+      getSearchStatusState: vi.fn().mockReturnValue({
+        hasError: false,
+      }),
+      getBindings: vi.fn().mockReturnValue({
+        i18n: {
+          t: vi.fn().mockReturnValue('test-translation'),
+        },
+        engine: {
+          logger: {
+            error: vi.fn(),
+          },
+        },
+      }),
+      getCopied: vi.fn().mockReturnValue(false),
+      setCopied: vi.fn(),
+      getCopyError: vi.fn().mockReturnValue(false),
+      setCopyError: vi.fn(),
+      setAriaMessage: vi.fn(),
+      buildInteractiveCitation: vi.fn().mockReturnValue({
+        select: vi.fn(),
+        beginDelayedSelect: vi.fn(),
+        cancelPendingSelect: vi.fn(),
+      }),
+    };
+
+    generatedAnswerCommon = new GeneratedAnswerCommon(mockProps);
+  });
+
+  describe('constructor', () => {
+    it('should initialize with stored data', () => {
+      expect(generatedAnswerCommon.data).toBeDefined();
+      expect(generatedAnswerCommon.data.isVisible).toBe(true);
+    });
+  });
+
+  describe('#validateProps', () => {
+    it('should validate props with correct schema when all props are valid', () => {
+      expect(() => generatedAnswerCommon.validateProps()).not.toThrow();
+    });
+
+    it('should validate props with boolean values', () => {
+      const validProps = {
+        ...mockProps,
+        withToggle: false,
+        collapsible: false,
+        disableCitationAnchoring: true,
+      };
+
+      const validGeneratedAnswerCommon = new GeneratedAnswerCommon(validProps);
+
+      expect(() => validGeneratedAnswerCommon.validateProps()).not.toThrow();
+    });
+
+    it('should throw error when required props are missing', () => {
+      const invalidProps = {
+        ...mockProps,
+        host: null as unknown as HTMLElement,
+      };
+
+      const invalidGeneratedAnswerCommon = new GeneratedAnswerCommon(
+        invalidProps
+      );
+
+      expect(() => invalidGeneratedAnswerCommon.validateProps()).toThrow();
+    });
+
+    it('should throw error when function props are missing', () => {
+      const invalidProps = {
+        ...mockProps,
+        getGeneratedAnswer: null as unknown as ReturnType<typeof vi.fn>,
+      };
+
+      const invalidGeneratedAnswerCommon = new GeneratedAnswerCommon(
+        invalidProps
+      );
+
+      expect(() => invalidGeneratedAnswerCommon.validateProps()).toThrow();
+    });
+
+    it('should use the schema validation', () => {
+      const schemaSpy = vi.spyOn(Schema.prototype, 'validate');
+
+      generatedAnswerCommon.validateProps();
+
+      expect(schemaSpy).toHaveBeenCalledWith(mockProps);
+      schemaSpy.mockRestore();
+    });
+  });
+
+  describe('#getGeneratedAnswerStatus', () => {
+    it('should return hidden status when answer is not visible', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: false,
+      });
+
+      const status = generatedAnswerCommon.getGeneratedAnswerStatus();
+
+      expect(status).toBe('test-translation');
+      expect(mockProps.getBindings().i18n.t).toHaveBeenCalledWith(
+        'generated-answer-hidden'
+      );
+    });
+
+    it('should return generating status when answer is streaming', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        isStreaming: true,
+      });
+
+      const status = generatedAnswerCommon.getGeneratedAnswerStatus();
+
+      expect(status).toBe('test-translation');
+      expect(mockProps.getBindings().i18n.t).toHaveBeenCalledWith(
+        'generating-answer'
+      );
+    });
+
+    it('should return error status when there is an error', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        isStreaming: false,
+        error: {message: 'Test error'},
+      });
+
+      const status = generatedAnswerCommon.getGeneratedAnswerStatus();
+
+      expect(status).toBe('test-translation');
+      expect(mockProps.getBindings().i18n.t).toHaveBeenCalledWith(
+        'answer-could-not-be-generated'
+      );
+    });
+
+    it('should return answer generated status when there is an answer', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        isStreaming: false,
+        answer: 'Test answer',
+      });
+
+      const status = generatedAnswerCommon.getGeneratedAnswerStatus();
+
+      expect(status).toBe('test-translation');
+      expect(mockProps.getBindings().i18n.t).toHaveBeenCalledWith(
+        'answer-generated',
+        {
+          answer: 'Test answer',
+        }
+      );
+    });
+
+    it('should return empty string when no conditions are met', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        isStreaming: false,
+        answer: undefined,
+        error: null,
+      });
+
+      const status = generatedAnswerCommon.getGeneratedAnswerStatus();
+
+      expect(status).toBe('');
+    });
+  });
+
+  describe('#insertFeedbackModal', () => {
+    it('should create and insert feedback modal', () => {
+      const mockModal = {
+        generatedAnswer: undefined,
+      } as unknown as HTMLAtomicGeneratedAnswerFeedbackModalElement;
+      const createElementSpy = vi
+        .spyOn(document, 'createElement')
+        .mockReturnValue(mockModal);
+      const insertAdjacentElementSpy = vi.fn();
+      mockHost.insertAdjacentElement = insertAdjacentElementSpy;
+
+      generatedAnswerCommon.insertFeedbackModal();
+
+      expect(createElementSpy).toHaveBeenCalledWith(
+        'atomic-generated-answer-feedback-modal'
+      );
+      expect(insertAdjacentElementSpy).toHaveBeenCalledWith(
+        'beforebegin',
+        mockModal
+      );
+
+      createElementSpy.mockRestore();
+    });
+  });
+
+  describe('#readStoredData', () => {
+    it('should return visible true when withToggle is false', () => {
+      const propsWithoutToggle = {
+        ...mockProps,
+        withToggle: false,
+      };
+
+      const commonWithoutToggle = new GeneratedAnswerCommon(propsWithoutToggle);
+      const data = commonWithoutToggle.readStoredData();
+
+      expect(data.isVisible).toBe(true);
+    });
+
+    it('should respect stored data when withToggle is true', () => {
+      const propsWithToggle = {
+        ...mockProps,
+        withToggle: true,
+      };
+
+      const commonWithToggle = new GeneratedAnswerCommon(propsWithToggle);
+      const data = commonWithToggle.readStoredData();
+
+      expect(typeof data.isVisible).toBe('boolean');
+    });
+  });
+
+  describe('#writeStoredData', () => {
+    it('should store data correctly', () => {
+      const testData = {isVisible: false};
+
+      generatedAnswerCommon.writeStoredData(testData);
+
+      // Since testing the actual storage mechanism would require more setup,
+      // we just verify the method exists and can be called
+      expect(() =>
+        generatedAnswerCommon.writeStoredData(testData)
+      ).not.toThrow();
+    });
+  });
+
+  describe('#render', () => {
+    it('should render content when there is an answer', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        answer: 'Test answer',
+        citations: [{id: '1', title: 'Test citation', uri: 'https://test.com'}],
+      });
+
+      const rendered = generatedAnswerCommon.render();
+
+      expect(rendered).toBeDefined();
+    });
+
+    it('should render null when there is no answer and no custom message', () => {
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        answer: undefined,
+        citations: [],
+        cannotAnswer: false,
+      });
+
+      const rendered = generatedAnswerCommon.render();
+
+      expect(rendered).toBeNull();
+    });
+
+    it('should render custom no answer message when available', () => {
+      const mockSlot = document.createElement('div');
+      mockSlot.setAttribute('slot', 'no-answer-message');
+      mockHost.appendChild(mockSlot);
+
+      mockProps.getGeneratedAnswerState.mockReturnValue({
+        isVisible: true,
+        answer: undefined,
+        citations: [],
+        cannotAnswer: true,
+      });
+
+      const rendered = generatedAnswerCommon.render();
+
+      expect(rendered).toBeDefined();
+    });
+  });
+});

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx
@@ -1,3 +1,4 @@
+import {BooleanValue, Schema, Value} from '@coveo/bueno';
 import {
   GeneratedAnswer,
   GeneratedAnswerCitation,
@@ -470,4 +471,28 @@ export class GeneratedAnswerCommon {
       </div>
     );
   }
+
+  public validateProps() {
+    const schema = new Schema({
+      host: new Value({required: true}),
+      withToggle: new BooleanValue({required: false, default: true}),
+      collapsible: new BooleanValue({required: false, default: true}),
+      disableCitationAnchoring: new BooleanValue({
+        required: false,
+        default: false,
+      }),
+      getGeneratedAnswer: new Value({required: true}),
+      getGeneratedAnswerState: new Value({required: true}),
+      getSearchStatusState: new Value({required: true}),
+      getBindings: new Value({required: true}),
+      getCopied: new Value({required: true}),
+      setCopied: new Value({required: true}),
+      getCopyError: new Value({required: true}),
+      setCopyError: new Value({required: true}),
+      setAriaMessage: new Value({required: true}),
+      buildInteractiveCitation: new Value({required: true}),
+    });
+    schema.validate(this.props);
+  }
+
 }

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.tsx
@@ -127,9 +127,10 @@ export class AtomicInsightGeneratedAnswer
 
   /**
    * Option to disable citation anchoring.
-   * @default false
+   * @default 'false'
    */
-  @Prop() disableCitationAnchoring?: boolean;
+  @Prop() disableCitationAnchoring?: string;
+  // disableCitationAnchoring is a boolean, but we use a string to allow defaulting to "false" in the HTML template.
 
   @AriaLiveRegion('generated-answer')
   protected ariaMessage!: string;
@@ -142,7 +143,7 @@ export class AtomicInsightGeneratedAnswer
       host: this.host,
       withToggle: this.withToggle,
       collapsible: this.collapsible,
-      disableCitationAnchoring: this.disableCitationAnchoring,
+      disableCitationAnchoring: this.disableCitationAnchoring === 'true',
       getGeneratedAnswer: () => this.generatedAnswer,
       getGeneratedAnswerState: () => this.generatedAnswerState,
       getSearchStatusState: () => this.searchStatusState,
@@ -155,6 +156,8 @@ export class AtomicInsightGeneratedAnswer
       buildInteractiveCitation: (props) =>
         buildInsightInteractiveCitation(this.bindings.engine, props),
     });
+    this.generatedAnswerCommon.validateProps();
+    
     this.generatedAnswer = buildInsightGeneratedAnswer(this.bindings.engine, {
       initialState: {
         isVisible: this.generatedAnswerCommon.data.isVisible,
@@ -263,7 +266,7 @@ export class AtomicInsightGeneratedAnswer
     );
   }
 
-  private getCitationFields() {
+  public getCitationFields() {
     return (this.fieldsToIncludeInCitations ?? '')
       .split(',')
       .map((field) => field.trim())

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -55,6 +55,6 @@ export const Default: Story = {
 export const DisableCitationAnchoring: Story = {
   name: 'Citation anchoring disabled',
   render: () => html`
-    <atomic-generated-answer disable-citation-anchoring></atomic-generated-answer>
+    <atomic-generated-answer disable-citation-anchoring="true"></atomic-generated-answer>
   `,
 };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.tsx
@@ -135,9 +135,11 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
 
   /**
    * Option to disable citation anchoring.
-   * @default false
+   * @default 'false'
    */
-  @Prop() disableCitationAnchoring?: boolean;
+  @Prop() disableCitationAnchoring?: string;
+  // disableCitationAnchoring is a boolean, but we use a string to allow defaulting to "false" in the HTML template.
+
 
   /**
    * The tabs on which the generated answer can be displayed. This property should not be used at the same time as `tabs-excluded`.
@@ -170,7 +172,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
 
   private generatedAnswerCommon!: GeneratedAnswerCommon;
   private fullAnswerHeight?: number;
-
+  
   public initialize() {
     if (
       [...this.tabsIncluded].length > 0 &&
@@ -184,7 +186,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
       host: this.host,
       withToggle: this.withToggle,
       collapsible: this.collapsible,
-      disableCitationAnchoring: this.disableCitationAnchoring,
+      disableCitationAnchoring: this.disableCitationAnchoring === 'true',
       getGeneratedAnswer: () => this.generatedAnswer,
       getGeneratedAnswerState: () => this.generatedAnswerState,
       getSearchStatusState: () => this.searchStatusState,
@@ -197,6 +199,8 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
       buildInteractiveCitation: (props) =>
         buildInteractiveCitation(this.bindings.engine, props),
     });
+    this.generatedAnswerCommon.validateProps();
+    
     this.generatedAnswer = buildGeneratedAnswer(this.bindings.engine, {
       initialState: {
         isVisible: this.generatedAnswerCommon.data.isVisible,
@@ -223,7 +227,7 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
     this.tabManager = buildTabManager(this.bindings.engine);
   }
 
-  @Watch('generatedAnswerState')
+  @Watch("generatedAnswerState")
   public updateAnswerCollapsed(
     newState: GeneratedAnswerState,
     oldState: GeneratedAnswerState
@@ -306,12 +310,12 @@ export class AtomicGeneratedAnswer implements InitializableComponent {
     );
   }
 
-  private getCitationFields() {
+  public getCitationFields() {
     return (this.fieldsToIncludeInCitations ?? '')
       .split(',')
       .map((field) => field.trim())
       .filter((field) => field.length > 0)
-      .concat(this.REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS)
+      .concat(this.REQUIRED_FIELDS_TO_INCLUDE_IN_CITATIONS);
   }
 
   private validateMaxCollapsedHeight(): number {


### PR DESCRIPTION
## Atomic Generated Answer Component

### The main fix
#### Problem statement
The disableCitationAnchoring default value when entering an invalid value is TRUE. When it should be FALSE.
The stencil way to handle boolean props is to default anything to true, actually. So it was impossible to dermine when the value was invalid if we kept the boolean type prop.

#### Solution
The workaround is to change the proptype to string and transorm it in a boolean later on. This way, we can assume that anything but "true" is false.

#### The Bonus
I added some Bueno props validation to the common component.

### Additionnal Test Coverage.
I want to take the opportunity to improve the test coverage of our generative answering solution. 
So I've added some component test to the common atomic component with the help of Claude.
The dependencies required make it difficult to test the `atomic-generated-answer` and the `atomic-insight-generated-answer` components

#### Potential TODO: 
Refactor the E2E tests in playwright to cover the answer génération component properly.

