### PR TITLE
chore: deprecate old alpha versions when publishing new ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,7 @@ jobs:
         shell: bash
       - name: Release
         run: |
+          npm run clean-npm-prerelease
           npm run nx:graph
           npm run release:phase1
           npm run release:phase3
@@ -809,6 +810,7 @@ jobs:
         shell: bash
       - name: Release
         run: |
+          npm run clean-npm-prerelease
           npm run nx:graph
           npm run release:phase1
           npm run release:phase3

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "notify:docs": "node ./scripts/notify-docs/published-ui-kit.mjs",
     "release": "npm run nx:graph && npm run release:phase0 && npm run release:phase1 && npm run release:phase2 && npm run release:phase3 && npm run release:phase4 && npm run release:phase5",
     "nx:graph": "turbo release:phase1 --dry-run=json > topology-raw.json && node scripts/transform-topology.mjs topology-raw.json topology.json",
+    "clean-npm-prerelease": "turbo clean-npm-prerelease",
     "release:phase0": "npm run-script -w=@coveo/ci git-lock",
     "release:phase1": "turbo release:phase1 --concurrency=1 && npm run build",
     "release:phase2": "npm run-script -w=@coveo/ci bump:root",

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -26,6 +26,7 @@
     "start": "node ./scripts/start.js",
     "e2e": "playwright test",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -18,6 +18,7 @@
     "build:bundles": "rollup --config rollup.config.js",
     "build:types": "tsc --project tsconfig.types.json",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
     "build:assets": "ncp ../atomic/dist/atomic/assets dist/assets && ncp ../atomic/dist/atomic/lang dist/lang "

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -76,6 +76,7 @@
     "e2e:insight:watch": "cypress open --config-file cypress-insight-panel.config.mjs --browser chrome",
     "generate-component": "node ./scripts/generate-component.mjs",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -20,6 +20,7 @@
     "build:definitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
     "clean": "rimraf -rf dist/*",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
     "e2e": "npm run e2e:saml",

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -31,6 +31,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/packages/create-atomic-component-project/package.json
+++ b/packages/create-atomic-component-project/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "publish:bump": "npm run-script -w=@coveo/ci bump",
     "release:phase1": "npm run publish:bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"

--- a/packages/create-atomic-component/package.json
+++ b/packages/create-atomic-component/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "publish:bump": "npm run-script -w=@coveo/ci bump",
     "release:phase1": "npm run publish:bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"

--- a/packages/create-atomic-rollup-plugin/package.json
+++ b/packages/create-atomic-rollup-plugin/package.json
@@ -14,6 +14,7 @@
     "build:ts": "tsc -p tsconfig.json",
     "lint": "npx @biomejs/biome check .",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -21,6 +21,7 @@
     "build:ts": "tsc -p tsconfig.json",
     "lint": "prettier --check . && eslint .",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -31,6 +31,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
     "build:typedoc": "npm run build:typedoc:docs && npm run build:typedoc:merge",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -84,6 +84,7 @@
     "integration-test": "vitest run --poolOptions.threads.singleThread src/integration-tests/**",
     "integration-test:watch": "vitest --poolOptions.threads.singleThread src/integration-tests/**",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "build:typedoc": "npm run build:typedoc:docs && npm run build:typedoc:merge",
     "build:typedoc:docs": "concurrently \"npm run build:typedoc:search\" \"npm run build:typedoc:commerce\" \"npm run build:typedoc:case-assist\" \"npm run build:typedoc:insight\" \"npm run build:typedoc:recommendation\" \"npm run build:typedoc:ssr\" \"npm run build:typedoc:ssr-commerce\"",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -41,6 +41,7 @@
     "promote:sfdx:ci": "npm run publish:sfdx -- --promote --ci",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+"clean-npm-prerelease" : "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
     "preinstall": "node scripts/npm/check-sfdx-project.js",
     "postinstall": "node scripts/npm/setup-quantic.js",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run",
     "clean": "rimraf -rf dist/* && rimraf -rf cdn/",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
+    "clean-npm-prerelease": "npm run-script -w=@coveo/ci npm-deprecate-alpha",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -86,6 +86,10 @@
         "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
       ],
       "cache": false
+    },
+    "clean-npm-prerelease": {
+      "env": ["NODE_AUTH_TOKEN", "NPM_CONFIG_USERCONFIG"],
+      "cache": false
     }
   },
   "globalDependencies": [

--- a/utils/ci/npm-deprecate-alpha.mjs
+++ b/utils/ci/npm-deprecate-alpha.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import {execSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {describeNpmTag} from '@coveo/semantic-monorepo-tools';
+
+if (!process.env.INIT_CWD) {
+  throw new Error('Should be called using npm run-script');
+}
+process.chdir(process.env.INIT_CWD);
+
+/**
+ * @param {string} name
+ * @param {string} tag
+ */
+async function getVersion(name, tag) {
+  try {
+    const publishedVersion = await describeNpmTag(name, tag);
+    return publishedVersion;
+  } catch (e) {
+    const message = /** @type {{stderr?: string}} */ (e).stderr;
+    if (message?.includes('code E404')) {
+      return false;
+    }
+    throw e;
+  }
+}
+
+const tagSuffix = process.env.TAG_SUFFIX || '';
+/** @type {import('@npmcli/package-json').PackageJson} */
+const {name} = JSON.parse(readFileSync('package.json', {encoding: 'utf-8'}));
+if (!name) {
+  throw 'Expected name to exist in package.json.';
+}
+const tag = ['alpha', ...(tagSuffix ? [tagSuffix] : [])].join('-');
+const version = await getVersion(name, tag);
+execSync(`npm deprecate ${name}@${version}`, {stdio: 'inherit'});

--- a/utils/ci/package.json
+++ b/utils/ci/package.json
@@ -25,6 +25,7 @@
     "bump": "node ./bump-package.mjs",
     "bump:root": "node ./bump-root.mjs",
     "npm-publish": "node ./npm-publish-package.mjs",
+    "npm-deprecate-alpha": "node ./npm-deprecate-alpha.mjs",
     "git-publish-all": "node ./git-publish-all.mjs",
     "if-not-cdn": "node ./if-not-cdn.mjs",
     "if-cdn": "node ./if-cdn.mjs",


### PR DESCRIPTION
Add a new step when running npm prerelease that checks either the npm tag `alpha` or `alpha-PRNUM` to get and deprecate its version before publishin a new one