### PR TITLE
 chore: disable dev tag for pr deployment

### DIFF
--- a/.deployment.config/pr.json
+++ b/.deployment.config/pr.json
@@ -99,5 +99,12 @@
     "observatory": {
       "no_endpoint": true
     }
+  },
+  "hooks": {
+    "post":{
+      "tag_after_deployment": {
+        "enabled": false
+      }
+    }
   }
 }


### PR DESCRIPTION
Disable the 'tagging' on dev done by the deployment pipeline for PR.

1. Not representative, "true" dev is the top of main.
2. Create flakyness in the release process (it tries to push dev but it's been moved, causing failure)

**Jira:** KIT-5365