### PR TITLE
feat: add "Edit in GitHub" button to Storybook and Typedoc

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -6,6 +6,8 @@ import {render} from 'lit';
 import {initialize, mswLoader} from 'msw-storybook-addon';
 import {within} from 'shadow-dom-testing-library';
 import {create} from 'storybook/theming';
+import {createEditInGithubElement} from '@/storybook-utils/documentation/edit-in-github-button';
+import {resolveGithubPath} from '@/storybook-utils/documentation/resolve-github-path';
 import customElements from '../custom-elements.json';
 import {defineCustomElements} from '../dist/atomic/loader/index.js';
 import {COVEO_PRIMARY, FONT_BASE, FONT_CODE} from './theme';
@@ -32,12 +34,31 @@ setStorybookHelpersConfig({
   hideArgRef: true,
 });
 
-function disableAnalytics(container, selectors) {
+function disableAnalytics(container: HTMLElement, selectors: string[]) {
   selectors.forEach((selector) => {
     container.querySelectorAll(selector).forEach((element) => {
       element.setAttribute('analytics', 'false');
     });
   });
+}
+
+function ensureGlobalEditButton(): HTMLAnchorElement | null {
+  if (typeof document === 'undefined') return null;
+  let btn = document.getElementById(
+    'sb-edit-in-github-global'
+  ) as HTMLAnchorElement | null;
+  if (btn) return btn;
+  btn = createEditInGithubElement();
+  btn.id = 'sb-edit-in-github-global';
+  Object.assign(btn.style, {
+    position: 'fixed',
+    top: '1rem',
+    right: '1rem',
+    zIndex: '10000',
+    display: 'none',
+  });
+  document.body.appendChild(btn);
+  return btn;
 }
 
 const preview: Preview = {
@@ -66,9 +87,6 @@ const preview: Preview = {
       expanded: true,
     },
     a11y: {
-      // 'todo' - show a11y violations in the test UI only
-      // 'error' - fail CI on a11y violations
-      // 'off' - skip a11y checks entirely
       test: 'error',
     },
     docs: {
@@ -90,7 +108,6 @@ const preview: Preview = {
 
       if (story?._$litType$) {
         const container = document.createElement('div');
-
         render(story, container);
 
         const isTestMode =
@@ -106,9 +123,37 @@ const preview: Preview = {
             'atomic-commerce-recommendation-interface',
           ]);
         }
-
-        return story;
       }
+
+      return story;
+    },
+
+    // Global "Edit in GitHub" button — auto-derives source path from story file,
+    // hidden on Docs pages where AtomicDocTemplate renders its own button.
+    (Story, context) => {
+      const storyResult = Story();
+      const isDocs = context?.viewMode === 'docs';
+      const isIntroduction =
+        context?.title?.endsWith('/Introduction') ||
+        context?.title === 'Introduction';
+
+      // Priority: explicit parameter > auto-derived from story file path
+      const githubPath =
+        context?.parameters?.githubPath ??
+        context?.parameters?.docs?.githubPath ??
+        resolveGithubPath(context?.parameters?.fileName) ??
+        null;
+
+      const btn = ensureGlobalEditButton();
+      if (btn) {
+        if (githubPath && !isDocs && !isIntroduction) {
+          btn.href = `https://github.com/coveo/ui-kit/blob/main/packages/atomic/src/components/${githubPath}`;
+          btn.style.display = '';
+        } else {
+          btn.style.display = 'none';
+        }
+      }
+      return storyResult;
     },
   ],
   beforeEach({canvasElement, canvas}) {

--- a/packages/atomic/storybook-utils/documentation/atomic-doc-template.jsx
+++ b/packages/atomic/storybook-utils/documentation/atomic-doc-template.jsx
@@ -9,6 +9,7 @@ import {
 // biome-ignore lint/correctness/noUnusedImports: Storybook needs this import
 import React from 'react';
 import {CanvasWithGithub} from './canvas-with-github';
+import {EditInGithubButton} from './edit-in-github-button';
 
 /**
  * Reusable documentation template for Atomic Commerce components
@@ -37,20 +38,36 @@ export const AtomicDocTemplate = ({
 
   return (
     <>
-      <Title />
-      {tagName && className && (
-        <div
-          style={{
-            fontSize: '14px',
-            color: '#6b7280',
-            marginBottom: '16px',
-            fontFamily:
-              'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-          }}
-        >
-          &lt;{tagName}&gt; | {className}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '1rem',
+          marginBottom: '1rem',
+          width: '100%',
+        }}
+      >
+        <div style={{display: 'flex', flexDirection: 'column', gap: '0.25rem'}}>
+          <Title />
+          {tagName && className && (
+            <div
+              style={{
+                fontSize: '14px',
+                color: '#6b7280',
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+              }}
+            >
+              &lt;{tagName}&gt; | {className}
+            </div>
+          )}
         </div>
-      )}
+
+        <div style={{display: 'flex', alignItems: 'center'}}>
+          <EditInGithubButton githubPath={githubPath} />
+        </div>
+      </div>
       <Subtitle>
         <Description />
       </Subtitle>

--- a/packages/atomic/storybook-utils/documentation/edit-in-github-button.jsx
+++ b/packages/atomic/storybook-utils/documentation/edit-in-github-button.jsx
@@ -1,0 +1,184 @@
+// biome-ignore lint/correctness/noUnusedImports: Storybook needs this import
+import React, {useState} from 'react';
+
+const GitHubIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    style={{flexShrink: 0}}
+    aria-hidden="true"
+  >
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+  </svg>
+);
+
+/**
+ * A floating "Edit in GitHub" button that links to the Atomic component's source file.
+ * Rendered as a sticky float at the top-right of the docs page, matching the
+ * docs.coveo.com floating button experience.
+ *
+ * @param {Object} props
+ * @param {string} props.githubPath - Path relative to `packages/atomic/src/components/`
+ * (e.g., `"search/atomic-did-you-mean/atomic-did-you-mean.ts"`)
+ */
+export const EditInGithubButton = ({githubPath}) => {
+  const [hovered, setHovered] = useState(false);
+
+  if (!githubPath) {
+    return null;
+  }
+
+  const githubUrl = `https://github.com/coveo/ui-kit/blob/main/packages/atomic/src/components/${githubPath}`;
+
+  const containerStyle = {
+    display: 'block',
+    textAlign: 'right',
+    float: 'none',
+    position: 'static',
+    top: '1rem',
+    zIndex: 1000,
+    marginBottom: '1rem',
+  };
+
+  const anchorStyle = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: hovered ? '0.375rem 0.75rem' : '0.25rem',
+    width: hovered ? 'auto' : '36px',
+    height: '36px',
+    boxSizing: 'border-box',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    fontSize: '0.875rem',
+    transition: 'width 160ms ease, padding 160ms ease, background-color 160ms ease, color 160ms ease, border-color 160ms ease, box-shadow 160ms ease',
+    fontFamily: 'inherit',
+    fontWeight: 500,
+    color: hovered ? 'rgba(0,0,0,0.85)' : 'rgba(0,0,0,0.72)',
+    backgroundColor: '#e5e8e8',
+    border: hovered ? '1px solid rgba(0,0,0,0.12)' : '1px solid transparent',
+    borderRadius: '0.5rem',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+    cursor: 'pointer',
+    boxShadow: hovered ? '0 2px 6px rgba(0,0,0,0.06)' : 'none',
+    backdropFilter: hovered ? 'saturate(120%) blur(4px)' : 'none',
+  };
+
+  return (
+    <div style={containerStyle}>
+      <a
+        href={githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Edit in GitHub"
+        style={anchorStyle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <GitHubIcon />
+        {hovered && 'Edit in GitHub'}
+      </a>
+    </div>
+  );
+}
+
+// export a DOM factory that matches the React component styling/behavior
+export function createEditInGithubElement() {
+  const wrapper = document.createElement('div');
+  // mirror the React `containerStyle` used around the anchor so visual parity is exact
+  Object.assign(wrapper.style, {
+    display: 'block',
+    textAlign: 'right',
+    float: 'none',
+    position: 'static',
+    top: '1rem',
+    zIndex: '1000',
+    marginBottom: '1rem',
+    // ensure wrapper and children inherit the same docs font by default
+    fontFamily:
+      (typeof window !== 'undefined' &&
+        (window.getComputedStyle(
+          document.querySelector('.sbdocs-wrapper, .sbdocs-preview, .docs-root') ||
+            document.body
+        )?.fontFamily)) ||
+      'inherit',
+  });
+
+  const a = document.createElement('a');
+  a.setAttribute('aria-label', 'Edit in GitHub');
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+
+  Object.assign(a.style, {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    width: '36px', // fixed compact width pre-hover
+    minWidth: '36px',
+    height: '36px',
+    boxSizing: 'border-box',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    fontSize: '14px',
+    lineHeight: '1',
+    transition:
+      'width 160ms ease, padding 160ms ease, background-color 160ms ease, color 160ms ease, border-color 160ms ease, box-shadow 160ms ease',
+    fontFamily: '"Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif',
+    fontWeight: 500,
+    padding: '0.25rem', // compact padding
+    color: 'rgba(0,0,0,0.72)',
+    backgroundColor: '#e5e8e8',
+    borderRadius: '0.5rem',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+    cursor: 'pointer',
+    boxShadow: 'none',
+  });
+
+  a.innerHTML = `
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true" style="flex-shrink:0; display:block;">
+      <g fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></g>
+    </svg>
+  `;
+
+  a.addEventListener('mouseenter', () => {
+    a.style.width = 'auto';
+    a.style.padding = '0.375rem 0.75rem';
+    a.style.boxShadow = '0 2px 6px rgba(0,0,0,0.06)';
+    a.style.border = '1px solid rgba(0,0,0,0.12)';
+    a.style.backdropFilter = 'saturate(120%) blur(4px)';
+    a.style.color = 'rgba(0,0,0,0.85)';
+    if (!a.textContent.includes('Edit in GitHub')) a.appendChild(document.createTextNode('Edit in GitHub'));
+  });
+  a.addEventListener('mouseleave', () => {
+    a.style.width = '36px';
+    a.style.padding = '0.25rem';
+    a.style.boxShadow = 'none';
+    a.style.border = '1px solid transparent';
+    a.style.backdropFilter = 'none';
+    a.style.color = 'rgba(0,0,0,0.72)';
+    Array.from(a.childNodes).filter(n => n.nodeType === Node.TEXT_NODE).forEach(t => a.removeChild(t));
+  });
+
+  wrapper.appendChild(a);
+
+  // expose `href` on the wrapper so existing preview code can set `btn.href`
+  Object.defineProperty(wrapper, 'href', {
+    get() {
+      return a.href;
+    },
+    set(v) {
+      a.href = v;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+
+  // expose a convenient method to update the inner anchor (in case callers want it)
+  wrapper._anchor = a;
+
+  return wrapper;
+}

--- a/packages/atomic/storybook-utils/documentation/resolve-github-path.ts
+++ b/packages/atomic/storybook-utils/documentation/resolve-github-path.ts
@@ -1,0 +1,52 @@
+const GITHUB_BASE =
+  'https://github.com/coveo/ui-kit/blob/main/packages/atomic/src/components/';
+
+/**
+ * Derives the relative component source path from a Storybook story's import path.
+ *
+ * Handles `.new.stories.tsx`, `.stories.tsx`, and `.mdx` files by mapping them
+ * back to the component's `.ts` source file.
+ *
+ * @example
+ * resolveGithubPath('./src/components/search/atomic-pager/atomic-pager.new.stories.tsx')
+ * // => 'search/atomic-pager/atomic-pager.ts'
+ */
+export function resolveGithubPath(
+  importPath: string | undefined
+): string | null {
+  if (!importPath) {
+    return null;
+  }
+
+  const componentsIndex = importPath.indexOf('src/components/');
+  if (componentsIndex === -1) {
+    return null;
+  }
+
+  const relativePath = importPath.substring(
+    componentsIndex + 'src/components/'.length
+  );
+
+  return relativePath
+    .replace(/\.new\.stories\.tsx$/, '.ts')
+    .replace(/\.stories\.tsx$/, '.ts')
+    .replace(/\.mdx$/, '.ts');
+}
+
+/**
+ * Derives the full GitHub URL for a component source file from a Storybook
+ * story's import path.
+ *
+ * @example
+ * resolveGithubUrl('./src/components/search/atomic-pager/atomic-pager.new.stories.tsx')
+ * // => 'https://github.com/coveo/ui-kit/blob/main/packages/atomic/src/components/search/atomic-pager/atomic-pager.ts'
+ */
+export function resolveGithubUrl(
+  importPath: string | undefined
+): string | null {
+  const path = resolveGithubPath(importPath);
+  if (!path) {
+    return null;
+  }
+  return `${GITHUB_BASE}${path}`;
+}

--- a/packages/documentation/assets/css/edit-in-github.css
+++ b/packages/documentation/assets/css/edit-in-github.css
@@ -1,0 +1,88 @@
+[data-theme="dark"] {
+  --edit-gh-bg: #8787db;
+  --edit-gh-color: #f9f9f9;
+}
+
+[data-theme="light"] {
+  --edit-gh-bg: #e5e8e8;
+  --edit-gh-color: rgba(0, 0, 0, 0.72);
+}
+
+.tsd-page-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.tsd-page-title-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.typedoc-edit-github {
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.typedoc-edit-github a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  box-sizing: border-box;
+  justify-content: center;
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1;
+  font-family: inherit;
+  font-weight: 500;
+  padding: 0.25rem;
+  color: var(--edit-gh-color);
+  background-color: var(--edit-gh-bg);
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: none;
+  backdrop-filter: none;
+  transition:
+    width 160ms ease,
+    min-width 160ms ease,
+    padding 160ms ease,
+    gap 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.typedoc-edit-github a svg {
+  flex-shrink: 0;
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
+.typedoc-edit-github-label {
+  display: none;
+}
+
+.typedoc-edit-github a:hover,
+.typedoc-edit-github a:focus-visible {
+  width: auto;
+  min-width: 36px;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  color: var(--edit-gh-color);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  backdrop-filter: saturate(120%) blur(4px);
+}
+
+.typedoc-edit-github a:hover .typedoc-edit-github-label,
+.typedoc-edit-github a:focus-visible .typedoc-edit-github-label {
+  display: inline;
+}

--- a/packages/documentation/assets/vars/dark-mode-toggle.js
+++ b/packages/documentation/assets/vars/dark-mode-toggle.js
@@ -37,7 +37,7 @@ const PERMANENT_COLOR_SCHEME = 'permanentcolorscheme';
 const ALL = 'all';
 const NOT_ALL = 'not all';
 const NAME = 'dark-mode-toggle';
-const DEFAULT_URL = '../assets/icons/';
+const DEFAULT_URL = '/assets/icons/';
 
 // See https://html.spec.whatwg.org/multipage/common-dom-interfaces.html ↵
 // #reflecting-content-attributes-in-idl-attributes.

--- a/packages/documentation/lib/index.tsx
+++ b/packages/documentation/lib/index.tsx
@@ -22,6 +22,7 @@ import {hoistOtherCategoryInArray, hoistOtherCategoryInNav} from './hoist.js';
 import {insertAtomicSearchBox} from './insertAtomicSearchBox.js';
 import {insertBetaNote} from './insertBetaNote.js';
 import {insertCustomComments} from './insertCustomComments.js';
+import {insertEditInGithub} from './insertEditInGithub.js';
 import {insertMetaTags} from './insertMetaTags.js';
 import {insertSiteHeaderBar} from './insertSiteHeaderBar.js';
 import {applyTopLevelRenameArray} from './renaming.js';
@@ -224,6 +225,10 @@ export const load = (app: Application) => {
         rel="stylesheet"
         href={event.relativeURL('assets/css/main-new.css')}
       />
+      <link
+        rel="stylesheet"
+        href={event.relativeURL('assets/css/edit-in-github.css')}
+      />
       <script
         type="module"
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
@@ -261,6 +266,7 @@ export const load = (app: Application) => {
   app.renderer.on(RendererEvent.END, () => {
     const baseAssetsPath = '../../documentation/assets';
     const filesToCopy = [
+      'css/edit-in-github.css',
       'css/docs-style.css',
       'css/main-new.css',
       'css/light-theme.css',
@@ -300,6 +306,7 @@ export const load = (app: Application) => {
   });
 
   app.renderer.on(PageEvent.END, insertMetaTags);
+  app.renderer.on(PageEvent.END, insertEditInGithub);
   app.renderer.on(Renderer.EVENT_END_PAGE, handleRendererEndPage);
 
   app.renderer.defineRouter('kebab', KebabRouter);

--- a/packages/documentation/lib/insertEditInGithub.ts
+++ b/packages/documentation/lib/insertEditInGithub.ts
@@ -1,0 +1,188 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {PageEvent, Reflection} from 'typedoc';
+
+const GITHUB_BASE = 'https://github.com/coveo/ui-kit/blob/main/';
+const SOURCE_DOCS_REPO_PATH = 'packages/headless/source_docs';
+const DOCUMENT_PAGE_PREFIX = 'documents/';
+
+let mdSourceMap: Map<string, string> | null = null;
+
+function normalizeKey(s?: string | null): string {
+  if (!s) return '';
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.html$/, '');
+}
+
+/**
+ * Scans `source_docs/` (relative to cwd, which is `packages/headless/`
+ * during TypeDoc builds) and builds a map of
+ * normalized slug → repo-relative file path.
+ *
+ * Example entry:
+ *   `"usage/server-side-rendering/implement-search-parameter-support"`
+ *     → `"packages/headless/source_docs/ssr-implement-search-parameter-support.md"`
+ */
+function buildMarkdownSourceMap(): Map<string, string> {
+  if (mdSourceMap) return mdSourceMap;
+  mdSourceMap = new Map();
+
+  const sourceDocsDir = path.resolve(process.cwd(), 'source_docs');
+
+  if (!fs.existsSync(sourceDocsDir)) {
+    return mdSourceMap;
+  }
+
+  try {
+    const files = fs
+      .readdirSync(sourceDocsDir)
+      .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+
+    for (const file of files) {
+      const filePath = path.join(sourceDocsDir, file);
+      const content = fs.readFileSync(filePath, 'utf8');
+      const repoRelativePath = `${SOURCE_DOCS_REPO_PATH}/${file}`;
+
+      const fmMatch = content.match(/^---\s*([\s\S]*?)\s*---/);
+      if (fmMatch) {
+        const block = fmMatch[1];
+
+        const slugMatch = block.match(/^\s*slug:\s*['"]?([^'"\n]+)['"]?\s*$/m);
+        if (slugMatch) {
+          mdSourceMap.set(normalizeKey(slugMatch[1]), repoRelativePath);
+        }
+
+        const titleMatch = block.match(
+          /^\s*title:\s*['"]?([^'"\n]+)['"]?\s*$/m
+        );
+        if (titleMatch) {
+          mdSourceMap.set(normalizeKey(titleMatch[1]), repoRelativePath);
+        }
+      }
+
+      const baseName = normalizeKey(path.basename(file, path.extname(file)));
+      mdSourceMap.set(baseName, repoRelativePath);
+    }
+  } catch {
+    // Silently ignore — button simply won't appear for document pages
+  }
+
+  return mdSourceMap;
+}
+
+/**
+ * Resolves a TypeDoc document page URL to a repo-relative `source_docs/` path.
+ *
+ * TypeDoc generates document pages at URLs like `documents/usage/proxy.html`
+ * while frontmatter slugs are `usage/proxy`. The function strips the
+ * `documents/` prefix and tries progressively shorter segments.
+ *
+ * Match strategies (in order):
+ *   1. Direct slug match (e.g., `"usage/proxy"`)
+ *   2. Progressive segment match — strips leading segments one at a time
+ *   3. Last URL segment match (e.g., `"proxy"`)
+ */
+function inferSourceDocPath(pageUrl: string): string | null {
+  let normalized = normalizeKey(pageUrl);
+
+  // Strip the TypeDoc "documents/" prefix so URLs align with frontmatter slugs
+  if (normalized.startsWith('documents/')) {
+    normalized = normalized.slice('documents/'.length);
+  }
+
+  const map = buildMarkdownSourceMap();
+
+  // 1) Direct match against slug
+  if (map.has(normalized)) {
+    return map.get(normalized)!;
+  }
+
+  // 2) Progressive segment match (handles nested slugs)
+  const segments = normalized.split('/').filter(Boolean);
+  for (let i = 1; i < segments.length; i++) {
+    const candidate = segments.slice(i).join('/');
+    if (map.has(candidate)) {
+      return map.get(candidate)!;
+    }
+  }
+
+  // 3) Last segment match (broadest, least precise)
+  const lastSegment = segments[segments.length - 1];
+  if (lastSegment && map.has(lastSegment)) {
+    return map.get(lastSegment)!;
+  }
+
+  return null;
+}
+
+/**
+ * TypeDoc `PageEvent.END` handler that injects a floating
+ * "Edit in GitHub" button into each rendered page.
+ *
+ * For code reflection pages the link points to the source file + line.
+ * For document pages (markdown articles) the link points to the
+ * corresponding file under `packages/headless/source_docs/`.
+ */
+export function insertEditInGithub(page: PageEvent<Reflection>) {
+  const model = page.model as Reflection & {
+    sources?: Array<{fullFileName?: string; line?: number}>;
+  };
+
+  let githubUrl: string | null = null;
+  const pageUrl = page.url ?? '';
+
+  // 1) Code reflections — derive from model.sources
+  if (model?.sources?.length && model.sources[0]?.fullFileName) {
+    const src = model.sources[0];
+    const idx = src.fullFileName.indexOf('packages/');
+    if (idx !== -1) {
+      const relativePath = src.fullFileName.substring(idx).replace(/\\/g, '/');
+      const line = src.line ?? 1;
+      githubUrl = `${GITHUB_BASE}${relativePath}#L${line}`;
+    }
+  }
+
+  // 2) Document pages — match page URL against source_docs slug map
+  if (!githubUrl && String(pageUrl).startsWith(DOCUMENT_PAGE_PREFIX)) {
+    const inferredPath = inferSourceDocPath(String(pageUrl));
+    if (inferredPath) {
+      githubUrl = `${GITHUB_BASE}${inferredPath}`;
+    }
+  }
+
+  if (!githubUrl || !page.contents) {
+    return;
+  }
+
+  function buildButtonHtml(url: string): string {
+    return `
+    <div class="typedoc-edit-github">
+      <a href="${url}" target="_blank" rel="noopener noreferrer" aria-label="Edit in GitHub">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        <span class="typedoc-edit-github-label">Edit in GitHub</span>
+      </a>
+    </div>`;
+  }
+
+  const buttonHtml = buildButtonHtml(githubUrl);
+
+  if (page.contents.includes('class="tsd-page-title"')) {
+    page.contents = page.contents.replace(
+      /(<div\s+class="tsd-page-title">)([\s\S]*?)(<\/div>)/i,
+      (_match, openTag, innerContent, closeTag) =>
+        `${openTag}<div class="tsd-page-title-content">${innerContent}</div>${buttonHtml}${closeTag}`
+    );
+    return;
+  }
+
+  if (page.contents.includes('</body>')) {
+    page.contents = page.contents.replace('</body>', `${buttonHtml}</body>`);
+  } else {
+    page.contents += buttonHtml;
+  }
+}

--- a/packages/headless/source_docs/headless-saml-authentication.md
+++ b/packages/headless/source_docs/headless-saml-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: SAML authentication
 group: Usage
-slug : usage/saml-authentication
+slug: usage/saml-authentication
 ---
 # Configure SAML authentication
 The [Search API](https://docs.coveo.com/en/52/) supports SAML authentication, and the [`@coveo/auth`](https://github.com/coveo/ui-kit/tree/master/packages/auth) package lets you easily enable SAML authentication in a search page built with the [Coveo Headless library](https://docs.coveo.com/en/lcdf0493/).

--- a/packages/headless/source_docs/relevance-generative-answering.md
+++ b/packages/headless/source_docs/relevance-generative-answering.md
@@ -1,6 +1,7 @@
 ---
 title: Use Relevance Generative Answering (RGA)
 group: Usage
+slug: usage/relevance-generative-answering
 ---
 # Use Relevance Generative Answering (RGA)
 


### PR DESCRIPTION
**Summary**

Make asset references resolve reliably for any doc page depth on Typedoc to resolve [DOC-18778](https://coveord.atlassian.net/browse/DOC-18778).

Introduces "Edit in Github" button to Storybook and Typedoc [DOC-18603](https://coveord.atlassian.net/browse/DOC-18603)

[DOC-18778]: https://coveord.atlassian.net/browse/DOC-18778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-18603]: https://coveord.atlassian.net/browse/DOC-18603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ