### PR TITLE
fix(atomic): CRGA Feedback modal options were unselectable

### DIFF
--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
@@ -9,6 +9,17 @@ import './atomic-generated-answer-feedback-modal';
 
 vi.mock('@/src/components/common/icon-button', {spy: true});
 
+// Feedback option values that users can select for each category
+const FEEDBACK_OPTIONS: string[] = ['yes', 'unknown', 'no'] as const;
+
+// Feedback categories that are evaluated (matching AtomicGeneratedAnswerFeedbackModal.options)
+const FEEDBACK_CATEGORIES = [
+  'correctTopic',
+  'hallucinationFree',
+  'documented',
+  'readable',
+] as const;
+
 describe('atomic-generated-answer-feedback-modal', () => {
   let mockedGeneratedAnswer: GeneratedAnswer;
 
@@ -181,6 +192,111 @@ describe('atomic-generated-answer-feedback-modal', () => {
 
       const successIcon = element.shadowRoot?.querySelector('atomic-icon');
       expect(successIcon).toBeTruthy();
+    });
+  });
+
+  describe('when selecting feedback options', () => {
+    it('should render radio buttons for each feedback category and option', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      );
+
+      const expectedCount =
+        FEEDBACK_CATEGORIES.length * FEEDBACK_OPTIONS.length;
+      expect(radioButtons?.length).toBe(expectedCount);
+
+      for (const category of FEEDBACK_CATEGORIES) {
+        const categoryButtons = element.shadowRoot?.querySelectorAll(
+          `input[type="radio"][name*="${category}"]`
+        );
+        expect(categoryButtons?.length).toBe(FEEDBACK_OPTIONS.length);
+      }
+    });
+
+    it('should apply active class to selected radio button', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      ) as NodeListOf<HTMLInputElement>;
+
+      const firstRadioButton = radioButtons[0];
+      firstRadioButton.click();
+      await element.updateComplete;
+
+      expect(firstRadioButton.className).toContain('active');
+    });
+
+    it('should not apply active class to unselected radio buttons', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      ) as NodeListOf<HTMLInputElement>;
+
+      const firstRadioButton = radioButtons[0];
+      const secondRadioButton = radioButtons[1];
+
+      firstRadioButton.click();
+      await element.updateComplete;
+
+      expect(firstRadioButton.className).toContain('active');
+      expect(secondRadioButton.className).not.toContain('active');
+    });
+
+    it('should not cause DOMTokenList error when toggling selection', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      ) as NodeListOf<HTMLInputElement>;
+
+      expect(() => {
+        const firstButton = radioButtons[0];
+        firstButton.click();
+        const secondButton = radioButtons[1];
+        secondButton.click();
+        firstButton.click();
+      }).not.toThrow();
+    });
+
+    it('should toggle active class when selecting different options in same category', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      ) as NodeListOf<HTMLInputElement>;
+
+      const firstOption = radioButtons[0];
+      firstOption.click();
+      await element.updateComplete;
+
+      expect(firstOption.className).toContain('active');
+
+      const secondOption = radioButtons[1];
+      secondOption.click();
+      await element.updateComplete;
+
+      expect(secondOption.className).toContain('active');
+      expect(firstOption.className).not.toContain('active');
+    });
+
+    it('should update currentAnswer state when radio button is clicked', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const radioButtons = element.shadowRoot?.querySelectorAll(
+        'input[type="radio"]'
+      ) as NodeListOf<HTMLInputElement>;
+
+      const firstRadioButton = radioButtons[0];
+      firstRadioButton.click();
+      await element.updateComplete;
+
+      // biome-ignore lint/suspicious/noExplicitAny: <>
+      const currentAnswer = (element as any).currentAnswer;
+      expect(Object.values(currentAnswer)).toContain('yes');
     });
   });
 

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
@@ -246,20 +246,31 @@ describe('atomic-generated-answer-feedback-modal', () => {
       expect(secondRadioButton.className).not.toContain('active');
     });
 
+    // This test was added to catch a specific bug where toggling radio button selection would cause a DOMTokenList error due to class manipulation on the radio buttons.
     it('should not cause DOMTokenList error when toggling selection', async () => {
       const {element} = await renderFeedbackModal({isOpen: true});
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
 
       const radioButtons = element.shadowRoot?.querySelectorAll(
         'input[type="radio"]'
       ) as NodeListOf<HTMLInputElement>;
 
-      expect(() => {
-        const firstButton = radioButtons[0];
-        firstButton.click();
-        const secondButton = radioButtons[1];
-        secondButton.click();
-        firstButton.click();
-      }).not.toThrow();
+      const firstButton = radioButtons[0];
+      firstButton.click();
+      await element.updateComplete;
+
+      const secondButton = radioButtons[1];
+      secondButton.click();
+      await element.updateComplete;
+
+      firstButton.click();
+      await element.updateComplete;
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
 
     it('should toggle active class when selecting different options in same category', async () => {

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
@@ -10,7 +10,7 @@ import './atomic-generated-answer-feedback-modal';
 vi.mock('@/src/components/common/icon-button', {spy: true});
 
 // Feedback option values that users can select for each category
-const FEEDBACK_OPTIONS: string[] = ['yes', 'unknown', 'no'] as const;
+const FEEDBACK_OPTIONS = ['yes', 'unknown', 'no'] as const;
 
 // Feedback categories that are evaluated (matching AtomicGeneratedAnswerFeedbackModal.options)
 const FEEDBACK_CATEGORIES = [

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
@@ -295,7 +295,9 @@ export class AtomicGeneratedAnswerFeedbackModal
         onChecked: () => {
           this.setCurrentAnswer(correspondingAnswer, option);
         },
-        class: `min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark ${isSelected ? 'active' : undefined}`,
+        class: isSelected
+          ? 'min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark active'
+          : 'min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark',
         text: this.bindings.i18n.t(option),
       },
     });

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
@@ -295,7 +295,7 @@ export class AtomicGeneratedAnswerFeedbackModal
         onChecked: () => {
           this.setCurrentAnswer(correspondingAnswer, option);
         },
-        class: `min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark ${isSelected ? 'active' : ''}`,
+        class: `min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark ${isSelected ? 'active' : undefined}`,
         text: this.bindings.i18n.t(option),
       },
     });


### PR DESCRIPTION
## SFINT-6625

Whenever we would click to select an option on the atomic-generated-answer-feedback-modal, Lit would throw an error:

```
class-map.ts:81 Uncaught (in promise) SyntaxError: Failed to execute 'remove' on 'DOMTokenList': The token provided must not be empty.
    at ClassMapDirective.update (class-map.ts:81:19)
    at ClassMapDirective._$resolve (directive.ts:135:17)
    at resolveDirective (lit-html.ts:1174:24)
    at resolveDirective (lit-html.ts:1172:13)
    at AttributePart._$setValue (lit-html.ts:1894:15)
    at TemplateInstance._update (lit-html.ts:1282:16)
    at _ChildPart._commitTemplateResult (lit-html.ts:1636:51)
    at _ChildPart._$setValue (lit-html.ts:1475:12)
    at TemplateInstance._update (lit-html.ts:1282:16)
    at _ChildPart._commitTemplateResult (lit-html.ts:1636:51)
target.update	@	watch.js:37
await in __enqueueUpdate		
setCurrentAnswer	@	atomic-generated-ans…eedback-modal.js:97
onChecked	@	atomic-generated-ans…edback-modal.js:155
onChange	@	radio-button.js:66 
```

This appears to be cause by the conditional class we try to pass to the `renderRadioButton`. If the conditional was false, we were sending `''` an empty string which appears to break the classMapDirective from Lit?

I replaced it with undefined which is a value that the ClassMapDirective is able to handle properly.

I don't know if it's a problem we should fix in the `renderRadioButton` instead, but for now this work.

I added tests to cover the correct rendering and behavior of the options in the Feedback Modal to prevent future errors to go unnoticed. 