### PR TITLE
chore: allow npm env for promote/tag update

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -65,6 +65,12 @@
     },
     "promote:npm:latest": {
       "dependsOn": [],
+      "env": [
+        "NODE_AUTH_TOKEN",
+        "NPM_CONFIG_USERCONFIG",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+      ],
       "cache": false
     },
     "release:phase1": {


### PR DESCRIPTION
[coveord.atlassian.net/browse/KIT-4720](https://coveord.atlassian.net/browse/KIT-4720)
Same as https://github.com/coveo/ui-kit/pull/5842 for promote.
Tho, I don't think we need the OIDC/GitHub variables, because the provenance is set when the version is published. Here, we are just moving the "latest" sticker from one place to another