### PR TITLE
fix(headless): only pass known properties when dispatching updateSearchConfiguration from search or insight engines

### DIFF
--- a/.changeset/tidy-donkeys-bathe.md
+++ b/.changeset/tidy-donkeys-bathe.md
@@ -1,0 +1,7 @@
+---
+'@coveo/headless': patch
+---
+
+Fix search and insight engine initialization so `updateSearchConfiguration` only receives serializable supported fields.
+
+This prevents Redux Toolkit dev warnings caused by function-valued configuration properties being forwarded in action payloads.

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -308,9 +308,9 @@ export class AtomicGeneratedAnswer
 
   protected willUpdate(changedProperties: PropertyValueMap<this>) {
     if (changedProperties.has('tabManagerState' as keyof this)) {
-      const oldValue = changedProperties.get(
-        'tabManagerState' as keyof this
-      ) as TabManagerState | undefined;
+      const oldValue = changedProperties.get('tabManagerState' as keyof this) as
+        | TabManagerState
+        | undefined;
       if (oldValue && this.tabManagerState?.activeTab !== oldValue?.activeTab) {
         if (
           !shouldDisplayOnCurrentTab(

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -308,9 +308,9 @@ export class AtomicGeneratedAnswer
 
   protected willUpdate(changedProperties: PropertyValueMap<this>) {
     if (changedProperties.has('tabManagerState' as keyof this)) {
-      const oldValue = changedProperties.get('tabManagerState' as keyof this) as
-        | TabManagerState
-        | undefined;
+      const oldValue = changedProperties.get(
+        'tabManagerState' as keyof this
+      ) as TabManagerState | undefined;
       if (oldValue && this.tabManagerState?.activeTab !== oldValue?.activeTab) {
         if (
           !shouldDisplayOnCurrentTab(

--- a/packages/headless/src/app/insight-engine/insight-engine.test.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.test.ts
@@ -1,14 +1,20 @@
 import * as InsightInterfaceActions from '../../features/insight-interface/insight-interface-actions.js';
+import * as ConfigurationActions from '../../features/configuration/configuration-actions.js';
 import {nextAnalyticsUsageWithServiceFeatureWarning} from '../engine.js';
 import {getSampleEngineConfiguration} from '../engine-configuration.js';
 import {
   buildInsightEngine,
   type InsightEngine,
   type InsightEngineConfiguration,
+  type InsightEngineSearchConfigurationOptions,
   type InsightEngineOptions,
 } from './insight-engine.js';
 
 const fetchInterfaceSpy = vi.spyOn(InsightInterfaceActions, 'fetchInterface');
+const updateSearchConfigurationSpy = vi.spyOn(
+  ConfigurationActions,
+  'updateSearchConfiguration'
+);
 
 function getSampleInsightEngineConfiguration(): InsightEngineConfiguration {
   return {
@@ -147,6 +153,25 @@ describe('buildInsightEngine', () => {
 
   it('sets the locale correctly', () => {
     expect(engine.state.configuration?.search?.locale).toEqual('en-US');
+  });
+
+  it('dispatches only serializable search configuration fields', () => {
+    options.configuration.search = {
+      locale: 'fr-CA',
+      proxyBaseUrl: 'https://example.com/insight',
+      preprocessSearchResponseMiddleware: () => ({}) as never,
+    } as unknown as InsightEngineSearchConfigurationOptions;
+
+    updateSearchConfigurationSpy.mockClear();
+    initEngine();
+
+    expect(updateSearchConfigurationSpy).toHaveBeenCalledTimes(1);
+    const [payload] = updateSearchConfigurationSpy.mock.calls[0];
+
+    expect(payload).toEqual({
+      locale: 'fr-CA',
+      proxyBaseUrl: 'https://example.com/insight',
+    });
   });
 
   it('should dispatch the fetchInterface action', () => {

--- a/packages/headless/src/app/insight-engine/insight-engine.ts
+++ b/packages/headless/src/app/insight-engine/insight-engine.ts
@@ -5,7 +5,10 @@ import {NoopPreprocessRequest} from '../../api/preprocess-request.js';
 import {InsightAPIClient} from '../../api/service/insight/insight-api-client.js';
 import {interfaceLoad} from '../../features/analytics/analytics-actions.js';
 import type {LegacySearchAction} from '../../features/analytics/analytics-utils.js';
-import {updateSearchConfiguration} from '../../features/configuration/configuration-actions.js';
+import {
+  type UpdateSearchConfigurationActionCreatorPayload,
+  updateSearchConfiguration,
+} from '../../features/configuration/configuration-actions.js';
 import {setInsightConfiguration} from '../../features/insight-configuration/insight-configuration-actions.js';
 import {insightConfigurationReducer as insightConfiguration} from '../../features/insight-configuration/insight-configuration-slice.js';
 import {fetchInterface} from '../../features/insight-interface/insight-interface-actions.js';
@@ -52,6 +55,23 @@ type InsightEngineReducers = typeof insightEngineReducers;
 
 type InsightEngineState = StateFromReducersMapObject<InsightEngineReducers> &
   Partial<InsightAppState>;
+
+function getUpdateSearchConfigurationPayload(
+  configuration: InsightEngineConfiguration
+): UpdateSearchConfigurationActionCreatorPayload | undefined {
+  const {search} = configuration;
+
+  if (!search) {
+    return;
+  }
+
+  const {locale, proxyBaseUrl} = search;
+
+  return {
+    locale,
+    proxyBaseUrl,
+  };
+}
 
 /**
  * The engine for powering insight experiences.
@@ -121,7 +141,8 @@ export function buildInsightEngine(
     engine.state.configuration.analytics.analyticsMode
   );
 
-  const {insightId, search} = options.configuration;
+  const {insightId} = options.configuration;
+  const search = getUpdateSearchConfigurationPayload(options.configuration);
 
   engine.dispatch(
     setInsightConfiguration({

--- a/packages/headless/src/app/search-engine/search-engine.test.ts
+++ b/packages/headless/src/app/search-engine/search-engine.test.ts
@@ -1,4 +1,5 @@
 import {enableDebug} from '../../features/debug/debug-actions.js';
+import * as ConfigurationActions from '../../features/configuration/configuration-actions.js';
 import {setSearchHub} from '../../features/search-hub/search-hub-actions.js';
 import {
   buildSearchEngine,
@@ -6,6 +7,11 @@ import {
   type SearchEngineOptions,
 } from './search-engine.js';
 import {getSampleSearchEngineConfiguration} from './search-engine-configuration.js';
+
+const updateSearchConfigurationSpy = vi.spyOn(
+  ConfigurationActions,
+  'updateSearchConfiguration'
+);
 
 describe('searchEngine', () => {
   let engine: SearchEngine;
@@ -183,6 +189,35 @@ describe('searchEngine', () => {
 
       it('sets the apiBaseUrl correctly', () => {
         expect(engine.state.configuration.search.apiBaseUrl).toBe(proxyBaseUrl);
+      });
+
+      it('dispatches only serializable search configuration fields', () => {
+        options.configuration.search = {
+          pipeline,
+          searchHub,
+          locale,
+          timezone,
+          proxyBaseUrl,
+          authenticationProviders: ['provider-a'],
+          preprocessSearchResponseMiddleware: (response) => response,
+          preprocessFacetSearchResponseMiddleware: (response) => response,
+          preprocessQuerySuggestResponseMiddleware: (response) => response,
+        };
+
+        updateSearchConfigurationSpy.mockClear();
+        initEngine();
+
+        expect(updateSearchConfigurationSpy).toHaveBeenCalledTimes(1);
+        const [payload] = updateSearchConfigurationSpy.mock.calls[0];
+
+        expect(payload).toEqual({
+          pipeline,
+          searchHub,
+          locale,
+          timezone,
+          proxyBaseUrl,
+          authenticationProviders: ['provider-a'],
+        });
       });
     });
 

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -1,7 +1,6 @@
 import type {StateFromReducersMapObject} from '@reduxjs/toolkit';
 import type {Logger} from 'pino';
 import {GeneratedAnswerAPIClient} from '../../api/generated-answer/generated-answer-client.js';
-import {getSearchApiBaseUrl} from '../../api/platform-client.js';
 import {NoopPreprocessRequest} from '../../api/preprocess-request.js';
 import {SearchAPIClient} from '../../api/search/search-api-client.js';
 import {
@@ -59,17 +58,24 @@ type SearchEngineState = StateFromReducersMapObject<SearchEngineReducers> &
 function getUpdateSearchConfigurationPayload(
   configuration: SearchEngineConfiguration
 ): UpdateSearchConfigurationActionCreatorPayload {
-  const {search, organizationId, environment} = configuration;
-  const apiBaseUrl = search?.proxyBaseUrl
-    ? search.proxyBaseUrl
-    : getSearchApiBaseUrl(organizationId, environment);
+  const {search} = configuration;
+  const {
+    proxyBaseUrl,
+    pipeline,
+    searchHub,
+    timezone,
+    locale,
+    authenticationProviders,
+  } = search ?? {};
 
-  const payloadWithURL = {
-    ...search,
-    apiBaseUrl,
+  return {
+    proxyBaseUrl,
+    pipeline,
+    searchHub,
+    timezone,
+    locale,
+    authenticationProviders,
   };
-
-  return payloadWithURL;
 }
 
 /**


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5634

In the search engine, we were spreading the `search`object from the `configuration` object into the payload of the `updateSearchConfiguration` action we were dispatching. Since the `search` object can contain non-serializable properties (e.g., middleware functions), Redux will show errors in the console if such properties are passed when the action is dispatched.

This issue has been present for years, and it causes no functional problems, only annoying Redux errors. The unserializable properties are simply ignored, and anyways the middlewares are set directly on the Search API client.

While fixing the issue, I noticed that we were passing another "legacy" property (apiBaseUrl) which is no longer used at all, so I removed it as well.

I also had a look at other engines to see if a similar pattern (i.e., dispatching action with unserializable properties) was present. I found that in the insight engine, while there is currently no actual issue, we were at risk of it if we eventually added non-serializable properties to the insight's search object, so I applied a preemptive fix there as well.

I also adjusted the tests for both engines (insight and search) accordingly.