### PR TITLE
fix(deps): use workspace:^ for internal peer dependencies j:KIT-5656

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
     "version": false,
     "tag": false
   },
+  "//": "onlyUpdatePeerDependentsWhenOutOfRange prevents major bumps on peer dependents when the new version still satisfies the declared range. This requires internal peerDependencies to use workspace:^ (caret range) instead of workspace:* (exact version). See KIT-5656.",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -25,7 +25,7 @@
     "vite": "^8.0.0"
   },
   "peerDependencies": {
-    "@coveo/headless": "workspace:*"
+    "@coveo/headless": "workspace:^"
   },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"

--- a/packages/atomic-angular/projects/atomic-angular/package.json
+++ b/packages/atomic-angular/projects/atomic-angular/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@angular/common": "14 - 21",
     "@angular/core": "14 - 21",
-    "@coveo/headless": "workspace:*"
+    "@coveo/headless": "workspace:^"
   },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -58,7 +58,7 @@
     "rollup-plugin-polyfill-node": "^0.13.0"
   },
   "peerDependencies": {
-    "@coveo/headless": "workspace:*",
+    "@coveo/headless": "workspace:^",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -142,8 +142,8 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@coveo/bueno": "workspace:*",
-    "@coveo/headless": "workspace:*",
+    "@coveo/bueno": "workspace:^",
+    "@coveo/headless": "workspace:^",
     "typescript": ">=5.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,7 +472,7 @@ importers:
         specifier: workspace:*
         version: link:../../../atomic
       '@coveo/headless':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../../headless
     publishDirectory: dist
 
@@ -520,7 +520,7 @@ importers:
         specifier: workspace:*
         version: link:../atomic
       '@coveo/headless':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../headless
       '@lit/react':
         specifier: 1.0.8


### PR DESCRIPTION
[KIT-5656](https://coveord.atlassian.net/browse/KIT-5656)

## Problem

Even with `onlyUpdatePeerDependentsWhenOutOfRange: true` in the changeset config (merged in #7497), `@coveo/atomic` still gets a major bump when headless has a minor update. 

This is because `workspace:*` resolves to the **exact current version** (e.g., `3.49.4`) in changesets' version range check, so `3.50.0` is considered "out of range" and triggers a major bump.

## Solution

Changed internal `peerDependencies` from `workspace:*` to `workspace:^`. This resolves to a **caret range** (e.g., `^3.49.4`) so minor/patch updates stay in range and don't trigger a major bump.

**Verified locally:**
- Before: `pnpm changeset status` → `@coveo/atomic 4.0.0` (major)
- After: `pnpm changeset status` → `@coveo/atomic 3.57.1` (patch) ✅

Affected packages: `@coveo/atomic`, `@coveo/atomic-react`, `@coveo/atomic-angular`

[KIT-5656]: https://coveord.atlassian.net/browse/KIT-5656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ