### PR TITLE
fix(atomic): ensure fieldsToInclude always get updated/registered when changed and during init

### DIFF
--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
@@ -126,7 +126,7 @@ export class AtomicSearchInterface
       toAttribute: (value: string[]) => JSON.stringify(value),
     },
   })
-  public fieldsToInclude: string[] = [];
+  public fieldsToInclude: string[] | string = '[]';
 
   /**
    * The search interface [query pipeline](https://docs.coveo.com/en/180/).
@@ -275,6 +275,7 @@ export class AtomicSearchInterface
     super.connectedCallback();
     this.store.setLoadingFlag(FirstSearchExecutedFlag);
     this.initRelevanceInspector();
+    this.initFieldsToInclude();
 
     this.addEventListener(
       'atomic/initializeComponent',
@@ -296,7 +297,7 @@ export class AtomicSearchInterface
     super.willUpdate(changedProperties);
 
     if (changedProperties.has('fieldsToInclude')) {
-      this.initFieldsToInclude();
+      this.updateFieldsToInclude();
     }
   }
 
@@ -494,6 +495,12 @@ export class AtomicSearchInterface
   private initFieldsToInclude() {
     const fields = EcommerceDefaultFieldsToInclude.concat(this.fieldsToInclude);
     this.store.addFieldsToInclude(fields);
+  }
+
+  private updateFieldsToInclude() {
+    this.store.state.fieldsToInclude = [];
+    this.initFieldsToInclude();
+    this.registerFieldsToInclude();
   }
 
   public registerFieldsToInclude() {

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
@@ -126,7 +126,7 @@ export class AtomicSearchInterface
       toAttribute: (value: string[]) => JSON.stringify(value),
     },
   })
-  public fieldsToInclude: string[] | string = '[]';
+  public fieldsToInclude: string[] = [];
 
   /**
    * The search interface [query pipeline](https://docs.coveo.com/en/180/).


### PR DESCRIPTION
This PR ensures that when fieldsToInclude is changed, and during initialization, the interface store and headless get updated with the correct values.

https://coveord.atlassian.net/browse/KIT-5091