### PR TITLE
feat(headless): exposed new attach to case action creators

### DIFF
--- a/packages/headless/src/controllers/insight/attach-to-case/headless-attach-to-case.test.ts
+++ b/packages/headless/src/controllers/insight/attach-to-case/headless-attach-to-case.test.ts
@@ -181,13 +181,15 @@ describe('insight attach to case', () => {
         testCaseId
       );
 
-      expect(attachResult).toHaveBeenCalledWith({result: attachedResult});
+      expect(attachResult).toHaveBeenCalledTimes(1);
+      expect(attachResult).toHaveBeenCalledWith(attachedResult);
     });
 
     it('calling #attach should trigger the #logCaseAttach usage analytics action', () => {
       attachToCase.attach();
 
       expect(logCaseAttach).toHaveBeenCalledTimes(1);
+      expect(logCaseAttach).toHaveBeenCalledWith(testResult);
     });
   });
 
@@ -219,13 +221,15 @@ describe('insight attach to case', () => {
         testCaseId
       );
 
-      expect(detachResult).toHaveBeenCalledWith({result: resultToDetach});
+      expect(detachResult).toHaveBeenCalledTimes(1);
+      expect(detachResult).toHaveBeenCalledWith(resultToDetach);
     });
 
     it('calling #detach should trigger the #logCaseDetach usage analytics action', () => {
       attachToCase.detach();
 
       expect(logCaseDetach).toHaveBeenCalledTimes(1);
+      expect(logCaseDetach).toHaveBeenCalledWith(testResult);
     });
   });
 });

--- a/packages/headless/src/controllers/insight/attach-to-case/headless-attach-to-case.ts
+++ b/packages/headless/src/controllers/insight/attach-to-case/headless-attach-to-case.ts
@@ -124,18 +124,14 @@ export function buildAttachToCase(
 
     attach() {
       dispatch(
-        attachResult({
-          result: buildAttachedResultFromSearchResult(result, caseId),
-        })
+        attachResult(buildAttachedResultFromSearchResult(result, caseId))
       );
       dispatch(logCaseAttach(result));
     },
 
     detach() {
       dispatch(
-        detachResult({
-          result: buildAttachedResultFromSearchResult(result, caseId),
-        })
+        detachResult(buildAttachedResultFromSearchResult(result, caseId))
       );
       dispatch(logCaseDetach(result));
     },

--- a/packages/headless/src/features/attached-results/attached-results-actions-loader.ts
+++ b/packages/headless/src/features/attached-results/attached-results-actions-loader.ts
@@ -1,13 +1,13 @@
 import type {PayloadAction} from '@reduxjs/toolkit';
 import type {InsightEngine} from '../../app/insight-engine/insight-engine.js';
-import {attachedResultsReducer as attachedResults} from '../../features/attached-results/attached-results-slice.js';
 import {
+  attachResult,
+  detachResult,
   type SetAttachedResultsActionCreatorPayload,
   setAttachedResults,
 } from './attached-results-actions.js';
+import {attachedResultsReducer as attachedResults} from './attached-results-slice.js';
 import type {AttachedResult} from './attached-results-state.js';
-
-export type {SetAttachedResultsActionCreatorPayload, AttachedResult};
 
 /**
  * The attached results action creators.
@@ -35,6 +35,22 @@ export interface AttachedResultsActionCreators {
   setAttachedResults(
     payload: SetAttachedResultsActionCreatorPayload
   ): PayloadAction<SetAttachedResultsActionCreatorPayload>;
+
+  /**
+   * Creates an action that attaches a result to a case.
+   *
+   * @param payload - The action creator payload containing the result to attach.
+   * @returns A dispatchable action.
+   */
+  attachResult(payload: AttachedResult): PayloadAction<AttachedResult>;
+
+  /**
+   * Creates an action that detaches a result from a case.
+   *
+   * @param payload - The action creator payload containing the result to detach.
+   * @returns A dispatchable action.
+   */
+  detachResult(payload: AttachedResult): PayloadAction<AttachedResult>;
 }
 
 /**
@@ -53,5 +69,7 @@ export function loadAttachedResultsActions(
 
   return {
     setAttachedResults,
+    detachResult,
+    attachResult,
   };
 }

--- a/packages/headless/src/features/attached-results/attached-results-actions.ts
+++ b/packages/headless/src/features/attached-results/attached-results-actions.ts
@@ -26,31 +26,25 @@ export interface SetAttachedResultsActionCreatorPayload {
   loading?: boolean;
 }
 
-interface SetAttachToCaseAttachActionCreatorPayload {
-  result: AttachedResult;
-}
-
-interface SetAttachToCaseDetachActionCreatorPayload {
-  result: AttachedResult;
-}
+const attachedResultPayloadDefinition = {
+  articleLanguage: nonEmptyString,
+  articlePublishStatus: nonEmptyString,
+  articleVersionNumber: nonEmptyString,
+  caseId: requiredNonEmptyString,
+  knowledgeArticleId: nonEmptyString,
+  name: nonEmptyString,
+  permanentId: nonEmptyString,
+  resultUrl: nonEmptyString,
+  source: nonEmptyString,
+  title: requiredNonEmptyString,
+  uriHash: nonEmptyString,
+};
 
 const RequiredAttachedResultRecord = new RecordValue({
   options: {
     required: true,
   },
-  values: {
-    articleLanguage: nonEmptyString,
-    articlePublishStatus: nonEmptyString,
-    articleVersionNumber: nonEmptyString,
-    caseId: requiredNonEmptyString,
-    knowledgeArticleId: nonEmptyString,
-    name: nonEmptyString,
-    permanentId: nonEmptyString,
-    resultUrl: nonEmptyString,
-    source: nonEmptyString,
-    title: requiredNonEmptyString,
-    uriHash: nonEmptyString,
-  },
+  values: attachedResultPayloadDefinition,
 });
 
 export const setAttachedResults = createAction(
@@ -69,24 +63,18 @@ export const setAttachedResults = createAction(
 
 export const attachResult = createAction(
   'insight/attachToCase/attach',
-  (payload: SetAttachToCaseAttachActionCreatorPayload) =>
-    validatePayloadAndPermanentIdOrUriHash(payload)
+  (payload: AttachedResult) => validatePayloadAndPermanentIdOrUriHash(payload)
 );
 
 export const detachResult = createAction(
   'insight/attachToCase/detach',
-  (payload: SetAttachToCaseDetachActionCreatorPayload) =>
-    validatePayloadAndPermanentIdOrUriHash(payload)
+  (payload: AttachedResult) => validatePayloadAndPermanentIdOrUriHash(payload)
 );
 
-const validatePayloadAndPermanentIdOrUriHash = (
-  payload:
-    | SetAttachToCaseAttachActionCreatorPayload
-    | SetAttachToCaseDetachActionCreatorPayload
-) => {
+const validatePayloadAndPermanentIdOrUriHash = (payload: AttachedResult) => {
   if (
-    isNullOrUndefined(payload.result.permanentId) &&
-    isNullOrUndefined(payload.result.uriHash)
+    isNullOrUndefined(payload.permanentId) &&
+    isNullOrUndefined(payload.uriHash)
   ) {
     return {
       payload,
@@ -97,7 +85,5 @@ const validatePayloadAndPermanentIdOrUriHash = (
       ),
     };
   }
-  return validatePayload(payload, {
-    result: RequiredAttachedResultRecord,
-  });
+  return validatePayload(payload, attachedResultPayloadDefinition);
 };

--- a/packages/headless/src/features/attached-results/attached-results-analytics-actions-loader.ts
+++ b/packages/headless/src/features/attached-results/attached-results-analytics-actions-loader.ts
@@ -1,0 +1,51 @@
+import type {Result} from '../../api/search/search/result.js';
+import type {InsightEngine} from '../../app/insight-engine/insight-engine.js';
+import type {InsightAction} from '../analytics/analytics-utils.js';
+import {
+  logCaseAttach,
+  logCaseDetach,
+} from './attached-results-analytics-actions.js';
+import {attachedResultsReducer as attachedResults} from './attached-results-slice.js';
+
+/**
+ * The attached results action creators.
+ *
+ * @group Actions
+ * @category AttachedResults
+ */
+export interface AttachedResultsAnalyticsActionCreators {
+  /**
+   * Creates an analytics action for when a case attach event occurs.
+   *
+   * @param result - The result to attach.
+   * @returns A dispatchable action.
+   */
+  logCaseAttach(result: Result): InsightAction;
+  /**
+   * Creates an analytics action for when a case detach event occurs.
+   *
+   * @param result - The result to detach.
+   * @returns A dispatchable action.
+   */
+  logCaseDetach(result: Result): InsightAction;
+}
+
+/**
+ * Loads the `attachedResults` reducer and returns possible analytics action creators.
+ *
+ * @param engine - The headless engine.
+ * @returns An object holding the analytics action creators.
+ *
+ * @group Actions
+ * @category AttachedResults
+ */
+export function loadAttachedResultsAnalyticsActions(
+  engine: InsightEngine
+): AttachedResultsAnalyticsActionCreators {
+  engine.addReducers({attachedResults});
+
+  return {
+    logCaseDetach,
+    logCaseAttach,
+  };
+}

--- a/packages/headless/src/features/attached-results/attached-results-slice.test.ts
+++ b/packages/headless/src/features/attached-results/attached-results-slice.test.ts
@@ -47,13 +47,12 @@ describe('attached results slice', () => {
     const finalState = attachedResultsReducer(state, action);
     expect(finalState).toStrictEqual(action.payload);
     expect(finalState.results.length).toEqual(0);
+    expect(finalState.loading).toBe(true);
   });
 
   it('#attachResult correctly adds a result in the attached state', () => {
     const testAttachedResult = createMockAttachedResult();
-    const action = attachResult({
-      result: testAttachedResult,
-    });
+    const action = attachResult(testAttachedResult);
     const finalState = attachedResultsReducer(state, action);
     expect(finalState.results.length).toEqual(1);
     expect(finalState.results).toStrictEqual([testAttachedResult]);
@@ -61,21 +60,19 @@ describe('attached results slice', () => {
 
   it('#attachResult correctly adds multiple results in the attached state', () => {
     const ids = ['foo', 'bar', 'baz'];
-    const results = ids.map((id) =>
+    const attachedResults = ids.map((id) =>
       createMockAttachedResult({
         permanentId: id,
       })
     );
     let finalState = attachedResultsReducer(state, {type: ''});
-    results.forEach((result) => {
-      const action = attachResult({
-        result: result,
-      });
+    attachedResults.forEach((attachedResult) => {
+      const action = attachResult(attachedResult);
       finalState = attachedResultsReducer(finalState, action);
     });
 
-    expect(finalState.results.length).toEqual(results.length);
-    expect(finalState.results).toStrictEqual([...results]);
+    expect(finalState.results.length).toEqual(attachedResults.length);
+    expect(finalState.results).toStrictEqual([...attachedResults]);
   });
 
   it('#attachResult correctly attaches results so we can find them later', () => {
@@ -83,9 +80,7 @@ describe('attached results slice', () => {
     const testAttachedResult = createMockAttachedResult({
       permanentId: testPermanentId,
     });
-    const action = attachResult({
-      result: testAttachedResult,
-    });
+    const action = attachResult(testAttachedResult);
     const finalState = attachedResultsReducer(state, action);
 
     expect(finalState.results).toContainEqual(testAttachedResult);
@@ -93,9 +88,7 @@ describe('attached results slice', () => {
 
   it('#detachResult can be called when no results are attached without breaking', () => {
     const testDetachResult = createMockAttachedResult();
-    const action = detachResult({
-      result: testDetachResult,
-    });
+    const action = detachResult(testDetachResult);
 
     const finalState = attachedResultsReducer(state, action);
     expect(finalState.results.length).toEqual(0);
@@ -107,14 +100,10 @@ describe('attached results slice', () => {
       permanentId: testPermanentId,
     });
 
-    const attachAction = attachResult({
-      result: testDetachResult,
-    });
+    const attachAction = attachResult(testDetachResult);
     const intermediateState = attachedResultsReducer(state, attachAction);
 
-    const detachAction = detachResult({
-      result: testDetachResult,
-    });
+    const detachAction = detachResult(testDetachResult);
     const finalState = attachedResultsReducer(intermediateState, detachAction);
 
     expect(finalState.results.length).toEqual(0);
@@ -140,9 +129,7 @@ describe('attached results slice', () => {
     const resultToDetach = createMockAttachedResult({
       permanentId: permanentIdToTest,
     });
-    const detachAction = detachResult({
-      result: resultToDetach,
-    });
+    const detachAction = detachResult(resultToDetach);
     const finalState = attachedResultsReducer(intermediateState, detachAction);
 
     const expectedAttachedResults = attachedResults.slice(1, 3);

--- a/packages/headless/src/features/attached-results/attached-results-slice.ts
+++ b/packages/headless/src/features/attached-results/attached-results-slice.ts
@@ -28,15 +28,15 @@ export const attachedResultsReducer = createReducer(
       })
       .addCase(attachResult, (state, action) => {
         if (
-          !isNullOrUndefined(action.payload.result.permanentId) ||
-          !isNullOrUndefined(action.payload.result.uriHash)
+          !isNullOrUndefined(action.payload.permanentId) ||
+          !isNullOrUndefined(action.payload.uriHash)
         ) {
-          state.results = [...state.results, action.payload.result];
+          state.results = [...state.results, action.payload];
         }
       })
       .addCase(detachResult, (state, action) => {
         state.results = state.results.filter((result) =>
-          attachedResultsMatchIds(result, action.payload.result)
+          attachedResultsMatchIds(result, action.payload)
         );
       });
   }

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -308,6 +308,7 @@ export {buildInsightInterface} from './controllers/insight-interface/insight-int
 export * from './features/analytics/generic-analytics-actions-loader.js';
 export * from './features/analytics/insight-analytics-actions-loader.js';
 export * from './features/attached-results/attached-results-actions-loader.js';
+export * from './features/attached-results/attached-results-analytics-actions-loader.js';
 export * from './features/case-context/case-context-actions-loader.js';
 export * from './features/context/context-actions-loader.js';
 export type {


### PR DESCRIPTION
## SFINT-6317

### 🎯 Summary
This PR exposes the attached results action creators and analytics actions for the Insight engine, making them available for programmatic use. It also simplifies the API for attach and detach actions by using direct payload structures.

### 🔧 Key Changes
 #### 1. Exposed Attached Results Actions
  - Added `attachResult` and `detachResult` to the AttachedResultsActionCreators interface.
  - Updated loadAttachedResultsActions to return these new action creators, Consumers can now programmatically   attach/detach results from cases.
 #### 2. New Attached Results Analytics Actions Loader
   - Created `loadAttachedResultsAnalyticsActions` function returning the `AttachedResultsAnalyticsActionCreators`
   - Included `logCaseAttach` and `logCaseDetach` analytics actions `AttachedResultsAnalyticsActionCreators`
   - Exposed the `loadAttachedResultsAnalyticsActions` function in the Headless  insight bundle.
 #### 3. Simplified Attached Results Action API
   - Streamlined `attachResult` and `detachResult` actions to accept an `AttachedResult` directly instead of `{result: AttachedResult}`, removed unnecessary wrapper objects for cleaner API
   - Updated controller and tests to use the simplified structure

### 📈 Benefits
  - Enhanced Developer Experience by providing direct programmatic access to attach/detach functionality, this will allow the implementation of the Standalone Attached Results feature documented here: [📎 Proposed Solution - Standalone Attached Results Component with Quantic](https://coveord.atlassian.net/wiki/spaces/SFINT/pages/5456822375/Proposed+Solution+-+Standalone+Attached+Results+Component+with+Quantic#Path-2-%E2%80%93-Minimalistic-Solution-%E2%9A%A1%EF%B8%8F)
  - Cleaner API: Simplified payload structure for more intuitive usage

### 🧪 Testing
  - Updated unit tests for controller and slice functionality
  - Enhanced test assertions for better coverage
  - All existing functionality preserved
