### PR TITLE
chore(atomic): remove border-color fallback from global styles

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-body/atomic-ipx-body.tsx
@@ -85,7 +85,7 @@ export class AtomicIPXBody implements InitializableComponent<AnyBindings> {
             <slot name="header"></slot>
           </div>
         </header>
-        <hr part="header-ruler" class=""></hr>
+        <hr part="header-ruler" class="border-neutral"></hr>
         <div
           part="body-wrapper"
           class="scrollbar flex w-full grow flex-col overflow-auto"

--- a/packages/atomic/src/utils/tailwind.global.tw.css
+++ b/packages/atomic/src/utils/tailwind.global.tw.css
@@ -5,14 +5,6 @@
 @reference './coveo.tw.css';
 
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    @apply border-gray-200;
-  }
-
   :host {
     display: block;
   }


### PR DESCRIPTION
Tailwind V4 removes the default border color, so we added a fallback:
[Default border color](https://tailwindcss.com/docs/upgrade-guide#default-border-color) 

However, this fallback is used only once, so we end up with the fallback styles added to a lot of files for no real benefit. This PR removes the fallback and adds border-neutral where it was missing.

https://coveord.atlassian.net/browse/KIT-4908
