### PR TITLE
chore: fix typo in CI command option

### DIFF
--- a/utils/ci/if-ci.mjs
+++ b/utils/ci/if-ci.mjs
@@ -7,7 +7,7 @@ if (!process.env.INIT_CWD) {
 process.chdir(process.env.INIT_CWD);
 
 if (process.argv.length === 3) {
-  execSync(`pnpm ${process.argv[2]}:${process.env.CI ? 'ci' : 'noci'}`, {
+  execSync(`pnpm ${process.argv[2]}:${process.env.CI ? 'ci' : 'no-ci'}`, {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
This pull request makes a minor fix to the `utils/ci/if-ci.mjs` script, correcting the script name used when running `pnpm` commands based on the environment.

- Fixed a typo in the command by changing `noci` to `no-ci` to ensure the correct script is executed in non-CI environments (`utils/ci/if-ci.mjs`).

[KIT-5214 GitHub PR #6518: Fix typo in CI command option](https://coveord.atlassian.net/browse/KIT-5214?atlOrigin=eyJpIjoiZmFiN2EzNTlmMDlkNDE3Zjg0ZTIyN2VkY2JhYTRhNTIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)