### PR TITLE
chore: ensure we use **ALL** components of the prerelesase and not only the `pre`

### DIFF
--- a/scripts/deploy/execute-deployment-pipeline.mjs
+++ b/scripts/deploy/execute-deployment-pipeline.mjs
@@ -40,7 +40,7 @@ function getVersionComponents(version) {
     parsedVersion?.major,
     parsedVersion?.minor,
     parsedVersion?.patch,
-    ...(parsedVersion?.prerelease[0] ? [parsedVersion.prerelease[0]] : []),
+    ...(parsedVersion?.prerelease.length > 0 ? parsedVersion.prerelease : []),
   ];
 }
 


### PR DESCRIPTION
:rage1::rage2::rage3::rage4::hurtrealbad::finnadie:
<img width="391" height="204" alt="image" src="https://github.com/user-attachments/assets/ece5a44b-8194-4ccb-bcd9-fa8c0a9fac3c" />
It happens that version.prerelease[0] is, always, at best `pre` and nothing more :finnadie: 
