### PR TITLE
test(atomic-a11y): add E2E smoke test for report generation pipeline

### DIFF
--- a/packages/atomic-a11y/package.json
+++ b/packages/atomic-a11y/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "test": "vitest run",
+    "test:e2e-smoke": "tsx scripts/e2e-report-smoke.ts",
     "generate:wcag": "node scripts/generate-wcag-criteria.mjs",
     "build": "pnpm generate:wcag && tsc -p tsconfig.json"
   },

--- a/packages/atomic-a11y/scripts/e2e-report-smoke.ts
+++ b/packages/atomic-a11y/scripts/e2e-report-smoke.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * E2E Smoke Test: a11y Report Generation Pipeline
+ *
+ * Verifies the full pipeline:
+ *   pnpm --filter @coveo/atomic run test:storybook -> VitestA11yReporter -> a11y-report.json
+ *
+ * Usage:
+ *   npx tsx packages/atomic-a11y/scripts/e2e-report-smoke.ts
+ *
+ * Prerequisites:
+ *   - packages/atomic must be built (pnpm build)
+ *   - Run from the monorepo root
+ */
+
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {isA11yReport} from '../src/shared/guards.js';
+import type {A11yReport} from '../src/shared/types.js';
+
+const REPORT_DIR = path.resolve(import.meta.dirname, '../reports');
+const REPORT_FILE = path.join(REPORT_DIR, 'a11y-report.json');
+const ATOMIC_DIR = path.resolve(import.meta.dirname, '../../atomic');
+
+const fail = (message: string): never => {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+};
+
+const run = (): void => {
+  try {
+    if (fs.existsSync(REPORT_FILE)) {
+      fs.rmSync(REPORT_FILE);
+    }
+
+    let storybookCommandFailed = false;
+    let primaryCommandError = '';
+
+    try {
+      execSync(
+        'npx vitest run --project=storybook --testPathPattern="atomic-search-box" --reporter=default',
+        {
+          cwd: ATOMIC_DIR,
+          stdio: 'pipe',
+          timeout: 180_000,
+          env: {...process.env, CI: 'true'},
+        }
+      );
+    } catch (error) {
+      storybookCommandFailed = true;
+      primaryCommandError =
+        error instanceof Error ? error.message : String(error);
+    }
+
+    if (storybookCommandFailed && !fs.existsSync(REPORT_FILE)) {
+      try {
+        execSync('npx vitest run --project=storybook atomic-search-box', {
+          cwd: ATOMIC_DIR,
+          stdio: 'pipe',
+          timeout: 180_000,
+          env: {...process.env, CI: 'true'},
+        });
+      } catch {}
+    }
+
+    if (!fs.existsSync(REPORT_FILE)) {
+      fail(
+        storybookCommandFailed
+          ? `storybook command failed and no report file was created. Command error: ${primaryCommandError}`
+          : 'report file was not created.'
+      );
+    }
+
+    const rawReport = fs.readFileSync(REPORT_FILE, 'utf-8');
+    let parsedReport: unknown;
+
+    try {
+      parsedReport = JSON.parse(rawReport);
+    } catch {
+      fail('report file is not valid JSON.');
+    }
+
+    if (!isA11yReport(parsedReport)) {
+      fail('report does not match isA11yReport() shape guard.');
+    }
+
+    const report = parsedReport as A11yReport;
+
+    if (report.report.product !== 'Coveo Atomic') {
+      fail(`unexpected product: ${String(report.report.product)}`);
+    }
+
+    if (report.report.standard !== 'WCAG 2.2 AA') {
+      fail(`unexpected standard: ${String(report.report.standard)}`);
+    }
+
+    if (report.components.length === 0) {
+      fail('components array is empty.');
+    }
+
+    if (report.criteria.length === 0) {
+      fail('criteria array is empty.');
+    }
+
+    const atomicPrefixCount = report.components.filter((component) =>
+      component.name.startsWith('atomic-')
+    ).length;
+
+    if (atomicPrefixCount === 0) {
+      fail('no component name starts with "atomic-".');
+    }
+
+    const criterionPattern = /^\d+\.\d+\.\d+$/;
+    const matchingCriteriaCount = report.criteria.filter((criterion) =>
+      criterionPattern.test(criterion.id)
+    ).length;
+
+    if (matchingCriteriaCount === 0) {
+      fail('no criterion id matches X.Y.Z format.');
+    }
+
+    if (!report.summary.automatedCoverage.endsWith('%')) {
+      fail(
+        `automatedCoverage does not end with %: ${String(report.summary.automatedCoverage)}`
+      );
+    }
+
+    const relativeReportPath = path.relative(process.cwd(), REPORT_FILE);
+
+    console.log(`PASS: Report file created: ${relativeReportPath}`);
+    console.log('PASS: Report passes isA11yReport() guard');
+    console.log(`PASS: Product: ${report.report.product}`);
+    console.log(`PASS: Standard: ${report.report.standard}`);
+    console.log(
+      `PASS: Components: ${report.components.length} (${atomicPrefixCount} with atomic- prefix)`
+    );
+    console.log(
+      `PASS: Criteria: ${report.criteria.length} (${matchingCriteriaCount} with X.Y.Z format)`
+    );
+    console.log(
+      `PASS: Automated coverage: ${report.summary.automatedCoverage}`
+    );
+    console.log();
+    console.log('E2E SMOKE TEST PASSED');
+
+    process.exit(0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`FAIL: unexpected error: ${message}`);
+    process.exit(1);
+  }
+};
+
+run();


### PR DESCRIPTION
## Summary

- Adds a standalone E2E smoke test script that verifies the full a11y report generation pipeline works end-to-end
- The script runs a minimal storybook test subset (`atomic-search-box` only), then validates the generated `a11y-report.json` against the `A11yReport` interface

## What it does

`packages/atomic-a11y/scripts/e2e-report-smoke.ts` is a standalone script (not a vitest test) that:

1. **Cleans** any existing `a11y-report.json`
2. **Runs** `npx vitest run --project=storybook --testPathPattern="atomic-search-box"` in `packages/atomic`
3. **Validates** the generated report:
   - File exists and is valid JSON
   - Passes `isA11yReport()` structural guard
   - Product is `"Coveo Atomic"`, standard is `"WCAG 2.2 AA"`
   - Contains ≥1 component with `atomic-` prefix
   - Contains ≥1 criterion with `X.Y.Z` format
   - `automatedCoverage` ends with `%`
4. **Exits** with code 0 (pass) or 1 (fail) with clear diagnostic messages

## Usage

```bash
# From monorepo root (requires packages/atomic to be built)
npx tsx packages/atomic-a11y/scripts/e2e-report-smoke.ts

# Or via package script
cd packages/atomic-a11y && pnpm test:e2e-smoke
```

## Why a separate PR

This E2E test is intentionally separated from the unit test infrastructure (Tasks 1-14) to limit scope. The unit tests cover the reporter's internal logic; this script validates the full integration pipeline from storybook test execution through report file generation.

## Files changed

- `packages/atomic-a11y/scripts/e2e-report-smoke.ts` — E2E smoke test script (157 lines)
- `packages/atomic-a11y/package.json` — Added `test:e2e-smoke` script entry