### PR TITLE
chore: add vitest.rootConfig to VS Code settings for Atomic

### DIFF
--- a/packages/atomic/vitest.config.js
+++ b/packages/atomic/vitest.config.js
@@ -4,7 +4,7 @@ import replacePlugin from '@rollup/plugin-replace';
 import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import {playwright} from '@vitest/browser-playwright';
-import {configDefaults, defineConfig} from 'vitest/config';
+import {configDefaults, defineConfig, mergeConfig} from 'vitest/config';
 import packageJsonHeadless from '../headless/package.json' with {type: 'json'};
 import packageJson from './package.json' with {type: 'json'};
 
@@ -67,7 +67,8 @@ const storybook = defineConfig({
   },
 });
 
-export default defineConfig({
+const atomicDefault = defineConfig({
+  name: 'atomic-default',
   server: {
     port: port,
   },
@@ -143,6 +144,9 @@ export default defineConfig({
         },
       ],
     },
-    projects: [storybook],
   },
+});
+
+export default mergeConfig(atomicDefault, {
+  test: {projects: [atomicDefault, storybook]},
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,10 +60,10 @@ catalog:
   rollup-plugin-node-polyfills: 0.2.1
   typedoc: 0.28.13
   typescript: 5.8.3
-  vite: 7.0.5
-  vitest: 4.0.7
-  '@vitest/coverage-v8': 4.0.7
-  '@vitest/browser-playwright': 4.0.7
+  vite: 7.2.2.
+  vitest: 4.0.10
+  '@vitest/coverage-v8': 4.0.10
+  '@vitest/browser-playwright': 4.0.10
 
 
 publicHoistPattern:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,11 +1,6 @@
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
-  resolve: {
-    alias: [
-      {find: '@/', replacement: `${path.resolve(import.meta.dirname, './')}/`},
-    ],
-  },
   test: {
     projects: [
       './packages/atomic/vitest.config.js',


### PR DESCRIPTION
KIT-5253

This fix the extension getting confused about `@/`