### PR TITLE
fix(headless): apply enableQuerySyntax option at search box construction

### DIFF
--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.test.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.test.ts
@@ -1,4 +1,5 @@
 import {configuration} from '../../../app/common-reducers.js';
+import {updateQuery} from '../../../features/query/query-actions.js';
 import {logSearchboxSubmit} from '../../../features/query/query-analytics-actions.js';
 import {queryReducer as query} from '../../../features/query/query-slice.js';
 import {
@@ -35,6 +36,7 @@ import {
 vi.mock('../../../features/query/query-analytics-actions', () => ({
   logSearchboxSubmit: vi.fn(() => () => {}),
 }));
+vi.mock('../../../features/query/query-actions');
 vi.mock('../../../features/query-suggest/query-suggest-actions');
 vi.mock('../../../features/query-set/query-set-actions');
 vi.mock('../../../features/search/search-actions');
@@ -165,6 +167,26 @@ describe('headless CoreSearchBox', () => {
     expect(registerQuerySuggest).toHaveBeenCalledWith({
       id,
       count: props.options!.numberOfSuggestions,
+    });
+  });
+
+  describe('enableQuerySyntax at initialization', () => {
+    it('should dispatch updateQuery with enableQuerySyntax when option is true', () => {
+      props.options!.enableQuerySyntax = true;
+      initController();
+      expect(updateQuery).toHaveBeenCalledWith({enableQuerySyntax: true});
+    });
+
+    it('should not dispatch updateQuery when enableQuerySyntax option is false', () => {
+      props.options!.enableQuerySyntax = false;
+      initController();
+      expect(updateQuery).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch updateQuery when enableQuerySyntax option is not set', () => {
+      delete props.options!.enableQuerySyntax;
+      initController();
+      expect(updateQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
+++ b/packages/headless/src/controllers/core/search-box/headless-core-search-box.ts
@@ -5,6 +5,7 @@ import type {
   InsightAction,
   LegacySearchAction,
 } from '../../../features/analytics/analytics-utils.js';
+import {updateQuery} from '../../../features/query/query-actions.js';
 import {logSearchboxSubmit} from '../../../features/query/query-analytics-actions.js';
 import {queryReducer as query} from '../../../features/query/query-slice.js';
 import {
@@ -242,6 +243,9 @@ export function buildCoreSearchBox(
         count: options.numberOfSuggestions,
       })
     );
+  }
+  if (options.enableQuerySyntax) {
+    dispatch(updateQuery({enableQuerySyntax: options.enableQuerySyntax}));
   }
 
   const getValue = () => engine.state.querySet[options.id];


### PR DESCRIPTION
## Summary
Fix bug where `enableQuerySyntax` option from search box is not applied to engine state during controller construction.

## Problem
When navigating directly to a URL with a query (e.g., `#q=@field=value`), the `enableQuerySyntax` preference from `atomic-search-box` was only applied when the user **submits** a search. This caused issues with folding "Show More" because the engine state had `enableQuerySyntax: false` even though the component was configured with `enable-query-syntax="true"`.

## Solution
Dispatch `updateQuery({enableQuerySyntax})` during `buildCoreSearchBox` construction when the option is set to `true`. This follows the same pattern used by other controllers like `DidYouMean`, `RecommendationList`, and `Tab` which dispatch actions at init.

## Jira
[KIT-5455](https://coveord.atlassian.net/browse/KIT-5455)

## Related
- Support case: 00133421

[KIT-5455]: https://coveord.atlassian.net/browse/KIT-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ