### PR TITLE
fix(ipxModal): init with classes

### DIFF
--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.spec.ts
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.spec.ts
@@ -173,6 +173,20 @@ describe('atomic-ipx-modal', () => {
 
       expect(element.id).toBe('custom-id');
     });
+
+    it('should apply atomic-ipx-modal-opened to the interface element on init when isOpen=true', async () => {
+      const {atomicInterface} =
+        await renderInAtomicSearchInterface<AtomicIpxModal>({
+          template: html`<atomic-ipx-modal .isOpen=${true}></atomic-ipx-modal>`,
+          selector: 'atomic-ipx-modal',
+          bindings: (bindings) => {
+            bindings.engine = mockedEngine;
+            return bindings;
+          },
+        });
+
+      expect(atomicInterface).toHaveClass('atomic-ipx-modal-opened');
+    });
   });
 
   describe('when handling touch events', () => {
@@ -289,7 +303,9 @@ describe('atomic-ipx-modal', () => {
 
   describe('when integrating with ipx-body functional component', () => {
     it('should render container with visible class when isOpen=true', async () => {
-      const {element, parts} = await renderIPXModal({props: {isOpen: true}});
+      const {element, parts} = await renderIPXModal({
+        props: {isOpen: true},
+      });
 
       await element.updateComplete;
 
@@ -297,7 +313,9 @@ describe('atomic-ipx-modal', () => {
     });
 
     it('should render container with invisible class when isOpen=false', async () => {
-      const {element, parts} = await renderIPXModal({props: {isOpen: false}});
+      const {element, parts} = await renderIPXModal({
+        props: {isOpen: false},
+      });
 
       await element.updateComplete;
 

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.ts
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.ts
@@ -89,7 +89,12 @@ export class AtomicIpxModal extends InitializeBindingsMixin(LitElement) {
   @state()
   error!: Error;
 
-  public initialize() {}
+  public initialize() {
+    if (this.isOpen) {
+      this.watchToggleOpen();
+      this.updateHostClasses();
+    }
+  }
 
   /**
    * The element that triggered opening the modal.
@@ -152,7 +157,6 @@ export class AtomicIpxModal extends InitializeBindingsMixin(LitElement) {
     const id = this.id || randomID('atomic-ipx-modal-');
     this.id = id;
     this.setAttribute('part', 'atomic-ipx-modal');
-    this.watchToggleOpen();
   }
 
   private onWindowTouchMove = (e: Event) => {


### PR DESCRIPTION
[KHUB-344](https://coveord.atlassian.net/browse/KHUB-344)

## Issue

The HSP IPX modal will not open on launch when we expect it to do. Even if the button is responding adequately, the modal doesnt. Lit migration is supected to have broken the behavior stencil had. 
https://github.com/coveo/ui-kit/pull/6967/changes

## Fix

Force the init to apply the necessary logic



[KHUB-344]: https://coveord.atlassian.net/browse/KHUB-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ