### PR TITLE
chore: include hidden files, otherwise .turbo is ignored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           path: ".turbo"
           name: "turborepo-cdn-cache"
+          include-hidden-files: true
   affected:
     name: "Determine affected projects"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Without this option, `.turbo` and all files/dir starting with a `.` are dropped.

https://github.com/actions/upload-artifact/blob/main/src/shared/search.ts#L19

https://github.com/actions/toolkit/blob/f58042f9cc16bcaa87afaa86c2974a8c771ce1ea/packages/glob/src/internal-glob-options.ts#L40-L47

https://coveord.atlassian.net/browse/KIT-4910