### PR TITLE
fix(atomic commerce): fix loader not detecting components in template elements

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import '@coveo/atomic/themes/coveo.css';
 import {setCustomElementsManifest} from '@storybook/web-components';
-import {html, render} from 'lit';
+import {render} from 'lit';
 import customElements from '../custom-elements.json';
 import {defineCustomElements} from '../dist/atomic/loader/index.js';
 
@@ -49,7 +49,7 @@ export const decorators = [
         ]);
       }
 
-      return html`${container}`;
+      return story;
     }
   },
 ];

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -27,20 +27,18 @@ export const parameters = {
 };
 
 export const decorators = [
-  (Story) => {
+  (Story, context) => {
     const story = Story();
 
     if (story?._$litType$) {
-      const container = document.createElement('div');
-
-      render(story, container);
+      render(story, context.canvasElement);
 
       const isTestMode =
         typeof window !== 'undefined' &&
         window.location.href.includes('localhost');
 
       if (!isTestMode) {
-        disableAnalytics(container, [
+        disableAnalytics(context.canvasElement, [
           'atomic-recs-interface',
           'atomic-insight-interface',
           'atomic-search-interface',
@@ -49,7 +47,7 @@ export const decorators = [
         ]);
       }
 
-      return container;
+      return context.canvasElement.children[0];
     }
   },
 ];

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -1,6 +1,6 @@
 import '@coveo/atomic/themes/coveo.css';
 import {setCustomElementsManifest} from '@storybook/web-components';
-import {render} from 'lit';
+import {html, render} from 'lit';
 import customElements from '../custom-elements.json';
 import {defineCustomElements} from '../dist/atomic/loader/index.js';
 
@@ -27,18 +27,20 @@ export const parameters = {
 };
 
 export const decorators = [
-  (Story, context) => {
+  (Story) => {
     const story = Story();
 
     if (story?._$litType$) {
-      render(story, context.canvasElement);
+      const container = document.createElement('div');
+
+      render(story, container);
 
       const isTestMode =
         typeof window !== 'undefined' &&
         window.location.href.includes('localhost');
 
       if (!isTestMode) {
-        disableAnalytics(context.canvasElement, [
+        disableAnalytics(container, [
           'atomic-recs-interface',
           'atomic-insight-interface',
           'atomic-search-interface',
@@ -47,7 +49,7 @@ export const decorators = [
         ]);
       }
 
-      return context.canvasElement.children[0];
+      return html`${container}`;
     }
   },
 ];

--- a/packages/atomic/src/autoloader/index.spec.ts
+++ b/packages/atomic/src/autoloader/index.spec.ts
@@ -1,0 +1,134 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {registerAutoloader} from './index';
+
+const mockCustomElementsRegistry = new Map<string, CustomElementConstructor>();
+
+const mockCustomElements = {
+  define: vi.fn((name: string, constructorFn: CustomElementConstructor) => {
+    mockCustomElementsRegistry.set(name, constructorFn);
+  }),
+  get: vi.fn((name: string) => mockCustomElementsRegistry.get(name)),
+  whenDefined: vi.fn((name: string) => {
+    const constructorFn = mockCustomElementsRegistry.get(name);
+    return constructorFn
+      ? Promise.resolve(constructorFn)
+      : new Promise(() => {});
+  }),
+  upgrade: vi.fn(),
+};
+
+vi.stubGlobal('customElements', mockCustomElements);
+
+vi.mock('../components/components/lazy-index.js', () => ({
+  __esModule: true,
+  default: {
+    'x-test-component': async () => {
+      customElements.define('x-test-component', HTMLElement);
+    },
+    'x-test-component-inside': async () => {
+      customElements.define('x-test-component-inside', HTMLElement);
+    },
+  },
+}));
+
+describe('autoloader', () => {
+  describe('#registerAutoloader', () => {
+    const waitForNextTick = () =>
+      new Promise((resolve) => setTimeout(resolve, 0));
+
+    const setupComponent = async (elementFactory: () => HTMLElement) => {
+      const element = elementFactory();
+      document.body.appendChild(element);
+      registerAutoloader();
+      await waitForNextTick();
+      return element;
+    };
+
+    beforeEach(() => {
+      mockCustomElementsRegistry.clear();
+      document.body.innerHTML = '';
+    });
+
+    it('should register components when added to DOM', async () => {
+      await setupComponent(() => document.createElement('x-test-component'));
+      expect(customElements.get('x-test-component')).toBeDefined();
+    });
+
+    it('should discover components in template content', async () => {
+      const template = document.createElement('template');
+      template.innerHTML = '<x-test-component></x-test-component>';
+      await setupComponent(() => template);
+      expect(customElements.get('x-test-component')).toBeDefined();
+    });
+
+    it('should discover nested components', async () => {
+      await setupComponent(() => {
+        const container = document.createElement('div');
+        container.innerHTML = `
+          <div>
+            <x-test-component></x-test-component>
+            <template>
+              <x-test-component-inside></x-test-component-inside>
+            </template>
+          </div>
+        `;
+        return container;
+      });
+
+      expect(customElements.get('x-test-component')).toBeDefined();
+      expect(customElements.get('x-test-component-inside')).toBeDefined();
+    });
+
+    it('should register components when dynamically added to DOM', async () => {
+      registerAutoloader();
+
+      const element = document.createElement('div');
+      element.innerHTML = '<x-test-component></x-test-component>';
+
+      document.body.appendChild(element);
+      await waitForNextTick();
+
+      expect(customElements.get('x-test-component')).toBeDefined();
+    });
+
+    it('should handle components inside templates within shadow DOM', async () => {
+      await setupComponent(() => {
+        const element = document.createElement('x-test-component');
+        element.attachShadow({mode: 'open'});
+        const template = document.createElement('template');
+        template.innerHTML =
+          '<x-test-component-inside>test</x-test-component-inside>';
+
+        element.shadowRoot!.appendChild(template);
+        return element;
+      });
+
+      expect(customElements.get('x-test-component-inside')).toBeDefined();
+    });
+
+    it('should handle components in shadow roots with hydration', async () => {
+      const el = await setupComponent(() =>
+        document.createElement('test-component')
+      );
+
+      el.attachShadow({mode: 'open'});
+      await waitForNextTick();
+
+      el.shadowRoot!.innerHTML = '<x-test-component></x-test-component>';
+      el.classList.add('hydrated');
+      await waitForNextTick();
+
+      const childElement = el?.querySelector('x-test-component') as HTMLElement;
+      expect(childElement).toBeDefined();
+      expect(customElements.get('x-test-component')).toBeDefined();
+    });
+
+    it('should upgrade custom elements on root', async () => {
+      const upgradeSpy = vi.spyOn(customElements, 'upgrade');
+
+      await setupComponent(() => document.createElement('div'));
+      expect(upgradeSpy).toHaveBeenCalled();
+      upgradeSpy.mockRestore();
+    });
+  });
+});

--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -77,17 +77,18 @@ export function registerAutoloader(
       }
     }
 
+    const childTemplates = root.querySelectorAll('template');
+    //This is necessary to load the components that are inside the templates
+    for (const template of childTemplates) {
+      if (visitedNodes.has(template.content)) {
+        continue;
+      }
+      await discover(template.content);
+      observer.observe(template.content, {subtree: true, childList: true});
+    }
+
     const litRegistrationPromises = [];
     for (const atomicElement of allCustomElements) {
-      const childTemplates = root.querySelectorAll('template');
-      //This is necessary to load the components that are inside the templates
-      for (const template of childTemplates) {
-        if (visitedNodes.has(template.content)) {
-          continue;
-        }
-        await discover(template.content);
-        observer.observe(template.content, {subtree: true, childList: true});
-      }
       const tagName = atomicElement.tagName.toLowerCase();
       if (tagName in elementMap && !customElements.get(tagName)) {
         // The element uses Lit already, we don't need to jam the lazy loader in the Shadow DOM.

--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -51,21 +51,22 @@ export function registerAutoloader(
 
     const rootTagName =
       root instanceof Element ? root.tagName.toLowerCase() : '';
-    const rootIsCustomElement = rootTagName?.includes('-');
+    const rootIsCustomElementOrDocumentRoot =
+      rootTagName?.includes('-') || rootTagName === 'html';
     const allCustomElements = [...root.querySelectorAll('*')].filter((el) =>
       el.tagName.toLowerCase().includes('-')
     );
 
     // If the root element is an undefined Atomic component, add it to the list
     if (
-      rootIsCustomElement &&
+      rootIsCustomElementOrDocumentRoot &&
       root instanceof Element &&
       !customElements.get(rootTagName) &&
       !allCustomElements.includes(root)
     ) {
       allCustomElements.push(root);
     }
-    if (rootIsCustomElement) {
+    if (rootIsCustomElementOrDocumentRoot) {
       const childTemplates = root.querySelectorAll('template');
       //This is necessary to load the components that are inside the templates
       for (const template of childTemplates) {

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.ts
@@ -15,6 +15,7 @@ import {
   type TruncateAfter,
 } from '../../common/expandable-text/expandable-text';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
+import '../atomic-product-text/atomic-product-text.js';
 
 /**
  * The `atomic-product-excerpt` component renders the excerpt of a product.

--- a/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.ts
@@ -9,19 +9,7 @@ import type {LitElementWithError} from '@/src/decorators/types';
 import {mapProperty} from '@/src/utils/props-utils';
 import {makeMatchConditions} from '../../common/product-template/product-template-common';
 import {ProductTemplateController} from '../../common/product-template/product-template-controller';
-import '../atomic-commerce-text/atomic-commerce-text';
-import '../atomic-product-text/atomic-product-text';
-import '../atomic-product-link/atomic-product-link';
 import '../atomic-product/atomic-product';
-import '../atomic-product-excerpt/atomic-product-excerpt';
-import '../atomic-product-children/atomic-product-children';
-import '../atomic-product-field-condition/atomic-product-field-condition';
-import '../atomic-product-multi-value-text/atomic-product-multi-value-text';
-import '../atomic-product-price/atomic-product-price';
-import '../atomic-product-numeric-field-value/atomic-product-numeric-field-value';
-import '../atomic-product-description/atomic-product-description';
-import '../atomic-product-image/atomic-product-image';
-import '../atomic-product-rating/atomic-product-rating';
 
 /**
  * * A product template determines the format of the query results, depending on the conditions that are defined for each template.

--- a/packages/atomic/vitest.config.ts
+++ b/packages/atomic/vitest.config.ts
@@ -50,6 +50,13 @@ export default defineConfig({
           '../headless/cdn/headless.esm.js'
         ),
       },
+      {
+        find: '../components/components/lazy-index.js',
+        replacement: path.resolve(
+          import.meta.dirname,
+          'src/components/lazy-index.js'
+        ),
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
This PR ensures that the autoloader will detect the custom elements inside `template` tags. It also removes the product template imports we had added to atomic-product-template as a workaround to this issue.

https://coveord.atlassian.net/browse/KIT-4785
