### PR TITLE
fix(atomic angular): ensure lit attribute converters get called

### DIFF
--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/angular-component-lib/utils.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/angular-component-lib/utils.ts
@@ -10,7 +10,10 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
         return this.el[item];
       },
       set(val: any) {
-        this.z.runOutsideAngular(() => (this.el[item] = val));
+        this.z.runOutsideAngular(() => {
+            const attrName = item.replace(/([A-Z])/g, '-$1').toLowerCase();
+            this.el.setAttribute(attrName,val);
+        });
       },
       /**
        * In the event that proxyInputs is called

--- a/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/angular-component-lib/utils.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/lib/stencil-generated/angular-component-lib/utils.ts
@@ -1,6 +1,33 @@
 /* eslint-disable */
 /* tslint:disable */
 import { fromEvent } from 'rxjs';
+import customElementsManifest from '@coveo/atomic/custom-elements-manifest';
+
+
+const createPropertyToAttributeMap = (): Map<string, string> => {
+  const map = new Map<string, string>();
+  
+  customElementsManifest.modules.forEach((module: any) => {
+    module.declarations?.forEach((declaration: any) => {
+      if (declaration.kind === 'class' && declaration.attributes) {
+        declaration.attributes.forEach((attr: any) => {
+          if (attr.fieldName && attr.name) {
+            map.set(attr.fieldName, attr.name);
+          }
+        });
+      }
+    });
+  });
+  
+  return map;
+};
+
+const propertyToAttributeMap = createPropertyToAttributeMap();
+
+const getAttributeName = (propertyName: string): string => {
+  const mappedAttr = propertyToAttributeMap.get(propertyName);
+  return mappedAttr || propertyName.replace(/([A-Z])/g, '-$1').toLowerCase();
+};
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
@@ -11,8 +38,8 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
       },
       set(val: any) {
         this.z.runOutsideAngular(() => {
-            const attrName = item.replace(/([A-Z])/g, '-$1').toLowerCase();
-            this.el.setAttribute(attrName,val);
+            const attrName = getAttributeName(item);
+            this.el.setAttribute(attrName, val);
         });
       },
       /**

--- a/patches/@stencil+angular-output-target+0.8.4.patch
+++ b/patches/@stencil+angular-output-target+0.8.4.patch
@@ -37,3 +37,52 @@ index 66792ef..3ca0509 100644
              // If an event name includes a dash, we need to wrap it in quotes.
              // https://github.com/ionic-team/stencil-ds-output-targets/issues/212
              eventName = `'${event.name}'`;
+diff --git a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
+index 1fd8c4a..2c8a5b1 100644
+--- a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
++++ b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
+@@ -1,6 +1,34 @@
+ /* eslint-disable */
+ /* tslint:disable */
+ import { fromEvent } from 'rxjs';
++import customElementsManifest from '@coveo/atomic/custom-elements-manifest';
++
++
++const createPropertyToAttributeMap = (): Map<string, string> => {
++  const map = new Map<string, string>();
++  
++  customElementsManifest.modules.forEach((module: any) => {
++    module.declarations?.forEach((declaration: any) => {
++      if (declaration.kind === 'class' && declaration.attributes) {
++        declaration.attributes.forEach((attr: any) => {
++          if (attr.fieldName && attr.name) {
++            map.set(attr.fieldName, attr.name);
++          }
++        });
++      }
++    });
++  });
++  
++  return map;
++};
++
++const propertyToAttributeMap = createPropertyToAttributeMap();
++
++const getAttributeName = (propertyName: string): string => {
++  const mappedAttr = propertyToAttributeMap.get(propertyName);
++  return mappedAttr || propertyName.replace(/([A-Z])/g, '-$1').toLowerCase();
++};
+ 
+ export const proxyInputs = (Cmp: any, inputs: string[]) => {
+   const Prototype = Cmp.prototype;
+@@ -11,7 +39,9 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
+       },
+       set(val: any) {
+-        this.z.runOutsideAngular(() => (this.el[item] = val));
++        this.z.runOutsideAngular(() => {
++            const attrName = getAttributeName(item);
++            this.el.setAttribute(attrName, val);
++        });
+       },
+       /**
+        * In the event that proxyInputs is called

--- a/patches/@stencil+angular-output-target+0.8.4.patch
+++ b/patches/@stencil+angular-output-target+0.8.4.patch
@@ -38,10 +38,10 @@ index 66792ef..3ca0509 100644
              // https://github.com/ionic-team/stencil-ds-output-targets/issues/212
              eventName = `'${event.name}'`;
 diff --git a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
-index 1fd8c4a..2c8a5b1 100644
+index b759048..03fd3da 100644
 --- a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
 +++ b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
-@@ -1,6 +1,34 @@
+@@ -1,6 +1,33 @@
  /* eslint-disable */
  /* tslint:disable */
  import { fromEvent } from 'rxjs';
@@ -75,7 +75,8 @@ index 1fd8c4a..2c8a5b1 100644
  
  export const proxyInputs = (Cmp: any, inputs: string[]) => {
    const Prototype = Cmp.prototype;
-@@ -11,7 +39,9 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
+@@ -10,7 +37,10 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
+         return this.el[item];
        },
        set(val: any) {
 -        this.z.runOutsideAngular(() => (this.el[item] = val));


### PR DESCRIPTION
The atomic-angular wrapper sets the properties directly instead of setting the attributes. This prevents the Lit attributes converters from running, as they only get called when the attribute value change, not when the property is set.

This PR ensures that the wrapper sets the value on the attributes instead of the properties

https://coveord.atlassian.net/browse/KIT-5070