### PR TITLE
chore: more cleanup of dependencies in multiples packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "patch-package": "8.0.0",
         "playwright": "1.54.1",
         "publint": "0.3.12",
-        "rimraf": "6.0.1",
         "semver": "7.7.2",
         "turbo": "2.5.5",
         "typescript": "5.8.3",
@@ -39733,109 +39732,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
@@ -46143,6 +46039,7 @@
         "@angular/cli": "19.2.3",
         "@angular/compiler-cli": "19.2.2",
         "@coveo/headless": "3.31.1",
+        "@types/node": "22.16.5",
         "ng-packagr": "19.2.0",
         "tslib": "2.8.1",
         "typescript": "5.8.3"
@@ -46182,28 +46079,10 @@
       "devDependencies": {
         "@playwright/test": "1.54.1",
         "@types/node": "22.16.5",
-        "rimraf": "3.0.2",
         "vite": "7.0.6"
       },
       "engines": {
         "node": "^20.9.0 || ^22.11.0"
-      }
-    },
-    "packages/atomic-hosted-page/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/atomic-react": {
@@ -46218,7 +46097,6 @@
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-typescript": "12.1.4",
-        "@types/node": "22.16.5",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "fix-esm-import-path": "1.10.1",
@@ -46282,7 +46160,6 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "29.7.0",
-        "rimraf": "6.0.1",
         "ts-jest": "29.4.0",
         "vite": "7.0.6"
       },
@@ -46308,7 +46185,6 @@
       "dependencies": {
         "@coveo/platform-client": "60.4.0",
         "abortcontroller-polyfill": "1.7.8",
-        "detect-indent": "7.0.1",
         "https-proxy-agent": "7.0.6",
         "isomorphic-fetch": "3.0.0",
         "minimist": "1.2.8",
@@ -46319,7 +46195,6 @@
         "create-atomic": "index.mjs"
       },
       "devDependencies": {
-        "fs-extra": "11.3.0",
         "typescript": "5.8.3"
       }
     },
@@ -46353,70 +46228,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "packages/create-atomic-component-project/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-component-project/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-component-project/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/create-atomic-component-project/node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^9.2.0"
-      },
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/create-atomic-component-project/template": {
       "name": "@coveo/sample-component-project",
       "version": "0.0.1",
@@ -46436,7 +46247,6 @@
         "jest": "29.7.0",
         "jest-cli": "29.7.0",
         "puppeteer": "24.15.0",
-        "rimraf": "6.0.1",
         "rollup-plugin-html": "0.2.1"
       }
     },
@@ -46521,70 +46331,6 @@
         }
       }
     },
-    "packages/create-atomic-component/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-component/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-component/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/create-atomic-component/node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^9.2.0"
-      },
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/create-atomic-component/template/src/components/sample-component": {
       "name": "@coveo/sample-component",
       "version": "0.0.1",
@@ -46602,7 +46348,6 @@
         "jest": "29.7.0",
         "jest-cli": "29.7.0",
         "puppeteer": "24.15.0",
-        "rimraf": "6.0.1",
         "rollup-plugin-html": "0.2.1"
       }
     },
@@ -46637,70 +46382,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "packages/create-atomic-result-component/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-result-component/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-atomic-result-component/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/create-atomic-result-component/node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^9.2.0"
-      },
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/create-atomic-result-component/template/src/components/sample-result-component": {
       "name": "@coveo/sample-result-component",
       "version": "0.0.1",
@@ -46717,7 +46398,6 @@
         "@types/jest": "29.5.14",
         "jest": "29.7.0",
         "jest-cli": "29.7.0",
-        "rimraf": "6.0.1",
         "rollup-plugin-html": "0.2.1"
       }
     },
@@ -46799,15 +46479,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "packages/create-atomic/node_modules/detect-indent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
-      "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "packages/create-atomic/node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -46874,7 +46545,6 @@
         "@coveo/documentation": "1.0.0",
         "@testing-library/react": "16.3.0",
         "live-server": "1.2.2",
-        "rimraf": "6.0.1",
         "typedoc": "0.28.8",
         "typescript": "5.8.3",
         "vitest": "3.2.4"
@@ -46937,7 +46607,6 @@
         "jest-junit": "16.0.0",
         "jsdoc": "4.0.4",
         "jsdoc-tsimport-plugin": "1.0.5",
-        "mkdirp": "3.0.1",
         "prettier-plugin-apex": "2.2.6",
         "ts-node": "10.9.2",
         "wait-on": "8.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22887,6 +22887,20 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "license": "MIT"
     },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -31150,6 +31164,34 @@
         }
       }
     },
+    "node_modules/less/node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/less/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -34352,9 +34394,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/needle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
       }
     },
     "node_modules/negotiator": {
@@ -38211,6 +38272,14 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -46074,8 +46143,6 @@
         "@angular/cli": "19.2.3",
         "@angular/compiler-cli": "19.2.2",
         "@coveo/headless": "3.31.1",
-        "@types/node": "22.16.5",
-        "ncp": "2.0.0",
         "ng-packagr": "19.2.0",
         "tslib": "2.8.1",
         "typescript": "5.8.3"
@@ -46155,7 +46222,6 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "fix-esm-import-path": "1.10.1",
-        "ncp": "2.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "rollup": "4.46.2",
@@ -46919,7 +46985,6 @@
         "@angular/platform-browser-dynamic": "19.2.2",
         "@angular/router": "19.2.2",
         "@coveo/atomic-angular": "3.7.8",
-        "ncp": "2.0.0",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",
         "zone.js": "0.15.1"
@@ -47037,7 +47102,6 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "@vitejs/plugin-react": "5.0.3",
-        "ncp": "2.0.0",
         "typescript": "5.8.3",
         "vite": "7.0.6"
       }
@@ -47078,7 +47142,6 @@
         "@types/node": "22.16.5",
         "@types/react": "19.1.1",
         "@types/react-dom": "19.1.2",
-        "ncp": "2.0.0",
         "typescript": "5.8.3"
       }
     },
@@ -47098,7 +47161,6 @@
         "@types/react": "19.1.1",
         "@types/react-dom": "19.1.2",
         "cypress": "13.7.3",
-        "ncp": "2.0.0",
         "typescript": "5.8.3"
       }
     },
@@ -47127,7 +47189,6 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "6.0.1",
         "cypress": "13.7.3",
-        "ncp": "2.0.0",
         "typescript": "5.8.3",
         "vite": "7.0.6"
       }
@@ -48126,10 +48187,6 @@
     "utils/cdn": {
       "name": "@coveo/cdn",
       "version": "1.0.0",
-      "devDependencies": {
-        "chalk": "5.4.1",
-        "ncp": "2.0.0"
-      },
       "engines": {
         "node": ">=22.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "patch-package": "8.0.0",
     "playwright": "1.54.1",
     "publint": "0.3.12",
-    "rimraf": "6.0.1",
     "semver": "7.7.2",
     "turbo": "2.5.5",
     "typescript": "5.8.3",

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -7,7 +7,7 @@
     "gen:lit": "node ./scripts/build-lit.mjs",
     "build": "npm run build:bundles && npm run build:assets",
     "build:bundles": "ng build",
-    "build:assets": "ncp ../atomic/dist/atomic/assets projects/atomic-angular/dist/assets && ncp ../atomic/dist/atomic/lang projects/atomic-angular/dist/lang",
+    "build:assets": "node ../../utils/ci/copy-files.mjs ../atomic/dist/atomic/assets projects/atomic-angular/dist/assets ../atomic/dist/atomic/lang projects/atomic-angular/dist/lang",
     "release:phase3": "node ./scripts/publish-npm.mjs",
     "release:phase1": "node ./scripts/bump.mjs"
   },
@@ -27,7 +27,6 @@
     "@coveo/headless": "3.31.1",
     "ng-packagr": "19.2.0",
     "typescript": "5.8.3",
-    "ncp": "2.0.0",
     "tslib": "2.8.1"
   },
   "engines": {

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -21,8 +21,8 @@
     "docs/"
   ],
   "scripts": {
-    "clean": "rimraf -rf dist/*",
-    "build": "rimraf -rf dist cdn && tsc --outdir dist && tsc --outdir cdn --project tsconfig.cdn.json && node ./scripts/esbuild.js",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/*",
+    "build": "node ../../utils/ci/rm-rf.mjs dist cdn && tsc --outdir dist && tsc --outdir cdn --project tsconfig.cdn.json && node ./scripts/esbuild.js",
     "start": "node ./scripts/start.js",
     "e2e": "playwright test",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@playwright/test": "1.54.1",
     "@types/node": "22.16.5",
-    "rimraf": "3.0.2",
     "vite": "7.0.6"
   },
   "engines": {

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "gen:lit": "node ./scripts/build-lit.mjs && npm run build:fixLoaderImportPaths && npm run build:fixGeneratedImportPaths",
     "build": "npm run build:bundles && npm run build:types && npm run build:assets",
-    "clean": "rimraf -rf dist",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist",
     "build:fixLoaderImportPaths": "node ./scripts/fix-loader-import-paths.js",
     "build:fixGeneratedImportPaths": "fix-esm-import-path src/components/stencil-generated",
     "build:bundles": "rollup --config rollup.config.js",
@@ -39,7 +39,6 @@
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-typescript": "12.1.4",
-    "@types/node": "22.16.5",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "fix-esm-import-path": "1.10.1",

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -20,7 +20,7 @@
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
-    "build:assets": "ncp ../atomic/dist/atomic/assets dist/assets && ncp ../atomic/dist/atomic/lang dist/lang "
+    "build:assets": "node ../../utils/ci/copy-files.mjs ../atomic/dist/atomic/assets dist/assets ../atomic/dist/atomic/lang dist/lang"
   },
   "module": "./dist/esm/atomic-react.mjs",
   "main": "./dist/cjs/atomic-react.cjs",
@@ -46,8 +46,7 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "rollup": "4.46.2",
-    "rollup-plugin-polyfill-node": "^0.13.0",
-    "ncp": "2.0.0"
+    "rollup-plugin-polyfill-node": "^0.13.0"
   },
   "peerDependencies": {
     "@coveo/headless": "3.31.1",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -47,10 +47,10 @@
     "licenses/"
   ],
   "scripts": {
-    "clean": "rimraf -rf dist/* dist-storybook/* www/* docs/* playwright-report/*",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/* dist-storybook/* www/* docs/* playwright-report/*",
     "build:storybook": "storybook build -o dist-storybook",
     "build:cem": "cem analyze",
-    "build:stencil-lit": "node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json && node ./scripts/stencil-proxy.mjs && node ./scripts/build.mjs --config=tsconfig.lit.json && esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js && esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js && rollup -c rollup.config.js && rimraf ./dist/atomic/loader/package.json && tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
+    "build:stencil-lit": "node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json && node ./scripts/stencil-proxy.mjs && node ./scripts/build.mjs --config=tsconfig.lit.json && esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js && esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js && rollup -c rollup.config.js && node ../../utils/ci/rm-rf.mjs ./dist/atomic/loader/package.json && tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
     "build:angular": "npx turbo gen:lit --filter=@coveo/atomic-angular-builder",
     "build:react": "npx turbo gen:lit --filter=@coveo/atomic-react",
     "build:locales": "node ./scripts/create-generated-folder.mjs && node ./scripts/split-locales.mjs && node ./scripts/copy-dayjs-locales.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch --colors --no-cache --silent=false",
     "build:bundles": "node esbuild.mjs",
     "build:definitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
-    "clean": "rimraf -rf dist/*",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/*",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod",
@@ -42,7 +42,6 @@
   "homepage": "https://github.com/coveo/ui-kit/packages/auth#readme",
   "devDependencies": {
     "jest": "29.7.0",
-    "rimraf": "6.0.1",
     "ts-jest": "29.4.0",
     "vite": "7.0.6"
   },

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:bundles && npm run build:definitions",
     "build:bundles": "node esbuild.mjs",
     "build:definitions": "tsc -p tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
-    "clean": "rimraf -rf dist/*",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/*",
     "test": "vitest run",
     "test:watch": "vitest",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",

--- a/packages/create-atomic-component-project/template/package.json
+++ b/packages/create-atomic-component-project/template/package.json
@@ -22,7 +22,6 @@
     "jest-cli": "29.7.0",
     "puppeteer": "24.15.0",
     "rollup-plugin-html": "0.2.1",
-    "rimraf": "6.0.1",
     "@coveo/create-atomic-rollup-plugin": "1.2.0"
   },
   "license": "Apache-2.0",

--- a/packages/create-atomic-component/template/src/components/sample-component/package.json
+++ b/packages/create-atomic-component/template/src/components/sample-component/package.json
@@ -35,7 +35,6 @@
     "jest-cli": "29.7.0",
     "puppeteer": "24.15.0",
     "rollup-plugin-html": "0.2.1",
-    "rimraf": "6.0.1",
     "@coveo/create-atomic-rollup-plugin": "1.2.0"
   },
   "keywords": [

--- a/packages/create-atomic-result-component/template/src/components/sample-result-component/package.json
+++ b/packages/create-atomic-result-component/template/src/components/sample-result-component/package.json
@@ -35,7 +35,6 @@
     "jest": "29.7.0",
     "jest-cli": "29.7.0",
     "rollup-plugin-html": "0.2.1",
-    "rimraf": "6.0.1",
     "@coveo/create-atomic-rollup-plugin": "1.2.0"
   },
   "keywords": [

--- a/packages/create-atomic-rollup-plugin/package.json
+++ b/packages/create-atomic-rollup-plugin/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "npm run clean && npm run build:ts",
-    "clean": "rimraf dist",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist",
     "build:ts": "tsc -p tsconfig.json",
     "lint": "npx @biomejs/biome check .",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "node ./index.mjs",
-    "build": "rimraf template && npm run build:ts && node ./scripts/preparePackageJsonTemplate.mjs",
+    "build": "node ../../utils/ci/rm-rf.mjs template && npm run build:ts && node ./scripts/preparePackageJsonTemplate.mjs",
     "build:ts": "tsc -p tsconfig.json",
     "lint": "prettier --check . && eslint .",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@coveo/platform-client": "60.4.0",
     "abortcontroller-polyfill": "1.7.8",
-    "detect-indent": "7.0.1",
     "https-proxy-agent": "7.0.6",
     "isomorphic-fetch": "3.0.0",
     "minimist": "1.2.8",
@@ -47,7 +46,6 @@
     "plop": "4.0.1"
   },
   "devDependencies": {
-    "fs-extra": "11.3.0",
     "typescript": "5.8.3"
   }
 }

--- a/packages/create-atomic/scripts/preparePackageJsonTemplate.mjs
+++ b/packages/create-atomic/scripts/preparePackageJsonTemplate.mjs
@@ -1,10 +1,38 @@
-import fs from 'fs-extra';
-
-const {readFileSync, writeFileSync, copySync, copyFileSync} = fs;
-
+import {copyFileSync, cpSync, readFileSync, writeFileSync} from 'node:fs';
 import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import detectIndent from 'detect-indent';
+
+/**
+ * Detects the indentation used in a string.
+ * @param {string} str - The string to analyze
+ * @returns {{indent: string, amount: number, type: 'tab' | 'space' | undefined}} The detected indentation
+ */
+function detectIndent(str) {
+  const tabMatch = str.match(/^(\t+)/m);
+  if (tabMatch) {
+    return {
+      indent: '\t',
+      amount: 1,
+      type: 'tab',
+    };
+  }
+
+  const spaceMatch = str.match(/^( +)/m);
+  if (spaceMatch) {
+    const amount = spaceMatch[1].length;
+    return {
+      indent: ' '.repeat(amount),
+      amount,
+      type: 'space',
+    };
+  }
+
+  return {
+    indent: '',
+    amount: 0,
+    type: undefined,
+  };
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,7 +44,7 @@ const atomicTemplatePath = resolve(
 );
 const bundledTemplatePath = resolve(__dirname, '..', 'template');
 
-copySync(atomicTemplatePath, bundledTemplatePath, {recursive: true});
+cpSync(atomicTemplatePath, bundledTemplatePath, {recursive: true});
 copyFileSync(
   join(__dirname, '!.eslintrc'),
   join(bundledTemplatePath, '.eslintrc')

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "tsc --project ./tsconfig.build.json",
-    "clean": "rimraf dist",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist",
     "test": "vitest run",
     "test:watch": "vitest",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@testing-library/react": "16.3.0",
     "live-server": "1.2.2",
-    "rimraf": "6.0.1",
     "typescript": "5.8.3",
     "typedoc": "0.28.8",
     "vitest": "3.2.4",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -78,7 +78,7 @@
     "build:bundles": "node esbuild.mjs",
     "build:esm": "node ./scripts/build.mjs --config=tsconfig.build-esm.json",
     "build:definitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
-    "clean": "rimraf -rf dist/*",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/*",
     "test": "vitest run --exclude \"src/integration-tests/**\"",
     "test:watch": "vitest --exclude \"src/integration-tests/**\"",
     "integration-test": "vitest run --poolOptions.threads.singleThread src/integration-tests/**",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --write",
     "lint:fix:apex": "prettier \"force-app/{,**}/*.{cls,trigger}\" --write",
     "build:staticresources": "node build-static-resources.js",
-    "dev": "npx rimraf .localdevserver && npm run build:staticresources && npm run dev:sfdx",
+    "dev": "node ../../utils/ci/rm-rf.mjs .localdevserver && npm run build:staticresources && npm run dev:sfdx",
     "dev:sfdx": "sf project deploy start --source-dir force-app/main && sfdx force:lightning:lwc:start --port 3334",
     "test:unit": "lwc-jest",
     "test:unit:debug": "lwc-jest --debug",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -74,7 +74,6 @@
     "jest-junit": "16.0.0",
     "jsdoc": "4.0.4",
     "jsdoc-tsimport-plugin": "1.0.5",
-    "mkdirp": "3.0.1",
     "prettier-plugin-apex": "2.2.6",
     "ts-node": "10.9.2",
     "wait-on": "8.0.4",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -51,7 +51,7 @@
     "build:bundles": "node esbuild.mjs",
     "build:definitions": "tsc -p src/tsconfig.build.json && node ./scripts/copy-types.mjs",
     "test": "vitest run",
-    "clean": "rimraf -rf dist/* && rimraf -rf cdn/",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist/* cdn/",
     "release:phase3": "npm run-script -w=@coveo/ci npm-publish",
     "release:phase1": "npm run-script -w=@coveo/ci bump",
     "promote:npm:latest": "npm run-script -w=@coveo/ci promote-npm-prod"

--- a/samples/atomic/search-commerce-angular/package.json
+++ b/samples/atomic/search-commerce-angular/package.json
@@ -7,7 +7,7 @@
     "build:angular": "ng build",
     "dev": "npm run build:assets && npm run dev:angular",
     "dev:angular": "ng serve --host=0.0.0.0 --prebundle=false",
-    "build:assets": "ncp ../../../packages/atomic-angular/projects/atomic-angular/dist/assets src/assets && ncp ../../../packages/atomic-angular/projects/atomic-angular/dist/lang src/lang"
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-angular/projects/atomic-angular/dist/assets src/assets ../../../packages/atomic-angular/projects/atomic-angular/dist/lang src/lang"
   },
   "private": true,
   "dependencies": {
@@ -21,7 +21,6 @@
     "@coveo/atomic-angular": "3.7.8",
     "rxjs": "7.8.2",
     "zone.js": "0.15.1",
-    "ncp": "2.0.0",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/samples/atomic/search-commerce-react/package.json
+++ b/samples/atomic/search-commerce-react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run build:assets && npm run dev:vite",
-    "build:assets": "ncp ../../../packages/atomic-react/dist/assets public/assets && ncp ../../../packages/atomic-react/dist/lang public/lang public/assets && ncp ../../../packages/atomic/dist/atomic/themes public/themes",
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-react/dist/assets public/assets ../../../packages/atomic-react/dist/lang public/lang ../../../packages/atomic/dist/atomic/themes public/themes",
     "dev:vite": "vite",
     "build": "npm run build:ts && npm run build:vite",
     "build:ts": "npm run-script -w=@coveo/ci if-not-cdn -- \"tsc -b\"",
@@ -23,7 +23,6 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "5.0.3",
-    "ncp": "2.0.0",
     "typescript": "5.8.3",
     "vite": "7.0.6"
   }

--- a/samples/atomic/search-nextjs-app-router/package.json
+++ b/samples/atomic/search-nextjs-app-router/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "npm run build:assets && next dev",
     "build": "npm run-script -w=@coveo/ci if-not-cdn -- \"npm run build:assets && next build\"",
-    "build:assets": "ncp ../../../packages/atomic-react/dist/assets public/assets && ncp ../../../packages/atomic-react/dist/lang public/lang",
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-react/dist/assets public/assets ../../../packages/atomic-react/dist/lang public/lang",
     "start": "next start",
     "lint": "next lint"
   },
@@ -21,7 +21,6 @@
     "typescript": "5.8.3",
     "@types/node": "22.16.5",
     "@types/react": "19.1.1",
-    "@types/react-dom": "19.1.2",
-    "ncp": "2.0.0"
+    "@types/react-dom": "19.1.2"
   }
 }

--- a/samples/atomic/search-nextjs-pages-router/package.json
+++ b/samples/atomic/search-nextjs-pages-router/package.json
@@ -16,7 +16,6 @@
     "@types/react": "19.1.1",
     "@types/react-dom": "19.1.2",
     "cypress": "13.7.3",
-    "ncp": "2.0.0",
     "typescript": "5.8.3"
   },
   "scripts": {
@@ -26,7 +25,7 @@
     "build:ts-cjs": "npm run-script -w=@coveo/ci if-not-cdn -- \"tsc --module commonjs --noEmit\"",
     "dev": "npm run build:assets && npm run dev:nextjs",
     "dev:nextjs": "next dev",
-    "build:assets": "ncp ../../../packages/atomic-react/dist/assets public/assets && ncp ../../../packages/atomic-react/dist/lang public/lang",
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-react/dist/assets public/assets ../../../packages/atomic-react/dist/lang public/lang",
     "e2e:watch": "cypress open --browser chrome --e2e",
     "e2e": "cypress run --browser chrome"
   }

--- a/samples/atomic/search-vuejs/package.json
+++ b/samples/atomic/search-vuejs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run build:assets && npm run build:vue",
     "dev": "npm run build:assets && npm run dev:vue",
-  "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic/dist/atomic/assets public/assets ../../../packages/atomic/dist/atomic/lang public/lang",
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic/dist/atomic/assets public/assets ../../../packages/atomic/dist/atomic/lang public/lang",
     "dev:vue": "vite",
     "build:vue": "vite build",
     "preview": "vite preview"

--- a/samples/atomic/search-vuejs/package.json
+++ b/samples/atomic/search-vuejs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run build:assets && npm run build:vue",
     "dev": "npm run build:assets && npm run dev:vue",
-    "build:assets": "ncp ../../../packages/atomic/dist/atomic/assets public/assets && ncp ../../../packages/atomic/dist/atomic/lang public/lang",
+  "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic/dist/atomic/assets public/assets ../../../packages/atomic/dist/atomic/lang public/lang",
     "dev:vue": "vite",
     "build:vue": "vite build",
     "preview": "vite preview"
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.1",
     "cypress": "13.7.3",
-    "ncp": "2.0.0",
     "typescript": "5.8.3",
     "vite": "7.0.6"
   }

--- a/samples/headless-ssr/commerce-express/src/lib/navigatorContext.ts
+++ b/samples/headless-ssr/commerce-express/src/lib/navigatorContext.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from 'crypto';
+import {randomUUID} from 'node:crypto';
 import type express from 'express';
 
 const getHeaderValue = (

--- a/samples/headless-ssr/commerce-express/src/middleware.ts
+++ b/samples/headless-ssr/commerce-express/src/middleware.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from 'crypto';
+import {randomUUID} from 'node:crypto';
 import type {NextFunction, Request, Response} from 'express';
 
 /**

--- a/utils/cdn/package.json
+++ b/utils/cdn/package.json
@@ -10,9 +10,5 @@
   },
   "engines": {
     "node": ">=22.14.0"
-  },
-  "devDependencies": {
-    "ncp": "2.0.0",
-    "chalk": "5.4.1"
   }
 }

--- a/utils/cdn/scripts/deploy-local-cdn.mjs
+++ b/utils/cdn/scripts/deploy-local-cdn.mjs
@@ -1,8 +1,7 @@
 import fs from 'node:fs/promises';
 import {findPackageJSON} from 'node:module';
 import path from 'node:path';
-import chalk from 'chalk';
-import ncp from 'ncp';
+import colors from '../../ci/colors.mjs';
 
 const currentDir = import.meta.dirname;
 const getVersionFromPackageJson = async (packageName, versionType) => {
@@ -89,19 +88,13 @@ const deploymentConfig = JSON.parse(processedConfigContent);
 const devCdnDir = path.resolve(currentDir, `../dist`);
 
 const copyFiles = async (source, destination) => {
-  return new Promise((resolve, reject) => {
-    ncp(source, destination, (err) => {
-      if (err) {
-        reject(
-          new Error(
-            `NCP error copying from ${source} to ${destination}: ${err ? err.map((e) => e.message).join(', ') : 'unknown error'}`
-          )
-        );
-      } else {
-        resolve();
-      }
-    });
-  });
+  try {
+    await fs.cp(source, destination, { recursive: true, force: true });
+  } catch (err) {
+    throw new Error(
+      `Error copying from ${source} to ${destination}: ${err.message}`
+    );
+  }
 };
 
 const ensureDirectoryExists = async (directory) => {
@@ -142,7 +135,7 @@ const main = async () => {
 
 main().catch((err) => {
   console.error(
-    chalk.red('An error occurred during local CDN deployment:'),
+    colors.red('An error occurred during local CDN deployment:'),
     err.message
   );
   process.exit(1);

--- a/utils/cdn/scripts/deploy-local-cdn.mjs
+++ b/utils/cdn/scripts/deploy-local-cdn.mjs
@@ -89,7 +89,7 @@ const devCdnDir = path.resolve(currentDir, `../dist`);
 
 const copyFiles = async (source, destination) => {
   try {
-    await fs.cp(source, destination, { recursive: true, force: true });
+    await fs.cp(source, destination, {recursive: true, force: true});
   } catch (err) {
     throw new Error(
       `Error copying from ${source} to ${destination}: ${err.message}`

--- a/utils/cdn/scripts/serve.mjs
+++ b/utils/cdn/scripts/serve.mjs
@@ -1,5 +1,5 @@
 import {spawn} from 'node:child_process';
-import colors from '../../ci/colors.mjs'
+import colors from '../../ci/colors.mjs';
 
 try {
   console.log(

--- a/utils/cdn/scripts/serve.mjs
+++ b/utils/cdn/scripts/serve.mjs
@@ -1,10 +1,10 @@
 import {spawn} from 'node:child_process';
-import chalk from 'chalk';
+import colors from '../../ci/colors.mjs'
 
 try {
   console.log(
     // eslint-disable-next-line @cspell/spellchecker
-    chalk.cyan(
+    colors.cyan(
       'Starting workspace server on port 3000 for ./dist/proda/StaticCDN directory...'
     )
   );
@@ -13,6 +13,6 @@ try {
     stdio: 'inherit',
   });
 } catch (err) {
-  console.error(chalk.red('Error starting the server:'), err);
+  console.error(colors.red('Error starting the server:'), err);
   process.exit(1);
 }

--- a/utils/ci/copy-files.mjs
+++ b/utils/ci/copy-files.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync } from 'fs';
-import { resolve } from 'path';
+import {cpSync, existsSync} from 'node:fs';
+import {resolve} from 'node:path';
 
 /**
  * Copy a single path (file or directory) to a target location
@@ -12,10 +12,10 @@ import { resolve } from 'path';
 function copyPath(source, target) {
   const resolvedSource = resolve(source);
   const resolvedTarget = resolve(target);
-  
+
   if (existsSync(resolvedSource)) {
     console.log(`Copying ${resolvedSource} to ${resolvedTarget}`);
-    cpSync(resolvedSource, resolvedTarget, { recursive: true, force: true });
+    cpSync(resolvedSource, resolvedTarget, {recursive: true, force: true});
     return true;
   } else {
     console.warn(`Source path does not exist: ${resolvedSource}`);
@@ -25,37 +25,41 @@ function copyPath(source, target) {
 
 function main() {
   const args = process.argv.slice(2);
-  
+
   if (args.length === 0) {
-    console.error('Usage: node copy-files.mjs <source> <target> [<source2> <target2> ...]');
+    console.error(
+      'Usage: node copy-files.mjs <source> <target> [<source2> <target2> ...]'
+    );
     console.error('');
     console.error('Examples:');
     console.error('  node copy-files.mjs ./src/assets ./dist/assets');
-    console.error('  node copy-files.mjs ./assets ./dist/assets ./lang ./dist/lang');
+    console.error(
+      '  node copy-files.mjs ./assets ./dist/assets ./lang ./dist/lang'
+    );
     process.exit(1);
   }
-  
+
   if (args.length % 2 !== 0) {
     console.error('Error: Arguments must be provided in pairs (source target)');
     process.exit(1);
   }
-  
+
   let allSuccessful = true;
-  
+
   for (let i = 0; i < args.length; i += 2) {
     const source = args[i];
     const target = args[i + 1];
-    
+
     if (!copyPath(source, target)) {
       allSuccessful = false;
     }
   }
-  
+
   if (!allSuccessful) {
     console.warn('Some copy operations failed - see warnings above');
     process.exit(1);
   }
-  
+
   console.log('All copy operations completed successfully');
 }
 

--- a/utils/ci/copy-files.mjs
+++ b/utils/ci/copy-files.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Copy a single path (file or directory) to a target location
+ * @param {string} source - Source path to copy from
+ * @param {string} target - Target path to copy to
+ * @returns {boolean} - True if copy was successful, false otherwise
+ */
+function copyPath(source, target) {
+  const resolvedSource = resolve(source);
+  const resolvedTarget = resolve(target);
+  
+  if (existsSync(resolvedSource)) {
+    console.log(`Copying ${resolvedSource} to ${resolvedTarget}`);
+    cpSync(resolvedSource, resolvedTarget, { recursive: true, force: true });
+    return true;
+  } else {
+    console.warn(`Source path does not exist: ${resolvedSource}`);
+    return false;
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length === 0) {
+    console.error('Usage: node copy-files.mjs <source> <target> [<source2> <target2> ...]');
+    console.error('');
+    console.error('Examples:');
+    console.error('  node copy-files.mjs ./src/assets ./dist/assets');
+    console.error('  node copy-files.mjs ./assets ./dist/assets ./lang ./dist/lang');
+    process.exit(1);
+  }
+  
+  if (args.length % 2 !== 0) {
+    console.error('Error: Arguments must be provided in pairs (source target)');
+    process.exit(1);
+  }
+  
+  let allSuccessful = true;
+  
+  for (let i = 0; i < args.length; i += 2) {
+    const source = args[i];
+    const target = args[i + 1];
+    
+    if (!copyPath(source, target)) {
+      allSuccessful = false;
+    }
+  }
+  
+  if (!allSuccessful) {
+    console.warn('Some copy operations failed - see warnings above');
+    process.exit(1);
+  }
+  
+  console.log('All copy operations completed successfully');
+}
+
+main();

--- a/utils/ci/rm-rf.mjs
+++ b/utils/ci/rm-rf.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { rmSync, readdirSync, existsSync } from 'fs';
-import { resolve, join, dirname, basename } from 'path';
+import {existsSync, readdirSync, rmSync} from 'node:fs';
+import {basename, dirname, join, resolve} from 'node:path';
 
 /**
  * Simple glob expansion for patterns like "dist/*"
@@ -10,11 +10,11 @@ import { resolve, join, dirname, basename } from 'path';
  */
 function expandGlob(pattern) {
   const resolvedPattern = resolve(pattern);
-  
+
   if (!pattern.includes('*')) {
     return [resolvedPattern];
   }
-  
+
   if (pattern.endsWith('/*')) {
     const dir = resolvedPattern.slice(0, -2);
     if (!existsSync(dir)) {
@@ -22,28 +22,28 @@ function expandGlob(pattern) {
     }
     try {
       const entries = readdirSync(dir);
-      return entries.map(entry => join(dir, entry));
-    } catch (err) {
+      return entries.map((entry) => join(dir, entry));
+    } catch (_err) {
       console.warn(`Warning: Could not read directory ${dir}`);
       return [];
     }
   }
-  
+
   const dir = dirname(resolvedPattern);
   const filePattern = basename(resolvedPattern);
-  
+
   if (!existsSync(dir)) {
     return [];
   }
-  
+
   try {
     const entries = readdirSync(dir);
     const regex = new RegExp(
-      '^' + filePattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
+      `^${filePattern.replace(/\*/g, '.*').replace(/\?/g, '.')}$`
     );
-    const matches = entries.filter(entry => regex.test(entry));
-    return matches.map(entry => join(dir, entry));
-  } catch (err) {
+    const matches = entries.filter((entry) => regex.test(entry));
+    return matches.map((entry) => join(dir, entry));
+  } catch (_err) {
     console.warn(`Warning: Could not read directory ${dir}`);
     return [];
   }
@@ -52,7 +52,7 @@ function expandGlob(pattern) {
 /**
  * Remove files and directories recursively (equivalent to rm -rf)
  * Supports simple glob patterns (e.g., dist/*, *.tmp)
- * 
+ *
  * @param {string[]} paths - Paths to remove (can include simple glob patterns)
  */
 function removeRecursive(paths) {
@@ -68,13 +68,18 @@ function removeRecursive(paths) {
 
   for (const path of paths) {
     const expandedPaths = expandGlob(path);
-    
+
     for (const resolvedPath of expandedPaths) {
       try {
-        rmSync(resolvedPath, { recursive: true, force: true });
+        rmSync(resolvedPath, {recursive: true, force: true});
         console.log(`Removed: ${resolvedPath}`);
       } catch (err) {
-        if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+        if (
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          err.code !== 'ENOENT'
+        ) {
           console.error(`Error removing ${resolvedPath}:`, String(err));
         }
       }

--- a/utils/ci/rm-rf.mjs
+++ b/utils/ci/rm-rf.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { rmSync, readdirSync, existsSync } from 'fs';
+import { resolve, join, dirname, basename } from 'path';
+
+/**
+ * Simple glob expansion for patterns like "dist/*"
+ * @param {string} pattern - Path pattern that may contain wildcards
+ * @returns {string[]} - Array of matched paths
+ */
+function expandGlob(pattern) {
+  const resolvedPattern = resolve(pattern);
+  
+  if (!pattern.includes('*')) {
+    return [resolvedPattern];
+  }
+  
+  if (pattern.endsWith('/*')) {
+    const dir = resolvedPattern.slice(0, -2);
+    if (!existsSync(dir)) {
+      return [];
+    }
+    try {
+      const entries = readdirSync(dir);
+      return entries.map(entry => join(dir, entry));
+    } catch (err) {
+      console.warn(`Warning: Could not read directory ${dir}`);
+      return [];
+    }
+  }
+  
+  const dir = dirname(resolvedPattern);
+  const filePattern = basename(resolvedPattern);
+  
+  if (!existsSync(dir)) {
+    return [];
+  }
+  
+  try {
+    const entries = readdirSync(dir);
+    const regex = new RegExp(
+      '^' + filePattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
+    );
+    const matches = entries.filter(entry => regex.test(entry));
+    return matches.map(entry => join(dir, entry));
+  } catch (err) {
+    console.warn(`Warning: Could not read directory ${dir}`);
+    return [];
+  }
+}
+
+/**
+ * Remove files and directories recursively (equivalent to rm -rf)
+ * Supports simple glob patterns (e.g., dist/*, *.tmp)
+ * 
+ * @param {string[]} paths - Paths to remove (can include simple glob patterns)
+ */
+function removeRecursive(paths) {
+  if (paths.length === 0) {
+    console.error('Usage: node rm-rf.mjs <path> [<path2> ...]');
+    console.error('');
+    console.error('Examples:');
+    console.error('  node rm-rf.mjs ./dist');
+    console.error('  node rm-rf.mjs ./dist ./build ./temp');
+    console.error('  node rm-rf.mjs dist/* build/*');
+    process.exit(1);
+  }
+
+  for (const path of paths) {
+    const expandedPaths = expandGlob(path);
+    
+    for (const resolvedPath of expandedPaths) {
+      try {
+        rmSync(resolvedPath, { recursive: true, force: true });
+        console.log(`Removed: ${resolvedPath}`);
+      } catch (err) {
+        if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+          console.error(`Error removing ${resolvedPath}:`, String(err));
+        }
+      }
+    }
+  }
+}
+
+const args = process.argv.slice(2);
+removeRecursive(args);


### PR DESCRIPTION
Continuation of 
https://coveord.atlassian.net/browse/KIT-5013

* Added a script for `copy-files.mjs`, and removed `ncp` from multiples packages
* Added a script for `rm-rf.mjs`, and removed `rimraf` from multiple packages
* Small miscellaneous dependencies cleanup
