### PR TITLE
chore(chromatic): do not trace `virtual:*` modules to enable precise turbosnap

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -75,7 +75,7 @@
     "test:storybook": "vitest run --project=storybook",
     "generate-component": "node ./scripts/generate-component.mjs",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
-    "chromatic": "chromatic -d=dist-storybook --only-changed",
+    "chromatic": "chromatic -d=dist-storybook --only-changed --untraced \"/virtual:*\"",
     "validate:light-dom-styles": "node ./scripts/check-light-dom-host-selectors.mjs",
     "validate:no-new-light-dom": "node ./scripts/check-no-new-light-dom-components.mjs"
   },


### PR DESCRIPTION
In #7417 , I tested whether a change to an atomic commerce component only triggered runs on the commerce stories... it did not 🤡 
Using [Chromatic Trace Utility](https://www.chromatic.com/docs/turbosnap/trace-utility/) I was able to determine that the issue lay with the `virtual-custom-elements` plugin we use for Storybook (it's a shortcut to not build the list of elements there too)

See plugin code:
https://github.com/coveo/ui-kit/blob/7b7de897f4c06e35e9c87189c2bc56cc078e6291/packages/atomic/.storybook/main.ts#L26-L50

Essentially, the "virtual:custom-elements-tags" module ends up importing lazy-index, which imports, well, everything 🤣 
And the virtual:custom-elements-tags is used by another than the `initialization-common-utils.ts`, which is, well, **everywhere**.

To illustrate, here is how a small change in the atomic-commerce-search-box affects the atomic-insight-result-attach-to-case-indicator story file.:

<details>
<summary>Log</summary>

```
pnpm exec chromatic trace -s dist-storybook/preview-stats.json src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
... #other components trees#...
— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/lazy-index.ts
    ∟ src/components/lazy-index.ts
      ∟ /virtual:custom-element-tags
        ∟ src/utils/initialization-common-utils.ts
          ∟ src/mixins/bindings-mixin.ts
            ∟ src/components/common/atomic-icon/atomic-icon.ts
              ∟ src/components/common/icon-button.ts
                ∟ src/components/insight/atomic-insight-result-attach-to-case-action/atomic-insight-result-attach-to-case-action.ts
                  ∟ src/components/insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.new.stories.tsx
                    ∟ [story index]
```

</details>

Which makes no sense.
By adding the untrace, we see that it becomes way more sensible:

<details>
<summary>Log</summary>

```
~/packages/atomic: pnpm exec chromatic trace -s dist-storybook/preview-stats.json src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts --untraced="/virtual:*"
ℹ Traced 1 changed file to 15 affected story files:

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.new.stories.tsx
    ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.new.stories.tsx
    ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
    ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-pages/commerce/search.new.stories.tsx
    ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
      ∟ src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.mdx
        ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
      ∟ src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.mdx
        ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-search-box-wrapper.tsx
    ∟ src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
      ∟ src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.mdx
        ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-searchbox-instant-products-wrapper.tsx
    ∟ src/components/commerce/atomic-product-template/atomic-product-template.new.stories.tsx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ storybook-utils/commerce/commerce-searchbox-instant-products-wrapper.tsx
    ∟ src/components/commerce/atomic-product-template/atomic-product-template.new.stories.tsx
      ∟ src/components/commerce/atomic-product-template/atomic-product-template.mdx
        ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
    ∟ src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.mdx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.new.stories.tsx
    ∟ src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.mdx
      ∟ [story index]

— src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts [changed]
  ∟ src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.new.stories.tsx
    ∟ src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.mdx
      ∟ [story index]

Set --trace-changed to 'expanded' to reveal underlying modules.
```

</details>


#7417 prove the changes work too:
- before untraced: https://github.com/coveo/ui-kit/actions/runs/24370473966/job/71173252647#step:7:3118
- after untraced: https://github.com/coveo/ui-kit/actions/runs/24372581711/job/71179701817#step:7:2821

We end up running the 2 snapshots (visual & a11y) for the Commerce Examples, and use the turbosnap cache for the rest 🎉 

[KIT-5614](https://coveord.atlassian.net/browse/KIT-5614)

[KIT-5614]: https://coveord.atlassian.net/browse/KIT-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ