### PR TITLE
fix: require slotId for recommendation-list

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.spec.ts
@@ -800,12 +800,14 @@ const setupElement = async ({
   imageSize = 'small',
   productsPerPage = 3,
   isAppLoaded = true,
+  slotId = 'Recommendation',
 }: {
   display?: ItemDisplayBasicLayout;
   density?: ItemDisplayDensity;
   imageSize?: ItemDisplayImageSize;
   productsPerPage?: number;
   isAppLoaded?: boolean;
+  slotId?: string;
 } = {}) => {
   const {element} =
     await renderInAtomicCommerceRecommendationInterface<AtomicCommerceRecommendationList>(
@@ -815,6 +817,7 @@ const setupElement = async ({
             .density=${density}
             .imageSize=${imageSize}
             .productsPerPage=${productsPerPage}
+            .slotId=${slotId}
           ></atomic-commerce-recommendation-list>`,
         selector: 'atomic-commerce-recommendation-list',
         bindings: (bindings) => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
@@ -105,7 +105,7 @@ export class AtomicCommerceRecommendationList
    * You can include multiple `atomic-commerce-recommendation-list` components with different slot IDs in the same page to display several recommendation lists.
    */
   @property({reflect: true, attribute: 'slot-id', type: String})
-  public slotId = 'Recommendation';
+  public slotId?: string;
 
   /**
    * The unique identifier of the product to use for seeded recommendations.
@@ -255,11 +255,13 @@ export class AtomicCommerceRecommendationList
         constrainTo: ['small', 'large', 'icon', 'none'],
       }),
       productsPerPage: new NumberValue({min: 0}),
+      slotId: new StringValue({emptyAllowed: false}),
     }).validate({
       density: this.density,
       display: this.display,
       imageSize: this.imageSize,
       productsPerPage: this.productsPerPage,
+      slotId: this.slotId,
     });
   }
 
@@ -335,7 +337,7 @@ export class AtomicCommerceRecommendationList
   private initRecommendations() {
     this.recommendations = buildRecommendations(this.bindings.engine, {
       options: {
-        slotId: this.slotId,
+        slotId: this.slotId!,
         productId: this.productId,
       },
     });


### PR DESCRIPTION
The default `slotId` is not that useful, I think it'd be best to for the code to :feelsgood: and flip table asap when implementers forget to specify a slotId.

https://coveord.atlassian.net/browse/KIT-4814