### PR TITLE
chore(atomic): migrate atomic-*-section-title styles

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.ts
@@ -1,7 +1,6 @@
-import {LitElement} from 'lit';
+import {css, LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
-
 /**
  * This section is intended to display the product's name, and its main use is to make the product list scannable.
  *
@@ -13,7 +12,21 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
  * @slot default - The name to display.
  */
 @customElement('atomic-product-section-name')
-export class AtomicProductSectionName extends ItemSectionMixin(LitElement) {}
+export class AtomicProductSectionName extends ItemSectionMixin(
+  LitElement,
+  css`
+@reference '../../common/template-system/sections/sections.css';
+atomic-product-section-name {
+  @apply section-title;
+
+  .with-sections {
+    &.display-grid {
+        min-height: calc(var(--line-height) * 2);
+        @apply line-clamp-2;
+    }
+  }
+}`
+) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -26,6 +26,43 @@ const styles = css`
           @apply line-clamp-2;
         }
       }
+      
+      @media (width >= theme(--breakpoint-desktop)) {
+        &.image-large atomic-product-section-children .product-child {
+          @apply aspect-square-[auto];
+          width: 16.65%;
+        }
+
+        &.image-small atomic-product-section-children .product-child {
+          @apply aspect-square-[auto];
+          width: 16.65%;
+        }
+
+        &.image-icon atomic-product-section-children .product-child,
+        &.image-none atomic-product-section-children .product-child {
+          width: 2rem;
+          height: 2rem;
+        }
+      }
+
+      @media not all and (width >= theme(--breakpoint-desktop)) {
+        &.image-large atomic-product-section-children .product-child {
+          @apply aspect-square-[auto];
+          width: 16.65%;
+        }
+
+        &.image-small atomic-product-section-children .product-child {
+          @apply aspect-square-[auto];
+          width: 16.65%;
+          max-width: 4.75rem;
+        }
+
+        &.image-icon atomic-product-section-children .product-child,
+        &.image-none atomic-product-section-children .product-child {
+          width: 2rem;
+          height: 2rem;
+        }
+      }
 
       &.density-comfortable {
         &.image-icon,
@@ -98,7 +135,6 @@ const styles = css`
     }
   }
 }
-
 `;
 
 export default styles;

--- a/packages/atomic/src/components/common/template-system/cell-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-desktop.pcss
@@ -53,8 +53,7 @@
       --row-height: 2.5rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-2xl;
       word-break: break-word;
 
@@ -127,8 +126,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
       word-break: break-word;
       @apply line-clamp-2;
@@ -199,8 +197,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
       word-break: break-word;
       @apply line-clamp-2;

--- a/packages/atomic/src/components/common/template-system/cell-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-mobile.pcss
@@ -41,8 +41,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-lg;
 
       max-height: 3rem;
@@ -108,8 +107,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-lg;
 
       max-height: 3rem;
@@ -181,8 +179,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-lg;
 
       max-height: 3rem;

--- a/packages/atomic/src/components/common/template-system/row-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/row-desktop.pcss
@@ -30,8 +30,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-2xl;
     }
 
@@ -69,8 +68,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
     }
 
@@ -108,8 +106,7 @@
       --row-height: 2rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
     }
 

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -25,8 +25,7 @@
       --row-height: 2.5rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
     }
 
@@ -68,8 +67,7 @@
       --row-height: 2.5rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
     }
 
@@ -111,8 +109,7 @@
       --row-height: 2.5rem;
     }
 
-    atomic-result-section-title,
-    atomic-product-section-name {
+    atomic-result-section-title {
       @apply set-font-size-xl;
     }
 

--- a/packages/atomic/src/components/common/template-system/sections/section-title.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-title.css
@@ -1,0 +1,41 @@
+@reference './sections-utilities.css';
+
+@utility section-title {
+  @apply section-base-overflow;
+  &.with-sections {
+    grid-area: title;
+    @apply text-on-background;
+    @apply set-font-size-xl;
+
+    &.density-comfortable {
+      @apply set-font-size-2xl;
+    }
+
+    @media (width >= theme(--breakpoint-desktop)) {
+      &.display-grid {
+        word-break: break-word;
+        @apply line-clamp-2;
+      }
+    }
+
+    @media not all and (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        @apply set-font-size-xl;
+      }
+      &.display-grid {
+        &.image-large {
+          @apply set-font-size-xl;
+        }
+
+        &.image-small,
+        &.image-icon,
+        &.image-none {
+          @apply set-font-size-lg;
+
+          max-height: 3rem;
+          @apply line-clamp-2;
+        }
+      }
+    }
+  }
+}

--- a/packages/atomic/src/components/common/template-system/sections/sections.css
+++ b/packages/atomic/src/components/common/template-system/sections/sections.css
@@ -5,4 +5,5 @@
 @import "./section-excerpt.css";
 @import "./section-metadata.css";
 @import "./section-actions.css";
+@import "./section-title.css";
 @reference '../../../../utils/tailwind.global.tw.css';

--- a/packages/atomic/src/components/common/template-system/with-sections.pcss
+++ b/packages/atomic/src/components/common/template-system/with-sections.pcss
@@ -20,8 +20,7 @@
     }
   }
 
-  atomic-result-section-title,
-  atomic-product-section-name {
+  atomic-result-section-title {
     grid-area: title;
     @apply text-on-background;
   }
@@ -61,7 +60,6 @@
   atomic-result-section-badges,
   atomic-result-section-actions,
   atomic-result-section-title,
-  atomic-product-section-name,
   atomic-result-section-title-metadata,
   atomic-result-section-emphasized,
   atomic-result-section-excerpt,


### PR DESCRIPTION
This PR migrates the styles for atomic-*-section-title to custom utilities that can be used directly on the section components.

[coveord.atlassian.net/browse/KIT-4794](https://coveord.atlassian.net/browse/KIT-4794)