### PR TITLE
fix(atomic): CSS layer

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet-number-input/atomic-commerce-facet-number-input.ts
@@ -50,29 +50,32 @@ export class AtomicCommerceFacetNumberInput
   private startRef?: HTMLInputElement;
   private endRef?: HTMLInputElement;
 
-  static styles = css`[part="input-form"] {
-    display: grid;
-    grid-template-areas:
-      "label-start label-end ."
-      "input-start input-end apply-button";
-    grid-template-columns: 1fr 1fr auto;
-  }
-  
-  [part="label-start"] {
-    grid-area: label-start;
-  }
-  [part="label-end"] {
-    grid-area: label-end;
-  }
-  [part="input-start"] {
-    grid-area: input-start;
-  }
-  [part="input-end"] {
-    grid-area: input-end;
-  }
-  
-  [part="input-apply-button"] {
-    grid-area: apply-button;
+  static styles = css`
+  @layer components {
+    [part="input-form"] {
+      display: grid;
+      grid-template-areas:
+        "label-start label-end ."
+        "input-start input-end apply-button";
+      grid-template-columns: 1fr 1fr auto;
+    }
+    
+    [part="label-start"] {
+      grid-area: label-start;
+    }
+    [part="label-end"] {
+      grid-area: label-end;
+    }
+    [part="input-start"] {
+      grid-area: input-start;
+    }
+    [part="input-end"] {
+      grid-area: input-end;
+    }
+    
+    [part="input-apply-button"] {
+      grid-area: apply-button;
+    }
   }
   `;
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.tw.css.ts
@@ -1,168 +1,170 @@
 import {css} from 'lit';
 
 const styles = css`
-.atomic-modal-opened {
-  overflow-y: hidden;
-}
-
-atomic-layout-section[section="search"] {
-  grid-area: atomic-section-search;
-}
-
-atomic-layout-section[section="facets"] {
-  grid-area: atomic-section-facets;
-}
-
-atomic-layout-section[section="main"] {
-  grid-area: atomic-section-main;
-}
-
-atomic-layout-section[section="status"] {
-  grid-area: atomic-section-status;
-}
-
-atomic-layout-section[section="pagination"] {
-  grid-area: atomic-section-pagination;
-}
-
-/**
- * @prop --atomic-layout-max-search-box-input-width: The maximum width that the search box input will take.
- * @prop --atomic-layout-max-search-box-double-suggestions-width: The maximum width that the search box suggestions will take when displaying a double list.
- * @prop --atomic-layout-search-box-left-suggestions-width: When displaying a double list, the width of the left list.
- */
-atomic-commerce-layout {
-  width: 100%;
-  height: 100%;
-  display: none;
-  grid-template-areas:
-    ". atomic-section-search ."
-    ". atomic-section-main .";
-  grid-template-columns: var(--atomic-layout-spacing-x) minmax(0, 1fr) var(
-      --atomic-layout-spacing-x
-    );
+@layer components {
+  .atomic-modal-opened {
+    overflow-y: hidden;
+  }
 
   atomic-layout-section[section="search"] {
-    margin: var(--atomic-layout-spacing-y) 0;
-    max-width: var(--atomic-layout-max-search-box-input-width, 678px);
-    width: 100%;
-    justify-self: center;
-
-    /* Only affects desktop */
-    atomic-commerce-search-box {
-      &::part(suggestions-double-list) {
-        width: 125%;
-        max-width: var(
-          --atomic-layout-max-search-box-double-suggestions-width,
-          800px
-        );
-      }
-
-      &::part(suggestions-left) {
-        flex-basis: var(--atomic-layout-search-box-left-suggestions-width, 30%);
-      }
-
-      &::part(suggestions-right) {
-        flex-basis: calc(
-          100% -
-          var(--atomic-layout-search-box-left-suggestions-width, 30%)
-        );
-      }
-    }
+    grid-area: atomic-section-search;
   }
 
   atomic-layout-section[section="facets"] {
-    display: none;
-
-    atomic-commerce-facets * {
-      margin-bottom: var(--atomic-layout-spacing-y);
-    }
+    grid-area: atomic-section-facets;
   }
 
   atomic-layout-section[section="main"] {
-    margin-bottom: var(--atomic-layout-spacing-y);
-  }
-
-  atomic-layout-section[section="horizontal-facets"] {
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: var(--atomic-layout-spacing-y);
-    row-gap: 0.5rem;
-
-    & > atomic-popover {
-      margin-right: 0.5rem;
-    }
-
-    & > atomic-popover {
-      display: none;
-    }
-  }
-
-  atomic-layout-section[section="horizontal-facets"] > * {
-    max-width: 100%;
+    grid-area: atomic-section-main;
   }
 
   atomic-layout-section[section="status"] {
-    display: grid;
-    justify-content: space-between;
-    grid-template-areas:
-      "atomic-breadbox       atomic-breadbox"
-      "atomic-query-summary  atomic-sort"
-      "atomic-did-you-mean   atomic-did-you-mean"
-      "atomic-notifications  atomic-notifications";
-
-    atomic-commerce-breadbox {
-      grid-area: atomic-breadbox;
-    }
-
-    atomic-commerce-query-summary {
-      grid-area: atomic-query-summary;
-      align-self: center;
-      overflow: hidden;
-    }
-
-    atomic-commerce-sort-dropdown {
-      grid-area: atomic-sort;
-      justify-self: end;
-    }
-
-    atomic-commerce-refine-toggle {
-      grid-area: atomic-sort;
-    }
-
-    atomic-commerce-did-you-mean {
-      grid-area: atomic-did-you-mean;
-    }
-
-    atomic-commerce-notifications {
-      grid-area: atomic-notifications;
-    }
-  }
-
-  atomic-layout-section[section="status"] > * {
-    margin-bottom: var(--atomic-layout-spacing-y);
+    grid-area: atomic-section-status;
   }
 
   atomic-layout-section[section="pagination"] {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-
-    atomic-commerce-load-more-products {
-      width: 100%;
-    }
-
-    &:has(:only-child) {
-      justify-content: center;
-    }
-
-    /* Approx. width of pager & products per page */
-    @media only screen and (min-width: 50rem) {
-      flex-direction: row;
-    }
+    grid-area: atomic-section-pagination;
   }
-  atomic-layout-section[section="pagination"] > * {
-    margin-top: var(--atomic-layout-spacing-y);
+
+  /**
+   * @prop --atomic-layout-max-search-box-input-width: The maximum width that the search box input will take.
+   * @prop --atomic-layout-max-search-box-double-suggestions-width: The maximum width that the search box suggestions will take when displaying a double list.
+   * @prop --atomic-layout-search-box-left-suggestions-width: When displaying a double list, the width of the left list.
+   */
+  atomic-commerce-layout {
+    width: 100%;
+    height: 100%;
+    display: none;
+    grid-template-areas:
+      ". atomic-section-search ."
+      ". atomic-section-main .";
+    grid-template-columns: var(--atomic-layout-spacing-x) minmax(0, 1fr) var(
+        --atomic-layout-spacing-x
+      );
+
+    atomic-layout-section[section="search"] {
+      margin: var(--atomic-layout-spacing-y) 0;
+      max-width: var(--atomic-layout-max-search-box-input-width, 678px);
+      width: 100%;
+      justify-self: center;
+
+      /* Only affects desktop */
+      atomic-commerce-search-box {
+        &::part(suggestions-double-list) {
+          width: 125%;
+          max-width: var(
+            --atomic-layout-max-search-box-double-suggestions-width,
+            800px
+          );
+        }
+
+        &::part(suggestions-left) {
+          flex-basis: var(--atomic-layout-search-box-left-suggestions-width, 30%);
+        }
+
+        &::part(suggestions-right) {
+          flex-basis: calc(
+            100% -
+            var(--atomic-layout-search-box-left-suggestions-width, 30%)
+          );
+        }
+      }
+    }
+
+    atomic-layout-section[section="facets"] {
+      display: none;
+
+      atomic-commerce-facets * {
+        margin-bottom: var(--atomic-layout-spacing-y);
+      }
+    }
+
+    atomic-layout-section[section="main"] {
+      margin-bottom: var(--atomic-layout-spacing-y);
+    }
+
+    atomic-layout-section[section="horizontal-facets"] {
+      display: flex;
+      flex-wrap: wrap;
+      margin-bottom: var(--atomic-layout-spacing-y);
+      row-gap: 0.5rem;
+
+      & > atomic-popover {
+        margin-right: 0.5rem;
+      }
+
+      & > atomic-popover {
+        display: none;
+      }
+    }
+
+    atomic-layout-section[section="horizontal-facets"] > * {
+      max-width: 100%;
+    }
+
+    atomic-layout-section[section="status"] {
+      display: grid;
+      justify-content: space-between;
+      grid-template-areas:
+        "atomic-breadbox       atomic-breadbox"
+        "atomic-query-summary  atomic-sort"
+        "atomic-did-you-mean   atomic-did-you-mean"
+        "atomic-notifications  atomic-notifications";
+
+      atomic-commerce-breadbox {
+        grid-area: atomic-breadbox;
+      }
+
+      atomic-commerce-query-summary {
+        grid-area: atomic-query-summary;
+        align-self: center;
+        overflow: hidden;
+      }
+
+      atomic-commerce-sort-dropdown {
+        grid-area: atomic-sort;
+        justify-self: end;
+      }
+
+      atomic-commerce-refine-toggle {
+        grid-area: atomic-sort;
+      }
+
+      atomic-commerce-did-you-mean {
+        grid-area: atomic-did-you-mean;
+      }
+
+      atomic-commerce-notifications {
+        grid-area: atomic-notifications;
+      }
+    }
+
+    atomic-layout-section[section="status"] > * {
+      margin-bottom: var(--atomic-layout-spacing-y);
+    }
+
+    atomic-layout-section[section="pagination"] {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+
+      atomic-commerce-load-more-products {
+        width: 100%;
+      }
+
+      &:has(:only-child) {
+        justify-content: center;
+      }
+
+      /* Approx. width of pager & products per page */
+      @media only screen and (min-width: 50rem) {
+        flex-direction: row;
+      }
+    }
+    atomic-layout-section[section="pagination"] > * {
+      margin-top: var(--atomic-layout-spacing-y);
+    }
   }
 }
 `;

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.tw.css.ts
@@ -3,9 +3,11 @@ import {css} from 'lit';
 const styles = css`
   @reference '../../../utils/tailwind.global.tw.css';
 
-  atomic-product-link a {
-    @apply link-style;
-    text-decoration: none;
+  @layer components {
+    atomic-product-link a {
+      @apply link-style;
+      text-decoration: none;
+    }
   }
 `;
 

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.ts
@@ -28,8 +28,10 @@ export class AtomicProductPrice
   implements InitializableComponent<CommerceBindings>
 {
   static styles = css`
-    atomic-product-price.display-grid div {
-      flex-direction: column;
+    @layer components {
+      atomic-product-price.display-grid div {
+        flex-direction: column;
+      }
     }
   `;
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.ts
@@ -16,11 +16,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionActions extends ItemSectionMixin(
   LitElement,
   css`
-        @reference '../../common/template-system/sections/sections.css';
-        atomic-product-section-actions {
-          @apply section-actions;
-        }
-        `
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-product-section-actions {
+        @apply section-actions;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.ts
@@ -16,11 +16,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionBadges extends ItemSectionMixin(
   LitElement,
   css`
-      @reference '../../common/template-system/sections/sections.css';
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
       atomic-product-section-badges {
         @apply section-badges;
       }
-      `
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.ts
@@ -15,11 +15,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionBottomMetadata extends ItemSectionMixin(
   LitElement,
   css`
-      @reference '../../common/template-system/sections/sections.css';
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
       atomic-product-section-bottom-metadata {
         @apply section-bottom-metadata;
       }
-      `
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.ts
@@ -12,59 +12,61 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionChildren extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../../utils/tailwind.global.tw.css';
-@reference '../../common/template-system/sections/sections.css';
-atomic-product-section-children {
-  @apply section-children;
-  &.with-sections {
-    &.image-icon,
-    &.image-none {
-      .product-child {
-        @apply size-8;
-      }
-    }
-    &.display-grid {
-      &.image-large,
-      &.image-small {
-        .product-child {
-          @apply aspect-square-[auto];
-          @apply w-1/6;
-        }
-      }
-      @media not all and (width >= theme(--breakpoint-desktop)) {
-        &.image-small .product-child {
-          @apply max-w-19;
-        }
-      }
-    }
+    @reference '../../../utils/tailwind.global.tw.css';
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-product-section-children {
+        @apply section-children;
+        &.with-sections {
+          &.image-icon,
+          &.image-none {
+            .product-child {
+              @apply size-8;
+            }
+          }
+          &.display-grid {
+            &.image-large,
+            &.image-small {
+              .product-child {
+                @apply aspect-square-[auto];
+                @apply w-1/6;
+              }
+            }
+            @media not all and (width >= theme(--breakpoint-desktop)) {
+              &.image-small .product-child {
+                @apply max-w-19;
+              }
+            }
+          }
 
-    &.display-list {
-      @media (width >= theme(--breakpoint-desktop)) {
-        &.image-large.density-comfortable,
-        &.image-large.density-normal {
-          .product-child {
-            @apply size-27;
+          &.display-list {
+            @media (width >= theme(--breakpoint-desktop)) {
+              &.image-large.density-comfortable,
+              &.image-large.density-normal {
+                .product-child {
+                  @apply size-27;
+                }
+              }
+              &.image-small,
+              &.image-large.density-compact {
+                .product-child {
+                  @apply size-8;
+                }
+              }
+            }
+            @media not all and (width >= theme(--breakpoint-desktop)) {
+              &.image-large .product-child {
+                @apply aspect-square-[auto] w-1/6;
+              }
+              &.image-small .product-child {
+                @apply size-8;
+              }
+            }
           }
-        }
-        &.image-small,
-        &.image-large.density-compact {
-          .product-child {
-            @apply size-8;
-          }
-        }
-      }
-      @media not all and (width >= theme(--breakpoint-desktop)) {
-        &.image-large .product-child {
-          @apply aspect-square-[auto] w-1/6;
-        }
-        &.image-small .product-child {
-          @apply size-8;
         }
       }
     }
-  }
-}
-`
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.ts
@@ -15,24 +15,27 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionDescription extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-product-section-description {
-  @apply section-excerpt;
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-product-section-description {
+        @apply section-excerpt;
 
-  &.with-sections {
-    &.display-grid {
-      &.density-comfortable {
-        margin-top: 1.25rem;
-      }
-      &.density-normal {
-        margin-top: 0.75rem;
-      }
-      &.density-compact {
-        margin-top: 0.25rem;
+        &.with-sections {
+          &.display-grid {
+            &.density-comfortable {
+              margin-top: 1.25rem;
+            }
+            &.density-normal {
+              margin-top: 0.75rem;
+            }
+            &.density-compact {
+              margin-top: 0.25rem;
+            }
+          }
+        }
       }
     }
-  }
-}`
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.ts
@@ -14,11 +14,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionEmphasized extends ItemSectionMixin(
   LitElement,
   css`
-      @reference '../../common/template-system/sections/sections.css';
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
       atomic-product-section-emphasized {
         @apply section-emphasized;
       }
-      `
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.ts
@@ -15,10 +15,12 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionMetadata extends ItemSectionMixin(
   LitElement,
   css`
-  @reference '../../common/template-system/sections/sections.css';
-  atomic-product-section-metadata {
-    @apply section-metadata;
-  }
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-product-section-metadata {
+        @apply section-metadata;
+      }
+    }
   `
 ) {}
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.ts
@@ -13,17 +13,19 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicProductSectionName extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-product-section-name {
-  @apply section-title;
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-product-section-name {
+        @apply section-title;
 
-  .with-sections {
-    &.display-grid {
-        min-height: calc(var(--line-height) * 2);
-        @apply line-clamp-2;
-    }
-  }
-}`
+        .with-sections {
+          &.display-grid {
+              min-height: calc(var(--line-height) * 2);
+              @apply line-clamp-2;
+          }
+        }
+      }
+    }`
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.ts
@@ -17,19 +17,22 @@ export class AtomicProductSectionVisual extends ItemSectionMixin(
   LitElement,
   css`
     @reference '../../common/template-system/sections/sections.css';
-    atomic-product-section-visual {
-      @apply section-visual;
+    @layer components {
+      atomic-product-section-visual {
+        @apply section-visual;
 
-      .with-sections {
-        &.image-icon {
-      atomic-product-image::part(previous-button),
-      atomic-product-image::part(next-button),
-      atomic-product-image::part(indicator) {
-        display: none;
+        .with-sections {
+          &.image-icon {
+            atomic-product-image::part(previous-button),
+            atomic-product-image::part(next-button),
+            atomic-product-image::part(indicator) {
+              display: none;
+            }
+          }
+        }
       }
-    }}
     }
-    `
+  `
 ) {
   /**
    * How large or small the visual section of product using this template should be.

--- a/packages/atomic/src/components/common/atomic-facet-number-input/atomic-facet-number-input.ts
+++ b/packages/atomic/src/components/common/atomic-facet-number-input/atomic-facet-number-input.ts
@@ -50,30 +50,32 @@ export class AtomicFacetNumberInput
   private endRef: Ref<HTMLInputElement> = createRef();
 
   static styles = css`
-    [part='input-form'] {
-      display: grid;
-      grid-template-areas:
-        'label-start label-end .'
-        'input-start input-end apply-button';
-      grid-template-columns: 1fr 1fr auto;
-    }
+  @layer components {
+      [part='input-form'] {
+        display: grid;
+        grid-template-areas:
+          'label-start label-end .'
+          'input-start input-end apply-button';
+        grid-template-columns: 1fr 1fr auto;
+      }
 
-    [part='label-start'] {
-      grid-area: label-start;
-    }
-    [part='label-end'] {
-      grid-area: label-end;
-    }
-    [part='input-start'] {
-      grid-area: input-start;
-    }
-    [part='input-end'] {
-      grid-area: input-end;
-    }
+      [part='label-start'] {
+        grid-area: label-start;
+      }
+      [part='label-end'] {
+        grid-area: label-end;
+      }
+      [part='input-start'] {
+        grid-area: input-start;
+      }
+      [part='input-end'] {
+        grid-area: input-end;
+      }
 
-    [part='input-apply-button'] {
-      grid-area: apply-button;
-    }
+      [part='input-apply-button'] {
+        grid-area: apply-button;
+      }
+  }
   `;
 
   public initialize() {

--- a/packages/atomic/src/components/common/atomic-layout-section/layout.ts
+++ b/packages/atomic/src/components/common/atomic-layout-section/layout.ts
@@ -97,8 +97,11 @@ export function buildCommonLayout(
       }
     }`;
   };
-
-  return [display, search, facets(), refine(), horizontalFacets()]
+  const stylesheet = [display, search, facets(), refine(), horizontalFacets()]
     .filter((declaration) => declaration !== '')
     .join('\n\n');
+
+  return `@layer components {
+    ${stylesheet}
+  }`;
 }

--- a/packages/atomic/src/components/search/atomic-result-fields-list/atomic-result-fields-list.ts
+++ b/packages/atomic/src/components/search/atomic-result-fields-list/atomic-result-fields-list.ts
@@ -22,25 +22,27 @@ export class AtomicResultFieldsList
   implements InitializableComponent<Bindings>
 {
   static styles = css`
-    atomic-result-fields-list {
-      display: flex;
-      flex-wrap: wrap;
-      width: 100%;
-      height: 100%;
-    }
+    @layer components {
+      atomic-result-fields-list {
+        display: flex;
+        flex-wrap: wrap;
+        width: 100%;
+        height: 100%;
+      }
 
-    atomic-result-fields-list > *::after {
-      display: block;
-      content: ' ';
-      width: 1px;
-      height: 1rem;
-      margin: 0 1rem;
-      background-color: var(--atomic-neutral);
-      vertical-align: middle;
-    }
+      atomic-result-fields-list > *::after {
+        display: block;
+        content: ' ';
+        width: 1px;
+        height: 1rem;
+        margin: 0 1rem;
+        background-color: var(--atomic-neutral);
+        vertical-align: middle;
+      }
 
-    atomic-result-fields-list > *.hide-divider::after {
-      visibility: hidden;
+      atomic-result-fields-list > *.hide-divider::after {
+        visibility: hidden;
+      }
     }
   `;
 

--- a/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.ts
+++ b/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.ts
@@ -24,19 +24,21 @@ export class AtomicResultImage
   implements InitializableComponent<Bindings>
 {
   static styles = css`
-atomic-result-image {
-  display: grid;
-  place-items: center;
-  grid-template-rows: 100%;
-  width: 100%;
-  height: 100%;
+  @layer components {
+    atomic-result-image {
+      display: grid;
+      place-items: center;
+      grid-template-rows: 100%;
+      width: 100%;
+      height: 100%;
 
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+      }
+    }
   }
-}
   `;
 
   private static readonly propsSchema = new Schema({

--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.tw.css.ts
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.tw.css.ts
@@ -2,10 +2,11 @@ import {css} from 'lit';
 
 const styles = css`
   @reference '../../../utils/tailwind.global.tw.css';
-
-  atomic-result-link a {
-    @apply link-style;
-    text-decoration: none;
+  @layer components {
+    atomic-result-link a {
+      @apply link-style;
+      text-decoration: none;
+    }
   }
 `;
 

--- a/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.tw.css.ts
+++ b/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.tw.css.ts
@@ -1,68 +1,70 @@
 import {css} from 'lit';
 
 const styles = css`
-  atomic-result-printable-uri {
-    max-width: 100%;
-    word-break: break-word;
-  }
+  @layer components {
+    atomic-result-printable-uri {
+      max-width: 100%;
+      word-break: break-word;
+    }
 
-  atomic-result-printable-uri a,
-  atomic-result-printable-uri button {
-    color: var(--atomic-primary);
-  }
+    atomic-result-printable-uri a,
+    atomic-result-printable-uri button {
+      color: var(--atomic-primary);
+    }
 
-  atomic-result-printable-uri a:hover,
-  atomic-result-printable-uri a:focus-visible,
-  atomic-result-printable-uri button:hover,
-  atomic-result-printable-uri button:focus-visible {
-    text-decoration: underline;
-    color: var(--atomic-primary);
-  }
+    atomic-result-printable-uri a:hover,
+    atomic-result-printable-uri a:focus-visible,
+    atomic-result-printable-uri button:hover,
+    atomic-result-printable-uri button:focus-visible {
+      text-decoration: underline;
+      color: var(--atomic-primary);
+    }
 
-  atomic-result-printable-uri a:focus,
-  atomic-result-printable-uri button:focus {
-    outline: none;
-  }
+    atomic-result-printable-uri a:focus,
+    atomic-result-printable-uri button:focus {
+      outline: none;
+    }
 
-  atomic-result-printable-uri a:visited {
-    color: var(--atomic-visited);
-  }
+    atomic-result-printable-uri a:visited {
+      color: var(--atomic-visited);
+    }
 
-  atomic-result-printable-uri ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
+    atomic-result-printable-uri ul {
+      display: flex;
+      flex-wrap: wrap;
+    }
 
-  atomic-result-printable-uri li {
-    display: inline-flex;
-    align-items: center;
-    max-width: 100%;
-    white-space: nowrap;
-  }
+    atomic-result-printable-uri li {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+      white-space: nowrap;
+    }
 
-  atomic-result-printable-uri li:last-child {
-    white-space: normal;
-  }
+    atomic-result-printable-uri li:last-child {
+      white-space: normal;
+    }
 
-  atomic-result-printable-uri li:last-child::after {
-    content: none;
-  }
+    atomic-result-printable-uri li:last-child::after {
+      content: none;
+    }
 
-  atomic-result-printable-uri li a {
-    display: inline-block;
-    vertical-align: middle;
-    max-width: 100%;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
+    atomic-result-printable-uri li a {
+      display: inline-block;
+      vertical-align: middle;
+      max-width: 100%;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
 
-  atomic-result-printable-uri li .result-printable-uri-separator {
-    display: inline-block;
-    margin: 0 0.5rem;
-    vertical-align: middle;
-    width: 0.75rem;
-    height: 0.75rem;
-    color: var(--atomic-neutral-dark);
+    atomic-result-printable-uri li .result-printable-uri-separator {
+      display: inline-block;
+      margin: 0 0.5rem;
+      vertical-align: middle;
+      width: 0.75rem;
+      height: 0.75rem;
+      color: var(--atomic-neutral-dark);
+    }
   }
 `;
 

--- a/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.ts
@@ -17,8 +17,10 @@ export class AtomicResultSectionActions extends ItemSectionMixin(
   LitElement,
   css`
 @reference '../../common/template-system/sections/sections.css';
-atomic-result-section-actions {
-  @apply section-actions;
+@layer components {
+  atomic-result-section-actions {
+    @apply section-actions;
+  }
 }`
 ) {}
 

--- a/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.ts
@@ -15,10 +15,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionBadges extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-badges {
-  @apply section-badges;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-badges {
+        @apply section-badges;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.ts
@@ -16,10 +16,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionBottomMetadata extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-bottom-metadata {
-  @apply section-bottom-metadata;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-bottom-metadata {
+        @apply section-bottom-metadata;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.ts
@@ -11,10 +11,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionChildren extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-children {
-  @apply section-children;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-children {
+        @apply section-children;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.ts
@@ -14,10 +14,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionEmphasized extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-emphasized {
-  @apply section-emphasized;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-emphasized {
+        @apply section-emphasized;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.ts
@@ -15,10 +15,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionExcerpt extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-excerpt {
-  @apply section-excerpt;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-excerpt {
+        @apply section-excerpt;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.ts
@@ -15,10 +15,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionTitleMetadata extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-title-metadata {
-  @apply section-metadata;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-title-metadata {
+        @apply section-metadata;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.ts
@@ -15,10 +15,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionTitle extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-title {
-  @apply section-title;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-title {
+        @apply section-title;
+      }
+    }
+  `
 ) {}
 
 declare global {

--- a/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.ts
+++ b/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.ts
@@ -17,10 +17,13 @@ import {ItemSectionMixin} from '@/src/mixins/item-section-mixin';
 export class AtomicResultSectionVisual extends ItemSectionMixin(
   LitElement,
   css`
-@reference '../../common/template-system/sections/sections.css';
-atomic-result-section-visual {
-  @apply section-visual;
-}`
+    @reference '../../common/template-system/sections/sections.css';
+    @layer components {
+      atomic-result-section-visual {
+        @apply section-visual;
+      }
+    }
+  `
 ) {
   /**
    * How large or small the visual section of result using this template should be.

--- a/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.tw.css.ts
+++ b/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.tw.css.ts
@@ -1,179 +1,181 @@
 import {css} from 'lit';
 
 const styles = css`
-.atomic-modal-opened {
-  overflow-y: hidden;
-}
-
-atomic-layout-section[section="search"] {
-  grid-area: atomic-section-search;
-}
-
-atomic-layout-section[section="facets"] {
-  grid-area: atomic-section-facets;
-}
-
-atomic-layout-section[section="main"] {
-  grid-area: atomic-section-main;
-}
-
-atomic-layout-section[section="status"] {
-  grid-area: atomic-section-status;
-}
-
-atomic-layout-section[section="pagination"] {
-  grid-area: atomic-section-pagination;
-}
-
-/**
- * @prop --atomic-layout-max-search-box-input-width: The maximum width that the search box input will take.
- * @prop --atomic-layout-max-search-box-double-suggestions-width: The maximum width that the search box suggestions will take when displaying a double list.
- * @prop --atomic-layout-search-box-left-suggestions-width: When displaying a double list, the width of the left list.
- */
-atomic-search-layout {
-  width: 100%;
-  height: 100%;
-  display: none;
-  grid-template-areas:
-    ". atomic-section-search ."
-    ". atomic-section-main .";
-  grid-template-columns: var(--atomic-layout-spacing-x) minmax(0, 1fr) var(
-      --atomic-layout-spacing-x
-    );
+@layer components {
+  .atomic-modal-opened {
+    overflow-y: hidden;
+  }
 
   atomic-layout-section[section="search"] {
-    margin: var(--atomic-layout-spacing-y) 0;
-    max-width: var(--atomic-layout-max-search-box-input-width, 678px);
-    width: 100%;
-    justify-self: center;
-
-    /* Only affects desktop */
-    atomic-search-box {
-      &::part(suggestions-double-list) {
-        width: 125%;
-        max-width: var(
-          --atomic-layout-max-search-box-double-suggestions-width,
-          800px
-        );
-      }
-
-      &::part(suggestions-left) {
-        flex-basis: var(--atomic-layout-search-box-left-suggestions-width, 30%);
-      }
-
-      &::part(suggestions-right) {
-        flex-basis: calc(
-          100% -
-          var(--atomic-layout-search-box-left-suggestions-width, 30%)
-        );
-      }
-    }
+    grid-area: atomic-section-search;
   }
 
   atomic-layout-section[section="facets"] {
-    display: none;
-
-    & * {
-      margin-bottom: var(--atomic-layout-spacing-y);
-    }
+    grid-area: atomic-section-facets;
   }
 
   atomic-layout-section[section="main"] {
-    margin-bottom: var(--atomic-layout-spacing-y);
-  }
-
-  atomic-layout-section[section="horizontal-facets"] {
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: var(--atomic-layout-spacing-y);
-    row-gap: 0.5rem;
-
-    & > * {
-      max-width: 100%;
-    }
-
-    & > atomic-segmented-facet,
-    & > atomic-popover {
-      margin-right: 0.5rem;
-    }
-
-    & > atomic-popover {
-      display: none;
-    }
+    grid-area: atomic-section-main;
   }
 
   atomic-layout-section[section="status"] {
-    display: grid;
-    justify-content: space-between;
-    grid-template-areas:
-      "atomic-breadbox       atomic-breadbox"
-      "atomic-query-summary  atomic-sort"
-      "atomic-did-you-mean   atomic-did-you-mean"
-      "atomic-notifications  atomic-notifications";
-
-    & > * {
-      margin-bottom: var(--atomic-layout-spacing-y);
-    }
-
-    atomic-breadbox {
-      grid-area: atomic-breadbox;
-    }
-
-    atomic-query-summary {
-      grid-area: atomic-query-summary;
-      align-self: center;
-      overflow: hidden;
-    }
-
-    atomic-sort-dropdown {
-      grid-area: atomic-sort;
-      justify-self: end;
-    }
-
-    atomic-refine-toggle {
-      grid-area: atomic-sort;
-    }
-
-    atomic-did-you-mean {
-      grid-area: atomic-did-you-mean;
-    }
-
-    atomic-notifications {
-      grid-area: atomic-notifications;
-    }
-  }
-
-  atomic-layout-section[section="results"] {
-    atomic-smart-snippet {
-      margin-bottom: 1.5rem;
-    }
-
-    atomic-smart-snippet-suggestions {
-      margin-bottom: 1.5rem;
-    }
+    grid-area: atomic-section-status;
   }
 
   atomic-layout-section[section="pagination"] {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
+    grid-area: atomic-section-pagination;
+  }
 
-    atomic-load-more-results {
+  /**
+   * @prop --atomic-layout-max-search-box-input-width: The maximum width that the search box input will take.
+   * @prop --atomic-layout-max-search-box-double-suggestions-width: The maximum width that the search box suggestions will take when displaying a double list.
+   * @prop --atomic-layout-search-box-left-suggestions-width: When displaying a double list, the width of the left list.
+   */
+  atomic-search-layout {
+    width: 100%;
+    height: 100%;
+    display: none;
+    grid-template-areas:
+      ". atomic-section-search ."
+      ". atomic-section-main .";
+    grid-template-columns: var(--atomic-layout-spacing-x) minmax(0, 1fr) var(
+        --atomic-layout-spacing-x
+      );
+
+    atomic-layout-section[section="search"] {
+      margin: var(--atomic-layout-spacing-y) 0;
+      max-width: var(--atomic-layout-max-search-box-input-width, 678px);
       width: 100%;
+      justify-self: center;
+
+      /* Only affects desktop */
+      atomic-search-box {
+        &::part(suggestions-double-list) {
+          width: 125%;
+          max-width: var(
+            --atomic-layout-max-search-box-double-suggestions-width,
+            800px
+          );
+        }
+
+        &::part(suggestions-left) {
+          flex-basis: var(--atomic-layout-search-box-left-suggestions-width, 30%);
+        }
+
+        &::part(suggestions-right) {
+          flex-basis: calc(
+            100% -
+            var(--atomic-layout-search-box-left-suggestions-width, 30%)
+          );
+        }
+      }
     }
 
-    &:has(:only-child) {
-      justify-content: center;
+    atomic-layout-section[section="facets"] {
+      display: none;
+
+      & * {
+        margin-bottom: var(--atomic-layout-spacing-y);
+      }
     }
 
-    & > * {
-      margin-top: var(--atomic-layout-spacing-y);
+    atomic-layout-section[section="main"] {
+      margin-bottom: var(--atomic-layout-spacing-y);
     }
 
-    /* Approx. width of pager & results per page */
-    @media only screen and (min-width: 50rem) {
-      flex-direction: row;
+    atomic-layout-section[section="horizontal-facets"] {
+      display: flex;
+      flex-wrap: wrap;
+      margin-bottom: var(--atomic-layout-spacing-y);
+      row-gap: 0.5rem;
+
+      & > * {
+        max-width: 100%;
+      }
+
+      & > atomic-segmented-facet,
+      & > atomic-popover {
+        margin-right: 0.5rem;
+      }
+
+      & > atomic-popover {
+        display: none;
+      }
+    }
+
+    atomic-layout-section[section="status"] {
+      display: grid;
+      justify-content: space-between;
+      grid-template-areas:
+        "atomic-breadbox       atomic-breadbox"
+        "atomic-query-summary  atomic-sort"
+        "atomic-did-you-mean   atomic-did-you-mean"
+        "atomic-notifications  atomic-notifications";
+
+      & > * {
+        margin-bottom: var(--atomic-layout-spacing-y);
+      }
+
+      atomic-breadbox {
+        grid-area: atomic-breadbox;
+      }
+
+      atomic-query-summary {
+        grid-area: atomic-query-summary;
+        align-self: center;
+        overflow: hidden;
+      }
+
+      atomic-sort-dropdown {
+        grid-area: atomic-sort;
+        justify-self: end;
+      }
+
+      atomic-refine-toggle {
+        grid-area: atomic-sort;
+      }
+
+      atomic-did-you-mean {
+        grid-area: atomic-did-you-mean;
+      }
+
+      atomic-notifications {
+        grid-area: atomic-notifications;
+      }
+    }
+
+    atomic-layout-section[section="results"] {
+      atomic-smart-snippet {
+        margin-bottom: 1.5rem;
+      }
+
+      atomic-smart-snippet-suggestions {
+        margin-bottom: 1.5rem;
+      }
+    }
+
+    atomic-layout-section[section="pagination"] {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+
+      atomic-load-more-results {
+        width: 100%;
+      }
+
+      &:has(:only-child) {
+        justify-content: center;
+      }
+
+      & > * {
+        margin-top: var(--atomic-layout-spacing-y);
+      }
+
+      /* Approx. width of pager & results per page */
+      @media only screen and (min-width: 50rem) {
+        flex-direction: row;
+      }
     }
   }
 }`;


### PR DESCRIPTION
> _Attache ta tuque avec d'la broche, ça va brasser fort dans le CSS_

# TL;DR
Implementers use unlayered CSS to override ours. Stencil was adding unlayered CSS in the document for LightDom elements, making it very easy for implementers to override. Our approach for LightDOM CSS makes it more challenging. Ez fix: Kick _our_ CSS down a layer so that the customer's CSS has prevalence in our light DOM.

# Long story, the problem:
To define which CSS rules "win", it's a succession of layering. What to keep in mind *the deciding factor `n` use the factor `n-1` as a tie breaker.* Now let's go through the `n`:

## 1.  [Origin Types](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Introduction#origin_types)

Good news, web devs all play in the same field using **author stylesheet**. (We'll see the notion of Origin just below.)

## 2. [Layers](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer).
Long story short:
<img width="574" height="781" alt="image" src="https://github.com/user-attachments/assets/d44517c1-7760-4f0f-9ad8-45fc1bf234eb" />.
**The important bit for the proposed implementation is that:
1. Implementer _usually_ uses unlayered CSS
2. `unlayered>@layer`** [^1]]
3. In the off-chance they do implement layers, they can redefine their order if they wish.

> Note: For inline style: `!important inline-style>inline-style>!important @layer`, within in a given Origin Type.

## 3. Specificity

- [RTM](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Specificity)
- TL;DR: ID>class>element, i.e.

## 4. Scoping proximity
- [RTM](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope#how_scope_conflicts_are_resolved)
- Unused in Atomic (all our stuff is "unscoped")

## 5. Order of appearance
- Last declared rules/stylesheet wins!

So, with all that in mind: Stencil was setting **unlayered**, **unscoped** the CSS of a light dom element in a CSS stylesheet, at the very top of the DOM, in the `head` element. Meaning that, any implementers that set a CSS rule with the same specificity as one of ours would be "winning" over ours as long as they put their style tag after Stencil's one. Easy.

However, this also means that the light DOM CSS was leaking in the whole page. That's suboptimal. So, with Lit, we decided to attach the stylesheet as close as possible to the light DOM element instances.

But, unknown to us then, this also meant that the light DOM CSS were much more likely to be closer to the styled element, which meant that **our** styles went from the easiest to win against on the order of appearance deciding factor to one of the hardest.

# The proposed solution
Essentially, rely on the deciding factor 2, the layers, and put all our light dom css in a layer, making any author's unlayered css wins on us.

Caveats: this means that:
- If anyone relies on **our** rule to be more specific than theirs, it will break their styling.

# Alternatives:
- Do nothing: This is quite a viable & safe alternative IMO: this has been out for a while, and the fact that we currently break only on the last tie breaker makes me think this is unlikely to occur very often
- Append styles to the head (w/ or w/o adoptedStylesheet): I think this is risky at this stage, as we saw issues with CSS leakage with TailwindCSS in the past that were likely preexisting in the past.

After writing the PR description, I'm personally in favour of **doing nothing**, because I think this is the option that has the lowest  chances of issues for our users.

[^1]: Technically, `!important @layer>!important unlayered>unlayered>@layer` but we don't use `!important` -nor should we- except for the styling of the quickview, within its iframe, so really narrow & extremely contained case.