### PR TITLE
chore: hange default code owner to @coveo/dxui

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything in the repo. Later matches take precedence.
-* @coveo/search
+* @coveo/dxui
 
 # Owners of the Quantic package
 /packages/quantic/ @coveo/salesforce-integration


### PR DESCRIPTION
Updated the default code owner from @coveo/search to @coveo/dxui.

For the Stencil to Lit migration, please tag the Pull Request with `new-lit-component`. Do not fill out the PR description initially; a template will be automatically generated for you to complete.

For all other contributors, please disregard this instruction.
