### PR TITLE
fix(atomic): fix error with atomic-product-link when selecting instant product

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -2677,7 +2677,7 @@ export declare interface AtomicProductImage extends LitAtomicProductImage {
 
 @ProxyCmp({
   inputs: ['hrefTemplate'],
-  methods: ['initialize', 'adoptChildren', 'renderDefaultSlotContent', 'getSlotNameForChild', 'isTextNodeEmpty', 'isSlotEmpty', '_initializeSlotState', '_ensureSlotsInitialized', '_hasDefaultSlotContent', '_mapChildrenToSlots', '_addChildToSlot', '_createSlotPlaceholder', '_relocateSingleSlot', '_moveNodeIfNeeded'],
+  methods: ['initialize', 'adoptChildren', 'isTextNodeEmpty', 'isSlotEmpty', 'renderDefaultSlotContent', 'createSlotPlaceholder'],
   defineCustomElementFn: () => {customElements.get('atomic-product-link') || customElements.define('atomic-product-link', LitAtomicProductLink);}
 })
 @Component({

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
@@ -74,28 +74,6 @@ export class AtomicProductLink
     }
   }
 
-  private extractAttributesFromSlot() {
-    const slotName = 'attributes';
-    const attributes = getAttributesFromLinkSlot(this, slotName);
-
-    if (!attributes) {
-      this.linkAttributes = undefined;
-      return;
-    }
-
-    const attributesSlot = this.slots.attributes?.[0];
-    if (
-      attributesSlot instanceof Element &&
-      !attributesSlot.hasAttribute('hidden')
-    ) {
-      attributesSlot.setAttribute('hidden', '');
-    }
-
-    this.linkAttributes = attributes.filter(
-      (attr: Attr) => attr.nodeName !== 'hidden'
-    );
-  }
-
   initialize() {
     if (!this.product && this.productController.item) {
       this.product = this.productController.item;
@@ -142,7 +120,7 @@ export class AtomicProductLink
           );
 
       const {warningMessage} = interactiveProduct;
-      this.extractAttributesFromSlot();
+      this.linkAttributes = getAttributesFromLinkSlot(this, 'attributes');
 
       return renderLinkWithItemAnalytics({
         props: {

--- a/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.spec.ts
+++ b/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.spec.ts
@@ -77,7 +77,7 @@ describe('SlotsForNoShadowDOMMixin', () => {
     });
 
     it('should adopt children into default slot', () => {
-      expect(element.slots['']).toHaveLength(1);
+      expect(element.slotContent['']).toHaveLength(1);
     });
 
     it('should render slot content in correct position', async () => {
@@ -96,8 +96,8 @@ describe('SlotsForNoShadowDOMMixin', () => {
     });
 
     it('should adopt unslotted content to default slot', () => {
-      expect(element.slots['']).toBeDefined();
-      expect(element.slots['']).toContain(
+      expect(element.slotContent['']).toBeDefined();
+      expect(element.slotContent['']).toContain(
         (element as Element).querySelector('p')
       );
     });
@@ -148,10 +148,9 @@ describe('SlotsForNoShadowDOMMixin', () => {
       expect((content as unknown[])[0]).toBe(fallbackContent);
     });
 
-    it('should return fallback content when default slot contains only comments or empty text nodes', async () => {
-      // Only a comment node
+    it('should return fallback content when default slot contains only comments', async () => {
       const commentElement = (await fixture(html`
-        <slotted-element><!-- a comment --></slotted-element>
+      <slotted-element><!-- a comment --></slotted-element>
       `)) as TestableSlottedElement;
       const fallbackContent = html`<span>Fallback</span>`;
       const contentComment =
@@ -159,11 +158,13 @@ describe('SlotsForNoShadowDOMMixin', () => {
       expect(Array.isArray(contentComment)).toBe(true);
       expect(contentComment).toHaveLength(1);
       expect((contentComment as unknown[])[0]).toBe(fallbackContent);
+    });
 
-      // Only empty text node
+    it('should return fallback content when default slot contains only empty text nodes', async () => {
       const emptyTextElement = (await fixture(html`
-        <slotted-element>   \n   </slotted-element>
+      <slotted-element>   \n   </slotted-element>
       `)) as TestableSlottedElement;
+      const fallbackContent = html`<span>Fallback</span>`;
       const contentEmptyText =
         emptyTextElement.renderDefaultSlotContent(fallbackContent);
       expect(Array.isArray(contentEmptyText)).toBe(true);

--- a/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
+++ b/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
@@ -8,7 +8,7 @@ interface SlotMapping {
 }
 
 export interface LightDOMWithSlots {
-  slots: SlotMapping;
+  slotContent: SlotMapping;
   renderDefaultSlotContent(
     defaultContent?: unknown
   ): TemplateResult | unknown[];
@@ -43,7 +43,7 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
     /**
      * @internal
      */
-    public slots: SlotMapping = {};
+    public slotContent: SlotMapping = {};
     /**
      * @internal
      */
@@ -89,10 +89,10 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
         const slotName =
           child instanceof Element ? child.getAttribute('slot') || '' : '';
 
-        if (!this.slots[slotName]) {
-          this.slots[slotName] = [];
+        if (!this.slotContent[slotName]) {
+          this.slotContent[slotName] = [];
         }
-        this.slots[slotName]!.push(child);
+        this.slotContent[slotName]!.push(child);
         child.remove();
       }
     }
@@ -102,9 +102,8 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
     }
 
     private isSlotEmpty(slot: string): boolean {
-      const content = this.slots[slot];
+      const content = this.slotContent[slot];
 
-      console.log(content);
       return (
         !content ||
         content.every((child: AdoptedNode) => {
@@ -127,7 +126,7 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
       defaultContent?: unknown
     ): TemplateResult | unknown[] {
       if (!this.isSlotEmpty('')) {
-        return this.createSlotPlaceholder(this.slots['']!);
+        return this.createSlotPlaceholder(this.slotContent['']!);
       }
       return defaultContent ? [defaultContent] : [];
     }

--- a/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
+++ b/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
@@ -1,16 +1,10 @@
 import type {LitElement, PropertyValues, TemplateResult} from 'lit';
 import type {Constructor} from './mixin-common';
 
-type AdoptedNode = ChildNode & {contentFor?: string};
+type AdoptedNode = ChildNode;
 
 interface SlotMapping {
   [name: string]: AdoptedNode[] | undefined;
-}
-
-interface SlotPlaceholder {
-  slotName: string;
-  placeholder: Comment;
-  originalNodes: AdoptedNode[];
 }
 
 export interface LightDOMWithSlots {
@@ -24,10 +18,7 @@ export interface LightDOMWithSlots {
  * A mixin class that provides slot functionality for LitElement components
  * that render in the light DOM (no shadow DOM).
  *
- * This class manages child node mapping to named slots, similar to how
- * shadow DOM slots work, but operates in the light DOM. It provides
- * methods to adopt children, map them to slots based on their `slot`
- * attribute, and yield slot content during rendering.
+ * Provides the `renderDefaultSlotContent()` method, which returns the default slot’s content or a fallback if the slot is empty.
  *
  * @example
  * ```typescript
@@ -52,69 +43,58 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
     /**
      * @internal
      */
-    slots: SlotMapping = {};
+    public slots: SlotMapping = {};
     /**
      * @internal
      */
-    private slotsInitialized = false;
-    /**
-     * @internal
-     */
-    private slotPlaceholders: SlotPlaceholder[] = [];
-    /**
-     * @internal
-     */
-    private pendingSlotRelocation = false;
+    private slotPlaceholders: {placeholder: Comment; nodes: AdoptedNode[]}[] =
+      [];
 
     createRenderRoot() {
       return this;
     }
 
+    /**
+     * We adopt the children here once, just before the first render.
+     */
     willUpdate(changedProperties: PropertyValues): void {
       super.willUpdate?.(changedProperties);
-      if (!this.hasUpdated && !this.slotsInitialized) {
+      if (!this.hasUpdated) {
         this.adoptChildren();
       }
     }
 
+    /**
+     * After Lit has rendered, we find our placeholders and swap them
+     * with the actual nodes from the slots.
+     */
     public updated(changedProperties: PropertyValues): void {
       super.updated?.(changedProperties);
-      // Relocate slot content after Lit has finished updating the DOM
-      if (!this.pendingSlotRelocation) {
-        return;
+
+      for (const {placeholder, nodes} of this.slotPlaceholders) {
+        placeholder.replaceWith(...nodes);
       }
-      for (const placeholderInfo of this.slotPlaceholders) {
-        this._relocateSingleSlot(placeholderInfo);
-      }
+      // Clear the list for the next render cycle.
       this.slotPlaceholders = [];
-      this.pendingSlotRelocation = false;
     }
 
+    /**
+     * Reads the initial child nodes, sorts them into the `slots` map,
+     * and removes them from the DOM temporarily.
+     */
     private adoptChildren(): void {
-      this.slots = {};
-      this.slotPlaceholders = [];
-      this._mapChildrenToSlots();
-      this.slotsInitialized = true;
-    }
+      const children = Array.from(this.childNodes);
 
-    public renderDefaultSlotContent(
-      defaultContent?: unknown
-    ): TemplateResult | unknown[] {
-      this._ensureSlotsInitialized();
-      if (this._hasDefaultSlotContent()) {
-        return this._createSlotPlaceholder('');
-      }
-      return defaultContent ? [defaultContent] : [];
-    }
+      for (const child of children) {
+        const slotName =
+          child instanceof Element ? child.getAttribute('slot') || '' : '';
 
-    private getSlotNameForChild(child: AdoptedNode): string {
-      if (child instanceof Comment && child.nextSibling instanceof Element) {
-        return this.getSlotNameForChild(child.nextSibling);
+        if (!this.slots[slotName]) {
+          this.slots[slotName] = [];
+        }
+        this.slots[slotName]!.push(child);
+        child.remove();
       }
-      if (child instanceof Element) {
-        return child.getAttribute('slot') || '';
-      }
-      return '';
     }
 
     private isTextNodeEmpty(node: Text): boolean {
@@ -123,6 +103,8 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
 
     private isSlotEmpty(slot: string): boolean {
       const content = this.slots[slot];
+
+      console.log(content);
       return (
         !content ||
         content.every((child: AdoptedNode) => {
@@ -134,70 +116,29 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
       );
     }
 
-    private _ensureSlotsInitialized(): void {
-      if (!this.slotsInitialized) {
-        this.adoptChildren();
+    /**
+     * Returns the content for the default slot.
+     * If no nodes are assigned to the default slot, returns the provided fallback content.
+     *
+     * @param defaultContent - Optional content to render if the default slot is empty.
+     * @returns A `TemplateResult` representing the slot placeholder if nodes exist, otherwise an array containing the default content or an empty array.
+     */
+    public renderDefaultSlotContent(
+      defaultContent?: unknown
+    ): TemplateResult | unknown[] {
+      if (!this.isSlotEmpty('')) {
+        return this.createSlotPlaceholder(this.slots['']!);
       }
+      return defaultContent ? [defaultContent] : [];
     }
 
-    private _hasDefaultSlotContent(): boolean {
-      return !this.isSlotEmpty('');
-    }
-
-    private _mapChildrenToSlots(): void {
-      const children = Array.from(this.childNodes as NodeListOf<ChildNode>);
-      for (const child of children) {
-        const slotName = this.getSlotNameForChild(child as AdoptedNode);
-        this._addChildToSlot(child as AdoptedNode, slotName);
-      }
-    }
-
-    private _addChildToSlot(child: AdoptedNode, slotName: string): void {
-      if (!this.slots[slotName]) {
-        this.slots[slotName] = [];
-      }
-      this.slots[slotName]!.push(child);
-    }
-
-    private _createSlotPlaceholder(slotName: string): unknown[] {
-      const slotContent = this.slots[slotName];
-      if (!slotContent) {
-        return [];
-      }
-      const placeholder = document.createComment(
-        `slot:${slotName || 'default'}`
-      );
-      this.slotPlaceholders.push({
-        slotName,
-        placeholder,
-        originalNodes: slotContent,
-      });
-      this.pendingSlotRelocation = true;
+    /**
+     * Creates a placeholder comment that will be replaced in `updated`.
+     */
+    private createSlotPlaceholder(nodes: AdoptedNode[]): [Comment] {
+      const placeholder = document.createComment('slot');
+      this.slotPlaceholders.push({placeholder, nodes});
       return [placeholder];
-    }
-
-    private _relocateSingleSlot(placeholderInfo: SlotPlaceholder): void {
-      const {placeholder, originalNodes} = placeholderInfo;
-      const parent = placeholder.parentNode;
-      if (!parent) {
-        return;
-      }
-      for (const node of originalNodes) {
-        this._moveNodeIfNeeded(node, parent, placeholder);
-      }
-      placeholder.remove();
-    }
-
-    private _moveNodeIfNeeded(
-      node: AdoptedNode,
-      parent: Node,
-      placeholder: Comment
-    ): void {
-      const needsMove =
-        node.parentNode !== parent || node.nextSibling !== placeholder;
-      if (needsMove) {
-        parent.insertBefore(node, placeholder);
-      }
     }
   }
 

--- a/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
+++ b/packages/atomic/src/mixins/slots-for-no-shadow-dom-mixin.ts
@@ -70,11 +70,6 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
       return this;
     }
 
-    connectedCallback() {
-      this._initializeSlotState();
-      super.connectedCallback?.();
-    }
-
     willUpdate(changedProperties: PropertyValues): void {
       super.willUpdate?.(changedProperties);
       if (!this.hasUpdated && !this.slotsInitialized) {
@@ -137,13 +132,6 @@ export const SlotsForNoShadowDOMMixin = <T extends Constructor<LitElement>>(
           );
         })
       );
-    }
-
-    private _initializeSlotState(): void {
-      this.slots = {};
-      this.slotsInitialized = false;
-      this.slotPlaceholders = [];
-      this.pendingSlotRelocation = false;
     }
 
     private _ensureSlotsInitialized(): void {

--- a/packages/atomic/src/utils/slot-utils.spec.ts
+++ b/packages/atomic/src/utils/slot-utils.spec.ts
@@ -1,0 +1,247 @@
+import {beforeEach, describe, expect, it, type MockInstance, vi} from 'vitest';
+import type {LightDOMWithSlots} from '@/src/mixins/slots-for-no-shadow-dom-mixin';
+import {getDefaultSlotFromHost, getNamedSlotFromHost} from './slot-utils';
+
+class MockLightDOMElement extends HTMLElement implements LightDOMWithSlots {
+  slotContent: {[name: string]: ChildNode[] | undefined} = {};
+
+  renderDefaultSlotContent(defaultContent?: unknown) {
+    return defaultContent ? [defaultContent] : [];
+  }
+}
+customElements.define('mock-light-dom-element', MockLightDOMElement);
+
+let consoleWarnSpy: MockInstance;
+
+beforeEach(() => {
+  consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('#getNamedSlotFromHost', () => {
+  describe('when host uses Light DOM with slotContent property', () => {
+    let host: MockLightDOMElement;
+
+    beforeEach(() => {
+      host = new MockLightDOMElement();
+    });
+
+    it('should return first Element from slotContent when slot exists', () => {
+      const element = document.createElement('div');
+      const textNode = document.createTextNode('text');
+      const comment = document.createComment('comment');
+
+      host.slotContent = {
+        'test-slot': [textNode, comment, element],
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBe(element);
+    });
+
+    it('should return undefined when slot does not exist', () => {
+      host.slotContent = {
+        'other-slot': [document.createElement('div')],
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when slot exists but is empty', () => {
+      host.slotContent = {
+        'test-slot': [],
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when slot exists but contains no Elements', () => {
+      const textNode = document.createTextNode('text');
+      const comment = document.createComment('comment');
+
+      host.slotContent = {
+        'test-slot': [textNode, comment],
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return first Element when multiple Elements exist', () => {
+      const element1 = document.createElement('div');
+      const element2 = document.createElement('span');
+
+      host.slotContent = {
+        'test-slot': [element1, element2],
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBe(element1);
+    });
+
+    it('should handle null slotContent gracefully', () => {
+      host.slotContent = {
+        'test-slot': undefined,
+      };
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when host uses Shadow DOM (fallback behavior)', () => {
+    let host: HTMLElement;
+
+    beforeEach(() => {
+      host = document.createElement('div');
+    });
+
+    it('should return child element with matching slot attribute', () => {
+      const childElement = document.createElement('span');
+      childElement.setAttribute('slot', 'test-slot');
+      host.appendChild(childElement);
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBe(childElement);
+    });
+
+    it('should return undefined when no children have matching slot attribute', () => {
+      const childElement = document.createElement('span');
+      childElement.setAttribute('slot', 'other-slot');
+      host.appendChild(childElement);
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when no children exist', () => {
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return first element when multiple elements have same slot attribute', () => {
+      const element1 = document.createElement('div');
+      const element2 = document.createElement('span');
+      element1.setAttribute('slot', 'test-slot');
+      element2.setAttribute('slot', 'test-slot');
+      host.appendChild(element1);
+      host.appendChild(element2);
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBe(element1);
+    });
+
+    it('should warn when multiple elements have same slot attribute', () => {
+      const element1 = document.createElement('div');
+      const element2 = document.createElement('span');
+      element1.setAttribute('slot', 'test-slot');
+      element2.setAttribute('slot', 'test-slot');
+      host.appendChild(element1);
+      host.appendChild(element2);
+
+      getNamedSlotFromHost(host, 'test-slot');
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Element should only have 1 slot named "test-slot".',
+        host
+      );
+    });
+
+    it('should ignore children without slot attribute when looking for named slot', () => {
+      const unslottedElement = document.createElement('div');
+      const slottedElement = document.createElement('span');
+      slottedElement.setAttribute('slot', 'test-slot');
+      host.appendChild(unslottedElement);
+      host.appendChild(slottedElement);
+
+      const result = getNamedSlotFromHost(host, 'test-slot');
+
+      expect(result).toBe(slottedElement);
+    });
+  });
+});
+
+describe('#getDefaultSlotFromHost', () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+  });
+
+  it('should return child element without slot attribute', () => {
+    const defaultChild = document.createElement('div');
+    const namedChild = document.createElement('span');
+    namedChild.setAttribute('slot', 'named-slot');
+
+    host.appendChild(defaultChild);
+    host.appendChild(namedChild);
+
+    const result = getDefaultSlotFromHost(host);
+
+    expect(result).toBe(defaultChild);
+  });
+
+  it('should return child element with empty slot attribute', () => {
+    const defaultChild = document.createElement('div');
+    defaultChild.setAttribute('slot', '');
+    host.appendChild(defaultChild);
+
+    const result = getDefaultSlotFromHost(host);
+
+    expect(result).toBe(defaultChild);
+  });
+
+  it('should return undefined when no default slot children exist', () => {
+    const namedChild = document.createElement('span');
+    namedChild.setAttribute('slot', 'named-slot');
+    host.appendChild(namedChild);
+
+    const result = getDefaultSlotFromHost(host);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when no children exist', () => {
+    const result = getDefaultSlotFromHost(host);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return first element when multiple default slot elements exist', () => {
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('span');
+    host.appendChild(element1);
+    host.appendChild(element2);
+
+    const result = getDefaultSlotFromHost(host);
+
+    expect(result).toBe(element1);
+  });
+
+  it('should warn when multiple default slot elements exist', () => {
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('span');
+    host.appendChild(element1);
+    host.appendChild(element2);
+
+    getDefaultSlotFromHost(host);
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Element should only have 1 default slot.',
+      host
+    );
+  });
+});

--- a/packages/atomic/src/utils/slot-utils.ts
+++ b/packages/atomic/src/utils/slot-utils.ts
@@ -1,4 +1,27 @@
+import type {LightDOMWithSlots} from '@/src/mixins/slots-for-no-shadow-dom-mixin';
+
+function hasLightDOMSlotContent(
+  element: HTMLElement
+): element is HTMLElement & LightDOMWithSlots {
+  return (
+    'slotContent' in element &&
+    typeof (element as HTMLElement & LightDOMWithSlots).slotContent === 'object'
+  );
+}
+
 export function getNamedSlotFromHost(host: HTMLElement, slotName: string) {
+  if (hasLightDOMSlotContent(host)) {
+    const targetLightDomSlotContent = host.slotContent[slotName];
+
+    if (!targetLightDomSlotContent) {
+      return;
+    }
+
+    return targetLightDomSlotContent.find(
+      (node: ChildNode) => node instanceof Element
+    );
+  }
+
   const children = Array.from(host.children);
   const targetSlot = children.filter(
     (child) => child.getAttribute('slot') === slotName


### PR DESCRIPTION
This PR improves and simplify the way `SlotsForNoShadowDOMMixin` works. This includes removing a second initialization step during connectedCallback, which was causing an issue when `atomic-suggestion-renderer` moves the instant products suggestions on hover/selection

https://coveord.atlassian.net/browse/KIT-4647