### PR TITLE
fix(atomic): hide section elements with margin when children become empty (KIT-5496)

### DIFF
--- a/.changeset/kit-5496-section-margin-fix.md
+++ b/.changeset/kit-5496-section-margin-fix.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fix section elements with margins showing unwanted whitespace when children are empty or hidden. Added a `MutationObserver` in `ItemSectionMixin` to re-check visibility when children are added/removed or their `style` attribute changes. Also updated `isVisualNode` to treat elements with `style.display: none` as non-visual.

--- a/packages/atomic/src/mixins/item-section-mixin.ts
+++ b/packages/atomic/src/mixins/item-section-mixin.ts
@@ -6,6 +6,8 @@ import type {Constructor} from './mixin-common.js';
 /**
  * Mixin for item section components that provides common functionality.
  * All item section components extend LitElement and call hideEmptySection in updated().
+ * A MutationObserver watches for child node additions/removals and style attribute changes
+ * so that sections are re-evaluated when children remove themselves or become hidden.
  *
  * @param superClass - The base class to extend
  * @param styles - The styles to apply to the section.
@@ -18,6 +20,27 @@ export function ItemSectionMixin<T extends Constructor<LitElement>>(
 ) {
   class ItemSectionMixinClass extends LightDomMixin(superClass) {
     static styles = styles;
+
+    private _sectionObserver?: MutationObserver;
+
+    connectedCallback() {
+      super.connectedCallback();
+      this._sectionObserver = new MutationObserver(() => {
+        hideEmptySection(this);
+      });
+      this._sectionObserver.observe(this, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style'],
+      });
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this._sectionObserver?.disconnect();
+      this._sectionObserver = undefined;
+    }
 
     protected updated() {
       hideEmptySection(this);

--- a/packages/atomic/src/utils/utils.spec.ts
+++ b/packages/atomic/src/utils/utils.spec.ts
@@ -2,7 +2,9 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   aggregate,
   camelToKebab,
+  containsVisualElement,
   isInDocument,
+  isVisualNode,
   kebabToCamel,
   once,
   randomID,
@@ -160,4 +162,85 @@ describe('utils', () => {
   });
 
   // TODO - KIT-4326:  add tests for all other functions exported from utils.ts.
+
+  describe('#isVisualNode', () => {
+    it('returns false for a style element', () => {
+      const el = document.createElement('style');
+      expect(isVisualNode(el)).toBe(false);
+    });
+
+    it('returns true for a regular element', () => {
+      const el = document.createElement('div');
+      expect(isVisualNode(el)).toBe(true);
+    });
+
+    it('returns false for an element with inline display:none', () => {
+      const el = document.createElement('div');
+      el.style.display = 'none';
+      expect(isVisualNode(el)).toBe(false);
+    });
+
+    it('returns true for an element with other inline display values', () => {
+      const el = document.createElement('div');
+      el.style.display = 'flex';
+      expect(isVisualNode(el)).toBe(true);
+    });
+
+    it('returns true for a non-empty text node', () => {
+      const text = document.createTextNode('hello');
+      expect(isVisualNode(text)).toBe(true);
+    });
+
+    it('returns false for a whitespace-only text node', () => {
+      const text = document.createTextNode('   ');
+      expect(isVisualNode(text)).toBe(false);
+    });
+
+    it('returns false for a comment node', () => {
+      const comment = document.createComment('comment');
+      expect(isVisualNode(comment)).toBe(false);
+    });
+  });
+
+  describe('#containsVisualElement', () => {
+    it('returns false for an element with no children', () => {
+      const el = document.createElement('div');
+      expect(containsVisualElement(el)).toBe(false);
+    });
+
+    it('returns true when a child element is present', () => {
+      const el = document.createElement('div');
+      el.appendChild(document.createElement('span'));
+      expect(containsVisualElement(el)).toBe(true);
+    });
+
+    it('returns false when the only child has display:none', () => {
+      const el = document.createElement('div');
+      const child = document.createElement('span');
+      child.style.display = 'none';
+      el.appendChild(child);
+      expect(containsVisualElement(el)).toBe(false);
+    });
+
+    it('returns true when at least one child is visible alongside hidden siblings', () => {
+      const el = document.createElement('div');
+      const hidden = document.createElement('span');
+      hidden.style.display = 'none';
+      el.appendChild(hidden);
+      el.appendChild(document.createElement('span'));
+      expect(containsVisualElement(el)).toBe(true);
+    });
+
+    it('returns true for non-empty text content', () => {
+      const el = document.createElement('div');
+      el.appendChild(document.createTextNode('some text'));
+      expect(containsVisualElement(el)).toBe(true);
+    });
+
+    it('returns false for whitespace-only text content', () => {
+      const el = document.createElement('div');
+      el.appendChild(document.createTextNode('  \n  '));
+      expect(containsVisualElement(el)).toBe(false);
+    });
+  });
 });

--- a/packages/atomic/src/utils/utils.ts
+++ b/packages/atomic/src/utils/utils.ts
@@ -65,7 +65,13 @@ export function isTextNode(node: Node): node is Text {
 
 export function isVisualNode(node: Node) {
   if (isElementNode(node)) {
-    return !(node instanceof HTMLStyleElement);
+    if (node instanceof HTMLStyleElement) {
+      return false;
+    }
+    if ((node as HTMLElement).style?.display === 'none') {
+      return false;
+    }
+    return true;
   }
   if (isTextNode(node)) {
     return !!node.textContent?.trim();


### PR DESCRIPTION
## Problem

Section elements (e.g. `atomic-result-section-badges`) have CSS margins applied via the template system. When their children asynchronously remove themselves from the DOM (e.g. `atomic-result-badge` calls `this.remove()` in `willUpdate()` when a field has no value), the section's `updated()` hook has already run — so the section remains visible with its margins despite being effectively empty, causing unwanted whitespace.

## Root Cause

- `ItemSectionMixin.updated()` only runs once because section components have no reactive Lit properties.
- `isVisualNode` treated any non-`HTMLStyleElement` element as visual, including elements with `style.display: none`.

## Fix

1. **`isVisualNode`** (`utils.ts`): Returns `false` for elements with `style.display === 'none'`.
2. **`ItemSectionMixin`** (`item-section-mixin.ts`): Added a `MutationObserver` that re-runs `hideEmptySection` whenever children are added/removed or any descendant's `style` attribute changes.

## Tests

Added unit tests to `utils.spec.ts` covering:
- `isVisualNode` with style elements, regular elements, `display: none` elements, text nodes, comment nodes
- `containsVisualElement` with empty, single visible, single hidden, mixed, and text-only containers

Fixes: [KIT-5496](https://coveord.atlassian.net/browse/KIT-5496)

[KIT-5496]: https://coveord.atlassian.net/browse/KIT-5496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ