### PR TITLE
fix(headless): fixed payload of the generate call

### DIFF
--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer-mocks.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer-mocks.ts
@@ -1286,8 +1286,8 @@ export const expectedStreamAnswerAPIParam = {
     },
   },
   searchHub: 'jstpierre2 test - Woods test',
-  facets: {
-    '0': {
+  facets: [
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 8,
@@ -1301,7 +1301,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'author',
       field: 'author',
     },
-    '1': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 7,
@@ -1315,7 +1315,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'date',
       generateAutomaticRanges: false,
     },
-    '2': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 0,
@@ -1329,7 +1329,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'date',
       generateAutomaticRanges: false,
     },
-    '3': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 1,
@@ -1343,7 +1343,7 @@ export const expectedStreamAnswerAPIParam = {
       generateAutomaticRanges: true,
       field: 'date',
     },
-    '4': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 6,
@@ -1357,7 +1357,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'filetype',
       field: 'filetype',
     },
-    '5': {
+    {
       delimitingCharacter: ';',
       filterFacetCount: true,
       injectionDepth: 1000,
@@ -1372,7 +1372,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'geographicalhierarchy',
       field: 'geographicalhierarchy',
     },
-    '6': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 8,
@@ -1386,7 +1386,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'sncost',
       generateAutomaticRanges: true,
     },
-    '7': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 5,
@@ -1431,7 +1431,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'snrating',
       generateAutomaticRanges: false,
     },
-    '8': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 5,
@@ -1476,7 +1476,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'snrating',
       generateAutomaticRanges: false,
     },
-    '9': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 8,
@@ -1490,7 +1490,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'source',
       field: 'source',
     },
-    '10': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 8,
@@ -1504,7 +1504,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'year',
       field: 'year',
     },
-    '11': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 0,
@@ -1518,7 +1518,7 @@ export const expectedStreamAnswerAPIParam = {
       field: 'ytviewcount',
       generateAutomaticRanges: false,
     },
-    '12': {
+    {
       filterFacetCount: true,
       injectionDepth: 1000,
       numberOfValues: 1,
@@ -1532,7 +1532,7 @@ export const expectedStreamAnswerAPIParam = {
       facetId: 'ytviewcount_input_range',
       field: 'ytviewcount',
     },
-  },
+  ],
   fieldsToInclude: [
     'author',
     'language',

--- a/packages/headless/src/features/generated-answer/generated-answer-request.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-request.ts
@@ -107,15 +107,14 @@ export const constructAnswerAPIQueryParams = (
   };
 };
 
-const getGeneratedFacetParams = (state: StreamAnswerAPIState) => ({
-  ...getFacets(state)
+const getGeneratedFacetParams = (state: StreamAnswerAPIState) =>
+  getFacets(state)
     ?.map((facetRequest) =>
       mapFacetRequest(facetRequest, initialSearchMappings())
     )
     .sort((a, b) =>
       a.facetId > b.facetId ? 1 : b.facetId > a.facetId ? -1 : 0
-    ),
-});
+    );
 
 const buildAdvancedSearchQueryParams = (state: StreamAnswerAPIState) => {
   const advancedSearchQueryParams = selectAdvancedSearchQueries(state);


### PR DESCRIPTION
## [SFINT-6349](https://coveord.atlassian.net/browse/SFINT-6349)

Fixed an issue that was recently introduced where the facets were sent in the following format in the payload to the `/generate` endpoint:
```
  "facets": {
    "0": { ... },
    "1": { ... },
    "2": { ... }
  },
```
while what's accepted is the following format:
```
 "facets": [
    { ... },
    { ... },
    { ... }
  ],
```
### Before:

https://github.com/user-attachments/assets/34fb45d2-b307-4796-a943-d1a3ce9dd1e3

### After:

https://github.com/user-attachments/assets/b2b67b54-9f64-495d-8c00-c7bf44c82bfd



[SFINT-6349]: https://coveord.atlassian.net/browse/SFINT-6349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ