### PR TITLE
chore(headless): remember to export types for spotlight content results COMHUB2-1318

### DIFF
--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -27,7 +27,11 @@ export type {
   ChildProduct,
   Product,
 } from './api/commerce/common/product.js';
-export type {Result} from './api/commerce/common/result.js';
+export type {
+  BaseResult,
+  Result,
+  SpotlightContent,
+} from './api/commerce/common/result.js';
 export {ResultType} from './api/commerce/common/result.js';
 export {
   getAnalyticsNextApiBaseUrl,


### PR DESCRIPTION
[COMHUB2-1318](https://coveord.atlassian.net/browse/COMHUB2-1318)

Followup to https://github.com/coveo/ui-kit/pull/6646

I realised, when trying to write docs for this, that these types should be exported too, in order to make the implementation easier

[COMHUB2-1318]: https://coveord.atlassian.net/browse/COMHUB2-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ