### PR TITLE
chore(cd): typo introduced in #6163

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: ./.github/actions
+      - uses: ./.github/actions/setup
         with:
           load-cache: false
       - name: Generate a token


### PR DESCRIPTION
[KIT-5128](https://coveord.atlassian.net/browse/KIT-5128)

[KIT-5128]: https://coveord.atlassian.net/browse/KIT-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ