### PR TITLE
perf: use threads pool for node-based package tests j:KIT-5632

### DIFF
--- a/packages/bueno/vitest.config.js
+++ b/packages/bueno/vitest.config.js
@@ -3,5 +3,6 @@ import {defineConfig} from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['**/*.test.?(c|m)[jt]s?(x)'],
+    pool: 'threads',
   },
 });

--- a/packages/headless-react/vitest.config.js
+++ b/packages/headless-react/vitest.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
+    pool: 'threads',
   },
   define: {
     global: 'window',

--- a/packages/headless/vitest.config.js
+++ b/packages/headless/vitest.config.js
@@ -5,8 +5,8 @@ process.env.TZ = 'Australia/Eucla';
 /// <reference types="vitest/config" />
 export default defineConfig({
   test: {
-    // ...
     globals: true,
     include: ['**/*.test.?(c|m)[jt]s?(x)'],
+    pool: 'threads',
   },
 });

--- a/packages/shopify/vitest.config.js
+++ b/packages/shopify/vitest.config.js
@@ -4,5 +4,6 @@ import {defineConfig} from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    pool: 'threads',
   },
 });


### PR DESCRIPTION
## [KIT-5632](https://coveord.atlassian.net/browse/KIT-5632) — Use threads pool for node-based package tests

Split from #7430 per Louis's review feedback.

Switch from `forks` (default) to `pool: 'threads'` in vitest config for `headless`, `bueno`, `headless-react`, and `shopify`. Threads have lower per-file startup overhead. Safe for these packages since they use pure Redux/functional patterns.

[Recommended by Vitest](https://vitest.dev/guide/improving-performance.html) for larger projects without compatibility constraints.

### Local benchmark — `@coveo/headless` (426 test files, 3 runs each)

| Pool | Run 1 | Run 2 | Run 3 | Avg |
|------|-------|-------|-------|-----|
| `threads` | 15.95s | 16.67s | 15.17s | **15.93s** |
| `forks` | 22.11s | 18.03s | 17.92s | **19.35s** |

**~18% faster with threads.**

[KIT-5632]: https://coveord.atlassian.net/browse/KIT-5632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ