### PR TITLE
chore: sync-up arborist & npm

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,7 +22,7 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'npm'
     - name: Install npm
-      run: npm i -g npm@11.4.2
+      run: npm i -g npm@11.6.0
       shell: bash
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - run: npm ci
       - run: npm run pr:report
@@ -61,7 +61,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - name: Install dependencies
         run: npm ci
@@ -642,7 +642,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - run: npm ci
         shell: bash
@@ -675,7 +675,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - run: npm ci
         shell: bash
@@ -811,7 +811,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - run: npm ci
         shell: bash
@@ -843,7 +843,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
       - name: Install npm
-        run: npm i -g npm@11.4.2
+        run: npm i -g npm@11.6.0
         shell: bash
       - run: npm ci
         shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11198,6 +11198,60 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/@npmcli/arborist": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.1.4.tgz",
+      "integrity": "sha512-2Co31oEFlzT9hYjGahGL4PqDXXpA18tX9yu55j5on+m2uDiyBoljQjHNnnNVCji4pFUjawlHi23tQ4j2A5gHow==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/metavuln-calculator": "^9.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/query": "^4.0.0",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "bin-links": "^5.0.0",
+        "cacache": "^19.0.1",
+        "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^8.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^8.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "pacote": "^21.0.0",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "proggy": "^3.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "read-package-json-fast": "^4.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^12.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/@npmcli/fs": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
@@ -50633,7 +50687,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@coveo/semantic-monorepo-tools": "2.6.11",
-        "@npmcli/arborist": "9.1.3",
+        "@npmcli/arborist": "9.1.4",
         "conventional-changelog-conventionalcommits": "8.0.0",
         "dependency-graph": "1.0.0",
         "octokit": "4.1.4",
@@ -50644,54 +50698,6 @@
         "@types/conventional-changelog-writer": "4.0.10",
         "@types/npmcli__arborist": "6.3.1",
         "typescript": "5.8.3"
-      }
-    },
-    "utils/ci/node_modules/@npmcli/arborist": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.1.3.tgz",
-      "integrity": "sha512-PvwtZD1dipP5VByHyWX28tZfan1AkfBLenJTgr0rDdEbdovZc06Z5PHdGb5SEeN7EERl68wFH8lq6WvuUHmgrw==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/metavuln-calculator": "^9.0.0",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "bin-links": "^5.0.0",
-        "cacache": "^19.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^8.0.0",
-        "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^10.2.2",
-        "minimatch": "^9.0.4",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "pacote": "^21.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^3.0.1",
-        "read-package-json-fast": "^4.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^12.0.0",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "utils/ci/node_modules/conventional-changelog-conventionalcommits": {
@@ -50705,12 +50711,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "utils/ci/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,5 +125,5 @@
     "node": "^22.14.0",
     "npm": ">=8.6.0"
   },
-  "packageManager": "npm@11.4.2"
+  "packageManager": "npm@11.6.0"
 }

--- a/utils/ci/package.json
+++ b/utils/ci/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@coveo/semantic-monorepo-tools": "2.6.11",
-    "@npmcli/arborist": "9.1.3",
+    "@npmcli/arborist": "9.1.4",
     "conventional-changelog-conventionalcommits": "8.0.0",
     "dependency-graph": "1.0.0",
     "octokit": "4.1.4",


### PR DESCRIPTION
With [Arborist 9.1.3](https://github.com/npm/cli/blob/latest/workspaces/arborist/CHANGELOG.md#913-2025-07-24), a tune-up on the Arborist algorithm was made so that optional "dangling" (i.e. without actual explicit dependency/ask) are now removed when the tree is reifed. See https://github.com/npm/cli/pull/8431

However, [NPM 11.4.2](https://github.com/npm/cli/releases/tag/v11.4.2) was explicitly using Arborist 9.1.2, which does not do that.

This caused a discrepancy between the package-lock check executed by `npm ci` (using arborist 9.1.2) and the result of our reify (using arborist 9.1.3/4).

One of the particularities of `npm ci` is that it fails early if the package-lock seems inadequate/incomplete, leading to `npm ci` failing as long as the version of arborist we use is out-of-sync (and incompatible) with the one used by the `npm` version that we use.

## Why do we reify?

We elected to run manual update operations using Arborist over using the npm-cli to avoid changes to the transitive dependency during the release process:
Indeed, we do not necessarily want to "unfreeze" our transitive dependency at release time; we just want to "bump" the version of **our** packages

## What's the fix-it-twice?

Switching to `pnpm` with its default options (notably [`preferFrozenLockFile`](https://pnpm.io/settings#preferfrozenlockfile)) and replacing the reify script with [`pnpm up --workspace`](https://pnpm.io/cli/update#--workspace) should fix the issue by using the exact same code-path (i.e. pnpm) for all lockfile operations.