### PR TITLE
chore: in Storybook dev mode, use sources of Headless & Bueno for faster development

### DIFF
--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -17,6 +17,8 @@ import {generateExternalPackageMappings} from '../scripts/externalPackageMapping
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const isCDN = process.env.DEPLOYMENT_ENVIRONMENT === 'CDN';
+const isVitest = process.env.VITEST !== undefined;
 
 // Ensure directories referenced in staticDirs exist before Storybook validates them.
 // The prepareStorybookAssets plugin populates these during buildStart, which runs later.
@@ -90,7 +92,10 @@ const virtualOpenApiModules = (): Plugin => {
   };
 };
 
-const externalizeDependencies = (): Plugin => {
+const externalizeDependencies = (
+  configType: 'DEVELOPMENT' | 'PRODUCTION' | undefined
+): Plugin => {
+  const packageMappings = generateExternalPackageMappings();
   return {
     name: 'externalize-dependencies',
     enforce: 'pre',
@@ -107,17 +112,22 @@ const externalizeDependencies = (): Plugin => {
         return false;
       }
 
-      const packageMappings = generateExternalPackageMappings();
       const packageMapping = packageMappings[source];
 
-      if (packageMapping) {
-        if (!isCDN) {
-          return false;
-        }
+      if (!packageMapping || isVitest) {
+        return null;
+      }
 
+      if (isCDN) {
         return {
           id: packageMapping.cdn,
           external: 'absolute',
+        };
+      }
+
+      if (configType === 'DEVELOPMENT') {
+        return {
+          id: packageMapping.local,
         };
       }
 
@@ -125,7 +135,6 @@ const externalizeDependencies = (): Plugin => {
     },
   };
 };
-const isCDN = process.env.DEPLOYMENT_ENVIRONMENT === 'CDN';
 
 function getPackageVersion(): string {
   return JSON.parse(
@@ -199,7 +208,7 @@ const config: StorybookConfig = {
         forceInlineCssImports(),
         svgTransform(),
         prepareStorybookAssets(),
-        configType === 'PRODUCTION' && isCDN && externalizeDependencies(),
+        externalizeDependencies(configType),
       ],
     });
   },

--- a/packages/atomic/scripts/externalPackageMappings.mjs
+++ b/packages/atomic/scripts/externalPackageMappings.mjs
@@ -1,13 +1,15 @@
 import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
 
-const buenoJsonPath = new URL('../../bueno/package.json', import.meta.url);
-const buenoJson = JSON.parse(readFileSync(buenoJsonPath, 'utf-8'));
-
-const headlessJsonPath = new URL(
-  '../../headless/package.json',
-  import.meta.url
+const buenoBaseDir = resolve(import.meta.dirname, '../../bueno');
+const buenoJson = JSON.parse(
+  readFileSync(resolve(buenoBaseDir, 'package.json'), 'utf-8')
 );
-const headlessJson = JSON.parse(readFileSync(headlessJsonPath, 'utf-8'));
+
+const headlessBaseDir = resolve(import.meta.dirname, '../../headless');
+const headlessJson = JSON.parse(
+  readFileSync(resolve(headlessBaseDir, 'package.json'), 'utf-8')
+);
 
 const isNightly = process.env.IS_NIGHTLY === 'true';
 
@@ -23,21 +25,27 @@ export function generateExternalPackageMappings() {
   return {
     '@coveo/headless/commerce': {
       cdn: `/headless/${headlessVersion}/commerce/headless.esm.js`,
+      local: resolve(headlessBaseDir, './src/commerce.index.ts'),
     },
     '@coveo/headless/insight': {
       cdn: `/headless/${headlessVersion}/insight/headless.esm.js`,
+      local: resolve(headlessBaseDir, './src/insight.index.ts'),
     },
     '@coveo/headless/recommendation': {
       cdn: `/headless/${headlessVersion}/recommendation/headless.esm.js`,
+      local: resolve(headlessBaseDir, './src/recommendation.index.ts'),
     },
     '@coveo/headless/case-assist': {
       cdn: `/headless/${headlessVersion}/case-assist/headless.esm.js`,
+      local: resolve(headlessBaseDir, './src/case-assist.index.ts'),
     },
     '@coveo/headless': {
       cdn: `/headless/${headlessVersion}/headless.esm.js`,
+      local: resolve(headlessBaseDir, './src/index.ts'),
     },
     '@coveo/bueno': {
       cdn: `/bueno/${buenoVersion}/bueno.esm.js`,
+      local: resolve(buenoBaseDir, './src/index.ts'),
     },
   };
 }

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -99,7 +99,7 @@
       "persistent": true
     },
     "dev:storybook": {
-      "dependsOn": ["^build", "build:locales"],
+      "dependsOn": ["build:locales"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
By mapping Headless import directly to the source barrel instead of the transpiled barrel:
- We no longer need to build Atomic _before_ entering the dev mode of Atomic
- We can make changes to Headless & Bueno while in dev mode, and the change will propagate to the dev server using Hot Module Reload in a fraction of a second

Demo:

https://github.com/user-attachments/assets/9d95e9c0-8a41-4329-989e-c87bc2f0afd7


[KIT-5613](https://coveord.atlassian.net/browse/KIT-5613)


[KIT-5613]: https://coveord.atlassian.net/browse/KIT-5613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ