### PR TITLE
chore: fix dev ci and improve consistency in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,7 @@ jobs:
           npm run release:phase4
         env:
           IS_PRERELEASE: "true"
-          TAG_SUFFIX: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.number }}
   prerelease-cdn-pr:
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     needs: build
@@ -777,7 +777,7 @@ jobs:
             exit 1
           fi
   prerelease-npm-merge:
-    if: ${{ !cancelled() && github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'merge_group' }}
     needs: is-valid
     timeout-minutes: 40
     name: Pre-release NPM at alpha (Merge group)
@@ -815,9 +815,8 @@ jobs:
           npm run release:phase4
         env:
           IS_PRERELEASE: "true"
-          TAG_SUFFIX: ${{ github.event.number }}
   prerelease-cdn-merge:
-    if: ${{ !cancelled() && github.event_name ==  'merge_group' }}
+    if: ${{ github.event_name ==  'merge_group' }}
     needs: is-valid
     name: Pre-release CDN in dev (Merge group)
     environment: "Prerelease (CDN)"

--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -56,7 +56,7 @@ function getVersionSubpaths(version) {
     : {
         major: versionComposantsOrdered.slice(0, 1),
         minor: versionComposantsOrdered.slice(0, 2).join('.'),
-        patch: versionComposantsOrdered.slice(0, 3).join('.'),
+        patch: versionComposantsOrdered.join('.'),
       };
 }
 

--- a/utils/ci/npm-publish-package.mjs
+++ b/utils/ci/npm-publish-package.mjs
@@ -26,7 +26,7 @@ async function isPublished(name, version, tag = version) {
 }
 
 const isPrerelease = process.env.IS_PRERELEASE === 'true';
-const tagSuffix = process.env.TAG_SUFFIX || '';
+const tagSuffix = process.env.PR_NUMBER || '';
 /** @type {import('@npmcli/package-json').PackageJson} */
 const {name, version} = JSON.parse(
   readFileSync('package.json', {encoding: 'utf-8'})


### PR DESCRIPTION
- Replace TAG_SUFFIX by PR_NUMBER for consistency
- Remove `!cancelled()` for `prerelease-*-merge` to ensure we only release succesful merges
- Fix `execute-deployment-pipeline` to always consider the full version for paths: We do use `X.Y.Z-pre.SHA` for dev, and because of the `.slice(0,3)` we were dropping the `-pre.SHA` 🤦 