### PR TITLE
ci: add commit artifact upload dispatch trigger (KIT-5477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,10 +733,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
   commit-artifact-upload:
-    if: ${{ !cancelled() && needs.is-valid.result == 'success' && needs.build-cdn.result == 'success' && github.event_name == 'merge_group' }}
+    if: ${{ !cancelled() && needs.is-valid.result == 'success' && github.event_name == 'merge_group' }}
     needs:
       - is-valid
-      - build-cdn
     name: Upload commit artifacts to S3 (Merge group)
     environment: 'Prerelease (CDN)'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,6 +732,28 @@ jobs:
         run: node ./scripts/deploy/trigger-ui-kit-cd-dev.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+  commit-artifact-upload:
+    if: ${{ !cancelled() && needs.is-valid.result == 'success' && needs.build-cdn.result == 'success' && github.event_name == 'merge_group' }}
+    needs:
+      - is-valid
+      - build-cdn
+    name: Upload commit artifacts to S3 (Merge group)
+    environment: 'Prerelease (CDN)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup
+        with:
+          skip-build: 'true'
+          load-cache: 'false'
+      - name: Trigger commit artifact upload on ui-kit-cd
+        run: node ./scripts/deploy/trigger-commit-upload.mjs
+        env:
+          GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     if: ${{ !cancelled() && needs.is-valid.result == 'success' && github.event_name == 'merge_group' }}

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -1,0 +1,13 @@
+import {context, getOctokit} from '@actions/github';
+
+const octokit = getOctokit(process.env.GH_TOKEN);
+
+await octokit.rest.repos.createDispatchEvent({
+  event_type: 'deploy-commit',
+  client_payload: {
+    run_id: context.runId,
+    sha: context.sha,
+  },
+  owner: 'coveo-platform',
+  repo: 'ui-kit-cd',
+});

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -5,7 +5,7 @@ const octokit = getOctokit(process.env.GH_TOKEN);
 await octokit.rest.repos.createDispatchEvent({
   event_type: 'deploy-commit',
   client_payload: {
-    run_id: context.runId,
+    run_Id: context.runId,
     sha: context.sha,
   },
   owner: 'coveo-platform',


### PR DESCRIPTION
## Summary

Adds a CI job to dispatch commit artifact uploads to `coveo-platform/ui-kit-cd` on every merge to `main` via merge queue.

**RFC**: [Pointer-Based CDN Deployment Architecture](https://coveord.atlassian.net/wiki/spaces/JSUI/pages/6143606839/RFC+Pointer-Based+CDN+Deployment+Architecture)
**Jira**: https://coveord.atlassian.net/browse/KIT-5601

### Changes

- **`scripts/deploy/trigger-commit-upload.mjs`** — Dispatch script that sends `deploy-commit` repository dispatch to ui-kit-cd with `run_id` and `sha` payload.
- **`.github/workflows/ci.yml`** — New `commit-artifact-upload` job that triggers on `merge_group` event and dispatches to ui-kit-cd.

### ⚠️ Dependencies

- **Depends on** [#7297](https://github.com/coveo/ui-kit/pull/7297) (KIT-5477: remove deployment config from ui-kit) — ✅ merged.
- **Companion PR** in `coveo-platform/ui-kit-cd`: [#126](https://github.com/coveo-platform/ui-kit-cd/pull/126)

### Notes

- The existing `prerelease-cdn-merge` job continues to dispatch `deploy-dev` (old pipeline unaffected)
- During transition, both `deploy-dev` and `deploy-commit` fire on every merge. The old one will be removed in a future cleanup PR.
- Safe to merge in any order relative to the ui-kit-cd companion PR — if this merges first, the dispatch is silently ignored until ui-kit-cd is ready.