### PR TITLE
feat(atomic): render markdown hyperlinks in generated answer

### DIFF
--- a/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.ts
@@ -14,7 +14,7 @@ export const renderGeneratedMarkdownContent: FunctionalComponent<
 > = ({props}) => {
   const answerAsHtml = DOMPurify.sanitize(
     transformMarkdownToHtml(props.answer ?? ''),
-    {ADD_ATTR: ['part']}
+    {ADD_ATTR: ['part', 'target', 'rel']}
   );
 
   return html`

--- a/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.tw.css.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/generated-markdown-content.tw.css.ts
@@ -43,6 +43,14 @@ const styles = css`
     @apply font-bold;
   }
 
+  [part='generated-text'] [part='answer-link'] {
+    @apply text-primary underline cursor-pointer;
+  }
+
+  [part='generated-text'] [part='answer-link']:hover {
+    @apply text-primary-light;
+  }
+
   [part='generated-text'] [part='answer-ordered-list'] {
     @apply mb-2 list-decimal ps-8;
   }

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
@@ -93,6 +93,11 @@ const customRenderer = {
     return `<p part="answer-paragraph">${text}</p>`;
   },
 
+  link(href: string, _title: string | null | undefined, text: string) {
+    const safeHref = href?.startsWith('http') ? href : '#';
+    return `<a part="answer-link" href="${safeHref}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+  },
+
   strong(text: string) {
     return `<strong part="answer-strong">${text}</strong>`;
   },


### PR DESCRIPTION
## Problem

Markdown hyperlinks produced by the generated answer agent (e.g. `[Reset Password](https://...)`) were not rendered as HTML `<a>` tags. The custom `marked` renderer in `markdown-utils.ts` had handlers for every block and inline element **except** `link`, so marked's default output was either stripped or displayed as raw markdown text.

Additionally, even when `<a>` tags were produced, DOMPurify stripped `target` and `rel` attributes since only `part` was in the `ADD_ATTR` allowlist. Finally, no visual styles existed for the `answer-link` CSS part, so links appeared unstyled (black, no underline).

## Changes

| File | Change |
|------|--------|
| `markdown-utils.ts` | Add custom `link` renderer — outputs `<a part="answer-link">` with safe href, `target="_blank"`, `rel="noopener noreferrer"` |
| `generated-markdown-content.ts` | Add `target` and `rel` to DOMPurify `ADD_ATTR` so those attributes survive sanitization |
| `generated-markdown-content.tw.css.ts` | Style `[part='answer-link']` with `text-primary underline cursor-pointer` and a hover state using `text-primary-light` |

## Test plan

- [ ] Run a query that returns a generated answer containing a markdown hyperlink
- [ ] Verify the link renders as a blue underlined anchor that opens in a new tab
- [ ] Verify links inside bold (`**[text](url)**`) and lists also render correctly
- [ ] Verify non-http(s) hrefs fall back to `#` (safe href guard)
- [ ] Run existing `markdown-utils.spec.ts` tests


## Changes
Add a custom `link` renderer to the marked custom renderer so that markdown hyperlinks in generated answers are converted to proper `<a>` tags instead of being left as raw markdown text.

Also allow `target` and `rel` attributes through DOMPurify so that `target="_blank"` and `rel="noopener noreferrer"` are preserved on the rendered anchor elements.

Finally, add `answer-link` CSS part styles so links appear in the component's primary color with an underline and a pointer cursor, and lighten on hover — consistent with the existing Atomic design tokens.