### PR TITLE
fix(ci): produce Linux-cdn-turbo artifact in prerelease-cdn job j:KIT-5618

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -1,0 +1,13 @@
+name: Build CDN
+description: Build with CDN deployment environment and save turbo cache artifact
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup
+      with:
+        cache-prefix: 'cdn'
+        save-cache: 'true'
+        load-cache: 'false'
+      env:
+        DEPLOYMENT_ENVIRONMENT: CDN

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -195,8 +195,19 @@ jobs:
         run: pnpm run notify:docs
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  build-cdn:
+    name: Build CDN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/build-cdn
   prerelease-cdn:
     name: Pre-release CDN in dev
+    needs: build-cdn
     environment: 'Prerelease (CDN)'
     runs-on: ubuntu-latest
     steps:
@@ -205,8 +216,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
         with:
           skip-build: 'true'
@@ -217,6 +226,7 @@ jobs:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
   commit-artifact-upload:
     name: Upload commit artifacts to S3
+    needs: build-cdn
     environment: 'Prerelease (CDN)'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,22 +120,16 @@ jobs:
         with:
           save-cache: 'true'
   build-cdn:
-    name: 'Build CDN'
+    name: Build CDN
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
-    env:
-      DEPLOYMENT_ENVIRONMENT: CDN
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup
-        with:
-          cache-prefix: 'cdn'
-          save-cache: 'true'
+      - uses: ./.github/actions/build-cdn
   affected:
     name: 'Determine affected projects'
     runs-on: ubuntu-latest


### PR DESCRIPTION
[KIT-5618](https://coveord.atlassian.net/browse/KIT-5618)

## Problem
Since commit c7b3a307 (PR #7441), the `prerelease-cdn` job was moved from `ci.yml` to `cd.yml`. However, this separated it from the `build-cdn` job that produced the `Linux-cdn-turbo` artifact. The `prerelease-cdn` job dispatches its own `run_id` to `ui-kit-cd`, but that workflow run no longer contains the `Linux-cdn-turbo` artifact — only `Linux-default-turbo`.

This has caused **all dev deploys in ui-kit-cd to fail** since Apr 16 with:
```
Artifact not found for name: Linux-cdn-turbo
```

Production deploys are unaffected (they do a full build from scratch).

## Solution
Make the `prerelease-cdn` job produce the `Linux-cdn-turbo` artifact by:
1. Setting `DEPLOYMENT_ENVIRONMENT: CDN` at the job level
2. Using `cache-prefix: 'cdn'` and `save-cache: 'true'` in the setup action (instead of `skip-build: 'true'`)

This ensures the `Linux-cdn-turbo` artifact exists in the same workflow run whose `run_id` is dispatched to `ui-kit-cd`.

[KIT-5618]: https://coveord.atlassian.net/browse/KIT-5618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ