### PR TITLE
chore(atomic): move item layout and custom render logic in reactive controllers

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product/atomic-product.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product/atomic-product.spec.ts
@@ -277,7 +277,7 @@ describe('atomic-product', () => {
       it('should log warning', async () => {
         await renderProduct({content: undefined});
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'AtomicProduct: content property is undefined. Cannot create layout.',
+          'atomic-product: content property is undefined. Cannot create layout.',
           expect.any(AtomicProduct)
         );
       });
@@ -305,7 +305,7 @@ describe('atomic-product', () => {
         getContentHTMLMethod();
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'AtomicProduct: content property is undefined. Cannot get content HTML.',
+          'atomic-product: content property is undefined. Cannot get content HTML.',
           expect.any(AtomicProduct)
         );
       });

--- a/packages/atomic/src/components/common/layout/custom-render-controller.spec.ts
+++ b/packages/atomic/src/components/common/layout/custom-render-controller.spec.ts
@@ -1,0 +1,212 @@
+import {LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {buildFakeProduct} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/product';
+import type {AnyItem} from '../item-list/unfolded-item';
+import {
+  CustomRenderController,
+  type CustomRenderHost,
+  type CustomRenderOptions,
+} from './custom-render-controller';
+
+@customElement('test-custom-render-element')
+class TestCustomRenderElement extends LitElement implements CustomRenderHost {
+  addController = vi.fn();
+
+  getRootNode(): Node {
+    return this.shadowRoot || document;
+  }
+}
+
+describe('CustomRenderController', () => {
+  let mockElement: TestCustomRenderElement;
+  let mockOptions: CustomRenderOptions;
+  let controller: CustomRenderController;
+  let mockRootElement: HTMLElement;
+  let mockLinkContainer: HTMLElement;
+  let mockItemData: AnyItem;
+  let mockRenderingFunction: ReturnType<typeof vi.fn>;
+  let mockOnRenderComplete: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockElement = new TestCustomRenderElement();
+    mockRootElement = document.createElement('div');
+    mockLinkContainer = document.createElement('div');
+    mockItemData = buildFakeProduct();
+
+    mockRenderingFunction = vi
+      .fn()
+      .mockReturnValue('<div>Custom render output</div>');
+    mockOnRenderComplete = vi.fn();
+
+    mockOptions = {
+      renderingFunction: vi.fn().mockReturnValue(mockRenderingFunction),
+      itemData: vi.fn().mockReturnValue(mockItemData),
+      rootElementRef: vi.fn().mockReturnValue(mockRootElement),
+      linkContainerRef: vi.fn().mockReturnValue(mockLinkContainer),
+      onRenderComplete: mockOnRenderComplete,
+    };
+  });
+
+  describe('#constructor', () => {
+    beforeEach(() => {
+      controller = new CustomRenderController(mockElement, mockOptions);
+    });
+
+    it('should initialize with provided parameters', () => {
+      expect(mockElement.addController).toHaveBeenCalledWith(controller);
+    });
+
+    it('should set default values for optional options', () => {
+      const minimalOptions = {
+        renderingFunction: vi.fn().mockReturnValue(mockRenderingFunction),
+        itemData: vi.fn().mockReturnValue(mockItemData),
+        rootElementRef: vi.fn().mockReturnValue(mockRootElement),
+      };
+
+      controller = new CustomRenderController(mockElement, minimalOptions);
+
+      expect(mockElement.addController).toHaveBeenCalledWith(controller);
+    });
+  });
+
+  describe('#hostConnected', () => {
+    beforeEach(() => {
+      controller = new CustomRenderController(mockElement, mockOptions);
+    });
+
+    it('should not throw when called', () => {
+      expect(() => controller.hostConnected()).not.toThrow();
+    });
+
+    it('should call render function execution after connection', () => {
+      controller.hostUpdated();
+      expect(mockRenderingFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reset state when #hostConnected is called', () => {
+      controller.hostUpdated();
+      expect(mockRenderingFunction).toHaveBeenCalledTimes(1);
+
+      controller.hostConnected();
+
+      controller.hostUpdated();
+      expect(mockRenderingFunction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('#hostUpdated', () => {
+    beforeEach(() => {
+      controller = new CustomRenderController(mockElement, mockOptions);
+    });
+
+    it('should execute render function when conditions are met', () => {
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).toHaveBeenCalledWith(
+        mockItemData,
+        mockRootElement,
+        mockLinkContainer
+      );
+    });
+
+    it('should call onRenderComplete callback with correct parameters', () => {
+      controller.hostUpdated();
+
+      expect(mockOnRenderComplete).toHaveBeenCalledWith(
+        mockRootElement,
+        '<div>Custom render output</div>'
+      );
+    });
+
+    it('should execute render function only once per cycle', () => {
+      controller.hostUpdated();
+      controller.hostUpdated();
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).toHaveBeenCalledTimes(1);
+      expect(mockOnRenderComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not execute when rendering function is undefined', () => {
+      mockOptions.renderingFunction = vi.fn().mockReturnValue(undefined);
+      controller = new CustomRenderController(mockElement, mockOptions);
+
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).not.toHaveBeenCalled();
+      expect(mockOnRenderComplete).not.toHaveBeenCalled();
+    });
+
+    it('should not execute when item data is undefined', () => {
+      mockOptions.itemData = vi.fn().mockReturnValue(undefined);
+      controller = new CustomRenderController(mockElement, mockOptions);
+
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).not.toHaveBeenCalled();
+      expect(mockOnRenderComplete).not.toHaveBeenCalled();
+    });
+
+    it('should not execute when root element ref is undefined', () => {
+      mockOptions.rootElementRef = vi.fn().mockReturnValue(undefined);
+      controller = new CustomRenderController(mockElement, mockOptions);
+
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).not.toHaveBeenCalled();
+      expect(mockOnRenderComplete).not.toHaveBeenCalled();
+    });
+
+    it('should execute when link container ref is undefined', () => {
+      mockOptions.linkContainerRef = vi.fn().mockReturnValue(undefined);
+      controller = new CustomRenderController(mockElement, mockOptions);
+
+      controller.hostUpdated();
+
+      expect(mockRenderingFunction).toHaveBeenCalledWith(
+        mockItemData,
+        mockRootElement,
+        undefined
+      );
+      expect(mockOnRenderComplete).toHaveBeenCalled();
+    });
+
+    it('should handle rendering function that returns different output types', () => {
+      const testCases = [
+        '',
+        '<div>Empty content</div>',
+        '<span>Multiple</span><div>Elements</div>',
+        'Plain text content',
+      ];
+
+      testCases.forEach((output) => {
+        mockRenderingFunction.mockReturnValue(output);
+        controller.hostConnected();
+        controller.hostUpdated();
+
+        expect(mockOnRenderComplete).toHaveBeenLastCalledWith(
+          mockRootElement,
+          output
+        );
+      });
+    });
+  });
+
+  describe('#hasCustomRenderFunction', () => {
+    beforeEach(() => {
+      controller = new CustomRenderController(mockElement, mockOptions);
+    });
+
+    it('should return true when rendering function is provided', () => {
+      expect(controller.hasCustomRenderFunction).toBe(true);
+    });
+
+    it('should return false when rendering function is undefined', () => {
+      mockOptions.renderingFunction = vi.fn().mockReturnValue(undefined);
+      controller = new CustomRenderController(mockElement, mockOptions);
+
+      expect(controller.hasCustomRenderFunction).toBe(false);
+    });
+  });
+});

--- a/packages/atomic/src/components/common/layout/custom-render-controller.ts
+++ b/packages/atomic/src/components/common/layout/custom-render-controller.ts
@@ -1,0 +1,86 @@
+import type {LitElement, ReactiveController, ReactiveControllerHost} from 'lit';
+import type {ItemRenderingFunction} from '../item-list/item-list-common';
+import type {AnyItem} from '../item-list/unfolded-item';
+
+export interface CustomRenderHost extends ReactiveControllerHost {
+  shadowRoot?: ShadowRoot | null;
+}
+
+export interface CustomRenderOptions {
+  renderingFunction: () => ItemRenderingFunction<AnyItem> | undefined;
+  itemData: () => AnyItem | undefined;
+  rootElementRef: () => HTMLElement | undefined;
+  linkContainerRef?: () => HTMLElement | undefined;
+  onRenderComplete?: (element: HTMLElement, output: string) => void;
+}
+
+/**
+ * A reactive controller that manages custom rendering function execution for item components.
+ */
+export class CustomRenderController implements ReactiveController {
+  private options: Required<CustomRenderOptions>;
+  private hasExecutedRenderFunction = false;
+
+  constructor(
+    host: CustomRenderHost & LitElement,
+    options: CustomRenderOptions
+  ) {
+    this.options = {
+      linkContainerRef: () => undefined,
+      onRenderComplete: () => {},
+      ...options,
+    };
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.resetRenderState();
+  }
+
+  hostUpdated(): void {
+    if (this.shouldExecuteRenderFunction()) {
+      this.executeRenderFunction();
+    }
+  }
+
+  hostDisconnected(): void {}
+
+  public get hasCustomRenderFunction(): boolean {
+    return this.options.renderingFunction() !== undefined;
+  }
+
+  private resetRenderState(): void {
+    this.hasExecutedRenderFunction = false;
+  }
+
+  private shouldExecuteRenderFunction(): boolean {
+    const renderingFunction = this.options.renderingFunction();
+    const rootElementRef = this.options.rootElementRef();
+
+    return !!(
+      renderingFunction &&
+      rootElementRef &&
+      !this.hasExecutedRenderFunction
+    );
+  }
+
+  private executeRenderFunction(): void {
+    const renderingFunction = this.options.renderingFunction();
+    const itemData = this.options.itemData();
+    const rootElementRef = this.options.rootElementRef();
+    const linkContainerRef = this.options.linkContainerRef();
+
+    if (!renderingFunction || !itemData || !rootElementRef) {
+      return;
+    }
+
+    const customRenderOutput = renderingFunction(
+      itemData,
+      rootElementRef,
+      linkContainerRef
+    );
+
+    this.options.onRenderComplete(rootElementRef, customRenderOutput);
+    this.hasExecutedRenderFunction = true;
+  }
+}

--- a/packages/atomic/src/components/common/layout/item-layout-controller.spec.ts
+++ b/packages/atomic/src/components/common/layout/item-layout-controller.spec.ts
@@ -1,0 +1,312 @@
+import {LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import * as displayOptions from './display-options';
+import {
+  ItemLayoutController,
+  type ItemLayoutHost,
+  type ItemLayoutOptions,
+} from './item-layout-controller';
+
+vi.mock('./display-options');
+
+const mockGetClasses = vi.fn();
+const MockedItemLayout = vi.mocked(displayOptions.ItemLayout);
+
+MockedItemLayout.mockImplementation(
+  () =>
+    ({
+      getClasses: mockGetClasses,
+    }) as unknown as displayOptions.ItemLayout
+);
+
+@customElement('test-item-element')
+class TestItemElement extends LitElement implements ItemLayoutHost {
+  addController = vi.fn();
+
+  getRootNode(): Node {
+    return this.shadowRoot || document;
+  }
+}
+
+describe('ItemLayoutController', () => {
+  let mockElement: TestItemElement;
+  let mockOptions: ItemLayoutOptions;
+  let controller: ItemLayoutController;
+  let mockContent: HTMLDivElement;
+
+  beforeEach(() => {
+    mockElement = new TestItemElement();
+    mockContent = document.createElement('div');
+    mockContent.appendChild(document.createElement('atomic-result-title'));
+    mockContent.appendChild(document.createElement('atomic-result-excerpt'));
+
+    mockOptions = {
+      elementPrefix: 'atomic-result',
+      hasCustomRenderFunction: vi.fn().mockReturnValue(false),
+      content: vi.fn().mockReturnValue(mockContent),
+      layoutConfig: vi.fn().mockReturnValue({
+        display: 'list',
+        density: 'normal',
+        imageSize: 'icon',
+      }),
+      itemClasses: vi.fn().mockReturnValue('custom-class extra-class'),
+    };
+
+    mockGetClasses.mockReturnValue([
+      'display-list',
+      'density-normal',
+      'image-icon',
+    ]);
+
+    MockedItemLayout.mockImplementation(
+      () =>
+        ({
+          getClasses: mockGetClasses,
+        }) as unknown as displayOptions.ItemLayout
+    );
+
+    Object.defineProperty(mockElement, 'shadowRoot', {
+      value: {
+        querySelector: vi.fn(),
+      } as unknown as ShadowRoot,
+      writable: true,
+      configurable: true,
+    });
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  describe('#constructor', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+    });
+
+    it('should initialize with provided parameters', () => {
+      expect(mockElement.addController).toHaveBeenCalledWith(controller);
+    });
+
+    it('should store the options', () => {
+      expect(mockOptions.elementPrefix).toBe('atomic-result');
+    });
+  });
+
+  describe('#hostConnected', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+    });
+
+    it('should create layout with correct parameters when content is provided', () => {
+      controller.hostConnected();
+
+      expect(MockedItemLayout).toHaveBeenCalledWith(
+        mockContent.children,
+        'list',
+        'normal',
+        'icon'
+      );
+    });
+
+    it('should handle undefined content gracefully', () => {
+      mockOptions.content = vi.fn().mockReturnValue(undefined);
+      controller = new ItemLayoutController(mockElement, mockOptions);
+
+      expect(() => controller.hostConnected()).not.toThrow();
+      expect(controller.getLayout()).toBeNull();
+    });
+  });
+
+  describe('#hostDisconnected', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+    });
+
+    it('should not throw when called', () => {
+      expect(() => controller.hostDisconnected()).not.toThrow();
+    });
+  });
+
+  describe('#hostUpdated', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+    });
+
+    it('should handle layout updates when not in custom render mode', () => {
+      const mockRoot = document.createElement('div');
+      mockRoot.className = 'result-root';
+      const element1 = document.createElement('atomic-result-title');
+      const element2 = document.createElement('atomic-result-excerpt');
+      mockRoot.appendChild(element1);
+      mockRoot.appendChild(element2);
+
+      vi.spyOn(mockElement.shadowRoot!, 'querySelector').mockReturnValue(
+        mockRoot
+      );
+
+      controller.hostUpdated();
+
+      expect(element1.classList.contains('display-list')).toBe(true);
+      expect(element2.classList.contains('display-list')).toBe(true);
+    });
+
+    it('should not apply layout classes when custom render mode with disabled classes', () => {
+      mockOptions.hasCustomRenderFunction = vi.fn().mockReturnValue(true);
+      mockOptions.disableLayoutClassesForCustomRender = vi
+        .fn()
+        .mockReturnValue(true);
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      const mockRoot = document.createElement('div');
+      mockRoot.className = 'result-root';
+      const element1 = document.createElement('atomic-result-title');
+      mockRoot.appendChild(element1);
+
+      vi.spyOn(mockElement.shadowRoot!, 'querySelector').mockReturnValue(
+        mockRoot
+      );
+
+      controller.hostUpdated();
+
+      expect(element1.classList.contains('display-list')).toBe(false);
+    });
+  });
+
+  describe('#getLayout', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+    });
+
+    it('should return layout instance when created', () => {
+      controller.hostConnected();
+      const layout = controller.getLayout();
+
+      expect(layout).toBeDefined();
+      expect(layout).not.toBeNull();
+    });
+
+    it('should return null when content is undefined', () => {
+      mockOptions.content = vi.fn().mockReturnValue(undefined);
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      expect(controller.getLayout()).toBeNull();
+    });
+  });
+
+  describe('#getCombinedClasses', () => {
+    beforeEach(() => {
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+    });
+
+    it('should return combined layout and item classes', () => {
+      const classes = controller.getCombinedClasses();
+
+      expect(classes).toEqual([
+        'display-list',
+        'density-normal',
+        'image-icon',
+        'custom-class',
+        'extra-class',
+      ]);
+    });
+
+    it('should pass additional content to layout.getClasses', () => {
+      const additionalContent =
+        '<atomic-result-section-visual></atomic-result-section-visual>';
+
+      controller.getCombinedClasses(additionalContent);
+
+      expect(mockGetClasses).toHaveBeenCalledWith(additionalContent);
+    });
+
+    it('should filter out empty item classes', () => {
+      mockOptions.itemClasses = vi.fn().mockReturnValue('  class1    class2  ');
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      const classes = controller.getCombinedClasses();
+
+      expect(classes).toEqual([
+        'display-list',
+        'density-normal',
+        'image-icon',
+        'class1',
+        'class2',
+      ]);
+    });
+
+    it('should return only layout classes when item classes are empty', () => {
+      mockOptions.itemClasses = vi.fn().mockReturnValue('');
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      const classes = controller.getCombinedClasses();
+
+      expect(classes).toEqual(['display-list', 'density-normal', 'image-icon']);
+    });
+
+    it('should return only item classes when layout is null', () => {
+      mockOptions.content = vi.fn().mockReturnValue(undefined);
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      const classes = controller.getCombinedClasses();
+
+      expect(classes).toEqual(['custom-class', 'extra-class']);
+    });
+  });
+
+  describe('#applyLayoutClassesToElement', () => {
+    let testElement: HTMLElement;
+
+    beforeEach(() => {
+      testElement = document.createElement('atomic-result-title');
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+    });
+
+    it('should apply classes to the specified element', () => {
+      controller.applyLayoutClassesToElement(testElement);
+
+      expect(testElement.classList.contains('display-list')).toBe(true);
+      expect(testElement.classList.contains('density-normal')).toBe(true);
+      expect(testElement.classList.contains('image-icon')).toBe(true);
+      expect(testElement.classList.contains('custom-class')).toBe(true);
+      expect(testElement.classList.contains('extra-class')).toBe(true);
+    });
+
+    it('should pass additional content to getCombinedClasses', () => {
+      const additionalContent =
+        '<atomic-result-section-visual></atomic-result-section-visual>';
+      vi.spyOn(controller, 'getCombinedClasses');
+
+      controller.applyLayoutClassesToElement(testElement, additionalContent);
+
+      expect(controller.getCombinedClasses).toHaveBeenCalledWith(
+        additionalContent
+      );
+    });
+
+    it('should not apply classes when layout is null', () => {
+      mockOptions.content = vi.fn().mockReturnValue(undefined);
+      controller = new ItemLayoutController(mockElement, mockOptions);
+      controller.hostConnected();
+
+      controller.applyLayoutClassesToElement(testElement);
+
+      expect(testElement.classList.length).toBe(0);
+    });
+
+    it('should not apply classes when classes array is empty', () => {
+      vi.mocked(mockOptions.itemClasses).mockReturnValue('');
+      mockGetClasses.mockReturnValue([]);
+
+      controller.applyLayoutClassesToElement(testElement);
+
+      expect(testElement.classList.length).toBe(0);
+    });
+  });
+});

--- a/packages/atomic/src/components/common/layout/item-layout-controller.ts
+++ b/packages/atomic/src/components/common/layout/item-layout-controller.ts
@@ -1,0 +1,168 @@
+import type {LitElement, ReactiveController, ReactiveControllerHost} from 'lit';
+import {
+  type ItemDisplayDensity,
+  type ItemDisplayImageSize,
+  type ItemDisplayLayout,
+  ItemLayout,
+} from './display-options';
+
+export interface ItemLayoutHost extends ReactiveControllerHost {
+  shadowRoot?: ShadowRoot | null;
+}
+
+export interface LayoutDisplayConfig {
+  display: ItemDisplayLayout;
+  density: ItemDisplayDensity;
+  imageSize: ItemDisplayImageSize;
+}
+
+export interface ItemLayoutOptions {
+  elementPrefix: string;
+  hasCustomRenderFunction: () => boolean;
+  disableLayoutClassesForCustomRender?: () => boolean;
+  content: () => ParentNode | undefined;
+  layoutConfig: () => LayoutDisplayConfig;
+  itemClasses: () => string;
+}
+
+/**
+ * A reactive controller that manages layout creation and class application for item components.
+ */
+export class ItemLayoutController implements ReactiveController {
+  private host: ItemLayoutHost & LitElement;
+  private options: Required<ItemLayoutOptions>;
+  private layoutInstance: ItemLayout | null = null;
+
+  constructor(host: ItemLayoutHost & LitElement, options: ItemLayoutOptions) {
+    this.host = host;
+    this.options = {
+      disableLayoutClassesForCustomRender: () => false,
+      ...options,
+    };
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.createLayout();
+  }
+
+  hostUpdated(): void {
+    if (
+      !(
+        this.options.hasCustomRenderFunction() &&
+        this.options.disableLayoutClassesForCustomRender()
+      )
+    ) {
+      this.applyLayoutClasses();
+    }
+  }
+
+  hostDisconnected(): void {}
+
+  /**
+   * Gets the current layout instance
+   */
+  public getLayout(): ItemLayout | null {
+    return this.layoutInstance;
+  }
+
+  /**
+   * Gets combined layout and extra classes
+   */
+  public getCombinedClasses(additionalContent?: string): string[] {
+    const layout = this.getLayout();
+    const layoutClasses = layout ? layout.getClasses(additionalContent) : [];
+    const itemClasses = this.options
+      .itemClasses()
+      .split(/\s+/)
+      .filter((c) => c);
+    return [...layoutClasses, ...itemClasses];
+  }
+
+  /**
+   * Applies layout classes to a specific element (useful for custom rendering)
+   */
+  public applyLayoutClassesToElement(
+    element: HTMLElement,
+    additionalContent?: string
+  ): void {
+    const layout = this.getLayout();
+    if (!layout) {
+      return;
+    }
+
+    const classes = this.getCombinedClasses(additionalContent);
+    if (classes.length > 0) {
+      element.classList.add(...classes);
+    }
+  }
+
+  private applyLayoutClasses(): void {
+    const layout = this.getLayout();
+    if (!layout) {
+      return;
+    }
+
+    const classes = this.getCombinedClasses();
+    const root = this.host.shadowRoot?.querySelector('.result-root');
+    if (!root || classes.length === 0) {
+      return;
+    }
+
+    if (this.options.hasCustomRenderFunction()) {
+      this.observeAndApplyClasses(root, classes);
+    } else {
+      this.addClassesToElements(root, classes);
+    }
+  }
+
+  private createLayout(): void {
+    const content = this.options.content();
+    if (!content) {
+      console.warn(
+        `${this.options.elementPrefix}: content property is undefined. Cannot create layout.`,
+        this.host
+      );
+      this.layoutInstance = null;
+      return;
+    }
+
+    const config = this.options.layoutConfig();
+    this.layoutInstance = new ItemLayout(
+      content.children,
+      config.display,
+      config.density,
+      config.imageSize
+    );
+  }
+
+  private addClassesToElements(root: Element, classes: string[]): void {
+    if (classes.length === 0) {
+      return;
+    }
+
+    const elements = root.querySelectorAll('*');
+    elements.forEach((element) => {
+      const tagName = element.tagName.toLowerCase();
+      if (tagName.startsWith(`${this.options.elementPrefix}-`)) {
+        element.classList.add(...classes);
+      }
+    });
+  }
+
+  private observeAndApplyClasses(root: Element, classes: string[]): void {
+    const observer = new MutationObserver((mutations) => {
+      const hasNewElements = mutations.some(
+        (mutation) =>
+          mutation.type === 'childList' && mutation.addedNodes.length > 0
+      );
+
+      if (hasNewElements) {
+        this.addClassesToElements(root, classes);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(root, {childList: true, subtree: true});
+  }
+}


### PR DESCRIPTION
This PR extract the item layout and custom render function logic into reactive controllers to simplify reuse between atomic-product and atomic-result. 

Additionally, it adds the `disableLayoutClassesForCustomRender` attribute on atomic-product. This attribute can be set to true to prevent the item layout classes to be added on the product template components when using the custom render function. 
By extension it also ensures that these classes do get added by default when using a custom render function, which is necessary to get the section styles since the changes made in https://coveord.atlassian.net/browse/KIT-4792.

https://coveord.atlassian.net/browse/KIT-5094
