### PR TITLE
docs(headless): ensuring installation and CDN examples pin to the current version

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -308,9 +308,9 @@ export class AtomicGeneratedAnswer
 
   protected willUpdate(changedProperties: PropertyValueMap<this>) {
     if (changedProperties.has('tabManagerState' as keyof this)) {
-      const oldValue = changedProperties.get(
-        'tabManagerState' as keyof this
-      ) as TabManagerState | undefined;
+      const oldValue = changedProperties.get('tabManagerState' as keyof this) as
+        | TabManagerState
+        | undefined;
       if (oldValue && this.tabManagerState?.activeTab !== oldValue?.activeTab) {
         if (
           !shouldDisplayOnCurrentTab(

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -308,9 +308,9 @@ export class AtomicGeneratedAnswer
 
   protected willUpdate(changedProperties: PropertyValueMap<this>) {
     if (changedProperties.has('tabManagerState' as keyof this)) {
-      const oldValue = changedProperties.get('tabManagerState' as keyof this) as
-        | TabManagerState
-        | undefined;
+      const oldValue = changedProperties.get(
+        'tabManagerState' as keyof this
+      ) as TabManagerState | undefined;
       if (oldValue && this.tabManagerState?.activeTab !== oldValue?.activeTab) {
         if (
           !shouldDisplayOnCurrentTab(

--- a/packages/documentation/lib/calloutParsing.ts
+++ b/packages/documentation/lib/calloutParsing.ts
@@ -1,6 +1,9 @@
 import type {PageEvent, RouterTarget} from 'typedoc';
 
+type VariableMap = Record<string, string>;
+
 let BLOCK_COUNTER = 0;
+let VARIABLES: VariableMap = {};
 const CODE_BLOCK_REGEX =
   /<pre\b[^>]*>[\s\S]*?<code\b[^>]*>[\s\S]*?<\/code>[\s\S]*?<\/pre>/gi;
 
@@ -145,6 +148,43 @@ const codifyCallout = (callout: string): string => {
   return callout.replace(/`([^`]+)`/g, '<code>$1</code>');
 };
 
+const replaceVariablesInCodeBlock = (html: string): string => {
+  if (Object.keys(VARIABLES).length === 0) return html;
+
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const open = html.indexOf('{{', cursor);
+    if (open === -1) {
+      result += html.slice(cursor);
+      break;
+    }
+
+    result += html.slice(cursor, open);
+
+    const close = html.indexOf('}}', open + 2);
+    if (close === -1) {
+      result += html.slice(open);
+      break;
+    }
+
+    const match = html.slice(open, close + 2);
+    const raw = html.slice(open + 2, close);
+    const key = stripAllTags(raw);
+
+    if (/^\w+$/.test(key) && key in VARIABLES) {
+      result += VARIABLES[key];
+    } else {
+      result += match;
+    }
+
+    cursor = close + 2;
+  }
+
+  return result;
+};
+
 const transformCodeBlockHtml = (blockHtml: string): string => {
   const codeStart = blockHtml.indexOf('<code');
   const codeTagEnd = blockHtml.indexOf('>', codeStart);
@@ -154,11 +194,14 @@ const transformCodeBlockHtml = (blockHtml: string): string => {
     return blockHtml;
 
   const beforeCode = blockHtml.slice(0, codeTagEnd + 1);
-  const originalCodeInner = blockHtml.slice(codeTagEnd + 1, codeClose);
   const afterCode = blockHtml.slice(codeClose);
+  const originalCodeInner = replaceVariablesInCodeBlock(
+    blockHtml.slice(codeTagEnd + 1, codeClose)
+  );
 
   const {codeInner, callouts} = processCodeInnerHtml(originalCodeInner);
-  if (callouts.length === 0) return blockHtml;
+  if (callouts.length === 0)
+    return `${beforeCode}${originalCodeInner}${afterCode}`;
 
   const calloutLineItems = callouts
     .map(
@@ -169,6 +212,10 @@ const transformCodeBlockHtml = (blockHtml: string): string => {
   const calloutsHtml = `<section class="code-callout-list"><ol>${calloutLineItems}</ol></section>`;
 
   return `${beforeCode}${codeInner}${afterCode}${calloutsHtml}`;
+};
+
+export const setCodeBlockVariables = (variables: VariableMap): void => {
+  VARIABLES = variables;
 };
 
 export const handleRendererEndPage = (page: PageEvent<RouterTarget>): void => {

--- a/packages/documentation/lib/index.tsx
+++ b/packages/documentation/lib/index.tsx
@@ -1,4 +1,4 @@
-import {cpSync} from 'node:fs';
+import {cpSync, readFileSync} from 'node:fs';
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {
@@ -16,7 +16,10 @@ import {
   Renderer,
   RendererEvent,
 } from 'typedoc';
-import {handleRendererEndPage} from './calloutParsing.js';
+import {
+  handleRendererEndPage,
+  setCodeBlockVariables,
+} from './calloutParsing.js';
 import {formatRightToc} from './formatRightToc.js';
 import {formatTypeDocToolbar} from './formatTypeDocToolbar.js';
 import {hoistOtherCategoryInArray, hoistOtherCategoryInNav} from './hoist.js';
@@ -28,6 +31,7 @@ import {insertMetaTags} from './insertMetaTags.js';
 import {insertSiteHeaderBar} from './insertSiteHeaderBar.js';
 import {removeNavSettings} from './removeNavSettings.js';
 import {applyTopLevelRenameArray} from './renaming.js';
+import {buildReplaceVariables} from './replaceVariables.js';
 import {
   applyNestedOrderingArray,
   applyNestedOrderingNode,
@@ -304,6 +308,31 @@ export const load = (app: Application) => {
     originalMethod = null;
 
     cpSync(darkModeJs.from, darkModeJs.to);
+  });
+
+  app.renderer.on(RendererEvent.BEGIN, (event: RendererEvent) => {
+    let version = event.project.packageVersion ?? '';
+
+    if (!version) {
+      const pkgPath = resolve(process.cwd(), 'package.json');
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        version = pkg.version;
+      } catch {
+        throw new Error(
+          `Failed to determine packageVersion: could not read or parse ${pkgPath}`
+        );
+      }
+      if (!version) {
+        throw new Error(
+          `Failed to determine packageVersion: no "version" field found in ${pkgPath}`
+        );
+      }
+    }
+
+    const variables = {packageVersion: version};
+    setCodeBlockVariables(variables);
+    app.renderer.on(PageEvent.END, buildReplaceVariables(variables));
   });
 
   app.renderer.on(PageEvent.END, insertMetaTags);

--- a/packages/documentation/lib/replaceVariables.ts
+++ b/packages/documentation/lib/replaceVariables.ts
@@ -1,0 +1,16 @@
+import type {PageEvent} from 'typedoc';
+
+type VariableMap = Record<string, string>;
+
+const VARIABLE_REGEX = /\{\{(\w+)\}\}/g;
+
+export const buildReplaceVariables =
+  (variables: VariableMap) => (page: PageEvent) => {
+    if (!page.contents) return;
+
+    page.contents = page.contents.replace(VARIABLE_REGEX, (match, key) => {
+      return Object.prototype.hasOwnProperty.call(variables, key)
+        ? variables[key]
+        : match;
+    });
+  };

--- a/packages/headless-react/source_docs/getting-started-with-commerce-ssr.md
+++ b/packages/headless-react/source_docs/getting-started-with-commerce-ssr.md
@@ -26,8 +26,12 @@ Before getting started, make sure that:
 Use [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) to install the package along with its peer dependencies:
 
 ```
-npm install @coveo/headless-react @coveo/headless react react-dom
+npm install @coveo/headless-react@{{packageVersion}} react react-dom
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless-react` dependency to a specific version to avoid unexpected changes.
 
 > [!NOTE]
 >

--- a/packages/headless-react/source_docs/getting-started-with-search-ssr.md
+++ b/packages/headless-react/source_docs/getting-started-with-search-ssr.md
@@ -22,8 +22,12 @@ Before getting started, make sure that:
 Use [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) to install the package along with its peer dependencies:
 
 ```
-npm install @coveo/headless-react @coveo/headless react react-dom
+npm install @coveo/headless-react@{{packageVersion}} react react-dom
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless-react` dependency to a specific version to avoid unexpected changes.
 
 > [!NOTE]
 >

--- a/packages/headless/source_docs/concepts.md
+++ b/packages/headless/source_docs/concepts.md
@@ -20,8 +20,12 @@ This article provides an overview of the core Headless concepts.
 Use [npm](https://www.npmjs.com/get-npm) to install the Headless library.
 
 ```
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Headless requires Node.js version 20.
 

--- a/packages/headless/source_docs/coveo-headless-home.md
+++ b/packages/headless/source_docs/coveo-headless-home.md
@@ -48,9 +48,9 @@ The following interactive code sample uses Coveo Headless alongside the [Materia
 
 <details>
         <summary>Click to show interactive demo</summary> 
-        <iframe src="https://stackblitz.com/github/coveo/headless-documentation-material-ui-react-codesandbox/tree/version-3.35.0/?embed=1&view=split&file=src%2FApp.tsx"
+        <iframe src="https://stackblitz.com/github/coveo/headless-documentation-material-ui-react-codesandbox/tree/version-{{packageVersion}}/?embed=1&view=split&file=src%2FApp.tsx"
             style="width:100%; height:1024px; border:0; border-radius: 4px; overflow:hidden;"
-            title="coveo-headless-demo-v3.35.0"
+            title="coveo-headless-demo-v{{packageVersion}}"
             allow=""
             sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
         ></iframe>

--- a/packages/headless/source_docs/getting-started-case-assist.md
+++ b/packages/headless/source_docs/getting-started-case-assist.md
@@ -13,8 +13,12 @@ Case Assist helps you build interfaces that assist agents and users in classifyi
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the Case Assist sub-package:
 
@@ -38,7 +42,7 @@ If you prefer not to use a package manager, you can load the Case Assist bundle 
     buildCaseAssistEngine,
     buildCaseInput,
     buildDocumentSuggestionList,
-  } from 'https://static.cloud.coveo.com/headless/v3/case-assist/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/case-assist/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -47,7 +51,7 @@ If you prefer not to use a package manager, you can load the Case Assist bundle 
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/case-assist/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/case-assist/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessCaseAssist object.
   const {buildCaseAssistEngine, buildCaseInput, buildDocumentSuggestionList} =
@@ -57,7 +61,7 @@ If you prefer not to use a package manager, you can load the Case Assist bundle 
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 

--- a/packages/headless/source_docs/getting-started-case-assist.md
+++ b/packages/headless/source_docs/getting-started-case-assist.md
@@ -59,10 +59,6 @@ If you prefer not to use a package manager, you can load the Case Assist bundle 
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example builds a Case Assist engine, creates a case input controller, and logs its state.

--- a/packages/headless/source_docs/getting-started-commerce.md
+++ b/packages/headless/source_docs/getting-started-commerce.md
@@ -58,10 +58,6 @@ If you prefer not to use a package manager, you can load the Commerce bundle dir
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example builds a commerce engine using the built-in sample configuration, executes a search, and logs the results.

--- a/packages/headless/source_docs/getting-started-commerce.md
+++ b/packages/headless/source_docs/getting-started-commerce.md
@@ -14,8 +14,12 @@ This guide walks you through installing and verifying a minimal Commerce setup.
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the Commerce sub-package:
 
@@ -37,7 +41,7 @@ If you prefer not to use a package manager, you can load the Commerce bundle dir
   import {
     buildCommerceEngine,
     getSampleCommerceEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/commerce/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/commerce/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -46,7 +50,7 @@ If you prefer not to use a package manager, you can load the Commerce bundle dir
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/commerce/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/commerce/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessCommerce object.
   const {buildCommerceEngine, getSampleCommerceEngineConfiguration} =
@@ -56,7 +60,7 @@ If you prefer not to use a package manager, you can load the Commerce bundle dir
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 
@@ -107,7 +111,7 @@ search.executeFirstSearch();
         buildCommerceEngine,
         buildSearch,
         getSampleCommerceEngineConfiguration,
-      } from 'https://static.cloud.coveo.com/headless/v3/commerce/headless.esm.js';
+      } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/commerce/headless.esm.js';
 
       const engine = buildCommerceEngine({
         configuration: getSampleCommerceEngineConfiguration(),

--- a/packages/headless/source_docs/getting-started-insight.md
+++ b/packages/headless/source_docs/getting-started-insight.md
@@ -57,10 +57,6 @@ If you prefer not to use a package manager, you can load Headless Insight direct
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example builds an Insight engine using the built-in sample configuration, executes a search, and logs the number of results.

--- a/packages/headless/source_docs/getting-started-insight.md
+++ b/packages/headless/source_docs/getting-started-insight.md
@@ -13,8 +13,12 @@ The Insight engine powers search interfaces embedded within service agent consol
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the Insight sub-package:
 
@@ -36,7 +40,7 @@ If you prefer not to use a package manager, you can load Headless Insight direct
   import {
     buildInsightEngine,
     getSampleInsightEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/insight/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/insight/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -45,7 +49,7 @@ If you prefer not to use a package manager, you can load Headless Insight direct
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/insight/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/insight/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessInsight object.
   const {buildInsightEngine, getSampleInsightEngineConfiguration} =
@@ -55,7 +59,7 @@ If you prefer not to use a package manager, you can load Headless Insight direct
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 
@@ -105,7 +109,7 @@ engine.executeFirstSearch();
         buildInsightEngine,
         buildResultList,
         getSampleInsightEngineConfiguration,
-      } from 'https://static.cloud.coveo.com/headless/v3/insight/headless.esm.js';
+      } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/insight/headless.esm.js';
 
       const engine = buildInsightEngine({
         configuration: getSampleInsightEngineConfiguration(),

--- a/packages/headless/source_docs/getting-started-recommendation.md
+++ b/packages/headless/source_docs/getting-started-recommendation.md
@@ -59,10 +59,6 @@ If you prefer not to use a package manager, you can load Headless Recommendation
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example builds a recommendation engine using the built-in sample configuration, fetches recommendations, and logs the results.

--- a/packages/headless/source_docs/getting-started-recommendation.md
+++ b/packages/headless/source_docs/getting-started-recommendation.md
@@ -13,8 +13,12 @@ The Recommendation engine powers content recommendation interfaces that suggest 
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the recommendation sub-package:
 
@@ -36,7 +40,7 @@ If you prefer not to use a package manager, you can load Headless Recommendation
   import {
     buildRecommendationEngine,
     getSampleRecommendationEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/recommendation/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/recommendation/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -45,7 +49,7 @@ If you prefer not to use a package manager, you can load Headless Recommendation
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/recommendation/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/recommendation/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessRecommendation object.
   const {
@@ -57,7 +61,7 @@ If you prefer not to use a package manager, you can load Headless Recommendation
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 
@@ -108,7 +112,7 @@ recommendationList.refresh();
         buildRecommendationEngine,
         buildRecommendationList,
         getSampleRecommendationEngineConfiguration,
-      } from 'https://static.cloud.coveo.com/headless/v3/recommendation/headless.esm.js';
+      } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/recommendation/headless.esm.js';
 
       const engine = buildRecommendationEngine({
         configuration: getSampleRecommendationEngineConfiguration(),

--- a/packages/headless/source_docs/getting-started-ssr-commerce.md
+++ b/packages/headless/source_docs/getting-started-ssr-commerce.md
@@ -18,8 +18,12 @@ The SSR Commerce engine enables server-side rendering of commerce interfaces —
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the SSR Commerce sub-package:
 
@@ -42,7 +46,7 @@ If you prefer not to use a package manager, you can load the SSR Commerce bundle
   import {
     defineCommerceEngine,
     getSampleCommerceEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/ssr-commerce/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/ssr-commerce/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -51,7 +55,7 @@ If you prefer not to use a package manager, you can load the SSR Commerce bundle
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/ssr-commerce/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/ssr-commerce/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessCommerceSSR object.
   const {defineCommerceEngine, getSampleCommerceEngineConfiguration} =
@@ -61,7 +65,7 @@ If you prefer not to use a package manager, you can load the SSR Commerce bundle
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 

--- a/packages/headless/source_docs/getting-started-ssr-commerce.md
+++ b/packages/headless/source_docs/getting-started-ssr-commerce.md
@@ -63,10 +63,6 @@ If you prefer not to use a package manager, you can load the SSR Commerce bundle
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example defines a commerce engine with a product list controller.

--- a/packages/headless/source_docs/getting-started-ssr-search.md
+++ b/packages/headless/source_docs/getting-started-ssr-search.md
@@ -62,10 +62,6 @@ If you prefer not to use a package manager, you can load Headless SSR directly f
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example defines a search engine with a result list controller using the built-in sample configuration.

--- a/packages/headless/source_docs/getting-started-ssr-search.md
+++ b/packages/headless/source_docs/getting-started-ssr-search.md
@@ -18,8 +18,12 @@ The SSR Search engine enables server-side rendering of search interfaces.
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the SSR sub-path in your project:
 
@@ -41,7 +45,7 @@ If you prefer not to use a package manager, you can load Headless SSR directly f
   import {
     defineSearchEngine,
     getSampleSearchEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/ssr/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/ssr/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -50,7 +54,7 @@ If you prefer not to use a package manager, you can load Headless SSR directly f
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/ssr/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/ssr/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadlessSSR object.
   const {defineSearchEngine, getSampleSearchEngineConfiguration} =
@@ -60,7 +64,7 @@ If you prefer not to use a package manager, you can load Headless SSR directly f
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 

--- a/packages/headless/source_docs/getting-started.md
+++ b/packages/headless/source_docs/getting-started.md
@@ -22,8 +22,12 @@ Headless requires Node.js version 20.9.0 or later when used in a Node.js environ
 Install `@coveo/headless` using npm (or any other package manager such as pnpm or yarn):
 
 ```bash
-npm install @coveo/headless
+npm install @coveo/headless@{{packageVersion}}
 ```
+
+> [!TIP]
+>
+> We recommend pinning your `@coveo/headless` dependency to a specific version to avoid unexpected changes.
 
 Once installed, you can import from the package in your project:
 
@@ -45,7 +49,7 @@ If you prefer not to use a package manager, you can load Headless directly from 
   import {
     buildSearchEngine,
     getSampleSearchEngineConfiguration,
-  } from 'https://static.cloud.coveo.com/headless/v3/headless.esm.js';
+  } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/headless.esm.js';
 
   // You can now use the imported functions.
 </script>
@@ -54,7 +58,7 @@ If you prefer not to use a package manager, you can load Headless directly from 
 ### UMD (Classic Script Tag)
 
 ```html
-<script src="https://static.cloud.coveo.com/headless/v3/headless.js"></script>
+<script src="https://static.cloud.coveo.com/headless/v{{packageVersion}}/headless.js"></script>
 <script>
   // All exports are available on the global CoveoHeadless object.
   const {buildSearchEngine, getSampleSearchEngineConfiguration} = CoveoHeadless;
@@ -63,7 +67,7 @@ If you prefer not to use a package manager, you can load Headless directly from 
 
 > [!TIP]
 >
-> Replace `v3` in the URL with a specific version (for example, `v3.46.0`) to pin your application to a known release.
+> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
 
 ## Verify Your Installation
 
@@ -114,7 +118,7 @@ engine.executeFirstSearch();
         buildSearchEngine,
         buildResultList,
         getSampleSearchEngineConfiguration,
-      } from 'https://static.cloud.coveo.com/headless/v3/headless.esm.js';
+      } from 'https://static.cloud.coveo.com/headless/v{{packageVersion}}/headless.esm.js';
 
       const engine = buildSearchEngine({
         configuration: getSampleSearchEngineConfiguration(),

--- a/packages/headless/source_docs/getting-started.md
+++ b/packages/headless/source_docs/getting-started.md
@@ -65,10 +65,6 @@ If you prefer not to use a package manager, you can load Headless directly from 
 </script>
 ```
 
-> [!TIP]
->
-> Replace `v{{packageVersion}}` in the URL with `v3` to always use the latest major version.
-
 ## Verify Your Installation
 
 The following example builds a search engine using the built-in sample configuration, executes a search, and logs the number of results.

--- a/packages/headless/source_docs/headless-code-samples.md
+++ b/packages/headless/source_docs/headless-code-samples.md
@@ -8,9 +8,9 @@ slug: code-samples
 
 The following interactive code sample uses Coveo Headless alongside the [Material-UI React framework](https://material-ui.com/) to create a simple search page.
 
-<iframe src="https://stackblitz.com/github/coveo/headless-documentation-material-ui-react-codesandbox/tree/version-3.35.0/?embed=1&view=split&file=src%2FApp.tsx"
-     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
-     title="coveo-headless-demo-v3.35.0"
+<iframe src="https://stackblitz.com/github/coveo/headless-documentation-material-ui-react-codesandbox/tree/version-{{packageVersion}}/?embed=1&view=split&file=src%2FApp.tsx"
+     style="width:100%; height:1024px; border:0; border-radius: 4px; overflow:hidden;"
+     title="coveo-headless-demo-v{{packageVersion}}"
      allow=""
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>

--- a/packages/headless/source_docs/versions.md
+++ b/packages/headless/source_docs/versions.md
@@ -14,7 +14,7 @@ slug: versioned-documentation
 >
 > As of v1.28.2 the default analytics endpoint has moved to `https://analytics.cloud.coveo.com/rest/ua`
 
-## Latest version (v3.35.0)
+## Latest version (v{{packageVersion}})
 
 [Documentation](./index.html)
 


### PR DESCRIPTION
## Purpose

To encourage our users to pin to versions to avoid errantly picking up updates, this updates the documentation to update all installation instructions - or CDN examples - to include the full semver to patch.