### PR TITLE
feat(quantic): Add an examplePageViewTracker with unit tests

### DIFF
--- a/packages/quantic/.gitignore
+++ b/packages/quantic/.gitignore
@@ -3,7 +3,7 @@
 # For useful gitignore templates see: https://github.com/github/gitignore
 
 # Salesforce cache
-.sfdx/
+.sfdx/**
 .sf/
 .localdevserver/
 
@@ -40,6 +40,7 @@ force-app/main/default/staticresources/coveoheadless
 force-app/main/default/staticresources/coveobueno
 force-app/main/default/staticresources/marked
 force-app/main/default/staticresources/dompurify
+force-app/main/default/staticresources/coveoua
 
 # Test Coverage & Report
 coverage

--- a/packages/quantic/build-static-resources.js
+++ b/packages/quantic/build-static-resources.js
@@ -4,6 +4,7 @@ const fs = require('fs').promises;
 const path = require('path');
 
 const STATIC_RESOURCES_PATH = './force-app/main/default/staticresources';
+const SOLUTION_EXAMPLES_STATIC_RESOURCES_PATH = './force-app/solutionExamples/main/staticresources';
 const TEMP_DIR = '.tmp/quantic-compiled';
 
 function resolveLibraryPath(packageName, relativePath) {
@@ -26,6 +27,15 @@ const LIBRARY_CONFIG = {
       {
         src: resolveLibraryPath('marked', '../marked.min.js'),
         dest: `${STATIC_RESOURCES_PATH}/marked/marked.min.js`,
+      },
+    ],
+  },
+  coveoua: {
+    directories: [`${SOLUTION_EXAMPLES_STATIC_RESOURCES_PATH}/coveoua`],
+    files: [
+      {
+        src: path.resolve(path.dirname(require.resolve('coveo.analytics')), '../dist/coveoua.js'),
+        dest: `${SOLUTION_EXAMPLES_STATIC_RESOURCES_PATH}/coveoua/coveoua.js`,
       },
     ],
   },
@@ -131,6 +141,30 @@ async function copyLibrary(config) {
   }
 }
 
+async function fixCoveoUA() {
+  // Fix the Coveo UA script, `globalThis` is not supported in Locker Service
+  // https://developer.salesforce.com/docs/component-library/tools/locker-service-viewer
+  const problemText = 'globalThis';
+  const solutionText = 'window';
+  const coveoUAFilePath = path.join(SOLUTION_EXAMPLES_STATIC_RESOURCES_PATH, 'coveoua', 'coveoua.js');
+  
+  try {
+    const coveoUAContent = await fs.readFile(coveoUAFilePath, 'utf8');
+    const fixedCoveoUAContent = coveoUAContent.replace(new RegExp(problemText, 'g'), solutionText);
+    
+    // Only write if changes were made
+    if (coveoUAContent !== fixedCoveoUAContent) {
+      await fs.writeFile(coveoUAFilePath, fixedCoveoUAContent, 'utf8');
+      console.info(`Fixed Coveo UA: replaced "${problemText}" with "${solutionText}"`);
+    } else {
+      console.info('Coveo UA: no fixes needed');
+    }
+  } catch (error) {
+    console.error(`Failed to fix Coveo UA script: ${coveoUAFilePath}\nError: ${error.message}`);
+    process.exit(1);
+  }
+}
+
 async function main() {
   console.info('Begin building static resources');
 
@@ -145,6 +179,10 @@ async function main() {
 
   await copyLibrary(LIBRARY_CONFIG.headless);
   console.info('Headless copied.');
+
+  await copyLibrary(LIBRARY_CONFIG.coveoua);
+  await fixCoveoUA();
+  console.info('Coveo.analytics copied to solutionsExamples.');
 
   LIBRARY_CONFIG.headless.files.forEach(async ({dest}) => {
     if (dest.includes('headless.js')) {

--- a/packages/quantic/force-app/solutionExamples/main/classes/PageViewTrackerHelper.cls
+++ b/packages/quantic/force-app/solutionExamples/main/classes/PageViewTrackerHelper.cls
@@ -1,0 +1,14 @@
+public with sharing class PageViewTrackerHelper {
+  @AuraEnabled(cacheable=true)
+  public static Id getArticleId(String urlName) {
+    return [
+      SELECT Id
+      FROM Knowledge__kav
+      WHERE
+        UrlName = :urlName
+        AND PublishStatus = 'Online'
+      LIMIT 1
+    ]
+    .Id;
+  }
+}

--- a/packages/quantic/force-app/solutionExamples/main/classes/PageViewTrackerHelper.cls-meta.xml
+++ b/packages/quantic/force-app/solutionExamples/main/classes/PageViewTrackerHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/packages/quantic/force-app/solutionExamples/main/lwc/.eslintrc.json
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/.eslintrc.json
@@ -1,9 +1,11 @@
 {
+  "ignorePatterns": "staticresources/**/*",
   "extends": ["@salesforce/eslint-config-lwc/recommended", "prettier"],
   "root": true,
   "globals": {
     "CoveoHeadless": "readonly",
-    "CoveoHeadlessCaseAssist": "readonly"
+    "CoveoHeadlessCaseAssist": "readonly",
+    "coveoua": "readonly"
   },
   "overrides": [
     {

--- a/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/__tests__/examplePageViewTracker.test.js
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/__tests__/examplePageViewTracker.test.js
@@ -1,0 +1,191 @@
+/* eslint-disable @lwc/lwc/no-unexpected-wire-adapter-usages */
+/* eslint-disable @lwc/lwc/no-async-operation */
+import {createElement} from '@lwc/engine-dom';
+import {loadScript} from 'lightning/platformResourceLoader';
+import ExamplePageViewTracker from 'c/examplePageViewTracker';
+import {CurrentPageReference} from 'lightning/navigation';
+import getHeadlessConfiguration from '@salesforce/apex/HeadlessController.getHeadlessConfiguration';
+import getArticleId from '@salesforce/apex/PageViewTrackerHelper.getArticleId';
+
+jest.mock(
+  '@salesforce/resourceUrl/coveoua',
+  () => ({default: '/resource/coveoua'}),
+  {virtual: true}
+);
+
+jest.mock(
+  'lightning/platformResourceLoader',
+  () => ({
+    loadScript: jest.fn(() => Promise.resolve()),
+  }),
+  {virtual: true}
+);
+
+jest.mock(
+  '@salesforce/apex/HeadlessController.getHeadlessConfiguration',
+  () => ({default: jest.fn()}),
+  {virtual: true}
+);
+
+jest.mock(
+  '@salesforce/apex/PageViewTrackerHelper.getArticleId',
+  () => ({default: jest.fn()}),
+  {virtual: true}
+);
+
+jest.mock(
+  'lightning/navigation',
+  () => {
+    const {
+      createTestWireAdapter,
+    } = require('@salesforce/wire-service-jest-util');
+    return {
+      CurrentPageReference: createTestWireAdapter(jest.fn()),
+    };
+  },
+  {virtual: true}
+);
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const DEFAULT_HEADLESS_CONFIGURATION = {
+  organizationId: 'myorg',
+  accessToken: 'abc123',
+};
+const DEFAULT_KAV_ID = 'ka0XX0000000001AAA';
+
+describe('c-example-page-view-tracker', () => {
+  beforeEach(() => {
+    window.coveoua = jest.fn();
+
+    getHeadlessConfiguration.mockResolvedValue(
+      JSON.stringify(DEFAULT_HEADLESS_CONFIGURATION)
+    );
+    getArticleId.mockResolvedValue(DEFAULT_KAV_ID);
+  });
+
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    jest.clearAllMocks();
+  });
+
+  it('loads the external script and initializes Coveo UA on connect', async () => {
+    const el = createElement('c-example-page-view-tracker', {
+      is: ExamplePageViewTracker,
+    });
+    document.body.appendChild(el);
+
+    await flushPromises();
+
+    expect(loadScript).toHaveBeenCalledTimes(1);
+    // loadScript is called with (this, <resourcePath>), we're just interested in the url part.
+    const url = loadScript.mock.calls[0][1];
+    expect(url).toBe('/resource/coveoua/coveoua.js');
+
+    expect(window.coveoua).toHaveBeenCalledWith(
+      'init',
+      'abc123',
+      'https://myorg.analytics.org.coveo.com/rest/ua'
+    );
+  });
+
+  it('sends a view for standard__recordPage using @sfid', async () => {
+    const el = createElement('c-example-page-view-tracker', {
+      is: ExamplePageViewTracker,
+    });
+    document.body.appendChild(el);
+
+    await flushPromises();
+
+    const testRecordId = '01t530000004iXsAAI';
+    const expectedContentIdKey = '@sfid';
+
+    // @ts-expect-error: in tests, lightning/navigation is mocked to a test adapter with .emit
+    CurrentPageReference.emit({
+      type: 'standard__recordPage',
+      attributes: {recordId: testRecordId, actionName: 'view'},
+      state: {recordName: 'Test'},
+    });
+
+    await flushPromises();
+
+    // A 'send view' call with @sfid + recordId must be present
+    expect(window.coveoua).toHaveBeenCalledWith(
+      'send',
+      'view',
+      expect.objectContaining({
+        contentIdKey: expectedContentIdKey,
+        contentIdValue: testRecordId,
+      })
+    );
+  });
+
+  it('sends a view for standard__knowledgeArticlePage using resolved article id and contentType=Knowledge', async () => {
+    const testKnowledgeArticleId = 'kA01U0000001234UAA';
+    // @ts-ignore TS doesn't know about our mock
+    getArticleId.mockResolvedValue(testKnowledgeArticleId);
+
+    const el = createElement('c-example-page-view-tracker', {
+      is: ExamplePageViewTracker,
+    });
+    document.body.appendChild(el);
+
+    await flushPromises();
+
+    const testArticleUrlName = 'how-to-reset-password';
+
+    // @ts-expect-error: in tests, lightning/navigation is mocked to a test adapter with .emit
+    CurrentPageReference.emit({
+      type: 'standard__knowledgeArticlePage',
+      attributes: {urlName: testArticleUrlName},
+      state: {},
+    });
+
+    await flushPromises();
+
+    // Verify Apex call params
+    expect(getArticleId).toHaveBeenCalledWith({
+      urlName: testArticleUrlName,
+    });
+
+    // Verify UA 'send view' with knowledge content
+    expect(window.coveoua).toHaveBeenCalledWith(
+      'send',
+      'view',
+      expect.objectContaining({
+        contentIdKey: '@sfid',
+        contentIdValue: testKnowledgeArticleId,
+        contentType: 'Knowledge',
+      })
+    );
+  });
+
+  it('falls back to @clickableuri for non-record/knowledge pages', async () => {
+    const el = createElement('c-example-page-view-tracker', {
+      is: ExamplePageViewTracker,
+    });
+    document.body.appendChild(el);
+
+    await flushPromises();
+
+    // @ts-expect-error: in tests, lightning/navigation is mocked to a test adapter with .emit
+    CurrentPageReference.emit({
+      type: 'standard__namedPage',
+      attributes: {pageName: 'home'},
+      state: {foo: 'bar'},
+    });
+
+    await flushPromises();
+
+    expect(window.coveoua).toHaveBeenCalledWith(
+      'send',
+      'view',
+      expect.objectContaining({
+        contentIdKey: '@clickableuri',
+        contentIdValue: window.location.href, // jsdom default like http://localhost/
+      })
+    );
+  });
+});

--- a/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.html
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.html
@@ -1,0 +1,5 @@
+<template>
+    <!-- This div is required to have a drag-and-drop-able component, you cannot drag-and-drop a LWC without a body. -->
+    <!-- Even if we don't need a body for the PageViewTracker -->
+    <div style="display:none" class="coveo-page-view-tracker"></div>
+</template>

--- a/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.js
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.js
@@ -1,0 +1,120 @@
+import {LightningElement} from 'lwc';
+import {CurrentPageReference} from 'lightning/navigation';
+import {wire} from 'lwc';
+// @ts-ignore
+import {loadScript} from 'lightning/platformResourceLoader';
+import COVEO_UA from '@salesforce/resourceUrl/coveoua';
+// @ts-ignore
+import getHeadlessConfiguration from '@salesforce/apex/HeadlessController.getHeadlessConfiguration';
+import getArticleId from '@salesforce/apex/PageViewTrackerHelper.getArticleId';
+
+export default class ExamplePageViewTracker extends LightningElement {
+  coveoUAInitialized = false;
+  _initializationPromises;
+
+  // Listen to navigation changes in an Experience Cloud site.
+  // Reference: https://developer.salesforce.com/docs/platform/lwc/guide/use-navigate-basic.html#pagereference-properties
+  // Example of PageReference data:
+  // {
+  //     "type": "standard__recordPage",
+  //     "attributes": {
+  //         "recordId": "01t530000004iXsAAI",
+  //         "actionName": "view"
+  //     },
+  //     "state": {
+  //         "recordName": "test"
+  //     }
+  // }
+  @wire(CurrentPageReference)
+  // eslint-disable-next-line no-unused-vars
+  trackPageChange({attributes, state, type, ...rest}) {
+    this.loadAndInitializeLibrary();
+    this._initializationPromises.then(() => {
+      this.triggerPageView({attributes, state, type});
+    });
+  }
+
+  connectedCallback() {
+    this.loadAndInitializeLibrary();
+  }
+
+  loadAndInitializeLibrary() {
+    if (!this._initializationPromises) {
+      this._initializationPromises = Promise.all([
+        loadScript(this, COVEO_UA + '/coveoua.js'),
+        getHeadlessConfiguration(),
+      ])
+        .then(([, endpointData]) => {
+          return this.initCoveoUA(endpointData);
+        })
+        .catch((error) => {
+          console.error('Error loading coveoua library', error);
+        });
+    }
+  }
+
+  initCoveoUA(endpointData) {
+    const {organizationId, accessToken} = JSON.parse(endpointData);
+    window.coveoua(
+      'init',
+      accessToken,
+      `https://${organizationId}.analytics.org.coveo.com/rest/ua`
+    );
+    this.coveoUAInitialized = true;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  triggerPageView({attributes, state, type}) {
+    switch (type) {
+      case 'standard__recordPage':
+        this.coveouaSendView({
+          contentIdKey: '@sfid', // @sfid is the default field where the Salesforce recordId is stored.
+          contentIdValue: attributes.recordId,
+        });
+        break;
+      case 'standard__knowledgeArticlePage':
+        getArticleId({urlName: attributes?.urlName})
+          .then((id) => {
+            if (id) {
+              this.coveouaSendView({
+                contentIdKey: '@sfid',
+                contentIdValue: id,
+                contentType: 'Knowledge',
+              });
+            }
+          })
+          .catch((err) => {
+            console.warn(
+              'Error searching for knowledge article by UrlName',
+              err
+            );
+          });
+        break;
+
+      default:
+        this.coveouaSendView({
+          contentIdKey: '@clickableuri',
+          contentIdValue: window.location.href,
+        });
+        break;
+    }
+  }
+
+  coveouaSendView({
+    contentIdKey,
+    contentIdValue,
+    contentType = undefined,
+    additionalContext = {},
+  }) {
+    if (this.coveoUAInitialized) {
+      window.coveoua('send', 'view', {
+        contentIdKey: contentIdKey,
+        contentIdValue: contentIdValue,
+        ...(contentType && {contentType: contentType}),
+        ...(additionalContext && {customData: {...additionalContext}}),
+      });
+    } else {
+      console.warn('Coveo UA called before initialized.');
+    }
+  }
+}

--- a/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.js-meta.xml
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/examplePageViewTracker/examplePageViewTracker.js-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
+    </targets>
+</LightningComponentBundle>

--- a/packages/quantic/force-app/solutionExamples/main/lwc/jsconfig.json
+++ b/packages/quantic/force-app/solutionExamples/main/lwc/jsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "checkJs": true,
+    "target": "es2016",
+    "module": "esnext",
+    "paths": {
+      "c/examplePageViewTracker": ["examplePageViewTracker/examplePageViewTracker.js"],
+      "c/*": ["*"]
+    }
+  },
+  "include": [
+    "**/*",
+    "../../../../.sfdx/typings/lwc/**/*.d.ts",
+    "../../../../typings/lwc/**/*.d.ts",
+    "../../../../coveo.d.ts"
+  ],
+  "exclude": ["**/e2e/**"],
+  "typeAcquisition": {
+    "include": ["jest"]
+  },
+  "paths": {
+    "c/*": ["*"]
+  }
+}

--- a/packages/quantic/force-app/solutionExamples/main/staticresources/coveoua.resource-meta.xml
+++ b/packages/quantic/force-app/solutionExamples/main/staticresources/coveoua.resource-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contentType>application/zip</contentType>
+    <description>Coveo Analytics JavaScript client</description>
+    <cacheControl>Public</cacheControl>
+</StaticResource>

--- a/packages/quantic/jest.config.js
+++ b/packages/quantic/jest.config.js
@@ -31,6 +31,11 @@ module.exports = {
       '<rootDir>/force-app/main/default/lwc/searchBoxStyle/searchBoxStyle',
     '^c/quanticFacetStyles$':
       '<rootDir>/force-app/main/default/lwc/quanticFacetStyles/quanticFacetStyles',
+    '^c/(.*)$': [
+      '<rootDir>/force-app/main/default/lwc/$1/$1',
+      '<rootDir>/force-app/solutionExamples/main/lwc/$1/$1',
+    ],
+    
   },
   modulePathIgnorePatterns: ['.cache'],
   // add any custom configurations here

--- a/packages/quantic/typings/lwc/coveoua.resource.d.ts
+++ b/packages/quantic/typings/lwc/coveoua.resource.d.ts
@@ -1,0 +1,4 @@
+declare module "@salesforce/resourceUrl/coveoua" {
+    var coveoua: string;
+    export default coveoua;
+}


### PR DESCRIPTION
### SFINT-6258

Example Quantic PageView Tracker

This component creates a ready-made starting point to send PageView events with Quantic.

1. It correctly builds a new static resource which is the `coveoua` library https://github.com/coveo/coveo.analytics.js/
2. It applies a small fix to the library to make sure it is compatible with Locker
3. It includes a new LWC that can be drag-and-droped in community pages
4. This component showcases how to listen to navigation of pages within a community
5. This component showcases how to load the coveoua library
6. This component initializes itself with the HeadlessController to get a token
7. This component showcases different types of page views to be sent depending on the content in the community
8. This component is covered by unit tests

