### PR TITLE
Update components.d.ts

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
@@ -77,6 +77,8 @@ export class AtomicCommerceBreadbox
 {
   static styles: CSSResultGroup = [
     css`
+      @reference '../../../utils/tailwind.global.tw.css';
+
       [part='breadcrumb-label'].excluded,
       [part='breadcrumb-value'].excluded {
         text-decoration: line-through;

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
@@ -54,6 +54,8 @@ export class AtomicBreadbox
 {
   static styles: CSSResultGroup = [
     css`
+      @reference '../../../utils/tailwind.global.tw.css';
+
       [part='breadcrumb-label'].excluded,
       [part='breadcrumb-value'].excluded {
         text-decoration: line-through;

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.ts
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.ts
@@ -92,6 +92,8 @@ export class AtomicRefineModal
 {
   static styles: CSSResultGroup = [
     css`
+    @reference '../../../utils/tailwind.global.tw.css';
+
     select:hover + div,
     select:focus-visible + div {
       @apply text-primary-light;

--- a/packages/atomic/src/components/search/atomic-result-children/atomic-result-children.ts
+++ b/packages/atomic/src/components/search/atomic-result-children/atomic-result-children.ts
@@ -56,6 +56,7 @@ export class AtomicResultChildren
   implements InitializableComponent<Bindings>
 {
   static styles = css`
+@reference '../../../utils/tailwind.global.tw.css';
 @reference '../../../utils/tailwind-utilities/set-font-size.css';
 
 .show-hide-button {


### PR DESCRIPTION
## Changes
- Update components.d.ts
- clean up the tests
- Merge branch 'main' into copilot/migrate-atomic-feedback-modal
- Merge branch 'main' into copilot/migrate-atomic-feedback-modal
- done
- fix
- Add generated files
- Merge branch 'main' into copilot/migrate-atomic-feedback-modal
- Merge branch 'copilot/migrate-atomic-feedback-modal' of https://github.com/coveo/ui-kit into copilot/migrate-atomic-feedback-modal
- remove stencil
- Merge branch 'main' into copilot/migrate-atomic-feedback-modal
- relocate
- fix build
- test(atomic): add unit tests for atomic-generated-answer-feedback-modal
- feat(atomic): migrate atomic-generated-answer-feedback-modal to Lit
- Initial plan

## Files Changed
- `packages/atomic-react/src/components/commerce/components.ts`
- `packages/atomic-react/src/components/search/components.ts`
- `packages/atomic/src/components.d.ts`
- `packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts`
- `packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts`
- `packages/atomic/src/components/common/generated-answer/atomic-generated-answer-feedback/atomic-generated-answer-feedback-modal.pcss`
- `packages/atomic/src/components/common/generated-answer/atomic-generated-answer-feedback/atomic-generated-answer-feedback-modal.tsx`
- `packages/atomic/src/components/common/generated-answer/generated-answer-common.tsx`
- `packages/atomic/src/components/common/generated-answer/generated-answer-controller.ts`
- `packages/atomic/src/components/common/index.ts`
- `packages/atomic/src/components/common/lazy-index.ts`
- `packages/atomic/src/components/search/atomic-generated-answer/e2e/atomic-generated-answer.e2e.ts`
- `packages/atomic/src/utils/custom-element-tags.ts`
- `packages/atomic-angular/scripts/build-lit.mjs`
- `packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts`
- `packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts`
- `packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.ts`
- `packages/atomic/src/components/search/atomic-result-children/atomic-result-children.ts`

## Summary
- 13 files changed
- +808, -593 lines