### PR TITLE
fix(atomic): fully hide modal on close

### DIFF
--- a/packages/atomic/src/global/global.pcss
+++ b/packages/atomic/src/global/global.pcss
@@ -7,7 +7,7 @@
 @keyframes scaleUp {
   0% {
     transform: scale(0.7) translateY(150vh);
-    opacity: 0.7;
+    opacity: 0;
   }
   100% {
     transform: scale(1) translateY(0px);
@@ -22,6 +22,6 @@
   }
   100% {
     transform: translateY(150vh);
-    opacity: 0.7;
+    opacity: 0;
   }
 }


### PR DESCRIPTION
This PR ensures that the refine modal always disappears fully when closed, even in rare situation where it stays in view.

Ideally we would want to transition to `display:none;` on browsers that support `transition-behavior: allow-discrete;` However we cannot as firefox returns truthy for `@supports (transition-behavior: allow-discrete) ` even though it cannot transition on the display property specifically. This would cause the modal to instantly disappears instead of fading out on firefox.

Note that `aria-hidden="true"` is added to the modal when closed, so It will not be visible to screenreaders

https://github.com/mdn/browser-compat-data/issues/26155

https://coveord.atlassian.net/browse/KIT-4774