### PR TITLE
fix(samples): replace catalog: vite version with real version in pkg-new-template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,6 +595,8 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           load-cache: 'false'
+      - name: Resolve catalog references in pkg.pr.new templates
+        run: node samples/pkg-new-template/scripts/flatten-catalog.mjs
       - name: Publish to pkg.pr.new
         run: |
           pnpm dlx pkg-pr-new publish --pnpm \

--- a/samples/pkg-new-template/scripts/flatten-catalog.mjs
+++ b/samples/pkg-new-template/scripts/flatten-catalog.mjs
@@ -1,0 +1,28 @@
+/**
+ * Resolves `catalog:` protocol references in pkg.pr.new template package.json
+ * files before publishing. The `catalog:` protocol is a pnpm workspace feature
+ * that does not resolve outside the workspace (e.g. in StackBlitz).
+ *
+ * See: https://github.com/stackblitz-labs/pkg.pr.new/issues/204
+ */
+
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgPath = path.resolve(__dirname, '../package.json');
+
+const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+const viteVersion = execSync('pnpm list vite --json --depth 0', {
+  cwd: path.dirname(pkgPath),
+  encoding: 'utf8',
+});
+const resolved = JSON.parse(viteVersion)[0].devDependencies.vite.version;
+
+pkgJson.devDependencies.vite = resolved;
+fs.writeFileSync(pkgPath, JSON.stringify(pkgJson, null, 2) + '\n');
+
+console.log(`Resolved vite "catalog:" → "${resolved}"`);


### PR DESCRIPTION
## Summary

The `samples/pkg-new-template/package.json` uses `"vite": "catalog:"` for the Vite dependency. The `catalog:` protocol is a pnpm workspace feature that resolves versions from the catalog defined in `pnpm-workspace.yaml`.

When the template is used in StackBlitz via **pkg.pr.new**, the `catalog:` protocol doesn't resolve because StackBlitz runs outside the pnpm workspace context, breaking the sample.

Note: the `--pnpm` flag on `pkg-pr-new publish` resolves `catalog:` for published **packages**, but not for **templates** which are copied as-is.

## Fix

Add a catalog-flattening script (`samples/pkg-new-template/scripts/flatten-catalog.mjs`) that runs in CI before `pkg-pr-new publish`. It resolves `catalog:` references in template `package.json` files with real versions. This keeps `catalog:` in source (no version drift) while ensuring templates work in StackBlitz.

## Upstream issue

[stackblitz-labs/pkg.pr.new#489](https://github.com/stackblitz-labs/pkg.pr.new/issues/489) — `--template` does not resolve pnpm `catalog:` references before uploading to StackBlitz

See also: [stackblitz-labs/pkg.pr.new#204](https://github.com/stackblitz-labs/pkg.pr.new/issues/204)

## Jira

[KIT-5629](https://coveord.atlassian.net/browse/KIT-5629)

[KIT-5629]: https://coveord.atlassian.net/browse/KIT-5629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ