### PR TITLE
fix(areas): Exempt DX Bot from areas rules

### DIFF
--- a/.areas/README.md
+++ b/.areas/README.md
@@ -19,6 +19,7 @@ reviewers:
 
 review_bypass:
   trusted-team: pull_request  # Can bypass these rules
+  integration/139346: exempt # Developer eXperience Bot. Important for releases
 ```
 
 For full documentation on how this works and available options, see [`coveo/areas`](https://github.com/coveo/areas).

--- a/.areas/github.yml
+++ b/.areas/github.yml
@@ -9,3 +9,6 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/headless.yml
+++ b/.areas/headless.yml
@@ -8,3 +8,6 @@ file_patterns:
   - samples/headless/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/insight.yml
+++ b/.areas/insight.yml
@@ -15,3 +15,6 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/internal-docs.yml
+++ b/.areas/internal-docs.yml
@@ -4,3 +4,6 @@ file_patterns:
 reviewers:
   dev-writers: ~
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/ipx.yml
+++ b/.areas/ipx.yml
@@ -5,3 +5,6 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/lint.yml
+++ b/.areas/lint.yml
@@ -6,3 +6,6 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/node-dependencies.yml
+++ b/.areas/node-dependencies.yml
@@ -12,3 +12,6 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/quantic.yml
+++ b/.areas/quantic.yml
@@ -6,3 +6,6 @@ reviewers:
   knowledge-ui-kit-reviewers: ~
   salesforce-integration: ~
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/root.yml
+++ b/.areas/root.yml
@@ -21,3 +21,6 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/shopify.yml
+++ b/.areas/shopify.yml
@@ -5,3 +5,6 @@ file_patterns:
 reviewers:
   shopify: ~
   dxui: ~
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.areas/ssr.yml
+++ b/.areas/ssr.yml
@@ -7,3 +7,6 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  integration/139346: exempt # Developer eXperience Bot. Important for releases

--- a/.github/workflows/areas-label-pr.yml
+++ b/.github/workflows/areas-label-pr.yml
@@ -29,7 +29,7 @@ jobs:
           app-id: ${{ vars.CODE_AREAS_APP_ID }}
           private-key: ${{ secrets.CODE_AREAS_PEM }}
 
-      - uses: coveooss/areas@b263fcec7d5a7df32b7aa58c553a056b639d1e1b # v0
+      - uses: coveooss/areas@b3ca247fb24809a01a25dc009f6754dd5c06f314 # v0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           command: label-pr

--- a/.github/workflows/areas-ruleset-sync.yml
+++ b/.github/workflows/areas-ruleset-sync.yml
@@ -30,7 +30,7 @@ jobs:
           app-id: ${{ vars.CODE_AREAS_APP_ID }}
           private-key: ${{ secrets.CODE_AREAS_PEM }}
 
-      - uses: coveooss/areas@b263fcec7d5a7df32b7aa58c553a056b639d1e1b # v0
+      - uses: coveooss/areas@b3ca247fb24809a01a25dc009f6754dd5c06f314 # v0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           command: ruleset-sync


### PR DESCRIPTION
The `Developer eXperience Bot` needs to be able to update refs directly:

https://github.com/coveo/ui-kit/blob/ea325a7371a1a64131b74a2bc6ab486a5aa4068b/utils/ci/git-publish-all.mjs#L68-L74

It may not be ideal, but that's the current process.

Bump the action to pickup https://github.com/coveooss/areas/pull/28

Fixes https://coveord.atlassian.net/browse/KIT-5446