### PR TITLE
chore: set server host to 127.0.0.1 in Vite config

### DIFF
--- a/packages/atomic/dev/vite.config.ts
+++ b/packages/atomic/dev/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
   appType: 'mpa',
   server: {
     port: 3333,
+    host: '127.0.0.1',
   },
   plugins: [configureAssetPaths()],
 });


### PR DESCRIPTION
**KIT-5312**

Notably, Cypress in watch uses DNS lookup on ipv4, causing compatibility issue