### PR TITLE
fix(atomic): remove aria-label from results per page toolbar for accessibility

### DIFF
--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.ts
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.ts
@@ -123,7 +123,7 @@ export class AtomicResultsPerPage
           this.isAppLoaded &&
           this.searchStatusState.hasResults,
         () => html`
-          <div class="flex items-center" role="toolbar" aria-label=${this.label}>
+          <div class="flex items-center">
             ${renderLabel()(html`${this.label}`)}
             ${renderFieldsetGroup({
               props: {


### PR DESCRIPTION
The double container (toolbar+radiogroup) cause AT to announce both when we focus in the first focusable element (radio element), which is noisy and redundant

**KIT-5394**