### PR TITLE
chore(atomic): migrate atomic-*-section-badges styles

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.ts
@@ -1,4 +1,4 @@
-import {LitElement} from 'lit';
+import {css, LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 
@@ -14,7 +14,15 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
  * @slot default - The badges to display.
  */
 @customElement('atomic-product-section-badges')
-export class AtomicProductSectionBadges extends ItemSectionMixin(LitElement) {}
+export class AtomicProductSectionBadges extends ItemSectionMixin(
+  LitElement,
+  css`
+      @reference '../../common/template-system/sections/sections.css';
+      atomic-product-section-badges {
+        @apply section-badges;
+      }
+      `
+) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/atomic/src/components/common/template-system/cell-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-desktop.pcss
@@ -23,8 +23,7 @@
     }
 
     &.image-icon {
-      atomic-result-section-badges,
-      atomic-product-section-badges {
+      atomic-result-section-badges{
         margin-bottom: 2rem;
       }
 
@@ -40,8 +39,7 @@
       margin-bottom: 0.5rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges{
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -101,8 +99,7 @@
     }
 
     &.image-icon {
-      atomic-result-section-badges,
-      atomic-product-section-badges {
+      atomic-result-section-badges {
         margin-bottom: 1.5rem;
       }
 
@@ -118,8 +115,7 @@
       margin-bottom: 0.5rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges{
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -178,8 +174,7 @@
     }
 
     &.image-icon {
-      atomic-result-section-badges,
-      atomic-product-section-badges {
+      atomic-result-section-badges{
         margin-bottom: 1rem;
       }
 
@@ -195,8 +190,7 @@
       margin-bottom: 0.5rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -253,8 +247,7 @@
       width: 100%;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       margin-bottom: 1rem;
     }
   }

--- a/packages/atomic/src/components/common/template-system/cell-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-desktop.pcss
@@ -23,7 +23,7 @@
     }
 
     &.image-icon {
-      atomic-result-section-badges{
+      atomic-result-section-badges {
         margin-bottom: 2rem;
       }
 
@@ -39,7 +39,7 @@
       margin-bottom: 0.5rem;
     }
 
-    atomic-result-section-badges{
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -115,7 +115,7 @@
       margin-bottom: 0.5rem;
     }
 
-    atomic-result-section-badges{
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -174,7 +174,7 @@
     }
 
     &.image-icon {
-      atomic-result-section-badges{
+      atomic-result-section-badges {
         margin-bottom: 1rem;
       }
 

--- a/packages/atomic/src/components/common/template-system/cell-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-mobile.pcss
@@ -27,8 +27,7 @@
       }
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -99,8 +98,7 @@
       }
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;
@@ -177,8 +175,7 @@
       }
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       @apply set-font-size-sm;
 
       margin-bottom: 1rem;

--- a/packages/atomic/src/components/common/template-system/row-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/row-desktop.pcss
@@ -54,7 +54,6 @@
     }
 
     atomic-result-section-badges,
-    atomic-product-section-badges,
     atomic-result-section-actions,
     atomic-product-section-actions {
       margin-bottom: 1.5rem;
@@ -97,7 +96,6 @@
     }
 
     atomic-result-section-badges,
-    atomic-product-section-badges,
     atomic-result-section-actions,
     atomic-product-section-actions {
       margin-bottom: 1rem;
@@ -140,7 +138,6 @@
     }
 
     atomic-result-section-badges,
-    atomic-product-section-badges,
     atomic-result-section-actions,
     atomic-product-section-actions {
       margin-bottom: 1rem;

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -46,8 +46,7 @@
       margin-right: 1rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges{
       margin-bottom: 1rem;
       --row-height: 2rem;
     }
@@ -93,8 +92,7 @@
       margin-right: 1rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       margin-bottom: 1rem;
       --row-height: 2rem;
     }
@@ -140,8 +138,7 @@
       margin-right: 1rem;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       margin-bottom: 1rem;
       --row-height: 2rem;
     }

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -46,7 +46,7 @@
       margin-right: 1rem;
     }
 
-    atomic-result-section-badges{
+    atomic-result-section-badges {
       margin-bottom: 1rem;
       --row-height: 2rem;
     }

--- a/packages/atomic/src/components/common/template-system/sections/section-badges.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-badges.css
@@ -1,0 +1,55 @@
+@reference './sections-utilities.css';
+
+@utility section-badges {
+  text-align: left;
+  @apply section-base-overflow;
+
+  &.with-sections {
+    grid-area: badges;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    max-height: calc(2 * var(--row-height, 2rem) + 0.5rem);
+
+    margin-bottom: 1rem;
+    --row-height: 2rem;
+
+    @media (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        &.density-comfortable {
+          margin-bottom: 1.5rem;
+        }
+      }
+
+      &.display-grid {
+        &.image-icon {
+          &.density-comfortable {
+            margin-bottom: 2rem;
+          }
+          &.density-normal {
+            margin-bottom: 1.5rem;
+          }
+        }
+        @apply set-font-size-sm;
+      }
+    }
+
+    @media not all and (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        @apply set-font-size-sm;
+      }
+      &.display-grid {
+        &.image-small,
+        &.image-icon,
+        &.image-none {
+          @apply set-font-size-sm;
+        }
+      }
+    }
+    &.display-table {
+      &.density-comfortable {
+        margin-bottom: 1.5rem;
+      }
+    }
+  }
+}

--- a/packages/atomic/src/components/common/template-system/sections/sections.css
+++ b/packages/atomic/src/components/common/template-system/sections/sections.css
@@ -1,3 +1,4 @@
 @import "./section-bottom-metadata.css";
 @import "./section-emphasized.css";
+@import "./section-badges.css";
 @reference '../../../../utils/tailwind.global.tw.css';

--- a/packages/atomic/src/components/common/template-system/template-system.pcss
+++ b/packages/atomic/src/components/common/template-system/template-system.pcss
@@ -14,8 +14,7 @@
       @apply font-sans font-normal;
     }
 
-    atomic-result-section-badges,
-    atomic-product-section-badges {
+    atomic-result-section-badges {
       text-align: left;
     }
 

--- a/packages/atomic/src/components/common/template-system/with-sections.pcss
+++ b/packages/atomic/src/components/common/template-system/with-sections.pcss
@@ -8,8 +8,7 @@
     grid-area: visual;
   }
 
-  atomic-result-section-badges,
-  atomic-product-section-badges {
+  atomic-result-section-badges {
     grid-area: badges;
   }
 
@@ -54,7 +53,6 @@
   }
 
   atomic-result-section-badges,
-  atomic-product-section-badges,
   atomic-result-section-actions,
   atomic-product-section-actions {
     display: flex;
@@ -66,7 +64,6 @@
   atomic-result-section-visual,
   atomic-product-section-visual,
   atomic-result-section-badges,
-  atomic-product-section-badges,
   atomic-result-section-actions,
   atomic-product-section-actions,
   atomic-result-section-title,


### PR DESCRIPTION
This PR migrates the styles for atomic-*-section-badges to custom utilities that can be used directly on the section components.

[coveord.atlassian.net/browse/KIT-4800](https://coveord.atlassian.net/browse/KIT-4800)