### PR TITLE
fix(atomic): prevent Shift+Enter from triggering search query (KIT-5559)

### DIFF
--- a/.changeset/kit-5559-shift-enter.md
+++ b/.changeset/kit-5559-shift-enter.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fix Shift+Enter in search box triggering a query. Pressing Shift+Enter now inserts a newline in the textarea without submitting the search.

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.spec.ts
@@ -399,6 +399,15 @@ describe('atomic-commerce-search-box', () => {
       expect(submitMock).toHaveBeenCalled();
     });
 
+    it('should not trigger the submit event when Shift+Enter is pressed', async () => {
+      const {textArea} = await renderSearchBox();
+
+      submitMock.mockClear();
+      await userEvent.type(textArea, '{shift>}{enter}{/shift}');
+
+      expect(submitMock).not.toHaveBeenCalled();
+    });
+
     it('should clear suggestions when the Escape key is pressed', async () => {
       const {element, suggestions} = await renderSearchBox();
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
@@ -473,7 +473,9 @@ export class AtomicCommerceSearchBox
 
     switch (e.key) {
       case 'Enter':
-        this.onSubmit();
+        if (!e.shiftKey) {
+          this.onSubmit();
+        }
         break;
       case 'Escape':
         this.suggestionManager.clearSuggestions();

--- a/packages/atomic/src/components/common/search-box/search-text-area.ts
+++ b/packages/atomic/src/components/common/search-box/search-text-area.ts
@@ -104,7 +104,7 @@ export const renderSearchBoxTextArea: FunctionalComponent<Props> = ({
         }}
         @keyup=${(e: KeyboardEvent) => {
           onKeyUp?.(e);
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             return;
           }

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.spec.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.spec.ts
@@ -176,6 +176,13 @@ describe('atomic-insight-search-box', () => {
       expect(submitMock).toHaveBeenCalled();
     });
 
+    it('should not submit when Shift+Enter is pressed', async () => {
+      const {textArea} = await renderComponent();
+      submitMock.mockClear();
+      await userEvent.type(textArea, '{shift>}{enter}{/shift}');
+      expect(submitMock).not.toHaveBeenCalled();
+    });
+
     it('should not submit when disableSearch is true', async () => {
       const {element, textArea} = await renderComponent();
       element.disableSearch = true;

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.ts
@@ -178,7 +178,9 @@ export class AtomicInsightSearchBox
 
     switch (e.key) {
       case 'Enter':
-        this.onSubmit();
+        if (!e.shiftKey) {
+          this.onSubmit();
+        }
         break;
       case 'Escape':
         this.suggestionManager.clearSuggestions();

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.spec.ts
@@ -395,6 +395,26 @@ describe('atomic-search-box', () => {
     });
   });
 
+  describe('when keys are pressed in the search box', () => {
+    it('should submit when Enter is pressed', async () => {
+      const {textArea} = await renderSearchBox();
+
+      submitMock.mockClear();
+      await userEvent.type(textArea, '{enter}');
+
+      expect(submitMock).toHaveBeenCalled();
+    });
+
+    it('should not submit when Shift+Enter is pressed', async () => {
+      const {textArea} = await renderSearchBox();
+
+      submitMock.mockClear();
+      await userEvent.type(textArea, '{shift>}{enter}{/shift}');
+
+      expect(submitMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when the search box is a standalone search box', () => {
     it('should not throw when redirectionUrl changes before the search box initializes', async () => {
       updateRedirectUrlMock.mockClear();

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.ts
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.ts
@@ -500,7 +500,9 @@ export class AtomicSearchBox
 
     switch (e.key) {
       case 'Enter':
-        this.onSubmit();
+        if (!e.shiftKey) {
+          this.onSubmit();
+        }
         break;
       case 'Escape':
         this.suggestionManager.clearSuggestions();


### PR DESCRIPTION
## Summary

Fixes KIT-5559 — Pressing Shift+Enter in the search textarea was incorrectly triggering a search query, making the multi-line textarea feature unusable.

## Root Cause

Three `onKeyDown` handlers in the search box components did not check `e.shiftKey` before calling `this.onSubmit()`. Additionally, the shared `search-text-area.ts` `@keyup` handler was not checking `!e.shiftKey`, which prevented the replica text from being synced after a Shift+Enter (causing the textarea not to expand on newline).

## Changes

- `atomic-search-box.ts` — add `!e.shiftKey` guard before submit on Enter
- `atomic-commerce-search-box.ts` — same fix
- `atomic-insight-search-box.ts` — same fix  
- `search-text-area.ts` — add `!e.shiftKey` guard in `@keyup` handler so the textarea expander syncs properly after a newline

## Tests

Added "should not submit when Shift+Enter is pressed" test to all three search box spec files.

## Jira

[KIT-5559](https://coveord.atlassian.net/browse/KIT-5559)

[KIT-5559]: https://coveord.atlassian.net/browse/KIT-5559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ