### PR TITLE
chore: remove outdated GitHub Copilot extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "biomejs.biome",
     "streetsidesoftware.code-spell-checker",
-    "github.copilot",
     "github.copilot-chat",
     "runem.lit-plugin",
     "unifiedjs.vscode-mdx",


### PR DESCRIPTION
The github.copilot VSCode extension is deprecated; only github.copilot-chat should be recommended now

https://coveord.atlassian.net/browse/KIT-5461