### PR TITLE
fix(numeric-facet): improve manual range attribute handling

### DIFF
--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.ts
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.ts
@@ -428,13 +428,12 @@ export class AtomicNumericFacet
     this.manualRanges = Array.from(
       this.querySelectorAll('atomic-numeric-range')
     ).map((range) => {
-      const start = Number(range.getAttribute('start'));
-      const end = Number(range.getAttribute('end'));
-      // TODO v4: change the logic to simply check for the presence of the attribute
-      const endInclusive =
-        range.hasAttribute('end-inclusive') &&
-        range.getAttribute('end-inclusive') !== 'false';
-      const label = range.getAttribute('label') ?? undefined;
+      const {start, end, endInclusive, label} = range as HTMLElement & {
+        start: number;
+        end: number;
+        endInclusive: boolean;
+        label?: string;
+      };
       return {
         ...buildNumericRange({start, end, endInclusive}),
         label,


### PR DESCRIPTION
There's a potential race condition here; if the atomic-numeric-facet goes through the modified lines _before_ the initialization/load of the atomic-numeric-range, the property will be undefined, leading to missing content, such as the label.

To alleviate this, we could either:
- Ensure the atomic-numeric-range has been loaded (`await import('pathTo/atomic-numeric-range.ts')`)
- Make it so we don't need the component to be loaded (which goes in the direction that this component is just a stub/option)

I elected to use the former here to cover a very hypothetical corner case with the following order of operation:
- Page load (HTML initial parsing) with atomic-numeric-range having some value set by attributes.
- Custom code set a **property** on an atomic-numeric-range using JS (why they didn't use attributes, heck if I know)
- `atomic-numeric-facet` initialize

Because the `atomic-numeric-range` didn't initialize prior, the atomic-numeric-facet will only have access to the options set in the properties manually.

However, if we do load the atomic-numeric-range file to be loaded and executed, we ensure that the Lit reactivity cycle runs up on each component, syncing stuff up, ensuring attributes & properties are 1-to-1 match up

---
**Jira:** KIT-5363