### PR TITLE
chore(atomic commerce): remove InitializeBindingsMixin on atomic commerce components

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -2105,7 +2105,7 @@ export declare interface AtomicCommerceNoProducts extends LitAtomicCommerceNoPro
 
 @ProxyCmp({
   inputs: ['summary', 'facet', 'isCollapsed', 'field'],
-  methods: ['initialize', 'initBindings'],
+  methods: ['initialize'],
   defineCustomElementFn: () => {customElements.get('atomic-commerce-numeric-facet') || customElements.define('atomic-commerce-numeric-facet', LitAtomicCommerceNumericFacet);}
 })
 @Component({
@@ -2521,7 +2521,7 @@ export declare interface AtomicCommerceText extends LitAtomicCommerceText {
 
 @ProxyCmp({
   inputs: ['summary', 'facet', 'isCollapsed', 'field'],
-  methods: ['initialize', 'initBindings'],
+  methods: ['initialize'],
   defineCustomElementFn: () => {customElements.get('atomic-commerce-timeframe-facet') || customElements.define('atomic-commerce-timeframe-facet', LitAtomicCommerceTimeframeFacet);}
 })
 @Component({

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -1897,7 +1897,7 @@ export declare interface AtomicCommerceBreadbox extends LitAtomicCommerceBreadbo
 
 @ProxyCmp({
   inputs: ['summary', 'facet', 'isCollapsed', 'field'],
-  methods: ['initialize', 'initBindings'],
+  methods: ['initialize'],
   defineCustomElementFn: () => {customElements.get('atomic-commerce-category-facet') || customElements.define('atomic-commerce-category-facet', LitAtomicCommerceCategoryFacet);}
 })
 @Component({
@@ -1949,7 +1949,7 @@ export declare interface AtomicCommerceDidYouMean extends LitAtomicCommerceDidYo
 
 @ProxyCmp({
   inputs: ['summary', 'facet', 'isCollapsed', 'field'],
-  methods: ['initialize', 'initBindings'],
+  methods: ['initialize'],
   defineCustomElementFn: () => {customElements.get('atomic-commerce-facet') || customElements.define('atomic-commerce-facet', LitAtomicCommerceFacet);}
 })
 @Component({

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
@@ -26,10 +26,10 @@ import {renderFacetValuesGroup} from '@/src/components/common/facets/facet-value
 import {booleanConverter} from '@/src/converters/boolean-converter';
 import {bindStateToController} from '@/src/decorators/bind-state';
 import {bindingGuard} from '@/src/decorators/binding-guard';
+import {bindings} from '@/src/decorators/bindings';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {
   AriaLiveRegionController,
   FocusTargetController,
@@ -87,9 +87,10 @@ import styles from './atomic-commerce-category-facet.tw.css';
  *
  */
 @customElement('atomic-commerce-category-facet')
+@bindings()
 @withTailwindStyles
 export class AtomicCommerceCategoryFacet
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   static styles: CSSResultGroup = [unsafeCSS(styles)];

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
@@ -34,6 +34,7 @@ import {
 } from '../../common/facets/facet-search/facet-search-utils';
 import type {FacetValueProps} from '../../common/facets/facet-value/facet-value';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
+import styles from './atomic-commerce-facet.tw.css';
 
 /**
  * The `atomic-commerce-facet` component renders a commerce facet that the end user can interact with to filter products.

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
@@ -19,10 +19,10 @@ import {renderFacetValuesGroup} from '@/src/components/common/facets/facet-value
 import {booleanConverter} from '@/src/converters/boolean-converter';
 import {bindStateToController} from '@/src/decorators/bind-state';
 import {bindingGuard} from '@/src/decorators/binding-guard';
+import {bindings} from '@/src/decorators/bindings';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {
   AriaLiveRegionController,
   FocusTargetController,
@@ -34,7 +34,6 @@ import {
 } from '../../common/facets/facet-search/facet-search-utils';
 import type {FacetValueProps} from '../../common/facets/facet-value/facet-value';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
-import styles from './atomic-commerce-facet.tw.css';
 
 /**
  * The `atomic-commerce-facet` component renders a commerce facet that the end user can interact with to filter products.
@@ -70,9 +69,10 @@ import styles from './atomic-commerce-facet.tw.css';
  * @part show-more-less-icon - The icons of the show more & show less buttons.
  */
 @customElement('atomic-commerce-facet')
+@bindings()
 @withTailwindStyles
 export class AtomicCommerceFacet
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   /**

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
@@ -125,7 +125,7 @@ export class AtomicCommerceFacet
     this.validateFacet();
     this.initFocusTargets();
     this.ensureSubscribed();
-    this.initAriaLive();
+    this.facet && this.initAriaLive();
   }
 
   public disconnectedCallback(): void {

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
@@ -20,7 +20,6 @@ import {
 } from 'vitest';
 import {bindings} from '@/src/decorators/bindings';
 import type {InitializableComponent} from '@/src/decorators/types';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {StorageItems} from '@/src/utils/local-storage-utils';
 import {DEFAULT_MOBILE_BREAKPOINT} from '@/src/utils/replace-breakpoint';
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
@@ -109,7 +108,7 @@ vi.mock('@coveo/headless/commerce', async () => {
 @customElement('test-element')
 @bindings()
 class TestElement
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   @state()

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
@@ -18,7 +18,6 @@ import {bindingGuard} from '@/src/decorators/binding-guard';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {FocusTargetController} from '@/src/utils/accessibility-utils';
 import {shouldDisplayInputForFacetRange} from '../../common/facets/facet-common';
 import {renderFacetContainer} from '../../common/facets/facet-container/facet-container';
@@ -30,6 +29,7 @@ import {
 } from '../../common/formats/format-common';
 import type {Range} from '../atomic-commerce-facet-number-input/atomic-commerce-facet-number-input';
 import '../atomic-commerce-facet-number-input/atomic-commerce-facet-number-input';
+import {bindings} from '@/src/decorators/bindings';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 import styles from './atomic-commerce-numeric-facet.tw.css';
 
@@ -54,9 +54,10 @@ import styles from './atomic-commerce-numeric-facet.tw.css';
  * @part input-apply-button - The button to apply custom numeric range values.
  */
 @customElement('atomic-commerce-numeric-facet')
+@bindings()
 @withTailwindStyles
 export class AtomicCommerceNumericFacet
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   /**

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.spec.ts
@@ -12,7 +12,6 @@ import {
 import {createCommerceRecommendationStore} from '@/src/components/commerce/atomic-commerce-recommendation-interface/store';
 import {bindings} from '@/src/decorators/bindings';
 import type {InitializableComponent} from '@/src/decorators/types';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {markParentAsReady} from '@/src/utils/init-queue';
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
 import {buildFakeContext} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/context-controller';
@@ -30,7 +29,7 @@ vi.mock('@/src/utils/init-queue', {spy: true});
 @customElement('test-element')
 @bindings()
 class TestElement
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   @state()

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
@@ -22,10 +22,10 @@ import {bindingGuard} from '@/src/decorators/binding-guard';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {FocusTargetController} from '@/src/utils/accessibility-utils';
 import {parseDate} from '@/src/utils/date-utils';
 import '../../common/atomic-facet-date-input/atomic-facet-date-input';
+import {bindings} from '@/src/decorators/bindings';
 import type {FacetDateInputEventDetails} from '../../common/atomic-facet-date-input/atomic-facet-date-input';
 import {shouldDisplayInputForFacetRange} from '../../common/facets/facet-common';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
@@ -51,9 +51,10 @@ import styles from './atomic-commerce-timeframe-facet.tw.css';
  * @part input-apply-button - The button to apply date range selection.
  */
 @customElement('atomic-commerce-timeframe-facet')
+@bindings()
 @withTailwindStyles
 export class AtomicCommerceTimeframeFacet
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
   static styles: CSSResultGroup = [unsafeCSS(styles)];

--- a/packages/atomic/src/components/common/atomic-facet-date-input/atomic-facet-date-input.ts
+++ b/packages/atomic/src/components/common/atomic-facet-date-input/atomic-facet-date-input.ts
@@ -9,10 +9,10 @@ import {ifDefined} from 'lit/directives/if-defined.js';
 import {createRef, type Ref, ref} from 'lit/directives/ref.js';
 import {renderButton} from '@/src/components/common/button';
 import {bindingGuard} from '@/src/decorators/binding-guard';
+import {bindings} from '@/src/decorators/bindings';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {LitElementWithError} from '@/src/decorators/types';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
-import {InitializeBindingsMixin} from '@/src/mixins/bindings-mixin';
 import {parseDate} from '@/src/utils/date-utils';
 import type {AnyBindings} from '../interface/bindings';
 
@@ -27,15 +27,18 @@ export type FacetDateInputEventDetails = Omit<DateRangeRequest, 'state'>;
  * @internal
  */
 @customElement('atomic-facet-date-input')
+@bindings()
 @withTailwindStyles
 export class AtomicFacetDateInput
-  extends InitializeBindingsMixin(LitElement)
+  extends LitElement
   implements LitElementWithError
 {
   @state() private start?: Date;
   @state() private end?: Date;
   private startRef: Ref<HTMLInputElement> = createRef();
   private endRef: Ref<HTMLInputElement> = createRef();
+
+  initialize() {}
 
   @property({type: Object}) public inputRange: DateFilterRange | undefined;
   @property() public facetId!: string;


### PR DESCRIPTION
This PR removes all uses of `InitializeBindingsMixin` on atomic commerce components and replaces them with the bindings decorator, as all the interface components have been migrated to lit.

https://coveord.atlassian.net/browse/KIT-4740
