### PR TITLE
fix(quantic): run the post scratch org links action only on PR

### DIFF
--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -26,6 +26,7 @@ jobs:
     name: 'Post Scratch Org Links to PR'
     needs: e2e-quantic-setup
     if: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## [SFINT-6267](https://coveord.atlassian.net/browse/SFINT-6267)

- Ensure to run the step that post scratch org links as pull request comments only in pull requests.
- Since this action is not mandatory to pass successfully, I added `continue-on-error` set to true.

[SFINT-6267]: https://coveord.atlassian.net/browse/SFINT-6267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ