### PR TITLE
Revert "fix(atomic): css from atomic-result-image should only affect itself (#6722)"

### DIFF
--- a/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.ts
+++ b/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.ts
@@ -24,19 +24,19 @@ export class AtomicResultImage
   implements InitializableComponent<Bindings>
 {
   static styles = css`
-atomic-result-image {
-  display: grid;
-  place-items: center;
-  grid-template-rows: 100%;
-  width: 100%;
-  height: 100%;
+    :host {
+      display: grid;
+      place-items: center;
+      grid-template-rows: 100%;
+      width: 100%;
+      height: 100%;
+    }
 
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
-}
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
   `;
 
   /**


### PR DESCRIPTION
This reverts commit c3f5e42358b41f8a111da4adac5129826197e6b5.
Demo for post mortem
