### PR TITLE
chore: add Kiro MCP server configuration

### DIFF
--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp"]
+    },
+    "storybook": {
+      "url": "http://localhost:4400/mcp"
+    }
+  }
+}


### PR DESCRIPTION
KIT-282
## Summary
Configure Model Context Protocol (MCP) servers for Kiro CLI to enable enhanced development tooling.

## Changes
- Add `.kiro/settings/mcp.json` with MCP server configuration

## Configured Servers
- **Atlassian**: Jira/Confluence integration
- **GitHub**: Repository operations  
- **Playwright**: Browser automation
- **Storybook**: Component testing (local)

## Benefits
- Enables AI-assisted workflows with external services
- Standardizes MCP configuration across the team
- Improves developer experience with integrated tooling