### PR TITLE
fix: use clickUri as citation url

### DIFF
--- a/packages/atomic/src/components/common/atomic-citation/atomic-citation.spec.ts
+++ b/packages/atomic/src/components/common/atomic-citation/atomic-citation.spec.ts
@@ -104,7 +104,18 @@ describe('atomic-citation', () => {
 
       expect(popover).toHaveClass('hidden');
       expect(popover?.textContent).toContain('Test Citation Title');
-      expect(popover?.textContent).toContain('https://example.com/test');
+      expect(popover?.textContent).toContain('https://example.com/test-click');
+    });
+
+    it('should render uri in the popover when clickUri is missing', async () => {
+      const citationWithoutClickUri = {...mockCitation, clickUri: undefined};
+      const {locators} = await renderComponent({
+        citation: citationWithoutClickUri,
+      });
+
+      expect(locators.citationPopover?.textContent).toContain(
+        'https://example.com/test'
+      );
     });
 
     it('should truncate citation text longer than 200 characters', async () => {

--- a/packages/atomic/src/components/common/atomic-citation/atomic-citation.ts
+++ b/packages/atomic/src/components/common/atomic-citation/atomic-citation.ts
@@ -257,7 +257,7 @@ export class AtomicCitation extends LitElement {
         @mouseleave=${this.delayedClosePopover}
       >
         <div class="text-neutral-dark truncate text-sm">
-          ${this.citation.uri}
+          ${this.citation.clickUri ?? this.citation.uri}
         </div>
         ${renderHeading({
           props: {


### PR DESCRIPTION
# Citation popover should display clickable URL

When a citation has both `uri` and `clickUri`, the popover should display `clickUri` so the visible URL matches the link destination. If `clickUri` is missing, fall back to `uri`.

## Acceptance criteria

1. Show `clickUri` in the citation popover when available
2. Fall back to `uri` when `clickUri` is missing
3. Keep existing link and anchoring behavior unchanged
4. 
https://coveord.atlassian.net/browse/KIT-5533
