### PR TITLE
Update react-router version to 7.12.0

### DIFF
--- a/samples/headless-ssr/commerce-react-router/package.json
+++ b/samples/headless-ssr/commerce-react-router/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@coveo/headless-react": "workspace:*",
-    "@react-router/fs-routes": "7.10.1",
-    "@react-router/node": "7.10.1",
-    "@react-router/serve": "7.10.1",
+    "@react-router/fs-routes": "7.12.0",
+    "@react-router/node": "7.12.0",
+    "@react-router/serve": "7.12.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-router": "7.12.0",
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@coveo/relay-event-types": "catalog:",
-    "@react-router/dev": "7.10.1",
+    "@react-router/dev": "7.12.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "typescript": "catalog:",


### PR DESCRIPTION
React Router is a router for React. In @remix-run/router version prior to 1.23.2. and react-router 7.0.0 through 7.11.0, React Router (and Remix v1/v2) SPA open navigation redirects originating from loaders or actions in Framework Mode, Data Mode, or the unstable RSC modes can result in unsafe URLs causing unintended javascript execution on the client. This is only an issue if you are creating redirect paths from untrusted content or via an open redirect. There is no impact if Declarative Mode (<BrowserRouter>) is being used. This issue has been patched in @remix-run/router version 1.23.2 and react-router version 7.12.0.