### PR TITLE
chore: update conditions for prerelease jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,7 +777,7 @@ jobs:
             exit 1
           fi
   prerelease-npm-merge:
-    if: ${{ !cancelled() && needs.is-valid.result === 'success' && github.event_name ==  'merge_group' }}
+    if: ${{ !cancelled() && needs.is-valid.result == 'success' && github.event_name == 'merge_group' }}
     needs: is-valid
     timeout-minutes: 40
     name: Pre-release NPM at alpha (Merge group)
@@ -816,7 +816,7 @@ jobs:
         env:
           IS_PRERELEASE: "true"
   prerelease-cdn-merge:
-    if: ${{ !cancelled() && needs.is-valid.result === 'success' && github.event_name ==  'merge_group' }}
+    if: ${{ !cancelled() && needs.is-valid.result == 'success' && github.event_name == 'merge_group' }}
     needs: is-valid
     name: Pre-release CDN in dev (Merge group)
     environment: "Prerelease (CDN)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,7 +777,7 @@ jobs:
             exit 1
           fi
   prerelease-npm-merge:
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ !cancelled() && needs.is-valid.result === 'success' && github.event_name ==  'merge_group' }}
     needs: is-valid
     timeout-minutes: 40
     name: Pre-release NPM at alpha (Merge group)
@@ -816,7 +816,7 @@ jobs:
         env:
           IS_PRERELEASE: "true"
   prerelease-cdn-merge:
-    if: ${{ github.event_name ==  'merge_group' }}
+    if: ${{ !cancelled() && needs.is-valid.result === 'success' && github.event_name ==  'merge_group' }}
     needs: is-valid
     name: Pre-release CDN in dev (Merge group)
     environment: "Prerelease (CDN)"


### PR DESCRIPTION
This pull request updates the CI workflow conditions for pre-release jobs to improve build reliability and prevent unnecessary executions. Now, the pre-release NPM and CDN jobs will only run if the workflow has not been cancelled, the `is-valid` job succeeded, and the event is a `merge_group`.

**CI workflow improvements:**

* Updated the condition for the `prerelease-npm-merge` job in `.github/workflows/ci.yml` to require that the workflow is not cancelled, the `is-valid` job succeeded, and the event is a `merge_group`.
* Updated the condition for the `prerelease-cdn-merge` job in `.github/workflows/ci.yml` with the same checks as above.