### PR TITLE
chore(atomic): move computeNumberOfStars into dedicated rating-utils file

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.ts
@@ -3,10 +3,7 @@ import {html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import ratingStyles from '@/src/components/common/atomic-rating/atomic-rating.tw.css.js';
-import {
-  computeNumberOfStars,
-  renderRating,
-} from '@/src/components/common/atomic-rating/rating.js';
+import {computeNumberOfStars} from '@/src/components/common/atomic-rating/rating-utils.js';
 import {bindingGuard} from '@/src/decorators/binding-guard';
 import {bindings} from '@/src/decorators/bindings.js';
 import {createProductContextController} from '@/src/decorators/commerce/product-template-decorators.js';
@@ -14,6 +11,7 @@ import {errorGuard} from '@/src/decorators/error-guard';
 import type {InitializableComponent} from '@/src/decorators/types.js';
 import {LightDomMixin} from '@/src/mixins/light-dom';
 import Star from '../../../images/star.svg';
+import {renderRating} from '../../common/atomic-rating/rating';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface.js';
 
 /**

--- a/packages/atomic/src/components/common/atomic-rating/rating-utils.spec.ts
+++ b/packages/atomic/src/components/common/atomic-rating/rating-utils.spec.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from 'vitest';
+import {FieldValueIsNaNError} from '../../commerce/product-template-component-utils/error';
+import {computeNumberOfStars} from './rating-utils';
+
+describe('rating-utils', () => {
+  describe('#computeNumberOfStars', () => {
+    it('should return number for valid numeric value', () => {
+      const result = computeNumberOfStars(4.5, 'rating');
+
+      expect(result).toBe(4.5);
+    });
+
+    it('should return number for string numeric value', () => {
+      const result = computeNumberOfStars('3.2', 'rating');
+
+      expect(result).toBe(3.2);
+    });
+
+    it('should return null for null value', () => {
+      const result = computeNumberOfStars(null, 'rating');
+
+      expect(result).toBe(null);
+    });
+
+    it('should throw FieldValueIsNaNError for non-numeric string', () => {
+      expect(() => computeNumberOfStars('not-a-number', 'rating')).toThrow(
+        FieldValueIsNaNError
+      );
+    });
+
+    it('should throw FieldValueIsNaNError for undefined value', () => {
+      expect(() => computeNumberOfStars(undefined, 'rating')).toThrow(
+        FieldValueIsNaNError
+      );
+    });
+
+    it('should include the field name and value in the error', () => {
+      expect(() => computeNumberOfStars('invalid', 'custom_field')).toThrow(
+        new FieldValueIsNaNError('custom_field', 'invalid')
+      );
+    });
+  });
+});

--- a/packages/atomic/src/components/common/atomic-rating/rating-utils.ts
+++ b/packages/atomic/src/components/common/atomic-rating/rating-utils.ts
@@ -1,0 +1,15 @@
+import {FieldValueIsNaNError} from '@/src/components/commerce/product-template-component-utils/error';
+
+export const computeNumberOfStars = (
+  value: unknown,
+  field: string
+): number | null => {
+  if (value === null) {
+    return null;
+  }
+  const valueAsNumber = parseFloat(`${value}`);
+  if (Number.isNaN(valueAsNumber)) {
+    throw new FieldValueIsNaNError(field, value);
+  }
+  return valueAsNumber;
+};

--- a/packages/atomic/src/components/common/atomic-rating/rating.spec.ts
+++ b/packages/atomic/src/components/common/atomic-rating/rating.spec.ts
@@ -3,177 +3,136 @@ import {html} from 'lit';
 import {beforeAll, describe, expect, it} from 'vitest';
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
-import {FieldValueIsNaNError} from '../../commerce/product-template-component-utils/error';
-import {computeNumberOfStars, type RatingProps, renderRating} from './rating';
+import {type RatingProps, renderRating} from './rating';
 
-describe('rating', () => {
-  describe('#renderRating', () => {
-    let i18n: i18n;
+describe('#renderRating', () => {
+  let i18n: i18n;
 
-    beforeAll(async () => {
-      i18n = await createTestI18n();
-    });
+  beforeAll(async () => {
+    i18n = await createTestI18n();
+  });
 
-    const renderComponent = async (overrides: Partial<RatingProps> = {}) => {
-      const defaultProps: RatingProps = {
-        i18n,
-        numberOfTotalIcons: 5,
-        numberOfActiveIcons: 3,
-        icon: '<svg>star</svg>',
-        ...overrides,
-      };
-
-      const element = await renderFunctionFixture(
-        html`${renderRating({props: defaultProps})}`
-      );
-
-      return {
-        ratingContainer: element.querySelector('div[part="value-rating"]'),
-        inactiveIcons: element.querySelectorAll('.z-0 atomic-icon'),
-        activeIconsContainer: element.querySelector('.z-1'),
-        activeIcons: element.querySelectorAll('.z-1 atomic-icon'),
-        allIcons: element.querySelectorAll('atomic-icon'),
-      };
+  const renderComponent = async (overrides: Partial<RatingProps> = {}) => {
+    const defaultProps: RatingProps = {
+      i18n,
+      numberOfTotalIcons: 5,
+      numberOfActiveIcons: 3,
+      icon: '<svg>star</svg>',
+      ...overrides,
     };
 
-    it('should render the rating container with correct part', async () => {
-      const {ratingContainer} = await renderComponent();
+    const element = await renderFunctionFixture(
+      html`${renderRating({props: defaultProps})}`
+    );
 
-      expect(ratingContainer).toHaveAttribute('part', 'value-rating');
+    return {
+      ratingContainer: element.querySelector('div[part="value-rating"]'),
+      inactiveIcons: element.querySelectorAll('.z-0 atomic-icon'),
+      activeIconsContainer: element.querySelector('.z-1'),
+      activeIcons: element.querySelectorAll('.z-1 atomic-icon'),
+      allIcons: element.querySelectorAll('atomic-icon'),
+    };
+  };
+
+  it('should render the rating container with correct part', async () => {
+    const {ratingContainer} = await renderComponent();
+
+    expect(ratingContainer).toHaveAttribute('part', 'value-rating');
+  });
+
+  it('should render the rating container with role img', async () => {
+    const {ratingContainer} = await renderComponent();
+
+    expect(ratingContainer).toHaveAttribute('role', 'img');
+  });
+
+  it('should render correct aria-label from i18n', async () => {
+    const {ratingContainer} = await renderComponent({
+      numberOfActiveIcons: 4,
+      numberOfTotalIcons: 5,
     });
 
-    it('should render the rating container with role img', async () => {
-      const {ratingContainer} = await renderComponent();
+    expect(ratingContainer).toHaveAttribute('aria-label', '4 stars out of 5');
+  });
 
-      expect(ratingContainer).toHaveAttribute('role', 'img');
-    });
+  it('should render correct number of total icons', async () => {
+    const {allIcons} = await renderComponent({numberOfTotalIcons: 7});
 
-    it('should render correct aria-label from i18n', async () => {
-      const {ratingContainer} = await renderComponent({
-        numberOfActiveIcons: 4,
-        numberOfTotalIcons: 5,
-      });
+    expect(allIcons).toHaveLength(14); // 7 inactive + 7 active
+  });
 
-      expect(ratingContainer).toHaveAttribute('aria-label', '4 stars out of 5');
-    });
+  it('should render inactive icons with correct class', async () => {
+    const {inactiveIcons} = await renderComponent();
 
-    it('should render correct number of total icons', async () => {
-      const {allIcons} = await renderComponent({numberOfTotalIcons: 7});
-
-      expect(allIcons).toHaveLength(14); // 7 inactive + 7 active
-    });
-
-    it('should render inactive icons with correct class', async () => {
-      const {inactiveIcons} = await renderComponent();
-
-      inactiveIcons.forEach((icon) => {
-        expect(icon).toHaveClass('text-rating-icon-inactive');
-      });
-    });
-
-    it('should render active icons with correct class', async () => {
-      const {activeIcons} = await renderComponent();
-
-      activeIcons.forEach((icon) => {
-        expect(icon).toHaveClass('text-rating-icon-active');
-      });
-    });
-
-    it('should set correct width percentage for active icons container', async () => {
-      const {activeIconsContainer} = await renderComponent({
-        numberOfActiveIcons: 3,
-        numberOfTotalIcons: 5,
-      });
-
-      expect(activeIconsContainer).toHaveStyle('width: 60%');
-    });
-
-    it('should apply custom icon size when provided', async () => {
-      const {allIcons} = await renderComponent({iconSize: 1.5});
-
-      allIcons.forEach((icon) => {
-        expect(icon).toHaveStyle('width: 1.5rem; height: 1.5rem');
-      });
-    });
-
-    it('should use default icon size when not provided', async () => {
-      const {allIcons} = await renderComponent();
-
-      allIcons.forEach((icon) => {
-        expect(icon).toHaveStyle('width: 0.75rem; height: 0.75rem');
-      });
-    });
-
-    it('should render icons with correct part attribute', async () => {
-      const {allIcons} = await renderComponent();
-
-      allIcons.forEach((icon) => {
-        expect(icon).toHaveAttribute('part', 'value-rating-icon');
-      });
-    });
-
-    it('should handle zero active icons', async () => {
-      const {activeIconsContainer} = await renderComponent({
-        numberOfActiveIcons: 0,
-      });
-
-      expect(activeIconsContainer).toHaveStyle('width: 0%');
-    });
-
-    it('should handle full rating', async () => {
-      const {activeIconsContainer} = await renderComponent({
-        numberOfActiveIcons: 5,
-        numberOfTotalIcons: 5,
-      });
-
-      expect(activeIconsContainer).toHaveStyle('width: 100%');
-    });
-
-    it('should handle fractional active icons', async () => {
-      const {activeIconsContainer} = await renderComponent({
-        numberOfActiveIcons: 3.7,
-        numberOfTotalIcons: 5,
-      });
-
-      expect(activeIconsContainer).toHaveStyle('width: 74%');
+    inactiveIcons.forEach((icon) => {
+      expect(icon).toHaveClass('text-rating-icon-inactive');
     });
   });
 
-  describe('#computeNumberOfStars', () => {
-    it('should return number for valid numeric value', () => {
-      const result = computeNumberOfStars(4.5, 'rating');
+  it('should render active icons with correct class', async () => {
+    const {activeIcons} = await renderComponent();
 
-      expect(result).toBe(4.5);
+    activeIcons.forEach((icon) => {
+      expect(icon).toHaveClass('text-rating-icon-active');
+    });
+  });
+
+  it('should set correct width percentage for active icons container', async () => {
+    const {activeIconsContainer} = await renderComponent({
+      numberOfActiveIcons: 3,
+      numberOfTotalIcons: 5,
     });
 
-    it('should return number for string numeric value', () => {
-      const result = computeNumberOfStars('3.2', 'rating');
+    expect(activeIconsContainer).toHaveStyle('width: 60%');
+  });
 
-      expect(result).toBe(3.2);
+  it('should apply custom icon size when provided', async () => {
+    const {allIcons} = await renderComponent({iconSize: 1.5});
+
+    allIcons.forEach((icon) => {
+      expect(icon).toHaveStyle('width: 1.5rem; height: 1.5rem');
+    });
+  });
+
+  it('should use default icon size when not provided', async () => {
+    const {allIcons} = await renderComponent();
+
+    allIcons.forEach((icon) => {
+      expect(icon).toHaveStyle('width: 0.75rem; height: 0.75rem');
+    });
+  });
+
+  it('should render icons with correct part attribute', async () => {
+    const {allIcons} = await renderComponent();
+
+    allIcons.forEach((icon) => {
+      expect(icon).toHaveAttribute('part', 'value-rating-icon');
+    });
+  });
+
+  it('should handle zero active icons', async () => {
+    const {activeIconsContainer} = await renderComponent({
+      numberOfActiveIcons: 0,
     });
 
-    it('should return null for null value', () => {
-      const result = computeNumberOfStars(null, 'rating');
+    expect(activeIconsContainer).toHaveStyle('width: 0%');
+  });
 
-      expect(result).toBe(null);
+  it('should handle full rating', async () => {
+    const {activeIconsContainer} = await renderComponent({
+      numberOfActiveIcons: 5,
+      numberOfTotalIcons: 5,
     });
 
-    it('should throw FieldValueIsNaNError for non-numeric string', () => {
-      expect(() => computeNumberOfStars('not-a-number', 'rating')).toThrow(
-        FieldValueIsNaNError
-      );
+    expect(activeIconsContainer).toHaveStyle('width: 100%');
+  });
+
+  it('should handle fractional active icons', async () => {
+    const {activeIconsContainer} = await renderComponent({
+      numberOfActiveIcons: 3.7,
+      numberOfTotalIcons: 5,
     });
 
-    it('should throw FieldValueIsNaNError for undefined value', () => {
-      expect(() => computeNumberOfStars(undefined, 'rating')).toThrow(
-        FieldValueIsNaNError
-      );
-    });
-
-    it('should include the field name and value in the error', () => {
-      expect(() => computeNumberOfStars('invalid', 'custom_field')).toThrow(
-        new FieldValueIsNaNError('custom_field', 'invalid')
-      );
-    });
+    expect(activeIconsContainer).toHaveStyle('width: 74%');
   });
 });

--- a/packages/atomic/src/components/common/atomic-rating/rating.ts
+++ b/packages/atomic/src/components/common/atomic-rating/rating.ts
@@ -3,7 +3,6 @@ import {html} from 'lit';
 import {styleMap} from 'lit/directives/style-map.js';
 import {multiClassMap, tw} from '@/src/directives/multi-class-map';
 import type {FunctionalComponent} from '@/src/utils/functional-component-utils';
-import {FieldValueIsNaNError} from '../../commerce/product-template-component-utils/error';
 
 interface RatingProps {
   i18n: i18n;
@@ -81,18 +80,4 @@ export const renderRating: FunctionalComponent<RatingProps> = ({props}) => {
       ${filledIconDisplay()}
     </div>
   </div>`;
-};
-
-export const computeNumberOfStars = (
-  value: unknown,
-  field: string
-): number | null => {
-  if (value === null) {
-    return null;
-  }
-  const valueAsNumber = parseFloat(`${value}`);
-  if (Number.isNaN(valueAsNumber)) {
-    throw new FieldValueIsNaNError(field, value);
-  }
-  return valueAsNumber;
 };


### PR DESCRIPTION
Simple refactoring, no change in the logic.

IMO it's a bit weird to have an exported util function in the same file as a functional component.

https://coveord.atlassian.net/browse/KIT-5005
