### PR TITLE
chore(atomic): add mockConsole testing util

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
@@ -38,7 +38,7 @@ describe('atomic-commerce-breadbox', () => {
   const mockedDeselectAll = vi.fn();
 
   beforeEach(() => {
-    mockConsole({silent: true});
+    mockConsole();
   });
 
   interface RenderBreadboxOptions {

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.spec.ts
@@ -31,7 +31,7 @@ describe('atomic-commerce-search-box-instant-products', () => {
   let mockedConsole: MockedObject<Console>;
 
   beforeEach(() => {
-    mockedConsole = mockConsole({silent: true});
+    mockedConsole = mockConsole();
     vi.mocked(buildInstantProducts).mockReturnValue(buildFakeInstantProducts());
   });
   const renderElements = async (bindings: Record<string, unknown> = {}) => {

--- a/packages/atomic/vitest-utils/testing-helpers/testing-utils/mock-console.ts
+++ b/packages/atomic/vitest-utils/testing-helpers/testing-utils/mock-console.ts
@@ -1,14 +1,14 @@
 import {vi} from 'vitest';
 
-export function mockConsole(options: {silent?: boolean} = {}) {
-  const errorSpy = vi.spyOn(console, 'error');
-  const logSpy = vi.spyOn(console, 'log');
-  const warnSpy = vi.spyOn(console, 'warn');
+export function mockConsole(options: {loud?: boolean} = {}) {
+  const mockedError = vi.spyOn(console, 'error');
+  const mockedLog = vi.spyOn(console, 'log');
+  const mockedWarn = vi.spyOn(console, 'warn');
 
-  if (options.silent) {
-    errorSpy.mockImplementation(() => {});
-    logSpy.mockImplementation(() => {});
-    warnSpy.mockImplementation(() => {});
+  if (!options.loud) {
+    mockedError.mockImplementation(() => {});
+    mockedLog.mockImplementation(() => {});
+    mockedWarn.mockImplementation(() => {});
   }
 
   return vi.mocked(console);


### PR DESCRIPTION
This new util will allow us to mock the console in a consistent way in our component tests, and get rid of the global `console.error` mock we're currently doing in atomic/vitest-utils/setup.ts.

The util spies on the console `error`, `log`, and `warn` methods, and by default uses a blank implementation to keep the logs clean (we can pass `loud: true` to use the original implementations).

https://coveord.atlassian.net/browse/KIT-5115