### PR TITLE
chore: do not run a11y automatically on stories

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -126,3 +126,9 @@ function disableAnalytics(container, selectors) {
     });
   });
 }
+
+export default {
+  globals: {
+    a11y: {manual: true},
+  },
+};


### PR DESCRIPTION
Temporarily disabled automatic accessibility testing on Storybook stories as part of the transition to vitest-storybook setup.

This should be reverted when we finish up setting up vitest-storybook.

**Jira:** KIT-5191