### PR TITLE
fix(cli): cleanup create-atomic-template

### DIFF
--- a/packages/create-atomic-template/stencil.config.ts
+++ b/packages/create-atomic-template/stencil.config.ts
@@ -1,29 +1,28 @@
-import replace from '@rollup/plugin-replace';
-import type {Config} from '@stencil/core';
-import {spawnSync} from 'node:child_process';
-import dotenvPlugin from 'rollup-plugin-dotenv';
-import html from 'rollup-plugin-html';
-import nodePolyfills from 'rollup-plugin-node-polyfills';
-import {coveoCdnResolve} from '@coveo/create-atomic-rollup-plugin';
+import replace from "@rollup/plugin-replace";
+import type { Config } from "@stencil/core";
+import dotenvPlugin from "rollup-plugin-dotenv";
+import html from "rollup-plugin-html";
+import nodePolyfills from "rollup-plugin-node-polyfills";
+import { coveoCdnResolve } from "@coveo/create-atomic-rollup-plugin";
 
 // https://stenciljs.com/docs/config
 
 export const config: Config = {
-  namespace: '{{project}}',
-  globalStyle: 'src/style/index.css',
-  taskQueue: 'async',
+  namespace: "{{project}}",
+  globalStyle: "src/style/index.css",
+  taskQueue: "async",
   outputTargets: [
     {
-      type: 'www',
+      type: "www",
       serviceWorker: null, // disable service workers
-      copy: [{src: 'pages', keepDirStructure: false}],
+      copy: [{ src: "pages", keepDirStructure: false }],
     },
     {
-      type: 'dist',
+      type: "dist",
     },
     {
-      type: 'dist-custom-elements',
-      customElementsExportBehavior: 'bundle',
+      type: "dist-custom-elements",
+      customElementsExportBehavior: "bundle",
       minify: false,
       includeGlobalScripts: true,
       generateTypeDeclarations: false,
@@ -33,15 +32,15 @@ export const config: Config = {
   plugins: [
     dotenvPlugin(),
     replace({
-      'process.env.PLATFORM_URL': `'${process.env.PLATFORM_URL}'`,
-      'process.env.ORGANIZATION_ID': `'${process.env.ORGANIZATION_ID}'`,
-      'process.env.API_KEY': `'${process.env.API_KEY}'`,
+      "process.env.PLATFORM_URL": `'${process.env.PLATFORM_URL}'`,
+      "process.env.ORGANIZATION_ID": `'${process.env.ORGANIZATION_ID}'`,
+      "process.env.API_KEY": `'${process.env.API_KEY}'`,
     }),
   ],
   rollupPlugins: {
     before: [
       html({
-        include: 'src/components/**/*.html',
+        include: "src/**/*.html",
       }),
       // Replace by `coveoNpmResolve()` to bundle Atomic & Headless directly, instead of using the CDN.
       coveoCdnResolve(),


### PR DESCRIPTION
*  Cleanup an unused import from create-atomic-template (`spawnSync`)
* Bundle all files in src/**/*.html instead of scoping only to /components. This is used by the cli `ui:atomic:deploy` command for a page created from `ui:atomic:create` command.

https://coveord.atlassian.net/browse/KIT-4522

