### PR TITLE
feat(atomic): migrating content from docs site to storybook

### DIFF
--- a/packages/atomic/src/components.d.ts
+++ b/packages/atomic/src/components.d.ts
@@ -77,7 +77,11 @@ export namespace Components {
         "updateCollapseFacetsDependingOnFacetsVisibility": (collapseAfter: number, numberOfVisibleFacets: number) => Promise<void>;
     }
     /**
-     * The `atomic-breadbox` component creates breadcrumbs that display a summary of the currently active facet values.
+     * The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+     * In most cases, these are on the top of a page between the search bar and the results.
+     * Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+     * By default, the field name is displayed before the field value to clarify which facet the value is from.
+     * You can clear a single selection by clicking the `x` inside of each pill, or clear all selections by using the `Clear` button.
      */
     interface AtomicBreadbox {
         /**
@@ -2671,7 +2675,11 @@ declare global {
         new (): HTMLAtomicAutomaticFacetGeneratorElement;
     };
     /**
-     * The `atomic-breadbox` component creates breadcrumbs that display a summary of the currently active facet values.
+     * The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+     * In most cases, these are on the top of a page between the search bar and the results.
+     * Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+     * By default, the field name is displayed before the field value to clarify which facet the value is from.
+     * You can clear a single selection by clicking the `x` inside of each pill, or clear all selections by using the `Clear` button.
      */
     interface HTMLAtomicBreadboxElement extends Components.AtomicBreadbox, HTMLStencilElement {
     }
@@ -4119,7 +4127,11 @@ declare namespace LocalJSX {
         "numberOfValues"?: number;
     }
     /**
-     * The `atomic-breadbox` component creates breadcrumbs that display a summary of the currently active facet values.
+     * The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+     * In most cases, these are on the top of a page between the search bar and the results.
+     * Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+     * By default, the field name is displayed before the field value to clarify which facet the value is from.
+     * You can clear a single selection by clicking the `x` inside of each pill, or clear all selections by using the `Clear` button.
      */
     interface AtomicBreadbox {
         /**
@@ -6713,7 +6725,11 @@ declare module "@stencil/core" {
              */
             "atomic-automatic-facet-generator": LocalJSX.AtomicAutomaticFacetGenerator & JSXBase.HTMLAttributes<HTMLAtomicAutomaticFacetGeneratorElement>;
             /**
-             * The `atomic-breadbox` component creates breadcrumbs that display a summary of the currently active facet values.
+             * The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+             * In most cases, these are on the top of a page between the search bar and the results.
+             * Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+             * By default, the field name is displayed before the field value to clarify which facet the value is from.
+             * You can clear a single selection by clicking the `x` inside of each pill, or clear all selections by using the `Clear` button.
              */
             "atomic-breadbox": LocalJSX.AtomicBreadbox & JSXBase.HTMLAttributes<HTMLAtomicBreadboxElement>;
             /**

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
@@ -10,31 +10,15 @@ import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/ato
   tagName="atomic-breadbox"
   className="AtomicBreadbox"
 >
-# UX notes
 
-## Introduction
+Include breadcrumbs in a search page when you want users to navigate the content using facets.
+For eaxmple, on an ecommerce website breadcrumbs help the users keep track of the selected filters and being able to confirm and adjust filtering encourages browsing.
 
-The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
-In most cases, these are on the top of a page between the search bar and the results.
-Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
-Clearing the breadcrumbs is possible individually or all-at-once.
-By default, having the field name displayed before the field value helps to clarify which facet the value is from. However, in the case where there are two or less facets, you can remove the field name through the `breadcrumb-label` shadow part.
 
-## User Experience and Best Practices
+## UX Best Practices
 
-### Usage Notes
-
-* Include breadcrumbs in a search page when you want users to navigate the content using facets.
-* When a page has more than two facet types, we recommended that breadcrumbs should include the facet title, helping the user distinguish the source of each breadcrumb.
-
-### Guidelines
-
-We display the field name to help clarify which facet the breadcrumb value associated with.
-However, in the case where there are two or less facets, you can remove the field name through the CSS shadow part, `breadcrumb-label`.
-
-## Use Cases and Examples
-
-On an ecommerce website, breadcrumbs help the users keep track of the selected filters during their browsing experience. Being able to confirm and adjust filtering encourages browsing.
+- **Field names provide context for the selected value**: displaying the field name next to the selected value clarifis which facet the breadcrumb value associated with.
+In the case where there are two or less facets, remove the field name through the CSS shadow part `breadcrumb-label` if the context is clear.
 
 </AtomicDocTemplate>
 

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicBreadboxStories from './atomic-breadbox.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicBreadboxStories} />
+
+<AtomicDocTemplate
+  stories={AtomicBreadboxStories}
+  githubPath="search/atomic-breadbox/atomic-breadbox.ts"
+  tagName="atomic-breadbox"
+  className="AtomicBreadbox"
+>
+# UX notes
+
+## Introduction
+
+The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+In most cases, these are on the top of a page between the search bar and the results.
+Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+Clearing the breadcrumbs is possible individually or all-at-once.
+By default, having the field name displayed before the field value helps to clarify which facet the value is from. However, in the case where there are two or less facets, you can remove the field name through the `breadcrumb-label` shadow part.
+
+## User Experience and Best Practices
+
+### Usage Notes
+
+* Include breadcrumbs in a search page when you want users to navigate the content using facets.
+* When a page has more than two facet types, we recommended that breadcrumbs should include the facet title, helping the user distinguish the source of each breadcrumb.
+
+### Guidelines
+
+We display the field name to help clarify which facet the breadcrumb value associated with.
+However, in the case where there are two or less facets, you can remove the field name through the CSS shadow part, `breadcrumb-label`.
+
+## Use Cases and Examples
+
+On an ecommerce website, breadcrumbs help the users keep track of the selected filters during their browsing experience. Being able to confirm and adjust filtering encourages browsing.
+
+</AtomicDocTemplate>
+

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.tsx
@@ -26,7 +26,15 @@ import {Hidden} from '../../common/stencil-hidden';
 import {Bindings} from '../atomic-search-interface/atomic-search-interface';
 
 /**
- * The `atomic-breadbox` component creates breadcrumbs that display a summary of the currently active facet values.
+ * The _Breadbox_ component helps the information seeker keep track of the navigational state of the currently active facet values, located in a single place on the search page.
+ *
+ * In most cases, these are on the top of a page between the search bar and the results.
+ * Each facet value that’s displayed in the breadcrumbs will appear as individual pill styled buttons.
+ *
+ * By default, the field name is displayed before the field value to clarify which facet the value is from.
+ *
+ * You can clear a single selection by clicking the `x` inside of each pill, or clear all selections by using the `Clear` button.
+ *
  *
  * @part container - The container of the whole component, list & label.
  * @part breadcrumb-list-container - The container of the list of breadcrumb buttons.

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
@@ -1,0 +1,46 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicDidYouMeanStories from './atomic-did-you-mean.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicDidYouMeanStories} />
+
+<AtomicDocTemplate
+  stories={AtomicDidYouMeanStories}
+  githubPath="search/atomic-did-you-mean/atomic-did-you-mean.ts"
+  tagName="atomic-did-you-mean"
+  className="AtomicDidYouMean"
+>
+# UX notes
+
+## Introduction
+
+The _Did You Mean_ component detects and corrects spelling errors in queries and provides suggestions when a similar term with more results is available.
+
+## User Experience and Best Practices
+
+The relevance of the corrections improves with the size of the index, as more terms become available for comparison.
+It’s possible to define certain phrases or terms in an organization’s thesaurus, which will expand or replace the query expression before executing the query.
+However, the Did You Mean component won’t process queries expanded by the thesaurus.
+
+### Usage Notes
+
+* When a query returns no results but finds a possible query correction, the component automatically triggers a new query with the suggested term.
+This prevents the user having to rewrite their query, which saves them time.
+* If the current query returns results but the index has more frequently occurring terms with similar spelling, the component presents a link containing the new terms.
+When clicked, the link triggers a new query using the corrected keywords.
+* A soft nudge asking them if that’s what they meant can direct them to the most relevant results.
+
+### Guidelines
+
+Using the Did You Mean component is good practice, especially if your index has search terms that can be misinterpreted as an error.
+
+## Use Cases and Examples
+
+When submitting a misspelled search of "guitr" in Google it’s automatically corrected, displaying the results for "guitar" and a message indicating that the correction occurred.
+
+### Reference
+[Designing Search: Staying on Track](https://uxmag.com/articles/designing-search-staying-on-track)
+
+[Searching "guitr" with Google](https://www.google.com/search?q=guitr&oq=guitr&aqs=chrome..69i57j0i10i433l3j69i60j69i65j69i60l2.538j0j7&sourceid=chrome&ie=UTF-8)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
@@ -10,35 +10,24 @@ import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/ato
   tagName="atomic-did-you-mean"
   className="AtomicDidYouMean"
 >
-# UX notes
 
-## Introduction
 
-The _Did You Mean_ component detects and corrects spelling errors in queries and provides suggestions when a similar term with more results is available.
-
-## User Experience and Best Practices
-
+Using the _Did You Mean_ component is with your search page is a best practice, especially if your index has search terms that can be misinterpreted as an error.
 The relevance of the corrections improves with the size of the index, as more terms become available for comparison.
-It’s possible to define certain phrases or terms in an organization’s thesaurus, which will expand or replace the query expression before executing the query.
-However, the Did You Mean component won’t process queries expanded by the thesaurus.
 
-### Usage Notes
+It's possible to define certain phrases or terms in an organization’s thesaurus, which will expand or replace the query expression before executing the query.
+However, the _Did You Mean_ component won’t process queries expanded by the thesaurus.
 
-* When a query returns no results but finds a possible query correction, the component automatically triggers a new query with the suggested term.
-This prevents the user having to rewrite their query, which saves them time.
-* If the current query returns results but the index has more frequently occurring terms with similar spelling, the component presents a link containing the new terms.
+
+### Common Use Cases
+* The current query returns results, but the index has more frequently occurring terms with similar spelling, the component presents a link containing the new terms.
 When clicked, the link triggers a new query using the corrected keywords.
-* A soft nudge asking them if that’s what they meant can direct them to the most relevant results.
+* A soft nudge asking them if that's what they meant can direct them to the most relevant results.
 
-### Guidelines
-
-Using the Did You Mean component is good practice, especially if your index has search terms that can be misinterpreted as an error.
-
-## Use Cases and Examples
+## Examples
 
 When submitting a misspelled search of "guitr" in Google it’s automatically corrected, displaying the results for "guitar" and a message indicating that the correction occurred.
 
-### Reference
 [Designing Search: Staying on Track](https://uxmag.com/articles/designing-search-staying-on-track)
 
 [Searching "guitr" with Google](https://www.google.com/search?q=guitr&oq=guitr&aqs=chrome..69i57j0i10i433l3j69i60j69i65j69i60l2.538j0j7&sourceid=chrome&ie=UTF-8)

--- a/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.mdx
+++ b/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.mdx
@@ -1,0 +1,21 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicFacetManagerStories from './atomic-facet-manager.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicFacetManagerStories} />
+
+<AtomicDocTemplate
+  stories={AtomicFacetManagerStories}
+  githubPath="search/atomic-facet-manager/atomic-facet-manager.ts"
+  tagName="atomic-facet-manager"
+  className="AtomicFacetManager"
+>
+# UX notes
+
+{facet} components that are slotted within an `atomic-facet-manager` are removed and reattached to the DOM by the {facet} manager.
+This means that the [Stencil lifecycle](https://stenciljs.com/docs/component-lifecycle#component-lifecycle-methods) applies to the slotted {facets}.
+
+If you [create your own custom facet component]({site-baseurl}/atomic/latest/usage/custom-web-components#custom-component-example) and slot it inside of the `atomic-facet-manager`, it will have to be able to handle the Stencil reattachment lifecycle.
+Alternately, you can place your custom component outside of the `atomic-facet-manager`, in which case the Stencil lifecycle won’t apply.
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.mdx
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.mdx
@@ -1,0 +1,41 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicLoadMoreResultsStories from './atomic-load-more-results.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicLoadMoreResultsStories} />
+
+<AtomicDocTemplate
+  stories={AtomicLoadMoreResultsStories}
+  githubPath="search/atomic-load-more-results/atomic-load-more-results.ts"
+  tagName="atomic-load-more-results"
+  className="AtomicLoadMoreResults"
+>
+# UX notes
+
+## Introduction
+
+This component allows a user to load more results when they reach the bottom of a page, assuming there are more results.
+This approach offers a smoother and more intuitive browsing experience, as there’s no "page reload."
+
+## User Experience and Best Practices
+
+### Usage Notes
+
+* The Load More Results component is especially useful when you want your user to browse more results, rather than return to and refine facets or reconsider their query.
+* When the items in a source are highly specific, a pager is a more appropriate component.
+
+### Guidelines
+
+Users browse longer than with Load more than with Pagination.
+Load more is less effective when the items in a source are very specific and require comparison.
+
+## Use Cases and Examples
+
+On an ecommerce site, users will view more products using a Load More button then with a Pager.
+When considering designing for mobile, a Load More button is a better experience for the user.
+
+### Reference
+
+[Pagination vs. Infinate Scroll vs. Load More Explained](https://crocoblock.com/blog/pagination-vs-infinite-scroll/)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.mdx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.mdx
@@ -1,0 +1,37 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicNoResultsStories from './atomic-no-results.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicNoResultsStories} />
+
+<AtomicDocTemplate
+  stories={AtomicNoResultsStories}
+  githubPath="search/atomic-no-results/atomic-no-results.ts"
+  tagName="atomic-no-results"
+  className="AtomicNoResults"
+>
+# UX notes
+
+## Introduction
+
+This component provides feedback to the user by indicating that the {query} didn’t return any results and guiding them to their next action.
+
+## User experience and best practices
+
+### Usage notes
+
+Used when the {query} returns no results.
+Displaying additional content from this component using a `<slot>` element is also possible.
+The `<slot>` element acts as a placeholder inside the {atomic} component, into which you can place your own markup to offer custom content such as messages, images, or links.
+
+### Guidelines
+
+Use this opportunity to provide support to your users in the form of advice and tools for {query} reformulation.
+If applicable, you should promote exploration and discovery using things like top searches, featured {items}, or popular {items}.
+
+## Use cases and examples
+
+When displaying a "no results" message on an ecommerce site, displaying popular products that relate to a selected category can help direct the user to a relevant result.
+It may also help increase sales.
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.mdx
@@ -1,0 +1,32 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicSearchBoxStories from './atomic-search-box.new.stories';
+import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicSearchBoxStories} />
+
+<AtomicDocTemplate
+  stories={AtomicSearchBoxStories}
+  githubPath="search/atomic-search-box/atomic-search-box.ts"
+  tagName="atomic-search-box"
+  className="AtomicSearchBox"
+>
+# UX notes
+
+## Introduction
+
+The _Search Box_ component is the core of a search page, allowing the user to type and submit a query.
+There is built-in support for query suggestions in the Search Box component.
+
+## User Experience and Best Practices
+
+### Guidelines
+
+It’s important to have it visible and clear to the user, best practices suggest that it should be in the top-center or upper-right section.
+
+### Reference
+
+[Search Best Practices Part 1 - The Search Box](https://source.coveo.com/2017/09/06/search-best-practices-1/)
+
+[Search: Visible and Simple](https://www.nngroup.com/articles/search-visible-and-simple/)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-category-facet/atomic-category-facet.mdx
@@ -1,0 +1,55 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicCategoryFacetStories from './atomic-category-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicCategoryFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicCategoryFacetStories}
+  githubPath="search/atomic-category-facet/atomic-category-facet.ts"
+  tagName="atomic-category-facet"
+  className="AtomicCategoryFacet"
+>
+# UX notes
+
+## Introduction
+
+A facet allows users to drill down inside a result set by filtering the result to certain field values.
+_Category Facets_ are browsable facets that display values in a hierarchical fashion, narrowing the available options through offering alternative starting points and sub-categories.
+
+The Category Facet is especially useful when making fundamental decisions on a starting point in a search or browsing session.
+For example, if the starting point was Clothing, available options to choose from might include t-shirts, sweaters, brands, sales, new arrivals, etc.
+Each one of those options would then offer a new list of surrogate categories.
+
+## Best Practices
+
+### Usage Notes
+
+* A Category Facet requires a multi-value field whose values are formatted hierarchically.
+The facet will determine the filter to apply based on the current selected path of values.
+This can offer a powerful navigational experience, quickly leading a user to relevant results.
+
+  This component uses `;` to separate individual values, and the character that’s defined with the `delimiting-character` attribute to separate hierarchical levels within each value.
+  Set this attribute to `|` instead of using the default, which is `;`.
+  The following is an example of the recommended hierarchical formatting:
+
+  `clothing; clothing|sale; clothing|sale|shoes; clothing|sale|shoes|kids; clothing|sale|shoes|kids|sneakers;`
+* It’s only possible to select one value at a time in a category facet.
+This is because they’re meant to ease navigation through their hierarchically organized content, as opposed to applying multiple hierarchical filters.
+
+### Guidelines
+
+It’s best practice to have hierarchies at five levels or less in depth.
+
+## Use Cases and Examples
+
+On an ecommerce website, a user may want to start browsing by the category _Men_, and then narrow their results to _Bottoms_, then further to _Pants_, etc.
+Instead of selecting the facet value directly, this allows them to navigate hierarchically and determine the right starting point.
+
+### References
+
+[Categories, Facets—and Browsable Facets?](https://www.uxmatters.com/mt/archives/2011/08/categories-facetsand-browsable-facets.php)
+
+[Don’t Lose Face with Facets](https://source.coveo.com/2018/04/18/facets/)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-color-facet/atomic-color-facet.mdx
@@ -1,0 +1,45 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicColorFacetStories from './atomic-color-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicColorFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicColorFacetStories}
+  githubPath="search/atomic-color-facet/atomic-color-facet.ts"
+  tagName="atomic-color-facet"
+  className="AtomicColorFacet"
+>
+# UX notes
+
+## Introduction
+
+A facet allows users to drill down inside a result set by filtering the result to certain field values.
+A _Color Facet_ presents its information in a visual way.
+
+## User Experience and Best Practices
+
+### Usage Notes
+
+* A color facet is best for placing emphasis on the visual aspect of a facet value.
+* The two available options to display the facet values are `box` and `checkbox`.
+  * The `box` display option will present the facet values in a grid with a larger tile format.
+  * The `checkbox` display option will present the values in a list with a smaller icon or color tile.
+
+### Guidelines
+
+When the facet doesn’t have too many values to display and the text labels are short, it’s best practice to use the `box` display option.
+
+When using an image instead of a color tile or icon, it’s best practice to use the `box` display.
+
+## Use Cases and Examples
+
+In commerce, a user shopping for a t-shirt can select the colors they want using a color-faceted.
+
+### Reference
+
+[Don’t Lose Face with Facets](https://source.coveo.com/2018/04/18/facets/)
+
+[Wayfair implementation of a visual facet](https://www.wayfair.com/furniture/sb0/bar-stools-counter-stools-c1767662.html)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-facet/atomic-facet.mdx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicFacetStories from './atomic-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicFacetStories}
+  githubPath="search/atomic-facet/atomic-facet.ts"
+  tagName="atomic-facet"
+  className="AtomicFacet"
+>
+# UX notes
+
+## Introduction
+
+A facet allows users to drill down inside a result set by filtering the result to certain field values.
+Adding an optional search box to a facet can help find specific values inside larger sets.
+
+## User Experience and Best Practices
+
+### Usage Notes
+
+* Checkboxes are the most commonly used display in most cases.
+* Boxes are multi-select, more visual, and able to present more values in a small space.
+* Links allow the user to select only one value at a time, and behave like a normal navigational link.
+
+### Guidelines
+
+Don’t use boxes if your facet values are long, it won’t provide a good experience for your users and you risk truncating values.
+Place facets on the left side of the search page; this is the most natural place for them and is where users expect to see them.
+Positioning facets on the right side results in lower adoption and decreases the usability of the search page.
+
+## Use Cases and Examples
+
+Facets are useful for large indexes because they provide multiple filters, one for every specific aspect of the content.
+Faceted navigation helps the user get an overview of the content available, helping them understand how to search for it.
+
+### Reference
+
+[Don’t Lose Face with Facets](https://source.coveo.com/2018/04/18/facets/)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-numeric-facet/atomic-numeric-facet.mdx
@@ -1,0 +1,37 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicNumericFacetStories from './atomic-numeric-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicNumericFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicNumericFacetStories}
+  githubPath="search/atomic-numeric-facet/atomic-numeric-facet.ts"
+  tagName="atomic-numeric-facet"
+  className="AtomicNumericFacet"
+>
+# UX notes
+
+## Introduction
+
+A _numeric facet_ allows users to drill down inside a result set by filtering the result to certain numeric field values.
+Adding an optional custom range selector to a numeric facet can help find specific ranges more efficiently.
+
+## User Experience and Best Practices
+
+### Usage Notes
+
+* Checkboxes let users select multiple values and are the most commonly used selection, being more visual and presenting more values in small spaces.
+* Links allow the user to select only one value at a time, behaving like a normal navigational link.
+
+### Guidelines
+
+## Use Cases and Examples
+
+In cases where the value has a units such as height, width, screen sizes, etc.
+
+### Reference
+
+[Don’t Lose Face with Facets](https://source.coveo.com/2018/04/18/facets/)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-rating-facet/atomic-rating-facet.mdx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicRatingFacetStories from './atomic-rating-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicRatingFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicRatingFacetStories}
+  githubPath="search/atomic-rating-facet/atomic-rating-facet.ts"
+  tagName="atomic-rating-facet"
+  className="AtomicRatingFacet"
+>
+# UX notes
+
+## Introduction
+
+A facet allows users to drill down inside a result set by filtering the result to certain field values.
+The _Rating Facet_ component displays a facet of the results for the current query as ratings.
+
+## User Experience and Best Practices
+
+* Use the Rating Facet when social proof is important in guiding the user’s decisions.
+* Ratings help users understand what others think, or how they have rated the item.
+* The Rating Facet only works with numeric field values.
+
+### Guidelines
+
+Don’t use a range that’s too large, keep it below ten.
+A five star rating system is ideal; this is a common system that’s familiar to most people.
+
+## Use Cases and Examples
+
+On an ecommerce website, a user may want to filter their results to display only the items that have a rating of four stars or above.
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.mdx
+++ b/packages/atomic/src/components/search/facets/atomic-timeframe-facet/atomic-timeframe-facet.mdx
@@ -1,0 +1,26 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicTimeframeFacetStories from './atomic-timeframe-facet.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicTimeframeFacetStories} />
+
+<AtomicDocTemplate
+  stories={AtomicTimeframeFacetStories}
+  githubPath="search/atomic-timeframe-facet/atomic-timeframe-facet.ts"
+  tagName="atomic-timeframe-facet"
+  className="AtomicTimeframeFacet"
+>
+# UX notes
+
+## Introduction
+
+A facet allows users to drill down inside a result set by restricting the result to certain field values.
+The _Timeframe Facet_ is used specifically with field values that are dates.
+An optional date picker is available to this facet, allowing users to set custom ranges.
+
+## User Experience and Best Practices
+
+* Users can search for items based on dates, such as: publication date, latest update date, submission date, etc.
+* Enabling the date picker allows users to set a custom date range, helping narrow results to a very specific range.
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.mdx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-list/atomic-result-list.mdx
@@ -1,0 +1,46 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicResultListStories from './atomic-result-list.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicResultListStories} />
+
+<AtomicDocTemplate
+  stories={AtomicResultListStories}
+  githubPath="search/atomic-result-list/atomic-result-list.ts"
+  tagName="atomic-result-list"
+  className="AtomicResultList"
+>
+# UX notes
+
+## Introduction
+
+Allows the maker to determine how the result set is shown by default by selecting 3 parameters.
+
+## User Experience and Best Practices
+
+Image size: determine how big the visual should be, depending on how important it is for the results.
+
+Density: how dense the results should be.
+
+Display:
+|     |     |
+| --- | --- |
+| Grid | Mainly for products, makes it easier to browse products and shows more of them at a time. |
+| List | The most common and versatile one, you rarely go wrong with that. |
+| Table | When showing the results as a table makes the most sense, for data-heavy results. |
+
+## Use Cases and Examples
+
+The following table outlines the key differences and best use cases for grids, lists, and tables, helping you choose the most appropriate format based on your content and user needs.
+
+|     |     |
+| --- | --- |
+| Grid | Greater emphasis on the image but less on the text.  Helps if the user want to compare items visually.  Allows to display more results.  Use when you know you’ll have recent images. |
+| List | Use when content or description is the most important things.  Helps the user compare textually, easier to scan the text.  Fewer results but reduced cognitive load since text is heavier than images.  Use when you aren’t sure of the quality of the images you’ll have. |
+| Table | Use when you want to show your data in a table. |
+
+### Reference
+
+[UI cheet sheet: list vs grid](https://uxdesign.cc/ui-cheat-sheet-list-vs-grids-48151a7262a7)
+
+</AtomicDocTemplate>

--- a/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.mdx
+++ b/packages/atomic/src/components/search/result-template-components/atomic-field-condition/atomic-field-condition.mdx
@@ -1,0 +1,45 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as AtomicFieldConditionStories from './atomic-field-condition.new.stories';
+import { AtomicDocTemplate } from '../../../../../storybook-utils/documentation/atomic-doc-template';
+
+<Meta of={AtomicFieldConditionStories} />
+
+<AtomicDocTemplate
+  stories={AtomicFieldConditionStories}
+  githubPath="search/atomic-field-condition/atomic-field-condition.ts"
+  tagName="atomic-field-condition"
+  className="AtomicFieldCondition"
+>
+# UX notes
+
+## Best practices
+
+### Usage notes
+
+* The `must-match` and `must-not-match` markup attributes require kebab-case when referring to a result property whose name is in camelCase.
+For example, the `isRecommendation` property should be written as `is-recommendation`.
+
+  ```html
+  <atomic-field-condition must-match-is-recommendation="true">
+    <!-- ... -->
+  </atomic-field-condition>
+  ```
+* Regardless of whether its condition is satisfied, the `atomic-field-condition` component will render all its children and itself.
+If its condition is not satsified, it will then remove itself and its children from the DOM.
+For example, consider the following:
+
+  ```html
+  <atomic-field-condition if-not-defined="thumbnailurl">
+    <atomic-result-icon class="icon"></atomic-result-icon>
+  </atomic-field-condition>
+
+  <atomic-field-condition if-defined="thumbnailurl">
+    <atomic-result-image field="thumbnailurl"></atomic-result-image>
+  </atomic-field-condition>
+  ```
+
+  When the `thumbnailurl` field isn’t defined on a result, the `atomic-result-icon` will be rendered as expected.
+  However, the `atomic-result-image` (nested in the second `atomic-field-condition`) will also be rendered and subsequently removed from the DOM.
+  This will produce a console warning, as the `thumbnailurl` is undefined when it’s referenced by the `atomic-result-image` component.
+
+</AtomicDocTemplate>


### PR DESCRIPTION
## JIRA
https://coveord.atlassian.net/browse/DOC-17699

This brings over handwritten content for the Search components from the docs site over into storybook. 

The intent was to add them as "docs" pages for each component that had notes. I followed the pattern I saw in place for existing search components that had doc pages. For example Query Summary (`/docs/atomic-query-summary--docs`)

<img width="323" height="200" alt="image" src="https://github.com/user-attachments/assets/153b4fb4-bc77-4d93-9afa-2db89be8dd77" />

<img width="1183" height="845" alt="image" src="https://github.com/user-attachments/assets/1b820679-f275-4d0c-bd95-3e8af054b3cc" />
