### PR TITLE
fix(headless-ssr): avoid `preprocessRequest` function chaining

### DIFF
--- a/packages/headless/src/ssr-next/common/augment-preprocess-request.test.ts
+++ b/packages/headless/src/ssr-next/common/augment-preprocess-request.test.ts
@@ -90,4 +90,23 @@ describe('#augmentPreprocessRequestWithForwardedFor', () => {
     const headers = new Headers(result.headers);
     expect(headers.get('x-forwarded-for')).toBe('9.9.9.9');
   });
+
+  describe('augmentation prevention', () => {
+    it('should not augment an already augmented function', () => {
+      const options: AugmentPreprocessRequestOptions = {
+        navigatorContext: {
+          forwardedFor: '127.0.0.1',
+        } as NavigatorContext,
+      };
+
+      const firstAugmented = augmentPreprocessRequestWithForwardedFor(options);
+
+      const secondAugmented = augmentPreprocessRequestWithForwardedFor({
+        ...options,
+        preprocessRequest: firstAugmented,
+      });
+
+      expect(firstAugmented).toBe(secondAugmented);
+    });
+  });
 });

--- a/packages/headless/src/ssr-next/common/augment-preprocess-request.ts
+++ b/packages/headless/src/ssr-next/common/augment-preprocess-request.ts
@@ -14,11 +14,23 @@ export interface AugmentPreprocessRequestOptions {
   loggerOptions?: LoggerOptions;
 }
 
+const AUGMENTED_MARKER = Symbol('augmentedWithForwardedFor');
+
+interface AugmentedPreprocessRequest extends PreprocessRequest {
+  [AUGMENTED_MARKER]?: boolean;
+}
+
 export function augmentPreprocessRequestWithForwardedFor(
   options: AugmentPreprocessRequestOptions
 ) {
-  const originalPreprocessRequest = options.preprocessRequest;
-  return async (
+  const originalPreprocessRequest =
+    options.preprocessRequest as AugmentedPreprocessRequest;
+
+  if (originalPreprocessRequest?.[AUGMENTED_MARKER]) {
+    return originalPreprocessRequest;
+  }
+
+  const augmentedFunction: AugmentedPreprocessRequest = async (
     request: PlatformRequestOptions,
     clientOrigin: PlatformClientOrigin,
     metadata?: RequestMetadata
@@ -41,4 +53,8 @@ export function augmentPreprocessRequestWithForwardedFor(
     }
     return request;
   };
+
+  augmentedFunction[AUGMENTED_MARKER] = true;
+
+  return augmentedFunction;
 }

--- a/packages/headless/src/ssr/common/augment-preprocess-request.test.ts
+++ b/packages/headless/src/ssr/common/augment-preprocess-request.test.ts
@@ -90,4 +90,23 @@ describe('#augmentPreprocessRequestWithForwardedFor', () => {
     const headers = new Headers(result.headers);
     expect(headers.get('x-forwarded-for')).toBe('9.9.9.9');
   });
+
+  describe('augmentation prevention', () => {
+    it('should not augment an already augmented function', () => {
+      const options: AugmentPreprocessRequestOptions = {
+        navigatorContextProvider: (() => ({
+          forwardedFor: '127.0.0.1',
+        })) as NavigatorContextProvider,
+      };
+
+      const firstAugmented = augmentPreprocessRequestWithForwardedFor(options);
+
+      const secondAugmented = augmentPreprocessRequestWithForwardedFor({
+        ...options,
+        preprocessRequest: firstAugmented,
+      });
+
+      expect(firstAugmented).toBe(secondAugmented);
+    });
+  });
 });

--- a/packages/headless/src/ssr/common/augment-preprocess-request.ts
+++ b/packages/headless/src/ssr/common/augment-preprocess-request.ts
@@ -14,11 +14,23 @@ export interface AugmentPreprocessRequestOptions {
   loggerOptions?: LoggerOptions;
 }
 
+const AUGMENTED_MARKER = Symbol('augmentedWithForwardedFor');
+
+interface AugmentedPreprocessRequest extends PreprocessRequest {
+  [AUGMENTED_MARKER]?: boolean;
+}
+
 export function augmentPreprocessRequestWithForwardedFor(
   options: AugmentPreprocessRequestOptions
 ) {
-  const originalPreprocessRequest = options.preprocessRequest;
-  return async (
+  const originalPreprocessRequest =
+    options.preprocessRequest as AugmentedPreprocessRequest;
+
+  if (originalPreprocessRequest?.[AUGMENTED_MARKER]) {
+    return originalPreprocessRequest;
+  }
+
+  const augmentedFunction: AugmentedPreprocessRequest = async (
     request: PlatformRequestOptions,
     clientOrigin: PlatformClientOrigin,
     metadata?: RequestMetadata
@@ -41,4 +53,8 @@ export function augmentPreprocessRequestWithForwardedFor(
     }
     return request;
   };
+
+  augmentedFunction[AUGMENTED_MARKER] = true;
+
+  return augmentedFunction;
 }


### PR DESCRIPTION
## Problem

`augmentPreprocessRequestWithForwardedFor` was creating multiple wrapper layers on page reloads, causing:

- Performance degradation (redundant operations)
- Memory leaks (growing function chains)
- Difficult debugging (nested calls)

**Root Cause**: Function always wrapped input without checking if already augmented.
This only happens on SSR search (non commerce), so a revisit of the implementation for that part is needed.

## Solution

Added marker-based detection to prevent re-augmentation:

https://coveord.atlassian.net/browse/KIT-5147
