### PR TITLE
fix(areas): add areas config for .changeset/ directory

### DIFF
--- a/.areas/changeset.yml
+++ b/.areas/changeset.yml
@@ -1,0 +1,3 @@
+description: Changeset files for package versioning
+file_patterns:
+  - .changeset/*.md


### PR DESCRIPTION
## [KIT-5596](https://coveord.atlassian.net/browse/KIT-5596)

### Problem
Changeset files (`.changeset/*.md`) don't have a dedicated areas configuration. This means the dxui team gets pinged for review on every PR that includes a changeset file, even when the change belongs to another team.

### Solution
Add a `.areas/changeset.yml` file that covers `.changeset/*.md` files with no required reviewers, so changeset entries don't trigger review requests for any specific team. Only the relevant package owners (determined by their own area configs) get notified.

### Changes
- Added `.areas/changeset.yml` with file pattern `.changeset/*.md` and no required reviewers

[KIT-5596]: https://coveord.atlassian.net/browse/KIT-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ