### PR TITLE
chore(atomic): migrate atomic-*-section-excerpt styles

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.ts
@@ -1,4 +1,4 @@
-import {LitElement} from 'lit';
+import {css, LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 
@@ -15,7 +15,26 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
  */
 @customElement('atomic-product-section-description')
 export class AtomicProductSectionDescription extends ItemSectionMixin(
-  LitElement
+  LitElement,
+  css`
+@reference '../../common/template-system/sections/sections.css';
+atomic-product-section-description {
+  @apply section-excerpt;
+
+  &.with-sections {
+    &.display-grid {
+      &.density-comfortable {
+        margin-top: 1.25rem;
+      }
+      &.density-normal {
+        margin-top: 0.75rem;
+      }
+      &.density-compact {
+        margin-top: 0.25rem;
+      }
+    }
+  }
+}`
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -58,10 +58,47 @@ const styles = css`
             margin-top: 0.25rem;
           }
         }
+        @media (width >= theme(--breakpoint-desktop)) {
+          &.image-large atomic-product-section-children .product-child {
+            @apply aspect-square-[auto];
+            width: 16.65%;
+          }
+
+          &.image-small atomic-product-section-children .product-child {
+            @apply aspect-square-[auto];
+            width: 16.65%;
+          }
+
+          &.image-icon atomic-product-section-children .product-child,
+          &.image-none atomic-product-section-children .product-child {
+            width: 2rem;
+            height: 2rem;
+          }
+        }
+
+        @media not all and (width >= theme(--breakpoint-desktop)) {
+          &.image-large atomic-product-section-children .product-child {
+            @apply aspect-square-[auto];
+            width: 16.65%;
+          }
+
+          &.image-small atomic-product-section-children .product-child {
+            @apply aspect-square-[auto];
+            width: 16.65%;
+            max-width: 4.75rem;
+          }
+
+          &.image-icon atomic-product-section-children .product-child,
+          &.image-none atomic-product-section-children .product-child {
+            width: 2rem;
+            height: 2rem;
+          }
+        }
       }
     }
   }
 }
+
 `;
 
 export default styles;

--- a/packages/atomic/src/components/common/template-system/cell-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-desktop.pcss
@@ -73,8 +73,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-lg;
 
       margin-top: 2.25rem;
@@ -148,8 +147,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-base;
 
       margin-top: 1.75rem;
@@ -223,8 +221,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-base;
 
       margin-top: 1.25rem;

--- a/packages/atomic/src/components/common/template-system/cell-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-mobile.pcss
@@ -61,8 +61,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-base;
 
       margin-top: 1.25rem;
@@ -131,8 +130,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-base;
 
       margin-top: 1rem;
@@ -207,8 +205,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       @apply set-font-size-base;
 
       margin-top: 0.75rem;

--- a/packages/atomic/src/components/common/template-system/row-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/row-desktop.pcss
@@ -36,8 +36,7 @@
       @apply set-font-size-2xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       margin-top: 1.75rem;
       @apply set-font-size-lg;
 
@@ -78,8 +77,7 @@
       @apply set-font-size-xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       margin-top: 1.25rem;
       @apply set-font-size-base;
 
@@ -120,8 +118,7 @@
       @apply set-font-size-xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       margin-top: 1rem;
       @apply set-font-size-base;
 

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -76,7 +76,7 @@
       @apply set-font-size-xl;
     }
 
-    atomic-result-section-excerpt{
+    atomic-result-section-excerpt {
       margin-top: 1rem;
       @apply set-font-size-base;
 

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -31,8 +31,7 @@
       @apply set-font-size-xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt {
       margin-top: 1.25rem;
       @apply set-font-size-base;
 
@@ -77,8 +76,7 @@
       @apply set-font-size-xl;
     }
 
-    atomic-result-section-excerpt,
-    atomic-product-section-description {
+    atomic-result-section-excerpt{
       margin-top: 1rem;
       @apply set-font-size-base;
 

--- a/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
@@ -1,0 +1,104 @@
+@reference './sections-utilities.css';
+
+@utility section-excerpt-row-result-desktop {
+  &.density-comfortable {
+    margin-top: 1.75rem;
+    max-height: 4.5rem;
+  }
+
+  &.density-normal {
+    margin-top: 1.25rem;
+    max-height: 2.5rem;
+  }
+
+  &.density-compact {
+    margin-top: 1rem;
+    max-height: 1.25rem;
+  }
+}
+@utility section-excerpt-row-result-mobile {
+  &.density-comfortable,
+  &.density-normal {
+    max-height: 2.5rem;
+  }
+
+  &.density-comfortable {
+    margin-top: 1.25rem;
+  }
+  &.density-normal {
+    margin-top: 1rem;
+  }
+}
+@utility section-excerpt-cell-result-desktop {
+  &.density-comfortable {
+    margin-top: 2.25rem;
+  }
+
+  &.density-normal {
+    margin-top: 1.75rem;
+  }
+
+  &.density-compact {
+    margin-top: 1.25rem;
+  }
+}
+@utility section-excerpt-cell-result-mobile {
+  &.density-comfortable {
+    margin-top: 1.25rem;
+  }
+
+  &.density-normal {
+    margin-top: 1rem;
+  }
+
+  &.density-compact {
+    margin-top: 0.75rem;
+    @apply line-clamp-1;
+  }
+}
+
+@utility section-excerpt {
+  @apply section-base-overflow;
+  &.with-sections {
+    grid-area: excerpt;
+    @apply text-neutral-dark;
+    @apply line-clamp-2;
+
+    @media (width >= theme(--breakpoint-desktop)) {
+      &.density-comfortable {
+        @apply set-font-size-lg;
+        @apply line-clamp-3;
+      }
+      &.density-compact {
+        @apply line-clamp-1;
+      }
+      &.display-list {
+        @apply section-excerpt-row-result-desktop;
+      }
+      &.display-grid {
+        @apply section-excerpt-cell-result-desktop;
+      }
+    }
+
+    @media not all and (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        @apply section-excerpt-row-result-mobile;
+      }
+
+      &.display-grid {
+        &.image-large {
+          @apply section-excerpt-row-result-mobile;
+        }
+
+        &.image-small,
+        &.image-icon,
+        &.image-none {
+          @apply section-excerpt-cell-result-mobile;
+        }
+      }
+    }
+    &.display-table {
+      @apply section-excerpt-row-result-desktop;
+    }
+  }
+}

--- a/packages/atomic/src/components/common/template-system/sections/sections.css
+++ b/packages/atomic/src/components/common/template-system/sections/sections.css
@@ -2,4 +2,5 @@
 @import "./section-emphasized.css";
 @import "./section-badges.css";
 @import "./section-children.css";
+@import "./section-excerpt.css";
 @reference '../../../../utils/tailwind.global.tw.css';

--- a/packages/atomic/src/components/common/template-system/with-sections.pcss
+++ b/packages/atomic/src/components/common/template-system/with-sections.pcss
@@ -36,8 +36,7 @@
     grid-area: emphasized;
   }
 
-  atomic-result-section-excerpt,
-  atomic-product-section-description {
+  atomic-result-section-excerpt {
     grid-area: excerpt;
     @apply text-neutral-dark;
   }


### PR DESCRIPTION
This PR migrates the styles for atomic-*-section-excerpt to custom utilities that can be used directly on the section components.

[coveord.atlassian.net/browse/KIT-4797](https://coveord.atlassian.net/browse/KIT-4797)