### PR TITLE
fix: adjust css reference path

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.ts
@@ -1,6 +1,6 @@
 import {isUndefined} from '@coveo/bueno';
 import type {InteractiveProduct, Product} from '@coveo/headless/commerce';
-import {type CSSResultGroup, css, html, LitElement} from 'lit';
+import {type CSSResultGroup, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {createInteractiveProductContextController} from '@/src/components/commerce/product-template-component-utils/context/interactive-product-context-controller.js';
@@ -20,6 +20,7 @@ import {
   type LightDOMWithSlots,
   SlotsForNoShadowDOMMixin,
 } from '@/src/mixins/slots-for-no-shadow-dom-mixin';
+import styles from './atomic-product-link.tw.css';
 
 /**
  * The `atomic-product-link` component automatically transforms a product `ec_name` into a clickable link that points to the original item.
@@ -33,14 +34,7 @@ export class AtomicProductLink
   extends LightDomMixin(SlotsForNoShadowDOMMixin(LitElement))
   implements InitializableComponent<CommerceBindings>
 {
-  static styles: CSSResultGroup =
-    css`@reference '../../../utils/tailwind.global.tw.css';
-
-atomic-product-link {
-  a {
-    @apply link-style;
-  }
-}`;
+  static styles: CSSResultGroup = styles;
 
   /**
    * The [template literal](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals) from which to generate the `href` attribute value
@@ -151,13 +145,13 @@ atomic-product-link {
           },
         },
       })(html`
-          ${this.renderDefaultSlotContent(
-            html`<atomic-product-text
+        ${this.renderDefaultSlotContent(
+          html`<atomic-product-text
             field="ec_name"
             default="no-title"
           ></atomic-product-text>`
-          )}
-        `);
+        )}
+      `);
     })}`;
   }
 }

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
@@ -1,0 +1,12 @@
+import {css} from 'lit';
+
+const styles = css`
+  @reference '../../../utils/tailwind.global.tw.css';
+
+  atomic-product-link a {
+    @apply link-style;
+    text-decoration: none;
+  }
+`;
+
+export default styles;

--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.ts
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.ts
@@ -1,6 +1,6 @@
 import {isUndefined} from '@coveo/bueno';
 import type {InteractiveResult, Result} from '@coveo/headless';
-import {type CSSResultGroup, css, html, LitElement} from 'lit';
+import {type CSSResultGroup, html, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {getAttributesFromLinkSlotContent} from '@/src/components/common/item-link/attributes-slot';
@@ -20,6 +20,7 @@ import {
 import {buildCustomEvent} from '@/src/utils/event-utils';
 import {buildStringTemplateFromResult} from '@/src/utils/result-utils';
 import '@/src/components/search/atomic-result-text/atomic-result-text';
+import styles from './atomic-result-link.tw.css';
 
 /**
  * The `atomic-result-link` component automatically transforms a search result title into a clickable link that points to the original item.
@@ -32,14 +33,7 @@ export class AtomicResultLink
   extends LightDomMixin(SlotsForNoShadowDOMMixin(LitElement))
   implements InitializableComponent<Bindings>
 {
-  static styles: CSSResultGroup = css`
-    @reference '../../../utils/tailwind.global.tw.css';
-
-atomic-result-link {
-  a {
-    @apply link-style;
-  }
-}`;
+  static styles: CSSResultGroup = styles;
 
   /**
    * Specifies a template literal from which to generate the `href` attribute value (see
@@ -135,7 +129,6 @@ atomic-result-link {
           onCancelPendingSelect: () => interactiveResult.cancelPendingSelect(),
           attributes: this.linkAttributes,
           stopPropagation: this.stopPropagation,
-          className: 'link-style',
           onInitializeLink: (cleanupCallback) => {
             if (this.removeLinkEventHandlers) {
               this.removeLinkEventHandlers();
@@ -144,13 +137,13 @@ atomic-result-link {
           },
         },
       })(html`
-          ${this.renderDefaultSlotContent(
-            html`<atomic-result-text
+        ${this.renderDefaultSlotContent(
+          html`<atomic-result-text
             field="title"
             default="no-title"
           ></atomic-result-text>`
-          )}
-        `);
+        )}
+      `);
     })}`;
   }
 }

--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.tw.css.ts
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.tw.css.ts
@@ -1,0 +1,12 @@
+import {css} from 'lit';
+
+const styles = css`
+  @reference '../../../utils/tailwind.global.tw.css';
+
+  atomic-result-link a {
+    @apply link-style;
+    text-decoration: none;
+  }
+`;
+
+export default styles;


### PR DESCRIPTION
After the result link component was migrated to lit, the css was no longer matching the stencil version
https://www.chromatic.com/test?appId=6932045129665d06f74ceb8e&id=69667ac2c31a4bf3ad007b78

KIT-5378
