### PR TITLE
fix(atomic): include custom-elements.json in npm package

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -42,6 +42,7 @@
     "./custom-elements-manifest": "./custom-elements.json"
   },
   "files": [
+    "custom-elements.json",
     "dist/",
     "docs/",
     "licenses/"


### PR DESCRIPTION
## Summary

- Adds `custom-elements.json` to the `files` array in `packages/atomic/package.json`

## Problem

The `@coveo/atomic` package exports `./custom-elements-manifest` pointing to `./custom-elements.json` (line 42 of package.json), but the file was not included in the `files` array and therefore never published to npm.

This caused builds to fail when consumers (like `@coveo/atomic-angular`) tried to import the manifest:

```
Could not resolve "@coveo/atomic/custom-elements-manifest"
The module "./custom-elements.json" was not found on the file system
```

## Root Cause

This is a general packaging bug, not Angular 20-specific. Angular 20's stricter esbuild just exposed the issue that was always present.

## Verification

- Built `@coveo/atomic` and `@coveo/atomic-angular` successfully
- Created Angular 20 test project and verified build succeeds
- Confirmed `npm pack --dry-run` now includes `custom-elements.json`
- Confirmed published npm package `@coveo/atomic@3.47.1` does NOT contain the file (proving this fix is needed)

Fixes #7062

https://coveord.atlassian.net/browse/KIT-5459