### PR TITLE
fix(atomic): timeframe facet e2e test

### DIFF
--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/atomic-timeframe-facet.e2e.ts
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/e2e/atomic-timeframe-facet.e2e.ts
@@ -62,7 +62,10 @@ test.describe('default', () => {
             '1401-01-01'
           );
           await facet.facetInputEnd.click();
-          await expect(facet.facetInputEnd).toHaveAttribute('max', '');
+          await expect(facet.facetInputEnd).toHaveAttribute(
+            'max',
+            '9999-12-31'
+          );
         });
 
         test('should hide the clear filter button', async ({facet}) => {
@@ -79,9 +82,9 @@ test.describe('default', () => {
     await expect(facet.facetInputStart).toHaveAttribute('min', '1401-01-01');
   });
 
-  test('should not limit the end date', async ({facet}) => {
+  test('should limit the end date to max', async ({facet}) => {
     await facet.facetInputEnd.click();
-    await expect(facet.facetInputEnd).not.toHaveAttribute('max');
+    await expect(facet.facetInputEnd).toHaveAttribute('max', '9999-12-31');
   });
 });
 


### PR DESCRIPTION
Raising this PR to resolve e2e tests for atomic-timeframe-facet based on this [Slack Discussion](https://coveo.slack.com/archives/G016TA2G485/p1755880787107139?thread_ts=1755701447.356389&cid=G016TA2G485)