### PR TITLE
fix(headless): reset numberOfValue when deselecting a manual numeric facet range

### DIFF
--- a/packages/headless/src/features/commerce/facets/core-facet/core-facet-actions.ts
+++ b/packages/headless/src/features/commerce/facets/core-facet/core-facet-actions.ts
@@ -35,6 +35,11 @@ export const updateCoreFacetIsFieldExpanded = createAction(
     })
 );
 
+/**
+ * Action to clear all core facet values.
+ *
+ * This is primarily used by the breadcrumb manager to reset all selected facets.
+ */
 export const clearAllCoreFacets = createAction('commerce/facets/core/clearAll');
 
 export const deleteAllCoreFacets = createAction(
@@ -48,6 +53,13 @@ export type DeselectAllValuesInCoreFacetPayload = {
   facetId: string;
 };
 
+/**
+ * Action to deselect all values for a given facet.
+ *
+ * This is primarily used in facets to clear all selected values at the same time.
+ *
+ * @param payload - The payload of type {@link DeselectAllValuesInCoreFacetPayload} containing the facet ID to clear.
+ */
 export const deselectAllValuesInCoreFacet = createAction(
   'commerce/facets/core/deselectAllValues',
   (payload: DeselectAllValuesInCoreFacetPayload) =>

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.test.ts
@@ -1442,6 +1442,35 @@ describe('commerceFacetSetReducer', () => {
             expect(finalState[facetId]?.request.preventAutoSelect).toBe(true);
           });
 
+          it('sets #numberOfValues to the #initialNumberOfValues', () => {
+            const initialNumberOfValues = 10;
+            const facetValue = buildMockCommerceNumericFacetValue({
+              start: 0,
+              end: 5,
+              endInclusive: true,
+            });
+            const facetValueRequests = convertToNumericRangeRequests([
+              facetValue,
+            ]);
+
+            state[facetId] = buildMockCommerceFacetSlice({
+              request: buildMockCommerceFacetRequest({
+                type: 'numericalRange',
+                values: facetValueRequests,
+                numberOfValues: 1,
+                initialNumberOfValues,
+              }),
+            });
+
+            const action = toggleAction({
+              facetId,
+              selection: facetValue,
+            });
+            const finalState = commerceFacetSetReducer(state, action);
+
+            expect(finalState[facetId]?.request.numberOfValues).toBe(10);
+          });
+
           it('clears the facet values if value is continuous range and new value state is "idle"', () => {
             const facetValue = buildMockCommerceNumericFacetValue({
               start: 0,
@@ -2748,7 +2777,55 @@ describe('commerceFacetSetReducer', () => {
       });
     });
 
-    it('when called on a non-hierarchical facet, sets all values to "idle"', () => {
+    describe('when called on a numericalRange facet', () => {
+      it('should set all values to "idle"', () => {
+        const facetId = '1';
+        state[facetId] = buildMockCommerceFacetSlice({
+          request: buildMockCommerceFacetRequest({
+            type: 'numericalRange',
+            values: [
+              buildMockCommerceNumericFacetValue({state: 'selected'}),
+              buildMockCommerceNumericFacetValue({state: 'excluded'}),
+            ],
+          }),
+        });
+
+        const finalState = commerceFacetSetReducer(
+          state,
+          deselectAllValuesInCoreFacet({facetId})
+        );
+
+        expect(
+          finalState[facetId]?.request.values.every(
+            (value) => value.state === 'idle'
+          )
+        ).toBe(true);
+      });
+
+      it('should set the #numberOfValues to the #initialNumberOfValues', () => {
+        const facetId = '1';
+        state[facetId] = buildMockCommerceFacetSlice({
+          request: buildMockCommerceFacetRequest({
+            type: 'numericalRange',
+            values: [
+              buildMockCommerceNumericFacetValue({state: 'selected'}),
+              buildMockCommerceNumericFacetValue({state: 'excluded'}),
+            ],
+            numberOfValues: 5,
+            initialNumberOfValues: 10,
+          }),
+        });
+
+        const finalState = commerceFacetSetReducer(
+          state,
+          deselectAllValuesInCoreFacet({facetId})
+        );
+
+        expect(finalState[facetId]?.request.numberOfValues).toBe(10);
+      });
+    });
+
+    it('when called on a non-hierarchical and non-numericalRange facet, sets all values to "idle"', () => {
       const facetId = '1';
       state[facetId] = buildMockCommerceFacetSlice({
         request: buildMockCommerceFacetRequest({

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-slice.ts
@@ -162,6 +162,7 @@ export const commerceFacetSetReducer = createReducer(
           return;
         }
         updateExistingFacetValueState(existingValue, 'select');
+        facetRequest.numberOfValues = facetRequest.initialNumberOfValues;
 
         if (
           facetRequest.interval === 'continuous' &&
@@ -261,6 +262,7 @@ export const commerceFacetSetReducer = createReducer(
         }
 
         updateExistingFacetValueState(existingValue, 'exclude');
+        facetRequest.numberOfValues = facetRequest.initialNumberOfValues;
 
         if (
           facetRequest.interval === 'continuous' &&
@@ -290,6 +292,7 @@ export const commerceFacetSetReducer = createReducer(
         }
 
         updateExistingFacetValueState(existingValue, 'exclude');
+        facetRequest.numberOfValues = facetRequest.initialNumberOfValues;
       })
       .addCase(updateCategoryFacetNumberOfValues, (state, action) => {
         const {facetId, numberOfValues} = action.payload;
@@ -510,15 +513,28 @@ function handleFieldSuggestionsFulfilled(
 }
 
 function handleDeselectAllFacetValues(request: AnyFacetRequest) {
-  if (request.type === 'hierarchical') {
-    request.initialNumberOfValues = undefined;
-    request.numberOfValues = undefined;
-    request.values = [];
-    request.preventAutoSelect = true;
-  } else {
+  const resetValues = () => {
     request.values.forEach((value) => {
       value.state = 'idle';
     });
+  };
+
+  switch (request.type) {
+    case 'hierarchical':
+      request.initialNumberOfValues = undefined;
+      request.numberOfValues = undefined;
+      request.values = [];
+      request.preventAutoSelect = true;
+      break;
+
+    case 'numericalRange':
+      request.numberOfValues = request.initialNumberOfValues;
+      resetValues();
+      break;
+
+    default:
+      resetValues();
+      break;
   }
 }
 

--- a/packages/headless/src/features/commerce/facets/numeric-facet/numeric-facet-actions.ts
+++ b/packages/headless/src/features/commerce/facets/numeric-facet/numeric-facet-actions.ts
@@ -25,7 +25,13 @@ export interface ToggleSelectNumericFacetValuePayload {
    */
   selection: NumericRangeRequest;
 }
-
+/**
+ * Action to toggle a facet value of a NumericFacet.
+ *
+ * This is primarily used in facets and in breadcrumbs to select or deselect a facet value.
+ *
+ * @param payload - The payload of type {@link ToggleSelectNumericFacetValuePayload} containing the facet ID and the selection to toggle.
+ */
 export const toggleSelectNumericFacetValue = createAction(
   'commerce/facets/numericFacet/toggleSelectValue',
   (payload: ToggleSelectNumericFacetValuePayload) =>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4723

Fixes it for deselecting all breadcrumbs, deselecting all facet values and deselecting the actual facet value.