### PR TITLE
fix(ci): disable turbo cache loading for chromatic CD job j:KIT-5630

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,4 +249,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        with:
+          load-cache: 'false'
       - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-zero-on-changes --auto-accept-changes --branchName=main


### PR DESCRIPTION
## [KIT-5630](https://coveord.atlassian.net/browse/KIT-5630)

### Problem

The `chromatic-update-main` job in the CD workflow has been failing on every push to `main` since it was introduced.

The job uses `.github/actions/setup` with default inputs (`load-cache: 'true'`), which causes `download-artifact@v8` to try downloading a `Linux-default-turbo` artifact. However, this artifact is only uploaded by the `release` job, which runs **in parallel** (no `needs:` dependency). Since `download-artifact@v8` fails when the artifact doesn't exist, the setup step fails.

### Fix

Set `load-cache: 'false'` on the chromatic job's setup step, consistent with how other parallel CD jobs (`prerelease-cdn`, `commit-artifact-upload`) handle this.

### Failing runs
- [Run #135](https://github.com/coveo/ui-kit/actions/runs/24574402302/job/71855810480)
- [Run #134](https://github.com/coveo/ui-kit/actions/runs/24568121273)
- [Run #133](https://github.com/coveo/ui-kit/actions/runs/24524464657)
- [Run #131](https://github.com/coveo/ui-kit/actions/runs/24514658537)

[KIT-5630]: https://coveord.atlassian.net/browse/KIT-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ