### PR TITLE
fix:(atomic): disable input for discrete range

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts
@@ -176,6 +176,7 @@ export class AtomicCommerceNumericFacet
       isLoading,
       hasProducts: hasResults,
     } = this.summaryState;
+
     return shouldDisplayInputForFacetRange({
       hasInputRange: this.hasInputRange,
       searchStatusState: {
@@ -185,6 +186,7 @@ export class AtomicCommerceNumericFacet
         isLoading,
       },
       facetValues: this.facetState.values,
+      isDiscrete: this.facetState.interval === 'discrete',
       hasInput: true,
     });
   }

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts
@@ -150,6 +150,7 @@ export class AtomicCommerceTimeframeFacet
         isLoading,
       },
       facetValues: this.facetState.values || [],
+      isDiscrete: false,
       hasInput: true,
     });
   }

--- a/packages/atomic/src/components/common/facets/facet-common.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.spec.ts
@@ -28,6 +28,7 @@ describe('facet-common', () => {
       expect(
         shouldDisplayInputForFacetRange({
           hasInput: false,
+          isDiscrete: false,
           hasInputRange: false,
           searchStatusState: {hasResults: true} as SearchStatusState,
           facetValues: [{}, {}] as NumericFacetValue[],
@@ -39,6 +40,7 @@ describe('facet-common', () => {
       expect(
         shouldDisplayInputForFacetRange({
           hasInput: true,
+          isDiscrete: false,
           hasInputRange: true,
           searchStatusState: {hasResults: false} as SearchStatusState,
           facetValues: [] as NumericFacetValue[],
@@ -50,6 +52,19 @@ describe('facet-common', () => {
       expect(
         shouldDisplayInputForFacetRange({
           hasInput: true,
+          isDiscrete: false,
+          hasInputRange: false,
+          searchStatusState: {hasResults: false} as SearchStatusState,
+          facetValues: [] as NumericFacetValue[],
+        })
+      ).toBe(false);
+    });
+
+    it('should return false when there the intervals are discrete', () => {
+      expect(
+        shouldDisplayInputForFacetRange({
+          hasInput: true,
+          isDiscrete: true,
           hasInputRange: false,
           searchStatusState: {hasResults: false} as SearchStatusState,
           facetValues: [] as NumericFacetValue[],
@@ -61,6 +76,7 @@ describe('facet-common', () => {
       expect(
         shouldDisplayInputForFacetRange({
           hasInput: true,
+          isDiscrete: false,
           hasInputRange: false,
           searchStatusState: {hasResults: true} as SearchStatusState,
           facetValues: [] as NumericFacetValue[],
@@ -72,6 +88,7 @@ describe('facet-common', () => {
       expect(
         shouldDisplayInputForFacetRange({
           hasInput: true,
+          isDiscrete: false,
           hasInputRange: false,
           searchStatusState: {hasResults: true} as SearchStatusState,
           facetValues: [{}, {}] as NumericFacetValue[],

--- a/packages/atomic/src/components/common/facets/facet-common.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.ts
@@ -18,16 +18,22 @@ export interface FacetValuePropsBase {
 export function shouldDisplayInputForFacetRange(facetRange: {
   hasInput: boolean;
   hasInputRange: boolean;
+  isDiscrete: boolean;
   searchStatusState: SearchStatusState;
   facetValues: Pick<FacetValue, 'numberOfResults' | 'state'>[];
 }) {
-  const {hasInput, hasInputRange, searchStatusState, facetValues} = facetRange;
+  const {hasInput, hasInputRange, searchStatusState, facetValues, isDiscrete} =
+    facetRange;
   if (!hasInput) {
     return false;
   }
 
   if (hasInputRange) {
     return true;
+  }
+
+  if (isDiscrete) {
+    return false;
   }
 
   if (!searchStatusState.hasResults) {

--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.test.ts
@@ -131,6 +131,17 @@ describe('NumericFacet', () => {
       expect(facet.state.domain).toEqual({min: domain.min, max: domain.max});
     });
 
+    it('includes #intervals if present in the response state', () => {
+      const interval = 'continuous';
+      facetResponseSelector.mockReturnValue(
+        buildMockCommerceNumericFacetResponse({facetId, interval})
+      );
+
+      initFacet();
+
+      expect(facet.state.interval).toEqual('continuous');
+    });
+
     it('does not include #domain if not present in the response state', () => {
       expect(facet.state.domain).toBeUndefined();
     });

--- a/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/numeric/headless-commerce-numeric-facet.ts
@@ -1,5 +1,6 @@
 import type {CommerceEngine} from '../../../../../app/commerce-engine/commerce-engine.js';
 import {stateKey} from '../../../../../app/state-key.js';
+import type {NumericFacetInterval} from '../../../../../features/commerce/facets/facet-set/interfaces/common.js';
 import type {NumericFacetResponse} from '../../../../../features/commerce/facets/facet-set/interfaces/response.js';
 import {manualNumericFacetSelector} from '../../../../../features/commerce/facets/numeric-facet/manual-numeric-facet-selectors.js';
 import {manualNumericFacetReducer as manualNumericFacetSet} from '../../../../../features/commerce/facets/numeric-facet/manual-numeric-facet-slice.js';
@@ -41,6 +42,10 @@ export type NumericFacetState = Omit<
    * The domain of the numeric facet.
    */
   domain?: NumericFacetDomain;
+  /**
+   * The interval of the numeric facet.
+   */
+  interval?: NumericFacetInterval;
   manualRange?: NumericRangeRequest;
   type: 'numericalRange';
 };
@@ -165,6 +170,9 @@ export const getNumericFacetState = (
         min: response.domain.min,
         max: response.domain.max,
       },
+    }),
+    ...(response?.interval && {
+      interval: response.interval,
     }),
     ...(manualFacetRangeSelector && {manualRange: manualFacetRangeSelector}),
     type: 'numericalRange',

--- a/packages/headless/src/features/commerce/facets/facet-set/interfaces/common.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/interfaces/common.ts
@@ -9,7 +9,11 @@ type NumericFacetDomain = {
   increment: number;
 };
 
-type NumericFacetInterval = 'continuous' | 'discrete' | 'even' | 'equiprobable';
+export type NumericFacetInterval =
+  | 'continuous'
+  | 'discrete'
+  | 'even'
+  | 'equiprobable';
 
 export type CategoryFacetDelimitingCharacter = {
   delimitingCharacter: string;


### PR DESCRIPTION
When a numerical facet uses the discrete algorithm, the manual input ranges no longer usable since discrete intervals generates predefined ranges rather than allowing continuous user input. 


https://coveord.atlassian.net/browse/KIT-4520
