### PR TITLE
chore(atomic): convert .css.tw component stylesheets to css-in-js

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
@@ -17,7 +17,7 @@ import {
   type RegularFacetValue,
   type Search,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, nothing, unsafeCSS} from 'lit';
+import {type CSSResultGroup, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {bindStateToController} from '@/src/decorators/bind-state';
 import {bindingGuard} from '@/src/decorators/binding-guard';
@@ -72,7 +72,7 @@ export class AtomicCommerceBreadbox
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = styles;
 
   private resizeObserver?: ResizeObserver;
   private lastRemovedBreadcrumbIndex = 0;

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.tw.css.ts
@@ -1,3 +1,6 @@
+import {css} from 'lit';
+
+const styles = css`
 @reference '../../../utils/tailwind.global.tw.css';
 
 [part="breadcrumb-label"].excluded,
@@ -9,4 +12,6 @@
 /* When excluded, strikethrough line must be continuous, so we must prepend empty character instead of margin */
 [part="breadcrumb-value"]::before {
   content: "\00a0";
-}
+}`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
@@ -7,7 +7,7 @@ import type {
   Summary,
 } from '@coveo/headless/commerce';
 import type {CSSResultGroup, TemplateResult} from 'lit';
-import {html, LitElement, nothing, unsafeCSS} from 'lit';
+import {html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {map} from 'lit/directives/map.js';
 import {when} from 'lit/directives/when.js';
@@ -93,7 +93,7 @@ export class AtomicCommerceCategoryFacet
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = styles;
 
   @state()
   bindings!: CommerceBindings;

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.tw.css.ts
@@ -1,7 +1,7 @@
-@import "../../common/facets/facet-search/facet-search.tw.css";
+import {css} from 'lit';
+
+const styles = css`@import "../../common/facets/facet-search/facet-search.tw.css";
 @import "../../common/facets/facet-common.tw.css";
-@reference '../../../utils/tailwind.global.tw.css';
-@reference '../../../utils/coveo.tw.css';
 
 [part~="active-parent"] {
   @apply pl-9;
@@ -19,3 +19,6 @@
 [part~="back-arrow"] {
   @apply absolute left-1 h-5 w-5;
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
@@ -1,6 +1,6 @@
 import {isUndefined} from '@coveo/bueno';
 import type {NumericFacet} from '@coveo/headless/commerce';
-import {html, LitElement, unsafeCSS} from 'lit';
+import {html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
@@ -54,7 +54,7 @@ export class AtomicCommerceFacetNumberInput
   private startRef?: HTMLInputElement;
   private endRef?: HTMLInputElement;
 
-  static styles = unsafeCSS(styles);
+  static styles = styles;
 
   initialize() {
     this.start = this.range?.start;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.tw.css.ts
@@ -1,4 +1,6 @@
-[part="input-form"] {
+import {css} from 'lit';
+
+const styles = css`[part="input-form"] {
   display: grid;
   grid-template-areas:
     "label-start label-end ."
@@ -22,3 +24,6 @@
 [part="input-apply-button"] {
   grid-area: apply-button;
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
@@ -5,7 +5,7 @@ import type {
   SearchSummaryState,
   Summary,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, nothing, unsafeCSS} from 'lit';
+import {type CSSResultGroup, css, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {renderFacetContainer} from '@/src/components/common/facets/facet-container/facet-container';
@@ -34,7 +34,6 @@ import {
 } from '../../common/facets/facet-search/facet-search-utils';
 import type {FacetValueProps} from '../../common/facets/facet-value/facet-value';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
-import styles from './atomic-commerce-facet.tw.css';
 
 /**
  * The `atomic-commerce-facet` component renders a commerce facet that the end user can interact with to filter products.
@@ -113,7 +112,13 @@ export class AtomicCommerceFacet
 
   @state() public error!: Error;
 
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = css`
+  @import "../../common/facets/facet-value-checkbox/facet-value-checkbox.tw.css";
+  @import "../../common/facets/facet-search/facet-search.tw.css";
+  @import "../../common/facets/facet-common.tw.css";
+  @import "../../common/facets/facet-value-exclude/facet-value-exclude.tw.css";
+  @import "../../common/facets/facet-value-box/facet-value-box.tw.css";
+  `;
 
   private showLessFocus!: FocusTargetController;
   private showMoreFocus!: FocusTargetController;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.tw.css
@@ -1,5 +1,0 @@
-@import "../../common/facets/facet-value-checkbox/facet-value-checkbox.tw.css";
-@import "../../common/facets/facet-search/facet-search.tw.css";
-@import "../../common/facets/facet-common.tw.css";
-@import "../../common/facets/facet-value-exclude/facet-value-exclude.tw.css";
-@import "../../common/facets/facet-value-box/facet-value-box.tw.css";

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.ts
@@ -1,4 +1,4 @@
-import {html, LitElement, unsafeCSS} from 'lit';
+import {html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard';
 import {CommerceLayoutMixin} from '@/src/mixins/commerce-layout-mixin';
@@ -13,7 +13,7 @@ import styles from './atomic-commerce-layout.tw.css';
 @customElement('atomic-commerce-layout')
 export class AtomicCommerceLayout extends CommerceLayoutMixin(
   LitElement,
-  unsafeCSS(styles)
+  styles
 ) {
   @state() error!: Error;
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css.ts
@@ -1,3 +1,6 @@
+import {css} from 'lit';
+
+const styles = css`
 .atomic-modal-opened {
   overflow-y: hidden;
 }
@@ -162,3 +165,6 @@ atomic-commerce-layout {
     margin-top: var(--atomic-layout-spacing-y);
   }
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
@@ -8,7 +8,7 @@ import {
   type SearchSummaryState,
   type Summary,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
+import {type CSSResultGroup, css, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {renderNumericFacetValuesGroup} from '@/src/components/common/facets/numeric-facet/values-container';
@@ -31,7 +31,6 @@ import type {Range} from '../atomic-commerce-facet-number-input/atomic-commerce-
 import '../atomic-commerce-facet-number-input/atomic-commerce-facet-number-input';
 import {bindings} from '@/src/decorators/bindings';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
-import styles from './atomic-commerce-numeric-facet.tw.css';
 
 /**
  * The `atomic-commerce-numeric-facet` component renders a commerce facet that allows the user to filter products using numeric ranges.
@@ -107,7 +106,8 @@ export class AtomicCommerceNumericFacet
   private headerFocus!: FocusTargetController;
   private unsubscribeFacetController?: () => void;
 
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup =
+    css`@import "../../common/facets/numeric-facet-common.tw.css";`;
 
   public initialize() {
     this.validateFacet();

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.tw.css
@@ -1,1 +1,0 @@
-@import "../../common/facets/numeric-facet-common.tw.css";

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -10,7 +10,7 @@ import {
   type SearchSummaryState,
   type Summary,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, nothing, unsafeCSS} from 'lit';
+import {type CSSResultGroup, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {keyed} from 'lit/directives/keyed.js';
 import {map} from 'lit/directives/map.js';
@@ -74,7 +74,7 @@ export class AtomicCommerceProductList
   extends ChildrenUpdateCompleteMixin(LitElement)
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = styles;
 
   public searchOrListing!: Search | ProductListing;
   public summary!: Summary<ProductListingSummaryState | SearchSummaryState>;

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.tw.css.ts
@@ -1,4 +1,6 @@
-@import "../../common/item-list/styles/placeholders.pcss";
+import {css} from 'lit';
+
+const styles = css`@import "../../common/item-list/styles/placeholders.pcss";
 @import "../../common/item-list/styles/table-display.pcss";
 @import "../../common/item-list/styles/list-display.pcss";
 @import "../../common/item-list/styles/grid-display.pcss";
@@ -47,3 +49,6 @@
     flex-direction: column;
   }
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
@@ -7,7 +7,7 @@ import {
   type RecommendationsSummaryState,
   type Summary,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, nothing, unsafeCSS} from 'lit';
+import {type CSSResultGroup, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {keyed} from 'lit/directives/keyed.js';
 import {map} from 'lit/directives/map.js';
@@ -66,7 +66,7 @@ export class AtomicCommerceRecommendationList
   extends ChildrenUpdateCompleteMixin(LitElement)
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = styles;
 
   public recommendations!: Recommendations;
   public summary!: Summary<RecommendationsSummaryState>;

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.tw.css.ts
@@ -1,7 +1,7 @@
-@import "../../common/item-list/styles/mixins.pcss";
+import {css} from 'lit';
+
+const styles = css`@import "../../common/item-list/styles/mixins.pcss";
 @import "../../common/item-list/styles/placeholders.pcss";
-@reference '../../../utils/tailwind.global.tw.css';
-@reference '../../../utils/coveo.tw.css';
 
 :host {
   @apply atomic-grid-clickable-elements;
@@ -22,3 +22,6 @@
     @apply font-sans text-2xl font-bold;
   }
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
@@ -8,7 +8,7 @@ import {
   type StandaloneSearchBox,
   type StandaloneSearchBoxState,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
+import {type CSSResultGroup, css, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {createRef, type RefOrCallback, ref} from 'lit/directives/ref.js';
@@ -47,7 +47,6 @@ import {
 } from '../../common/suggestions/suggestions-common';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 import type {SelectChildProductEventArgs} from '../atomic-product-children/select-child-product-event';
-import styles from './atomic-commerce-search-box.tw.css';
 import '../atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products';
 import '../atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions';
 import '../atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries';
@@ -103,7 +102,8 @@ export class AtomicCommerceSearchBox
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup =
+    css`@import "../../search/atomic-search-box/atomic-search-box.pcss";`;
 
   @state() bindings!: CommerceBindings;
   @state() error!: Error;

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.tw.css
@@ -1,2 +1,0 @@
-@import "../../search/atomic-search-box/atomic-search-box.pcss";
-@reference '../../../utils/tailwind.global.tw.css';

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
@@ -8,7 +8,7 @@ import {
   type SearchSummaryState,
   type Summary,
 } from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
+import {type CSSResultGroup, css, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {renderFacetContainer} from '@/src/components/common/facets/facet-container/facet-container';
@@ -29,7 +29,6 @@ import {bindings} from '@/src/decorators/bindings';
 import type {FacetDateInputEventDetails} from '../../common/atomic-facet-date-input/atomic-facet-date-input';
 import {shouldDisplayInputForFacetRange} from '../../common/facets/facet-common';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
-import styles from './atomic-commerce-timeframe-facet.tw.css';
 
 /**
  * A facet is a list of values for a certain field occurring in the results.
@@ -57,7 +56,8 @@ export class AtomicCommerceTimeframeFacet
   extends LitElement
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup =
+    css`@import "../../common/facets/facet-common.tw.css";`;
 
   /**
    * The Summary controller instance.

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.tw.css
@@ -1,1 +1,0 @@
-@import "../../common/facets/facet-common.tw.css";

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
@@ -1,6 +1,6 @@
 import {isUndefined} from '@coveo/bueno';
 import type {InteractiveProduct, Product} from '@coveo/headless/commerce';
-import {html, LitElement, unsafeCSS} from 'lit';
+import {html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {getAttributesFromLinkSlot} from '@/src/components/common/item-link/attributes-slot';
@@ -39,7 +39,7 @@ export class AtomicProductLink
   extends SlotsForNoShadowDOMMixin(LitElement)
   implements InitializableComponent<CommerceBindings>
 {
-  static styles = unsafeCSS(styles);
+  static styles = styles;
 
   /**
    * The [template literal](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals) from which to generate the `href` attribute value

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css
@@ -1,7 +1,0 @@
-@reference '../../../utils/tailwind-utilities/link-style.tw.css';
-
-atomic-product-link {
-  a {
-    @apply link-style;
-  }
-}

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
@@ -1,0 +1,11 @@
+import {css} from 'lit';
+
+const styles = css`@reference '../../../utils/tailwind-utilities/link-style.tw.css';
+
+atomic-product-link {
+  a {
+    @apply link-style;
+  }
+}`;
+
+export default styles;

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
@@ -1,13 +1,13 @@
 import {type Product, ProductTemplatesHelpers} from '@coveo/headless/commerce';
-import {html, LitElement} from 'lit';
+import {css, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings.js';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard';
+import {injectStylesForNoShadowDOM} from '@/src/decorators/inject-styles-for-no-shadow-dom';
 import type {InitializableComponent} from '@/src/decorators/types.js';
-import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import Star from '../../../images/star.svg';
 import {
   computeNumberOfStars,
@@ -27,7 +27,7 @@ import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerc
  */
 @customElement('atomic-product-rating')
 @bindings()
-@withTailwindStyles
+@injectStylesForNoShadowDOM
 export class AtomicProductRating
   extends LitElement
   implements InitializableComponent<CommerceBindings>
@@ -38,6 +38,9 @@ export class AtomicProductRating
   private productController = createProductContextController(this);
 
   @state() private product!: Product;
+
+  static styles =
+    css`@import "../../common/atomic-rating/atomic-rating.tw.css";`;
 
   /**
    * The numerical field whose values you want to display as a rating.
@@ -117,10 +120,6 @@ export class AtomicProductRating
     }
     this.updateNumberOfStars();
     this.updateRatingDetailsValue();
-  }
-
-  protected createRenderRoot() {
-    return this;
   }
 
   @bindingGuard()

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.tw.css
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.tw.css
@@ -1,1 +1,0 @@
-@import "../../common/atomic-rating/atomic-rating.tw.css";

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.ts
@@ -1,5 +1,5 @@
 import type {InteractiveProduct, Product} from '@coveo/headless/commerce';
-import {type CSSResultGroup, html, LitElement, unsafeCSS} from 'lit';
+import {type CSSResultGroup, html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {ref} from 'lit/directives/ref.js';
 import type {DisplayConfig} from '@/src/components/common/item-list/context/item-display-config-context-controller';
@@ -36,7 +36,7 @@ export class AtomicProduct extends ChildrenUpdateCompleteMixin(LitElement) {
   private linkContainerRef?: HTMLElement;
   private executedRenderingFunctionOnce = false;
 
-  static styles: CSSResultGroup = [unsafeCSS(styles)];
+  static styles: CSSResultGroup = styles;
 
   /**
    * Whether `atomic-product-link` components nested in the `atomic-product` should stop click event propagation.

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -1,5 +1,7 @@
+import {css} from 'lit';
+
+const styles = css`
 @import "../../common/template-system/template-system.pcss";
-@reference '../../../utils/coveo.tw.css';
 
 :host {
   @apply atomic-template-system;
@@ -131,3 +133,6 @@
     }
   }
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css
+++ b/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css
@@ -1,15 +1,15 @@
-
 @reference '../../../utils/tailwind.global.tw.css';
 @reference '../../../utils/coveo.tw.css';
 /**
  * @prop --atomic-rating-icon-outline: currentColor;line: Color of the icon's outline.
  */
- @layer components {
-atomic-product-rating {
-.text-rating-icon-active,
-.text-rating-icon-inactive {
-  & svg path {
-    @apply stroke-rating-icon-outline;
+@layer components {
+  atomic-product-rating {
+    .text-rating-icon-active,
+    .text-rating-icon-inactive {
+      & svg path {
+        @apply stroke-rating-icon-outline;
+      }
+    }
   }
-}}
- }
+}

--- a/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css
+++ b/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css
@@ -1,9 +1,15 @@
+
+@reference '../../../utils/tailwind.global.tw.css';
+@reference '../../../utils/coveo.tw.css';
 /**
  * @prop --atomic-rating-icon-outline: currentColor;line: Color of the icon's outline.
  */
+ @layer components {
+atomic-product-rating {
 .text-rating-icon-active,
 .text-rating-icon-inactive {
   & svg path {
-    stroke: var(--atomic-rating-icon-outline);
+    @apply stroke-rating-icon-outline;
   }
-}
+}}
+ }

--- a/packages/atomic/src/components/common/item-list/styles/mixins.pcss
+++ b/packages/atomic/src/components/common/item-list/styles/mixins.pcss
@@ -1,3 +1,6 @@
+@reference '../../../../utils/tailwind.global.tw.css';
+@reference '../../../../utils/coveo.tw.css';
+
 @utility atomic-list-with-cards {
   [part~='outline'] {
     @apply border-neutral border;

--- a/packages/atomic/src/utils/coveo.tw.css
+++ b/packages/atomic/src/utils/coveo.tw.css
@@ -24,9 +24,6 @@
   --atomic-error-background: #fcbdc0;
   --atomic-primary-background: #edf6ff;
   --atomic-inline-code: #cd2113;
-
-  --atomic-rating-icon-outline: none;
-
   /* Border radius */
   --atomic-border-radius: 0.25rem;
   --atomic-border-radius-md: 0.5rem;
@@ -80,6 +77,11 @@
     var(--atomic-neutral)
   );
   --color-rating-icon-active: var(--atomic-rating-icon-active-color, #f6ce3c);
+
+  --color-rating-icon-outline: var(
+    --atomic-rating-icon-outline-color,
+    none
+  );
 
   --color-more-results-progress-bar-color-from: var(
     --atomic-more-results-progress-bar-color-from,

--- a/packages/atomic/src/utils/coveo.tw.css
+++ b/packages/atomic/src/utils/coveo.tw.css
@@ -78,10 +78,7 @@
   );
   --color-rating-icon-active: var(--atomic-rating-icon-active-color, #f6ce3c);
 
-  --color-rating-icon-outline: var(
-    --atomic-rating-icon-outline-color,
-    none
-  );
+  --color-rating-icon-outline: var(--atomic-rating-icon-outline-color, none);
 
   --color-more-results-progress-bar-color-from: var(
     --atomic-more-results-progress-bar-color-from,


### PR DESCRIPTION
This PR converts all the component-level stylesheets for atomic commerce to css-in-js files. For stylesheets that contain a small number of styles, these are instead added directly in the static style property of their component. 

https://coveord.atlassian.net/browse/KIT-4746