### PR TITLE
fix(atomic commerce): missing min-height for atomic-product-excerpt/description

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.ts
@@ -9,20 +9,20 @@ import {bindings} from '@/src/decorators/bindings.js';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
 import {errorGuard} from '@/src/decorators/error-guard.js';
 import type {InitializableComponent} from '@/src/decorators/types.js';
-import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import {
   renderExpandableText,
   type TruncateAfter,
 } from '../../common/expandable-text/expandable-text.js';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface.js';
 import '../atomic-product-text/atomic-product-text.js';
+import {injectStylesForNoShadowDOM} from '@/src/decorators/inject-styles-for-no-shadow-dom.js';
 
 /**
  * The `atomic-product-description` component renders the description of a product.
  */
 @customElement('atomic-product-description')
-@withTailwindStyles
 @bindings()
+@injectStylesForNoShadowDOM
 export class AtomicProductDescription
   extends LitElement
   implements InitializableComponent<CommerceBindings>
@@ -70,10 +70,6 @@ export class AtomicProductDescription
 
   initialize() {
     this.validateProps();
-  }
-
-  createRenderRoot() {
-    return this;
   }
 
   constructor() {

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.spec.ts
@@ -1,5 +1,5 @@
 import {html} from 'lit';
-import {describe, expect, it} from 'vitest';
+import {beforeEach, describe, expect, it} from 'vitest';
 import {renderInAtomicProduct} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-product-fixture';
 import {buildFakeProduct} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/product';
 import './atomic-product-excerpt';
@@ -9,7 +9,15 @@ import {ifDefined} from 'lit/directives/if-defined.js';
 import type {TruncateAfter} from '../../common/expandable-text/expandable-text';
 import type {AtomicProductExcerpt} from './atomic-product-excerpt';
 
+const LINE_HEIGHT = 16;
+
 describe('atomic-product-excerpt', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty(
+      '--line-height',
+      `${LINE_HEIGHT}px`
+    );
+  });
   const renderProductExcerpt = async (
     props: {
       truncateAfter?: TruncateAfter;
@@ -87,41 +95,64 @@ describe('atomic-product-excerpt', () => {
   });
 
   it('should expand when clicking on the show more button', async () => {
-    const {locators} = await renderProductExcerpt();
-
+    const {element, locators} = await renderProductExcerpt({
+      truncateAfter: '2',
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: <>
+    (element as any).isTruncated = true;
     await userEvent.click(locators.button!);
 
     expect(locators.expandableDiv).toHaveClass('min-lines-2');
   });
 
-  it('should collapse when isCollapsible is true and clicking on the show less button', async () => {
-    const {locators} = await renderProductExcerpt({isCollapsible: true});
-
-    await userEvent.click(locators.button!);
-
+  it('should set the correct min-height based on the truncateAfter value', async () => {
+    const {element, locators} = await renderProductExcerpt({
+      truncateAfter: '2',
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: <>
+    (element as any).isTruncated = true;
     expect(locators.expandableDiv).toHaveClass('min-lines-2');
+    expect(locators.expandableDiv).toHaveStyle({
+      'min-height': `${LINE_HEIGHT * 2}px`,
+    });
+  });
 
-    await userEvent.click(locators.button!);
+  describe('when isCollapsible is true', () => {
+    let locators: Awaited<ReturnType<typeof renderProductExcerpt>>['locators'];
+    let element: AtomicProductExcerpt;
 
-    expect(locators.expandableDiv).toHaveClass('line-clamp-2');
+    beforeEach(async () => {
+      ({element, locators} = await renderProductExcerpt({
+        isCollapsible: true,
+        truncateAfter: '2',
+      }));
+    });
+
+    it('should collapse when clicking on the show less button', async () => {
+      await userEvent.click(locators.button!);
+
+      expect(locators.expandableDiv).not.toHaveClass('line-clamp-2');
+
+      // biome-ignore lint/suspicious/noExplicitAny: <>
+      (element as any).isTruncated = true;
+      await userEvent.click(locators.button!);
+
+      expect(locators.expandableDiv).toHaveClass('line-clamp-2');
+    });
+
+    it('should have the correct text on the show more button', async () => {
+      expect(locators.button).toHaveTextContent('Show more');
+    });
+
+    it('should have the correct text on the show less button when expanded', async () => {
+      await userEvent.click(locators.button!);
+
+      expect(locators.button).toHaveTextContent('Show less');
+    });
   });
 
   it('should have the correct part attribute on the expandable text', async () => {
     const {locators} = await renderProductExcerpt();
     expect(locators.expandableDiv).toHaveAttribute('part', 'expandable-text');
-  });
-
-  it('should have the correct text on the show more button', async () => {
-    const {locators} = await renderProductExcerpt();
-
-    expect(locators.button).toHaveTextContent('Show more');
-  });
-
-  it('should have the correct text on the show less button when expanded', async () => {
-    const {locators} = await renderProductExcerpt({isCollapsible: true});
-
-    await userEvent.click(locators.button!);
-
-    expect(locators.button).toHaveTextContent('Show less');
   });
 });

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.ts
@@ -9,20 +9,20 @@ import {bindings} from '@/src/decorators/bindings';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators';
 import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types';
-import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
 import {
   renderExpandableText,
   type TruncateAfter,
 } from '../../common/expandable-text/expandable-text';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 import '../atomic-product-text/atomic-product-text.js';
+import {injectStylesForNoShadowDOM} from '@/src/decorators/inject-styles-for-no-shadow-dom';
 
 /**
  * The `atomic-product-excerpt` component renders the excerpt of a product.
  */
 @customElement('atomic-product-excerpt')
 @bindings()
-@withTailwindStyles
+@injectStylesForNoShadowDOM
 export class AtomicProductExcerpt
   extends LitElement
   implements InitializableComponent<CommerceBindings>
@@ -57,10 +57,6 @@ export class AtomicProductExcerpt
   public isCollapsible = false;
 
   public initialize() {}
-
-  createRenderRoot() {
-    return this;
-  }
 
   constructor() {
     super();

--- a/packages/atomic/src/utils/tailwind-utilities/min-lines.css
+++ b/packages/atomic/src/utils/tailwind-utilities/min-lines.css
@@ -1,3 +1,4 @@
 @utility min-lines-* {
-  min-height: calc(var(--line-height) * --value([\*]));
+  min-height: calc(var(--line-height) * --value(integer));
 }
+

--- a/packages/atomic/src/utils/tailwind-utilities/min-lines.css
+++ b/packages/atomic/src/utils/tailwind-utilities/min-lines.css
@@ -1,4 +1,3 @@
 @utility min-lines-* {
   min-height: calc(var(--line-height) * --value(integer));
 }
-

--- a/packages/atomic/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-product-fixture.ts
+++ b/packages/atomic/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-product-fixture.ts
@@ -1,6 +1,7 @@
 import type {InteractiveProduct, Product} from '@coveo/headless/commerce';
 import {html, LitElement, nothing, type TemplateResult} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
+import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles.js';
 import type {CommerceBindings} from '../../../../../src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.js';
 import {fixture} from '../../../fixture.js';
 import {
@@ -10,6 +11,7 @@ import {
 } from './atomic-commerce-interface-fixture.js';
 
 @customElement('atomic-product')
+@withTailwindStyles
 export class FixtureAtomicProduct extends LitElement {
   @state() template!: TemplateResult;
   @property({type: Object}) product?: Product;


### PR DESCRIPTION
This PR fixes an issue that prevented the min-lines-* utilities from being generated, which in turned led to atomic-product-excerpt and atomic-product-description to not have the min-height required to keep the product grid aligned correctly.

## Before

<img width="600"  alt="image (4)" src="https://github.com/user-attachments/assets/1fb9c686-37ab-4e9f-88a5-fd0beddc1265" />

## After

<img width="600" alt="image (3)" src="https://github.com/user-attachments/assets/f7f8856d-65f9-479f-bdcf-84b84104aa71" />


https://coveord.atlassian.net/browse/KIT-4836