### PR TITLE
ci: fix atomic-angular pnpm release from a dist folder

### DIFF
--- a/packages/atomic-angular/scripts/publish-npm.mjs
+++ b/packages/atomic-angular/scripts/publish-npm.mjs
@@ -1,4 +1,53 @@
-import {resolve} from 'node:path';
+import {readFileSync, writeFileSync} from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-process.env.INIT_CWD = resolve('./projects/atomic-angular/dist');
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(scriptsDir, '..');
+const packagesDir = resolve(packageDir, '..');
+const distDir = resolve(packageDir, 'projects/atomic-angular/dist');
+const distPackageJsonPath = resolve(distDir, 'package.json');
+
+const resolveWorkspaceVersions = () => {
+  const distPackageJson = JSON.parse(
+    readFileSync(distPackageJsonPath, {encoding: 'utf-8'})
+  );
+  const entries = [
+    {
+      section: 'dependencies',
+      name: '@coveo/atomic',
+      source: resolve(packagesDir, 'atomic/package.json'),
+    },
+    {
+      section: 'peerDependencies',
+      name: '@coveo/headless',
+      source: resolve(packagesDir, 'headless/package.json'),
+    },
+  ];
+  for (const {section, name, source} of entries) {
+    const sectionData = distPackageJson[section];
+    if (!sectionData) {
+      continue;
+    }
+    const currentValue = sectionData[name];
+    if (
+      typeof currentValue !== 'string' ||
+      !currentValue.startsWith('workspace:')
+    ) {
+      continue;
+    }
+    const {version} = JSON.parse(readFileSync(source, {encoding: 'utf-8'}));
+    if (!version) {
+      throw new Error(`Missing version in ${source}`);
+    }
+    sectionData[name] = version;
+  }
+  writeFileSync(
+    distPackageJsonPath,
+    `${JSON.stringify(distPackageJson, null, 2)}\n`
+  );
+};
+
+resolveWorkspaceVersions();
+process.env.INIT_CWD = distDir;
 await import('@coveo/ci/npm-publish-package.mjs');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5109

Atomic angular is a bit tricky to release, compared to other packages. It gets released from a dist folder (as you can see from the `process.env.INIT_CWD = resolve('./projects/atomic-angular/dist');` line in the script.

This means that when pnpm publish runs for that folder, it sees a bunch of `workplace:` protocol, which it does not know what to do with/how to resolve the proper version because its not really part of the workspace.

I tried using https://pnpm.io/package_json#publishconfigdirectory but, alas, would require more tricky change to `utils/ci/npm-publish-package.mjs` used by every other package.

So I opted with "fixing" the version manually in the dist folder in the existing script specific for `atomic-angular`.


