### PR TITLE
test(atomicGeneratedAnswer): citations with mocks [SFINT-6430]

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/e2e/page-object.ts
@@ -19,6 +19,10 @@ export class GeneratedAnswerPageObject extends BasePageObject<'atomic-generated-
     return this.page.locator('atomic-citation [part="citation"]');
   }
 
+  get citationPopovers() {
+    return this.page.locator('atomic-citation [part="citation-popover"]');
+  }
+
   get answerContent() {
     return this.page.locator('atomic-generated-answer [part="answer-content"]');
   }
@@ -98,5 +102,19 @@ export class GeneratedAnswerPageObject extends BasePageObject<'atomic-generated-
 
   async getTableTexts(): Promise<string[]> {
     return await this.tables.allTextContents();
+  }
+
+  async getCitationPopover(index: number = 0) {
+    return this.citationPopovers.nth(index);
+  }
+
+  async isCitationPopoverVisible(index: number = 0): Promise<boolean> {
+    const popover = await this.getCitationPopover(index);
+    return await popover.isVisible();
+  }
+
+  async getCitationPopoverText(index: number = 0): Promise<string> {
+    const popover = await this.getCitationPopover(index);
+    return (await popover.textContent()) || '';
   }
 }


### PR DESCRIPTION

https://coveord.atlassian.net/browse/SFINT-6430

## Description

### TLDR
Addition of Citations tests for the `atomic-generated-answer` component. 

### Description

The acceptance criterias of the linked ticket arent met.
1. The E2E rendering flow is not responsible if the citation is duplicated. This check should happen at the API or the Headless level. 
2. The analytics cannot be tested from the Storybook+MSW+Playwright setup since MSW service worker is interception all calls and the analytics call cannot be listen too. 

<img width="862" height="398" alt="image" src="https://github.com/user-attachments/assets/26eeef92-c067-4a9a-b1dc-923c4a097fa4" />

