### PR TITLE
chore: fix dev watcher thundering-herd builds on branch switches

### DIFF
--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -271,6 +271,8 @@ await startServers();
 let debounceTimer = null;
 let buildInProgress = false;
 const DEBOUNCE_MS = 300;
+let pendingChangeCount = 0;
+let lastChangedFile = '';
 
 async function runBuild() {
   if (buildInProgress) {
@@ -378,13 +380,29 @@ watch('src', {recursive: true}, (_, filename) => {
   // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
   // Without this, fs.watch fires concurrent async callbacks for each changed file,
   // causing a thundering herd of parallel build processes.
+  pendingChangeCount += 1;
+  lastChangedFile = filename;
+
   if (debounceTimer) {
     clearTimeout(debounceTimer);
   }
 
   debounceTimer = setTimeout(() => {
     debounceTimer = null;
-    console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+    const changeCount = pendingChangeCount;
+    const changedFile = lastChangedFile;
+    pendingChangeCount = 0;
+    lastChangedFile = '';
+
+    if (changeCount > 1) {
+      console.log(
+        colors.yellow(
+          `⚡ Detected ${changeCount} rapid file changes; coalescing into a single rebuild (e.g., branch checkout).`
+        )
+      );
+    }
+
+    console.log(colors.cyanBright(`📂 File changed: ${changedFile}`));
     runBuild();
   }, DEBOUNCE_MS);
 });

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -267,7 +267,100 @@ const isStencil = process.argv.includes('--stencil');
 await startServers();
 
 // Watch the src folder for changes
-watch('src', {recursive: true}, async (_, filename) => {
+/** @type {ReturnType<typeof setTimeout> | null} */
+let debounceTimer = null;
+let buildInProgress = false;
+const DEBOUNCE_MS = 300;
+
+async function runBuild() {
+  if (buildInProgress) {
+    await stopAllProcesses();
+  }
+
+  buildInProgress = true;
+  isStopped = false;
+
+  try {
+    if (isStencil) {
+      await nextTask(
+        'Rebuilding Stencil...',
+        'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
+      );
+
+      if (isStopped) {
+        return;
+      }
+
+      await nextTask(
+        'Placing the Stencil Proxy...',
+        'node ./scripts/stencil-proxy.mjs'
+      );
+
+      if (isStopped) {
+        return;
+      }
+    }
+
+    await nextTask(
+      'Rebuilding Lit...',
+      'node ./scripts/build.mjs --config=tsconfig.lit.json'
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask(
+      'Running esbuild for autoloader ESM...',
+      'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask(
+      'Running esbuild for autoloader CJS...',
+      'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask('Building the custom elements manifest...', 'cem analyze');
+
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask(
+      'Building storybook...',
+      'npx storybook build -o dist-storybook'
+    );
+
+    // Restart storybook server
+    // Somehow even after a build, the dev server doesn't pick up the changes.
+    // It needs a dev restart to pick them up.
+    storybookServer.kill('SIGTERM');
+    storybookServer = exec(
+      `npx storybook dev -p ${activePorts.storybook} --no-open`,
+      {
+        stdio: 'ignore',
+      }
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
+  } finally {
+    buildInProgress = false;
+  }
+}
+
+watch('src', {recursive: true}, (_, filename) => {
   // Ignore irrelevant files
   if (
     filename.endsWith('.mdx') ||
@@ -282,85 +375,16 @@ watch('src', {recursive: true}, async (_, filename) => {
     return;
   }
 
-  // Stop all processes if a file changes to prevent multiple builds at once
-  await stopAllProcesses();
-  console.log(colors.cyanBright(`📂 File changed: ${filename}`));
-
-  // Flag to stop the build process if a file changes during the build
-  isStopped = false;
-
-  if (isStencil) {
-    await nextTask(
-      'Rebuilding Stencil...',
-      'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
-    );
-
-    if (isStopped) {
-      return;
-    }
-
-    await nextTask(
-      'Placing the Stencil Proxy...',
-      'node ./scripts/stencil-proxy.mjs'
-    );
-
-    if (isStopped) {
-      return;
-    }
+  // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
+  // Without this, fs.watch fires concurrent async callbacks for each changed file,
+  // causing a thundering herd of parallel build processes.
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
   }
 
-  await nextTask(
-    'Rebuilding Lit...',
-    'node ./scripts/build.mjs --config=tsconfig.lit.json'
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Running esbuild for autoloader ESM...',
-    'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Running esbuild for autoloader CJS...',
-    'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask('Building the custom elements manifest...', 'cem analyze');
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Building storybook...',
-    'npx storybook build -o dist-storybook'
-  );
-
-  // Restart storybook server
-  // Somehow even after a build, the dev server doesn't pick up the changes.
-  // It needs a dev restart to pick them up.
-  storybookServer.kill('SIGTERM');
-  storybookServer = exec(
-    `npx storybook dev -p ${activePorts.storybook} --no-open`,
-    {
-      stdio: 'ignore',
-    }
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+    runBuild();
+  }, DEBOUNCE_MS);
 });

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -268,10 +268,10 @@ await startServers();
 
 // Watch the src folder for changes
 /** @type {ReturnType<typeof setTimeout> | null} */
-let changeLogTimer = null;
-const CHANGE_LOG_WINDOW_MS = 300;
+let debounceTimer = null;
+const DEBOUNCE_MS = 300;
 let pendingChangeCount = 0;
-watch('src', {recursive: true}, async (_, filename) => {
+watch('src', {recursive: true}, (_, filename) => {
   // Ignore irrelevant files
   if (
     filename.endsWith('.mdx') ||
@@ -288,11 +288,16 @@ watch('src', {recursive: true}, async (_, filename) => {
 
   pendingChangeCount += 1;
 
-  if (changeLogTimer) {
-    clearTimeout(changeLogTimer);
+  // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
+  // Without this, fs.watch fires concurrent async callbacks for each changed file,
+  // causing a thundering herd of parallel build processes.
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
   }
 
-  changeLogTimer = setTimeout(() => {
+  debounceTimer = setTimeout(async () => {
+    debounceTimer = null;
+
     if (pendingChangeCount > 1) {
       console.log(
         colors.yellow(
@@ -302,19 +307,37 @@ watch('src', {recursive: true}, async (_, filename) => {
     }
 
     pendingChangeCount = 0;
-  }, CHANGE_LOG_WINDOW_MS);
 
-  // Stop all processes if a file changes to prevent multiple builds at once
-  await stopAllProcesses();
-  console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+    // Stop all processes if a file changes to prevent multiple builds at once
+    await stopAllProcesses();
+    console.log(colors.cyanBright(`📂 File changed: ${filename}`));
 
-  // Flag to stop the build process if a file changes during the build
-  isStopped = false;
+    // Flag to stop the build process if a file changes during the build
+    isStopped = false;
 
-  if (isStencil) {
+    if (isStencil) {
+      await nextTask(
+        'Rebuilding Stencil...',
+        'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
+      );
+
+      if (isStopped) {
+        return;
+      }
+
+      await nextTask(
+        'Placing the Stencil Proxy...',
+        'node ./scripts/stencil-proxy.mjs'
+      );
+
+      if (isStopped) {
+        return;
+      }
+    }
+
     await nextTask(
-      'Rebuilding Stencil...',
-      'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
+      'Rebuilding Lit...',
+      'node ./scripts/build.mjs --config=tsconfig.lit.json'
     );
 
     if (isStopped) {
@@ -322,67 +345,49 @@ watch('src', {recursive: true}, async (_, filename) => {
     }
 
     await nextTask(
-      'Placing the Stencil Proxy...',
-      'node ./scripts/stencil-proxy.mjs'
+      'Running esbuild for autoloader ESM...',
+      'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
     );
 
     if (isStopped) {
       return;
     }
-  }
 
-  await nextTask(
-    'Rebuilding Lit...',
-    'node ./scripts/build.mjs --config=tsconfig.lit.json'
-  );
+    await nextTask(
+      'Running esbuild for autoloader CJS...',
+      'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
+    );
 
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Running esbuild for autoloader ESM...',
-    'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Running esbuild for autoloader CJS...',
-    'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
-  );
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask('Building the custom elements manifest...', 'cem analyze');
-
-  if (isStopped) {
-    return;
-  }
-
-  await nextTask(
-    'Building storybook...',
-    'npx storybook build -o dist-storybook'
-  );
-
-  // Restart storybook server
-  // Somehow even after a build, the dev server doesn't pick up the changes.
-  // It needs a dev restart to pick them up.
-  storybookServer.kill('SIGTERM');
-  storybookServer = exec(
-    `npx storybook dev -p ${activePorts.storybook} --no-open`,
-    {
-      stdio: 'ignore',
+    if (isStopped) {
+      return;
     }
-  );
 
-  if (isStopped) {
-    return;
-  }
+    await nextTask('Building the custom elements manifest...', 'cem analyze');
 
-  console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask(
+      'Building storybook...',
+      'npx storybook build -o dist-storybook'
+    );
+
+    // Restart storybook server
+    // Somehow even after a build, the dev server doesn't pick up the changes.
+    // It needs a dev restart to pick them up.
+    storybookServer.kill('SIGTERM');
+    storybookServer = exec(
+      `npx storybook dev -p ${activePorts.storybook} --no-open`,
+      {
+        stdio: 'ignore',
+      }
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
+  }, DEBOUNCE_MS);
 });

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -147,10 +147,6 @@ async function nextTask(text, command) {
   return new Promise((resolve, reject) => {
     const childProcess = exec(command);
 
-    if (childProcess.stdout) {
-      childProcess.stdout.pipe(process.stdout);
-    }
-
     if (childProcess.stderr) {
       childProcess.stderr.pipe(process.stderr);
     }

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -145,7 +145,15 @@ async function nextTask(text, command) {
   const spinner = createSpinner(text).start();
 
   return new Promise((resolve, reject) => {
-    const childProcess = exec(command, {stdio: 'inherit'});
+    const childProcess = exec(command);
+
+    if (childProcess.stdout) {
+      childProcess.stdout.pipe(process.stdout);
+    }
+
+    if (childProcess.stderr) {
+      childProcess.stderr.pipe(process.stderr);
+    }
 
     // Add the process to the list of running processes to be able to stop them
     runningProcesses.push(childProcess);
@@ -158,6 +166,7 @@ async function nextTask(text, command) {
         resolve();
       } else {
         spinner.fail(colors.red.bold(`${text}`));
+        reject(new Error(`${text} failed with exit code ${code}`));
       }
     });
 

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -268,101 +268,10 @@ await startServers();
 
 // Watch the src folder for changes
 /** @type {ReturnType<typeof setTimeout> | null} */
-let debounceTimer = null;
-let buildInProgress = false;
-const DEBOUNCE_MS = 300;
+let changeLogTimer = null;
+const CHANGE_LOG_WINDOW_MS = 300;
 let pendingChangeCount = 0;
-let lastChangedFile = '';
-
-async function runBuild() {
-  if (buildInProgress) {
-    await stopAllProcesses();
-  }
-
-  buildInProgress = true;
-  isStopped = false;
-
-  try {
-    if (isStencil) {
-      await nextTask(
-        'Rebuilding Stencil...',
-        'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
-      );
-
-      if (isStopped) {
-        return;
-      }
-
-      await nextTask(
-        'Placing the Stencil Proxy...',
-        'node ./scripts/stencil-proxy.mjs'
-      );
-
-      if (isStopped) {
-        return;
-      }
-    }
-
-    await nextTask(
-      'Rebuilding Lit...',
-      'node ./scripts/build.mjs --config=tsconfig.lit.json'
-    );
-
-    if (isStopped) {
-      return;
-    }
-
-    await nextTask(
-      'Running esbuild for autoloader ESM...',
-      'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
-    );
-
-    if (isStopped) {
-      return;
-    }
-
-    await nextTask(
-      'Running esbuild for autoloader CJS...',
-      'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
-    );
-
-    if (isStopped) {
-      return;
-    }
-
-    await nextTask('Building the custom elements manifest...', 'cem analyze');
-
-    if (isStopped) {
-      return;
-    }
-
-    await nextTask(
-      'Building storybook...',
-      'npx storybook build -o dist-storybook'
-    );
-
-    // Restart storybook server
-    // Somehow even after a build, the dev server doesn't pick up the changes.
-    // It needs a dev restart to pick them up.
-    storybookServer.kill('SIGTERM');
-    storybookServer = exec(
-      `npx storybook dev -p ${activePorts.storybook} --no-open`,
-      {
-        stdio: 'ignore',
-      }
-    );
-
-    if (isStopped) {
-      return;
-    }
-
-    console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
-  } finally {
-    buildInProgress = false;
-  }
-}
-
-watch('src', {recursive: true}, (_, filename) => {
+watch('src', {recursive: true}, async (_, filename) => {
   // Ignore irrelevant files
   if (
     filename.endsWith('.mdx') ||
@@ -377,32 +286,103 @@ watch('src', {recursive: true}, (_, filename) => {
     return;
   }
 
-  // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
-  // Without this, fs.watch fires concurrent async callbacks for each changed file,
-  // causing a thundering herd of parallel build processes.
   pendingChangeCount += 1;
-  lastChangedFile = filename;
 
-  if (debounceTimer) {
-    clearTimeout(debounceTimer);
+  if (changeLogTimer) {
+    clearTimeout(changeLogTimer);
   }
 
-  debounceTimer = setTimeout(() => {
-    debounceTimer = null;
-    const changeCount = pendingChangeCount;
-    const changedFile = lastChangedFile;
-    pendingChangeCount = 0;
-    lastChangedFile = '';
-
-    if (changeCount > 1) {
+  changeLogTimer = setTimeout(() => {
+    if (pendingChangeCount > 1) {
       console.log(
         colors.yellow(
-          `⚡ Detected ${changeCount} rapid file changes; coalescing into a single rebuild (e.g., branch checkout).`
+          `⚡ Detected ${pendingChangeCount} rapid file changes; coalescing into a single rebuild (e.g., branch checkout).`
         )
       );
     }
 
-    console.log(colors.cyanBright(`📂 File changed: ${changedFile}`));
-    runBuild();
-  }, DEBOUNCE_MS);
+    pendingChangeCount = 0;
+  }, CHANGE_LOG_WINDOW_MS);
+
+  // Stop all processes if a file changes to prevent multiple builds at once
+  await stopAllProcesses();
+  console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+
+  // Flag to stop the build process if a file changes during the build
+  isStopped = false;
+
+  if (isStencil) {
+    await nextTask(
+      'Rebuilding Stencil...',
+      'node --max_old_space_size=6144 ../../node_modules/@stencil/core/bin/stencil build --tsConfig tsconfig.stencil.json'
+    );
+
+    if (isStopped) {
+      return;
+    }
+
+    await nextTask(
+      'Placing the Stencil Proxy...',
+      'node ./scripts/stencil-proxy.mjs'
+    );
+
+    if (isStopped) {
+      return;
+    }
+  }
+
+  await nextTask(
+    'Rebuilding Lit...',
+    'node ./scripts/build.mjs --config=tsconfig.lit.json'
+  );
+
+  if (isStopped) {
+    return;
+  }
+
+  await nextTask(
+    'Running esbuild for autoloader ESM...',
+    'esbuild src/autoloader/index.ts --format=esm --outfile=dist/atomic/autoloader/index.esm.js'
+  );
+
+  if (isStopped) {
+    return;
+  }
+
+  await nextTask(
+    'Running esbuild for autoloader CJS...',
+    'esbuild src/autoloader/index.ts --format=cjs --outfile=dist/atomic/autoloader/index.cjs.js'
+  );
+
+  if (isStopped) {
+    return;
+  }
+
+  await nextTask('Building the custom elements manifest...', 'cem analyze');
+
+  if (isStopped) {
+    return;
+  }
+
+  await nextTask(
+    'Building storybook...',
+    'npx storybook build -o dist-storybook'
+  );
+
+  // Restart storybook server
+  // Somehow even after a build, the dev server doesn't pick up the changes.
+  // It needs a dev restart to pick them up.
+  storybookServer.kill('SIGTERM');
+  storybookServer = exec(
+    `npx storybook dev -p ${activePorts.storybook} --no-open`,
+    {
+      stdio: 'ignore',
+    }
+  );
+
+  if (isStopped) {
+    return;
+  }
+
+  console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
 });

--- a/packages/atomic/scripts/dev.mjs
+++ b/packages/atomic/scripts/dev.mjs
@@ -145,11 +145,7 @@ async function nextTask(text, command) {
   const spinner = createSpinner(text).start();
 
   return new Promise((resolve, reject) => {
-    const childProcess = exec(command);
-
-    if (childProcess.stderr) {
-      childProcess.stderr.pipe(process.stderr);
-    }
+    const childProcess = exec(command, {stdio: 'inherit'});
 
     // Add the process to the list of running processes to be able to stop them
     runningProcesses.push(childProcess);
@@ -162,7 +158,6 @@ async function nextTask(text, command) {
         resolve();
       } else {
         spinner.fail(colors.red.bold(`${text}`));
-        reject(new Error(`${text} failed with exit code ${code}`));
       }
     });
 
@@ -274,52 +269,18 @@ await startServers();
 // Watch the src folder for changes
 /** @type {ReturnType<typeof setTimeout> | null} */
 let debounceTimer = null;
+let buildInProgress = false;
 const DEBOUNCE_MS = 300;
-let pendingChangeCount = 0;
-watch('src', {recursive: true}, (_, filename) => {
-  // Ignore irrelevant files
-  if (
-    filename.endsWith('.mdx') ||
-    filename.endsWith('.new.stories.tsx') ||
-    filename.endsWith('.spec.ts') ||
-    filename.includes('e2e') ||
-    filename.endsWith('index.ts') ||
-    filename.endsWith('lazy-index.ts') ||
-    filename.endsWith('.DS_Store') ||
-    filename.endsWith('custom-element-tags.ts')
-  ) {
-    return;
-  }
 
-  pendingChangeCount += 1;
-
-  // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
-  // Without this, fs.watch fires concurrent async callbacks for each changed file,
-  // causing a thundering herd of parallel build processes.
-  if (debounceTimer) {
-    clearTimeout(debounceTimer);
-  }
-
-  debounceTimer = setTimeout(async () => {
-    debounceTimer = null;
-
-    if (pendingChangeCount > 1) {
-      console.log(
-        colors.yellow(
-          `⚡ Detected ${pendingChangeCount} rapid file changes; coalescing into a single rebuild (e.g., branch checkout).`
-        )
-      );
-    }
-
-    pendingChangeCount = 0;
-
-    // Stop all processes if a file changes to prevent multiple builds at once
+async function runBuild() {
+  if (buildInProgress) {
     await stopAllProcesses();
-    console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+  }
 
-    // Flag to stop the build process if a file changes during the build
-    isStopped = false;
+  buildInProgress = true;
+  isStopped = false;
 
+  try {
     if (isStencil) {
       await nextTask(
         'Rebuilding Stencil...',
@@ -394,5 +355,36 @@ watch('src', {recursive: true}, (_, filename) => {
     }
 
     console.log(colors.magenta.bold(' 🎇 Build process completed! 🎇 '));
+  } finally {
+    buildInProgress = false;
+  }
+}
+
+watch('src', {recursive: true}, (_, filename) => {
+  // Ignore irrelevant files
+  if (
+    filename.endsWith('.mdx') ||
+    filename.endsWith('.new.stories.tsx') ||
+    filename.endsWith('.spec.ts') ||
+    filename.includes('e2e') ||
+    filename.endsWith('index.ts') ||
+    filename.endsWith('lazy-index.ts') ||
+    filename.endsWith('.DS_Store') ||
+    filename.endsWith('custom-element-tags.ts')
+  ) {
+    return;
+  }
+
+  // Debounce: coalesce rapid file changes (e.g., branch switches) into a single build.
+  // Without this, fs.watch fires concurrent async callbacks for each changed file,
+  // causing a thundering herd of parallel build processes.
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    console.log(colors.cyanBright(`📂 File changed: ${filename}`));
+    runBuild();
   }, DEBOUNCE_MS);
 });


### PR DESCRIPTION
## Reason
Switching branches triggered dozens of simultaneous rebuilds, spawning many `npx @biomejs/biome format --write` processes and spiking CPU/memory.
<img width="972" height="1088" alt="image" src="https://github.com/user-attachments/assets/acef3c94-91b8-4106-82f8-3988930aaeba" />


## Root Cause
`fs.watch` fires one callback per changed file and does not await async handlers. During branch switches, many callbacks ran concurrently, each launching `build.mjs` (which runs Biome). The existing `isStopped` flag didn’t provide mutual exclusion, so parallel builds stacked up.
<img width="508" height="328" alt="image" src="https://github.com/user-attachments/assets/9c548243-05f6-413f-be53-fabeafd386be" />


## Fix
Add a debounce to coalesce rapid file-change bursts into a single build and introduce a simple build-in-progress guard that stops any running build before starting a new one. This eliminates concurrent rebuilds and prevents runaway Biome processes.