### PR TITLE
chore(atomic-quickview-modal): add style template to Storybook helpers

### DIFF
--- a/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
@@ -53,9 +53,12 @@ const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface({
 const {decorator: resultListDecorator} = wrapInResultList('list', false);
 const {decorator: resultTemplateDecorator} = wrapInResultTemplate();
 
-const {events, args, argTypes} = getStorybookHelpers('atomic-quickview-modal', {
-  excludeCategories: ['methods'],
-});
+const {events, args, argTypes, styleTemplate} = getStorybookHelpers(
+  'atomic-quickview-modal',
+  {
+    excludeCategories: ['methods'],
+  }
+);
 
 const meta: Meta = {
   component: 'atomic-quickview-modal',
@@ -66,6 +69,10 @@ const meta: Meta = {
     resultTemplateDecorator,
     resultListDecorator,
     searchInterfaceDecorator,
+    (story, {args}) => html`
+      ${styleTemplate(args)}
+      ${story()}
+    `,
   ],
   parameters: {
     ...commonParameters,


### PR DESCRIPTION
This allows users to tweak CSS Shadow Part using the Control tab in Storybook, and for those tweaks to reflect to the preview

https://coveord.atlassian.net/browse/KIT-5537