### PR TITLE
fix(security): patch validation type and cookie for HTTPS in samples j:KIT-5636

### DIFF
--- a/packages/headless/src/api/analytics/coveo.analytics/cookie.ts
+++ b/packages/headless/src/api/analytics/coveo.analytics/cookie.ts
@@ -58,5 +58,7 @@ function writeCookie(
     `${name}=${value}` +
     (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
     (domain ? `;domain=${domain}` : '') +
-    ';path=/;SameSite=Lax';
+    ';path=/' +
+    ';SameSite=Lax' +
+    (location.protocol === 'https:' ? ';Secure' : '');
 }

--- a/packages/headless/src/api/analytics/coveo.analytics/cookie.ts
+++ b/packages/headless/src/api/analytics/coveo.analytics/cookie.ts
@@ -58,7 +58,5 @@ function writeCookie(
     `${name}=${value}` +
     (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
     (domain ? `;domain=${domain}` : '') +
-    ';path=/' +
-    ';SameSite=Lax' +
-    (location.protocol === 'https:' ? ';Secure' : '');
+    ';path=/;SameSite=Lax';
 }

--- a/samples/headless-ssr/commerce-express/src/server.ts
+++ b/samples/headless-ssr/commerce-express/src/server.ts
@@ -25,7 +25,7 @@ app.use(express.static('dist'));
 
 app.get('/', async (req, res) => {
   try {
-    const queryFromRequest = req.query.q?.toString?.() ?? '';
+    const queryFromRequest = typeof req.query.q === 'string' ? req.query.q : '';
 
     const staticState = await searchEngineDefinition.fetchStaticState({
       searchParams: {q: queryFromRequest},

--- a/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
+++ b/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
@@ -13,12 +13,7 @@ export function setCookie(
   path = '/',
   maxAge = 60 * 60 * 24 * 365
 ) {
-  document.cookie =
-    `${name}=${value}` +
-    `;path=${path}` +
-    `;Max-Age=${maxAge}` +
-    ';SameSite=Lax' +
-    `${location.protocol === 'https:' ? ';Secure' : ''}`;
+  document.cookie = `${name}=${value}; path=${path}; Max-Age=${maxAge}; SameSite=Lax`;
 }
 
 /**

--- a/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
+++ b/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
@@ -13,7 +13,12 @@ export function setCookie(
   path = '/',
   maxAge = 60 * 60 * 24 * 365
 ) {
-  document.cookie = `${name}=${value}; path=${path}; Max-Age=${maxAge}; SameSite=Lax`;
+  document.cookie =
+    `${name}=${value}` +
+    `;path=${path}` +
+    `;Max-Age=${maxAge}` +
+    ';SameSite=Lax' +
+    `${window.location.protocol === 'https:' ? ';Secure' : ''}`;
 }
 
 /**

--- a/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
+++ b/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts
@@ -13,7 +13,12 @@ export function setCookie(
   path = '/',
   maxAge = 60 * 60 * 24 * 365
 ) {
-  document.cookie = `${name}=${value}; path=${path}; Max-Age=${maxAge}; SameSite=Lax`;
+  document.cookie =
+    `${name}=${value}` +
+    `;path=${path}` +
+    `;Max-Age=${maxAge}` +
+    ';SameSite=Lax' +
+    `${location.protocol === 'https:' ? ';Secure' : ''}`;
 }
 
 /**


### PR DESCRIPTION
Patch vulnerability issues reported by Snyk in headless samples

**Improper Type Validation**
> The type of this object, coming from query and the value of its `toString` property can be controlled by the user. An attacker may craft the properties of the object to crash the application or bypass its logic. Consider checking the type of the object.
> [‎samples/headless-ssr/commerce-express/src/server.ts](https://github.com/coveo/ui-kit/tree/7fa989528665a8c2fe4156fac2072b6405b2062e/samples/headless-ssr/commerce-express/src/server.ts#L28)

**Sensitive Cookie in HTTPS Session Without 'Secure' Attribute**
> Cookie misses the `Secure` attribute (it is false by default). Set it to true to protect the cookie from man-in-the-middle attacks.
> [‎samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts](https://github.com/coveo/ui-kit/tree/2de5a5986f3a1ac39c566c09cd1604e7ef330d73/samples/headless-ssr/commerce-react-router/utils/cookie-utils.client.ts#L16)