### PR TITLE
test: use more precise path for querySuggest detection

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/e2e/atomic-commerce-search-box.e2e.ts
@@ -286,7 +286,7 @@ test.describe('atomic-commerce-search-box', () => {
     test.beforeEach(async ({page, searchBox}) => {
       querySuggestionRequestPerformed = false;
       page.on('request', (request) => {
-        if (request.url().includes('/querySuggest')) {
+        if (request.url().includes('/v2/search/querySuggest')) {
           querySuggestionRequestPerformed = true;
         }
       });
@@ -337,7 +337,7 @@ test.describe('atomic-commerce-search-box', () => {
     test.beforeEach(async ({page, searchBox}) => {
       querySuggestionRequestPerformed = false;
       page.on('request', (request) => {
-        if (request.url().includes('/querySuggest')) {
+        if (request.url().includes('/v2/search/querySuggest')) {
           querySuggestionRequestPerformed = true;
         }
       });


### PR DESCRIPTION
We have JS/TS files named `querySuggest-response` that were incorrectly detected as a querySuggest query.

[KIT-5616](https://coveord.atlassian.net/browse/KIT-5616)

[KIT-5616]: https://coveord.atlassian.net/browse/KIT-5616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ