### PR TITLE
chore(codeowners): docs ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,15 +5,14 @@
 # Doc owners
 ## Doc files
 
-packages/**/*.mdx @coveo/dev-writers
-packages/**/*.md @coveo/dev-writers
-packages/**/typedoc.json @coveo/dev-writers
-packages/**/*.typedoc.json @coveo/dev-writers
-packages/**/docs.config.json @coveo/dev-writers
+packages/**/*.mdx @coveo/dx
+packages/**/*.md @coveo/dx
+packages/**/typedoc.json @coveo/dx
+packages/**/*.typedoc.json @coveo/dx
 
 ## Doc package
 
-packages/documentation/ @coveo/dev-writers
+packages/documentation/ @coveo/dx
 
 # Knowledge Owners
 ## Quantic package


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5308

As discussed on slack, this change is meant to let dev writers approve PRs that only affect docs.

If this PR looks good, could someone with the appropriate access level grant "write" access to the [dev-writers](https://github.com/orgs/coveo/teams/dev-writers) group in this repo, please? (currently, we have this access through the [api-writers](https://github.com/orgs/coveo/teams/api-writers) group, which is deprecated, as we've changed the team name)