### PR TITLE
feat(ci): shard unit tests into 3 parallel matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,9 +238,13 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm --filter @coveo/atomic run validate:no-new-light-dom
   unit-test:
-    name: 'Run unit tests'
+    name: 'Run unit tests (shard ${{ matrix.shard }})'
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/3, 2/3, 3/3]
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
       options: --user 1001
@@ -260,7 +264,7 @@ jobs:
       - run: git branch main origin/main
         if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo test --affected
+      - run: pnpm exec turbo test --affected -- --shard=${{ matrix.shard }}
   package-compatibility:
     name: 'Verify compatibility of packages'
     needs: build

--- a/packages/headless/src/shard-test-trigger.ts
+++ b/packages/headless/src/shard-test-trigger.ts
@@ -1,0 +1,1 @@
+// test file for CI shard validation


### PR DESCRIPTION
## [KIT-5595](https://coveord.atlassian.net/browse/KIT-5595) — Shard unit tests to reduce CI wall-clock time

### Problem

The unit test job takes **5–6 minutes** wall-clock, bottlenecked by `@coveo/atomic` (444 test files, 6,626 tests in vitest browser mode). The import/setup phase alone dominates (~607s of vitest's reported time).

### Solution

Shard the unit test job using a **GitHub Actions matrix strategy** with vitest's built-in `--shard` flag:

- **3 parallel shards** (`1/3`, `2/3`, `3/3`) via matrix strategy
- `--shard` passed through turbo to vitest via the `--` separator
- `fail-fast: false` so all shards complete even if one fails
- Turbo still handles `--affected` filtering and per-package caching

### Expected impact

Splitting into 3 shards should reduce unit test wall-clock from ~350s to ~120s per shard, saving **~4 minutes** on the CI critical path.

[KIT-5595]: https://coveord.atlassian.net/browse/KIT-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ