### PR TITLE
chore: temporarily increase CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     name: "Run unit tests"
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
My current PR https://github.com/coveo/ui-kit/pull/5857 is failing the Run Unit Tests certifier because it’s taking over 15 minutes which is the current timeout. The PR affects a lot of code so that could be expected.

Up until very recently these were passing for this PR.

I propose to increase the value to let my other PR pass and then I would lower it back down.
I don't think we should increase it if it works for most PRs as there are advantages to failing fast.
