### PR TITLE
chore(atomic commerce): deprecate language property and add updateLocale method on atomic-commerce-interface

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/components.ts
@@ -2094,7 +2094,7 @@ export declare interface AtomicCommerceFacets extends LitAtomicCommerceFacets {
 
 @ProxyCmp({
   inputs: ['type', 'analytics', 'logLevel', 'language', 'reflectStateInUrl', 'disableStateReflectionInUrl', 'scrollContainer', 'languageAssetsPath', 'iconAssetsPath'],
-  methods: ['initialize', 'initializeWithEngine', 'executeFirstRequest', 'toggleAnalytics', 'updateIconAssetsPath', 'updateLanguage', 'scrollToTop'],
+  methods: ['initialize', 'initializeWithEngine', 'executeFirstRequest', 'updateLocale', 'toggleAnalytics', 'updateIconAssetsPath', 'updateLanguage', 'scrollToTop'],
   defineCustomElementFn: () => {customElements.get('atomic-commerce-interface') || customElements.define('atomic-commerce-interface', LitAtomicCommerceInterface);}
 })
 @Component({

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
@@ -7,6 +7,7 @@ import {
   getSampleCommerceEngineConfiguration,
   type LogLevel,
   loadConfigurationActions,
+  loadContextActions,
   loadQueryActions,
   type ProductListingSummaryState,
   type SearchSummaryState,
@@ -325,8 +326,13 @@ describe('atomic-commerce-interface', () => {
       expect(updateLanguageSpy).toHaveBeenCalledOnce();
     });
 
+    // TODO - (v4) KIT-4365: Eliminate the describe wrapper; we'll always set the language from the context state in v4.
     describe('when the language prop is not specified', () => {
       it('should set the language from the context state', async () => {
+        const onLanguageChangeSpy = vi.spyOn(
+          InterfaceController.prototype,
+          'onLanguageChange'
+        );
         const element = await setupElement();
         const fakeContext = buildFakeContext({
           state: {language: 'es'},
@@ -337,18 +343,17 @@ describe('atomic-commerce-interface', () => {
 
         await callTestedInitMethod(element);
 
-        expect(element.language).toBe('es');
+        expect(onLanguageChangeSpy).toHaveBeenCalledExactlyOnceWith('es');
       });
 
-      it('should call #updateLanguage twice', async () => {
+      // TODO - (v4) KIT-4365: Remove this test in v4
+      it('should call #updateLanguage', async () => {
         const element = await setupElement();
         const updateLanguageSpy = vi.spyOn(element, 'updateLanguage');
 
         await callTestedInitMethod(element);
 
-        // 1st call: exit early because language is not specified
-        // 2nd call: triggered by the @watch decorator when language is set from context state
-        expect(updateLanguageSpy).toHaveBeenCalledTimes(2);
+        expect(updateLanguageSpy).toHaveBeenCalledOnce();
       });
     });
 
@@ -1064,6 +1069,126 @@ describe('atomic-commerce-interface', () => {
     });
   });
 
+  describe('#updateLocale', () => {
+    it('should do nothing when the engine has not been created', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const element = await setupElement();
+      const onLanguageChangeSpy = vi.spyOn(
+        InterfaceController.prototype,
+        'onLanguageChange'
+      );
+      const setContextMock = vi.fn();
+      vi.mocked(loadContextActions).mockReturnValue({
+        setContext: setContextMock,
+      } as unknown as ReturnType<typeof loadContextActions>);
+
+      element.updateLocale('fr', 'FR', 'EUR');
+
+      expect(onLanguageChangeSpy).not.toHaveBeenCalled();
+      expect(setContextMock).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when the context is not defined', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(buildContext).mockReturnValue(undefined as never);
+      const element = await setupElement();
+      const engine = buildFakeCommerceEngine();
+      element.initializeWithEngine(engine);
+      const onLanguageChangeSpy = vi.spyOn(
+        InterfaceController.prototype,
+        'onLanguageChange'
+      );
+      const setContextMock = vi.fn();
+      vi.mocked(loadContextActions).mockReturnValue({
+        setContext: setContextMock,
+      } as unknown as ReturnType<typeof loadContextActions>);
+
+      element.updateLocale('fr', 'FR', 'EUR');
+
+      expect(onLanguageChangeSpy).not.toHaveBeenCalled();
+      expect(setContextMock).not.toHaveBeenCalled();
+    });
+
+    describe('when the engine has been created and the context is defined', () => {
+      let element: AtomicCommerceInterface;
+      let engine: ReturnType<typeof buildFakeCommerceEngine>;
+      let onLanguageChangeSpy: ReturnType<typeof vi.spyOn>;
+      let setContextMock: ReturnType<typeof vi.fn>;
+
+      beforeEach(async () => {
+        element = await setupElement();
+        engine = buildFakeCommerceEngine({});
+
+        await element.initializeWithEngine(engine);
+
+        setContextMock = vi.fn();
+        vi.mocked(loadContextActions).mockReturnValue({
+          setContext: setContextMock,
+        } as unknown as ReturnType<typeof loadContextActions>);
+        onLanguageChangeSpy = vi.spyOn(
+          InterfaceController.prototype,
+          'onLanguageChange'
+        );
+      });
+
+      it('should call InterfaceController.onLanguageChange when the language parameter is provided', async () => {
+        element.updateLocale('fr');
+
+        expect(onLanguageChangeSpy).toHaveBeenCalledExactlyOnceWith('fr');
+      });
+
+      it('should not call InterfaceController.onLanguageChange when the language parameter is not provided', async () => {
+        element.updateLocale(undefined, 'FR', 'EUR');
+
+        expect(onLanguageChangeSpy).not.toHaveBeenCalled();
+      });
+
+      it('should dispatch a setContext action with the new language when it is defined and different from the language value in the context', async () => {
+        element.updateLocale('fr');
+
+        expect(setContextMock).toHaveBeenCalledExactlyOnceWith({
+          ...element.context.state,
+          language: 'fr',
+        });
+      });
+
+      it('should dispatch a setContext action with the new country when it is defined and different from the country value in the context', async () => {
+        element.updateLocale(undefined, 'FR');
+
+        expect(setContextMock).toHaveBeenCalledExactlyOnceWith({
+          ...element.context.state,
+          country: 'FR',
+        });
+      });
+
+      it('should dispatch a setContext action with the new currency when it is defined and different from the currency value in the context', async () => {
+        element.updateLocale(undefined, undefined, 'EUR');
+
+        expect(setContextMock).toHaveBeenCalledExactlyOnceWith({
+          ...element.context.state,
+          currency: 'EUR',
+        });
+      });
+
+      it('should dispatch a setContext action with all values when all parameters are provided and any of them is different from its corresponding value in the context', async () => {
+        element.updateLocale('fr', 'US', 'USD'); // Only 'fr' is different
+
+        expect(setContextMock).toHaveBeenCalledExactlyOnceWith({
+          ...element.context.state,
+          language: 'fr',
+          country: 'US',
+          currency: 'USD',
+        });
+      });
+
+      it('should not dispatch a setContext action when each provided parameters is identical to its corresponding value in the context', async () => {
+        element.updateLocale('en', 'US', 'USD');
+
+        expect(setContextMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   // #toggleAnalytics
   it('should call InterfaceController.onAnalyticsChange when the analytics attribute changes', async () => {
     const element = await setupElement();
@@ -1115,7 +1240,7 @@ describe('atomic-commerce-interface', () => {
       element.language = 'fr';
       await element.updateComplete;
 
-      expect(element.context).toBeUndefined();
+      expect(element.engine).toBeUndefined();
       expect(onLanguageChangeSpy).not.toHaveBeenCalled();
     });
 
@@ -1133,9 +1258,33 @@ describe('atomic-commerce-interface', () => {
       expect(onLanguageChangeSpy).not.toHaveBeenCalled();
     });
 
+    it('should do nothing when the context is not defined', async () => {
+      const onLanguageChangeSpy = vi.spyOn(
+        InterfaceController.prototype,
+        'onLanguageChange'
+      );
+      const element = await setupElement({language: 'en'});
+      element.engine = buildFakeCommerceEngine(); // Simulate that the engine was created but the context wasn't built
+
+      element.language = 'fr';
+      await element.updateComplete;
+
+      expect(element.context).toBeUndefined();
+      expect(onLanguageChangeSpy).not.toHaveBeenCalled();
+    });
+
     describe('when the engine has been created & the language attribute is defined & the context is defined', () => {
       it('should log a deprecation warning', async () => {
-        // TODO - KIT-4993: Add this test temporarily.
+        const element = await setupElement();
+        const engine = buildFakeCommerceEngine();
+        await element.initializeWithEngine(engine);
+
+        element.language = 'fr';
+        await element.updateComplete;
+
+        expect(engine.logger.warn).toHaveBeenCalledExactlyOnceWith(
+          'The `language` property will be removed in the next major version of Atomic (v4). Rather than using this property, set the initial language through the engine configuration when calling `initialize` or `initializeWithEngine`, and update the language as needed using the `updateLocale` method.'
+        );
       });
 
       it('should call InterfaceController.onLanguageChange with no argument', async () => {
@@ -1153,9 +1302,6 @@ describe('atomic-commerce-interface', () => {
       });
     });
   });
-
-  // #updateLocale
-  // TODO - KIT-4993: Add these tests.
 
   describe('#disconnectedCallback (when removed from the DOM)', () => {
     // Done through the InterfaceController

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
@@ -9,6 +9,7 @@ import {
   VERSION as HEADLESS_VERSION,
   type LogLevel,
   loadConfigurationActions,
+  loadContextActions,
   loadQueryActions,
   type ProductListing,
   type ProductListingSummaryState,
@@ -18,6 +19,7 @@ import {
   type Unsubscribe,
   type UrlManager,
 } from '@coveo/headless/commerce';
+import type {CurrencyCodeISO4217} from '@coveo/relay-event-types';
 import {provide} from '@lit/context';
 import i18next, {type i18n} from 'i18next';
 import {type CSSResultGroup, css, html, LitElement} from 'lit';
@@ -138,12 +140,17 @@ export class AtomicCommerceInterface
    */
   @property({type: Object, attribute: false}) i18n: i18n;
 
-  // TODO - KIT-4993: Mark as deprecated in favor of updateLocale method.
-  // TODO - (v4) KIT-4365: Remove.
+  // TODO - (v4) KIT-4365: Remove (or turn into private state attribute)
   /**
    * The commerce interface language.
    *
-   * Will default to the value set in the Headless engine context if not provided.
+   * Will default to the value set in the Headless engine context if not
+   * provided.
+   *
+   * @deprecated - This property will be removed in the next major version of
+   * Atomic (v4). Rather than using this property, set the initial language
+   * through the engine configuration when calling `initializeWithEngine`, and
+   * update the language as needed using the `updateLocale` method.
    */
   @property({type: String, attribute: 'language', reflect: true})
   language?: string;
@@ -292,6 +299,52 @@ export class AtomicCommerceInterface
     }
   }
 
+  /**
+   * Updates the locale settings for the commerce interface and headless commerce
+   * engine. Only the provided parameters will be updated.
+   *
+   * Calling this method affects the localization of the interface as well as
+   * the catalog configuration being used by the Commerce API. If the resulting
+   * language-country-currency combination matches no existing catalog
+   * configuration in your Coveo organization, requests made through the
+   * commerce engine will start failing.
+   *
+   * @param language - (Optional) The IETF language code tag (e.g., `en`).
+   * @param country - (Optional) The ISO-3166-1 country tag (e.g., `US`).
+   * @param currency - (Optional) The ISO-4217 currency code (e.g., `USD`).
+   *
+   * @example
+   * ```typescript
+   * interface.updateLocale('fr', 'CA', 'CAD');
+   * ```
+   */
+  public updateLocale(
+    language?: string,
+    country?: string,
+    currency?: CurrencyCodeISO4217
+  ): void {
+    if (
+      !this.interfaceController.engineIsCreated(this.engine) ||
+      !this.context
+    ) {
+      return;
+    }
+
+    language && this.interfaceController.onLanguageChange(language);
+
+    if (this.isNewLocale(language, country, currency)) {
+      const {setContext} = loadContextActions(this.engine);
+      this.engine.dispatch(
+        setContext({
+          ...this.context.state,
+          ...(language && {language}),
+          ...(country && {country}),
+          ...(currency && {currency}),
+        })
+      );
+    }
+  }
+
   @watch('analytics')
   public toggleAnalytics() {
     this.interfaceController.onAnalyticsChange();
@@ -313,13 +366,14 @@ export class AtomicCommerceInterface
       return;
     }
 
-    // TODO - KIT-4993: Add temporary deprecation warning.
+    this.engine.logger.warn(
+      'The `language` property will be removed in the next major version of Atomic (v4). Rather than using this property, set the initial language through the engine configuration when calling `initialize` or `initializeWithEngine`, and update the language as needed using the `updateLocale` method.'
+    );
 
     this.context.setLanguage(this.language);
+
     return this.interfaceController.onLanguageChange();
   }
-
-  // TODO - KIT-4993: Add updateLocale public method.
 
   public disconnectedCallback() {
     super.disconnectedCallback();
@@ -387,11 +441,12 @@ export class AtomicCommerceInterface
     }
   }
 
-  // TODO - KIT-4993: Adjust.
   private initLanguage() {
-    if (!this.language) {
-      this.language = this.context.state.language;
+    if (!this.context || this.language) {
+      return;
     }
+
+    this.interfaceController.onLanguageChange(this.context.state.language);
   }
 
   private initRequestStatus() {
@@ -445,7 +500,7 @@ export class AtomicCommerceInterface
       this.i18Initialized,
     ]);
     this.initContext();
-    this.updateLanguage();
+    this.updateLanguage(); // TODO - (v4) KIT-4365: Remove.
     this.bindings = this.getBindings();
     markParentAsReady(this);
     this.initRequestStatus();
@@ -454,6 +509,18 @@ export class AtomicCommerceInterface
     await this.getUpdateComplete();
     this.initUrlManager();
     this.initialized = true;
+  }
+
+  private isNewLocale(language?: string, country?: string, currency?: string) {
+    if (!this.context) {
+      return false;
+    }
+
+    return (
+      (language && language !== this.context.state.language) ||
+      (country && country !== this.context.state.country) ||
+      (currency && currency !== this.context.state.currency)
+    );
   }
 
   private onHashChange = () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
@@ -55,7 +55,6 @@ export class AtomicCommerceRecommendationInterface
   @provide({context: bindingsContext})
   public bindings: CommerceBindings = {} as CommerceBindings;
   @state() public error!: Error;
-
   public context!: Context;
   private store: CommerceRecommendationStore;
 
@@ -75,7 +74,7 @@ export class AtomicCommerceRecommendationInterface
           height: inherit;
         }
       }
-    `,
+      `,
   ];
 
   /**
@@ -112,6 +111,7 @@ export class AtomicCommerceRecommendationInterface
   @property({type: String, attribute: 'icon-assets-path', reflect: true})
   iconAssetsPath: string = './assets';
 
+  // TODO - (v4) KIT-4365: Remove (or more likely turn into private state attribute)
   /**
    * The commerce interface language.
    *
@@ -125,6 +125,10 @@ export class AtomicCommerceRecommendationInterface
    */
   @property({type: String, reflect: true}) language?: string;
 
+  // TODO - KIT-4994: Add disableAnalytics property that defaults to false.
+
+  // TODO - KIT-4994: Deprecate in favor of disableAnalytics property.
+  // TODO - (v4) KIT-4990: Remove.
   /**
    * Whether to enable analytics.
    */
@@ -134,7 +138,6 @@ export class AtomicCommerceRecommendationInterface
     reflect: true,
   })
   analytics: boolean = true;
-
   private i18Initialized: Promise<void>;
 
   public constructor() {
@@ -207,16 +210,17 @@ export class AtomicCommerceRecommendationInterface
 
     language && this.interfaceController.onLanguageChange(language);
 
-    const {setContext} = loadContextActions(this.engine);
-
-    this.engine.dispatch(
-      setContext({
-        ...this.context.state,
-        ...(language && {language}),
-        ...(country && {country}),
-        ...(currency && {currency}),
-      })
-    );
+    if (this.isNewLocale(language, country, currency)) {
+      const {setContext} = loadContextActions(this.engine);
+      this.engine.dispatch(
+        setContext({
+          ...this.context.state,
+          ...(language && {language}),
+          ...(country && {country}),
+          ...(currency && {currency}),
+        })
+      );
+    }
   }
 
   @watch('analytics')
@@ -229,6 +233,7 @@ export class AtomicCommerceRecommendationInterface
     this.store.state.iconAssetsPath = this.iconAssetsPath;
   }
 
+  // TODO - (v4) KIT-4365: Remove.
   @watch('language')
   public async updateLanguage() {
     if (
@@ -288,7 +293,7 @@ export class AtomicCommerceRecommendationInterface
       this.i18Initialized,
     ]);
     this.initContext();
-    this.language && this.updateLanguage();
+    this.updateLanguage();
     this.bindings = this.getBindings();
     markParentAsReady(this);
     this.initLanguage();
@@ -306,11 +311,24 @@ export class AtomicCommerceRecommendationInterface
       interfaceElement: this as AtomicCommerceRecommendationInterface,
     };
   }
-
   private initLanguage() {
-    if (!this.language) {
-      this.interfaceController.onLanguageChange(this.context.state.language);
+    if (!this.context || this.language) {
+      return;
     }
+
+    this.interfaceController.onLanguageChange(this.context.state.language);
+  }
+
+  private isNewLocale(language?: string, country?: string, currency?: string) {
+    if (!this.context) {
+      return false;
+    }
+
+    return (
+      (language && language !== this.context.state.language) ||
+      (country && country !== this.context.state.country) ||
+      (currency && currency !== this.context.state.currency)
+    );
   }
 }
 


### PR DESCRIPTION
Essentially, I copied what we do in atomic-commerce-recommendation-interface and adapted it for atomic-commerce-interface.

I also added a check (on both interfaces) to ensure that we only dispatch the action to update the context only if the new locale would be different from the current one in the context state. The reason for this is that in Commerce, you would normally use the same engine for all interfaces on a page, so when you update the locale through the method on the different interfaces, you don't want to dispatch the action multiple times if the state has already been updated previously.

I also updated the tests accordingly.

https://coveord.atlassian.net/browse/KIT-4366