### PR TITLE
fix(docs): address missing parameter on insight panel interface

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticInsightInterface/quanticInsightInterface.js
@@ -20,7 +20,7 @@ import {LightningElement, api} from 'lwc';
  * @fires CustomEvent#quantic__insightinterfaceinitialized
  * @category Insight Panel
  * @example
- * <c-quantic-insight-interface engine-id={engineId} insight-id={insightId}></c-quantic-insight-interface>
+ * <c-quantic-insight-interface engine-id={engineId} insight-id={insightId} record-id={recordId}></c-quantic-insight-interface>
  */
 export default class QuanticInsightInterface extends LightningElement {
   /**


### PR DESCRIPTION
**JIRA Link:** [DOC-17916](https://coveord.atlassian.net/browse/DOC-17916)

Addressing a missing required parameter, `recordId`, on the `quantic-insight-interface` component, see [this slack thread](https://coveo.slack.com/archives/CE62A58E9/p1759933305787039) for reference.

[DOC-17916]: https://coveord.atlassian.net/browse/DOC-17916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ