### PR TITLE
fix: ensure atomic-timeframe is loaded when querying its fields

### DIFF
--- a/packages/atomic/src/components/common/facets/timeframe-facet-common.ts
+++ b/packages/atomic/src/components/common/facets/timeframe-facet-common.ts
@@ -27,6 +27,7 @@ import {renderFacetValueLabelHighlight} from './facet-value-label-highlight/face
 import {renderFacetValueLink} from './facet-value-link/facet-value-link';
 import {renderFacetValuesGroup} from './facet-values-group/facet-values-group';
 import {initializePopover} from './popover/popover-type';
+import '@/src/components/common/atomic-timeframe/atomic-timeframe';
 
 export interface Timeframe {
   period: RelativeDatePeriod;


### PR DESCRIPTION
otherwise their will be unset

KIT-5424
