### PR TITLE
fix(headless): properly reset isEnabled property representing follow up capability

### DIFF
--- a/packages/headless/src/features/follow-up-answers/follow-up-answers-slice.test.ts
+++ b/packages/headless/src/features/follow-up-answers/follow-up-answers-slice.test.ts
@@ -875,13 +875,13 @@ describe('follow-up answers slice', () => {
       expect(finalState.conversationId).toBe('');
     });
 
-    it('preserves isEnabled', () => {
+    it('clears isEnabled', () => {
       state.isEnabled = true;
       state.followUpAnswers = [createInitialFollowUpAnswer('Question?')];
 
       const finalState = followUpAnswersReducer(state, resetFollowUpAnswers());
 
-      expect(finalState.isEnabled).toBe(true);
+      expect(finalState.isEnabled).toBe(false);
       expect(finalState.followUpAnswers).toEqual([]);
     });
 
@@ -890,6 +890,7 @@ describe('follow-up answers slice', () => {
 
       expect(finalState.followUpAnswers).toEqual([]);
       expect(finalState.conversationId).toBe('');
+      expect(finalState.isEnabled).toBe(false);
     });
   });
 

--- a/packages/headless/src/features/follow-up-answers/follow-up-answers-slice.ts
+++ b/packages/headless/src/features/follow-up-answers/follow-up-answers-slice.ts
@@ -207,5 +207,6 @@ export const followUpAnswersReducer = createReducer(
       .addCase(resetFollowUpAnswers, (state) => {
         state.followUpAnswers = [];
         state.conversationId = '';
+        state.isEnabled = false;
       })
 );


### PR DESCRIPTION
## [SFINT-6671](https://coveord.atlassian.net/browse/SFINT-6671)

This PR ensures that the isEnabled flag is also reset when resetFollowUpAnswers is dispatched.

Currently, only the follow-up answers and conversation ID are cleared, which can leave the slice in an inconsistent state.

At the moment, this issue is not visible because the follow-up capability cannot be toggled after an agent is created. However, this may change in the future, so it’s safer to fully reset the state now to prevent potential issues later.

[SFINT-6671]: https://coveord.atlassian.net/browse/SFINT-6671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ