### PR TITLE
test(atomic): fix flaky `atomic-result-template` e2e test for instant results

### DIFF
--- a/packages/atomic/src/components/search/atomic-result-template/atomic-result-template.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-template/atomic-result-template.new.stories.tsx
@@ -3,9 +3,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {parameters as searchBoxParameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+
+const searchApiHarness = new MockSearchApi();
 
 const TEMPLATE_EXAMPLE = `<template>
   <atomic-result-section-visual>
@@ -171,6 +174,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...searchApiHarness.handlers],
+    },
+  },
+  beforeEach: () => {
+    searchApiHarness.clearAll();
   },
   args: {
     ...args,
@@ -283,7 +292,7 @@ export const InASearchBoxInstantResults: Story = {
   name: 'In a search box instant results',
   decorators: [
     (story) => html`
-      <atomic-search-box style="width: 600px;">
+      <atomic-search-box suggestion-timeout="30000" style="width: 600px;">
         <atomic-search-box-query-suggestions>
           <atomic-search-box-instant-results>
             ${story()}


### PR DESCRIPTION
## Description

Fixes flakiness in the `atomic-result-template` e2e test: *"should display atomic result components when a child of a search box instant results"*.

## Root Cause

Two issues in the `InASearchBoxInstantResults` story, both of which the commerce equivalent (`atomic-product-template`) already handles correctly:

1. **Missing MSW handlers** — The story had no mocked API endpoints. Without mocks, the `querySuggest` call hit real endpoints and failed silently, so instant results never appeared.
2. **Default `suggestion-timeout` of 400ms** — Even with MSW, this is tight in CI. The commerce equivalent sets `30000ms`.

## Fix

Aligned the story with the `atomic-product-template` commerce pattern:
- Added `MockSearchApi` MSW handlers + `beforeEach` cleanup to the story meta
- Added `suggestion-timeout="30000"` to the `<atomic-search-box>` decorator
- Reverted `.click()` to `.focus()` in the play function (matching commerce)

The e2e test stays a simple `load()` + `toBeVisible()` — no workarounds needed.

## Example failure

https://github.com/coveo/ui-kit/actions/runs/23754603407/job/69206717259?pr=7303

KIT-5548