### PR TITLE
feat(atomic): enable tsc --noEmit type-checking for production source code

### DIFF
--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -75,6 +75,7 @@
     "test:storybook": "vitest run --project=storybook",
     "test:storybook-utils": "vitest run --project=storybookPure",
     "generate-component": "node ./scripts/generate-component.mjs",
+    "tsc:check": "tsc --noEmit -p tsconfig.check.json",
     "validate:definitions": "tsc --noEmit --esModuleInterop --skipLibCheck ./dist/types/components.d.ts",
     "chromatic": "chromatic -d=dist-storybook --only-changed --untraced \"/virtual:*\"",
     "validate:light-dom-styles": "node ./scripts/check-light-dom-host-selectors.mjs",

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
@@ -1,7 +1,6 @@
 import {
   buildContext,
   type CommerceEngine,
-  type CommerceEngineConfiguration,
   type Context,
   VERSION as HEADLESS_VERSION,
   loadConfigurationActions,
@@ -31,7 +30,6 @@ import {
   createCommerceRecommendationStore,
 } from './store.js';
 
-type CommerceInitializationOptions = CommerceEngineConfiguration;
 export type CommerceBindings = CommonBindings<
   CommerceEngine,
   CommerceRecommendationStore,

--- a/packages/atomic/src/components/common/interface/bindings.ts
+++ b/packages/atomic/src/components/common/interface/bindings.ts
@@ -50,19 +50,6 @@ export interface NonceBindings {
   createScriptElement: () => HTMLScriptElement;
 }
 
-/**
- * @deprecated
- * If used to inject style on a component with no shadow DOM, use the `LightDomMixin` mixin on Lit component.
- * If used to inject a styled layout, consider using `CommerceLayoutMixin` instead.
- */
-interface AdoptedStylesBindings {
-  /**
-   * @deprecated
-   * An array of adopted stylesheets to be used in the shadow DOM.
-   */
-  addAdoptedStyleSheets: (stylesheet: CSSStyleSheet) => void;
-}
-
 export type AnyBindings = CommonBindings<AnyEngineType, AnyStore, HTMLElement>;
 
 export type AnyEngineType =

--- a/packages/atomic/src/components/common/item-list/context/item-display-config-context-controller.ts
+++ b/packages/atomic/src/components/common/item-list/context/item-display-config-context-controller.ts
@@ -48,7 +48,3 @@ export class ItemDisplayConfigContextController implements ReactiveController {
     }
   }
 }
-
-type ItemDisplayConfigContextEventHandler = (config: DisplayConfig) => void;
-type ItemDisplayConfigContextEvent =
-  CustomEvent<ItemDisplayConfigContextEventHandler>;

--- a/packages/atomic/src/components/common/template-controller/template-utils.ts
+++ b/packages/atomic/src/components/common/template-controller/template-utils.ts
@@ -1,7 +1,5 @@
 import {intersection} from '@/src/utils/set';
 
-type TemplateContent = DocumentFragment;
-
 export interface TemplateHelpers<TCondition> {
   fieldMustMatch: (field: string, values: string[]) => TCondition;
   fieldMustNotMatch: (field: string, values: string[]) => TCondition;

--- a/packages/atomic/src/utils/functional-component-utils.ts
+++ b/packages/atomic/src/utils/functional-component-utils.ts
@@ -1,5 +1,4 @@
 import type {nothing, TemplateResult} from 'lit';
-import type {DirectiveResult} from 'lit/directive.js';
 
 export type FunctionalComponentNoProps = () => TemplateResult | typeof nothing;
 
@@ -28,11 +27,5 @@ export type FunctionalComponentWithOptionalChildren<T> = ({
 }) => (
   children?: FunctionalComponentChildren
 ) => TemplateResult | typeof nothing;
-
-type FunctionalComponentGuard<T> = ({
-  props,
-}: {
-  props: T;
-}) => (children: FunctionalComponentChildren) => DirectiveResult;
 
 type FunctionalComponentChildren = TemplateResult | typeof nothing;

--- a/packages/atomic/tsconfig.check.json
+++ b/packages/atomic/tsconfig.check.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "src/external-builds",
+    "src/**/*.spec.ts",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx",
+    "src/**/e2e/**",
+    "src/index.ts",
+    "src/cdn.ts",
+    "src/loader.ts",
+    "src/autoloader/**",
+    "src/components/**/index.ts",
+    "src/components/**/lazy-index.ts",
+    "src/utils/custom-element-tags.ts"
+  ]
+}

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["build:storybook", "build:lit", "build:cdn"],
+      "dependsOn": ["tsc:check", "build:storybook", "build:lit", "build:cdn"],
       "outputs": []
     },
     "build:locales": {
@@ -83,6 +83,10 @@
         "./dist/themes/**",
         "./rsbuild.cdn.mjs"
       ]
+    },
+    "tsc:check": {
+      "dependsOn": ["^build", "build:locales"],
+      "outputs": []
     },
     "test:lit": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
[KIT-5628](https://coveord.atlassian.net/browse/KIT-5628)

## Problem
`@coveo/atomic` does not run `tsc --noEmit` in CI. Since the package uses esbuild/Vite for bundling (which erases types), type errors go undetected. This was discovered when knip caught a broken `import type` pointing to a non-existent module that had been silently broken.

## Solution
- Added `tsconfig.check.json` that runs `tsc --noEmit` scoped to `src/` production code, excluding generated barrel files, tests, stories, and e2e files
- Added `tsc:check` script to `package.json` with proper Turbo dependency chain (`^build` + `build:locales`)
- Removed 5 unused type declarations that were flagged by the new strict check:
  - `CommerceInitializationOptions` (dead type alias)
  - `AdoptedStylesBindings` (deprecated, never used)
  - `ItemDisplayConfigContextEvent` / `ItemDisplayConfigContextEventHandler` (unused types)
  - `TemplateContent` (shadowed by export in `base-template-controller.ts`)
  - `FunctionalComponentGuard` (unused type)

## Commit structure

This PR is split into two commits for easier review:

1. **Config** — adds `tsconfig.check.json`, the `tsc:check` script in `package.json`, and the Turbo wiring in `turbo.json`
2. **Fixes** — removes the unused type declarations flagged by the new check

## Why `tsc --noEmit` and not OxLint / Biome?

We investigated using OxLint's `no-unused-vars` rule as a lighter alternative. It only found 4 results on `packages/atomic/src/` — 3 were false positives on underscore-prefixed catch parameters, and 1 was in a test file. **It did not detect any of the unused type aliases or interfaces** that `tsc --noEmit` caught. Linters like OxLint and Biome operate at the syntax level and cannot perform the cross-file type resolution that TypeScript's type checker does. `tsc --noEmit` is the only tool that can catch these classes of errors.


[KIT-5628]: https://coveord.atlassian.net/browse/KIT-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ