### PR TITLE
fix(headless): ensure capture depends on `clientId` value

### DIFF
--- a/packages/headless/src/features/commerce/common/base-commerce-api-request-builder.test.ts
+++ b/packages/headless/src/features/commerce/common/base-commerce-api-request-builder.test.ts
@@ -164,10 +164,24 @@ describe('#buildBaseCommerceAPIRequest', () => {
       expect(request).toHaveProperty('clientId', clientId);
     });
 
-    it('when #navigatorContext.capture is undefined, sets #context.capture to true', () => {
+    it('when #navigatorContext.capture is undefined and #navigatorContext.clientId is not empty, sets #context.capture to true', () => {
+      setNavigatorContext({
+        clientId: 'some-client-id',
+        capture: undefined,
+      });
       request = buildBaseCommerceAPIRequest(state, navigatorContext);
 
       expect(request.context.capture).toBe(true);
+    });
+
+    it('when #navigatorContext.capture is undefined and #navigatorContext.clientId is empty, sets #context.capture to false', () => {
+      setNavigatorContext({
+        clientId: '',
+        capture: undefined,
+      });
+      request = buildBaseCommerceAPIRequest(state, navigatorContext);
+
+      expect(request.context.capture).toBe(false);
     });
 
     it('when #navigatorContext.capture is defined, sets #context.capture to its specified value', () => {

--- a/packages/headless/src/features/commerce/common/base-commerce-api-request-builder.ts
+++ b/packages/headless/src/features/commerce/common/base-commerce-api-request-builder.ts
@@ -49,7 +49,9 @@ export const buildBaseCommerceAPIRequest = (
           : {}),
       },
       capture:
-        navigatorContext.capture ?? state.configuration.analytics.enabled,
+        navigatorContext.capture ??
+        (state.configuration.analytics.enabled &&
+          navigatorContext.clientId !== ''),
       cart: getProductsFromCartState(state.cart),
       source: getAnalyticsSource(state.configuration.analytics),
     },


### PR DESCRIPTION
KIT-5279

Fixes #6595