### PR TITLE
chore(test): accessibility violations

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/e2e/atomic-commerce-did-you-mean.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/e2e/atomic-commerce-did-you-mean.e2e.ts
@@ -8,7 +8,7 @@ test.describe('AtomicCommerceDidYouMean', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should display the auto correction message', async ({

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/e2e/atomic-commerce-product-list.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/e2e/atomic-commerce-product-list.e2e.ts
@@ -21,7 +21,7 @@ test.describe('atomic-commerce-product-list', () => {
         await productList.load({story: 'default'});
 
         const accessibilityResults = await makeAxeBuilder().analyze();
-        expect(accessibilityResults.violations.length).toEqual(0);
+        expect(accessibilityResults.violations).toEqual([]);
       });
 
       test('should render the products when there is no custom template', async ({
@@ -72,7 +72,7 @@ test.describe('atomic-commerce-product-list', () => {
         await productList.load({story: 'default'});
 
         const accessibilityResults = await makeAxeBuilder().analyze();
-        expect(accessibilityResults.violations.length).toEqual(0);
+        expect(accessibilityResults.violations).toEqual([]);
       });
 
       test('should render the products when there is no custom template', async ({
@@ -122,7 +122,7 @@ test.describe('atomic-commerce-product-list', () => {
 
       test('should be a11y compliant', async ({makeAxeBuilder}) => {
         const accessibilityResults = await makeAxeBuilder().analyze();
-        expect(accessibilityResults.violations.length).toEqual(0);
+        expect(accessibilityResults.violations).toEqual([]);
       });
 
       test('should render the products', async ({productList}) => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/e2e/atomic-commerce-products-per-page.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/e2e/atomic-commerce-products-per-page.e2e.ts
@@ -8,7 +8,7 @@ test.describe('AtomicCommerceProductsPerPage', () => {
 
   test('should be A11Y compliant', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should display the correct number of choices', async ({

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/e2e/atomic-commerce-recommendation-list.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/e2e/atomic-commerce-recommendation-list.e2e.ts
@@ -8,7 +8,7 @@ test.describe('AtomicCommerceRecommendationList', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have recommendations', async ({recommendationList}) => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/e2e/atomic-commerce-refine-modal.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/e2e/atomic-commerce-refine-modal.e2e.ts
@@ -12,7 +12,7 @@ test.describe('AtomicCommerceRefineModal', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should be able to close the modal', async ({page}) => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/e2e/atomic-commerce-refine-toggle.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/e2e/atomic-commerce-refine-toggle.e2e.ts
@@ -8,7 +8,7 @@ test.describe('AtomicCommerceRefineToggle', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should open the modal when the button is clicked', async ({

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/e2e/atomic-commerce-search-box-query-suggestions.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/e2e/atomic-commerce-search-box-query-suggestions.e2e.ts
@@ -9,7 +9,7 @@ test.describe('AtomicCommerceSearchBoxQuerySuggestions', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('when clicking a suggestion, it should hide the suggestions', async ({

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/e2e/atomic-commerce-search-box-recent-queries.e2e.ts
@@ -14,7 +14,7 @@ test.describe('AtomicCommerceSearchBoxRecentQueries', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('when clicking a recent query, it should hide the suggestions', async ({

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/e2e/atomic-commerce-timeframe-facet.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/e2e/atomic-commerce-timeframe-facet.e2e.ts
@@ -11,7 +11,7 @@ test.describe.skip('AtomicCommerceTimeframeFacet', () => {
     });
 
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should complete the full date picker workflow', async ({

--- a/packages/atomic/src/components/commerce/atomic-product-description/e2e/atomic-product-description.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-description/e2e/atomic-product-description.e2e.ts
@@ -8,7 +8,7 @@ test.describe('atomic-product-description', async () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should render description text and the show more button', async ({

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/e2e/atomic-product-excerpt.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/e2e/atomic-product-excerpt.e2e.ts
@@ -8,7 +8,7 @@ test.describe('atomic-product-excerpt', async () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should render excerpt text and the show more button', async ({

--- a/packages/atomic/src/components/commerce/atomic-product-image/e2e/atomic-product-image.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-image/e2e/atomic-product-image.e2e.ts
@@ -9,7 +9,7 @@ test.describe('default', async () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should render the image', async ({productImage}) => {
@@ -32,7 +32,7 @@ test.describe('as a carousel', async () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should render the first image by default', async ({productImage}) => {

--- a/packages/atomic/src/components/commerce/atomic-product-link/e2e/atomic-product-link.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/e2e/atomic-product-link.e2e.ts
@@ -8,7 +8,7 @@ test.describe('default', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should render as links', async ({productLink, page}) => {

--- a/packages/atomic/src/components/commerce/atomic-product-text/e2e/atomic-product-text.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/e2e/atomic-product-text.e2e.ts
@@ -9,7 +9,7 @@ test.describe('atomic-product-text', () => {
 
     test('should be accessible', async ({makeAxeBuilder}) => {
       const accessibilityResults = await makeAxeBuilder().analyze();
-      expect(accessibilityResults.violations.length).toEqual(0);
+      expect(accessibilityResults.violations).toEqual([]);
     });
 
     test.describe('when field has no value and default is set', async () => {

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/e2e/atomic-recs-list.e2e.ts
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/e2e/atomic-recs-list.e2e.ts
@@ -8,7 +8,7 @@ test.describe('before query is loaded', () => {
 
   test('should be a11y compliant', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have placeholders', async ({recsList}) => {
@@ -24,7 +24,7 @@ test.describe('after query is loaded', () => {
 
   test('should be a11y compliant', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have recommendations', async ({recsList}) => {
@@ -40,7 +40,7 @@ test.describe('with a full result template', () => {
 
   test('should be a11y compliant', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have recommendations', async ({recsList}) => {
@@ -56,7 +56,7 @@ test.describe('with a carousel', () => {
 
   test('should be a11y compliant', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have recommendations', async ({recsList}) => {

--- a/packages/atomic/src/components/search/atomic-results-per-page/e2e/atomic-results-per-page.e2e.ts
+++ b/packages/atomic/src/components/search/atomic-results-per-page/e2e/atomic-results-per-page.e2e.ts
@@ -7,6 +7,6 @@ test.describe('AtomicResultsPerPage', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 });

--- a/packages/atomic/src/components/search/facets/atomic-facet/e2e/atomic-facet.e2e.ts
+++ b/packages/atomic/src/components/search/facets/atomic-facet/e2e/atomic-facet.e2e.ts
@@ -39,7 +39,7 @@ test.describe('when the "Show more" button has not been selected', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should not display the "Show less" button', async ({facet}) => {
@@ -87,7 +87,7 @@ test.describe('when the "Show more" button has been selected', () => {
 
   test('should be accessible', async ({makeAxeBuilder}) => {
     const accessibilityResults = await makeAxeBuilder().analyze();
-    expect(accessibilityResults.violations.length).toEqual(0);
+    expect(accessibilityResults.violations).toEqual([]);
   });
 
   test('should have facet values sorted alphabetically', async ({facet}) => {

--- a/packages/atomic/src/components/search/result-template-components/atomic-result-image/e2e/atomic-result-image.e2e.ts
+++ b/packages/atomic/src/components/search/result-template-components/atomic-result-image/e2e/atomic-result-image.e2e.ts
@@ -12,7 +12,7 @@ test.describe('with an alt text field', async () => {
 
     test('should be accessible', async ({makeAxeBuilder}) => {
       const accessibilityResults = await makeAxeBuilder().analyze();
-      expect(accessibilityResults.violations.length).toEqual(0);
+      expect(accessibilityResults.violations).toEqual([]);
     });
 
     test('should use the alt text', async ({resultImage}) => {


### PR DESCRIPTION
I have another PR [https://github.com/coveo/ui-kit/pull/5857](https://github.com/coveo/ui-kit/pull/5857) that is blocked by a failing accessibility test on the merge queue. It’s not failing locally or in the PR certifier, so I can't reproduce.

With the current assertions we can't see what the actual accessibility issue are.
This changes the expect so we get the actual error messages.

Before:

```
Error: expect(received).toEqual(expected) // deep equality Expected: 0 Received: 1
```

After:

```
Error: expect(received).toEqual(expected) // deep equality

- Expected  -  1
+ Received  + 16

- Array []
+ Array [
+   Object {
+     "all": Array [],
+     "any": Array [],
+     "description": "This is a bogus violation for testing.",
+     "help": "Bogus violation help text.",
+     "helpUrl": "https://example.com/bogus-violation",
+     "id": "bogus-violation",
+     "impact": "minor",
+     "nodes": Array [],
+     "nodesData": Array [],
+     "none": Array [],
+     "tags": Array [],
+     "wcagTags": Array [],
+   },
+ ]
```

Please note that this violation was created by me for test purposes and to highlight the difference in messaging.

This change will make any future accessibility errors more visible as I've modified all the accessibility tests.

-----

SVCC-5388