### PR TITLE
chore(atomic): migrate atomic-*-section-visual styles

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.ts
@@ -1,4 +1,4 @@
-import {LitElement} from 'lit';
+import {css, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import type {ItemDisplayImageSize} from '@/src/components/common/layout/display-options';
 import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
@@ -15,11 +15,28 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
  * @slot default - The image to display.
  */
 @customElement('atomic-product-section-visual')
-export class AtomicProductSectionVisual extends ItemSectionMixin(LitElement) {
+export class AtomicProductSectionVisual extends ItemSectionMixin(
+  LitElement,
+  css`
+    @reference '../../common/template-system/sections/sections.css';
+    atomic-product-section-visual {
+      @apply section-visual;
+
+      .with-sections {
+        &.image-icon {
+      atomic-product-image::part(previous-button),
+      atomic-product-image::part(next-button),
+      atomic-product-image::part(indicator) {
+        display: none;
+      }
+    }}
+    }
+    `
+) {
   /**
    * How large or small the visual section of product using this template should be.
    */
-  @property({reflect: true, attribute: 'image-size'})
+  @property({reflect: true, attribute: 'image-size', type: Object})
   public imageSize?: Omit<ItemDisplayImageSize, 'icon'>;
 }
 

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -8,14 +8,6 @@ const styles = css`
   @apply relative;
 
   .with-sections {
-    &.image-icon {
-      atomic-product-image::part(previous-button),
-      atomic-product-image::part(next-button),
-      atomic-product-image::part(indicator) {
-        display: none;
-      }
-    }
-
     &.display-grid {
       &.image-large,
       &.image-small,

--- a/packages/atomic/src/components/common/template-system/cell-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-desktop.pcss
@@ -16,8 +16,7 @@
   &.density-comfortable {
     &.image-large,
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         margin: 0 auto 2rem auto;
       }
     }
@@ -27,15 +26,13 @@
         margin-bottom: 2rem;
       }
 
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 2rem;
         height: 2rem;
       }
     }
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 0.5rem;
     }
 
@@ -89,8 +86,7 @@
   &.density-normal {
     &.image-large,
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         margin: 0 auto 1.5rem auto;
       }
     }
@@ -100,15 +96,13 @@
         margin-bottom: 1.5rem;
       }
 
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 2rem;
         height: 2rem;
       }
     }
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 0.5rem;
     }
 
@@ -160,8 +154,7 @@
   &.density-compact {
     &.image-large,
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         margin: 0 auto 1rem auto;
       }
     }
@@ -171,15 +164,13 @@
         margin-bottom: 1rem;
       }
 
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 2rem;
         height: 2rem;
       }
     }
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 0.5rem;
     }
 
@@ -230,8 +221,7 @@
 
   /* == Image styles == */
   &.image-large {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       @apply aspect-square-[19.75rem];
       width: 100%;
     }
@@ -242,16 +232,14 @@
   }
 
   &.image-small {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       @apply aspect-square-[14rem];
       width: 100%;
     }
   }
 
   &.image-none {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       display: none;
     }
   }

--- a/packages/atomic/src/components/common/template-system/cell-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/cell-mobile.pcss
@@ -14,14 +14,12 @@
 
   /* == Density styles == */
   &.density-comfortable {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 1rem;
     }
 
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 10.25rem;
         height: 10.25rem;
       }
@@ -80,14 +78,12 @@
   }
 
   &.density-normal {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 0.75rem;
     }
 
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 10.25rem;
         height: 10.25rem;
       }
@@ -146,20 +142,17 @@
   }
 
   &.density-compact {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-bottom: 0.5rem;
     }
 
     &.image-large {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 100%;
       }
     }
     &.image-small {
-      atomic-result-section-visual,
-      atomic-product-section-visual {
+      atomic-result-section-visual {
         width: 10.25rem;
         height: 10.25rem;
       }
@@ -219,24 +212,21 @@
 
   /* == Image styles == */
   &.image-small {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       @apply aspect-square-[9rem];
       width: 100%;
     }
   }
 
   &.image-icon {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 2rem;
       height: 2rem;
     }
   }
 
   &.image-none {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       display: none;
     }
   }

--- a/packages/atomic/src/components/common/template-system/row-desktop.pcss
+++ b/packages/atomic/src/components/common/template-system/row-desktop.pcss
@@ -2,8 +2,7 @@
 
 @utility row-result-desktop {
   &.image-large.density-compact {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 10.25rem;
       height: 10.25rem;
     }
@@ -19,8 +18,7 @@
 
   /* == Density styles == */
   &.density-comfortable {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1.5rem;
     }
 
@@ -57,8 +55,7 @@
   }
 
   &.density-normal {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1rem;
     }
 
@@ -95,8 +92,7 @@
   }
 
   &.density-compact {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1rem;
     }
 
@@ -149,8 +145,7 @@
 
   &.image-large.density-comfortable,
   &.image-large.density-normal {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 20.375rem;
       height: 20.375rem;
     }
@@ -158,8 +153,7 @@
 
   &.image-small,
   &.image-large.density-compact {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 10rem;
       height: 10rem;
     }
@@ -177,8 +171,7 @@
     grid-template-columns: minmax(0, min-content) auto 1fr auto;
     grid-template-rows: repeat(7, minmax(0, min-content));
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 2rem;
       height: 2rem;
     }
@@ -196,8 +189,7 @@
     grid-template-columns: auto 1fr auto;
     grid-template-rows: repeat(6, auto);
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       display: none;
     }
   }

--- a/packages/atomic/src/components/common/template-system/row-mobile.pcss
+++ b/packages/atomic/src/components/common/template-system/row-mobile.pcss
@@ -10,8 +10,7 @@
 
   /* == Density styles == */
   &.density-comfortable {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1rem;
     }
 
@@ -52,8 +51,7 @@
   }
 
   &.density-normal {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1rem;
     }
 
@@ -94,8 +92,7 @@
   }
 
   &.density-compact {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       margin-right: 1rem;
     }
 
@@ -150,8 +147,7 @@
     grid-template-columns: 100%;
     grid-template-rows: repeat(8, auto);
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       @apply aspect-square-[7.25rem];
       width: 100%;
       margin-right: 0;
@@ -173,8 +169,7 @@
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: repeat(4, auto) minmax(0, 1fr) repeat(3, auto);
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 24vw;
       height: 24vw;
       margin-bottom: 1rem;
@@ -194,8 +189,7 @@
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: repeat(7, auto) 1fr;
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       width: 2rem;
       height: 2rem;
       margin-bottom: 0;
@@ -215,8 +209,7 @@
     grid-template-columns: 100%;
     grid-template-rows: repeat(7, auto);
 
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       display: none;
     }
   }

--- a/packages/atomic/src/components/common/template-system/sections/section-visual.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-visual.css
@@ -1,0 +1,145 @@
+@reference './sections-utilities.css';
+
+@utility section-visual-row-result-desktop {
+  margin-right: 1rem;
+  &.density-comfortable {
+    margin-right: 1.5rem;
+  }
+
+  &.image-large {
+    &.density-compact {
+      width: 10rem;
+      height: 10rem;
+    }
+
+    &.density-comfortable,
+    &.density-normal {
+      width: 20.375rem;
+      height: 20.375rem;
+    }
+  }
+
+  &.image-small {
+    width: 10rem;
+    height: 10rem;
+  }
+}
+
+@utility section-visual-row-result-mobile {
+  margin-right: 1rem;
+
+  &.image-large {
+    @apply aspect-square-[7.25rem];
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 1rem;
+  }
+
+  &.image-small {
+    width: 24vw;
+    height: 24vw;
+    margin-bottom: 1rem;
+  }
+
+  &.image-icon {
+    margin-bottom: 0;
+  }
+}
+
+@utility section-visual-cell-result-desktop {
+  margin-bottom: 0.5rem;
+
+  &.image-large,
+  &.image-small {
+    &.density-comfortable {
+      margin: 0 auto 2rem auto;
+    }
+    &.density-normal {
+      margin: 0 auto 1.5rem auto;
+    }
+    &.density-compact {
+      margin: 0 auto 1rem auto;
+    }
+
+    width: 100%;
+  }
+
+  &.image-large {
+    @apply aspect-square-[19.75rem];
+  }
+
+  &.image-small {
+    @apply aspect-square-[14rem];
+  }
+}
+
+@utility section-visual-cell-result-mobile {
+  &.image-large,
+  &.image-small {
+    &.density-comfortable {
+      margin-bottom: 1rem;
+    }
+    &.density-normal {
+      margin-bottom: 0.75rem;
+    }
+    &.density-compact {
+      margin-bottom: 0.5rem;
+    }
+
+    width: 100%;
+  }
+
+  &.image-small {
+    @apply aspect-square-[9rem];
+
+    width: 10.25rem;
+    height: 10.25rem;
+  }
+}
+
+@utility section-visual {
+  @apply section-base-overflow;
+  &.with-sections {
+    grid-area: visual;
+
+    &.image-icon {
+      @apply rounded-sm;
+      width: 2rem;
+      height: 2rem;
+    }
+
+    &.image-none {
+      display: none;
+    }
+
+    @media (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        @apply section-visual-row-result-desktop;
+      }
+
+      &.display-grid {
+        @apply section-visual-cell-result-desktop;
+      }
+    }
+
+    @media not all and (width >= theme(--breakpoint-desktop)) {
+      &.display-list {
+        @apply section-visual-row-result-mobile;
+      }
+      &.display-grid {
+        &.image-large {
+          @apply section-visual-row-result-mobile;
+        }
+
+        &.image-small,
+        &.image-icon,
+        &.image-none {
+          @apply section-visual-cell-result-mobile;
+        }
+      }
+    }
+    &.display-table {
+      @apply section-visual-row-result-desktop;
+    }
+  }
+}

--- a/packages/atomic/src/components/common/template-system/sections/sections.css
+++ b/packages/atomic/src/components/common/template-system/sections/sections.css
@@ -6,4 +6,5 @@
 @import "./section-metadata.css";
 @import "./section-actions.css";
 @import "./section-title.css";
+@import "./section-visual.css";
 @reference '../../../../utils/tailwind.global.tw.css';

--- a/packages/atomic/src/components/common/template-system/with-sections.pcss
+++ b/packages/atomic/src/components/common/template-system/with-sections.pcss
@@ -3,8 +3,7 @@
   justify-items: stretch;
 
   /* == Common styles == */
-  atomic-result-section-visual,
-  atomic-product-section-visual {
+  atomic-result-section-visual {
     grid-area: visual;
   }
 
@@ -56,22 +55,19 @@
   }
 
   atomic-result-section-visual,
-  atomic-product-section-visual,
   atomic-result-section-badges,
   atomic-result-section-actions,
   atomic-result-section-title,
   atomic-result-section-title-metadata,
   atomic-result-section-emphasized,
   atomic-result-section-excerpt,
-  atomic-product-section-description,
   atomic-result-section-bottom-metadata {
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   &.image-icon {
-    atomic-result-section-visual,
-    atomic-product-section-visual {
+    atomic-result-section-visual {
       @apply rounded-sm;
     }
   }


### PR DESCRIPTION
This PR migrates the styles for atomic-*-section-visual to custom utilities that can be used directly on the section components.

[coveord.atlassian.net/browse/KIT-4793](https://coveord.atlassian.net/browse/KIT-4793)