### PR TITLE
chore: save cache on first job so it is available on following ones

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           load-cache: false
+          save-cache: true
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2


### PR DESCRIPTION
This causes https://github.com/coveo/ui-kit/actions/runs/18541203399/attempts/1

KIT-5129
