### PR TITLE
chore: removing jsxFactory from tsconfig

### DIFF
--- a/packages/atomic/tsconfig.json
+++ b/packages/atomic/tsconfig.json
@@ -13,7 +13,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h",
     "types": ["@testing-library/jest-dom"],
     "plugins": [
       {

--- a/packages/atomic/tsconfig.storybook.json
+++ b/packages/atomic/tsconfig.storybook.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "composite": true,
-    "jsxFactory": "h",
     "declaration": true
   },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],


### PR DESCRIPTION
All of the documentation pages currently in production are broken: https://static.cloud.coveo.com/atomic/v3/storybook/index.html?path=/docs/atomic-automatic-facet-generator--docs

I was not able to repro the specific error locally, but a separate error - or a different representation of the same error - regarding the `jsxFactory: "h"` as defined in the tsconfig.json files was preventing the docs pages from rendering.

Asking an LLM to audit the `atomic` codebae it indicated that this was a legacy directive from `stencil` and was not being used anywhere.

There is an alternative approach of adding pragma's to the affected files if this approach is verboten

DOC-18963