### PR TITLE
chore: shift chromatic gate from GitHub Action to Chromatic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,4 +752,4 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic --  --exit-once-uploaded --exit-zero-on-changes --auto-accept-changes --branchName=main
+      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-once-uploaded --exit-zero-on-changes --auto-accept-changes --branchName=main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,10 +374,10 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic
+      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-once-uploaded --exit-zero-on-changes
         id: chromatic-run
         if: contains(needs.affected.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'chromatic')
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
+      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-once-uploaded --exit-zero-on-changes --skip
         working-directory: packages/atomic
         if: steps.chromatic-run.outcome == 'skipped'
   playwright-atomic:
@@ -752,4 +752,4 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-zero-on-changes --auto-accept-changes --branchName=main
+      - run: pnpm exec turbo chromatic --filter=@coveo/atomic --  --exit-once-uploaded --exit-zero-on-changes --auto-accept-changes --branchName=main


### PR DESCRIPTION
https://github.com/coveo/ui-kit/settings/rules/1210409 (main ruleset) has been modified to add the Chromatic checks as a required status check.
<img width="790" height="588" alt="image" src="https://github.com/user-attachments/assets/485ca20a-b5aa-49e2-9670-d253223b2404" />

Hence, we don't need this to be part of the "Confirm build is Valid", so we just need to upload the stories, not wait for the Chromatic test to run fully (in the scope of Confirm build is valid)