### PR TITLE
chore(headless-ssr): replace single search action to search action array

### DIFF
--- a/packages/headless/src/ssr-next/commerce/controller-utils.ts
+++ b/packages/headless/src/ssr-next/commerce/controller-utils.ts
@@ -4,6 +4,7 @@ import {clone, filterObject, mapObject} from '../../utils/utils.js';
 import {ControllerBuilder} from '../common/builders/controller-builder.js';
 import {createStaticControllerBuilder} from '../common/builders/static-controller-builder.js';
 import {InvalidControllerDefinition} from '../common/errors.js';
+import type {EngineStaticState} from '../common/types/engine.js';
 import type {SSRCommerceEngine} from './factories/build-factory.js';
 import type {SolutionType} from './types/controller-constants.js';
 import type {
@@ -15,7 +16,6 @@ import type {
   InferControllerStaticStateMapFromDefinitionsWithSolutionType,
   InferControllersMapFromDefinition,
 } from './types/controller-inference.js';
-import type {EngineStaticState} from './types/engine.js';
 
 export function createStaticState<
   TSearchAction extends UnknownAction,

--- a/packages/headless/src/ssr-next/commerce/factories/recommendation-static-state-factory.ts
+++ b/packages/headless/src/ssr-next/commerce/factories/recommendation-static-state-factory.ts
@@ -1,4 +1,5 @@
 import type {UnknownAction} from '@reduxjs/toolkit';
+import type {EngineStaticState} from '../../common/types/engine.js';
 import {createStaticState} from '../controller-utils.js';
 import type {BuildConfig, RecommendationBuildConfig} from '../types/build.js';
 import {SolutionType} from '../types/controller-constants.js';
@@ -11,7 +12,6 @@ import type {
   BuildResult,
   CommerceControllerDefinitionsMap,
   CommerceEngineDefinitionOptions,
-  EngineStaticState,
   FetchStaticStateFunction,
   FetchStaticStateParameters,
 } from '../types/engine.js';

--- a/packages/headless/src/ssr-next/commerce/types/engine.ts
+++ b/packages/headless/src/ssr-next/commerce/types/engine.ts
@@ -1,10 +1,8 @@
 import type {UnknownAction} from '@reduxjs/toolkit';
 import type {NavigatorContextProvider} from '../../../app/navigator-context-provider.js';
 import type {Controller} from '../../../controllers/controller/headless-controller.js';
-import type {
-  ControllerStaticStateMap,
-  ControllersMap,
-} from '../../common/types/controllers.js';
+import type {ControllersMap} from '../../common/types/controllers.js';
+import type {EngineStaticState} from '../../common/types/engine.js';
 import type {SSRCommerceEngine} from '../factories/build-factory.js';
 import type {Build, SSRCommerceEngineOptions} from './build.js';
 import type {SolutionType} from './controller-constants.js';
@@ -23,15 +21,12 @@ import type {
   HydrateStaticStateOptions,
 } from './hydrate-static-state.js';
 
-export type {HydrateStaticState, HydrateStaticStateOptions, FetchStaticState};
-
-export interface EngineStaticState<
-  TSearchAction extends UnknownAction,
-  TControllers extends ControllerStaticStateMap,
-> {
-  searchActions: TSearchAction[];
-  controllers: TControllers;
-}
+export type {
+  HydrateStaticState,
+  HydrateStaticStateOptions,
+  FetchStaticState,
+  EngineStaticState,
+};
 
 type ReservedControllerNames = 'context' | 'parameterManager' | 'cart';
 

--- a/packages/headless/src/ssr-next/commerce/types/fetch-static-state.ts
+++ b/packages/headless/src/ssr-next/commerce/types/fetch-static-state.ts
@@ -4,6 +4,7 @@ import type {
   ControllerStaticStateMap,
   ControllersPropsMap,
 } from '../../common/types/controllers.js';
+import type {EngineStaticState} from '../../common/types/engine.js';
 import type {BuildConfig} from './build.js';
 import type {SolutionType} from './controller-constants.js';
 import type {
@@ -12,7 +13,6 @@ import type {
   FilteredBakedInControllers,
   OptionsTuple,
 } from './controller-definitions.js';
-import type {EngineStaticState} from './engine.js';
 
 /**
  * Executes only the initial search for a given configuration, then returns a resumable snapshot of engine state along with the state of the controllers.

--- a/packages/headless/src/ssr-next/common/types/engine.ts
+++ b/packages/headless/src/ssr-next/common/types/engine.ts
@@ -5,8 +5,7 @@ export interface EngineStaticState<
   TSearchAction extends UnknownAction,
   TControllers extends ControllerStaticStateMap,
 > {
-  // TODO: KIT-4684: make searchAction an array an avoid use the same EngineStaticState for both search and commerce
-  searchAction: TSearchAction;
+  searchActions: TSearchAction[];
   controllers: TControllers;
 }
 

--- a/packages/headless/src/ssr-next/search/controller-utils.test.ts
+++ b/packages/headless/src/ssr-next/search/controller-utils.test.ts
@@ -119,7 +119,7 @@ describe('controller-utils', () => {
         }),
       };
       createStaticState({
-        searchAction: mockSearchAction,
+        searchActions: [mockSearchAction],
         controllers,
       });
     });
@@ -146,7 +146,7 @@ describe('controller-utils', () => {
 
     it('should call #clone once with the proper arguments', () => {
       expect(utils.clone).toHaveBeenCalledTimes(1);
-      expect(utils.clone).toHaveBeenCalledWith(mockSearchAction);
+      expect(utils.clone).toHaveBeenCalledWith([mockSearchAction]);
     });
   });
 });

--- a/packages/headless/src/ssr-next/search/controller-utils.ts
+++ b/packages/headless/src/ssr-next/search/controller-utils.ts
@@ -40,10 +40,10 @@ export function createStaticState<
     Controller
   >,
 >({
-  searchAction,
+  searchActions,
   controllers,
 }: {
-  searchAction: TSearchAction;
+  searchActions: TSearchAction[];
   controllers: InferControllersMapFromDefinition<TControllerDefinitions>;
 }): EngineStaticState<
   TSearchAction,
@@ -53,6 +53,6 @@ export function createStaticState<
     controllers: mapObject(controllers, (controller) =>
       createStaticControllerBuilder(controller).build()
     ) as InferControllerStaticStateMapFromDefinitions<TControllerDefinitions>,
-    searchAction: clone(searchAction),
+    searchActions: clone(searchActions),
   };
 }

--- a/packages/headless/src/ssr-next/search/engine/search-engine.ssr.ts
+++ b/packages/headless/src/ssr-next/search/engine/search-engine.ssr.ts
@@ -152,7 +152,7 @@ export function defineSearchEngine<
 
     engine.executeFirstSearch();
     const staticState = createStaticState({
-      searchAction: await engine.waitForSearchCompletedAction(),
+      searchActions: [await engine.waitForSearchCompletedAction()],
       controllers: controllers,
     }) as EngineStaticState<
       UnknownAction,
@@ -166,7 +166,9 @@ export function defineSearchEngine<
     ...params: HydrateStaticStateParameters
   ) => {
     const {engine, controllers} = await build(...(params as BuildParameters));
-    engine.dispatch(params[0]!.searchAction);
+    params[0]!.searchActions.forEach((action) => {
+      engine.dispatch(action);
+    });
     await engine.waitForSearchCompletedAction();
     return {engine, controllers};
   };

--- a/packages/headless/src/ssr-next/search/types/hydrate-static-state.ts
+++ b/packages/headless/src/ssr-next/search/types/hydrate-static-state.ts
@@ -16,7 +16,7 @@ export type HydratedState<
 > = SearchEngineDefinitionBuildResult<TEngine, TControllers>;
 
 interface HydrateStaticStateOptions<TSearchAction> {
-  searchAction: TSearchAction;
+  searchActions: TSearchAction[];
 }
 
 /**

--- a/packages/headless/src/ssr/common/types/hydrate-static-state.ts
+++ b/packages/headless/src/ssr/common/types/hydrate-static-state.ts
@@ -9,6 +9,10 @@ import type {FromBuildResult} from './from-build-result.js';
 import type {OptionsTuple} from './utilities.js';
 
 interface HydrateStaticStateOptions<TSearchAction> {
+  /**
+   * @deprecated The `searchAction` property will be replaced with `searchActions` in the next major release.
+   * The new property will accept an array of actions instead of a single action to support multiple search operations (e.g. search and recommendation).
+   */
   searchAction: TSearchAction;
 }
 


### PR DESCRIPTION
# Update Search SSR Hydrate Interface to Use `searchActions` Array

## Summary
This PR updates the search SSR hydrate interface to use `searchActions` (array) instead of `searchAction` (single action), aligning it with the commerce SSR interface and preparing for future recommendation support.

## Background
Currently, the search SSR and commerce SSR implementations have inconsistent interfaces for hydrating static state:
- **Commerce SSR**: Uses `searchActions: TSearchAction[]` (array)
- **Search SSR**: Used `searchAction: TSearchAction` (single action)

This inconsistency can create confusion for developers working across both implementations and limits future extensibility.

## Goals
1. **Interface Consistency**: Align search SSR with commerce SSR by using the same `searchActions` array pattern
2. **Future-Proofing**: Prepare the search SSR interface to support recommendations in the future, even though recommendation functionality is not yet implemented
3. **Breaking Change Timing**: Make this breaking change now while we're already introducing other breaking changes, rather than forcing another breaking change later

## Changes Made
- **Updated `HydrateStaticStateOptions`**: Changed `searchAction: TSearchAction` to `searchActions: TSearchAction[]`
- **Interface Alignment**: Ensured search SSR follows the same patterns as commerce SSR

## Migration Impact
This is a breaking change for existing search SSR implementations. Users will need to:
- Change `searchAction: action` to `searchActions: [action]`
- Update any code that expects a single action to handle an array of actions

## Future Considerations
When recommendation support is added to search SSR, the existing `searchActions` array will seamlessly support both search and recommendation actions without requiring additional interface changes.

https://coveord.atlassian.net/browse/KIT-4684