### PR TITLE
ci: remove NPM Production environment from cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,7 +75,6 @@ jobs:
   npm-prod:
     if: ${{ !cancelled() && needs.release.result == 'success' }}
     needs: release
-    environment: 'NPM Production'
     runs-on: 'ubuntu-latest'
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Removes the `environment: 'NPM Production'` from the `npm-prod` job in `cd.yml`.

After migrating to OIDC trusted publishers in #7198, the NPM Production environment is no longer needed. Keeping it risks environment-level secrets (e.g. `NODE_AUTH_TOKEN`) silently overriding OIDC authentication, which would defeat the purpose of trusted publishing.

## Changes

- Removed `environment: 'NPM Production'` from the `npm-prod` job in `.github/workflows/cd.yml`