### PR TITLE
fix(atomic commerce): prevent scroll to top on product children selection/hover in grid mode

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
@@ -196,7 +196,56 @@ describe('AtomicCommerceProductList', () => {
     );
   });
 
-  // #disconnectedCallback =============================================================================================
+  describe('#updated', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: <accessing private properties in tests>
+    let element: any;
+
+    beforeEach(async () => {
+      element = await setupElement();
+      element.isEveryProductReady = true;
+    });
+
+    it.each([
+      {
+        description:
+          'should set #isEveryProductReady to false when transitioning from not loading to loading',
+        oldState: false,
+        newState: true,
+        expectedResult: false,
+      },
+      {
+        description:
+          'should not change #isEveryProductReady when transitioning from loading to not loading',
+        oldState: true,
+        newState: false,
+        expectedResult: true,
+      },
+      {
+        description:
+          'should not change #isEveryProductReady when staying in loading state',
+        oldState: true,
+        newState: true,
+        expectedResult: true,
+      },
+      {
+        description:
+          'should not change #isEveryProductReady when staying in not loading state',
+        oldState: false,
+        newState: false,
+        expectedResult: true,
+      },
+    ])('$description', ({oldState, newState, expectedResult}) => {
+      element.searchOrListingState = {
+        isLoading: newState,
+        products: [buildFakeProduct()],
+      };
+      element.updated(
+        new Map([['searchOrListingState', {isLoading: oldState}]])
+      );
+
+      expect(element.isEveryProductReady).toBe(expectedResult);
+    });
+  });
 
   describe('when removed from the DOM', () => {
     it('should unsubscribe from summary controller state changes', async () => {
@@ -226,8 +275,6 @@ describe('AtomicCommerceProductList', () => {
       );
     });
   });
-
-  // #render ===========================================================================================================
 
   it('should not render when bindings are undefined', async () => {
     const element = await setupElement();
@@ -1193,8 +1240,6 @@ describe('AtomicCommerceProductList', () => {
       await element.updateComplete;
     };
   };
-
-  // Fixture utils for this test suite
 
   const setupElement = async ({
     display = 'grid',

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -223,11 +223,14 @@ export class AtomicCommerceProductList
   }
   public async updated(changedProperties: Map<string, unknown>) {
     super.updated(changedProperties);
-    if (
-      changedProperties.has('searchOrListingState') &&
-      this.isEveryProductsReady
-    ) {
-      this.isEveryProductsReady = false;
+    if (changedProperties.has('searchOrListingState')) {
+      const oldState = changedProperties.get('searchOrListingState') as
+        | ProductListingState
+        | SearchState;
+
+      if (!oldState?.isLoading && this.searchOrListingState.isLoading) {
+        this.isEveryProductsReady = false;
+      }
     }
     await this.updateProductsReadyState();
   }

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -146,7 +146,7 @@ export class AtomicCommerceProductList
   @state()
   private isAppLoaded = false;
   @state()
-  private isEveryProductsReady = false;
+  private isEveryProductReady = false;
   @state()
   private resultTemplateRegistered = false;
   @state()
@@ -229,7 +229,7 @@ export class AtomicCommerceProductList
         | SearchState;
 
       if (!oldState?.isLoading && this.searchOrListingState.isLoading) {
-        this.isEveryProductsReady = false;
+        this.isEveryProductReady = false;
       }
     }
     await this.updateProductsReadyState();
@@ -238,12 +238,12 @@ export class AtomicCommerceProductList
   private async updateProductsReadyState() {
     if (
       this.isAppLoaded &&
-      !this.isEveryProductsReady &&
+      !this.isEveryProductReady &&
       this.summaryState?.firstRequestExecuted &&
       this.searchOrListingState?.products?.length > 0
     ) {
       await this.getUpdateComplete();
-      this.isEveryProductsReady = true;
+      this.isEveryProductReady = true;
     }
   }
 
@@ -258,7 +258,7 @@ export class AtomicCommerceProductList
           () => html`<slot></slot>`,
           () => {
             const listClasses = this.computeListDisplayClasses();
-            const productClasses = `${listClasses} ${!this.isEveryProductsReady && 'hidden'}`;
+            const productClasses = `${listClasses} ${!this.isEveryProductReady && 'hidden'}`;
 
             // Products must be rendered immediately (though hidden) to start their initialization and loading processes.
             // If we wait to render products until placeholders are removed, the components won't begin loading until then,
@@ -281,7 +281,7 @@ export class AtomicCommerceProductList
                   )}`
                 )
               )}
-              ${when(!this.isEveryProductsReady, () =>
+              ${when(!this.isEveryProductReady, () =>
                 renderDisplayWrapper({
                   props: {listClasses, display: this.display},
                 })(
@@ -382,9 +382,7 @@ export class AtomicCommerceProductList
   }
 
   private computeListDisplayClasses() {
-    const displayPlaceholders = !(
-      this.isAppLoaded && this.isEveryProductsReady
-    );
+    const displayPlaceholders = !(this.isAppLoaded && this.isEveryProductReady);
 
     return getItemListDisplayClasses(
       this.display,


### PR DESCRIPTION
This PR fixes a bug that was causing a scroll to top when selecting/hovering on a product children in grid mode.

https://coveord.atlassian.net/browse/KIT-4901