### PR TITLE
fix(docs): ensuring documentation pages in storybook load correctly

### DIFF
--- a/packages/atomic/README.md
+++ b/packages/atomic/README.md
@@ -72,6 +72,24 @@ To run the unit tests for the components, run:
 pnpm turbo run test --filter=@coveo/atomic
 ```
 
+### Building and serving Storybook locally
+
+To build the Storybook site for production and serve it locally:
+
+```sh
+# Build the Atomic library and Storybook
+pnpm turbo build --filter=@coveo/atomic
+
+# Serve the production Storybook build
+pnpm turbo run prod --filter=@coveo/atomic
+```
+
+The production Storybook site will be available at `http://localhost:4400`.
+
+> [!NOTE]
+> The `build` command includes the `build:storybook` step, which outputs the static site to `dist-storybook/`.
+> This is the same output that gets deployed to the CDN. Use this to verify that components render correctly in a production build.
+
 ### Storybook MCP (Model Context Protocol)
 
 This Storybook instance is configured with the MCP addon, which enables AI agents to programmatically interact with component stories. When Storybook is running, the MCP server is accessible at `http://localhost:4400/mcp`.

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -68,7 +68,7 @@
     "dev": "node ./scripts/dev.mjs",
     "web:dev": "npx vite serve dev",
     "web:cdn": "node ./scripts/start-cdn.mjs",
-    "prod": "npx serve www -l 3333 --no-request-logging",
+    "prod": "npx serve dist-storybook -l 4400 --no-request-logging",
     "test": "pnpm run test:lit",
     "test:stencil": "stencil test --spec -- src/utils/initialization-utils.spec.ts",
     "test:lit": "vitest run --project=atomic-default",

--- a/packages/atomic/scripts/generate-component-templates/component.mdx.hbs
+++ b/packages/atomic/scripts/generate-component-templates/component.mdx.hbs
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as {{namePascalCase}}Stories from './{{name}}.new.stories';
+import meta, { Default } from './{{name}}.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ {{namePascalCase}}Stories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ {{namePascalCase}}Stories }
+  stories={{ Default }}
   githubPath="{{githubPath}}"
   tagName="{{name}}"
   className="{{namePascalCase}}"

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceBreadboxStories from './atomic-commerce-breadbox.new.stories';
+import meta, { Default } from './atomic-commerce-breadbox.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicCommerceBreadboxStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceBreadboxStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts"
   tagName="atomic-commerce-breadbox"
   className="AtomicCommerceBreadbox"

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceCategoryFacetStories from './atomic-commerce-category-facet.new.stories';
+import meta, { Default } from './atomic-commerce-category-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceCategoryFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceCategoryFacetStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts"
   tagName="atomic-commerce-category-facet"
   className="AtomicCommerceCategoryFacet"

--- a/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.mdx
@@ -1,12 +1,12 @@
 import { Canvas, ArgTypes, Meta, Title, Description, Stories, Subtitle } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceDidYouMeanStories from './atomic-commerce-did-you-mean.new.stories';
+import meta, { Default } from './atomic-commerce-did-you-mean.new.stories';
 import { CanvasWithGithub } from '../../../../storybook-utils/documentation/canvas-with-github';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicCommerceDidYouMeanStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceDidYouMeanStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.ts"
   tagName="atomic-commerce-did-you-mean"
   className="AtomicCommerceDidYouMean"

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceFacetStories from './atomic-commerce-facet.new.stories';
+import meta, { Default } from './atomic-commerce-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceFacetStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-facet/atomic-commerce-facet.ts"
   tagName="atomic-commerce-facet"
   className="AtomicCommerceCategoryFacet"

--- a/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceFacetsStories from './atomic-commerce-facets.new.stories';
+import meta, { Default, LoadingState } from './atomic-commerce-facets.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceFacetsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceFacetsStories}
+  stories={{ Default, LoadingState }}
   githubPath="commerce/atomic-commerce-facets/atomic-commerce-facets.ts"
   tagName="atomic-commerce-facets"
   className="AtomicCommerceFacets"

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceInterfaceStories from './atomic-commerce-interface.new.stories';
+import meta, { Default, WithProductList, WithSearch } from './atomic-commerce-interface.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceInterfaceStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceInterfaceStories}
+  stories={{ Default, WithProductList, WithSearch }}
   githubPath="commerce/atomic-commerce-interface/atomic-commerce-interface.ts"
   tagName="atomic-commerce-interface"
   className="AtomicCommerceInterface"

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceLayoutStories from './atomic-commerce-layout.new.stories';
+import meta, { Default } from './atomic-commerce-layout.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceLayoutStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceLayoutStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-layout/atomic-commerce-layout.ts"
   tagName="atomic-commerce-layout"
   className="AtomicCommerceLayout"

--- a/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceLoadMoreProductsStories from './atomic-commerce-load-more-products.new.stories';
+import meta, { Default } from './atomic-commerce-load-more-products.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceLoadMoreProductsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceLoadMoreProductsStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.ts"
   tagName="atomic-commerce-load-more-products"
   className="AtomicCommerceLoadMoreProducts"

--- a/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceNoProductsStories from './atomic-commerce-no-products.new.stories';
+import meta, { Default } from './atomic-commerce-no-products.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceNoProductsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceNoProductsStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-no-products/atomic-commerce-no-products.ts"
   tagName="atomic-commerce-no-products"
   className="AtomicCommerceNoProducts"

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceNumericFacetStories from './atomic-commerce-numeric-facet.new.stories';
+import meta, { Default } from './atomic-commerce-numeric-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceNumericFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceNumericFacetStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.ts"
   tagName="atomic-commerce-numeric-facet"
   className="AtomicCommerceNumericFacet"

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommercePagerStories from './atomic-commerce-pager.new.stories';
+import meta, { Default, CustomIcon, WithACustomNumberOfPages } from './atomic-commerce-pager.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommercePagerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommercePagerStories}
+  stories={{ Default, CustomIcon, WithACustomNumberOfPages }}
   githubPath="commerce/atomic-commerce-pager/atomic-commerce-pager.ts"
   tagName="atomic-commerce-pager"
   className="AtomicCommercePager"

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceProductListStories from './atomic-commerce-product-list.new.stories';
+import meta, { Default, GridDisplayWithTemplate, GridDisplayBeforeQuery, ListDisplay, ListDisplayWithTemplate, ListDisplayBeforeQuery, TableDisplay, TableDisplayBeforeQuery, NoProducts } from './atomic-commerce-product-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceProductListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceProductListStories}
+  stories={{ Default, GridDisplayWithTemplate, GridDisplayBeforeQuery, ListDisplay, ListDisplayWithTemplate, ListDisplayBeforeQuery, TableDisplay, TableDisplayBeforeQuery, NoProducts }}
   githubPath="commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts"
   tagName="atomic-commerce-product-list"
   className="AtomicCommerceProductList"

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceProductsPerPageStories from './atomic-commerce-products-per-page.new.stories';
+import meta, { Default, WithCustomChoicesDisplayed } from './atomic-commerce-products-per-page.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceProductsPerPageStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceProductsPerPageStories}
+  stories={{ Default, WithCustomChoicesDisplayed }}
   githubPath="commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.ts"
   tagName="atomic-commerce-products-per-page"
   className="AtomicCommerceProductsPerPage"

--- a/packages/atomic/src/components/commerce/atomic-commerce-query-error/atomic-commerce-query-error.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-error/atomic-commerce-query-error.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceQueryErrorStories from './atomic-commerce-query-error.new.stories';
+import meta, { Default, With418Error } from './atomic-commerce-query-error.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceQueryErrorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceQueryErrorStories}
+  stories={{ Default, With418Error }}
   githubPath="commerce/atomic-commerce-query-error/atomic-commerce-query-error.ts"
   tagName="atomic-commerce-query-error"
   className="AtomicCommerceQueryError"

--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceQuerySummaryStories from './atomic-commerce-query-summary.new.stories';
+import meta, { Default } from './atomic-commerce-query-summary.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceQuerySummaryStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceQuerySummaryStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.ts"
   tagName="atomic-commerce-query-summary"
   className="AtomicCommerceQuerySummary"

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceRecommendationInterfaceStories from './atomic-commerce-recommendation-interface.new.stories';
+import meta, { Default, WithRecommendationList } from './atomic-commerce-recommendation-interface.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceRecommendationInterfaceStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceRecommendationInterfaceStories}
+  stories={{ Default, WithRecommendationList }}
   githubPath="commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts"
   tagName="atomic-commerce-recommendation-interface"
   className="AtomicCommerceRecommendationInterface"

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceRecommendationListStories from './atomic-commerce-recommendation-list.new.stories';
+import meta, { Default, WithFullTemplate, AsCarousel, NoRecommendations } from './atomic-commerce-recommendation-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceRecommendationListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceRecommendationListStories}
+  stories={{ Default, WithFullTemplate, AsCarousel, NoRecommendations }}
   githubPath="commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts"
   tagName="atomic-commerce-recommendation-list"
   className="AtomicCommerceRecommendationList"

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.mdx
@@ -1,13 +1,13 @@
 
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceRefineModalStories from './atomic-commerce-refine-modal.new.stories';
+import meta, { DefaultModal } from './atomic-commerce-refine-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceRefineModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceRefineModalStories}
+  stories={{ DefaultModal }}
   githubPath="commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.ts"
   tagName="atomic-commerce-refine-modal"
   className="AtomicCommerceRefineModal"

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceRefineToggleStories from './atomic-commerce-refine-toggle.new.stories';
+import meta, { Default } from './atomic-commerce-refine-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceRefineToggleStories} name="Docs toggle"/>
+<Meta of={meta} name="Docs toggle"/>
 
 <AtomicDocTemplate
-  stories={AtomicCommerceRefineToggleStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.ts"
   tagName="atomic-commerce-refine-toggle"
   className="AtomicCommerceRefineToggle"

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceSearchBoxInstantProductsStories from './atomic-commerce-search-box-instant-products.new.stories';
+import meta, { Default, WithComfortableDensity, WithNoImage } from './atomic-commerce-search-box-instant-products.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceSearchBoxInstantProductsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceSearchBoxInstantProductsStories}
+  stories={{ Default, WithComfortableDensity, WithNoImage }}
   githubPath="commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.ts"
   tagName="atomic-commerce-search-box-instant-products"
   className="AtomicCommerceSearchBoxInstantProducts"

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceSearchBoxQuerySuggestionsStories from './atomic-commerce-search-box-query-suggestions.new.stories';
+import meta, { Default } from './atomic-commerce-search-box-query-suggestions.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceSearchBoxQuerySuggestionsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceSearchBoxQuerySuggestionsStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.ts"
   tagName="atomic-commerce-search-box-query-suggestions"
   className="AtomicCommerceSearchBoxQuerySuggestions"

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceSearchBoxRecentQueriesStories from './atomic-commerce-search-box-recent-queries.new.stories';
+import meta, { Default } from './atomic-commerce-search-box-recent-queries.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceSearchBoxRecentQueriesStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceSearchBoxRecentQueriesStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.ts"
   tagName="atomic-commerce-search-box-recent-queries"
   className="AtomicCommerceSearchBoxRecentQueries"

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceSearchBoxStories from './atomic-commerce-search-box.new.stories';
+import meta, { Default, RichSearchBox, StandaloneSearchBox, WithSuggestions, WithSuggestionsAndRecentQueries, WithNoSuggestions } from './atomic-commerce-search-box.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceSearchBoxStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceSearchBoxStories}
+  stories={{ Default, RichSearchBox, StandaloneSearchBox, WithSuggestions, WithSuggestionsAndRecentQueries, WithNoSuggestions }}
   githubPath="commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts"
   tagName="atomic-commerce-search-box"
   className="AtomicCommerceSearchBox"

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceSortDropdownStories from './atomic-commerce-sort-dropdown.new.stories';
+import meta, { Default } from './atomic-commerce-sort-dropdown.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceSortDropdownStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceSortDropdownStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.ts"
   tagName="atomic-commerce-sort-dropdown"
   className="AtomicCommerceSortDropdown"

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceTextStories from './atomic-commerce-text.new.stories';
+import meta, { Default, WithTranslations } from './atomic-commerce-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicCommerceTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceTextStories}
+  stories={{ Default, WithTranslations }}
   githubPath="commerce/atomic-commerce-text/atomic-commerce-text.ts"
   tagName="atomic-commerce-text"
   className="AtomicCommerceText"

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCommerceTimeframeFacetStories from './atomic-commerce-timeframe-facet.new.stories';
+import meta, { Default } from './atomic-commerce-timeframe-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicCommerceTimeframeFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicCommerceTimeframeFacetStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.ts"
   tagName="atomic-commerce-timeframe-facet"
   className="AtomicCommerceTimeframeFacet"

--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductChildrenStories from './atomic-product-children.new.stories';
+import meta, { Default } from './atomic-product-children.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductChildrenStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductChildrenStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-product-children/atomic-product-children.ts"
   tagName="atomic-product-children"
   className="AtomicProductChildren"

--- a/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductDescriptionStories from './atomic-product-description.new.stories';
+import meta, { Default, Collapsible, UsingECDescription } from './atomic-product-description.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductDescriptionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductDescriptionStories}
+  stories={{ Default, Collapsible, UsingECDescription }}
   githubPath="commerce/atomic-product-description/atomic-product-description.ts"
   tagName="atomic-product-description"
   className="AtomicProductDescription"

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductExcerptStories from './atomic-product-excerpt.new.stories';
+import meta, { Default, Collapsible } from './atomic-product-excerpt.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductExcerptStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductExcerptStories}
+  stories={{ Default, Collapsible }}
   githubPath="commerce/atomic-product-excerpt/atomic-product-excerpt.ts"
   tagName="atomic-product-excerpt"
   className="AtomicProductExcerpt"

--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductFieldConditionStories from './atomic-product-field-condition.new.stories';
+import meta, { Default } from './atomic-product-field-condition.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductFieldConditionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductFieldConditionStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-product-field-condition/atomic-product-field-condition.ts"
   tagName="atomic-product-field-condition"
   className="AtomicProductFieldCondition"

--- a/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductImageStories from './atomic-product-image.new.stories';
+import meta, { Default, withAFallbackImage } from './atomic-product-image.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductImageStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductImageStories}
+  stories={{ Default, withAFallbackImage }}
   githubPath="commerce/atomic-product-image/atomic-product-image.ts"
   tagName="atomic-product-image"
   className="AtomicProductImage"

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductLinkStories from './atomic-product-link.new.stories';
+import meta, { Default, WithSlotsAttributes, WithAlternativeContent, WithHrefTemplate } from './atomic-product-link.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductLinkStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductLinkStories}
+  stories={{ Default, WithSlotsAttributes, WithAlternativeContent, WithHrefTemplate }}
   githubPath="commerce/atomic-product-link/atomic-product-link.ts"
   tagName="atomic-product-link"
   className="AtomicProductLink"

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductMultiValueTextStories from './atomic-product-multi-value-text.new.stories';
+import meta, { Default, WithMaxValuesToDisplaySetToMinimum, WithMaxValuesToDisplaySetToTotalNumberOfValues } from './atomic-product-multi-value-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductMultiValueTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductMultiValueTextStories}
+  stories={{ Default, WithMaxValuesToDisplaySetToMinimum, WithMaxValuesToDisplaySetToTotalNumberOfValues }}
   githubPath="commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.ts"
   tagName="atomic-product-multi-value-text"
   className="AtomicProductMultiValueText"

--- a/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductNumericFieldValueStories from './atomic-product-numeric-field-value.new.stories';
+import meta, { Default } from './atomic-product-numeric-field-value.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductNumericFieldValueStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductNumericFieldValueStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.ts"
   tagName="atomic-product-numeric-field-value"
   className="AtomicProductNumericFieldValue"

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductPriceStories from './atomic-product-price.new.stories';
+import meta, { Default, WithEURCurrency } from './atomic-product-price.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductPriceStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductPriceStories}
+  stories={{ Default, WithEURCurrency }}
   githubPath="commerce/atomic-product-price/atomic-product-price.ts"
   tagName="atomic-product-price"
   className="AtomicProductPrice"

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductRatingStories from './atomic-product-rating.new.stories';
+import meta, { Default, WithARatingDetailsField, WithAMaxValueInIndex, WithADifferentIcon } from './atomic-product-rating.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductRatingStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductRatingStories}
+  stories={{ Default, WithARatingDetailsField, WithAMaxValueInIndex, WithADifferentIcon }}
   githubPath="commerce/atomic-product-rating/atomic-product-rating.ts"
   tagName="atomic-product-rating"
   className="AtomicProductRating"

--- a/packages/atomic/src/components/commerce/atomic-product-section-actions/Docs.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-actions/Docs.mdx
@@ -1,16 +1,16 @@
 import { Meta, Title, Description, Canvas, Subtitle, Story } from '@storybook/addon-docs/blocks';
-import * as ProductSectionActionsStories from './atomic-product-section-actions.new.stories';
-import * as ProductSectionBadgesStories from '../atomic-product-section-badges/atomic-product-section-badges.new.stories';
+import meta, { Default as ProductSectionActionsStoriesDefault } from './atomic-product-section-actions.new.stories';
+import { Default as ProductSectionBadgesStoriesDefault } from '../atomic-product-section-badges/atomic-product-section-badges.new.stories';
 import { CanvasWithGithub } from '../../../../storybook-utils/documentation/canvas-with-github';
-import * as ProductSectionBottomMetadataStories from '../atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories';
-import * as ProductSectionChildrenStories from '../atomic-product-section-children/atomic-product-section-children.new.stories';
-import * as ProductSectionDescriptionStories from '../atomic-product-section-description/atomic-product-section-description.new.stories';
-import * as ProductSectionEmphasizedStories from '../atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories';
-import * as ProductSectionMetadataStories from '../atomic-product-section-metadata/atomic-product-section-metadata.new.stories';
-import * as ProductSectionNameStories from '../atomic-product-section-name/atomic-product-section-name.new.stories';
-import * as ProductSectionVisualStories from '../atomic-product-section-visual/atomic-product-section-visual.new.stories';
+import { Default as ProductSectionBottomMetadataStoriesDefault } from '../atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories';
+import { Default as ProductSectionChildrenStoriesDefault } from '../atomic-product-section-children/atomic-product-section-children.new.stories';
+import { Default as ProductSectionDescriptionStoriesDefault } from '../atomic-product-section-description/atomic-product-section-description.new.stories';
+import { Default as ProductSectionEmphasizedStoriesDefault } from '../atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories';
+import { Default as ProductSectionMetadataStoriesDefault } from '../atomic-product-section-metadata/atomic-product-section-metadata.new.stories';
+import { Default as ProductSectionNameStoriesDefault } from '../atomic-product-section-name/atomic-product-section-name.new.stories';
+import { Default as ProductSectionVisualStoriesDefault } from '../atomic-product-section-visual/atomic-product-section-visual.new.stories';
 
-<Meta of={ProductSectionActionsStories} />
+<Meta of={meta} />
 
 # Product Sections
 
@@ -61,47 +61,47 @@ They work together to present a complete product view, including images, descrip
 ## Components 
 
 ### atomic-product-section-badges
-<CanvasWithGithub of={ProductSectionBadgesStories.Default}  
+<CanvasWithGithub of={ProductSectionBadgesStoriesDefault}  
   githubPath="commerce/atomic-product-section-badges/atomic-product-section-badges.ts"
 />
 
 ### atomic-product-section-actions
-<CanvasWithGithub of={ProductSectionActionsStories.Default}  
+<CanvasWithGithub of={ProductSectionActionsStoriesDefault}  
   githubPath="commerce/atomic-product-section-actions/atomic-product-section-actions.ts"
 />
 
 ### atomic-product-section-bottom-metadata
-<CanvasWithGithub of={ProductSectionBottomMetadataStories.Default}  
+<CanvasWithGithub of={ProductSectionBottomMetadataStoriesDefault}  
   githubPath="commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.ts"
 />
 
 ### atomic-product-section-children
-<CanvasWithGithub of={ProductSectionChildrenStories.Default}  
+<CanvasWithGithub of={ProductSectionChildrenStoriesDefault}  
   githubPath="commerce/atomic-product-section-children/atomic-product-section-children.ts"
 />
 
 ### atomic-product-section-description
-<CanvasWithGithub of={ProductSectionDescriptionStories.Default}  
+<CanvasWithGithub of={ProductSectionDescriptionStoriesDefault}  
   githubPath="commerce/atomic-product-section-description/atomic-product-section-description.ts"
 />
 
 ### atomic-product-section-emphasized
-<CanvasWithGithub of={ProductSectionEmphasizedStories.Default}  
+<CanvasWithGithub of={ProductSectionEmphasizedStoriesDefault}  
   githubPath="commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.ts"
 />
 
 ### atomic-product-section-metadata
-<CanvasWithGithub of={ProductSectionMetadataStories.Default}  
+<CanvasWithGithub of={ProductSectionMetadataStoriesDefault}  
   githubPath="commerce/atomic-product-section-metadata/atomic-product-section-metadata.ts"
 />
 
 ### atomic-product-section-name
-<CanvasWithGithub of={ProductSectionNameStories.Default}  
+<CanvasWithGithub of={ProductSectionNameStoriesDefault}  
   githubPath="commerce/atomic-product-section-name/atomic-product-section-name.ts"
 />
 
 ### atomic-product-section-visual
-<CanvasWithGithub of={ProductSectionVisualStories.Default}  
+<CanvasWithGithub of={ProductSectionVisualStoriesDefault}  
   githubPath="commerce/atomic-product-section-visual/atomic-product-section-visual.ts"
 />
 

--- a/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-template/atomic-product-template.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductTemplateStories from './atomic-product-template.new.stories';
+import meta, { InAProductList, InARecommendationList, InASearchBoxInstantProducts } from './atomic-product-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductTemplateStories}
+  stories={{ InAProductList, InARecommendationList, InASearchBoxInstantProducts }}
   defaultStory="InAProductList"
   githubPath="commerce/atomic-product-template/atomic-product-template.ts"
   tagName="atomic-product-template"

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.mdx
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicProductTextStories from './atomic-product-text.new.stories';
+import meta, { Default } from './atomic-product-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicProductTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicProductTextStories}
+  stories={{ Default }}
   githubPath="commerce/atomic-product-text/atomic-product-text.ts"
   tagName="atomic-product-text"
   className="AtomicProductText"

--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.mdx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicAriaLiveStories from './atomic-aria-live.new.stories';
+import meta, { Default } from './atomic-aria-live.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicAriaLiveStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicAriaLiveStories}
+  stories={{ Default }}
   githubPath="common/atomic-aria-live/atomic-aria-live.ts"
   tagName="atomic-aria-live"
   className="AtomicAriaLive"

--- a/packages/atomic/src/components/common/atomic-icon/atomic-icon.mdx
+++ b/packages/atomic/src/components/common/atomic-icon/atomic-icon.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIconStories from './atomic-icon.new.stories';
+import meta, { Default, AllIcons } from './atomic-icon.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicIconStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicIconStories}
+  stories={{ Default, AllIcons }}
   githubPath="common/atomic-icon/atomic-icon.ts"
   tagName="atomic-icon"
   className="AtomicIcon"

--- a/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.mdx
+++ b/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicLayoutSectionStories from './atomic-layout-section.new.stories';
+import meta, { Default } from './atomic-layout-section.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicLayoutSectionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicLayoutSectionStories}
+  stories={{ Default }}
   githubPath="common/atomic-layout-section/atomic-layout-section.ts"
   tagName="atomic-layout-section"
   className="AtomicLayoutSection"

--- a/packages/atomic/src/components/common/atomic-timeframe/atomic-timeframe.mdx
+++ b/packages/atomic/src/components/common/atomic-timeframe/atomic-timeframe.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicTimeframeStories from './atomic-timeframe.new.stories';
+import meta, { Default, WithPastPeriod, WithNextPeriod, WithCustomLabel } from './atomic-timeframe.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicTimeframeStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicTimeframeStories}
+  stories={{ Default, WithPastPeriod, WithNextPeriod, WithCustomLabel }}
   githubPath="common/atomic-timeframe/atomic-timeframe.ts"
   tagName="atomic-timeframe"
   className="AtomicTimeframe"

--- a/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightEditToggleStories from './atomic-insight-edit-toggle.new.stories';
+import meta, { Default, WithTooltip } from './atomic-insight-edit-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightEditToggleStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightEditToggleStories}
+  stories={{ Default, WithTooltip }}
   githubPath="insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.ts"
   tagName="atomic-insight-edit-toggle"
   className="AtomicInsightEditToggle"

--- a/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightFacetStories from './atomic-insight-facet.new.stories';
+import meta, { Default, AsLink, AsBox, WithExclusion, WithSelectedValue, Collapsed } from './atomic-insight-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightFacetStories}
+  stories={{ Default, AsLink, AsBox, WithExclusion, WithSelectedValue, Collapsed }}
   githubPath="insight/atomic-insight-facet/atomic-insight-facet.ts"
   tagName="atomic-insight-facet"
   className="AtomicInsightFacet"

--- a/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightFoldedResultListStories from './atomic-insight-folded-result-list.new.stories';
+import meta, { Default } from './atomic-insight-folded-result-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightFoldedResultListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightFoldedResultListStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.ts"
   tagName="atomic-insight-folded-result-list"
   className="AtomicInsightFoldedResultList"

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.mdx
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicInsightGeneratedAnswerStories from './atomic-insight-generated-answer.new.stories';
+import meta, { Default, DisableCitationAnchoring } from './atomic-insight-generated-answer.new.stories';
 import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightGeneratedAnswerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightGeneratedAnswerStories}
+  stories={{ Default, DisableCitationAnchoring }}
   githubPath="insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts"
   tagName="atomic-insight-generated-answer"
   className="AtomicInsightGeneratedAnswer"

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightInterfaceStories from './atomic-insight-interface.new.stories';
+import meta, { Default } from './atomic-insight-interface.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicInsightInterfaceStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicInsightInterfaceStories }
+  stories={{ Default }}
   githubPath="insight/atomic-insight-interface/atomic-insight-interface.ts"
   tagName="atomic-insight-interface"
   className="AtomicInsightInterface"

--- a/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightLayoutStories from './atomic-insight-layout.new.stories';
+import meta, { Default } from './atomic-insight-layout.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightLayoutStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightLayoutStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-layout/atomic-insight-layout.ts"
   tagName="atomic-insight-layout"
   className="AtomicInsightLayout"

--- a/packages/atomic/src/components/insight/atomic-insight-no-results/atomic-insight-no-results.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-no-results/atomic-insight-no-results.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightNoResultsStories from './atomic-insight-no-results.new.stories';
+import meta, { Default } from './atomic-insight-no-results.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicInsightNoResultsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightNoResultsStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-no-results/atomic-insight-no-results.ts"
   tagName="atomic-insight-no-results"
   className="AtomicInsightNoResults"

--- a/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightNumericFacetStories from './atomic-insight-numeric-facet.new.stories';
+import meta, { Default, WithInputInteger, DisplayAsLink, Collapsed, WithSelectedValue } from './atomic-insight-numeric-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightNumericFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicInsightNumericFacetStories }
+  stories={{ Default, WithInputInteger, DisplayAsLink, Collapsed, WithSelectedValue }}
   githubPath="insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.ts"
   tagName="atomic-insight-numeric-facet"
   className="AtomicInsightNumericFacet"

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightPagerStories from './atomic-insight-pager.new.stories';
+import meta, { Default } from './atomic-insight-pager.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightPagerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightPagerStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-pager/atomic-insight-pager.ts"
   tagName="atomic-insight-pager"
   className="AtomicInsightPager"

--- a/packages/atomic/src/components/insight/atomic-insight-query-error/atomic-insight-query-error.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-error/atomic-insight-query-error.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightQueryErrorStories from './atomic-insight-query-error.new.stories';
+import meta, { Default, WithInvalidToken, WithDisconnected, WithOrganizationPaused } from './atomic-insight-query-error.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicInsightQueryErrorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightQueryErrorStories}
+  stories={{ Default, WithInvalidToken, WithDisconnected, WithOrganizationPaused }}
   githubPath="insight/atomic-insight-query-error/atomic-insight-query-error.ts"
   tagName="atomic-insight-query-error"
   className="AtomicInsightQueryError"

--- a/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightQuerySummaryStories from './atomic-insight-query-summary.new.stories';
+import meta, { Default } from './atomic-insight-query-summary.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicInsightQuerySummaryStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicInsightQuerySummaryStories }
+  stories={{ Default }}
   githubPath="insight/atomic-insight-query-summary/atomic-insight-query-summary.ts"
   tagName="atomic-insight-query-summary"
   className="AtomicInsightQuerySummary"

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightRefineModalStories from './atomic-insight-refine-modal.new.stories';
+import meta, { Default } from './atomic-insight-refine-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicInsightRefineModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightRefineModalStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-refine-modal/atomic-insight-refine-modal.ts"
   tagName="atomic-insight-refine-modal"
   className="AtomicInsightRefineModal"

--- a/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightRefineToggleStories from './atomic-insight-refine-toggle.new.stories';
+import meta, { Default } from './atomic-insight-refine-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicInsightRefineToggleStories} name="Docs"/>
+<Meta of={meta} name="Docs"/>
 
 <AtomicDocTemplate
-  stories={AtomicInsightRefineToggleStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.ts"
   tagName="atomic-insight-refine-toggle"
   className="AtomicInsightRefineToggle"

--- a/packages/atomic/src/components/insight/atomic-insight-result-action-bar/atomic-insight-result-action-bar.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-action-bar/atomic-insight-result-action-bar.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultActionBarStories from './atomic-insight-result-action-bar.new.stories';
+import meta, { Default, WithCopyAction, WithAllActions } from './atomic-insight-result-action-bar.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultActionBarStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultActionBarStories}
+  stories={{ Default, WithCopyAction, WithAllActions }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-action-bar/atomic-insight-result-action-bar.ts"
   tagName="atomic-insight-result-action-bar"

--- a/packages/atomic/src/components/insight/atomic-insight-result-action/atomic-insight-result-action.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-action/atomic-insight-result-action.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultActionStories from './atomic-insight-result-action.new.stories';
+import meta, { Default, InActionBar } from './atomic-insight-result-action.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultActionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultActionStories}
+  stories={{ Default, InActionBar }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-action/atomic-insight-result-action.ts"
   tagName="atomic-insight-result-action"

--- a/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-action/atomic-insight-result-attach-to-case-action.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-action/atomic-insight-result-attach-to-case-action.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultAttachToCaseActionStories from './atomic-insight-result-attach-to-case-action.new.stories';
+import meta, { Default, WithOtherActions } from './atomic-insight-result-attach-to-case-action.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultAttachToCaseActionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultAttachToCaseActionStories}
+  stories={{ Default, WithOtherActions }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-attach-to-case-action/atomic-insight-result-attach-to-case-action.ts"
   tagName="atomic-insight-result-attach-to-case-action"

--- a/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultAttachToCaseIndicatorStories from './atomic-insight-result-attach-to-case-indicator.new.stories';
+import meta, { Default } from './atomic-insight-result-attach-to-case-indicator.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultAttachToCaseIndicatorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultAttachToCaseIndicatorStories}
+  stories={{ Default }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.ts"
   tagName="atomic-insight-result-attach-to-case-indicator"

--- a/packages/atomic/src/components/insight/atomic-insight-result-children-template/atomic-insight-result-children-template.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-children-template/atomic-insight-result-children-template.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultChildrenTemplateStories from './atomic-insight-result-children-template.new.stories';
+import meta, { Default, WithNestedChildren, WithConditions } from './atomic-insight-result-children-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultChildrenTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultChildrenTemplateStories}
+  stories={{ Default, WithNestedChildren, WithConditions }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-children-template/atomic-insight-result-children-template.ts"
   tagName="atomic-insight-result-children-template"

--- a/packages/atomic/src/components/insight/atomic-insight-result-children/atomic-insight-result-children.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-children/atomic-insight-result-children.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultChildrenStories from './atomic-insight-result-children.new.stories';
+import meta, { Default, WithBeforeChildrenSlot, WithAfterChildrenSlot, WithBothSlots } from './atomic-insight-result-children.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultChildrenStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultChildrenStories}
+  stories={{ Default, WithBeforeChildrenSlot, WithAfterChildrenSlot, WithBothSlots }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-children/atomic-insight-result-children.ts"
   tagName="atomic-insight-result-children"

--- a/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultListStories from './atomic-insight-result-list.new.stories';
+import meta, { Default } from './atomic-insight-result-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultListStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-result-list/atomic-insight-result-list.ts"
   tagName="atomic-insight-result-list"
   className="AtomicInsightResultList"

--- a/packages/atomic/src/components/insight/atomic-insight-result-quickview-action/atomic-insight-result-quickview-action.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-quickview-action/atomic-insight-result-quickview-action.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultQuickviewActionStories from './atomic-insight-result-quickview-action.new.stories';
+import meta, { Default, CustomSandbox } from './atomic-insight-result-quickview-action.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultQuickviewActionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultQuickviewActionStories}
+  stories={{ Default, CustomSandbox }}
   githubPath="insight/atomic-insight-result-quickview-action/atomic-insight-result-quickview-action.ts"
   tagName="atomic-insight-result-quickview-action"
   className="AtomicInsightResultQuickviewAction"

--- a/packages/atomic/src/components/insight/atomic-insight-result-template/atomic-insight-result-template.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-template/atomic-insight-result-template.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightResultTemplateStories from './atomic-insight-result-template.new.stories';
+import meta, { Default, InAFoldedResultList, WithConditions } from './atomic-insight-result-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightResultTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightResultTemplateStories}
+  stories={{ Default, InAFoldedResultList, WithConditions }}
   defaultStory="Default"
   githubPath="insight/atomic-insight-result-template/atomic-insight-result-template.ts"
   tagName="atomic-insight-result-template"

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightSearchBoxStories from './atomic-insight-search-box.new.stories';
+import meta, { Default, WithDisabledSearch } from './atomic-insight-search-box.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightSearchBoxStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightSearchBoxStories}
+  stories={{ Default, WithDisabledSearch }}
   githubPath="insight/atomic-insight-search-box/atomic-insight-search-box.ts"
   tagName="atomic-insight-search-box"
   className="AtomicInsightSearchBox"

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightSmartSnippetStories from './atomic-insight-smart-snippet.new.stories';
+import meta, { Default } from './atomic-insight-smart-snippet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicInsightSmartSnippetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightSmartSnippetStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.ts"
   tagName="atomic-insight-smart-snippet"
   className="AtomicInsightSmartSnippet"

--- a/packages/atomic/src/components/insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightTimeframeFacetStories from './atomic-insight-timeframe-facet.new.stories';
+import meta, { Default, WithSelectedValue, WithDatePicker } from './atomic-insight-timeframe-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicInsightTimeframeFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicInsightTimeframeFacetStories }
+  stories={{ Default, WithSelectedValue, WithDatePicker }}
   githubPath="insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.ts"
   tagName="atomic-insight-timeframe-facet"
   className="AtomicInsightTimeframeFacet"

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightUserActionsTimelineStories from './atomic-insight-user-actions-timeline.new.stories';
+import meta, { Default } from './atomic-insight-user-actions-timeline.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicInsightUserActionsTimelineStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicInsightUserActionsTimelineStories}
+  stories={{ Default }}
   githubPath="insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.ts"
   tagName="atomic-insight-user-actions-timeline"
   className="AtomicInsightUserActionsTimeline"

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicInsightUserActionsToggleStories from './atomic-insight-user-actions-toggle.new.stories';
+import meta, { Default } from './atomic-insight-user-actions-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicInsightUserActionsToggleStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicInsightUserActionsToggleStories }
+  stories={{ Default }}
   githubPath="insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.ts"
   tagName="atomic-insight-user-actions-toggle"
   className="AtomicInsightUserActionsToggle"

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxButtonStories from './atomic-ipx-button.new.stories';
+import meta, { Default, WithLabel } from './atomic-ipx-button.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxButtonStories} name="Docs" />
+<Meta of={meta} name="Docs" />
 
 <AtomicDocTemplate
-  stories={AtomicIpxButtonStories}
+  stories={{ Default, WithLabel }}
   githubPath="ipx/atomic-ipx-button/atomic-ipx-button.ts"
   tagName="atomic-ipx-button"
   className="AtomicIpxButton"

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxEmbeddedStories from './atomic-ipx-embedded.new.stories';
+import meta, { Default } from './atomic-ipx-embedded.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxEmbeddedStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicIpxEmbeddedStories}
+  stories={{ Default }}
   githubPath="ipx/atomic-ipx-embedded/atomic-ipx-embedded.ts"
   tagName="atomic-ipx-embedded"
   className="AtomicIpxEmbedded"

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxModalStories from './atomic-ipx-modal.new.stories';
+import meta, { Default, WithoutFooter, Closed } from './atomic-ipx-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicIpxModalStories}
+  stories={{ Default, WithoutFooter, Closed }}
   githubPath="ipx/atomic-ipx-modal/atomic-ipx-modal.ts"
   tagName="atomic-ipx-modal"
   className="AtomicIpxModal"

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxRecsListStories from './atomic-ipx-recs-list.new.stories';
+import meta, { Default, RecsWithFullTemplate, RecsOpeningInNewTab, RecsAsCarousel, NotEnoughRecsForCarousel } from './atomic-ipx-recs-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxRecsListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicIpxRecsListStories}
+  stories={{ Default, RecsWithFullTemplate, RecsOpeningInNewTab, RecsAsCarousel, NotEnoughRecsForCarousel }}
   githubPath="ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.ts"
   tagName="atomic-ipx-recs-list"
   className="AtomicIpxRecsList"

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxRefineModalStories from './atomic-ipx-refine-modal.new.stories';
+import meta, { Default } from './atomic-ipx-refine-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxRefineModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicIpxRefineModalStories}
+  stories={{ Default }}
   githubPath="ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.ts"
   tagName="atomic-ipx-refine-modal"
   className="AtomicIpxRefineModal"

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxRefineToggleStories from './atomic-ipx-refine-toggle.new.stories';
+import meta, { Default, WithCollapsedFacets } from './atomic-ipx-refine-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxRefineToggleStories} name="Docs" />
+<Meta of={meta} name="Docs" />
 
 <AtomicDocTemplate
-  stories={AtomicIpxRefineToggleStories}
+  stories={{ Default, WithCollapsedFacets }}
   githubPath="ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.ts"
   tagName="atomic-ipx-refine-toggle"
   className="AtomicIpxRefineToggle"

--- a/packages/atomic/src/components/ipx/atomic-ipx-result-link/atomic-ipx-result-link.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-result-link/atomic-ipx-result-link.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicIpxResultLinkStories from './atomic-ipx-result-link.new.stories';
+import meta, { Default, WithCustomText, WithHrefTemplate, WithTargetBlank } from './atomic-ipx-result-link.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicIpxResultLinkStories} name="Docs" />
+<Meta of={meta} name="Docs" />
 
 <AtomicDocTemplate
-  stories={AtomicIpxResultLinkStories}
+  stories={{ Default, WithCustomText, WithHrefTemplate, WithTargetBlank }}
   githubPath="ipx/atomic-ipx-result-link/atomic-ipx-result-link.ts"
   tagName="atomic-ipx-result-link"
   className="AtomicIpxResultLink"

--- a/packages/atomic/src/components/recommendations/atomic-recs-error/atomic-recs-error.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-error/atomic-recs-error.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRecsErrorStories from './atomic-recs-error.new.stories';
+import meta, { Default, WithDisconnected, WithOrganizationPaused } from './atomic-recs-error.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicRecsErrorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRecsErrorStories}
+  stories={{ Default, WithDisconnected, WithOrganizationPaused }}
   githubPath="recommendations/atomic-recs-error/atomic-recs-error.ts"
   tagName="atomic-recs-error"
   className="AtomicRecsError"

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRecsInterfaceStories from './atomic-recs-interface.new.stories';
+import meta, { Default, RecsBeforeInit, WithRecsList } from './atomic-recs-interface.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicRecsInterfaceStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicRecsInterfaceStories }
+  stories={{ Default, RecsBeforeInit, WithRecsList }}
   githubPath="recommendations/atomic-recs-interface/atomic-recs-interface.ts"
   tagName="atomic-recs-interface"
   className="AtomicRecsInterface"

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRecsListStories from './atomic-recs-list.new.stories';
+import meta, { Default, RecsBeforeQuery, RecsWithFullTemplate, RecsOpeningInNewTab, RecsAsCarousel, NotEnoughRecsForCarousel, NoRecommendations } from './atomic-recs-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicRecsListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRecsListStories}
+  stories={{ Default, RecsBeforeQuery, RecsWithFullTemplate, RecsOpeningInNewTab, RecsAsCarousel, NotEnoughRecsForCarousel, NoRecommendations }}
   githubPath="recommendations/atomic-recs-list/atomic-recs-list.ts"
   tagName="atomic-recs-list"
   className="AtomicRecsList"

--- a/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRecsResultTemplateStories from './atomic-recs-result-template.new.stories';
+import meta, { Default, WithMinimalTemplate, WithLinkSlot } from './atomic-recs-result-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicRecsResultTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRecsResultTemplateStories}
+  stories={{ Default, WithMinimalTemplate, WithLinkSlot }}
   defaultStory="Default"
   githubPath="recommendations/atomic-recs-result-template/atomic-recs-result-template.ts"
   tagName="atomic-recs-result-template"

--- a/packages/atomic/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.mdx
+++ b/packages/atomic/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicAutomaticFacetGeneratorStories from './atomic-automatic-facet-generator.new.stories';
+import meta, { Default } from './atomic-automatic-facet-generator.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicAutomaticFacetGeneratorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicAutomaticFacetGeneratorStories}
+  stories={{ Default }}
   githubPath="search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.ts"
   tagName="atomic-automatic-facet-generator"
   className="AtomicAutomaticFacetGenerator"

--- a/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
-import * as AtomicAutomaticFacetStories from './atomic-automatic-facet.new.stories';
+import meta, { Default } from './atomic-automatic-facet.new.stories';
 
-<Meta of={AtomicAutomaticFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicAutomaticFacetStories}
+  stories={{ Default }}
   githubPath="search/atomic-automatic-facet/atomic-automatic-facet.ts"
   tagName="atomic-automatic-facet"
   className="AtomicAutomaticFacet"

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicBreadboxStories from './atomic-breadbox.new.stories';
+import meta, { Default } from './atomic-breadbox.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicBreadboxStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicBreadboxStories}
+  stories={{ Default }}
   githubPath="search/atomic-breadbox/atomic-breadbox.ts"
   tagName="atomic-breadbox"
   className="AtomicBreadbox"

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicCategoryFacetStories from './atomic-category-facet.new.stories';
+import meta, { Default, WithSelectedRootValue, WithSelectedChildValue, WithSelectedChildValueAndMoreAvailable } from './atomic-category-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicCategoryFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicCategoryFacetStories }
+  stories={{ Default, WithSelectedRootValue, WithSelectedChildValue, WithSelectedChildValueAndMoreAvailable }}
   githubPath="search/atomic-category-facet/atomic-category-facet.ts"
   tagName="atomic-category-facet"
   className="AtomicCategoryFacet"

--- a/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicColorFacetStories from './atomic-color-facet.new.stories';
+import meta, { Default, CheckboxDisplay, WithSelectedValue } from './atomic-color-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicColorFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicColorFacetStories }
+  stories={{ Default, CheckboxDisplay, WithSelectedValue }}
   githubPath="search/atomic-color-facet/atomic-color-facet.ts"
   tagName="atomic-color-facet"
   className="AtomicColorFacet"

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicDidYouMeanStories from './atomic-did-you-mean.new.stories';
+import meta, { WithAutomaticQueryCorrection, WithoutAutomaticQueryCorrection } from './atomic-did-you-mean.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicDidYouMeanStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicDidYouMeanStories}
+  stories={{ WithAutomaticQueryCorrection, WithoutAutomaticQueryCorrection }}
   githubPath="search/atomic-did-you-mean/atomic-did-you-mean.ts"
   tagName="atomic-did-you-mean"
   className="AtomicDidYouMean"

--- a/packages/atomic/src/components/search/atomic-external/atomic-external.mdx
+++ b/packages/atomic/src/components/search/atomic-external/atomic-external.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicExternalStories from './atomic-external.new.stories';
+import meta, { Default } from './atomic-external.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicExternalStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicExternalStories }
+  stories={{ Default }}
   githubPath="search/atomic-external/atomic-external.ts"
   tagName="atomic-external"
   className="AtomicExternal"

--- a/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.mdx
+++ b/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFacetManagerStories from './atomic-facet-manager.new.stories';
+import meta, { Default } from './atomic-facet-manager.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicFacetManagerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicFacetManagerStories}
+  stories={{ Default }}
   githubPath="search/atomic-facet-manager/atomic-facet-manager.ts"
   tagName="atomic-facet-manager"
   className="AtomicFacetManager"

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFacetStories from './atomic-facet.new.stories';
+import meta, { Default, LowFacetValues, monthFacet, CustomSort } from './atomic-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicFacetStories }
+  stories={{ Default, LowFacetValues, monthFacet, CustomSort }}
   githubPath="search/facets/atomic-facet/atomic-facet.ts"
   tagName="atomic-facet"
   className="AtomicFacet"

--- a/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.mdx
+++ b/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFieldConditionStories from './atomic-field-condition.new.stories';
+import meta, { Default } from './atomic-field-condition.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicFieldConditionStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicFieldConditionStories }
+  stories={{ Default }}
   githubPath="search/result-template-components/atomic-field-condition/atomic-field-condition.ts"
   tagName="atomic-field-condition"
   className="AtomicFieldCondition"

--- a/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.mdx
+++ b/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFoldedResultListStories from './atomic-folded-result-list.new.stories';
+import meta, { Default, WithNoResultChildren, WithFewResultChildren, WithMoreResultsAvailableAndNoChildren } from './atomic-folded-result-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicFoldedResultListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicFoldedResultListStories}
+  stories={{ Default, WithNoResultChildren, WithFewResultChildren, WithMoreResultsAvailableAndNoChildren }}
   githubPath="search/atomic-folded-result-list/atomic-folded-result-list.ts"
   tagName="atomic-folded-result-list"
   className="AtomicFoldedResultList"

--- a/packages/atomic/src/components/search/atomic-format-currency/atomic-format-currency.mdx
+++ b/packages/atomic/src/components/search/atomic-format-currency/atomic-format-currency.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFormatCurrencyStories from './atomic-format-currency.new.stories';
+import meta, { Facet, Result } from './atomic-format-currency.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicFormatCurrencyStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicFormatCurrencyStories}
+  stories={{ Facet, Result }}
   githubPath="search/atomic-format-currency/atomic-format-currency.ts"
   tagName="atomic-format-currency"
   className="AtomicFormatCurrency"

--- a/packages/atomic/src/components/search/atomic-format-number/atomic-format-number.mdx
+++ b/packages/atomic/src/components/search/atomic-format-number/atomic-format-number.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFormatNumberStories from './atomic-format-number.new.stories';
+import meta, { Facet, Result } from './atomic-format-number.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicFormatNumberStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicFormatNumberStories}
+  stories={{ Facet, Result }}
   githubPath="search/atomic-format-number/atomic-format-number.ts"
   tagName="atomic-format-number"
   className="AtomicFormatNumber"

--- a/packages/atomic/src/components/search/atomic-format-unit/atomic-format-unit.mdx
+++ b/packages/atomic/src/components/search/atomic-format-unit/atomic-format-unit.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicFormatUnitStories from './atomic-format-unit.new.stories';
+import meta, { Facet, Result } from './atomic-format-unit.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicFormatUnitStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicFormatUnitStories}
+  stories={{ Facet, Result }}
   githubPath="search/atomic-format-unit/atomic-format-unit.ts"
   tagName="atomic-format-unit"
   className="AtomicFormatUnit"

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.mdx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.mdx
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicGeneratedAnswerStories from './atomic-generated-answer.new.stories';
+import meta, { Default, DisableCitationAnchoring, WithLegacyAnalytics } from './atomic-generated-answer.new.stories';
 import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicGeneratedAnswerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicGeneratedAnswerStories}
+  stories={{ Default, DisableCitationAnchoring, WithLegacyAnalytics }}
   githubPath="search/atomic-generated-answer/atomic-generated-answer.ts"
   tagName="atomic-generated-answer"
   className="AtomicGeneratedAnswer"

--- a/packages/atomic/src/components/search/atomic-html/atomic-html.mdx
+++ b/packages/atomic/src/components/search/atomic-html/atomic-html.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicHtmlStories from './atomic-html.new.stories';
+import meta, { Default } from './atomic-html.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template.jsx';
 
-<Meta of={ AtomicHtmlStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicHtmlStories }
+  stories={{ Default }}
   githubPath="search/atomic-html/atomic-html.ts"
   tagName="atomic-html"
   className="AtomicHtml"

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.mdx
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicLoadMoreResultsStories from './atomic-load-more-results.new.stories';
+import meta, { Default } from './atomic-load-more-results.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicLoadMoreResultsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicLoadMoreResultsStories}
+  stories={{ Default }}
   githubPath="search/atomic-load-more-results/atomic-load-more-results.ts"
   tagName="atomic-load-more-results"
   className="AtomicLoadMoreResults"

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.mdx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicNoResultsStories from './atomic-no-results.new.stories';
+import meta, { Default } from './atomic-no-results.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicNoResultsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicNoResultsStories}
+  stories={{ Default }}
   githubPath="search/atomic-no-results/atomic-no-results.ts"
   tagName="atomic-no-results"
   className="AtomicNoResults"

--- a/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.mdx
+++ b/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicNotificationsStories from './atomic-notifications.new.stories';
+import meta, { Default, CustomIcon } from './atomic-notifications.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicNotificationsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicNotificationsStories}
+  stories={{ Default, CustomIcon }}
   githubPath="search/atomic-notifications/atomic-notifications.ts"
   tagName="atomic-notifications"
   className="AtomicNotifications"

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicNumericFacetStories from './atomic-numeric-facet.new.stories';
+import meta, { Default, WithInputInteger, WithDependsOn, DisplayAsLink, Collapsed, WithSelectedValue } from './atomic-numeric-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicNumericFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicNumericFacetStories }
+  stories={{ Default, WithInputInteger, WithDependsOn, DisplayAsLink, Collapsed, WithSelectedValue }}
   githubPath="search/atomic-numeric-facet/atomic-numeric-facet.ts"
   tagName="atomic-numeric-facet"
   className="AtomicNumericFacet"

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.mdx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.mdx
@@ -1,12 +1,12 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicPagerStories from './atomic-pager.new.stories';
+import meta, { Default, CustomIcon, WithACustomNumberOfPages } from './atomic-pager.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicPagerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicPagerStories}
+  stories={{ Default, CustomIcon, WithACustomNumberOfPages }}
   githubPath="search/atomic-pager/atomic-pager.ts"
   tagName="atomic-pager"
   className="AtomicPager"

--- a/packages/atomic/src/components/search/atomic-popover/atomic-popover.mdx
+++ b/packages/atomic/src/components/search/atomic-popover/atomic-popover.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicPopoverStories from './atomic-popover.new.stories';
+import meta, { Default } from './atomic-popover.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicPopoverStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicPopoverStories}
+  stories={{ Default }}
   githubPath="search/atomic-popover/atomic-popover.ts"
   tagName="atomic-popover"
   className="AtomicPopover"

--- a/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.mdx
+++ b/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicQueryErrorStories from './atomic-query-error.new.stories';
+import meta, { Default, WithInvalidToken, WithDisconnected, WithNoEndpoints, WithOrganizationPaused } from './atomic-query-error.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicQueryErrorStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicQueryErrorStories}
+  stories={{ Default, WithInvalidToken, WithDisconnected, WithNoEndpoints, WithOrganizationPaused }}
   githubPath="search/atomic-query-error/atomic-query-error.ts"
   tagName="atomic-query-error"
   className="AtomicQueryError"

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.mdx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicQuerySummaryStories from './atomic-query-summary.new.stories';
+import meta, { Default } from './atomic-query-summary.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicQuerySummaryStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicQuerySummaryStories }
+  stories={{ Default }}
   githubPath="search/atomic-query-summary/atomic-query-summary.ts"
   tagName="atomic-query-summary"
   className="AtomicQuerySummary"

--- a/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.mdx
+++ b/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicQuickviewModalStories from './atomic-quickview-modal.new.stories';
+import meta, { Default, Closed } from './atomic-quickview-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicQuickviewModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicQuickviewModalStories}
+  stories={{ Default, Closed }}
   githubPath="search/atomic-quickview-modal/atomic-quickview-modal.ts"
   tagName="atomic-quickview-modal"
   className="AtomicQuickviewModal"

--- a/packages/atomic/src/components/search/atomic-quickview/atomic-quickview.mdx
+++ b/packages/atomic/src/components/search/atomic-quickview/atomic-quickview.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicQuickviewStories from './atomic-quickview.new.stories';
+import meta, { Default, CustomSandbox } from './atomic-quickview.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicQuickviewStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicQuickviewStories}
+  stories={{ Default, CustomSandbox }}
   githubPath="search/atomic-quickview/atomic-quickview.ts"
   tagName="atomic-quickview"
   className="AtomicQuickview"

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRatingFacetStories from './atomic-rating-facet.new.stories';
+import meta, { Default, DisplayAsLink } from './atomic-rating-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicRatingFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRatingFacetStories}
+  stories={{ Default, DisplayAsLink }}
   githubPath="search/facets/atomic-rating-facet/atomic-rating-facet.ts"
   tagName="atomic-rating-facet"
   className="AtomicRatingFacet"

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.mdx
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicRatingRangeFacetStories from './atomic-rating-range-facet.new.stories';
+import meta, { Default } from './atomic-rating-range-facet.new.stories';
 import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicRatingRangeFacetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRatingRangeFacetStories}
+  stories={{ Default }}
   githubPath="search/facets/atomic-rating-range-facet/atomic-rating-range-facet.ts"
   tagName="atomic-rating-range-facet"
   className="AtomicRatingRangeFacet"

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.mdx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRefineModalStories from './atomic-refine-modal.new.stories';
+import meta, { Default } from './atomic-refine-modal.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicRefineModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicRefineModalStories}
+  stories={{ Default }}
   githubPath="search/atomic-refine-modal/atomic-refine-modal.ts"
   tagName="atomic-refine-modal"
   className="AtomicRefineModal"

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.mdx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicRefineToggleStories from './atomic-refine-toggle.new.stories';
+import meta, { Default, WithAtomicExternals } from './atomic-refine-toggle.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicRefineToggleStories} name="Docs"/>
+<Meta of={meta} name="Docs"/>
 
 <AtomicDocTemplate
-  stories={AtomicRefineToggleStories}
+  stories={{ Default, WithAtomicExternals }}
   githubPath="search/atomic-refine-toggle/atomic-refine-toggle.ts"
   tagName="atomic-refine-toggle"
   className="AtomicRefineToggle"

--- a/packages/atomic/src/components/search/atomic-result-badge/atomic-result-badge.mdx
+++ b/packages/atomic/src/components/search/atomic-result-badge/atomic-result-badge.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultBadgeStories from './atomic-result-badge.new.stories';
+import meta, { Default, WithLabel, WithIcon } from './atomic-result-badge.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultBadgeStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultBadgeStories}
+  stories={{ Default, WithLabel, WithIcon }}
   githubPath="search/atomic-result-badge/atomic-result-badge.ts"
   tagName="atomic-result-badge"
   className="AtomicResultBadge"

--- a/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.mdx
+++ b/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultChildrenTemplateStories from './atomic-result-children-template.new.stories';
+import meta, { Default } from './atomic-result-children-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultChildrenTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultChildrenTemplateStories}
+  stories={{ Default }}
   defaultStory="Default"
   githubPath="search/atomic-result-children-template/atomic-result-children-template.ts"
   tagName="atomic-result-children-template"

--- a/packages/atomic/src/components/search/atomic-result-children/atomic-result-children.mdx
+++ b/packages/atomic/src/components/search/atomic-result-children/atomic-result-children.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultChildrenStories from './atomic-result-children.new.stories';
+import meta, { Default, WithInheritTemplates } from './atomic-result-children.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicResultChildrenStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicResultChildrenStories }
+  stories={{ Default, WithInheritTemplates }}
   githubPath="search/atomic-result-children/atomic-result-children.ts"
   tagName="atomic-result-children"
   className="AtomicResultChildren"

--- a/packages/atomic/src/components/search/atomic-result-date/atomic-result-date.mdx
+++ b/packages/atomic/src/components/search/atomic-result-date/atomic-result-date.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultDateStories from './atomic-result-date.new.stories';
+import meta, { Default, CustomFormat, RelativeTime } from './atomic-result-date.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultDateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultDateStories}
+  stories={{ Default, CustomFormat, RelativeTime }}
   githubPath="search/atomic-result-date/atomic-result-date.ts"
   tagName="atomic-result-date"
   className="AtomicResultDate"

--- a/packages/atomic/src/components/search/atomic-result-fields-list/atomic-result-fields-list.mdx
+++ b/packages/atomic/src/components/search/atomic-result-fields-list/atomic-result-fields-list.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultFieldsListStories from './atomic-result-fields-list.new.stories';
+import meta, { Default } from './atomic-result-fields-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultFieldsListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultFieldsListStories}
+  stories={{ Default }}
   githubPath="search/atomic-result-fields-list/atomic-result-fields-list.ts"
   tagName="atomic-result-fields-list"
   className="AtomicResultFieldsList"

--- a/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.mdx
+++ b/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultHtmlStories from './atomic-result-html.new.stories';
+import meta, { Default } from './atomic-result-html.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicResultHtmlStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultHtmlStories}
+  stories={{ Default }}
   githubPath="search/atomic-result-html/atomic-result-html.ts"
   tagName="atomic-result-html"
   className="AtomicResultHtml"

--- a/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.mdx
+++ b/packages/atomic/src/components/search/atomic-result-image/atomic-result-image.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultImageStories from './atomic-result-image.new.stories';
+import meta, { Default, WithAltTextField, WithFallback } from './atomic-result-image.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicResultImageStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicResultImageStories }
+  stories={{ Default, WithAltTextField, WithFallback }}
   githubPath="search/atomic-result-image/atomic-result-image.ts"
   tagName="atomic-result-image"
   className="AtomicResultImage"

--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.mdx
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultLinkStories from './atomic-result-link.new.stories';
+import meta, { Default, WithSlotsAttributes, WithAlternativeContent, WithHrefTemplate } from './atomic-result-link.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicResultLinkStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultLinkStories}
+  stories={{ Default, WithSlotsAttributes, WithAlternativeContent, WithHrefTemplate }}
   githubPath="search/atomic-result-link/atomic-result-link.ts"
   tagName="atomic-result-link"
   className="AtomicResultLink"

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.mdx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultListStories from './atomic-result-list.new.stories';
+import meta, { Default, ListDisplayWithTemplate, ListDisplayBeforeQuery, GridDisplay, GridDisplayWithTemplate, GridDisplayBeforeQuery, TableDisplay, TableDisplayBeforeQuery, NoResults } from './atomic-result-list.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultListStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultListStories}
+  stories={{ Default, ListDisplayWithTemplate, ListDisplayBeforeQuery, GridDisplay, GridDisplayWithTemplate, GridDisplayBeforeQuery, TableDisplay, TableDisplayBeforeQuery, NoResults }}
   githubPath="search/atomic-result-list/atomic-result-list.ts"
   tagName="atomic-result-list"
   className="AtomicResultList"

--- a/packages/atomic/src/components/search/atomic-result-localized-text/atomic-result-localized-text.mdx
+++ b/packages/atomic/src/components/search/atomic-result-localized-text/atomic-result-localized-text.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultLocalizedTextStories from './atomic-result-localized-text.new.stories';
+import meta, { Default } from './atomic-result-localized-text.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultLocalizedTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultLocalizedTextStories}
+  stories={{ Default }}
   githubPath="search/atomic-result-localized-text/atomic-result-localized-text.ts"
   tagName="atomic-result-localized-text"
   className="AtomicResultLocalizedText"

--- a/packages/atomic/src/components/search/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
+++ b/packages/atomic/src/components/search/atomic-result-multi-value-text/atomic-result-multi-value-text.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultMultiValueTextStories from './atomic-result-multi-value-text.new.stories';
+import meta, { Default, WithMaxValues } from './atomic-result-multi-value-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultMultiValueTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultMultiValueTextStories}
+  stories={{ Default, WithMaxValues }}
   githubPath="search/atomic-result-multi-value-text/atomic-result-multi-value-text.ts"
   tagName="atomic-result-multi-value-text"
   className="AtomicResultMultiValueText"

--- a/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.mdx
+++ b/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultNumberStories from './atomic-result-number.new.stories';
+import meta, { Default, WithCurrencyFormatting, WithNumberFormatting, WithUnitFormatting } from './atomic-result-number.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicResultNumberStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultNumberStories}
+  stories={{ Default, WithCurrencyFormatting, WithNumberFormatting, WithUnitFormatting }}
   githubPath="search/atomic-result-number/atomic-result-number.ts"
   tagName="atomic-result-number"
   className="AtomicResultNumber"

--- a/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.mdx
+++ b/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultPrintableUriStories from './atomic-result-printable-uri.new.stories';
+import meta, { Default, WithEllipsis } from './atomic-result-printable-uri.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicResultPrintableUriStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicResultPrintableUriStories }
+  stories={{ Default, WithEllipsis }}
   githubPath="search/atomic-result-printable-uri/atomic-result-printable-uri.ts"
   tagName="atomic-result-printable-uri"
   className="AtomicResultPrintableUri"

--- a/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.mdx
+++ b/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultRatingStories from './atomic-result-rating.new.stories';
+import meta, { Default, WithAMaxValueInIndex, WithADifferentIcon } from './atomic-result-rating.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultRatingStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultRatingStories}
+  stories={{ Default, WithAMaxValueInIndex, WithADifferentIcon }}
   githubPath="search/atomic-result-rating/atomic-result-rating.ts"
   tagName="atomic-result-rating"
   className="AtomicResultRating"

--- a/packages/atomic/src/components/search/atomic-result-section-actions/Docs.mdx
+++ b/packages/atomic/src/components/search/atomic-result-section-actions/Docs.mdx
@@ -1,16 +1,16 @@
 import { Meta, Title, Description, Canvas, Subtitle, Story } from '@storybook/addon-docs/blocks';
-import * as ResultSectionActionsStories from './atomic-result-section-actions.new.stories';
-import * as ResultSectionBadgesStories from '../atomic-result-section-badges/atomic-result-section-badges.new.stories';
+import meta, { Default as ResultSectionActionsStoriesDefault } from './atomic-result-section-actions.new.stories';
+import { Default as ResultSectionBadgesStoriesDefault } from '../atomic-result-section-badges/atomic-result-section-badges.new.stories';
 import { CanvasWithGithub } from '../../../../storybook-utils/documentation/canvas-with-github';
-import * as ResultSectionBottomMetadataStories from '../atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories';
-import * as ResultSectionChildrenStories from '../atomic-result-section-children/atomic-result-section-children.new.stories';
-import * as ResultSectionExcerptStories from '../atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories';
-import * as ResultSectionEmphasizedStories from '../atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories';
-import * as ResultSectionTitleMetadataStories from '../atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories';
-import * as ResultSectionTitleStories from '../atomic-result-section-title/atomic-result-section-title.new.stories';
-import * as ResultSectionVisualStories from '../atomic-result-section-visual/atomic-result-section-visual.new.stories';
+import { Default as ResultSectionBottomMetadataStoriesDefault } from '../atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories';
+import { Default as ResultSectionChildrenStoriesDefault } from '../atomic-result-section-children/atomic-result-section-children.new.stories';
+import { Default as ResultSectionExcerptStoriesDefault } from '../atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories';
+import { Default as ResultSectionEmphasizedStoriesDefault } from '../atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories';
+import { Default as ResultSectionTitleMetadataStoriesDefault } from '../atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories';
+import { Default as ResultSectionTitleStoriesDefault } from '../atomic-result-section-title/atomic-result-section-title.new.stories';
+import { Default as ResultSectionVisualStoriesDefault } from '../atomic-result-section-visual/atomic-result-section-visual.new.stories';
 
-<Meta of={ResultSectionActionsStories} />
+<Meta of={meta} />
 
 # Result Sections
 
@@ -57,47 +57,47 @@ They work together to present a complete result view, including images, descript
 ## Components 
 
 ### atomic-result-section-badges
-<CanvasWithGithub of={ResultSectionBadgesStories.Default}  
+<CanvasWithGithub of={ResultSectionBadgesStoriesDefault}  
   githubPath="search/atomic-result-section-badges/atomic-result-section-badges.ts"
 />
 
 ### atomic-result-section-actions
-<CanvasWithGithub of={ResultSectionActionsStories.Default}  
+<CanvasWithGithub of={ResultSectionActionsStoriesDefault}  
   githubPath="search/atomic-result-section-actions/atomic-result-section-actions.ts"
 />
 
 ### atomic-result-section-bottom-metadata
-<CanvasWithGithub of={ResultSectionBottomMetadataStories.Default}  
+<CanvasWithGithub of={ResultSectionBottomMetadataStoriesDefault}  
   githubPath="search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.ts"
 />
 
 ### atomic-result-section-children
-<CanvasWithGithub of={ResultSectionChildrenStories.Default}  
+<CanvasWithGithub of={ResultSectionChildrenStoriesDefault}  
   githubPath="search/atomic-result-section-children/atomic-result-section-children.ts"
 />
 
 ### atomic-result-section-description
-<CanvasWithGithub of={ResultSectionExcerptStories.Default}  
+<CanvasWithGithub of={ResultSectionExcerptStoriesDefault}  
   githubPath="search/atomic-result-section-description/atomic-result-section-description.ts"
 />
 
 ### atomic-result-section-emphasized
-<CanvasWithGithub of={ResultSectionEmphasizedStories.Default}  
+<CanvasWithGithub of={ResultSectionEmphasizedStoriesDefault}  
   githubPath="search/atomic-result-section-emphasized/atomic-result-section-emphasized.ts"
 />
 
 ### atomic-result-section-metadata
-<CanvasWithGithub of={ResultSectionTitleMetadataStories.Default}  
+<CanvasWithGithub of={ResultSectionTitleMetadataStoriesDefault}  
   githubPath="search/atomic-result-section-metadata/atomic-result-section-metadata.ts"
 />
 
 ### atomic-result-section-name
-<CanvasWithGithub of={ResultSectionTitleStories.Default}  
+<CanvasWithGithub of={ResultSectionTitleStoriesDefault}  
   githubPath="search/atomic-result-section-name/atomic-result-section-name.ts"
 />
 
 ### atomic-result-section-visual
-<CanvasWithGithub of={ResultSectionVisualStories.Default}  
+<CanvasWithGithub of={ResultSectionVisualStoriesDefault}  
   githubPath="search/atomic-result-section-visual/atomic-result-section-visual.ts"
 />
 

--- a/packages/atomic/src/components/search/atomic-result-template/atomic-result-template.mdx
+++ b/packages/atomic/src/components/search/atomic-result-template/atomic-result-template.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultTemplateStories from './atomic-result-template.new.stories';
+import meta, { Default, InAFoldedResultList, InASearchBoxInstantResults } from './atomic-result-template.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultTemplateStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultTemplateStories}
+  stories={{ Default, InAFoldedResultList, InASearchBoxInstantResults }}
   defaultStory="Default"
   githubPath="search/atomic-result-template/atomic-result-template.ts"
   tagName="atomic-result-template"

--- a/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.mdx
+++ b/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultTextStories from './atomic-result-text.new.stories';
+import meta, { Default, WithTitle, WithFirstSentences, WithPrintableUri, WithSummary, WithoutHighlights } from './atomic-result-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultTextStories}
+  stories={{ Default, WithTitle, WithFirstSentences, WithPrintableUri, WithSummary, WithoutHighlights }}
   githubPath="search/atomic-result-text/atomic-result-text.ts"
   tagName="atomic-result-text"
   className="AtomicResultText"

--- a/packages/atomic/src/components/search/atomic-result-timespan/atomic-result-timespan.mdx
+++ b/packages/atomic/src/components/search/atomic-result-timespan/atomic-result-timespan.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicResultTimespanStories from './atomic-result-timespan.new.stories';
+import meta, { Default } from './atomic-result-timespan.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultTimespanStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultTimespanStories}
+  stories={{ Default }}
   githubPath="search/atomic-result-timespan/atomic-result-timespan.ts"
   tagName="atomic-result-timespan"
   className="AtomicResultTimespan"

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.mdx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.mdx
@@ -1,12 +1,12 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicResultsPerPageStories from './atomic-results-per-page.new.stories';
+import meta, { Default } from './atomic-results-per-page.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicResultsPerPageStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicResultsPerPageStories}
+  stories={{ Default }}
   githubPath="search/atomic-results-per-page/atomic-results-per-page.ts"
   tagName="atomic-results-per-page"
   className="AtomicResultsPerPage"

--- a/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSearchBoxInstantResultsStories from './atomic-search-box-instant-results.new.stories';
+import meta, { Default } from './atomic-search-box-instant-results.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicSearchBoxInstantResultsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSearchBoxInstantResultsStories}
+  stories={{ Default }}
   githubPath="search/atomic-search-box-instant-results/atomic-search-box-instant-results.ts"
   tagName="atomic-search-box-instant-results"
   className="AtomicSearchBoxInstantResults"

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.mdx
@@ -1,12 +1,12 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicSearchBoxQuerySuggestionsStories from './atomic-search-box-query-suggestions.new.stories';
+import meta, { Default } from './atomic-search-box-query-suggestions.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSearchBoxQuerySuggestionsStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSearchBoxQuerySuggestionsStories}
+  stories={{ Default }}
   githubPath="search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.ts"
   tagName="atomic-search-box-query-suggestions"
   className="AtomicSearchBoxQuerySuggestions"

--- a/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSearchBoxRecentQueriesStories from './atomic-search-box-recent-queries.new.stories';
+import meta, { Default } from './atomic-search-box-recent-queries.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSearchBoxRecentQueriesStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSearchBoxRecentQueriesStories}
+  stories={{ Default }}
   githubPath="search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.ts"
   tagName="atomic-search-box-recent-queries"
   className="AtomicSearchBoxRecentQueries"

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSearchBoxStories from './atomic-search-box.new.stories';
+import meta, { Default, RichSearchBox, StandaloneSearchBox } from './atomic-search-box.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSearchBoxStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSearchBoxStories}
+  stories={{ Default, RichSearchBox, StandaloneSearchBox }}
   githubPath="search/atomic-search-box/atomic-search-box.ts"
   tagName="atomic-search-box"
   className="AtomicSearchBox"

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.mdx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSearchInterfaceStories from './atomic-search-interface.new.stories';
+import meta, { Default, WithAResultList } from './atomic-search-interface.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicSearchInterfaceStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicSearchInterfaceStories }
+  stories={{ Default, WithAResultList }}
   githubPath="search/atomic-search-interface/atomic-search-interface.ts"
   tagName="atomic-search-interface"
   className="AtomicSearchInterface"

--- a/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.mdx
+++ b/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSearchLayoutStories from './atomic-search-layout.new.stories';
+import meta, { Default } from './atomic-search-layout.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSearchLayoutStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSearchLayoutStories}
+  stories={{ Default }}
   githubPath="search/atomic-search-layout/atomic-search-layout.ts"
   tagName="atomic-search-layout"
   className="AtomicSearchLayout"

--- a/packages/atomic/src/components/search/atomic-segmented-facet-scrollable/atomic-segmented-facet-scrollable.mdx
+++ b/packages/atomic/src/components/search/atomic-segmented-facet-scrollable/atomic-segmented-facet-scrollable.mdx
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicSegmentedFacetScrollableStories from './atomic-segmented-facet-scrollable.new.stories';
+import meta, { Default } from './atomic-segmented-facet-scrollable.new.stories';
 import {AtomicDocTemplate} from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicSegmentedFacetScrollableStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSegmentedFacetScrollableStories}
+  stories={{ Default }}
   githubPath="search/facets/atomic-segmented-facet-scrollable/atomic-segmented-facet-scrollable.ts"
   tagName="atomic-segmented-facet-scrollable"
   className="AtomicSegmentedFacetScrollable"

--- a/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSegmentedFacetStories from './atomic-segmented-facet.new.stories';
+import meta, { Default } from './atomic-segmented-facet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicSegmentedFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicSegmentedFacetStories }
+  stories={{ Default }}
   githubPath="search/facets/atomic-segmented-facet/atomic-segmented-facet.ts"
   tagName="atomic-segmented-facet"
   className="AtomicSegmentedFacet"

--- a/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.mdx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.mdx
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import * as AtomicSmartSnippetFeedbackModalStories from './atomic-smart-snippet-feedback-modal.new.stories';
+import meta, { Default, OpenedModal } from './atomic-smart-snippet-feedback-modal.new.stories';
 import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicSmartSnippetFeedbackModalStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSmartSnippetFeedbackModalStories}
+  stories={{ Default, OpenedModal }}
   githubPath="search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.ts"
   tagName="atomic-smart-snippet-feedback-modal"
   className="AtomicSmartSnippetFeedbackModal"

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.mdx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSmartSnippetStories from './atomic-smart-snippet.new.stories';
+import meta, { Default } from './atomic-smart-snippet.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSmartSnippetStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSmartSnippetStories}
+  stories={{ Default }}
   githubPath="search/atomic-smart-snippet/atomic-smart-snippet/atomic-smart-snippet.ts"
   tagName="atomic-smart-snippet"
   className="AtomicSmartSnippet"

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.mdx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSortDropdownStories from './atomic-sort-dropdown.new.stories';
+import meta, { Default } from './atomic-sort-dropdown.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSortDropdownStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSortDropdownStories}
+  stories={{ Default }}
   githubPath="search/atomic-sort-dropdown/atomic-sort-dropdown.ts"
   tagName="atomic-sort-dropdown"
   className="AtomicSortDropdown"

--- a/packages/atomic/src/components/search/atomic-sort-expression/atomic-sort-expression.mdx
+++ b/packages/atomic/src/components/search/atomic-sort-expression/atomic-sort-expression.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicSortExpressionStories from './atomic-sort-expression.new.stories';
+import meta, { Default, DateDescending, WithTabsIncluded, WithTabsExcluded, ComplexExpression } from './atomic-sort-expression.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicSortExpressionStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicSortExpressionStories}
+  stories={{ Default, DateDescending, WithTabsIncluded, WithTabsExcluded, ComplexExpression }}
   githubPath="search/atomic-sort-expression/atomic-sort-expression.ts"
   tagName="atomic-sort-expression"
   className="AtomicSortExpression"

--- a/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.mdx
+++ b/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicTabManagerStories from './atomic-tab-manager.new.stories';
+import meta, { Default } from './atomic-tab-manager.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicTabManagerStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicTabManagerStories}
+  stories={{ Default }}
   githubPath="search/atomic-tab-manager/atomic-tab-manager.ts"
   tagName="atomic-tab-manager"
   className="AtomicTabManager"

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.mdx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicTabStories from './atomic-tab.new.stories';
+import meta, { Default } from './atomic-tab.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
 
-<Meta of={AtomicTabStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicTabStories}
+  stories={{ Default }}
   githubPath="search/atomic-tab/atomic-tab.ts"
   tagName="atomic-tab"
   className="AtomicTab"

--- a/packages/atomic/src/components/search/atomic-text/atomic-text.mdx
+++ b/packages/atomic/src/components/search/atomic-text/atomic-text.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicTextStories from './atomic-text.new.stories';
+import meta, { Default, WithTranslations } from './atomic-text.new.stories';
 import { AtomicDocTemplate } from '@/storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={AtomicTextStories} />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={AtomicTextStories}
+  stories={{ Default, WithTranslations }}
   githubPath="search/atomic-text/atomic-text.ts"
   tagName="atomic-text"
   className="AtomicText"

--- a/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.mdx
+++ b/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import * as AtomicTimeframeFacetStories from './atomic-timeframe-facet.new.stories';
+import meta, { Default, WithSelectedValue, WithDatePicker, WithDependsOn, Collapsed } from './atomic-timeframe-facet.new.stories';
 import { AtomicDocTemplate } from '../../../../storybook-utils/documentation/atomic-doc-template';
 
-<Meta of={ AtomicTimeframeFacetStories } />
+<Meta of={meta} />
 
 <AtomicDocTemplate
-  stories={ AtomicTimeframeFacetStories }
+  stories={{ Default, WithSelectedValue, WithDatePicker, WithDependsOn, Collapsed }}
   githubPath="search/atomic-timeframe-facet/atomic-timeframe-facet.ts"
   tagName="atomic-timeframe-facet"
   className="AtomicTimeframeFacet"


### PR DESCRIPTION
## Purpose

Due the way that the production bundler works (as least this is my current understanding), the namespace import from the component lost its `meta` reference. This caused the storybook `Meta` component to fail to load.

The `Meta` component was used in every documentation page, thus all documentation pages failed to load.

This updates all mdx files to explicitly import `meta` and `Default` from the source components and updates the documentation pages accordingly (which introduces a great deal of churn in this PR).

I have also ensured that the Atomic README includes steps on build and running a production build of the site.

## JIRA
https://coveord.atlassian.net/browse/DOC-19023

Fixes #7334