### PR TITLE
fix: observer stencil more and always

### DIFF
--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -22,11 +22,18 @@ export function registerAutoloader(
    */
   const observeStencilElementHydration = (atomicElement: Element) => {
     const attributeObserver = new MutationObserver(async () => {
-      if (atomicElement.classList.contains('hydrated')) {
+      if (
+        atomicElement.classList.contains('hydrated') &&
+        'shadowRoot' in atomicElement &&
+        atomicElement.shadowRoot &&
+        !visitedNodes.has(atomicElement.shadowRoot)
+      ) {
         attributeObserver.disconnect();
-        if ('shadowRoot' in atomicElement && atomicElement.shadowRoot) {
-          await discover(atomicElement.shadowRoot);
-        }
+        await discover(atomicElement.shadowRoot);
+        observer.observe(atomicElement.shadowRoot, {
+          subtree: true,
+          childList: true,
+        });
       }
     });
 


### PR DESCRIPTION
In some off-case race conditions, it is possible for the hydrated class to be added to a given stencil element before its shadowRoot is attached. This solves this race condition by observing until we find a shadowRoot (even if none may come)
https://coveord.atlassian.net/browse/KIT-4734
