### PR TITLE
chore: restore NODE_AUTH_TOKEN auth for prod promotion

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,8 @@ jobs:
     permissions:
       contents: read
       discussions: write
-
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
We need this to be resolved https://github.com/npm/cli/issues/8547 to use dist-tag with TP.

https://coveord.atlassian.net/browse/KIT-5141
