### PR TITLE
chore(headless-ssr-sample): add search express sample

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -70,6 +70,9 @@
     "samples/headless-ssr/commerce-express": {
       "entry": ["src/server.ts", "src/client.ts"]
     },
+    "samples/headless-ssr/search-express": {
+      "entry": ["src/server.ts", "src/client.ts"]
+    },
     "samples/headless/search-react": {
       "entry": ["server/server.tsx", "src/index.tsx"],
       "ignoreDependencies": ["jsdom"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -939,10 +939,10 @@ importers:
         version: 1.56.1
       '@salesforce/eslint-config-lwc':
         specifier: 3.7.2
-        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.28.6)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))(typescript@5.8.3))(eslint@8.57.1)
+        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.28.6)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))(typescript@5.8.3))(eslint@8.57.1)
       '@salesforce/sfdx-lwc-jest':
         specifier: 6.0.0
-        version: 6.0.0(@types/node@22.16.5)(eslint@8.57.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))(typescript@5.8.3)
+        version: 6.0.0(@types/node@25.0.10)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))(typescript@5.8.3)
       '@types/wait-on':
         specifier: 5.3.4
         version: 5.3.4
@@ -963,7 +963,7 @@ importers:
         version: 3.1.2
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -978,7 +978,7 @@ importers:
         version: 2.2.6(prettier@3.8.1)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.16.5)(typescript@5.8.3)
+        version: 10.9.2(@types/node@25.0.10)(typescript@5.8.3)
       wait-on:
         specifier: 8.0.4
         version: 8.0.4
@@ -1288,6 +1288,31 @@ importers:
       vite-tsconfig-paths:
         specifier: 5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
+
+  samples/headless-ssr/search-express:
+    dependencies:
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.56.1
+      '@types/express':
+        specifier: ^4.17.17
+        version: 4.17.25
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.16.5
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.25.8
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   samples/headless-ssr/search-nextjs:
     dependencies:
@@ -17741,33 +17766,33 @@ snapshots:
       globals: 13.24.0
       minimatch: 9.0.5
 
-  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))':
+  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
       '@lwc/synthetic-shadow': 7.1.2
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))':
+  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
 
-  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))':
+  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
       pretty-format: 29.7.0
 
   '@lwc/jest-shared@16.0.0': {}
 
-  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))':
+  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.28.6)
@@ -17778,7 +17803,7 @@ snapshots:
       '@lwc/compiler': 7.1.2
       '@lwc/jest-shared': 16.0.0
       babel-preset-jest: 29.6.3(@babel/core@7.28.6)
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
       magic-string: 0.30.21
       semver: 7.7.2
     transitivePeerDependencies:
@@ -18892,7 +18917,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.28.6)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))(typescript@5.8.3))(eslint@8.57.1)':
+  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.28.6)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))(typescript@5.8.3))(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/eslint-parser': 7.24.8(@babel/core@7.24.9)(eslint@8.57.1)
@@ -18900,7 +18925,7 @@ snapshots:
       '@salesforce/eslint-plugin-lightning': 1.0.1(eslint@8.57.1)
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
-      eslint-plugin-jest: 29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))(typescript@5.8.3)
+      eslint-plugin-jest: 29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-restricted-globals: 0.2.0
       semver: 7.7.2
     transitivePeerDependencies:
@@ -18910,21 +18935,21 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@22.16.5)(eslint@8.57.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))(typescript@5.8.3)':
+  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@25.0.10)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))
+      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))
       '@lwc/module-resolver': 7.1.2
       '@lwc/synthetic-shadow': 7.1.2
       '@lwc/wire-service': 7.1.2
       '@salesforce/wire-service-jest-util': 4.1.4(@lwc/engine-dom@7.1.2)(eslint@8.57.1)(typescript@5.8.3)
       fast-glob: 3.3.3
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
       jest-environment-jsdom: 29.7.0(patch_hash=b419a992476c3323e67ee6c86f3f9ecf6f4f073127cb572aa9af3b9c6550751d)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -19990,11 +20015,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(playwright@1.56.1)(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.10)':
+  '@vitest/browser-playwright@4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(playwright@1.58.0-alpha-1763757971000)(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.10)':
     dependencies:
       '@vitest/browser': 4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.10)
       '@vitest/mocker': 4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
-      playwright: 1.56.1
+      playwright: 1.58.0-alpha-1763757971000
       tinyrainbow: 3.0.3
       vitest: 4.0.10(@types/debug@4.1.12)(@types/node@25.0.10)(@vitest/browser-playwright@4.0.10)(jiti@2.6.1)(jsdom@20.0.3)(less@4.5.1)(lightningcss@1.30.1)(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -22641,12 +22666,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3)))(typescript@5.8.3):
+  eslint-plugin-jest@29.12.1(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.53.1(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
     optionalDependencies:
-      jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@25.0.10)(ts-node@10.9.2(@types/node@25.0.10)(typescript@5.8.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -29131,7 +29156,6 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-simple-type@2.0.0-next.0: {}
 
@@ -29954,7 +29978,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 25.0.10
-      '@vitest/browser-playwright': 4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(playwright@1.56.1)(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.10)
+      '@vitest/browser-playwright': 4.0.10(msw@2.11.4(@types/node@25.0.10)(typescript@5.8.3))(playwright@1.58.0-alpha-1763757971000)(vite@7.2.2(@types/node@25.0.10)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.1)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))(vitest@4.0.10)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - jiti

--- a/samples/README.md
+++ b/samples/README.md
@@ -33,6 +33,7 @@ Samples demonstrating server-side rendering (SSR) with Headless controllers for 
 | Sample | Description | Framework | Use Case |
 |--------|-------------|-----------|----------|
 | [commerce-express](./headless-ssr/commerce-express/) | Generic SSR implementation with Express server | Express + TypeScript | Commerce |
+| [search-express](./headless-ssr/search-express/) | Generic SSR implementation with Express server | Express + TypeScript | Search |
 | [commerce-nextjs](./headless-ssr/commerce-nextjs/) | Commerce SSR with Next.js App Router (current version) | Next.js (App Router) | Commerce |
 | [commerce-nextjs-v4](./headless-ssr/commerce-nextjs-v4/) | Commerce SSR with Next.js App Router (preview - Headless V4) | Next.js (App Router) | Commerce |
 | [commerce-react-router](./headless-ssr/commerce-react-router/) | Commerce SSR with React Router | React Router | Commerce |

--- a/samples/headless-ssr/search-express/.gitignore
+++ b/samples/headless-ssr/search-express/.gitignore
@@ -1,0 +1,35 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+
+# Test artifacts
+test-results/
+playwright-report/
+playwright/.cache/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage
+coverage/
+*.lcov

--- a/samples/headless-ssr/search-express/README.md
+++ b/samples/headless-ssr/search-express/README.md
@@ -9,6 +9,8 @@ This sample demonstrates server-side rendering (SSR) with Coveo Headless search 
 - Implement a simple search interface with plain HTML/CSS/JS
 - Handle search state on both server and client sides
 
+> **Note:** This sample uses the latest SSR approach (next version, not yet published). It represents the future recommended way of implementing server-side rendering with Coveo Headless, featuring improved patterns and best practices that will be officially released in next major Headless version.
+
 ## Prerequisites
 
 - Node.js 22+ (LTS v22.18.0)

--- a/samples/headless-ssr/search-express/README.md
+++ b/samples/headless-ssr/search-express/README.md
@@ -9,6 +9,8 @@ This sample demonstrates server-side rendering (SSR) with Coveo Headless search 
 - Implement a simple search interface with plain HTML/CSS/JS
 - Handle search state on both server and client sides
 
+> **Note:** This sample uses the latest SSR approach (next version, not yet published). It represents the future recommended way of implementing server-side rendering with Coveo Headless, featuring improved patterns and best practices that will be officially released in upcoming versions.
+
 ## Prerequisites
 
 - Node.js 22+ (LTS v22.18.0)

--- a/samples/headless-ssr/search-express/README.md
+++ b/samples/headless-ssr/search-express/README.md
@@ -1,0 +1,69 @@
+# Headless Search SSR Generic Sample
+
+## Purpose
+
+This sample demonstrates server-side rendering (SSR) with Coveo Headless search controllers using a generic implementation. It shows how to:
+
+- Set up a search interface with server-side rendering
+- Use Headless controllers for search and result listing
+- Implement a simple search interface with plain HTML/CSS/JS
+- Handle search state on both server and client sides
+
+## Prerequisites
+
+- Node.js 22+ (LTS v22.18.0)
+- npm 10+
+
+## Key Features
+
+- **Server-side rendering**: Initial page load with pre-rendered search results
+- **Client-side hydration**: Interactive search functionality after page load
+- **esbuild bundling**: Fast and efficient bundling for the client-side code
+- **TypeScript**: Full type safety throughout the application
+- **Express server**: Simple HTTP server for handling requests
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Build the project:
+   ```bash
+   npm run build
+   ```
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+4. Open your browser to `http://localhost:3000`
+
+## Development
+
+For development with automatic rebuilding:
+
+```bash
+npm run dev
+```
+
+This will start the client bundler in watch mode and run the server with hot reload using tsx.
+
+
+## Testing
+
+```bash
+npm run test
+```
+
+Runs the Playwright end-to-end tests.
+
+
+```bash
+npm run test:headed
+```
+
+Runs the Playwright tests in headed mode (with a visible browser).
+

--- a/samples/headless-ssr/search-express/e2e/search.page.ts
+++ b/samples/headless-ssr/search-express/e2e/search.page.ts
@@ -1,0 +1,33 @@
+import type {Page} from '@playwright/test';
+
+export function createSearchPage(page: Page) {
+  const searchInput = page.locator('#search-input');
+  const searchButton = page.locator('#search-button');
+  const resultList = page.locator('#result-list');
+  const results = page.locator('.result-card');
+  const querySummary = page.locator('#query-summary');
+
+  async function goto() {
+    await page.goto('/');
+  }
+
+  async function searchFor(query: string) {
+    await searchInput.clear();
+    await searchInput.fill(query);
+    await searchButton.click();
+
+    await resultList.waitFor({state: 'visible'});
+    await results.first().waitFor({state: 'visible'});
+  }
+
+  return {
+    page,
+    searchInput,
+    searchButton,
+    resultList,
+    results,
+    querySummary,
+    goto,
+    searchFor,
+  };
+}

--- a/samples/headless-ssr/search-express/e2e/search.spec.ts
+++ b/samples/headless-ssr/search-express/e2e/search.spec.ts
@@ -1,0 +1,24 @@
+import {expect, test} from '@playwright/test';
+import {createSearchPage} from './search.page.js';
+
+test.describe('SSR Search Sample', () => {
+  test('should load and render the search interface', async ({page}) => {
+    const search = createSearchPage(page);
+    await search.goto();
+    await expect(page).toHaveTitle(/SSR Search/);
+    await expect(search.searchInput).toBeVisible();
+    await expect(search.resultList).toBeVisible();
+    await expect(search.results.first()).toBeVisible();
+  });
+
+  test('should allow searching', async ({page}) => {
+    const search = createSearchPage(page);
+    await search.goto();
+    await page.waitForLoadState('networkidle');
+
+    await search.searchFor('machine');
+
+    await expect(page).toHaveURL(/\?q=machine/);
+    await expect(search.results.first()).toBeVisible();
+  });
+});

--- a/samples/headless-ssr/search-express/package.json
+++ b/samples/headless-ssr/search-express/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@samples/headless-ssr-search-express",
+  "description": "Headless Search SSR Generic Sample using the ssr-next API",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "pnpm build:client --watch=forever & pnpm build:server --watch & pnpm start -- --watch",
+    "build": "pnpm build:server && pnpm build:client",
+    "build:server": "tsc",
+    "build:client": "esbuild ./src/client.ts --bundle --outfile=dist/client.js --format=esm --target=es2022",
+    "start": "node ./dist/server.js",
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@coveo/headless": "workspace:*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "@types/express": "^4.17.17",
+    "@types/node": "catalog:",
+    "esbuild": "catalog:",
+    "typescript": "catalog:"
+  },
+  "type": "module"
+}

--- a/samples/headless-ssr/search-express/playwright.config.ts
+++ b/samples/headless-ssr/search-express/playwright.config.ts
@@ -1,0 +1,29 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  expect: {
+    timeout: 7 * 1000,
+  },
+  webServer: {
+    command: 'pnpm start',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/samples/headless-ssr/search-express/src/client.ts
+++ b/samples/headless-ssr/search-express/src/client.ts
@@ -1,0 +1,50 @@
+/**
+ * Client-side hydration for Coveo Headless Search SSR sample.
+ *
+ * Client-side lifecycle:
+ * 1. On page load, reads the SSR static state injected by the server (see server.ts)
+ * 2. Hydrates the Coveo engine and controllers with this state
+ * 3. Initializes UI components (search box, result list, query summary) with hydrated controllers
+ * 4. Handles errors gracefully if hydration fails
+ *
+ * See server.ts for the server-side SSR lifecycle.
+ */
+import type {
+  QuerySummary,
+  ResultList,
+  SearchBox,
+} from '@coveo/headless/ssr-next';
+import type {SearchStaticState} from './common/types.js';
+import {ErrorMessage} from './components/ErrorMessage.js';
+import {QuerySummary as initQuerySummary} from './components/QuerySummary.js';
+import {ResultList as initResultList} from './components/ResultList.js';
+import {Search} from './components/Search.js';
+import {searchEngineDefinition} from './lib/engine-definition.js';
+
+async function initApp() {
+  try {
+    const staticState: SearchStaticState = window.__STATIC_STATE__!;
+    const {controllers} =
+      await searchEngineDefinition.hydrateStaticState(staticState);
+
+    Search(controllers.searchBox as SearchBox);
+    initResultList(controllers.resultList as ResultList);
+    initQuerySummary(controllers.querySummary as QuerySummary);
+  } catch (_error) {
+    const err = document.getElementById('query-error');
+    if (!err) {
+      const container = document.createElement('div');
+      container.innerHTML = ErrorMessage(
+        'Something went wrong. Please try again.'
+      );
+      document.body.appendChild(container.firstElementChild!);
+    }
+  }
+}
+
+// ===== Boot =====
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initApp);
+} else {
+  initApp();
+}

--- a/samples/headless-ssr/search-express/src/common/renderApp.ts
+++ b/samples/headless-ssr/search-express/src/common/renderApp.ts
@@ -1,0 +1,92 @@
+import type {
+  QuerySummary,
+  ResultList,
+  SearchBox,
+} from '@coveo/headless/ssr-next';
+import type {SearchStaticState} from './types.js';
+
+function selectResults(resultList: ResultList) {
+  return resultList.state.results;
+}
+
+function selectQuerySummary(querySummary: QuerySummary) {
+  return querySummary.state;
+}
+
+function selectSearchValue(searchBox: SearchBox) {
+  return searchBox.state.value;
+}
+
+function formatQuerySummary(summary: ReturnType<typeof selectQuerySummary>) {
+  if (!summary.hasQuery) {
+    return 'Enter a search query to see results';
+  }
+  if (summary.total === 0) {
+    return `No results found for "${summary.query}"`;
+  }
+  return `Showing ${summary.firstResult}-${summary.lastResult} of ${summary.total} results for "${summary.query}"`;
+}
+
+function renderResultCard(result: ReturnType<typeof selectResults>[number]) {
+  return `
+    <div class="result-card">
+      <h3 class="result-title">${result.title}</h3>
+      <p class="result-excerpt">${result.excerpt || 'No description available'}</p>
+      <a href="${result.clickUri}" class="result-link" target="_blank">View →</a>
+    </div>
+  `;
+}
+
+function renderResultList(results: ReturnType<typeof selectResults>) {
+  if (results.length === 0) {
+    return '';
+  }
+  return results.map(renderResultCard).join('');
+}
+
+export const renderApp = (staticState: SearchStaticState) => {
+  const {controllers} = staticState;
+  const results = selectResults(controllers.resultList as ResultList);
+  const summary = selectQuerySummary(controllers.querySummary as QuerySummary);
+  const searchValue = selectSearchValue(controllers.searchBox as SearchBox);
+
+  return `
+    <div class="app-container">
+      <header class="app-header">
+        <h1>🔍 SSR Search Demo</h1>
+        <p class="subtitle">Search and discover content</p>
+      </header>
+
+      <main class="main-content">
+        <section class="search-section">
+          <form class="search-box" method="GET">
+            <input type="text" id="search-input" name="q" placeholder="Search..." value="${searchValue}" />
+            <button id="search-button" type="submit">Search</button>
+          </form>
+        </section>
+
+        <section class="main-results">
+          <div class="results-header">
+            <div class="results-controls">
+              <div id="query-summary" class="query-summary">
+                ${formatQuerySummary(summary)}
+              </div>
+            </div>
+          </div>
+
+          <div id="result-list" class="result-list">
+            ${renderResultList(results)}
+          </div>
+
+          <div id="no-results" class="no-results" style="${results.length === 0 ? 'display: block;' : 'display: none;'}">
+            <p>No results found. Try adjusting your search.</p>
+          </div>
+        </section>
+      </main>
+
+      <footer class="app-footer">
+        <p>🔍 SSR Search Demo</p>
+      </footer>
+    </div>
+  `;
+};

--- a/samples/headless-ssr/search-express/src/common/renderHtml.ts
+++ b/samples/headless-ssr/search-express/src/common/renderHtml.ts
@@ -1,0 +1,23 @@
+import {getSharedStyles} from './styles.js';
+import type {SearchStaticState} from './types.js';
+
+export const renderHtml = (
+  content: string,
+  staticState: SearchStaticState
+): string =>
+  `<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>🔍 SSR Search Demo</title>    
+        ${getSharedStyles()}
+      </head>
+      <body>
+        <div id="app">${content}</div>
+        <script>
+            window.__STATIC_STATE__ = ${JSON.stringify(staticState)};
+        </script>
+        <script type="module" src="/client.js"></script>
+      </body>
+    </html>`;

--- a/samples/headless-ssr/search-express/src/common/styles.ts
+++ b/samples/headless-ssr/search-express/src/common/styles.ts
@@ -1,0 +1,233 @@
+export function getSharedStyles(): string {
+  return `<style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        line-height: 1.6;
+        color: #333;
+        background-color: #f8f9fa;
+      }
+
+      .app-container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: white;
+        min-height: 100vh;
+      }
+
+      .app-header {
+        text-align: center;
+        margin-bottom: 40px;
+        padding: 30px 0;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        border-radius: 12px;
+      }
+
+      .app-header h1 {
+        margin: 0 0 10px 0;
+        font-size: 2.5em;
+        font-weight: 700;
+      }
+
+      .subtitle {
+        margin: 0;
+        font-size: 1.2em;
+        opacity: 0.9;
+      }
+
+      .search-section {
+        margin-bottom: 40px;
+        padding: 0 20px;
+      }
+
+      .search-box {
+        display: flex;
+        gap: 12px;
+        max-width: 700px;
+        margin: 0 auto;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      #search-input {
+        flex: 1;
+        padding: 16px 20px;
+        border: none;
+        font-size: 16px;
+        outline: none;
+      }
+
+      #search-button {
+        padding: 16px 32px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        border: none;
+        cursor: pointer;
+        font-size: 16px;
+        font-weight: 600;
+        transition: all 0.3s ease;
+      }
+
+      #search-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+      }
+
+      .main-results {
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        border: 1px solid #e9ecef;
+        overflow: hidden;
+        margin: 0 20px;
+      }
+
+      .results-header {
+        padding: 24px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #e9ecef;
+      }
+
+      .results-controls {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .query-summary {
+        font-size: 1.1em;
+        font-weight: 500;
+        color: #495057;
+        text-align: center;
+      }
+
+      .result-list {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        padding: 24px;
+        min-height: 400px;
+      }
+
+      .result-card {
+        border: 1px solid #e9ecef;
+        border-radius: 8px;
+        padding: 20px;
+        background: white;
+        transition: all 0.3s ease;
+        position: relative;
+      }
+
+      .result-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        border-color: #667eea;
+      }
+
+      .result-title {
+        font-weight: 600;
+        margin-bottom: 8px;
+        color: #333;
+        font-size: 1.2em;
+        line-height: 1.4;
+      }
+
+      .result-excerpt {
+        color: #6c757d;
+        font-size: 0.95em;
+        margin-bottom: 12px;
+        line-height: 1.6;
+      }
+
+      .result-link {
+        color: #667eea;
+        text-decoration: none;
+        font-weight: 500;
+        font-size: 0.9em;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        transition: color 0.2s ease;
+      }
+
+      .result-link:hover {
+        color: #764ba2;
+        text-decoration: underline;
+      }
+
+      .pagination {
+        padding: 24px;
+        text-align: center;
+        background: #f8f9fa;
+        border-top: 1px solid #e9ecef;
+      }
+
+      .load-more-btn {
+        padding: 16px 40px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        min-width: 200px;
+      }
+
+      .load-more-btn:hover:not(:disabled) {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+      }
+
+      .load-more-btn:disabled {
+        background: #6c757d;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      .app-footer {
+        text-align: center;
+        margin-top: 60px;
+        padding: 30px 0;
+        border-top: 1px solid #e9ecef;
+        color: #6c757d;
+        font-size: 1.1em;
+      }
+
+      .query-error, .no-results {
+        text-align: center;
+        padding: 60px 40px;
+        color: #6c757d;
+        font-size: 1.2em;
+      }
+
+      @media (max-width: 768px) {
+        .result-list {
+          gap: 16px;
+          padding: 16px;
+        }
+        
+        .search-box {
+          flex-direction: column;
+        }
+        
+        .app-header h1 {
+          font-size: 2em;
+        }
+        
+        .main-results {
+          margin: 0 10px;
+        }
+      }
+    </style>`;
+}

--- a/samples/headless-ssr/search-express/src/common/types.ts
+++ b/samples/headless-ssr/search-express/src/common/types.ts
@@ -1,0 +1,10 @@
+import type {InferStaticState} from '@coveo/headless/ssr-next';
+import type {searchEngineDefinition} from '../lib/engine-definition.js';
+
+export type SearchStaticState = InferStaticState<typeof searchEngineDefinition>;
+
+declare global {
+  interface Window {
+    __STATIC_STATE__?: SearchStaticState;
+  }
+}

--- a/samples/headless-ssr/search-express/src/common/utils.ts
+++ b/samples/headless-ssr/search-express/src/common/utils.ts
@@ -1,0 +1,11 @@
+export function getElement<T extends HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
+}
+
+export function updateQueryParam(key: string, value: string) {
+  const params = new URLSearchParams(window.location.search);
+  value ? params.set(key, value) : params.delete(key);
+
+  const nextUrl = `${window.location.pathname}${params.toString() ? `?${params}` : ''}`;
+  window.history.pushState(null, '', nextUrl);
+}

--- a/samples/headless-ssr/search-express/src/components/ErrorMessage.ts
+++ b/samples/headless-ssr/search-express/src/components/ErrorMessage.ts
@@ -1,0 +1,8 @@
+export function ErrorMessage(message?: string): string {
+  if (!message) return '';
+  return `
+    <div id="query-error" class="query-error">
+      <p>${message}</p>
+    </div>
+  `;
+}

--- a/samples/headless-ssr/search-express/src/components/QuerySummary.ts
+++ b/samples/headless-ssr/search-express/src/components/QuerySummary.ts
@@ -1,0 +1,31 @@
+import type {
+  QuerySummary as QuerySummaryController,
+  QuerySummaryState,
+} from '@coveo/headless/ssr-next';
+import {getElement} from '../common/utils.js';
+
+export function QuerySummary(summary: QuerySummaryController) {
+  if (!summary) return;
+
+  const container = getElement<HTMLDivElement>('query-summary');
+  if (!container) return;
+
+  const render = () => {
+    const sum = selectSummary(summary);
+    container.textContent = formatQuerySummary(sum);
+  };
+
+  summary.subscribe(render);
+  render();
+}
+
+export function selectSummary(summary: QuerySummaryController) {
+  return summary?.state as QuerySummaryState;
+}
+
+export function formatQuerySummary(summary: QuerySummaryState): string {
+  if (summary.hasQuery === false) return '';
+  const total = summary.total || 0;
+
+  return `${total} results found${summary.query ? ` for "${summary.query}"` : ''}`;
+}

--- a/samples/headless-ssr/search-express/src/components/ResultList.ts
+++ b/samples/headless-ssr/search-express/src/components/ResultList.ts
@@ -1,0 +1,47 @@
+import type {
+  Result,
+  ResultList as ResultListController,
+} from '@coveo/headless/ssr-next';
+import {getElement} from '../common/utils.js';
+
+export function ResultList(resultList: ResultListController) {
+  if (!resultList) return;
+
+  const grid = getElement<HTMLDivElement>('result-list');
+  const noResults = getElement<HTMLDivElement>('no-results');
+  if (!grid) return;
+
+  const render = () => {
+    const results = selectResults(resultList);
+    const hasResults = results.length > 0;
+
+    if (noResults) {
+      noResults.style.display = hasResults ? 'none' : 'block';
+    }
+    grid.innerHTML = hasResults ? renderResultList(results) : '';
+  };
+
+  resultList.subscribe(render);
+  render();
+}
+
+function renderResultCard(result: Result): string {
+  const title = result.title ?? 'Unknown Result';
+  const excerpt = result.excerpt ?? 'No description available';
+
+  return `
+    <div class="result-card">
+      <h3 class="result-title">${title}</h3>
+      <p class="result-excerpt">${excerpt}</p>
+      <a href="${result.clickUri}" class="result-link" target="_blank" rel="noopener noreferrer">View →</a>
+    </div>
+  `;
+}
+
+export function renderResultList(results: Result[]): string {
+  return results.map(renderResultCard).join('');
+}
+
+export function selectResults(resultList: ResultListController): Result[] {
+  return resultList?.state?.results || [];
+}

--- a/samples/headless-ssr/search-express/src/components/Search.ts
+++ b/samples/headless-ssr/search-express/src/components/Search.ts
@@ -1,0 +1,33 @@
+import type {SearchBox} from '@coveo/headless/ssr-next';
+import {getElement, updateQueryParam} from '../common/utils.js';
+
+export function Search(searchBox: SearchBox) {
+  if (!searchBox) return;
+
+  const input = getElement<HTMLInputElement>('search-input');
+  const form = input?.form;
+  if (!input || !form) return;
+
+  const render = () => {
+    input.value = selectSearchValue(searchBox);
+  };
+
+  searchBox.subscribe(render);
+  render();
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault();
+    const query = input.value.trim();
+
+    updateQueryParam('q', query);
+
+    searchBox.updateText(query);
+    searchBox.submit();
+  };
+
+  form.addEventListener('submit', handleSubmit);
+}
+
+export function selectSearchValue(searchBox: SearchBox): string {
+  return searchBox?.state?.value ?? '';
+}

--- a/samples/headless-ssr/search-express/src/lib/engine-config.ts
+++ b/samples/headless-ssr/search-express/src/lib/engine-config.ts
@@ -1,0 +1,15 @@
+import {
+  defineQuerySummary,
+  defineResultList,
+  defineSearchBox,
+  getSampleSearchEngineConfiguration,
+} from '@coveo/headless/ssr-next';
+
+export const engineConfig = {
+  configuration: getSampleSearchEngineConfiguration(),
+  controllers: {
+    resultList: defineResultList(),
+    querySummary: defineQuerySummary(),
+    searchBox: defineSearchBox(),
+  },
+};

--- a/samples/headless-ssr/search-express/src/lib/engine-definition.ts
+++ b/samples/headless-ssr/search-express/src/lib/engine-definition.ts
@@ -1,0 +1,4 @@
+import {defineSearchEngine} from '@coveo/headless/ssr-next';
+import {engineConfig} from './engine-config.js';
+
+export const {searchEngineDefinition} = defineSearchEngine(engineConfig);

--- a/samples/headless-ssr/search-express/src/lib/navigatorContext.ts
+++ b/samples/headless-ssr/search-express/src/lib/navigatorContext.ts
@@ -1,0 +1,29 @@
+import {randomUUID} from 'node:crypto';
+import type express from 'express';
+
+const getHeaderValue = (
+  headerName: string,
+  headers: express.Request['headers']
+) => {
+  const value = headers[headerName];
+  const str = (Array.isArray(value) ? value[0] : value)?.toString();
+  return str ? str.trim() : undefined;
+};
+
+export function getNavigatorContext({headers, url, ip}: express.Request) {
+  return {
+    clientId: getHeaderValue('x-coveo-client-id', headers) ?? randomUUID(),
+    location: url ?? getHeaderValue('x-href', headers) ?? null,
+    referrer:
+      getHeaderValue('referer', headers) ??
+      getHeaderValue('referrer', headers) ??
+      null,
+    userAgent: getHeaderValue('user-agent', headers) ?? null,
+    forwardedFor:
+      getHeaderValue('x-forwarded-for', headers) ||
+      getHeaderValue('x-forwarded-host', headers) ||
+      ip ||
+      undefined,
+    capture: false,
+  };
+}

--- a/samples/headless-ssr/search-express/src/middleware.ts
+++ b/samples/headless-ssr/search-express/src/middleware.ts
@@ -1,0 +1,22 @@
+import {randomUUID} from 'node:crypto';
+import type {NextFunction, Request, Response} from 'express';
+
+/**
+ * Express middleware to inject Coveo-specific headers for SSR analytics and context.
+ *
+ * - Sets a unique client ID (`x-coveo-client-id`) on both the request and response.
+ * - Sets the current page URL (`x-href`) on the response.
+ *
+ * Why middleware?
+ * - Ensures these headers are consistently set for every request, regardless of route.
+ * - Centralizes logic, making it easier to maintain and less error-prone than duplicating on each page/route.
+ * - Guarantees analytics and context are always available for SSR and client-side hydration.
+ */
+export const middleware = (req: Request, res: Response, next: NextFunction) => {
+  const uuid = randomUUID();
+
+  req.headers['x-coveo-client-id'] = uuid;
+  res.setHeader('x-coveo-client-id', uuid);
+  res.setHeader('x-href', req.originalUrl);
+  next();
+};

--- a/samples/headless-ssr/search-express/src/server.ts
+++ b/samples/headless-ssr/search-express/src/server.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import {renderApp} from './common/renderApp.js';
+import {renderHtml} from './common/renderHtml.js';
+import {searchEngineDefinition} from './lib/engine-definition.js';
+import {getNavigatorContext} from './lib/navigatorContext.js';
+import {middleware} from './middleware.js';
+
+const app = express();
+const port = process.env.PORT || 3000;
+app.use(middleware);
+app.use(express.static('dist'));
+
+app.get('/', async (req, res) => {
+  try {
+    const queryFromRequest = req.query.q?.toString?.() ?? '';
+
+    const staticState = await searchEngineDefinition.fetchStaticState({
+      searchParams: {q: queryFromRequest},
+      navigatorContext: getNavigatorContext(req),
+    });
+
+    const appHtml = renderApp(staticState);
+    const html = renderHtml(appHtml, staticState);
+
+    res.send(html);
+  } catch (error) {
+    console.error('❌ Error fetching static state:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+app.listen(port, () => {
+  console.log(`🚀 Server running at http://localhost:${port}`);
+});

--- a/samples/headless-ssr/search-express/tsconfig.json
+++ b/samples/headless-ssr/search-express/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "e2e",
+    "playwright.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Add an  Express.js sample for Headless SSR. Similar to what was done for commerce express

This sample demonstrates server-side rendering with Coveo Headless search controllers using a generic Express implementation. This sample showcases the next-generation SSR approach (ssr-next API) that represents the future recommended way of implementing SSR with Coveo Headless.

https://coveord.atlassian.net/browse/KIT-5148
fixes #6285
