### PR TITLE
fix: generated-text styles to use Tailwind utilities

### DIFF
--- a/.changeset/nervous-gifts-promise.md
+++ b/.changeset/nervous-gifts-promise.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Restore CSS customization that was accidentally removed in `atomic-generated-answer`

--- a/packages/atomic/src/components/common/generated-answer/styles/generated-text.tw.css.ts
+++ b/packages/atomic/src/components/common/generated-answer/styles/generated-text.tw.css.ts
@@ -1,9 +1,11 @@
 import {css} from 'lit';
 
 const styles = css`
+  @reference '../../../../utils/tailwind.global.tw.css';
+  @reference '../../../../utils/tailwind-utilities/set-font-size.css';
+
   [part='generated-text'] {
-    font-size: 1.125rem;
-    line-height: 1.75rem;
+    @apply set-font-size-lg;
   }
 
   [part='generated-text'].cursor::after {
@@ -11,7 +13,7 @@ const styles = css`
     width: 8px;
     height: 1em;
     margin-left: 0.1em;
-    background-color: var(--atomic-neutral-dark);
+    @apply bg-neutral-dark;
     display: inline-block;
     animation: cursor-blink 1.5s steps(2) infinite;
     vertical-align: text-bottom;


### PR DESCRIPTION
KIT-282
During the lit migration, we mistakenly replaced Tailwind Utilities with hard-coded values for some CSS properties.
This removed the possibility for the user to style the component with the associated CSS variable.

Fixes #7381