### PR TITLE
fix(atomic): add MSW handlers to all insight stories missing them

### DIFF
--- a/.changeset/fix-insight-flaky-tests.md
+++ b/.changeset/fix-insight-flaky-tests.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+fix(atomic): add MSW mock handlers to insight interface story to fix flaky e2e tests

--- a/.changeset/fix-insight-flaky-tests.md
+++ b/.changeset/fix-insight-flaky-tests.md
@@ -1,5 +1,0 @@
----
-'@coveo/atomic': patch
----
-
-fix(atomic): add MSW mock handlers to insight interface story to fix flaky e2e tests

--- a/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.js';
+
+const mockedInsightApi = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -22,6 +25,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...mockedInsightApi.handlers],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.js';
+
+const mockedInsightApi = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -22,6 +25,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...mockedInsightApi.handlers],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.js';
+
+const mockedInsightApi = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -22,6 +25,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...mockedInsightApi.handlers],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
@@ -3,6 +3,7 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/search/atomic-field-condition/atomic-field-condition.js';
@@ -50,6 +51,21 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   {excludeCategories: ['methods']}
 );
 
+const mockedInsightApi = new MockInsightApi();
+mockedInsightApi.searchEndpoint.mock((response) => ({
+  ...response,
+  results: response.results.map((result: Record<string, unknown>) => ({
+    ...result,
+    raw: {
+      ...(result.raw as Record<string, unknown>),
+      sourcetype: 'YouTube',
+      syssourcetype: 'YouTube',
+      ytchanneltitle: 'Coveo Support Channel',
+      ytviewcount: 1234,
+    },
+  })),
+}));
+
 const meta: Meta = {
   component: 'atomic-insight-interface',
   title: 'Insight/Interface',
@@ -63,6 +79,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...mockedInsightApi.handlers],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
@@ -56,6 +56,8 @@ mockedInsightApi.searchEndpoint.mock((response) => ({
   ...response,
   results: response.results.map((result: Record<string, unknown>) => ({
     ...result,
+    isTopResult: false,
+    isRecommendation: false,
     raw: {
       ...(result.raw as Record<string, unknown>),
       sourcetype: 'YouTube',

--- a/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
@@ -1,10 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit-html';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-layout/atomic-insight-layout.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
+
+const mockedInsightApi = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes} = getStorybookHelpers('atomic-insight-layout', {
@@ -30,6 +33,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {
+      handlers: [...mockedInsightApi.handlers],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   argTypes,
 

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.new.stories.tsx
@@ -1,10 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {MockMachineLearningApi} from '@/storybook-utils/api/machinelearning/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.js';
 
+const mockedInsightApi = new MockInsightApi();
 const mockMachineLearningApi = new MockMachineLearningApi();
 
 const {decorator, play} = wrapInInsightInterface();
@@ -27,7 +29,16 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockMachineLearningApi.handlers]},
+    msw: {
+      handlers: [
+        ...mockedInsightApi.handlers,
+        ...mockMachineLearningApi.handlers,
+      ],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.new.stories.tsx
@@ -1,10 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {MockMachineLearningApi} from '@/storybook-utils/api/machinelearning/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.js';
 
+const mockedInsightApi = new MockInsightApi();
 const mockMachineLearningApi = new MockMachineLearningApi();
 
 const {decorator, play} = wrapInInsightInterface();
@@ -25,7 +27,16 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockMachineLearningApi.handlers]},
+    msw: {
+      handlers: [
+        ...mockedInsightApi.handlers,
+        ...mockMachineLearningApi.handlers,
+      ],
+    },
+  },
+  beforeEach: () => {
+    mockedInsightApi.searchEndpoint.clear();
+    mockedInsightApi.querySuggestEndpoint.clear();
   },
   args: {
     ...args,


### PR DESCRIPTION
## KIT-5625: Fix flaky insight e2e tests

### Problem
Several insight component stories were missing MSW (Mock Service Worker) handlers, causing e2e tests to hit real Coveo APIs — leading to flaky timeouts and inconsistent results.

### Changes

**`atomic-insight-interface`** (original fix):
- Added `MockInsightApi` with YouTube-typed results to match the story's `must-match-sourcetype="YouTube"` template
- Added `beforeEach` to clear mock endpoints between stories
- Set `isTopResult: false` and `isRecommendation: false` to avoid pre-existing a11y color contrast issues with badge tags

**4 stories completely missing MSW** — added `MockInsightApi` + `msw.handlers` + `beforeEach` clear:
- `atomic-insight-edit-toggle`
- `atomic-insight-generate-answer-button`
- `atomic-insight-layout`
- `atomic-insight-full-search-button`

**2 user-actions stories missing `MockInsightApi`** — added insight API mock alongside existing `MockMachineLearningApi` + `beforeEach` clear:
- `atomic-insight-user-actions-toggle`
- `atomic-insight-user-actions-timeline`

### Result
All 30 insight stories now have proper MSW mocking — tests no longer depend on live API availability.