### PR TITLE
fix(atomic): make product children click open the product page

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
@@ -1081,7 +1081,7 @@ describe('AtomicCommerceProductList', () => {
           vi.spyOn(
             // @ts-expect-error - spying on private property: mocking the template provider would be complex.
             element.productTemplateProvider,
-            'getEmptyLinkTemplateContent'
+            'getLinkTemplateContent'
           ).mockReturnValue(mockEmptyLinkTemplate);
 
           if (display === 'table') {

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -405,7 +405,7 @@ export class AtomicCommerceProductList
           .interactiveProduct=${this.searchOrListing.interactiveProduct({
             options: {product},
           })}
-          .linkContent=${this.productTemplateProvider.getEmptyLinkTemplateContent()}
+          .linkContent=${this.productTemplateProvider.getLinkTemplateContent(product)}
           .loadingFlag=${this.loadingFlag}
           .product=${product}
           .renderingFunction=${this.itemRenderingFunction}
@@ -465,7 +465,7 @@ export class AtomicCommerceProductList
                         .interactiveProduct=${this.searchOrListing.interactiveProduct(
                           {options: {product}}
                         )}
-                        .linkContent=${this.productTemplateProvider.getEmptyLinkTemplateContent()}
+                        .linkContent=${this.productTemplateProvider.getLinkTemplateContent(product)}
                         .loadingFlag=${this.loadingFlag}
                         .product=${product}
                         .renderingFunction=${this.itemRenderingFunction}

--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.ts
@@ -14,6 +14,8 @@ import type {SelectChildProductEventArgs} from './select-child-product-event';
 import '../atomic-commerce-text/atomic-commerce-text';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {multiClassMap, tw} from '@/src/directives/multi-class-map';
+import {closest} from '@/src/utils/dom-utils';
+import type {AtomicProduct} from '../atomic-product/atomic-product';
 
 /**
  * Maximum number of child products to display before showing a "+N" button.
@@ -101,6 +103,15 @@ export class AtomicProductChildren
     return filterProtocol(this.fallback);
   }
 
+  private handleClick = (event: MouseEvent) => {
+    if (this.parentElement?.tagName !== 'A') {
+      console.log('here', closest);
+      closest<AtomicProduct>(this, 'atomic-product')!.clickLinkContainer();
+    } else {
+      event.stopPropagation();
+    }
+  };
+
   private renderChild(child: ChildProduct) {
     const childName = child.ec_name ?? '';
 
@@ -122,6 +133,7 @@ export class AtomicProductChildren
           event.preventDefault();
           this.onSelectChild(child);
         }}
+        @click=${this.handleClick}
       >
         <img
           class="aspect-square p-1"
@@ -188,6 +200,7 @@ export class AtomicProductChildren
                 props: {
                   style: 'text-primary',
                   class: 'product-child',
+                  onClick: this.handleClick,
                 },
               })(html`+${this.count}`)
             : nothing

--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.ts
@@ -105,7 +105,6 @@ export class AtomicProductChildren
 
   private handleClick = (event: MouseEvent) => {
     if (this.parentElement?.tagName !== 'A') {
-      console.log('here', closest);
       closest<AtomicProduct>(this, 'atomic-product')!.clickLinkContainer();
     } else {
       event.stopPropagation();

--- a/packages/atomic/src/components/commerce/atomic-product-children/e2e/atomic-product-children.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-children/e2e/atomic-product-children.e2e.ts
@@ -12,7 +12,7 @@ test.describe('AtomicProductChildren', () => {
   });
 
   test('should render a label', async ({productChildren}) => {
-    await expect(productChildren.label).toHaveText('Available in:');
+    await expect(productChildren.availableInLabel).toBeVisible();
   });
 
   test('should render child products', async ({productChildren}) => {

--- a/packages/atomic/src/components/commerce/atomic-product-children/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-children/e2e/page-object.ts
@@ -6,8 +6,10 @@ export class AtomicProductChildrenPageObject extends BasePageObject {
     super(page, 'atomic-product-children');
   }
 
-  get label() {
-    return this.page.locator('atomic-commerce-text');
+  get availableInLabel() {
+    return this.page
+      .locator('atomic-commerce-text')
+      .filter({hasText: 'Available in:'});
   }
 
   get childProducts() {

--- a/packages/atomic/src/components/commerce/atomic-product-text/e2e/atomic-product-text.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/e2e/atomic-product-text.e2e.ts
@@ -59,7 +59,6 @@ test.describe('atomic-product-text', () => {
         await productText.hydrated.first().waitFor();
 
         await expect(productText.textContent.first()).toContainText(/kayak/i);
-
         const highlightedText =
           await productText.highlightedText.allTextContents();
         expect(highlightedText.length).toEqual(0);

--- a/packages/atomic/src/components/commerce/atomic-product-text/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-text/e2e/page-object.ts
@@ -7,10 +7,14 @@ export class ProductTextPageObject extends BasePageObject {
   }
 
   get textContent() {
-    return this.page.locator('atomic-product-text');
+    return this.page.locator(
+      'atomic-product-text:not(atomic-product-link atomic-product-text)'
+    );
   }
 
   get highlightedText() {
-    return this.page.locator('atomic-product-text b');
+    return this.page.locator(
+      'atomic-product-text:not(atomic-product-link atomic-product-text) b'
+    );
   }
 }

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.spec.ts
@@ -97,6 +97,45 @@ describe('atomic-product', () => {
     expect(stopPropagationSpy).toHaveBeenCalled();
   });
 
+  it('should click the link container when the display is "grid"', async () => {
+    const clickLinkContainerSpy = vi.fn();
+    const element = await renderProduct({
+      display: 'grid',
+    });
+
+    element.clickLinkContainer = clickLinkContainerSpy;
+
+    const clickEvent = new MouseEvent('click');
+    element.dispatchEvent(clickEvent);
+    expect(clickLinkContainerSpy).toHaveBeenCalled();
+  });
+
+  it('should not click the link container when the display is "list"', async () => {
+    const clickLinkContainerSpy = vi.fn();
+    const element = await renderProduct({
+      display: 'list',
+    });
+
+    element.clickLinkContainer = clickLinkContainerSpy;
+
+    const clickEvent = new MouseEvent('click');
+    element.dispatchEvent(clickEvent);
+    expect(clickLinkContainerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not click the link container when the display is "table"', async () => {
+    const clickLinkContainerSpy = vi.fn();
+    const element = await renderProduct({
+      display: 'table',
+    });
+
+    element.clickLinkContainer = clickLinkContainerSpy;
+
+    const clickEvent = new MouseEvent('click');
+    element.dispatchEvent(clickEvent);
+    expect(clickLinkContainerSpy).not.toHaveBeenCalled();
+  });
+
   it('should render default template content', async () => {
     const element = await renderProduct();
     const resultRoot = element.shadowRoot!.querySelector('.result-root');
@@ -124,6 +163,44 @@ describe('atomic-product', () => {
     ).firstUpdated(new Map());
 
     expect(mockUnsetLoadingFlag).toHaveBeenCalledWith(loadingFlag);
+  });
+
+  describe('#clickLinkContainer', () => {
+    it('should click the anchor element when found', async () => {
+      const element = await renderProduct();
+      const mockClick = vi.fn();
+      const mockAnchor = {click: mockClick};
+      const mockQuerySelector = vi.fn().mockReturnValue(mockAnchor);
+      vi.spyOn(element.shadowRoot!, 'querySelector').mockImplementation(
+        mockQuerySelector
+      );
+
+      element.clickLinkContainer();
+
+      expect(mockQuerySelector).toHaveBeenCalledWith(
+        '.link-container > atomic-product-link a:not([slot])'
+      );
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it('should not throw when anchor element is not found', async () => {
+      const element = await renderProduct();
+
+      vi.spyOn(element.shadowRoot!, 'querySelector').mockReturnValue(null);
+
+      expect(() => element.clickLinkContainer()).not.toThrow();
+    });
+
+    it('should not throw when shadowRoot is null', async () => {
+      const element = await renderProduct();
+
+      Object.defineProperty(element, 'shadowRoot', {
+        get: () => null,
+        configurable: true,
+      });
+
+      expect(() => element.clickLinkContainer()).not.toThrow();
+    });
   });
 
   describe('when using the default rendering function', () => {

--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.ts
@@ -156,6 +156,12 @@ export class AtomicProduct extends ChildrenUpdateCompleteMixin(LitElement) {
     if (this.stopPropagation) {
       event.stopPropagation();
     }
+    if (this.display === 'grid') {
+      this.clickLinkContainer();
+    }
+  };
+
+  public clickLinkContainer = () => {
     this.shadowRoot
       ?.querySelector<HTMLAnchorElement>(
         '.link-container > atomic-product-link a:not([slot])'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4758

Problem: 
The product children are buttons and don't currently do anything when clicked. From the feedback we got, it feels like they should open the product page. 

Proposed solution: 

1. To make a template component clickable, we need to make the `link-container` available for all types of product list displays. We can achieve that by changing the `getEmptyLinkTemplateContent` call by `getLinkTemplateContent`.

2. Then for it to not be clicked in displays other than `grid`, we need to handle that logic in `atomic-product`.

3. Then to make a template component clickable, we first make the `clickLinkContainer` function public and then we can use `closest` to query it's `atomic-product` and call it's public `clickLinkContainer` function.
