### PR TITLE
chore: remove user-specific MCP servers from repo config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,13 +1,5 @@
 {
   "servers": {
-    "atlassian": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/mcp"]
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    },
     "playwright": {
       "type": "stdio",
       "command": "npx",


### PR DESCRIPTION
## [KIT-5554](https://coveord.atlassian.net/browse/KIT-5554)

Remove the `atlassian` and `github` MCP server entries from `.vscode/mcp.json` since they require personal authentication and belong in user-level VS Code settings instead.

Only repo-specific servers (`playwright`, `storybook`) are kept in the shared config.

[KIT-5554]: https://coveord.atlassian.net/browse/KIT-5554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ