### PR TITLE
ci(KIT-5588): set cancel-in-progress to true on CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## ⚠️ Closed — Risk of cancelling publish runs

This PR changed `cancel-in-progress` from `false` to `true` on the CD workflow to prevent a race condition where concurrent runs briefly close and reopen the release PR (observed on PR #7373).

However, as raised during review, this introduces a **worse risk**: if the release PR merges and a subsequent PR merges to `main` shortly after, the publish run (`pnpm run release`) would be **cancelled mid-way**, potentially causing a **partial npm publish**. Downstream jobs (`quantic-prod`, `typedoc-headless`, `docs-prod`) would also be cancelled.

The original race condition (PR briefly closed and reopened) is cosmetic and self-healing — a partial publish is not. Closing this PR.

---

### Original description

When multiple commits land on `main` in quick succession, the CD workflow queues multiple concurrent runs. Each run checks out its triggering commit SHA, so each sees a different subset of changeset files. This causes a race condition where the release PR gets briefly closed and reopened.

[KIT-5588](https://coveord.atlassian.net/browse/KIT-5588)

[KIT-5588]: https://coveord.atlassian.net/browse/KIT-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ