### PR TITLE
fix(atomic-hosted-page): remove dead CDN PR release logic from esbuild

### DIFF
--- a/packages/atomic-hosted-page/scripts/esbuild.js
+++ b/packages/atomic-hosted-page/scripts/esbuild.js
@@ -11,19 +11,13 @@ const headlessJson = JSON.parse(
   readFileSync(resolve(__dirname, '../../headless/package.json'), 'utf8')
 );
 const isNightly = process.env.IS_NIGHTLY === 'true';
-const isPrRelease =
-  process.env.IS_PRERELEASE === 'true' && process.env.PR_NUMBER;
 
 const headlessVersion = isNightly
   ? `v${headlessJson.version.split('.').shift()}-nightly`
-  : isPrRelease
-    ? `v${headlessJson.version.split('-').shift()}.${process.env.PR_NUMBER}`
-    : `v${headlessJson.version}`;
+  : `v${headlessJson.version}`;
 const buenoVersion = isNightly
   ? `v${buenoJson.version.split('.').shift()}-nightly`
-  : isPrRelease
-    ? `v${buenoJson.version.split('-').shift()}.${process.env.PR_NUMBER}`
-    : `v${buenoJson.version}`;
+  : `v${buenoJson.version}`;
 const packageMappings = {
   '@coveo/headless': `/headless/${headlessVersion}/headless.esm.js`,
   '@coveo/bueno': `/bueno/${buenoVersion}/bueno.esm.js`,


### PR DESCRIPTION
## [KIT-5502](https://coveord.atlassian.net/browse/KIT-5502)

### Problem

The `atomic-hosted-page` esbuild script still contains dead code for CDN PR preview releases (`isPrRelease`). This was forgotten in [#7357](https://github.com/coveo/ui-kit/pull/7357) which removed the other CDN PR deployment remnants.

This code path generated versioned URLs like `v1.0.0.123` when both `IS_PRERELEASE=true` and `PR_NUMBER` were set. Since CDN PR releases have been removed and replaced by [pkg-pr-new](https://github.com/stackblitz-labs/pkg.pr.new), this code is now unreachable.

### Solution

Remove the `isPrRelease` variable and its ternary branches for `headlessVersion` and `buenoVersion`, simplifying the version resolution to only handle nightly vs regular releases.

[KIT-5502]: https://coveord.atlassian.net/browse/KIT-5502