### PR TITLE
chore: migrate tab-common

### DIFF
--- a/packages/atomic/src/components/common/tabs/tab-common.ts
+++ b/packages/atomic/src/components/common/tabs/tab-common.ts
@@ -1,6 +1,6 @@
 import {buildCustomEvent} from '../../../utils/event-utils.js';
 
-export const tabLoadedEventName = 'atomic/tabRendered';
+const tabLoadedEventName = 'atomic/tabRendered';
 
 export const dispatchTabLoaded = (element: HTMLElement) => {
   const event = buildCustomEvent(tabLoadedEventName, {});


### PR DESCRIPTION
There is no jsx or any stencil related stuff here so just having the .ts extension makes it work with lit.

close #6379 
KIT-5021