### PR TITLE
chore: relax pnpm dedupe

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,12 +38,6 @@ runs:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
-    # Workaround for PNPM catalog bug: ensure lockfile is sane before installing
-    # https://github.com/pnpm/pnpm/issues/9112
-    # If this fails, run `pnpm dedupe` locally and commit the updated lockfile
-    - name: Check lockfile deduplication
-      run: pnpm dedupe --check
-      shell: bash
     - run: pnpm install --frozen-lockfile --prefer-offline
       shell: bash
 #endregion


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow by removing a workaround step related to PNPM lockfile deduplication. The workflow is now simplified and no longer checks for lockfile deduplication before installing dependencies.

Enforcing on each PR slow significantly our development process; we will instead dedupe periodically

[KIT-5448](https://coveord.atlassian.net/browse/KIT-5448)

[KIT-5448]: https://coveord.atlassian.net/browse/KIT-5448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ