### PR TITLE
fix(changesets): prevent major bumps on in-range peer dep updates j:KIT-5656

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,8 @@
   "privatePackages": {
     "version": false,
     "tag": false
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,12 @@
       ],
     },
     {
+      groupName: 'Changesets',
+      groupSlug: 'changesets',
+      description: 'Isolate @changesets/* since we rely on experimental options that may change in a patch update',
+      matchPackageNames: ['@changesets/*'],
+    },
+    {
       groupName: 'wc-toolkit storybook-helpers',
       groupSlug: 'wc-toolkit-storybook-helpers',
       rangeStrategy: 'replace',


### PR DESCRIPTION
[KIT-5656](https://coveord.atlassian.net/browse/KIT-5656)

## Problem

The current Changesets configuration causes a **major version bump** on `@coveo/atomic` (and dependents like `atomic-react`, `atomic-angular`) whenever `@coveo/headless` receives even a minor bump. This is because Changesets' default behavior treats any peer dependency version change beyond patch as a breaking change for the dependent package.

This caused `@coveo/atomic` to jump from v3.57.0 → v4.0.0 in PR #7488, despite having no actual breaking changes.

## Solution

Added `onlyUpdatePeerDependentsWhenOutOfRange: true` to the Changesets experimental options in `.changeset/config.json`. This tells Changesets to only trigger a major bump on peer dependents when the new version falls **outside** the declared peer dependency range (e.g., headless going to v4 would trigger it, but a minor within v3 would not).

[KIT-5656]: https://coveord.atlassian.net/browse/KIT-5656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ