### PR TITLE
test: make CDN export snapshot test version-agnostic

### DIFF
--- a/utils/cdn/tests/__snapshots__/exports.spec.ts.snap
+++ b/utils/cdn/tests/__snapshots__/exports.spec.ts.snap
@@ -2,17 +2,17 @@
 
 exports[`CDN exports checks > did atomic.esm exports changed? 1`] = `
 {
-  "atomicVersion": "3.53.3",
-  "headlessVersion": "3.48.0",
+  "atomicVersion": "<version>",
+  "headlessVersion": "<version>",
 }
 `;
 
 exports[`CDN exports checks > did index exports changed? 1`] = `
 {
   "applyPolyfills": [Function],
-  "atomicVersion": "3.53.3",
+  "atomicVersion": "<version>",
   "defineCustomElements": [Function],
-  "headlessVersion": "3.48.0",
+  "headlessVersion": "<version>",
   "setNonce": [Function],
 }
 `;

--- a/utils/cdn/tests/exports.spec.ts
+++ b/utils/cdn/tests/exports.spec.ts
@@ -1,5 +1,21 @@
 import {describe, expect, it} from 'vitest';
 
+const SEMVER_REGEX = /^\d+\.\d+\.\d+/;
+
+function replaceVersions(mod: Record<string, unknown>) {
+  const snapshot = {...mod};
+  for (const key of Object.keys(snapshot)) {
+    if (
+      key.toLowerCase().includes('version') &&
+      typeof snapshot[key] === 'string'
+    ) {
+      expect(snapshot[key]).toMatch(SEMVER_REGEX);
+      snapshot[key] = '<version>';
+    }
+  }
+  return snapshot;
+}
+
 describe('CDN exports checks', () => {
   it.each([
     'index',
@@ -7,6 +23,6 @@ describe('CDN exports checks', () => {
     'atomic.esm',
   ])('did %s exports changed?', async (file) => {
     const module = await import(`../dist/proda/StaticCDN/atomic/v3/${file}.js`);
-    expect(module).toMatchSnapshot();
+    expect(replaceVersions(module)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## KIT-5567

The CDN export snapshot test fails on every PR after a release because version strings in the snapshot don't match.

### Changes

- Replace exact version strings in the snapshot with a stable `<version>` placeholder
- Added semver validation to ensure version exports are still valid strings
- The test now verifies export shape/keys without breaking on version bumps

### Testing

All 3 CDN export tests pass.