### PR TITLE
chore: adapt bump-package to support new packages

### DIFF
--- a/utils/ci/bump-package.mjs
+++ b/utils/ci/bump-package.mjs
@@ -147,7 +147,6 @@ const lastTag = await getLastTag({
   prefix: versionPrefix,
   onBranch: `refs/remotes/origin/${REPO_RELEASE_BRANCH}`,
 }).catch(() => REPO_RELEASE_BRANCH); // if no tag is found, we consider all commits since the release branch as part of this release, which is the expected behavior for the first release or when a new package is added.
-console.log('beep');
 const commits = await getCommits(PATH, lastTag);
 if (
   commits.length === 0 &&


### PR DESCRIPTION
Adapt the bump package script to accommodate new packages.
To note, new packages still must be registered by hand, with both a latest & beta tag.

Pseudo script to register a new package; 
```bash
mdkir pkgName
cd pkgName
npm init -y \
  --scope=coveo \
  --init-type=module \
  --init-version=0.0.0 \
  --init-license=Apache-2.0
npm publish
npm dist-tag add @coveo/pkgName@0.0.0 beta
```

https://coveord.atlassian.net/browse/KIT-5476