### PR TITLE
chore: migrate to trusted publisher

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,6 @@ jobs:
           DEBUG: ${{ inputs.debug && '@coveo/semantic-monorepo-tools:*' || '' }}
           GITHUB_INSTALLATION_TOKEN: ${{ steps.generate-token.outputs.token }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Call ui-kit-cd
         run: node ./scripts/deploy/trigger-ui-kit-cd.mjs
         env:
@@ -75,8 +74,7 @@ jobs:
     permissions:
       contents: read
       discussions: write
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
Remove `NODE_AUTH_TOKEN`: if it works, then TP is properly set up. Huzzah.

KIT-5123
