### PR TITLE
fix(headless): preserve query syntax in folding loadCollection

### DIFF
--- a/packages/headless/src/features/folding/folding-actions.ts
+++ b/packages/headless/src/features/folding/folding-actions.ts
@@ -114,16 +114,13 @@ export const loadCollection = createAsyncThunk<
 );
 
 function getQForHighlighting(state: StateNeededByLoadCollection) {
-  // This piece of code serves the following purpose:
-  // Inject the "original" query "q" to get proper keywords highlighting when loading a full collection
-  // However, the intent behind this feature is to load "every results available for this collection", regardless of other end user filters (including the search box itself)
-  // For that reason, we force enable query syntax + inject an `OR @uri` expression in the query.
+  // Pass the original query for keyword highlighting in expanded collection results.
+  // `OR @uri` ensures all collection documents are returned regardless of query match.
+  // Query is passed as-is since enableQuerySyntax is forced true in the request.
 
   if (state.query.q === '') {
     return '';
   }
 
-  return state.query.enableQuerySyntax
-    ? `${state.query.q} OR @uri`
-    : `( <@- ${state.query.q} -@> ) OR @uri`;
+  return `${state.query.q} OR @uri`;
 }

--- a/packages/headless/src/features/folding/folding-slice.test.ts
+++ b/packages/headless/src/features/folding/folding-slice.test.ts
@@ -258,7 +258,7 @@ describe('folding slice', () => {
         );
       });
 
-      it('when #querySyntax is enabled and #q is non empty, it build a proper query expression to get keywords highlighting', async () => {
+      it('when #querySyntax is enabled and #q is non empty, it builds a proper query expression to get keywords highlighting', async () => {
         mockEngine = buildMockSearchEngine({
           ...createMockState(),
           query: {enableQuerySyntax: true, q: 'hello'},
@@ -273,7 +273,7 @@ describe('folding slice', () => {
         );
       });
 
-      it('when #querySyntax is disabled and #q is non empty, it build a proper query expression to get keywords highlighting', async () => {
+      it('when #querySyntax is disabled and #q is non empty, it builds a proper query expression to get keywords highlighting', async () => {
         mockEngine = buildMockSearchEngine({
           ...createMockState(),
           query: {enableQuerySyntax: false, q: 'hello'},
@@ -281,7 +281,22 @@ describe('folding slice', () => {
         await doLoadCollection();
         expect(apiClient.search).toHaveBeenCalledWith(
           expect.objectContaining({
-            q: '( <@- hello -@> ) OR @uri',
+            q: 'hello OR @uri',
+            enableQuerySyntax: true,
+          }),
+          {origin: 'foldingCollection'}
+        );
+      });
+
+      it('when #q contains a field query, it preserves the field syntax', async () => {
+        mockEngine = buildMockSearchEngine({
+          ...createMockState(),
+          query: {enableQuerySyntax: false, q: '@field=value'},
+        });
+        await doLoadCollection();
+        expect(apiClient.search).toHaveBeenCalledWith(
+          expect.objectContaining({
+            q: '@field=value OR @uri',
             enableQuerySyntax: true,
           }),
           {origin: 'foldingCollection'}


### PR DESCRIPTION
## Summary

- Fix bug where clicking "Show More" on folded results breaks field queries (e.g., `@etq_number=doc-08887`)
- Remove unnecessary no-syntax block wrapper (`<@- -@>`) from `getQForHighlighting()`
- Query is now passed as-is since `enableQuerySyntax: true` is always forced in the request

## Problem

The no-syntax block was stripping special characters from field queries when expanding folded result collections. Users navigating directly via URL with field queries would see incorrect results after clicking "Show More".

## Solution

Since `enableQuerySyntax: true` is forced in the `loadCollection` request, the conditional no-syntax block wrapping was both unnecessary and harmful. Removed it to preserve field query syntax.

## Jira

[KIT-5455](https://coveord.atlassian.net/browse/KIT-5455)

## Related

- Support case: 00133421

[KIT-5455]: https://coveord.atlassian.net/browse/KIT-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ