### PR TITLE
docs(internal): remove examples of using turbo globally in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run build
 To build a single project for production (for instance, the `atomic` package), run:
 
 ```sh
-turbo run @coveo/atomic#build
+npx turbo run @coveo/atomic#build
 ```
 
 ## Development mode
@@ -44,13 +44,13 @@ Add the `--stencil` switch if you are changing stencil files.
 To start a single project in development (for instance, the `quantic` package), run:
 
 ```sh
-turbo run @coveo/quantic#dev
+npx turbo run @coveo/quantic#dev
 ```
 
 To run a specific task in a package separate it with colon e.g. to run `test:watch` inside quantic
 
 ```sh
-turbo test:watch --filter=@coveo/quantic
+npx turbo test:watch --filter=@coveo/quantic
 ```
 
 ## Test
@@ -58,15 +58,15 @@ turbo test:watch --filter=@coveo/quantic
 To run the tests for a specific package (recommended) e.g. `atomic` package
 
 ```sh
-turbo test --filter=@coveo/atomic
+npx turbo test --filter=@coveo/atomic
 ```
 
 For e2e tests
 
 ```sh
-turbo run @coveo/atomic#dev
+npx turbo run @coveo/atomic#dev
 # In a separate terminal
-turbo run @coveo/atomic#e2e
+npx turbo run @coveo/atomic#e2e
 ```
 
 To run e2e tests for specific files/components using the Cypress GUI

--- a/internal-docs/scripts-and-tasks.md
+++ b/internal-docs/scripts-and-tasks.md
@@ -71,9 +71,9 @@ When adding new packages, they will automatically inherit the caching behavior f
    ```
 
 4. **Running builds**: Use Turborepo commands to run builds:
-   - `turbo build` - Build all packages
-   - `turbo build --filter=package-name` - Build a specific package
-   - `turbo build --filter=...package-name` - Build a package and its dependencies
+   - `npx turbo build` - Build all packages
+   - `npx turbo build --filter=package-name` - Build a specific package
+   - `npx turbo build --filter=...package-name` - Build a package and its dependencies
 
 ## `dev` script
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4733

Suggested by @erocheleau to improve the initial experience for contributors by avoiding global Turbo usage examples. Using turbo globally could potentially lead to errors and confusion.