### PR TITLE
chore(atomic): disable flaky facet tests

### DIFF
--- a/packages/atomic/cypress/e2e/common-assertions.ts
+++ b/packages/atomic/cypress/e2e/common-assertions.ts
@@ -1,7 +1,5 @@
-import {Result} from 'axe-core';
-import {getFocusableDescendants} from '../../src/utils/accessibility-utils';
-import {TestFixture} from '../fixtures/test-fixture';
-import {ComponentErrorSelectors} from './component-error-selectors';
+import { TestFixture } from '../fixtures/test-fixture';
+import { ComponentErrorSelectors } from './component-error-selectors';
 
 export interface ComponentSelector {
   // Setting JQuery<HTMLElement> is incompatible with Stencil's HTML elements
@@ -14,92 +12,45 @@ export function should(should: boolean) {
 }
 
 export function assertAccessibility<T extends HTMLElement>(
-  component?: string | (() => Cypress.Chainable<JQuery<T>>)
+  _component?: string | (() => Cypress.Chainable<JQuery<T>>)
 ) {
-  it('should pass accessibility tests', () => {
-    assertAccessibilityWithoutIt(component);
-  });
-
-  it.skip('every interactive element with innerText and an aria label passes WCAG success criterion 2.5.3', () => {
-    assertWCAG2_5_3(component);
-  });
+  return;
 }
 
 export function assertWCAG2_5_3<T extends HTMLElement>(
-  component?: string | (() => Cypress.Chainable<JQuery<T>>)
+  _component?: string | (() => Cypress.Chainable<JQuery<T>>)
 ) {
-  function splitIntoWords(text: string) {
-    return text
-      .split(/\b/g)
-      .filter((word) => !word.match(/[^a-z]/i))
-      .map((word) => word.toLowerCase());
-  }
-
-  function runCheck(root: HTMLElement) {
-    const elements = getFocusableDescendants(root).filter(
-      (el) => el.hasAttribute('aria-label') && el.innerText
-    );
-    elements.forEach((el) =>
-      expect(splitIntoWords(el.getAttribute('aria-label')!)).to.include.all.members(
-        splitIntoWords(el.innerText),
-        'The aria-label should include the innerText. https://www.w3.org/WAI/WCAG22/Techniques/failures/F96.html'
-      )
-    );
-  }
-
-  if (component) {
-    if (typeof component === 'string') {
-      cy.get<T>(component).then(($els) => runCheck($els[0] as unknown as HTMLElement));
-    } else {
-      component().then(($els) => runCheck($els[0] as unknown as HTMLElement));
-    }
-  } else {
-    cy.window().then((win) => runCheck(win.document.body));
-  }
+  return;
 }
 
 // https://github.com/component-driven/cypress-axe#in-your-spec-file
-function logAxeIssues(violations: Result[]) {
-  cy.task(
-    'log',
-    `${violations.length} accessibility violation${
-      violations.length === 1 ? '' : 's'
-    } ${violations.length === 1 ? 'was' : 'were'} detected`
-  );
-  // pluck specific keys to keep the table readable
-  const violationData = violations.flatMap(({id, impact, description, nodes}) =>
-    // log per node so that we know which HTML element has the issue.
-    nodes.map((node) => ({
-      id,
-      impact,
-      description,
-      node: node.html,
-    }))
-  );
+// function logAxeIssues(violations: Result[]) {
+//   cy.task(
+//     'log',
+//     `${violations.length} accessibility violation${
+//       violations.length === 1 ? '' : 's'
+//     } ${violations.length === 1 ? 'was' : 'were'} detected`
+//   );
+//   // pluck specific keys to keep the table readable
+//   const violationData = violations.flatMap(({id, impact, description, nodes}) =>
+//     // log per node so that we know which HTML element has the issue.
+//     nodes.map((node) => ({
+//       id,
+//       impact,
+//       description,
+//       node: node.html,
+//     }))
+//   );
 
-  cy.task('table', violationData);
-}
+//   cy.task('table', violationData);
+// }
 
 export function assertAccessibilityWithoutIt<T extends HTMLElement>(
-  component?: string | (() => Cypress.Chainable<JQuery<T>>)
+  _component?: string | (() => Cypress.Chainable<JQuery<T>>)
 ) {
-  const rulesToIgnore = ['landmark-one-main', 'page-has-heading-one', 'region'];
-  const rules = rulesToIgnore.reduce(
-    (obj, rule) => ({...obj, [rule]: {enabled: false}}),
-    {}
-  );
-  const axeOptions = {rules, retries: 3};
-
-  if (typeof component === 'string') {
-    cy.checkA11y(component, axeOptions, logAxeIssues);
-  } else if (typeof component === 'function') {
-    component().then(([el]) => {
-      cy.checkA11y(el, axeOptions, logAxeIssues);
-    });
-  } else {
-    cy.checkA11y(undefined, axeOptions, logAxeIssues);
-  }
+  return;
 }
+
 export function assertContainsComponentError(
   componentSelector: ComponentSelector,
   display: boolean
@@ -107,7 +58,7 @@ export function assertContainsComponentError(
   it(`${should(display)} display an error component`, () => {
     componentSelector
       .shadow()
-      .find(ComponentErrorSelectors.component, {includeShadowDom: true})
+      .find(ComponentErrorSelectors.component, { includeShadowDom: true })
       .should(display ? 'be.visible' : 'not.exist');
   });
 }
@@ -118,7 +69,7 @@ export function assertContainsComponentErrorWithoutIt(
 ) {
   componentSelector
     .shadow()
-    .find(ComponentErrorSelectors.component, {includeShadowDom: true})
+    .find(ComponentErrorSelectors.component, { includeShadowDom: true })
     .should(display ? 'be.visible' : 'not.exist');
 }
 

--- a/packages/atomic/cypress/e2e/facets/automatic-facet/automatic-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/automatic-facet/automatic-facet.cypress.ts
@@ -27,7 +27,7 @@ describe('Automatic Facet Test Suites', () => {
   describe('verify rendering', () => {
     beforeEach(setup);
 
-    CommonAssertions.assertAccessibility(automaticFacetComponent);
+    // CommonAssertions.assertAccessibility(automaticFacetComponent);
     CommonAssertions.assertContainsComponentError(
       AutomaticFacetSelectors,
       false
@@ -100,7 +100,7 @@ describe('Automatic Facet Test Suites', () => {
     describe('verify rendering', () => {
       beforeEach(setupSelectValue);
 
-      CommonAssertions.assertAccessibility(automaticFacetComponent);
+      // CommonAssertions.assertAccessibility(automaticFacetComponent);
       CommonFacetAssertions.assertDisplayClearButton(
         AutomaticFacetSelectors,
         true
@@ -128,7 +128,7 @@ describe('Automatic Facet Test Suites', () => {
       describe('verify rendering', () => {
         beforeEach(setupSelectSecondValue);
 
-        CommonAssertions.assertAccessibility(automaticFacetComponent);
+        // CommonAssertions.assertAccessibility(automaticFacetComponent);
         CommonFacetAssertions.assertDisplayClearButton(
           AutomaticFacetSelectors,
           true

--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
@@ -38,7 +38,14 @@ import {
   categoryFacetComponent,
 } from './category-facet-selectors';
 
-describe('Category Facet Test Suites', () => {
+describe.skip('Category Facet Test Suites', () => {
+
+  var i = 0;
+for (i = 0; i < 500 ; i++) {    
+  it('Yeah - ' + i, () => {
+    cy.visit('https://www.google.com/');
+  });
+}
   describe('with default settings', () => {
     function setupWithDefaultSettings() {
       new TestFixture().with(addCategoryFacet()).init();

--- a/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/category-facet/category-facet.cypress.ts
@@ -39,13 +39,6 @@ import {
 } from './category-facet-selectors';
 
 describe.skip('Category Facet Test Suites', () => {
-
-  var i = 0;
-for (i = 0; i < 500 ; i++) {    
-  it('Yeah - ' + i, () => {
-    cy.visit('https://www.google.com/');
-  });
-}
   describe('with default settings', () => {
     function setupWithDefaultSettings() {
       new TestFixture().with(addCategoryFacet()).init();

--- a/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/color-facet/color-facet.cypress.ts
@@ -34,7 +34,7 @@ import {
   ColorFacetSelectors,
 } from './color-facet-selectors';
 
-describe('Color Facet Test Suites', () => {
+describe.skip('Color Facet Test Suites', () => {
   describe('with default setting', () => {
     function setupColorFacet() {
       new TestFixture()

--- a/packages/atomic/cypress/e2e/facets/facet/facet.1.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.1.cypress.ts
@@ -20,7 +20,7 @@ import * as FacetAssertions from './facet-assertions';
 import {facetComponent, FacetSelectors} from './facet-selectors';
 
 // This is the first half of the facet test suite. It was split in two to speed up the test execution.
-describe('Facet Test Suite 1', () => {
+describe.skip('Facet Test Suite 1', () => {
   describe('with checkbox values', () => {
     function setupWithCheckboxValues() {
       new TestFixture().with(addFacet({field, label})).init();

--- a/packages/atomic/cypress/e2e/facets/facet/facet.2.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/facet/facet.2.cypress.ts
@@ -21,7 +21,7 @@ import * as FacetAssertions from './facet-assertions';
 import {facetComponent, FacetSelectors} from './facet-selectors';
 
 // This is the second half of the facet test suite. It was split in two to speed up the test execution.
-describe('Facet Test Suite 2', () => {
+describe.skip('Facet Test Suite 2', () => {
   describe('when selecting the label button to collapse', () => {
     function setupSelectLabelCollapse() {
       new TestFixture().with(addFacet({field, label})).init();

--- a/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/numeric-facet/numeric-facet.cypress.ts
@@ -35,7 +35,7 @@ import {
   NumericFacetSelectors,
 } from './numeric-facet-selectors';
 
-describe('Numeric Facet V1 Test Suites', () => {
+describe.skip('Numeric Facet V1 Test Suites', () => {
   const min = 0;
   const max = 100000;
   const minDecimal = 1.5;

--- a/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-facet/rating-facet.cypress.ts
@@ -21,7 +21,7 @@ import {
   RatingFacetSelectors,
 } from './rating-facet-selectors';
 
-describe('Rating Facet Test Suites', () => {
+describe.skip('Rating Facet Test Suites', () => {
   describe('with default rating facet', () => {
     describe('with checkbox values', () => {
       function setupRatingFacet() {

--- a/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/rating-range-facet/rating-range-facet.cypress.ts
@@ -22,7 +22,7 @@ import {
   RatingRangeFacetSelectors,
 } from './rating-range-facet-selectors';
 
-describe('Rating Range Test Suites', () => {
+describe.skip('Rating Range Test Suites', () => {
   describe('with default rating facet', () => {
     function setupRatingRangeFacet() {
       new TestFixture()

--- a/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/segmented-facet/segmented-facet.cypress.ts
@@ -14,7 +14,7 @@ import {
   SegmentedFacetSelectors,
 } from './segmented-facet-selectors';
 
-describe('Segmented Facet Test Suites', () => {
+describe.skip('Segmented Facet Test Suites', () => {
   function setupSegmentedFacet() {
     new TestFixture().with(addSegmentedFacet({field, label})).init();
   }

--- a/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet.cypress.ts
+++ b/packages/atomic/cypress/e2e/facets/timeframe-facet/timeframe-facet.cypress.ts
@@ -37,7 +37,7 @@ import {
 const startDate = '2020-08-06';
 const endDate = '2021-09-03';
 
-describe('Timeframe Facet V1 Test Suites', () => {
+describe.skip('Timeframe Facet V1 Test Suites', () => {
   const defaultNumberOfValues = unitFrames.length;
   describe('does not throw on init when there is no filter and timeframe configured', () => {
     beforeEach(() => {

--- a/packages/atomic/cypress/e2e/result-list/result-list.commons.ts
+++ b/packages/atomic/cypress/e2e/result-list/result-list.commons.ts
@@ -183,7 +183,7 @@ export default (
           .init();
       });
 
-      withAnySectionnableResultList(
+     /*  withAnySectionnableResultList(
         () => {
           CommonAssertions.assertAccessibility(componentTag);
         },
@@ -193,7 +193,7 @@ export default (
           componentTag,
           useBeforeEach: true,
         }
-      );
+      ); */
     });
   });
 };


### PR DESCRIPTION
As discussed in Slack, with the migration of the Search Interface, Cypress crashes a lot when running facet test suites.
The boons are not worth the cost here, let's shut them down, and focus on replacing them by Playwright/Storybook a11y tests instead as we migrates.

https://coveord.atlassian.net/browse/KIT-5107