### PR TITLE
chore(atomic): add custom lit converter for arrays

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.ts
@@ -11,6 +11,7 @@ import {errorGuard} from '@/src/decorators/error-guard';
 import type {LitElementWithError} from '@/src/decorators/types';
 import {mapProperty} from '@/src/utils/props-utils';
 import '../atomic-product/atomic-product';
+import {arrayConverter} from '@/src/converters/array-converter';
 
 /**
  * * A product template determines the format of the products, depending on the conditions that are defined for each template.
@@ -39,7 +40,7 @@ export class AtomicProductTemplate
    * For example, the following targets a template and sets a condition to make it apply only to products whose `ec_name` contains `singapore`:
    * `document.querySelector('#target-template').conditions = [(product) => /singapore/i.test(product.ec_name)];`
    */
-  @property({attribute: false, type: Array})
+  @property({attribute: false, type: Array, converter: arrayConverter})
   conditions: ProductTemplateCondition[] = [];
 
   /**

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.ts
@@ -20,6 +20,7 @@ import {
   InterfaceController,
 } from '@/src/components/common/interface/interface-controller';
 import {bindingsContext} from '@/src/components/context/bindings-context';
+import {arrayConverter} from '@/src/converters/array-converter.js';
 import {booleanConverter} from '@/src/converters/boolean-converter';
 import {errorGuard} from '@/src/decorators/error-guard';
 import {watch} from '@/src/decorators/watch';
@@ -138,8 +139,12 @@ export class AtomicInsightInterface
    * <atomic-insight-interface fields-to-include='["fieldA", "fieldB"]'></atomic-insight-interface>
    * ```
    */
-  @property({type: Array, attribute: 'fields-to-include'})
-  public fieldsToInclude: string[] | string = [];
+  @property({
+    type: Array,
+    attribute: 'fields-to-include',
+    converter: arrayConverter,
+  })
+  public fieldsToInclude: string[] = [];
 
   /**
    * The number of results per page. By default, this is set to `5`.

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
@@ -53,6 +53,7 @@ import {createSearchStore, type SearchStore} from './store';
 // TODO - Remove once all components that use atomic-modal have been migrated.
 import '@/src/components/common/atomic-modal/atomic-modal';
 import {augmentAnalyticsConfigWithAtomicVersion} from '@/src/components/common/interface/analytics-config';
+import {arrayConverter} from '@/src/converters/array-converter';
 
 const FirstSearchExecutedFlag = 'firstSearchExecuted';
 export type InitializationOptions = SearchEngineConfiguration;
@@ -119,18 +120,7 @@ export class AtomicSearchInterface
   @property({
     type: Array,
     attribute: 'fields-to-include',
-    converter: {
-      fromAttribute: (value: string | null) => {
-        if (!value) return [];
-        try {
-          const parsed = JSON.parse(value);
-          return Array.isArray(parsed) ? parsed : [];
-        } catch {
-          return [];
-        }
-      },
-      toAttribute: (value: string[]) => JSON.stringify(value),
-    },
+    converter: arrayConverter,
   })
   public fieldsToInclude: string[] = [];
 

--- a/packages/atomic/src/converters/array-converter.spec.ts
+++ b/packages/atomic/src/converters/array-converter.spec.ts
@@ -1,0 +1,107 @@
+import {page} from '@vitest/browser/context';
+import {html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {arrayConverter} from './array-converter';
+
+describe('arrayConverter', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  @customElement('test-element')
+  class TestElement extends LitElement {
+    @property({
+      converter: arrayConverter,
+      type: Array,
+    })
+    value: string[] = [];
+
+    render() {
+      return html`<div>${JSON.stringify(this.value)}</div>`;
+    }
+  }
+
+  @customElement('test-element-with-default')
+  class TestElementWithDefault extends LitElement {
+    @property({
+      converter: arrayConverter,
+      type: Array,
+    })
+    value: string[] = ['default'];
+
+    render() {
+      return html`<div>${JSON.stringify(this.value)}</div>`;
+    }
+  }
+
+  it('should convert a valid JSON array string to an array', async () => {
+    await fixture<TestElement>(
+      html`<test-element value='["item1","item2","item3"]'></test-element>`
+    );
+
+    await expect
+      .element(page.getByText('["item1","item2","item3"]'))
+      .toBeInTheDocument();
+  });
+
+  it('should convert an empty JSON array to an empty array', async () => {
+    await fixture<TestElement>(html`<test-element value="[]"></test-element>`);
+
+    await expect.element(page.getByText('[]')).toBeInTheDocument();
+  });
+
+  it('should convert invalid JSON to an empty array', async () => {
+    await fixture<TestElement>(
+      html`<test-element value="not-json"></test-element>`
+    );
+
+    await expect.element(page.getByText('[]')).toBeInTheDocument();
+  });
+
+  it('should convert a non-array JSON value to an empty array', async () => {
+    await fixture<TestElement>(
+      html`<test-element value='{"key":"value"}'></test-element>`
+    );
+
+    await expect.element(page.getByText('[]')).toBeInTheDocument();
+  });
+
+  it('an omitted attribute should convert to an empty array', async () => {
+    await fixture<TestElement>(html`<test-element></test-element>`);
+
+    await expect.element(page.getByText('[]')).toBeInTheDocument();
+  });
+
+  it('should print a warning when parsing fails', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    await fixture<TestElement>(
+      html`<test-element value="invalid-json"></test-element>`
+    );
+
+    await expect.element(page.getByText('[]')).toBeInTheDocument();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Failed to parse the array attribute value: invalid-json. Ensure the value is a valid JSON array.'
+    );
+  });
+
+  it('an omitted attribute should use the default value when provided', async () => {
+    await fixture<TestElementWithDefault>(
+      html`<test-element-with-default></test-element-with-default>`
+    );
+
+    await expect.element(page.getByText('["default"]')).toBeInTheDocument();
+  });
+
+  it('should handle arrays with different types of values', async () => {
+    await fixture<TestElement>(
+      html`<test-element value='["string",123,true,null]'></test-element>`
+    );
+
+    await expect
+      .element(page.getByText('["string",123,true,null]'))
+      .toBeInTheDocument();
+  });
+});

--- a/packages/atomic/src/converters/array-converter.ts
+++ b/packages/atomic/src/converters/array-converter.ts
@@ -1,0 +1,17 @@
+import type {ComplexAttributeConverter} from 'lit';
+
+export const arrayConverter: ComplexAttributeConverter<string[]> = {
+  fromAttribute: (value: string | null) => {
+    if (!value) return [];
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      console.warn(
+        `Failed to parse the array attribute value: ${value}. Ensure the value is a valid JSON array.`
+      );
+      return [];
+    }
+  },
+  toAttribute: (value: string[]) => JSON.stringify(value),
+};


### PR DESCRIPTION
This PR adds a custom lit converter for arrays. The main difference between this converter and the [default converter](https://github.com/lit/lit/blob/12109c25997ef03180d7eefe05c64e0fb20dd2b0/packages/reactive-element/src/reactive-element.ts#L313) is that this one fallbacks to an empty array instead of null.

This is a prerequisite for atomic-result-list

Unlike Stencil, which will always fallback to its default value, Lit array properties can return different values:
- If the attribute value is a stringified valid array, **the provided array**
- If the attribute value is an invalid stringified array,  **null**, regardless of if a default value is present. If useDefault is set to true, it will return the default value, but that is not recommended for arrays/objects for performance reasons
- If the attribute is not set and has a default value, **the default value** 
- If the attribute is not set and does not have a default value, **undefined**


This [playground](https://lit.dev/playground/#sample=properties%2Fattributereflect&project=W3sibmFtZSI6Im15LWVsZW1lbnQudHMiLCJjb250ZW50IjoiaW1wb3J0IHtMaXRFbGVtZW50LCBodG1sLCBjc3MsIFByb3BlcnR5RGVjbGFyYXRpb259IGZyb20gJ2xpdCc7XG5pbXBvcnQge2N1c3RvbUVsZW1lbnQsIHByb3BlcnR5fSBmcm9tICdsaXQvZGVjb3JhdG9ycy5qcyc7XG5cbkBjdXN0b21FbGVtZW50KCdteS1lbGVtZW50JylcbmNsYXNzIE15RWxlbWVudCBleHRlbmRzIExpdEVsZW1lbnQge1xuICAvKiBwbGF5Z3JvdW5kLWZvbGQgKi8gXG4gIHN0YXRpYyBzdHlsZXMgPSBjc3NgXG4gICAgOmhvc3Qge1xuICAgICAgZGlzcGxheTogaW5saW5lLWJsb2NrOyBcbiAgICAgIHBhZGRpbmc6IDRweDtcbiAgICB9XG4gICAgOmhvc3QoW2FjdGl2ZV0pIHtcbiAgICAgIGZvbnQtd2VpZ2h0OiA4MDA7XG4gICAgfVxuICAgIDpob3N0KFt2YXJpYW50XSkge1xuICAgICAgb3V0bGluZTogNHB4IHNvbGlkIGdyZWVuO1xuICAgIH1cbiAgICA6aG9zdChbdmFyaWFudD1cInNwZWNpYWxcIl0pIHtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDhweDsgYm9yZGVyOiA0cHggc29saWQgcmVkO1xuICAgIH1gO1xuICAvKiBwbGF5Z3JvdW5kLWZvbGQtZW5kICovICBcbiAgQHByb3BlcnR5KHt0eXBlOiBCb29sZWFuLCByZWZsZWN0OiB0cnVlfSlcbiAgYWN0aXZlOiBib29sZWFuID0gZmFsc2U7XG4gIFxuICBAcHJvcGVydHkoe3R5cGU6IEFycmF5LCByZWZsZWN0OiB0cnVlfSlcbiAgc2V0dmFsaWR3aXRoZGVmYXVsdDogU3RyaW5nW10gPSBbXTtcbiAgXG4gIEBwcm9wZXJ0eSh7dHlwZTogQXJyYXksIHJlZmxlY3Q6IHRydWV9KVxuICBzZXRpbnZhbGlkd2l0aGRlZmF1bHQ6IFN0cmluZ1tdID0gW107XG4gIFxuICBAcHJvcGVydHkoe3R5cGU6IEFycmF5LCByZWZsZWN0OiB0cnVlfSlcbiAgc2V0aW52YWxpZHdpdGhvdXRkZWZhdWx0OiBTdHJpbmdbXTtcblxuICBAcHJvcGVydHkoe3R5cGU6IEFycmF5LCByZWZsZWN0OiB0cnVlfSlcbiAgbm90c2V0d2l0aGRlZmF1bHQ6IFN0cmluZ1tdID0gW107XG4gIFxuICBAcHJvcGVydHkoe3R5cGU6IEFycmF5LCByZWZsZWN0OiB0cnVlfSlcbiAgbm90c2V0d2l0aG91dGRlZmF1bHQ6IFN0cmluZ1tdO1xuXG4gIEBwcm9wZXJ0eSh7cmVmbGVjdDogdHJ1ZSwgdXNlRGVmYXVsdDogdHJ1ZX0gYXMgUHJvcGVydHlEZWNsYXJhdGlvbilcbiAgdmFyaWFudCA9ICdub3JtYWwnOyBcblxuICBjb25uZWN0ZWRDYWxsYmFjaygpIHtcbiAgICBzdXBlci5jb25uZWN0ZWRDYWxsYmFjaygpXG4gICAgdGhpcy5ub3RzZXR3aXRob3V0ZGVmYXVsdCA9ICdbJ1xuICB9XG5cbiAgcmVuZGVyKCkge1xuICAgIGNvbnNvbGUubG9nKCdzZXR2YWxpZHdpdGhkZWZhdWx0JywgdGhpcy5zZXR2YWxpZHdpdGhkZWZhdWx0KVxuICAgIGNvbnNvbGUubG9nKCdzZXRpbnZhbGlkd2l0aGRlZmF1bHQnLCB0aGlzLnNldGludmFsaWR3aXRoZGVmYXVsdClcbiAgICBjb25zb2xlLmxvZygnc2V0aW52YWxpZHdpdGhvdXRkZWZhdWx0JywgdGhpcy5zZXRpbnZhbGlkd2l0aG91dGRlZmF1bHQpXG4gICAgY29uc29sZS5sb2coJ25vdHNldHdpdGhkZWZhdWx0JywgdGhpcy5ub3RzZXR3aXRoZGVmYXVsdClcbiAgICBjb25zb2xlLmxvZygnbm90c2V0d2l0aG91dGRlZmF1bHQnLCB0aGlzLm5vdHNldHdpdGhvdXRkZWZhdWx0KVxuICAgXG4gICAgcmV0dXJuIGh0bWxgXG4gICAgIDxkaXY-c2V0dmFsaWR3aXRoZGVmYXVsdDogJHtKU09OLnN0cmluZ2lmeSh0aGlzLnNldHZhbGlkd2l0aGRlZmF1bHQpfTwvZGl2PlxuICAgICA8ZGl2PnNldGludmFsaWR3aXRoZGVmYXVsdDogJHtKU09OLnN0cmluZ2lmeSh0aGlzLnNldGludmFsaWR3aXRoZGVmYXVsdCl9PC9kaXY-XG4gICAgIDxkaXY-c2V0aW52YWxpZHdpdGhvdXRkZWZhdWx0OiAke0pTT04uc3RyaW5naWZ5KHRoaXMuc2V0aW52YWxpZHdpdGhvdXRkZWZhdWx0KX08L2Rpdj5cbiAgICAgPGRpdj5ub3RzZXR3aXRoZGVmYXVsdDogJHtKU09OLnN0cmluZ2lmeSh0aGlzLm5vdHNldHdpdGhkZWZhdWx0KX08L2Rpdj5cbiAgICAgPGRpdj5ub3RzZXR3aXRob3V0ZGVmYXVsdDogJHtKU09OLnN0cmluZ2lmeSh0aGlzLm5vdHNldHdpdGhvdXRkZWZhdWx0KX08L2Rpdj5cbiAgICAgIDxkaXY-PGxhYmVsPmFjdGl2ZTogPGlucHV0IHR5cGU9XCJjaGVja2JveFwiXG4gICAgICAgIC52YWx1ZT1cIiR7dGhpcy5hY3RpdmV9XCJcbiAgICAgICAgQGNoYW5nZT1cIiR7KGU6IHt0YXJnZXQ6IEhUTUxJbnB1dEVsZW1lbnR9KSA9PiBcbiAgICAgICAgICB0aGlzLmFjdGl2ZSA9IGUudGFyZ2V0LmNoZWNrZWR9XCI-XG4gICAgICAgICR7dGhpcy5hY3RpdmV9XG4gICAgICA8L2xhYmVsPjwvZGl2PlxuICAgICAgPGRpdj48bGFiZWw-dmFyaWFudDogPGlucHV0IHR5cGU9XCJjaGVja2JveFwiXG4gICAgICAgIC52YWx1ZT1cIiR7dGhpcy52YXJpYW50ID09PSAnc3BlY2lhbCd9XCJcbiAgICAgICAgQGNoYW5nZT1cIiR7KGU6IHt0YXJnZXQ6IEhUTUxJbnB1dEVsZW1lbnR9KSA9PiBcbiAgICAgICAgICB0aGlzLnZhcmlhbnQgPSBlLnRhcmdldC5jaGVja2VkID8gJ3NwZWNpYWwnIDogJ25vcm1hbCd9XCI-XG4gICAgICAgICR7dGhpcy52YXJpYW50fVxuICAgICAgPC9sYWJlbD48L2Rpdj5cbiAgICBgO1xuICB9XG59XG4ifSx7Im5hbWUiOiJpbmRleC5odG1sIiwiY29udGVudCI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWwgbGFuZz1cImVuXCI-XG48aGVhZD5cbiAgPG1ldGEgY2hhcnNldD1cIlVURi04XCI-XG4gIDxtZXRhIG5hbWU9XCJ2aWV3cG9ydFwiIGNvbnRlbnQ9XCJ3aWR0aD1kZXZpY2Utd2lkdGgsIGluaXRpYWwtc2NhbGU9MS4wXCI-XG4gIDx0aXRsZT5saXQtZWxlbWVudCBjb2RlIHNhbXBsZTwvdGl0bGU-XG4gIDxzY3JpcHQgdHlwZT1cIm1vZHVsZVwiIHNyYz1cIm15LWVsZW1lbnQuanNcIj48L3NjcmlwdD5cbjwvaGVhZD5cbiAgPGJvZHk-XG4gICAgPG15LWVsZW1lbnQgc2V0dmFsaWR3aXRoZGVmYXVsdD0nW1widmFsaWRcIl0nIHNldGludmFsaWR3aXRoZGVmYXVsdD0nWycgc2V0aW52YWxpZHdpdGhvdXRkZWZhdWx0PSdbJz48L215LWVsZW1lbnQ-XG4gIDwvYm9keT5cbjwvaHRtbD5cbiJ9LHsibmFtZSI6InBhY2thZ2UuanNvbiIsImNvbnRlbnQiOiJ7XG4gIFwiZGVwZW5kZW5jaWVzXCI6IHtcbiAgICBcImxpdFwiOiBcIl4zLjAuMFwiLFxuICAgIFwiQGxpdC9yZWFjdGl2ZS1lbGVtZW50XCI6IFwiXjIuMC4wXCIsXG4gICAgXCJsaXQtZWxlbWVudFwiOiBcIl40LjAuMFwiLFxuICAgIFwibGl0LWh0bWxcIjogXCJeMy4wLjBcIlxuICB9XG59IiwiaGlkZGVuIjp0cnVlfV0) demonstrates that

Note that Typescript will not warn if the type of an Array property can be something else than the default value.

https://coveord.atlassian.net/browse/KIT-5135


