### PR TITLE
fix(cli): fix plop choice type to simple list

### DIFF
--- a/packages/create-atomic/src/plopfile.ts
+++ b/packages/create-atomic/src/plopfile.ts
@@ -123,8 +123,7 @@ export default function (plop: NodePlopAPI) {
         message: 'The search hub to use',
       },
       {
-        // Custom type necessary to allow bypassing async choices
-        type: 'customList',
+        type: 'list',
         name: 'page-id',
         default: undefined,
         loop: false,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-4522

Plop was updated from 3.x to 4.x semi recently. With 4.x, we don't need that `customList` hack anymore.
