### PR TITLE
fix(atomic): commerce-layout margin

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css
@@ -136,7 +136,7 @@ atomic-commerce-layout {
   }
 
   atomic-layout-section[section="status"] > * {
-    margin-top: var(--atomic-layout-spacing-y);
+    margin-bottom: var(--atomic-layout-spacing-y);
   }
 
   atomic-layout-section[section="pagination"] {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4741

Bug introduced during https://github.com/coveo/ui-kit/pull/5669

Now : 

<img width="731" height="272" alt="image" src="https://github.com/user-attachments/assets/686e96cb-acf8-446f-a5da-8c90e8f5f632" />


