### PR TITLE
chore(headless): Refactor token renewal logic

### DIFF
--- a/packages/headless/src/app/renew-access-token-middleware.ts
+++ b/packages/headless/src/app/renew-access-token-middleware.ts
@@ -20,16 +20,13 @@ export function createRenewAccessTokenMiddleware(
   renewToken?: () => Promise<string>
 ): Middleware {
   let accessTokenRenewalsAttempts = 0;
-  let pendingTokenRenewal: Promise<string | null> | null = null;
+  let pendingTokenRenewal: Promise<string> | null = null;
   const hasRenewFunction = typeof renewToken === 'function';
   const resetRenewalTriesAfterDelay = debounce(() => {
     accessTokenRenewalsAttempts = 0;
   }, 500);
 
-  const handleTokenRenewal = async (
-    store: MiddlewareAPI,
-    handleErrors = false
-  ): Promise<string | null> => {
+  const handleTokenRenewal = async (store: MiddlewareAPI): Promise<string | null> => {
     if (!hasRenewFunction) {
       return null;
     }
@@ -38,14 +35,7 @@ export function createRenewAccessTokenMiddleware(
 
     if (shouldInitiateRenewal) {
       pendingTokenRenewal = (async () => {
-        try {
-          return await renewToken();
-        } catch (error) {
-          if (!handleErrors) {
-            throw error;
-          }
-          return null;
-        }
+        return await renewToken();
       })().finally(() => {
         pendingTokenRenewal = null;
       });
@@ -105,7 +95,12 @@ export function createRenewAccessTokenMiddleware(
     accessTokenRenewalsAttempts++;
     resetRenewalTriesAfterDelay();
 
-    await handleTokenRenewal(store, true);
+    try {
+      await handleTokenRenewal(store);
+    } catch (_) {
+      // Ignore
+    }
+
     store.dispatch(action as unknown as UnknownAction);
     return;
   };

--- a/packages/headless/src/app/renew-access-token-middleware.ts
+++ b/packages/headless/src/app/renew-access-token-middleware.ts
@@ -21,6 +21,7 @@ export function createRenewAccessTokenMiddleware(
 ): Middleware {
   let accessTokenRenewalsAttempts = 0;
   let pendingTokenRenewal: Promise<string | null> | null = null;
+  const hasRenewFunction = typeof renewToken === 'function';
   const resetRenewalTriesAfterDelay = debounce(() => {
     accessTokenRenewalsAttempts = 0;
   }, 500);
@@ -29,9 +30,13 @@ export function createRenewAccessTokenMiddleware(
     store: MiddlewareAPI,
     handleErrors = false
   ): Promise<string | null> => {
+    if (!hasRenewFunction) {
+      return null;
+    }
+
     const shouldInitiateRenewal = !pendingTokenRenewal;
 
-    if (shouldInitiateRenewal && renewToken) {
+    if (shouldInitiateRenewal) {
       pendingTokenRenewal = (async () => {
         try {
           return await renewToken();
@@ -107,7 +112,6 @@ export function createRenewAccessTokenMiddleware(
 
   return (store) => (next) => async (action) => {
     const isThunk = typeof action === 'function';
-    const hasRenewFunction = typeof renewToken === 'function';
 
     if (!isThunk) {
       return next(action);

--- a/packages/headless/src/app/renew-access-token-middleware.ts
+++ b/packages/headless/src/app/renew-access-token-middleware.ts
@@ -43,7 +43,7 @@ export function createRenewAccessTokenMiddleware(
 
     const accessToken = await pendingTokenRenewal;
 
-    if (shouldInitiateRenewal && accessToken) {
+    if (accessToken) {
       store.dispatch(updateBasicConfiguration({accessToken}));
     }
 

--- a/packages/headless/src/app/renew-access-token-middleware.ts
+++ b/packages/headless/src/app/renew-access-token-middleware.ts
@@ -13,35 +13,26 @@ import type {
 } from '../state/state-sections.js';
 import {UnauthorizedTokenError} from '../utils/errors.js';
 import {shouldRenewJWT as shouldRenewAccessToken} from '../utils/jwt-utils.js';
-import {debounce} from '../utils/utils.js';
+import {debounce, deduplicatePendingPromise} from '../utils/utils.js';
 
 export function createRenewAccessTokenMiddleware(
   logger: Logger,
   renewToken?: () => Promise<string>
 ): Middleware {
   let accessTokenRenewalsAttempts = 0;
-  let pendingTokenRenewal: Promise<string> | null = null;
-  const hasRenewFunction = typeof renewToken === 'function';
   const resetRenewalTriesAfterDelay = debounce(() => {
     accessTokenRenewalsAttempts = 0;
   }, 500);
 
-  const handleTokenRenewal = async (store: MiddlewareAPI): Promise<string | null> => {
-    if (!hasRenewFunction) {
-      return null;
-    }
+  const hasRenewFunction = typeof renewToken === 'function';
+  const dedupedRenewToken = hasRenewFunction
+    ? deduplicatePendingPromise(renewToken)
+    : () => Promise.resolve(null);
 
-    const shouldInitiateRenewal = !pendingTokenRenewal;
-
-    if (shouldInitiateRenewal) {
-      pendingTokenRenewal = (async () => {
-        return await renewToken();
-      })().finally(() => {
-        pendingTokenRenewal = null;
-      });
-    }
-
-    const accessToken = await pendingTokenRenewal;
+  const handleTokenRenewal = async (
+    store: MiddlewareAPI
+  ): Promise<string | null> => {
+    const accessToken = await dedupedRenewToken();
 
     if (accessToken) {
       store.dispatch(updateBasicConfiguration({accessToken}));

--- a/packages/headless/src/utils/utils.test.ts
+++ b/packages/headless/src/utils/utils.test.ts
@@ -1,4 +1,8 @@
-import {debounce, removeDuplicates} from './utils.js';
+import {
+  debounce,
+  deduplicatePendingPromise,
+  removeDuplicates,
+} from './utils.js';
 
 describe('removeDuplicates', () => {
   it('should return reduced array based on received predicate', () => {
@@ -215,5 +219,74 @@ describe('debounce', () => {
 
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(mockFn).toHaveBeenCalledWith('second');
+  });
+});
+
+describe('deduplicatePendingPromise', () => {
+  const createDeferred = <T>() => {
+    let resolve: (value: T) => void;
+    let reject: (error: unknown) => void;
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve;
+      reject = promiseReject;
+    });
+    return {promise, resolve: resolve!, reject: reject!};
+  };
+
+  it('should return the same pending promise for concurrent calls', async () => {
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(() => deferred.promise);
+    const deduplicated = deduplicatePendingPromise(fn);
+
+    const firstCall = deduplicated();
+    const secondCall = deduplicated();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(firstCall).toBe(secondCall);
+
+    deferred.resolve('done');
+
+    await expect(firstCall).resolves.toBe('done');
+    await expect(secondCall).resolves.toBe('done');
+  });
+
+  it('should call the function again after the pending promise resolves', async () => {
+    const firstDeferred = createDeferred<string>();
+    const secondDeferred = createDeferred<string>();
+    const fn = vi
+      .fn()
+      .mockImplementationOnce(() => firstDeferred.promise)
+      .mockImplementationOnce(() => secondDeferred.promise);
+    const deduplicated = deduplicatePendingPromise(fn);
+
+    const firstCall = deduplicated();
+    firstDeferred.resolve('first');
+    await expect(firstCall).resolves.toBe('first');
+
+    const secondCall = deduplicated();
+    secondDeferred.resolve('second');
+    await expect(secondCall).resolves.toBe('second');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reset pending state after rejection', async () => {
+    const firstDeferred = createDeferred<string>();
+    const secondDeferred = createDeferred<string>();
+    const fn = vi
+      .fn()
+      .mockImplementationOnce(() => firstDeferred.promise)
+      .mockImplementationOnce(() => secondDeferred.promise);
+    const deduplicated = deduplicatePendingPromise(fn);
+
+    const firstCall = deduplicated();
+    firstDeferred.reject(new Error('boom'));
+    await expect(firstCall).rejects.toThrow('boom');
+
+    const secondCall = deduplicated();
+    secondDeferred.resolve('recovered');
+    await expect(secondCall).resolves.toBe('recovered');
+
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/headless/src/utils/utils.ts
+++ b/packages/headless/src/utils/utils.ts
@@ -228,3 +228,18 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
     }
   }) as T;
 }
+
+export function deduplicatePendingPromise<T>(
+  fn: () => Promise<T>
+): () => Promise<T> {
+  let pending: Promise<T> | null = null;
+
+  return async (): Promise<T> => {
+    if (!pending) {
+      pending = fn().finally(() => {
+        pending = null;
+      });
+    }
+    return pending;
+  };
+}


### PR DESCRIPTION
Follow up to https://github.com/coveo/ui-kit/pull/7109

- Skip the renew logic entirely if `renewToken` is null.
- Add a `deduplicatePendingPromise` util method to abstract the pattern.
- Remove the `handleErrors` argument, simply catching the error when called.

https://coveord.atlassian.net/browse/KIT-5478
