### PR TITLE
lab: allow redaction of some slice of the state

### DIFF
--- a/packages/atomic/dev/examples/headless.html
+++ b/packages/atomic/dev/examples/headless.html
@@ -20,7 +20,7 @@
     </script>
 
     <script type="module">
-      const {loadAdvancedSearchQueryActions, loadContextActions} = await (import.meta.env
+      const {loadAdvancedSearchQueryActions, loadContextActions, buildPotato} = await (import.meta.env
         ? import('@coveo/headless')
         : import('http://localhost:3000/headless/v0.0.0/headless.esm.js'));
 
@@ -52,7 +52,8 @@
         const engine = searchInterface.engine;
         setExpression(engine);
         setContext(engine);
-
+        buildPotato(engine);
+        console.log('Potato state:', engine.state.potato);
         searchInterface.executeFirstSearch();
       }
       main();

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -40,7 +40,7 @@ import {
 } from './navigator-context-provider.js';
 import {createReducerManager, type ReducerManager} from './reducer-manager.js';
 import {createRenewAccessTokenMiddleware} from './renew-access-token-middleware.js';
-import {stateKey} from './state-key.js';
+import {redactEngine, selectPublicState, stateKey} from './state-key.js';
 import {type CoreExtraArguments, configureStore, type Store} from './store.js';
 import type {ThunkExtraArguments} from './thunk-extra-arguments.js';
 
@@ -295,7 +295,7 @@ export function buildCoreEngine<
     reducerManager
   );
 
-  const engine = {
+  const engine = redactEngine({
     addReducers(reducers: ReducersMapObject) {
       if (reducerManager.containsAll(reducers)) {
         return;
@@ -317,8 +317,12 @@ export function buildCoreEngine<
       store.dispatch(disableAnalytics());
     },
 
-    get state() {
+    get [stateKey]() {
       return store.getState();
+    },
+
+    get state() {
+      return selectPublicState(store.getState());
     },
 
     get relay() {
@@ -332,7 +336,7 @@ export function buildCoreEngine<
     logger,
 
     store,
-  };
+  });
   return engine;
 }
 

--- a/packages/headless/src/controllers/potato/headless-potato.ts
+++ b/packages/headless/src/controllers/potato/headless-potato.ts
@@ -1,0 +1,6 @@
+import type {SearchEngine} from '../../app/search-engine/search-engine.js';
+import {potato} from './potato-slice.js';
+
+export function buildPotato(engine: SearchEngine) {
+  engine.addReducers({potato});
+}

--- a/packages/headless/src/controllers/potato/potato-slice.ts
+++ b/packages/headless/src/controllers/potato/potato-slice.ts
@@ -1,0 +1,8 @@
+import {createReducer} from '@reduxjs/toolkit';
+
+export const potato = createReducer(
+  {
+    potato: "HI I'M A POTATO",
+  },
+  () => {}
+);

--- a/packages/headless/src/controllers/potato/potato-slice.ts
+++ b/packages/headless/src/controllers/potato/potato-slice.ts
@@ -1,4 +1,7 @@
 import {createReducer} from '@reduxjs/toolkit';
+import {sliceRedactorsMap} from '../../app/state-key.js';
+
+sliceRedactorsMap.potato = () => undefined;
 
 export const potato = createReducer(
   {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -527,6 +527,7 @@ export type {
   PhrasesToHighlight,
   TermsToHighlight,
 } from './api/search/search/stemming.js';
+export {buildPotato} from './controllers/potato/headless-potato.js';
 export type {
   CategoryFacetSortCriterion,
   CategoryFacetValueRequest,


### PR DESCRIPTION
a679da80f25932f7913c46aa3c47435beab124d2 add a new potato controller & slice, for demo purpose
d66b24a92bc90c09699fc284e524650c0eab1b3a when running from there, going in headless.html, we should see the engine.state.potato having not as undefined

And finally the last commit redact the state