### PR TITLE
docs(atomic): intro and example pages for commerce

### DIFF
--- a/packages/atomic/.storybook/main.mts
+++ b/packages/atomic/.storybook/main.mts
@@ -47,6 +47,8 @@ const config: StorybookConfig = {
     './Introduction.stories.tsx',
     '../src/**/*.new.stories.tsx',
     '../src/**/*.mdx',
+    '../storybook-pages/**/*.new.stories.tsx',
+    '../storybook-pages/**/*.mdx',
   ],
   staticDirs: [
     {from: '../dist/atomic/assets', to: '/assets'},

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -18,10 +18,54 @@ export const parameters = {
     },
   },
   options: {
-    storySort: {
-      order: ['Introduction'],
-      method: 'alphabetical',
-      locales: 'en-US',
+    storySort: (a, b) => {
+      const topOrder = [
+        'Introduction',
+        'Commerce',
+        'Search',
+        'Recommendations',
+        'Insight',
+        'Common',
+      ];
+
+      const getTopLevel = (story) => story.title.split('/')[0];
+
+      const aTop = getTopLevel(a);
+      const bTop = getTopLevel(b);
+
+      const aIndex = topOrder.indexOf(aTop);
+      const bIndex = topOrder.indexOf(bTop);
+
+      // Top-level order
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex;
+      }
+
+      // Commerce subfolder custom ordering
+      if (aTop === 'Commerce' && bTop === 'Commerce') {
+        const aParts = a.title.split('/').slice(1); // skip top-level
+        const bParts = b.title.split('/').slice(1);
+
+        // Define subfolder priority: Docs -> Example Pages -> others
+        const subPriority = ['Docs', 'Example Pages'];
+
+        const aPriority = subPriority.indexOf(aParts[0]);
+        const bPriority = subPriority.indexOf(bParts[0]);
+
+        if (aPriority !== bPriority) {
+          // Docs/Example Pages first, then others
+          return (
+            (aPriority === -1 ? subPriority.length : aPriority) -
+            (bPriority === -1 ? subPriority.length : bPriority)
+          );
+        }
+
+        // If same priority or both other folders, sort alphabetically
+        return aParts.join('/').localeCompare(bParts.join('/'), 'en-US');
+      }
+
+      // Fallback alphabetical for all other stories
+      return a.title.localeCompare(b.title, 'en-US');
     },
   },
 };

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.ts
@@ -7,7 +7,6 @@ import type {InitializableComponent} from '@/src/decorators/types';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 
 /**
- * @alpha
  * The `atomic-commerce-text` component leverages the I18n translation module through the atomic-commerce-interface.
  */
 @customElement('atomic-commerce-text')

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -38,7 +38,7 @@ const {decorator, play} = wrapInSearchInterface({
 
 const meta: Meta = {
   component: 'atomic-generated-answer',
-  title: 'Atomic/GeneratedAnswer',
+  title: 'Search/Generated Answer',
   id: 'atomic-generated-answer',
   render: renderComponent,
   decorators: [layoutDecorator, decorator],

--- a/packages/atomic/storybook-pages/commerce/Introduction.mdx
+++ b/packages/atomic/storybook-pages/commerce/Introduction.mdx
@@ -1,0 +1,8 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Commerce/Docs" />
+
+# Commerce
+
+Welcome to the Commerce section.  ...
+Here you'll find docs for all components under **Commerce**.

--- a/packages/atomic/storybook-pages/commerce/search.mdx
+++ b/packages/atomic/storybook-pages/commerce/search.mdx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/blocks';
+import * as AtomicCommerceTextStories from './search.new.stories';
+
+<Meta of={AtomicCommerceTextStories} />
+
+This is how you make a search page ...
+
+
+```
+boom
+```

--- a/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
@@ -1,0 +1,140 @@
+import {getSampleCommerceEngineConfiguration} from '@coveo/headless/commerce';
+import type {Meta, StoryObj as Story} from '@storybook/web-components';
+import {html} from 'lit';
+import {parameters} from '../../storybook-utils/common/common-meta-parameters.js';
+
+async function initializeCommerceInterface(canvasElement: HTMLElement) {
+  await customElements.whenDefined('atomic-commerce-interface');
+  const commerceInterface = canvasElement.querySelector(
+    'atomic-commerce-interface'
+  );
+  await commerceInterface!.initialize(getSampleCommerceEngineConfiguration());
+}
+
+const meta: Meta = {
+  component: 'search-page',
+  title: 'Commerce/Example Pages/Search',
+  id: 'search-page',
+  parameters: {
+    ...parameters,
+    layout: 'fullscreen',
+  },
+  render: () => html`
+    <atomic-commerce-interface type="search" language-assets-path="./lang" icon-assets-path="./assets">
+          <atomic-commerce-layout>
+            <atomic-layout-section section="search">
+              <atomic-commerce-search-box>
+                <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
+                <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
+                <atomic-commerce-search-box-instant-products image-size="small">
+                  <atomic-product-template>
+                    <template>
+                      <atomic-product-section-name>
+                        <atomic-product-link class="font-bold"></atomic-product-link>
+                      </atomic-product-section-name>
+                      <atomic-product-section-visual>
+                        <atomic-product-field-condition if-defined="ec_thumbnails">
+                          <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                        </atomic-product-field-condition>
+                      </atomic-product-section-visual>
+                      <atomic-product-section-metadata>
+                        <atomic-product-field-condition if-defined="ec_brand">
+                          <atomic-product-text field="ec_brand" class="text-neutral-dark block"></atomic-product-text>
+                        </atomic-product-field-condition>
+                        <atomic-product-field-condition if-defined="cat_available_sizes">
+                          <atomic-product-multi-value-text
+                            field="cat_available_sizes"
+                          ></atomic-product-multi-value-text>
+                        </atomic-product-field-condition>
+                        <atomic-product-field-condition if-defined="ec_rating">
+                          <atomic-product-rating field="ec_rating"></atomic-product-rating>
+                        </atomic-product-field-condition>
+                      </atomic-product-section-metadata>
+                      <atomic-product-section-emphasized>
+                        <atomic-product-price></atomic-product-price>
+                      </atomic-product-section-emphasized>
+                      <atomic-product-section-children>
+                        <atomic-product-children></atomic-product-children>
+                      </atomic-product-section-children>
+                    </template>
+                  </atomic-product-template>
+                </atomic-commerce-search-box-instant-products>
+              </atomic-commerce-search-box>
+            </atomic-layout-section>
+            <atomic-layout-section section="facets"
+              ><atomic-commerce-facets></atomic-commerce-facets
+            ></atomic-layout-section>
+            <atomic-layout-section section="main">
+              <atomic-layout-section section="status">
+                <atomic-commerce-breadbox></atomic-commerce-breadbox>
+                <atomic-commerce-query-summary></atomic-commerce-query-summary>
+                <atomic-commerce-sort-dropdown></atomic-commerce-sort-dropdown>
+                <atomic-commerce-did-you-mean></atomic-commerce-did-you-mean>
+                <atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>
+              </atomic-layout-section>
+              <atomic-layout-section section="products">
+                <atomic-commerce-product-list display="grid" density="compact" image-size="small">
+                  <atomic-product-template>
+                    <template>
+                      <atomic-product-section-name id="product-name-section">
+                        <style>
+                        </style>
+                        <atomic-product-link class="font-bold"></atomic-product-link>
+                      </atomic-product-section-name>
+                      <atomic-product-section-visual>
+                        <atomic-product-field-condition if-defined="ec_thumbnails">
+                          <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                        </atomic-product-field-condition>
+                      </atomic-product-section-visual>
+                      <atomic-product-section-metadata>
+                        <atomic-product-field-condition if-defined="ec_brand">
+                          <atomic-product-text field="ec_brand" class="text-neutral-dark block"></atomic-product-text>
+                        </atomic-product-field-condition>
+                        <atomic-product-field-condition if-defined="cat_available_sizes">
+                          <atomic-product-multi-value-text
+                            field="cat_available_sizes"
+                          ></atomic-product-multi-value-text>
+                        </atomic-product-field-condition>
+                        <atomic-product-field-condition if-defined="ec_rating">
+                          <atomic-product-rating field="ec_rating"></atomic-product-rating>
+                        </atomic-product-field-condition>
+                        <atomic-product-field-condition if-defined="concepts">
+                          <atomic-product-multi-value-text field="concepts"></atomic-product-multi-value-text>
+                        </atomic-product-field-condition>
+                      </atomic-product-section-metadata>
+                      <atomic-product-section-emphasized>
+                        <atomic-product-price currency="USD"></atomic-product-price>
+                      </atomic-product-section-emphasized>
+                      <atomic-product-section-description>
+                        <atomic-product-excerpt></atomic-product-excerpt>
+                      </atomic-product-section-description>
+                      <atomic-product-section-children>
+                        <atomic-product-children></atomic-product-children>
+                      </atomic-product-section-children>
+                    </template>
+                  </atomic-product-template>
+                </atomic-commerce-product-list>
+                <atomic-commerce-query-error></atomic-commerce-query-error>
+                <atomic-commerce-no-products></atomic-commerce-no-products>
+              </atomic-layout-section>
+              <atomic-layout-section section="pagination">
+                <atomic-commerce-load-more-products></atomic-commerce-load-more-products>
+              </atomic-layout-section>
+            </atomic-layout-section>
+          </atomic-commerce-layout>
+        </atomic-commerce-interface>
+  `,
+  play: async (context) => {
+    await initializeCommerceInterface(context.canvasElement);
+    const searchInterface = context.canvasElement.querySelector(
+      'atomic-commerce-interface'
+    );
+    await searchInterface!.executeFirstRequest();
+  },
+};
+
+export default meta;
+
+export const Default: Story = {
+  name: 'Page',
+};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-3285

For @eguyon-coveo, you can use this PR to make the proper pages. I already made one for search so you can follow the pattern for a listing and a recs example. I added .mdx files as well next to the page if you want to add some comments or indications. 

I also added an intro page for Atomic commerce, I think it would be nice to have one, explain a bit the concepts and then have three links to the examples pages. What do you think ? 