### PR TITLE
docs(headless-react): update sample links in README files to use the correct path

### DIFF
--- a/packages/headless-react/COMMERCEREADME.md
+++ b/packages/headless-react/COMMERCEREADME.md
@@ -5,4 +5,4 @@
 ## Learn more
 
 - Checkout our [Documentation](https://docs.coveo.com/en/obif0156)
-- Refer to [samples/headless-ssr-commerce-nextjs](https://github.com/coveo/ui-kit/tree/master/packages/samples/headless-ssr-commerce--nextjs/) for examples.
+- Refer to [samples/headless-ssr-commerce-nextjs](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr/commerce-nextjs/) for examples.

--- a/packages/headless-react/README.md
+++ b/packages/headless-react/README.md
@@ -12,6 +12,6 @@
 
 ## Learn more
 
-- Checkout our [Documentation for SSR Search](https://docs.coveo.com/en/headless/latest/usage/headless-server-side-rendering/) and refer to [samples/headless-ssr](https://github.com/coveo/ui-kit/tree/master/packages/samples/headless-ssr) for examples.
-- Checkout our [Documentation for SSR Commerce](https://docs.coveo.com/en/obif0156) and refer to [samples/headless-ssr-commerce](https://github.com/coveo/ui-kit/tree/master/packages/samples/headless-ssr-commerce/) for examples.
+- Checkout our [Documentation for SSR Search](https://docs.coveo.com/en/headless/latest/usage/headless-server-side-rendering/) and refer to [samples/headless-ssr](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr) for examples.
+- Checkout our [Documentation for SSR Commerce](https://docs.coveo.com/en/obif0156) and refer to [samples/headless-ssr/commerce-express](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr/commerce-express), [samples/headless-ssr/commerce-nextjs](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr/commerce-nextjs), or [samples/headless-ssr/commerce-react-router](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr/commerce-react-router) for examples.
 - For the latest features and upcoming breaking changes, see the `ssr-next` and `ssr-commerce-next` sub-packages and their respective documentation and samples.

--- a/packages/headless-react/SEARCHREADME.md
+++ b/packages/headless-react/SEARCHREADME.md
@@ -5,4 +5,4 @@
 ## Learn more
 
 - Checkout our [Documentation for SSR Search](https://docs.coveo.com/en/headless/latest/usage/headless-server-side-rendering/)
-- Refer to [samples/headless-ssr](https://github.com/coveo/ui-kit/tree/master/packages/samples/headless-ssr) for examples.
+- Refer to [samples/headless-ssr](https://github.com/coveo/ui-kit/tree/main/samples/headless-ssr) for examples.


### PR DESCRIPTION
[DOC-17855](https://coveord.atlassian.net/browse/DOC-17855)

There are a few broken links in the README files associated with the `headless-react` package that are getting picked up when Typedoc does its build process.

This PR updates the references that are remaining from the branch change of "master" -> "main", and the samples package move to the top-most level. 
