### PR TITLE
chore(chromatic): disable turbosnap

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -81,7 +81,7 @@
     "promote:npm:latest": "pnpm --filter @coveo/ci promote-npm-prod",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
     "chromatic:build": "IS_CHROMATIC=true storybook build -o dist-chromatic --stats-json",
-    "chromatic": "chromatic -d=dist-chromatic --only-changed"
+    "chromatic": "chromatic -d=dist-chromatic"
   },
   "dependencies": {
     "@coveo/bueno": "workspace:*",


### PR DESCRIPTION
**KIT-5316**

We need to get rid of Stencil first to simplify the build process, thus allowing more direct use of the source file into the stories (like we do elsewhere)

We&#39;ll then be able to explictly import the component we need in there, the module graph (and its change) to be adequate, allowing turbosnap to work proper.