### PR TITLE
chore(headless-ssr): deprecate `BuildOption`

### DIFF
--- a/packages/headless/src/ssr-next/common/types/utilities.ts
+++ b/packages/headless/src/ssr-next/common/types/utilities.ts
@@ -33,7 +33,3 @@ export type OptionsTuple<TOptions> = HasKeys<TOptions> extends false
   : HasKeys<ExtractRequiredOptions<TOptions>> extends false
     ? [options?: TOptions]
     : [options: TOptions];
-
-export type OptionsExtender<TOptions> = (
-  options: TOptions
-) => TOptions | Promise<TOptions>;

--- a/packages/headless/src/ssr-next/search/engine/search-engine.ssr.ts
+++ b/packages/headless/src/ssr-next/search/engine/search-engine.ssr.ts
@@ -90,8 +90,7 @@ export function defineSearchEngine<
   const {controllers: controllerDefinitions, ...engineOptions} = options;
   type BuildFunction = EngineBuildResult<
     SSRSearchEngine,
-    TControllerDefinitions,
-    SearchEngineOptions
+    TControllerDefinitions
   >;
   type Definition = SearchEngineDefinition<
     SSRSearchEngine,
@@ -120,11 +119,7 @@ export function defineSearchEngine<
         '[WARNING] Missing navigator context in server-side code. Make sure to set it with `setNavigatorContextProvider` before calling fetchStaticState()'
       );
     }
-    const engine = buildSSRSearchEngine(
-      buildOptions?.extend
-        ? await buildOptions.extend(getOptions())
-        : getOptions()
-    );
+    const engine = buildSSRSearchEngine(getOptions());
     const controllers = buildControllerDefinitions({
       definitionsMap: (controllerDefinitions ?? {}) as TControllerDefinitions,
       engine,

--- a/packages/headless/src/ssr-next/search/types/build.ts
+++ b/packages/headless/src/ssr-next/search/types/build.ts
@@ -3,30 +3,21 @@ import type {
   ControllersMap,
   ControllersPropsMap,
 } from '../../common/types/controllers.js';
-import type {
-  OptionsExtender,
-  OptionsTuple,
-} from '../../common/types/utilities.js';
+import type {OptionsTuple} from '../../common/types/utilities.js';
 import type {
   SearchEngineDefinitionBuildResult,
   SearchEngineDefinitionControllersPropsOption,
 } from './engine.js';
-
-interface BuildOptions<TEngineOptions> {
-  extend?: OptionsExtender<TEngineOptions>;
-}
 
 /**
  * @internal
  */
 export type Build<
   TEngine extends CoreEngine | CoreEngineNext,
-  TEngineOptions,
   TControllersMap extends ControllersMap,
   TControllersProps extends ControllersPropsMap,
 > = (
   ...params: OptionsTuple<
-    BuildOptions<TEngineOptions> &
-      SearchEngineDefinitionControllersPropsOption<TControllersProps>
+    SearchEngineDefinitionControllersPropsOption<TControllersProps>
   >
 ) => Promise<SearchEngineDefinitionBuildResult<TEngine, TControllersMap>>;

--- a/packages/headless/src/ssr-next/search/types/engine.ts
+++ b/packages/headless/src/ssr-next/search/types/engine.ts
@@ -22,10 +22,8 @@ import type {HydrateStaticState} from './hydrate-static-state.js';
 export type EngineBuildResult<
   TEngine extends CoreEngine | CoreEngineNext,
   TControllers extends ControllerDefinitionsMap<TEngine, Controller>,
-  TEngineOptions,
 > = Build<
   TEngine,
-  TEngineOptions,
   InferControllersMapFromDefinition<TControllers>,
   InferControllerPropsMapFromDefinitions<TControllers>
 >;


### PR DESCRIPTION
Since, in the next major release we no longer publicly expose the `build` method, there is no point to keep the `BuildOption` to extend the engine build option

https://coveord.atlassian.net/browse/KIT-4747