### PR TITLE
fix(atomic): fix product children placement in grid mode

### DIFF
--- a/packages/atomic/dev/examples/commerce-website/search.html
+++ b/packages/atomic/dev/examples/commerce-website/search.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html dir="ltr" lang="en">
+
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
@@ -7,7 +8,7 @@
 
     <script type="module">
       if (import.meta.env) {
-        const {defineCustomElements} = await import('@coveo/atomic/loader');
+        const { defineCustomElements } = await import('@coveo/atomic/loader');
         import('@coveo/atomic/themes/coveo.css');
         defineCustomElements();
       } else {
@@ -20,7 +21,7 @@
     </script>
 
     <script type="module">
-      import {commerceEngine} from './engine.mjs';
+      import { commerceEngine } from './engine.mjs';
 
       (async () => {
         await customElements.whenDefined('atomic-commerce-interface');
@@ -61,8 +62,7 @@
                         </atomic-product-field-condition>
                         <atomic-product-field-condition if-defined="cat_available_sizes">
                           <atomic-product-multi-value-text
-                            field="cat_available_sizes"
-                          ></atomic-product-multi-value-text>
+                            field="cat_available_sizes"></atomic-product-multi-value-text>
                         </atomic-product-field-condition>
                         <atomic-product-field-condition if-defined="ec_rating">
                           <atomic-product-rating field="ec_rating"></atomic-product-rating>
@@ -79,9 +79,8 @@
                 </atomic-commerce-search-box-instant-products>
               </atomic-commerce-search-box>
             </atomic-layout-section>
-            <atomic-layout-section section="facets"
-              ><atomic-commerce-facets></atomic-commerce-facets
-            ></atomic-layout-section>
+            <atomic-layout-section
+              section="facets"><atomic-commerce-facets></atomic-commerce-facets></atomic-layout-section>
             <atomic-layout-section section="main">
               <atomic-layout-section section="status">
                 <atomic-commerce-breadbox></atomic-commerce-breadbox>
@@ -121,8 +120,7 @@
                         </atomic-product-field-condition>
                         <atomic-product-field-condition if-defined="cat_available_sizes">
                           <atomic-product-multi-value-text
-                            field="cat_available_sizes"
-                          ></atomic-product-multi-value-text>
+                            field="cat_available_sizes"></atomic-product-multi-value-text>
                         </atomic-product-field-condition>
                         <atomic-product-field-condition if-defined="ec_rating">
                           <atomic-product-rating field="ec_rating"></atomic-product-rating>
@@ -140,6 +138,15 @@
                       <atomic-product-section-children>
                         <atomic-product-children></atomic-product-children>
                       </atomic-product-section-children>
+                      <atomic-product-section-badges>
+                        <atomic-product-field-condition must-match-ec_in_stock="true">
+                          <span class="rounded-xl border border-primary text-primary px-2">In Stock</span>
+                        </atomic-product-field-condition>
+
+                      </atomic-product-section-badges>
+                      <atomic-product-section-actions>
+                        <button class="btn-primary p-2">Add to Cart</button>
+                      </atomic-product-section-actions>
                     </template>
                   </atomic-product-template>
                 </atomic-commerce-product-list>
@@ -161,4 +168,5 @@
     <script src="../../header.js" type="text/javascript"></script>
     <script src="commerce-nav.mjs" type="module"></script>
   </body>
+
 </html>

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.pcss
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.pcss
@@ -1,1 +1,0 @@
-@import '../../../global/global.pcss';

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.ts
@@ -12,7 +12,6 @@ import {bindings} from '@/src/decorators/bindings.js';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard.js';
 import type {InitializableComponent} from '@/src/decorators/types.js';
-import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import {multiClassMap, tw} from '@/src/directives/multi-class-map.js';
 import {LightDomMixin} from '@/src/mixins/light-dom.js';
 import {defaultCurrencyFormatter} from '../../common/formats/format-common.js';
@@ -24,7 +23,6 @@ import {parseValue} from '../product-template-component-utils/product-utils.js';
  */
 @customElement('atomic-product-price')
 @bindings()
-@withTailwindStyles
 export class AtomicProductPrice
   extends LightDomMixin(LitElement)
   implements InitializableComponent<CommerceBindings>
@@ -104,7 +102,7 @@ export class AtomicProductPrice
           ${this.getFormattedValue(hasPromo ? 'ec_promo_price' : 'ec_price')}
         </div>
         <div class=${multiClassMap(promoClasses)}>
-          ${hasPromo ? this.getFormattedValue('ec_price') : ''}
+          ${hasPromo ? this.getFormattedValue('ec_price') : '\u200B'}
         </div>
       </div>
     `;

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
@@ -1,7 +1,12 @@
 import {type Product, ProductTemplatesHelpers} from '@coveo/headless/commerce';
-import {css, html, LitElement} from 'lit';
+import {html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
+import ratingStyles from '@/src/components/common/atomic-rating/atomic-rating.tw.css.js';
+import {
+  computeNumberOfStars,
+  renderRating,
+} from '@/src/components/common/atomic-rating/rating.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings.js';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
@@ -9,10 +14,6 @@ import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types.js';
 import {LightDomMixin} from '@/src/mixins/light-dom';
 import Star from '../../../images/star.svg';
-import {
-  computeNumberOfStars,
-  renderRating,
-} from '../../common/atomic-rating/rating.js';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface.js';
 
 /**
@@ -38,8 +39,7 @@ export class AtomicProductRating
 
   @state() private product!: Product;
 
-  static styles =
-    css`@import "../../common/atomic-rating/atomic-rating.tw.css";`;
+  static styles = ratingStyles;
 
   /**
    * The numerical field whose values you want to display as a rating.

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -7,6 +7,19 @@ const styles = css`
   @apply atomic-template-system;
   @apply relative;
 
+  .result-root.display-grid {
+    grid-template-areas:
+      "badges"
+      "visual"
+      "title"
+      "title-metadata"
+      "emphasized"
+      "excerpt"
+      "bottom-metadata"
+      "actions"
+      "children";
+  }
+
   .with-sections {
     &.display-grid {
       &.image-large,

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.tw.css.ts
@@ -1,7 +1,7 @@
 import {css} from 'lit';
 
 const styles = css`
-@import "../../common/template-system/template-system.pcss";
+@import "../../common/template-system/template-system.css";
 
 :host {
   @apply atomic-template-system;

--- a/packages/atomic/src/components/common/atomic-rating/atomic-rating.pcss
+++ b/packages/atomic/src/components/common/atomic-rating/atomic-rating.pcss
@@ -14,7 +14,7 @@
   @apply text-rating-icon-inactive;
 }
 /**
- * @prop --atomic-rating-icon-outfill: currentColor;line: Color of the icon's outline.
+ * @prop --atomic-rating-icon-outline: Color of the icon's outline.
  */
 .icon-active,
 .icon-inactive {

--- a/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css.ts
+++ b/packages/atomic/src/components/common/atomic-rating/atomic-rating.tw.css.ts
@@ -1,7 +1,9 @@
+import {css} from 'lit';
+
+const styles = css`
 @reference '../../../utils/tailwind.global.tw.css';
-@reference '../../../utils/coveo.tw.css';
 /**
- * @prop --atomic-rating-icon-outline: currentColor;line: Color of the icon's outline.
+ * @prop --atomic-rating-icon-outline: Color of the icon's outline.
  */
 @layer components {
   atomic-product-rating {
@@ -13,3 +15,6 @@
     }
   }
 }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/common/template-system/template-system.css
+++ b/packages/atomic/src/components/common/template-system/template-system.css
@@ -1,0 +1,178 @@
+@reference '../../../utils/tailwind.global.tw.css';
+
+@utility atomic-template-system-base-sections {
+  display: grid;
+  justify-items: stretch;
+}
+
+@utility atomic-template-system-cell-result {
+  grid-template-areas:
+    "badges"
+    "visual"
+    "title"
+    "title-metadata"
+    "emphasized"
+    "excerpt"
+    "children"
+    "bottom-metadata"
+    "actions";
+  grid-template-columns: 100%;
+  grid-template-rows: repeat(9, auto);
+}
+
+@utility atomic-template-system-row-result-desktop-template {
+  grid-template-areas:
+    "badges badges          .               actions"
+    "visual title           title           title"
+    "visual title-metadata  title-metadata  title-metadata"
+    "visual emphasized      emphasized      emphasized"
+    "visual excerpt         excerpt         excerpt"
+    "visual bottom-metadata bottom-metadata bottom-metadata"
+    "visual children        children        children";
+  grid-template-columns: minmax(0, min-content) auto 1fr auto;
+}
+
+@utility atomic-template-system-row-result-desktop {
+  /* == Image styles == */
+  &.image-large,
+  &.image-small {
+    @apply atomic-template-system-row-result-desktop-template;
+    grid-template-rows: repeat(6, auto) minmax(0, 1fr);
+  }
+
+  &.image-icon {
+    @apply atomic-template-system-row-result-desktop-template;
+    grid-template-rows: repeat(7, minmax(0, min-content));
+  }
+
+  &.image-none {
+    grid-template-areas:
+      "badges          .               actions"
+      "title           title           title"
+      "title-metadata  title-metadata  title-metadata"
+      "emphasized      emphasized      emphasized"
+      "excerpt         excerpt         excerpt"
+      "bottom-metadata bottom-metadata bottom-metadata"
+      "children        children        children";
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: repeat(6, auto);
+  }
+}
+@utility atomic-template-system-row-result-mobile {
+  /* == Image styles == */
+  &.image-large {
+    grid-template-areas:
+      "visual"
+      "badges"
+      "title"
+      "title-metadata"
+      "emphasized"
+      "excerpt"
+      "bottom-metadata"
+      "actions"
+      "children";
+    grid-template-columns: 100%;
+    grid-template-rows: repeat(8, auto);
+  }
+
+  &.image-small {
+    grid-template-areas:
+      "badges          badges"
+      "visual          title"
+      "visual          title-metadata"
+      "visual          emphasized"
+      "visual          ."
+      "excerpt         excerpt"
+      "bottom-metadata bottom-metadata"
+      "actions         actions"
+      "children        children";
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: repeat(4, auto) minmax(0, 1fr) repeat(3, auto);
+  }
+
+  &.image-icon {
+    grid-template-areas:
+      "badges          badges"
+      "visual          title"
+      "visual          title-metadata"
+      "visual          emphasized"
+      "visual          excerpt"
+      "visual          bottom-metadata"
+      "visual          actions"
+      "visual          children";
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: repeat(7, auto) 1fr;
+  }
+
+  &.image-none {
+    grid-template-areas:
+      "badges"
+      "title"
+      "title-metadata"
+      "emphasized"
+      "excerpt"
+      "bottom-metadata"
+      "actions"
+      "children";
+    grid-template-columns: 100%;
+    grid-template-rows: repeat(7, auto);
+  }
+}
+
+@utility atomic-template-system {
+  @layer components {
+    /* == Common styles == */
+    :host {
+      @apply font-sans font-normal;
+    }
+
+    .result-root {
+      &.with-sections {
+        @apply atomic-template-system-base-sections;
+
+        /* Desktop layouts */
+        &.display-list {
+          @media (width >= theme(--breakpoint-desktop)) {
+            @apply atomic-template-system-row-result-desktop;
+          }
+        }
+
+        &.display-table {
+          @apply atomic-template-system-row-result-desktop;
+        }
+
+        /* Mobile layout for list display */
+        &.display-list {
+          @media not all and (width >= theme(--breakpoint-desktop)) {
+            @apply atomic-template-system-row-result-mobile;
+          }
+        }
+
+        /* Grid display */
+        &.display-grid {
+          @apply atomic-template-system-cell-result;
+
+          a,
+          button {
+            position: relative;
+          }
+
+          /* Large images in grid use mobile layout on mobile */
+          @media not all and (width >= theme(--breakpoint-desktop)) {
+            &.image-large {
+              @apply atomic-template-system-row-result-mobile;
+            }
+          }
+        }
+      }
+
+      atomic-table-element {
+        display: none;
+      }
+    }
+
+    .link-container {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
This PR ensures that the product children section is always placed last in all modes.

It also adds the atomic-product-section-badges and atomic-product-section-actions sections to the search.html example as we currently have no example with those sections.

**This PR can only be merged once all the product sections have been migrated to the new system.**
https://coveord.atlassian.net/browse/KIT-4703