### PR TITLE
docs(headless-react): typedoc site name

### DIFF
--- a/packages/headless-react/typedoc.json
+++ b/packages/headless-react/typedoc.json
@@ -1,4 +1,5 @@
 {
+  "name": "Coveo Headless React",
   "entryPointStrategy": "merge",
   "projectDocuments": ["documents/headless-react/hooks.md", "README.md"],
   "navigation": {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-18390

Quick win; I had forgotten to update the name of the Headless React Typedoc site when [updating the Headless one](https://github.com/coveo/ui-kit/pull/6817/files#diff-8e59e3284c9cf3e05b9ac39bee6ff7be265bb7ac2a97808454a6dd80907e9c89).