### PR TITLE
chore: remove turborepo workaround on non-pr workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - run: git branch main origin/main
       - uses: ./.github/actions/setup
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,6 +33,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - run: git branch main origin/main
       - uses: ./.github/actions/setup
         continue-on-error: true # Allow Copilot to keep on working even if it goofed up midway


### PR DESCRIPTION
Been overzealous; on the workflow changed in this pr, `main` exists already, so the git branch fails. see https://github.com/coveo/ui-kit/actions/runs/16755155429/job/47435786385 for example