### PR TITLE
chore: fix affected in ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: ./.github/actions/setup
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - run: npx turbo test --affected -vvv
+      - run: npx turbo test --affected
   package-compatibility:
     name: "Verify compatibility of packages"
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - name: Beep-boop I am turbo
-        run: git rev-parse main
+      - run: git remote set-head origin --auto
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - run: npx turbo test --affected -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".nvmrc"
@@ -133,6 +134,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
+      - run: git branch main origin/main
       - uses: ./.github/actions/setup
       - name: Get affected projects
         id: set
@@ -205,8 +207,8 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
+      - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - run: git remote set-head origin --auto
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - run: npx turbo test --affected -vvv
@@ -276,6 +278,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: ./.github/actions/setup
       - run: npm run build
       - name: Identify E2E Test Files to run
@@ -620,6 +623,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"
@@ -652,6 +656,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"
@@ -786,6 +791,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"
@@ -818,6 +824,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - run: npx turbo test --affected
+      - run: npx turbo test --affected -vvv
   package-compatibility:
     name: "Verify compatibility of packages"
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Get affected projects
         id: set
@@ -201,8 +199,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - name: Beep-boop I am turbo
+        run: git rev-parse main
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - run: npx turbo test --affected -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - uses: ./.github/actions/setup
       - name: Get affected projects
         id: set
@@ -199,6 +202,9 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - uses: ./.github/actions/setup
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,5 +33,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - run: git branch main origin/main
       - uses: ./.github/actions/setup
         continue-on-error: true # Allow Copilot to keep on working even if it goofed up midway

--- a/packages/atomic/src/noop.ts
+++ b/packages/atomic/src/noop.ts
@@ -1,1 +1,0 @@
-console.log('No operation performed. This is a noop module.');

--- a/packages/atomic/src/noop.ts
+++ b/packages/atomic/src/noop.ts
@@ -1,0 +1,1 @@
+console.log('No operation performed. This is a noop module.');


### PR DESCRIPTION
KIT-4686

relates to https://github.com/vercel/turborepo/issues/9320
essentially, turborepo runs `git rev-parse localBranchName`,  but `actions/checkout` do not create local branches for all remote branch, especially in `pull_request` where no branch (I think) are created, given that we are checking out a detached head.