### PR TITLE
chore: Add atlassian server type

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,6 +1,7 @@
 {
   "servers": {
     "atlassian": {
+      "type": "http",
       "url": "https://mcp.atlassian.com/v1/sse"
     },
     "github": {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5202

Copilot Chat in VSCode is always complaining that the Atlassian MCP server failed to start. I believe this is because we’re not explicitly specifying “type”: “http” in the mcp.json config.