### PR TITLE
chore(atomic): remove deprecation mark on initializeBindings

### DIFF
--- a/packages/atomic/src/utils/initialization-utils.tsx
+++ b/packages/atomic/src/utils/initialization-utils.tsx
@@ -17,6 +17,7 @@ import {
   InitializeEventHandler,
   initializableElements,
   initializeEventName,
+  fetchBindings,
 } from './initialization-lit-stencil-common-utils';
 
 export type InitializeEvent = CustomEvent<InitializeEventHandler>;
@@ -25,26 +26,11 @@ export type InitializeEvent = CustomEvent<InitializeEventHandler>;
  * Retrieves `Bindings` or `CommerceBindings` on a configured parent interface.
  * @param event - The element on which to dispatch the event, which must be the child of a configured Atomic container element.
  * @returns A promise that resolves upon initialization of the parent container element, and rejects otherwise.
- * @deprecated should only be used for Stencil components. For Lit components, use `initializeBindings` from @/src/decorators/initialize-bindings.
  */
 export function initializeBindings<
   SpecificBindings extends AnyBindings = Bindings,
 >(element: Element) {
-  return new Promise<SpecificBindings>((resolve, reject) => {
-    const event = buildCustomEvent<InitializeEventHandler>(
-      initializeEventName,
-      (bindings) => resolve(bindings as SpecificBindings)
-    );
-
-    const parent = closest(element, initializableElements.join(', '));
-
-    if (!parent) {
-      reject(new MissingInterfaceParentError(element.nodeName.toLowerCase()));
-      return;
-    }
-
-    enqueueOrDispatchInitializationEvent(parent, event, element);
-  });
+  return fetchBindings<SpecificBindings>(element);
 }
 
 export {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4760

`initializeBindings` should not be deprecated as it is framework-agnostic and used by custom components. Its logic is currently duplicated in `fetchBindings`. This PR removes the deprecation and refactors initializebindings to use fetchBindings