### PR TITLE
fix(atomic): fix link template content retrieval

### DIFF
--- a/packages/atomic/src/components/common/product-template/product-template-controller.spec.ts
+++ b/packages/atomic/src/components/common/product-template/product-template-controller.spec.ts
@@ -166,8 +166,7 @@ describe('ProductTemplateController', () => {
       const {controller} = await setupElement(
         html`<test-element>
           <template data-testId="product-template">
-            <atomic-result-section-visual>section</atomic-result-section-visual>
-            <atomic-product-link><a href="https://www.example.com/123"></a></atomic-product-link>
+            <atomic-result-section-visual>section</atomic-result-section-visual><atomic-product-link><a href="https://www.example.com/123"></a></atomic-product-link>
           </template>
         </test-element>`
       );
@@ -184,7 +183,7 @@ describe('ProductTemplateController', () => {
 
     it('getTemplate returns the correct content', () => {
       const contentTemplate = buildTemplateHtml(
-        '<atomic-result-section-visual>section</atomic-result-section-visual>'
+        '<atomic-result-section-visual>section</atomic-result-section-visual><atomic-product-link><a href="https://www.example.com/123"></a></atomic-product-link>'
       );
       expect(result && fragmentToHTML(result.content!)).toBe(
         fragmentToHTML(contentTemplate.content)

--- a/packages/atomic/src/components/common/product-template/product-template-controller.spec.ts
+++ b/packages/atomic/src/components/common/product-template/product-template-controller.spec.ts
@@ -167,6 +167,7 @@ describe('ProductTemplateController', () => {
         html`<test-element>
           <template data-testId="product-template">
             <atomic-result-section-visual>section</atomic-result-section-visual>
+            <atomic-product-link><a href="https://www.example.com/123"></a></atomic-product-link>
           </template>
         </test-element>`
       );
@@ -192,9 +193,13 @@ describe('ProductTemplateController', () => {
 
     it('getTemplate returns the correct linkContent', () => {
       const linkTemplate = buildTemplateHtml(
-        '<atomic-product-link></atomic-product-link>'
+        '<atomic-product-link><a href="https://www.example.com/123"></a></atomic-product-link>'
       );
+
       expect(result).toHaveProperty('linkContent', linkTemplate.content);
+      expect(fragmentToHTML(result!.linkContent as DocumentFragment)).toBe(
+        fragmentToHTML(linkTemplate.content)
+      );
     });
 
     it('getTemplate returns the correct priority', () => {

--- a/packages/atomic/src/components/common/product-template/product-template-controller.ts
+++ b/packages/atomic/src/components/common/product-template/product-template-controller.ts
@@ -111,7 +111,7 @@ export class ProductTemplateController implements ReactiveController {
     return {
       conditions: conditions.concat(this.matchConditions),
       content: getTemplateElement(this.host).content!,
-      linkContent: this.getLinkTemplateElement(this.host).content!,
+      linkContent: this.getLinkTemplateContent(this.host),
       priority: 1,
     };
   }
@@ -122,11 +122,19 @@ export class ProductTemplateController implements ReactiveController {
     return linkTemplate;
   }
 
-  getLinkTemplateElement(host: HTMLElement) {
-    return (
-      host.querySelector<HTMLTemplateElement>('template[slot="link"]') ??
-      this.getDefaultLinkTemplateElement()
+  getLinkTemplateContent(host: HTMLElement): DocumentFragment {
+    const template = host.querySelector<HTMLTemplateElement>('template');
+    const productLinkElement = template?.content.querySelector(
+      'atomic-product-link'
     );
+
+    if (productLinkElement) {
+      const fragment = document.createDocumentFragment();
+      fragment.appendChild(productLinkElement.cloneNode(true));
+      return fragment;
+    } else {
+      return this.getDefaultLinkTemplateElement().content;
+    }
   }
 
   private get parentElement() {


### PR DESCRIPTION
This PR fixes an issue with the linkContent always defaulting to the default link template. This issue was introduced when atomic-product-link got migrated to Lit, as the component does not contain an actual HtmlTemplateElement.

https://coveord.atlassian.net/browse/KIT-4828
