### PR TITLE
chore: remove Slack notifications from dev deployment config

### DIFF
--- a/.deployment.config/dev.json
+++ b/.deployment.config/dev.json
@@ -9,7 +9,7 @@
     "environments_order": {
       "sequential": ["dev"]
     },
-    "start_environment_automatically": false,
+    "start_environment_automatically": false
   },
   "dag_phases": [
     {


### PR DESCRIPTION
**Jira:** KIT-5242

Clean up.

Configuration still exists in `prod.json` and `staging.json`.