### PR TITLE
chore: prerelease-cdn needs build-cdn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,7 +657,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
   prerelease-cdn-pr:
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-    needs: build
+    needs: build-cdn
     name: Pre-release CDN in dev (PR)
     environment: "Prerelease (CDN)"
     runs-on: ubuntu-latest


### PR DESCRIPTION
build is cool, but relevant for NPM, not for the CDN

this ensures the CDN CD for PR only runs when the turborepo cache associated is generated & present, preventing issues & limiting CI cost waste
