### PR TITLE
docs(headless-react): adjusting styleing of typedoc site; aligning TOC

### DIFF
--- a/packages/documentation/assets/css/dark-theme.css
+++ b/packages/documentation/assets/css/dark-theme.css
@@ -610,6 +610,18 @@ code.code-text-red mark {
   color: #f1f2ff !important;
 }
 
+.tsd-page-navigation {
+  background-color: #333357;
+}
+
+.tsd-page-navigation a {
+  color: #f1f2ff;
+}
+
+.tsd-page-navigation-section > .tsd-accordion-summary + h3 {
+  color: #f1f2ff;
+}
+
 .btn-outline-primary.toc-thumbs-up-btn,
 .btn-outline-primary.toc-thumbs-down-btn {
   border: none;

--- a/packages/documentation/assets/css/docs-style.css
+++ b/packages/documentation/assets/css/docs-style.css
@@ -65,6 +65,64 @@ body {
   font-weight: 400;
 }
 
+.tsd-page-navigation {
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.tsd-page-navigation a {
+  font-size: 12px;
+}
+
+.tsd-accordion-summary::marker {
+  display: none;
+  content: "";
+}
+
+.tsd-accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tsd-page-navigation-section > .tsd-accordion-summary {
+  display: none;
+}
+.tsd-page-navigation-section > .tsd-accordion-summary + h3{
+  font-weight: bold;
+  font-size: 12px;
+}
+
+.tsd-page-navigation-section > .tsd-accordion-summary > svg {
+  display: none;
+}
+
+.tsd-page-navigation .tsd-accordion-details {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.tsd-page-navigation .tsd-accordion-details ul {
+  list-style-type: none;
+  padding-left: 0.75rem;
+}
+
+.col-content a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.col-content a:hover {
+  color: inherit;
+}
+
+.col-content .tsd-signature a {
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+.col-content .tsd-signature a:hover {
+  color: var(--color-link);
+}
+
 @media (max-width: 769px) {
   .feedback {
     display: none;
@@ -88,5 +146,28 @@ body {
   }
   .tsd-widget.active {
     background-color: inherit;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 200;
+  line-height: 1.2;
+}
+
+h1 { font-size: 2.5rem; }
+h2 { font-size: 2rem; }
+h3 { font-size: 1.75rem; }
+h4 { font-size: 1.5rem; }
+h5 { font-size: 1.25rem; }
+h6 { font-size: 1rem; }
+
+.col-content {
+  min-width: 36rem;
+}
+
+@media (max-width: 575.98px) {
+  .col-content {
+    min-width: 0;
+    width: 100%;
   }
 }

--- a/packages/documentation/assets/css/light-theme.css
+++ b/packages/documentation/assets/css/light-theme.css
@@ -604,6 +604,18 @@ code.code-text-red mark {
   color: #525296 !important;
 }
 
+.tsd-page-navigation {
+  background-color: #f1f2ff;
+}
+
+.tsd-page-navigation a {
+  color: #333357;
+}
+
+.tsd-page-navigation-section > .tsd-accordion-summary + h3 {
+  color: #333357;
+}
+
 .btn-outline-primary.toc-thumbs-up-btn,
 .btn-outline-primary.toc-thumbs-down-btn {
   border: none;

--- a/packages/documentation/lib/formatRightToc.ts
+++ b/packages/documentation/lib/formatRightToc.ts
@@ -1,0 +1,16 @@
+import type {PageEvent} from 'typedoc';
+
+export const formatRightToc = (page: PageEvent) => {
+  if (!page.contents) return;
+
+  page.contents = page.contents.replace(
+    /(tsd-page-navigation">)<summary class="tsd-accordion-summary">[\s\S]*?<\/summary>/,
+    '$1<summary class="tsd-accordion-summary"></summary><div class="right-toc-text">In this article</div>'
+  );
+
+  // Remove the top-level heading link from the right-hand TOC while preserving the list structure
+  page.contents = page.contents.replace(
+    /(<div class="tsd-accordion-details">)\s*<a[^>]*>[\s\S]*?<\/a>\s*(<ul>[\s\S]*?<\/ul>)\s*(<\/div>\s*<\/details>)/,
+    '$1$2$3'
+  );
+};

--- a/packages/documentation/lib/index.tsx
+++ b/packages/documentation/lib/index.tsx
@@ -17,6 +17,7 @@ import {
   RendererEvent,
 } from 'typedoc';
 import {handleRendererEndPage} from './calloutParsing.js';
+import {formatRightToc} from './formatRightToc.js';
 import {formatTypeDocToolbar} from './formatTypeDocToolbar.js';
 import {hoistOtherCategoryInArray, hoistOtherCategoryInNav} from './hoist.js';
 import {insertAtomicSearchBox} from './insertAtomicSearchBox.js';
@@ -24,6 +25,7 @@ import {insertBetaNote} from './insertBetaNote.js';
 import {insertCustomComments} from './insertCustomComments.js';
 import {insertMetaTags} from './insertMetaTags.js';
 import {insertSiteHeaderBar} from './insertSiteHeaderBar.js';
+import {removeNavSettings} from './removeNavSettings.js';
 import {applyTopLevelRenameArray} from './renaming.js';
 import {
   applyNestedOrderingArray,
@@ -163,6 +165,7 @@ export const load = (app: Application) => {
 
   app.renderer.hooks.on('head.end', (event) => (
     <>
+      <link rel="stylesheet" href="https://use.typekit.net/bqa0xml.css" />
       <script>
         <JSX.Raw html={`(${insertBetaNote.toString()})();`} />
       </script>
@@ -296,6 +299,8 @@ export const load = (app: Application) => {
   });
 
   app.renderer.on(PageEvent.END, insertMetaTags);
+  app.renderer.on(PageEvent.END, formatRightToc);
+  app.renderer.on(PageEvent.END, removeNavSettings);
   app.renderer.on(Renderer.EVENT_END_PAGE, handleRendererEndPage);
 
   app.renderer.defineRouter('kebab', KebabRouter);

--- a/packages/documentation/lib/removeNavSettings.ts
+++ b/packages/documentation/lib/removeNavSettings.ts
@@ -1,0 +1,14 @@
+import {DocumentReflection, type PageEvent} from 'typedoc';
+
+export const removeNavSettings = (page: PageEvent) => {
+  if (!page.contents) return;
+
+  const isHandwrittenDoc = page.model instanceof DocumentReflection;
+
+  if (isHandwrittenDoc || page.url === 'index.html') {
+    page.contents = page.contents.replace(
+      /<div class="tsd-navigation settings">[\s\S]*?<\/details>\s*<\/div>/,
+      ''
+    );
+  }
+};

--- a/packages/headless-react/CONTRIBUTING.md
+++ b/packages/headless-react/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+---
+title: Contributing
+---
+# Contributing to @coveo/headless-react
+
+## Entry points
+
+| Sub-package                                    | Entry point                               |
+| ---------------------------------------------- | ----------------------------------------- |
+| Search SSR                                     | `@coveo/headless-react/ssr`               |
+| Commerce SSR (Open Beta)                       | `@coveo/headless-react/ssr-commerce`      |
+| Search SSR (experimental, subject to change)   | `@coveo/headless-react/ssr-next`          |
+| Commerce SSR (experimental, subject to change) | `@coveo/headless-react/ssr-commerce-next` |
+
+## Getting started
+
+Once you have cloned the repo, follow the instructions in the top-level [README.md](https://github.com/coveo/ui-kit/blob/main/README.md) to install dependencies and link packages.
+
+To build the library for production, run:
+
+```bash
+pnpm run build
+```
+
+To run the unit tests, run:
+
+```bash
+pnpm test
+```
+
+To run the unit tests in watch mode, run:
+
+```bash
+pnpm run test:watch
+```
+
+## Generating documentation
+
+The documentation is built in two stages using [TypeDoc](https://typedoc.org/) with the `@coveo/documentation` plugin.
+
+**Stage 1** generates intermediate JSON for each sub-package:
+
+```bash
+pnpm run build:typedoc:docs
+```
+
+**Stage 2** merges the JSON and produces the final HTML site:
+
+```bash
+pnpm run build:typedoc:merge
+```
+
+Or run both stages together:
+
+```bash
+pnpm run build:typedoc
+```
+
+To preview the generated documentation locally:
+
+```bash
+pnpm run serve:typedoc
+```
+
+Handwritten documentation articles live in `source_docs/` and are included via the `projectDocuments` option in `typedoc.json`.
+
+## Source folder structure
+
+`/src/ssr` contains the search SSR engine definition, React hooks, and context providers.
+
+`/src/ssr-commerce` contains the commerce SSR engine definition, React hooks, and context providers.
+
+`/src/ssr-next` re-exports from `ssr` for experimental/upcoming breaking changes.
+
+`/src/ssr-commerce-next` re-exports from `ssr-commerce` for experimental/upcoming breaking changes.
+
+`/src/__tests__` contains shared test utilities, mocks, and setup.
+
+`/src/client-utils.ts` contains client-side utility functions.
+
+`/src/errors.ts` defines custom error types.
+
+`/src/utils.ts` contains shared utility functions.

--- a/packages/headless-react/README.md
+++ b/packages/headless-react/README.md
@@ -1,7 +1,7 @@
 ---
 title: Home
 ---
-# Headless React Utils for SSR
+# Use the Headless React library for Server Side Rendering
 
 
 `@coveo/headless-react` provides React utilities for server-side rendering with headless controllers. This package includes several sub-packages:

--- a/packages/headless-react/source_docs/commerce-hooks.md
+++ b/packages/headless-react/source_docs/commerce-hooks.md
@@ -1,18 +1,17 @@
 ---
 title: Commerce Controller hooks
-group: Usage
+group: Guides
 ---
 
-# Hooks
+# Commerce Hooks
 
 This package provides React hooks for controllers defined in the Engine Definition. Hooks allow you to access controller state and methods easily within your React components.
 Without these hooks, you would need to manually pass down props through every component or implement your own provider solution, which can be cumbersome and error-prone.
 
 See [Headless commerce usage (SSR): Define the commerce engine and controllers](https://docs.coveo.com/en/obif0156/#define-the-commerce-engine-and-controllers)
 
-## Usage
 
-### 1. Create an engine configuration
+## Create an engine configuration
 
 Define the controllers you need in your engine configuration. This example includes `Summary`, `ProductList` and `Cart` controllers:
 
@@ -37,7 +36,7 @@ const config : CommerceEngineDefinitionOptions {
 }
 ```
 
-### 2. Define the engine
+## Define the engine
 
 Use `defineCommerceEngine` to define the engine with your configuration:
 
@@ -45,7 +44,7 @@ Use `defineCommerceEngine` to define the engine with your configuration:
 export const engineDefinition = defineCommerceEngine(engineConfig);
 ```
 
-### 3. Export hooks
+## Export hooks
 
 Extract hooks for each controller from the engine definition.
 
@@ -57,7 +56,7 @@ export const {
 } = engineDefinition.controllers;
 ```
 
-### 4. Use Hooks in Components
+## Use hooks in components
 
 Access controller methods and state in your components through the hooks.
 The controller methods and state attributes exposed through controller hooks are the same as the ones exposed by the controllers.

--- a/packages/headless-react/source_docs/getting-started-with-commerce-ssr.md
+++ b/packages/headless-react/source_docs/getting-started-with-commerce-ssr.md
@@ -16,7 +16,7 @@ This guide walks through setting up a server-side rendered commerce storefront u
 Before getting started, make sure that:
 
 * You have a working knowledge of [React](https://react.dev/) and a React-based framework such as [Next.js](https://nextjs.org/).
-* You're familiar with [Coveo Headless](https://docs.coveo.com/en/lcdf0493/) engines and controllers.
+* You're familiar with Coveo Headless engines and controllers.
   You can refer to the [Headless usage documentation](https://docs.coveo.com/en/headless/latest/reference/documents/usage/index.html) for an introduction.
 * You have Node.js version 20 or later installed.
 

--- a/packages/headless-react/source_docs/getting-started-with-search-ssr.md
+++ b/packages/headless-react/source_docs/getting-started-with-search-ssr.md
@@ -12,7 +12,7 @@ This guide walks through setting up a server-side rendered search interface usin
 Before getting started, make sure that:
 
 * You have a working knowledge of [React](https://react.dev/) and a React-based framework such as [Next.js](https://nextjs.org/).
-* You're familiar with [Coveo Headless](https://docs.coveo.com/en/lcdf0493/) engines and controllers.
+* You're familiar with Coveo Headless engines and controllers.
   You can refer to the [Headless usage documentation](https://docs.coveo.com/en/headless/latest/reference/documents/usage/index.html) for an introduction.
 * You have Node.js version 20 or later installed.
 

--- a/packages/headless-react/source_docs/search-hooks.md
+++ b/packages/headless-react/source_docs/search-hooks.md
@@ -1,18 +1,17 @@
 ---
 title: Search Controller hooks
-group: Usage
+group: Guides
 ---
 
-# Hooks
+# Search Hooks
 
 This package provides React hooks for controllers defined in the Engine Definition. Hooks allow you to access controller state and methods easily within your React components.
 Without these hooks, you would need to manually pass down props through every component or implement your own provider solution, which can be cumbersome and error-prone.
 
 See [Headless SSR usage: Define the search engine and controllers](https://docs.coveo.com/en/headless/latest/reference/documents/usage/server-side-rendering/implement-server-side-rendering.html#create-an-engine-definition)
 
-## Usage
 
-### 1. Create an engine configuration
+## Create an engine configuration
 
 Define the controllers you need in your engine configuration. This example includes `SearchBox`, `ResultList` and `Facet` controllers:
 
@@ -37,7 +36,7 @@ const engineConfig = {
 };
 ```
 
-### 2. Define the engine
+## Define the engine
 
 Use `defineSearchEngine` to define the engine with your configuration:
 
@@ -45,7 +44,7 @@ Use `defineSearchEngine` to define the engine with your configuration:
 export const engineDefinition = defineSearchEngine(engineConfig);
 ```
 
-### 3. Export hooks
+## Export hooks
 
 Extract hooks for each controller from the engine definition.
 
@@ -57,7 +56,7 @@ export const {
 } = engineDefinition.controllers;
 ```
 
-### 4. Use Hooks in Components
+## Use hooks in components
 
 Access controller methods and state in your components through the hooks.
 The controller methods and state attributes exposed through controller hooks are the same as the ones exposed by the controllers.

--- a/packages/headless-react/source_docs/ssr-commerce-overview.md
+++ b/packages/headless-react/source_docs/ssr-commerce-overview.md
@@ -1,0 +1,12 @@
+# SSR Commerce
+
+This module provides the React utilities for building server-side rendered commerce storefronts with `@coveo/headless-react/ssr-commerce`.
+
+It includes:
+
+- **Engine definition** — `defineCommerceEngine` to configure and instantiate a headless commerce engine for SSR.
+- **Controllers** — Pre-built React hooks for commerce controllers such as product listings, cart, facets, recommendations, and more.
+- **Actions** — Redux action creators to dispatch commerce-related actions (e.g., cart operations, product navigation, facet management).
+- **Providers** — React context providers that supply the engine and controller state to your component tree.
+
+See [Getting started with Commerce SSR](../documents/getting-started/commerce-ssr.html) for a setup guide.

--- a/packages/headless-react/source_docs/ssr-search-overview.md
+++ b/packages/headless-react/source_docs/ssr-search-overview.md
@@ -1,0 +1,12 @@
+# SSR Search
+
+This module provides the React utilities for building server-side rendered search interfaces with `@coveo/headless-react/ssr`.
+
+It includes:
+
+- **Engine definition** — `defineSearchEngine` to configure and instantiate a headless search engine for SSR.
+- **Controllers** — Pre-built React hooks for search controllers such as facets, result lists, query suggestions, breadcrumbs, and more.
+- **Actions** — Redux action creators to dispatch search-related actions (e.g., executing a search, updating query, managing facet state).
+- **Providers** — React context providers that supply the engine and controller state to your component tree.
+
+See [Getting started with Search SSR](../documents/getting-started/search-ssr.html) for a setup guide.

--- a/packages/headless-react/typedoc-configs/ssr-commerce.typedoc.json
+++ b/packages/headless-react/typedoc-configs/ssr-commerce.typedoc.json
@@ -5,6 +5,7 @@
     "includeFolders": true
   },
   "categorizeByGroup": true,
+  "readme": "../source_docs/ssr-commerce-overview.md",
   "name": "SSR Commerce",
   "entryPoints": ["../src/ssr-commerce/index.ts"],
   "gitRevision": "main",

--- a/packages/headless-react/typedoc-configs/ssr.typedoc.json
+++ b/packages/headless-react/typedoc-configs/ssr.typedoc.json
@@ -5,6 +5,7 @@
     "includeFolders": true
   },
   "categorizeByGroup": true,
+  "readme": "../source_docs/ssr-search-overview.md",
   "name": "SSR Search",
   "entryPoints": ["../src/ssr/index.ts"],
   "gitRevision": "main",

--- a/packages/headless-react/typedoc.json
+++ b/packages/headless-react/typedoc.json
@@ -1,19 +1,25 @@
 {
-  "name": "Coveo Headless React",
   "entryPointStrategy": "merge",
   "projectDocuments": [
     "source_docs/getting-started-with-search-ssr.md",
     "source_docs/getting-started-with-commerce-ssr.md",
     "source_docs/search-hooks.md",
     "source_docs/commerce-hooks.md",
-    "README.md"
+    "README.md",
+    "CONTRIBUTING.md"
   ],
   "navigation": {
     "includeCategories": true,
     "includeGroups": true,
     "includeFolders": true
   },
-  "hoistOther.topLevelOrder": ["Home", "Getting Started", "Usage", "Reference"],
+  "hoistOther.topLevelOrder": [
+    "Home",
+    "Getting Started",
+    "Guides",
+    "Reference",
+    "Contributing"
+  ],
   "categorizeByGroup": true,
   "entryPoints": ["./temp/ssr-commerce.json", "./temp/ssr.json"],
   "gitRevision": "main",


### PR DESCRIPTION
## Purpose

This aligns the TOC on our current guidelines.

It also brings the general design of the Typedoc sites more in line with docs.coveo.com
This includes
* right hand toc
* fonts
* headers
* body min widht
* link colours

A few new documents are also introduced:
*  a search corollary to the commerce hooks doc
* brief introductory docs used on the Reference home pages
* contributing.md

This is to increase parity across all offerings and improve standardization of the navigation experience.

DOC-18864