### PR TITLE
fix(ci): remove unused IS_PRERELEASE to fix cdn-checks turbo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         run: pnpm run knip
   cdn-checks:
     name: 'CDN Checks'
-    needs: [affected]
+    needs: [affected, build-cdn]
     if: contains(needs.affected.outputs.projects, '@coveo/atomic') || contains(needs.affected.outputs.projects, '@samples/headless-commerce-react') || contains(needs.affected.outputs.projects, '@coveo/atomic-hosted-page')
     env:
       DEPLOYMENT_ENVIRONMENT: CDN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEPLOYMENT_ENVIRONMENT: CDN
-      IS_PRERELEASE: 'true'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/turbo.json
+++ b/turbo.json
@@ -69,7 +69,7 @@
     ".oxfmtrc.json",
     ".cspell.json"
   ],
-  "globalEnv": ["DEPLOYMENT_ENVIRONMENT", "IS_PRERELEASE", "NODE_ENV", "CI"],
+  "globalEnv": ["DEPLOYMENT_ENVIRONMENT", "NODE_ENV", "CI"],
   "globalPassThroughEnv": [
     "GITHUB_*",
     "RUNNER_*",


### PR DESCRIPTION
## [KIT-5594](https://coveord.atlassian.net/browse/KIT-5594)

### Problem

The `cdn-checks` CI job rebuilds all 42 packages from scratch (~3 min) despite downloading a 215MB turbo cache artifact from the `build-cdn` job.

**Root cause:** `turbo.json` lists `IS_PRERELEASE` in `globalEnv`, making it part of every task's cache key. The `build-cdn` job sets `IS_PRERELEASE: 'true'`, but `cdn-checks` leaves it unset — this single env var mismatch invalidates the entire turbo cache (`Cached: 0 cached, 42 total`).

`IS_PRERELEASE` was originally used for CDN PR preview releases, which generated versioned URLs like `v1.0.0.123`. This feature was removed in [#7357](https://github.com/coveo/ui-kit/pull/7357) and replaced by [pkg-pr-new](https://github.com/stackblitz-labs/pkg.pr.new), but the env var was left behind in CI and turbo config.

### Solution

- Remove `IS_PRERELEASE` from the `build-cdn` job env in CI (no longer consumed by any build step)
- Remove `IS_PRERELEASE` from `turbo.json` `globalEnv` (no longer needed as a cache key)
- Add `build-cdn` to `cdn-checks` `needs` array (ensures the turbo cache artifact is always available)

### Results

| Step | Before | After | Saved |
|---|---|---|---|
| **Setup + Build** | ~208s | **~43s** | 165s |
| **CDN checks (tests)** | ~121s | ~127s | — |
| **Total job** | **423s (7.0 min)** | **253s (4.2 min)** | **170s (40%)** |

The `pnpm run build` step now correctly uses the turbo cache from `build-cdn` instead of rebuilding everything.

[KIT-5594]: https://coveord.atlassian.net/browse/KIT-5594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ