### PR TITLE
chore: change slack channel to dxui-deployments

### DIFF
--- a/.deployment.config/dev.json
+++ b/.deployment.config/dev.json
@@ -11,7 +11,7 @@
     },
     "start_environment_automatically": false,
     "notifications": {
-      "slack_channels": ["#searchuibuilds"]
+      "slack_channels": ["#dxui-deployments"]
     }
   },
   "dag_phases": [

--- a/.deployment.config/prd.json
+++ b/.deployment.config/prd.json
@@ -12,7 +12,7 @@
     "team_jenkins": "searchuibuilds",
     "start_environment_automatically": false,
     "notifications": {
-      "slack_channels": ["#searchuibuilds"]
+      "slack_channels": ["#dxui-deployments"]
     }
   },
   "dag_phases": [


### PR DESCRIPTION
We are now using `#dxui-deployments` to track our deployments, so let's change it ;) 