### PR TITLE
ci: use dx-bot GitHub App token for changeset action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,9 +25,18 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: coveo
+          repositories: 'ui-kit'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/actions/setup
         with:
           load-cache: false
@@ -43,7 +52,7 @@ jobs:
           commit: 'ci(changesets): version packages'
           commitMode: github-api
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Update release/v3 bookmark
         if: ${{ steps.changesets.outputs.published == 'true' }}
         run: git push origin HEAD:refs/heads/release/v3 --force


### PR DESCRIPTION
KIT-5598
## Summary

Replace the default `GITHUB_TOKEN` with a token generated from the dx-bot GitHub App (`GH_APP_ID` / `GH_APP_PRIVATE_KEY`) in the CD workflow's changeset action.

## Changes

- Added a "Generate a token" step using `actions/create-github-app-token` (same pattern used in CI workflows)
- Pass the generated token to `actions/checkout` so git operations are authenticated as the dx-bot
- Replace `secrets.GITHUB_TOKEN` with the app token in the `changesets/action` env

## Why

The changeset version PR and commits will now be authored by the dx-bot, consistent with how it is used elsewhere in the repository. This avoids the default GitHub Actions bot identity.