### PR TITLE
fix(atomic) issue with the Atomic-generated-answer collapsible parameter is not working as expected

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -707,25 +707,21 @@ describe('atomic-generated-answer', () => {
     await expect.element(showMoreButton).not.toBeInTheDocument();
   });
 
-  it('should pass collapsible as false to renderAnswerContent when content is short', async () => {
-    const renderedAnswer = await renderGeneratedAnswer({
-      props: {collapsible: true, maxCollapsedHeight: 16},
+  it('should pass collapsible as false to renderAnswerContent when collapsible is disabled', async () => {
+    await renderGeneratedAnswer({
+      props: {collapsible: false, maxCollapsedHeight: 16},
       generatedAnswerState: {
         isVisible: true,
         answer: 'Short text',
       },
     });
 
-    Reflect.set(renderedAnswer.element, 'fullAnswerHeight', 8);
-    await renderedAnswer.element.requestUpdate();
-    await renderedAnswer.element.updateComplete;
-
     const lastCall = vi.mocked(renderAnswerContent).mock.calls.at(-1);
     expect(lastCall).toBeDefined();
     expect(lastCall?.[0].props.collapsible).toBe(false);
   });
 
-  it('should pass collapsible as true to renderAnswerContent when content is taller than maxCollapsedHeight', async () => {
+  it('should pass collapsible as true to renderAnswerContent when collapsible is enabled and content is tall', async () => {
     const renderedAnswer = await renderGeneratedAnswer({
       props: {collapsible: true, maxCollapsedHeight: 16},
       generatedAnswerState: {
@@ -734,7 +730,7 @@ describe('atomic-generated-answer', () => {
       },
     });
 
-    Reflect.set(renderedAnswer.element, 'fullAnswerHeight', 20);
+    Reflect.set(renderedAnswer.element, 'fullAnswerHeight', 100);
     await renderedAnswer.element.requestUpdate();
     await renderedAnswer.element.updateComplete;
 

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -288,7 +288,7 @@ export class AtomicGeneratedAnswer
 
     this.controller.insertFeedbackModal();
 
-    if (window.ResizeObserver && this.isCollapsibleEnabled) {
+    if (window.ResizeObserver && this.collapsible) {
       const debouncedAdaptAnswerHeight = debounce(
         () => this.adaptAnswerHeight(),
         100


### PR DESCRIPTION
[SFINT-6691](https://coveord.atlassian.net/browse/SFINT-6691)

This is following a support case from a client, the issue was introduced in v3.52.1

## ISSUE:
The answer collapse behaviour was inconsistent because the collapsibility of the answer depended on measured content height too early in the lifecycle. This could prevent long answers from appearing collapsible even when `collapsible` was enabled.


## SOLUTION:
The fix ensures resize observation starts whenever `collapsible` is enabled, so answer height is measured and updated reliably after render. Collapsibility is then applied only when all required conditions are met: `collapsible=true`, follow-ups are not enabled, and content height exceeds the configured collapsed height. This guarantees that follow-up mode is never collapsible while preserving correct collapse/expand behaviour for long single answers.


### Why not just change the `isCollapsibleEnabled` ?

Because they solve different problems.

isCollapsibleEnabled is :

- collapsible prop is on
- follow-ups are off
- measured height is above threshold

The initialization condition controls whether measurement starts at all ( ResizeObserver setup)

If that condition depends on isCollapsibleEnabled, it creates a  problem: height is unknown before observing, so isCollapsibleEnabled is initially false, so observer never starts, so height never updates.

So the observer condition should stay broad (this.collapsible) to start measuring, while isCollapsibleEnabled should stay strict to decide when collapse UI is actually enabled.

[SFINT-6691]: https://coveord.atlassian.net/browse/SFINT-6691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ