### PR TITLE
fix(atomic) Answer content shifts upward when generation steps component disappears after answer generation

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/render-agent-generation-steps.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/render-agent-generation-steps.spec.ts
@@ -145,22 +145,6 @@ describe('#renderAgentGenerationSteps', () => {
       .toHaveTextContent(i18n.t('agent-generation-step-think'));
   });
 
-  it('should render the active answering step label when streaming', async () => {
-    const {element} = await renderComponent({
-      agentSteps: [
-        buildStep({
-          name: GENERATION_STEPS.answering,
-          status: STEP_STATUS.active,
-        }),
-      ],
-      isStreaming: true,
-    });
-
-    await expect
-      .element(element)
-      .toHaveTextContent(i18n.t('generating-answer'));
-  });
-
   it('should not render anything when there is no active step', async () => {
     const {element} = await renderComponent({
       agentSteps: [

--- a/packages/atomic/src/components/common/generated-answer/render-agent-generation-steps.ts
+++ b/packages/atomic/src/components/common/generated-answer/render-agent-generation-steps.ts
@@ -5,10 +5,9 @@ import {keyed} from 'lit/directives/keyed.js';
 import {when} from 'lit/directives/when.js';
 import type {FunctionalComponent} from '@/src/utils/functional-component-utils';
 
-const stepLabelKeys: Record<GenerationStepName, string> = {
+const stepLabelKeys: Partial<Record<GenerationStepName, string>> = {
   searching: 'agent-generation-step-search',
   thinking: 'agent-generation-step-think',
-  answering: 'generating-answer',
 };
 
 export interface RenderAgentGenerationStepsProps {


### PR DESCRIPTION
[SFINT-6684](https://coveord.atlassian.net/browse/SFINT-6684)

## ISSUE

Once the generation steps disappear, the content that is generated shifts upwards creating a glitchy look and feel to the component.

## SOLUTION

We decided to remove the "Generating answer" step since it appears when the content itself is generating so its already pretty obvious it is generating.

Now we will support Searching, Thinking steps which appears before the content is generated so it is not impacting the height and therefore not doing the glitchy behaviour.

### ALTERNATIVE SOLUTION CONSIDERED

We considered adding a fixed height to the steps container. This fixed the issue, but then would leave a weird gap between the query and the content. Since we already had customers complaining about the unecessary spacing for the query we deemed this to not be a good solution.

## DEMO

https://github.com/user-attachments/assets/e10f75d1-cbf1-4eda-8fe6-ce09c4fe924e



[SFINT-6684]: https://coveord.atlassian.net/browse/SFINT-6684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ