### PR TITLE
chore: use the remote ref

### DIFF
--- a/utils/ci/bump-package.mjs
+++ b/utils/ci/bump-package.mjs
@@ -146,7 +146,7 @@ const convention = await changelogConvention();
 const lastTag = await getLastTag({
   prefix: versionPrefix,
   onBranch: `refs/remotes/origin/${REPO_RELEASE_BRANCH}`,
-}).catch(() => REPO_RELEASE_BRANCH); // if no tag is found, we consider all commits since the release branch as part of this release, which is the expected behavior for the first release or when a new package is added.
+}).catch(() => `refs/remotes/origin/${REPO_RELEASE_BRANCH}`); // if no tag is found, we consider all commits since the release branch as part of this release, which is the expected behavior for the first release or when a new package is added.
 const commits = await getCommits(PATH, lastTag);
 if (
   commits.length === 0 &&


### PR DESCRIPTION
`  stderr: "fatal: ambiguous argument 'release/v3..HEAD': unknown revision or path not in the working tree.\n"`

`release/v3` ref doesn't exist in the local working tree, no matter, let's target the remote ref instead

https://coveord.atlassian.net/browse/KIT-5476