### PR TITLE
(docs): Remove request duration info on the  atomic-commerce-query-summary component

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.ts
@@ -21,7 +21,7 @@ import {getProductQuerySummaryI18nParameters} from '../../common/query-summary/u
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
 
 /**
- * The `atomic-commerce-query-summary` component displays information about the current range of products and the request duration (e.g., "Products 1-10 of 123").
+ * The `atomic-commerce-query-summary` component displays information about the current range of products (e.g., "Products 1-10 of 123").
  *
  * @part container - The container for the whole summary.
  * @part highlight - The summary highlights.


### PR DESCRIPTION
Removed request duration info for the `atomic-commerce-query-summary` component