### PR TITLE
fix(ci): add environment to CD release job for dx-bot secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: Release
     permissions:
       contents: write
       pull-requests: write
@@ -29,8 +30,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
           owner: coveo
           repositories: 'ui-kit'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## KIT-5598

Fixes the failing [Create release workflow](https://github.com/coveo/ui-kit/actions/runs/24252307115/job/70814682720) introduced by #7388.

### Problem

The `GH_APP_ID` and `GH_APP_PRIVATE_KEY` secrets are configured as **environment-level secrets** in the `PR Artifacts` environment. The `release` job in `cd.yml` was missing the `environment` declaration, causing the `create-github-app-token` action to fail with:

```
[@octokit/auth-app] appId option is required
```

All CI jobs that use these secrets (e.g., `pr-report`, `build-missing`, `merge-atomic-playwright-reports`) correctly specify `environment: PR Artifacts`, but this was missed when the dx-bot token was added to the CD workflow.

### Fix

Add `environment: PR Artifacts` to the `release` job so the environment-level secrets are accessible.