### PR TITLE
fix(atomic): enforce a11y through Storybook

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -85,7 +85,7 @@ export const parameters: Parameters = {
     // 'todo' - show a11y violations in the test UI only
     // 'error' - fail CI on a11y violations
     // 'off' - skip a11y checks entirely
-    test: 'todo',
+    test: 'error',
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
@@ -148,7 +148,6 @@ export class AtomicCommerceFacetNumberInput
           ${minText}
         </label>
         <input
-          role="textbox"
           part="input-start"
           id="${facetId}_start"
           type="number"

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -60,13 +60,14 @@ const meta: Meta = {
   },
   argTypes,
 
-  afterEach,
+  afterEach: afterEachNoFirstQuery,
 };
 
 export default meta;
 
 export const Default: Story = {
   name: 'Using grid display',
+  afterEach,
 };
 
 export const GridDisplayWithTemplate: Story = {
@@ -110,17 +111,17 @@ export const GridDisplayWithTemplate: Story = {
   </template>
 </atomic-product-template>`,
   },
+  afterEach,
 };
 
 export const GridDisplayBeforeQuery: Story = {
   name: 'Using grid display before query',
-  afterEach: async (context) => {
-    await afterEachNoFirstQuery(context);
-  },
+  tags: ['!test'],
 };
 
 export const ListDisplay: Story = {
   name: 'Using list display',
+  afterEach,
   args: {
     display: 'list',
   },
@@ -128,6 +129,7 @@ export const ListDisplay: Story = {
 
 export const ListDisplayWithTemplate: Story = {
   name: 'Using list display with template',
+  afterEach,
   args: {
     display: 'list',
     'default-slot': `<atomic-product-template>
@@ -175,13 +177,11 @@ export const ListDisplayBeforeQuery: Story = {
   args: {
     display: 'list',
   },
-  afterEach: async (context) => {
-    await afterEachNoFirstQuery(context);
-  },
 };
 
 export const TableDisplay: Story = {
   name: 'Using table display',
+  afterEach,
   args: {
     display: 'table',
     'default-slot': `<atomic-product-template>
@@ -208,9 +208,23 @@ export const TableDisplayBeforeQuery: Story = {
   name: 'Using table display before query',
   args: {
     display: 'table',
-  },
-  afterEach: async (context) => {
-    await afterEachNoFirstQuery(context);
+    'default-slot': `<atomic-product-template>
+      <template>
+        <atomic-table-element label="Product">
+          <atomic-product-link></atomic-product-link>
+          <atomic-product-field-condition if-defined="ec_brand">
+            <atomic-product-text field="ec_brand" class="text-neutral-dark block"></atomic-product-text>
+          </atomic-product-field-condition>
+        </atomic-table-element>
+        <atomic-table-element label="ID">
+          <atomic-product-text field="permanentid"></atomic-product-text>
+        </atomic-table-element>
+        <atomic-table-element label="Price">
+          <atomic-product-price></atomic-product-price>
+        </atomic-table-element>
+
+      </template>
+    </atomic-product-template>`,
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -116,7 +116,6 @@ export const GridDisplayWithTemplate: Story = {
 
 export const GridDisplayBeforeQuery: Story = {
   name: 'Using grid display before query',
-  tags: ['!test'],
 };
 
 export const ListDisplay: Story = {

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
@@ -2,14 +2,12 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
-import {userEvent} from 'storybook/test';
+import {expect, userEvent} from 'storybook/test';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
 
-const {decorator, afterEach} = wrapInCommerceInterface({
-  includeCodeRoot: false,
-});
-const {events, args, argTypes, template} = getStorybookHelpers(
+const {decorator, afterEach} = wrapInCommerceInterface();
+const {events, args, argTypes, styleTemplate} = getStorybookHelpers(
   'atomic-commerce-refine-modal',
   {excludeCategories: ['methods']}
 );
@@ -18,12 +16,9 @@ const meta: Meta = {
   component: 'atomic-commerce-refine-modal',
   title: 'Commerce/Refine Modal',
   id: 'atomic-commerce-refine-toggle',
-  render: (args) => html`${template(args)}`,
-  decorators: [
-    (story) =>
-      html`<atomic-commerce-refine-toggle></atomic-commerce-refine-toggle><div id="code-root">${story()}</div>`,
-    decorator,
-  ],
+  render: (args) =>
+    html`${styleTemplate(args)}<atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>`,
+  decorators: [decorator],
   parameters: {
     ...commonParameters,
     actions: {
@@ -34,7 +29,36 @@ const meta: Meta = {
     ...args,
     'collapse-facets-after': '0',
   },
-  argTypes,
+  argTypes: {
+    ...argTypes,
+    'open-button': {
+      ...argTypes['open-button'],
+      control: {
+        disable: true,
+      },
+      table: {
+        defaultValue: {summary: undefined},
+      },
+    },
+    'is-open': {
+      ...argTypes['is-open'],
+      control: {
+        disable: true,
+      },
+      table: {
+        defaultValue: {summary: undefined},
+      },
+    },
+    'collapse-facets-after': {
+      ...argTypes['collapse-facets-after'],
+      control: {
+        disable: true,
+      },
+      table: {
+        defaultValue: {summary: undefined},
+      },
+    },
+  },
   globals: {
     layout: 'fullscreen',
     docs: {
@@ -45,16 +69,26 @@ const meta: Meta = {
       },
     },
   },
-  afterEach: async (context) => {
-    await afterEach(context);
-    const canvas = within(
-      context.canvasElement.querySelector('atomic-commerce-refine-toggle')!
-    );
+  //TODO KIT-5111: Remove beforeEach when refactored in preview.ts
+  beforeEach({canvasElement, canvas}) {
+    Object.assign(canvas, {...within(canvasElement)});
+  },
+  play: async ({mount, step, ...restOfContext}) => {
+    const canvas = (await mount()) as ReturnType<typeof within>;
+    await afterEach({mount, step, ...restOfContext});
     const refineToggle = await canvas.findByShadowRole('button', {
       name: 'Sort & Filter',
     });
-
-    await userEvent.click(refineToggle);
+    await step('Open refine modal', async () => {
+      await userEvent.click(refineToggle);
+      await expect(
+        await canvas.findByShadowText(
+          'View products',
+          {exact: false},
+          {timeout: 10e3}
+        )
+      ).toBeVisible();
+    });
   },
 };
 

--- a/packages/atomic/src/components/search/atomic-result-table-placeholder/atomic-result-table-placeholder.tsx
+++ b/packages/atomic/src/components/search/atomic-result-table-placeholder/atomic-result-table-placeholder.tsx
@@ -28,7 +28,7 @@ export class AtomicResultTablePlaceholder {
   public render() {
     return (
       <table class={`list-root animate-pulse ${this.getClasses().join(' ')}`}>
-        <thead>
+        <thead aria-hidden="true">
           <tr>
             <th>
               <div

--- a/packages/atomic/storybook-utils/common/common-meta-parameters.ts
+++ b/packages/atomic/storybook-utils/common/common-meta-parameters.ts
@@ -2,12 +2,17 @@ import type {Parameters, StoryContext} from '@storybook/web-components-vite';
 
 const formatCode = async (code: string) => {
   const prettier = await import('prettier/standalone');
-  const prettierPluginBabel = await import('prettier/plugins/babel');
+  const prettierPluginHtml = await import('prettier/plugins/html');
   const prettierPluginEstree = await import('prettier/plugins/estree');
+  const prettierPluginPostCSS = await import('prettier/plugins/postcss');
 
   return prettier.format(code, {
-    parser: 'babel',
-    plugins: [prettierPluginBabel.default, prettierPluginEstree.default],
+    parser: 'html',
+    plugins: [
+      prettierPluginHtml.default,
+      prettierPluginEstree.default,
+      prettierPluginPostCSS.default,
+    ],
   });
 };
 


### PR DESCRIPTION
- Enforce a11y through Storybook.
- Fix accessibility issues by-the-by:
  - remove explicit & incorrect role for numeric input
  - Hide from the AOM tree the "placeholder" for the tab: it's not meaningful content, I think, and should be 🫥 
- Fix Storybook issues:
  - Code tab crashing when adding custom CSS part (need to use HTML format lang for prettier over jsx, as the latter wants a single child)
  - Non-writtable props/attr now identified as such for the refineModal
  - Rework of the rendering logic of the refine-modal logic (before, we had 2 refine-modal... yikes)