### PR TITLE
fix: do not wait for 1st discover to avoid race conditions

### DIFF
--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -133,11 +133,9 @@ export function registerAutoloader(
     }
   });
 
-  const initializeDiscovery = async () => {
+  const initializeDiscovery = () => {
     for (const root of roots) {
-      // Initial discovery
-      await discover(root);
-      // Listen for new undefined elements
+      discover(root);
       observer.observe(root, {
         subtree: true,
         childList: true,


### PR DESCRIPTION
If we wait for the `discovery` call before registering the MutationObserver, DOM modification can "slip through" between the start of `discovery` and the observer's registration.

Given that we do not await `initialDiscovery`, we can make it synchronous and just schedule the discovery promise and unawait it.

https://coveord.atlassian.net/browse/KIT-4806