### PR TITLE
fix(atomic): double analytics on show-more button in result-children components

### DIFF
--- a/packages/atomic/src/components/common/result-children/show-hide-button.tsx
+++ b/packages/atomic/src/components/common/result-children/show-hide-button.tsx
@@ -29,9 +29,7 @@ export const ShowHideButton: FunctionalComponent<ShowHideButtonProps> = ({
       onClick={() => {
         if (moreResultsAvailable) {
           loadFullCollection();
-          toggleShowInitialChildren();
         }
-
         toggleShowInitialChildren();
       }}
     >

--- a/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children/atomic-insight-result-children.tsx
+++ b/packages/atomic/src/components/insight/result-templates/atomic-insight-result-children/atomic-insight-result-children.tsx
@@ -64,7 +64,7 @@ export class AtomicResultChildren
   @State()
   private foldedResultListState!: InsightFoldedResultListState;
   @State()
-  private showInitialChildren = false;
+  private showInitialChildren = true;
 
   /**
    * Whether to inherit templates defined in a parent atomic-result-children. Only works for the second level of child nesting.

--- a/packages/atomic/src/components/search/result-lists/atomic-result-children/atomic-result-children.tsx
+++ b/packages/atomic/src/components/search/result-lists/atomic-result-children/atomic-result-children.tsx
@@ -77,7 +77,7 @@ export class AtomicResultChildren implements InitializableComponent {
   @State()
   private foldedResultListState!: FoldedResultListState;
   @State()
-  private showInitialChildren = false;
+  private showInitialChildren = true;
 
   /**
    * Whether to inherit templates defined in a parent atomic-result-children. Only works for the second level of child nesting.


### PR DESCRIPTION
KIT-5254

close #6573 
Introduced here : https://github.com/coveo/ui-kit/pull/4341

The state variable `showInitialChildren` was set to false which is wrong. The initial children are always shown at first. Due to this mistake, incorrect logic was able to slip through to the functional component which called `toggleShowInitialChildren` twice on the first click thus triggering double analytics.