### PR TITLE
ci(changesets): add Jira KIT-5605 to version packages PR j:KIT-5604

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           version: pnpm changeset version
           publish: pnpm run release
-          title: 'ci(changesets): version packages'
-          commit: 'ci(changesets): version packages'
+          title: 'ci(changesets): version packages j:KIT-5605'
+          commit: 'ci(changesets): version packages j:KIT-5605'
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Adds the recurring Jira ticket `KIT-5605` to the changeset "Version Packages" PR title and commit message, so it satisfies the deployment pipeline requirement that every PR has a linked Jira.

https://coveord.atlassian.net/browse/KIT-5604