### PR TITLE
fix(quantic): remove random result list render key fallback

### DIFF
--- a/.changeset/remove-random-quantic-render-key.md
+++ b/.changeset/remove-random-quantic-render-key.md
@@ -1,0 +1,5 @@
+---
+"@coveo/quantic": patch
+---
+
+Remove the random fallback used for Quantic result list render keys.

--- a/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/__tests__/quanticFoldedResultList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/__tests__/quanticFoldedResultList.test.js
@@ -319,5 +319,36 @@ describe('c-quantic-folded-result-list', () => {
       });
       expect(results[0].getAttribute('result')).toBeDefined();
     });
+
+    it('should use a stable fallback key prefix when the search response id is missing', async () => {
+      foldedResultsListState = {
+        ...foldedResultsListState,
+        searchResponseId: undefined,
+      };
+
+      const element = createTestComponent();
+      await flushPromises();
+
+      const collectionKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.result)
+      ).map((resultElement) => resultElement.collection.keyResultList);
+      const fallbackPrefix = collectionKeys[0].replace(
+        `_${fakeCollections[0].result.uniqueId}`,
+        ''
+      );
+      const stableCollectionKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.result)
+      ).map((resultElement) => resultElement.collection.keyResultList);
+
+      expect(collectionKeys.length).toBe(fakeCollections.length);
+      expect(fallbackPrefix).toMatch(/^quantic-folded-result-list-\d+$/);
+      expect(new Set(collectionKeys).size).toBe(fakeCollections.length);
+      collectionKeys.forEach((key, index) => {
+        expect(key).toBe(
+          `${fallbackPrefix}_${fakeCollections[index].result.uniqueId}`
+        );
+      });
+      expect(stableCollectionKeys).toEqual(collectionKeys);
+    });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/__tests__/quanticFoldedResultList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/__tests__/quanticFoldedResultList.test.js
@@ -341,7 +341,7 @@ describe('c-quantic-folded-result-list', () => {
       ).map((resultElement) => resultElement.collection.keyResultList);
 
       expect(collectionKeys.length).toBe(fakeCollections.length);
-      expect(fallbackPrefix).toMatch(/^quantic-folded-result-list-\d+$/);
+      expect(fallbackPrefix).toMatch(/^quantic-folded-result-list-\d+-\d+$/);
       expect(new Set(collectionKeys).size).toBe(fakeCollections.length);
       collectionKeys.forEach((key, index) => {
         expect(key).toBe(
@@ -349,6 +349,38 @@ describe('c-quantic-folded-result-list', () => {
         );
       });
       expect(stableCollectionKeys).toEqual(collectionKeys);
+
+      const updatedCollections = fakeCollections.map((collection) => ({
+        ...collection,
+        result: {
+          ...collection.result,
+          title: `${collection.result.title} updated`,
+        },
+      }));
+      functionsMocks.buildFoldedResultList.mock.results[0].value.state = {
+        ...foldedResultsListState,
+        results: updatedCollections,
+      };
+      functionsMocks.subscribeFoldedResultList.mock.calls[0][0]();
+      await flushPromises();
+
+      const updatedCollectionKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.result)
+      ).map((resultElement) => resultElement.collection.keyResultList);
+      const updatedFallbackPrefix = updatedCollectionKeys[0].replace(
+        `_${updatedCollections[0].result.uniqueId}`,
+        ''
+      );
+
+      expect(updatedFallbackPrefix).toMatch(
+        /^quantic-folded-result-list-\d+-\d+$/
+      );
+      expect(updatedFallbackPrefix).not.toBe(fallbackPrefix);
+      updatedCollectionKeys.forEach((key, index) => {
+        expect(key).toBe(
+          `${updatedFallbackPrefix}_${updatedCollections[index].result.uniqueId}`
+        );
+      });
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.js
@@ -13,6 +13,8 @@ import {LightningElement, api} from 'lwc';
 /** @typedef {import("coveo").ResultTemplatesManager} ResultTemplatesManager */
 /** @typedef {import("coveo").ResultsPerPage} ResultsPerPage */
 
+let foldedResultListFallbackId = 0;
+
 /**
  * The `QuanticFoldedResultList` component is responsible for displaying query results by applying one or more result templates.
  * This component can display query results that have a parent-child relationship with any level of nesting.
@@ -87,6 +89,8 @@ export default class QuanticFoldedResultList extends LightningElement {
   hasInitializationError = false;
   /** @type {import('c/quanticUtils').AriaLiveUtils} */
   loadingAriaLiveMessage;
+  /** @type {string} */
+  fallbackSearchResponseId = `quantic-folded-result-list-${++foldedResultListFallbackId}`;
 
   labels = {
     loadingResults,
@@ -172,7 +176,8 @@ export default class QuanticFoldedResultList extends LightningElement {
   get collections() {
     // We need to add a unique key to each result to make sure to re-render the LWC when the results change.
     // If the unique key is only the result uniqueId, the LWC will not re-render when the results change AND the same result is still in the results.
-    const searchResponseId = this?.state?.searchResponseId || Math.random();
+    const searchResponseId =
+      this.state?.searchResponseId || this.fallbackSearchResponseId;
     return (
       this?.state?.results?.map((collection) => ({
         ...collection,

--- a/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.js
@@ -90,7 +90,11 @@ export default class QuanticFoldedResultList extends LightningElement {
   /** @type {import('c/quanticUtils').AriaLiveUtils} */
   loadingAriaLiveMessage;
   /** @type {string} */
-  fallbackSearchResponseId = `quantic-folded-result-list-${++foldedResultListFallbackId}`;
+  fallbackSearchResponseIdPrefix = `quantic-folded-result-list-${++foldedResultListFallbackId}`;
+  /** @type {number} */
+  fallbackSearchResponseIdVersion = 0;
+  /** @type {FoldedResultListState} */
+  fallbackSearchResponseState;
 
   labels = {
     loadingResults,
@@ -151,7 +155,9 @@ export default class QuanticFoldedResultList extends LightningElement {
   }
 
   updateState() {
-    this.state = this.foldedResultList.state;
+    const nextState = this.foldedResultList.state;
+    this.updateFallbackSearchResponseId(nextState);
+    this.state = nextState;
     this.showPlaceholder =
       this?.state?.isLoading &&
       !this?.state?.hasError &&
@@ -160,6 +166,20 @@ export default class QuanticFoldedResultList extends LightningElement {
     if (this.showPlaceholder) {
       this.loadingAriaLiveMessage.dispatchMessage(this.labels.loadingResults);
     }
+  }
+
+  /** @param {FoldedResultListState} state */
+  updateFallbackSearchResponseId(state) {
+    if (
+      !state ||
+      state.searchResponseId ||
+      state === this.fallbackSearchResponseState
+    ) {
+      return;
+    }
+
+    this.fallbackSearchResponseState = state;
+    this.fallbackSearchResponseIdVersion++;
   }
 
   updateResultPerPage() {
@@ -184,6 +204,10 @@ export default class QuanticFoldedResultList extends LightningElement {
         keyResultList: `${searchResponseId}_${collection.result.uniqueId}`,
       })) || []
     );
+  }
+
+  get fallbackSearchResponseId() {
+    return `${this.fallbackSearchResponseIdPrefix}-${this.fallbackSearchResponseIdVersion}`;
   }
 
   /**

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/__tests__/quanticResultList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/__tests__/quanticResultList.test.js
@@ -379,12 +379,39 @@ describe('c-quantic-result-list', () => {
       ).map((resultElement) => resultElement.result.keyResultList);
 
       expect(resultKeys.length).toBe(fakeResults.length);
-      expect(fallbackPrefix).toMatch(/^quantic-result-list-\d+$/);
+      expect(fallbackPrefix).toMatch(/^quantic-result-list-\d+-\d+$/);
       expect(new Set(resultKeys).size).toBe(fakeResults.length);
       resultKeys.forEach((key, index) => {
         expect(key).toBe(`${fallbackPrefix}_${fakeResults[index].uniqueId}`);
       });
       expect(stableResultKeys).toEqual(resultKeys);
+
+      const updatedResults = fakeResults.map((result) => ({
+        ...result,
+        title: `${result.title} updated`,
+      }));
+      functionsMocks.buildResultList.mock.results[0].value.state = {
+        ...resultListState,
+        results: updatedResults,
+      };
+      functionsMocks.resultsListSubscriber.mock.calls[0][0]();
+      await flushPromises();
+
+      const updatedResultKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.quanticResult)
+      ).map((resultElement) => resultElement.result.keyResultList);
+      const updatedFallbackPrefix = updatedResultKeys[0].replace(
+        `_${updatedResults[0].uniqueId}`,
+        ''
+      );
+
+      expect(updatedFallbackPrefix).toMatch(/^quantic-result-list-\d+-\d+$/);
+      expect(updatedFallbackPrefix).not.toBe(fallbackPrefix);
+      updatedResultKeys.forEach((key, index) => {
+        expect(key).toBe(
+          `${updatedFallbackPrefix}_${updatedResults[index].uniqueId}`
+        );
+      });
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/__tests__/quanticResultList.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/__tests__/quanticResultList.test.js
@@ -338,5 +338,53 @@ describe('c-quantic-result-list', () => {
         );
       });
     });
+
+    it('should use a stable fallback key prefix when the search response id is missing', async () => {
+      const fakeResults = [
+        {
+          uniqueId: 'foo',
+          title: 'Foo',
+          excerpt: 'Foo',
+          raw: {
+            foo: 'foo',
+          },
+        },
+        {
+          uniqueId: 'Bar',
+          title: 'Bar',
+          excerpt: 'Bar',
+          raw: {
+            foo: 'bar',
+          },
+        },
+      ];
+      resultListState = {
+        ...initialResultListState,
+        searchResponseId: undefined,
+        results: fakeResults,
+      };
+
+      const element = createTestComponent();
+      await flushPromises();
+
+      const resultKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.quanticResult)
+      ).map((resultElement) => resultElement.result.keyResultList);
+      const fallbackPrefix = resultKeys[0].replace(
+        `_${fakeResults[0].uniqueId}`,
+        ''
+      );
+      const stableResultKeys = Array.from(
+        element.shadowRoot.querySelectorAll(selectors.quanticResult)
+      ).map((resultElement) => resultElement.result.keyResultList);
+
+      expect(resultKeys.length).toBe(fakeResults.length);
+      expect(fallbackPrefix).toMatch(/^quantic-result-list-\d+$/);
+      expect(new Set(resultKeys).size).toBe(fakeResults.length);
+      resultKeys.forEach((key, index) => {
+        expect(key).toBe(`${fallbackPrefix}_${fakeResults[index].uniqueId}`);
+      });
+      expect(stableResultKeys).toEqual(resultKeys);
+    });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -14,6 +14,8 @@ import {LightningElement, api, track} from 'lwc';
 /** @typedef {import("coveo").SearchStatus} SearchStatus */
 /** @typedef {import("coveo").SearchEngine} SearchEngine */
 
+let resultListFallbackId = 0;
+
 /**
  * The `QuanticResultList` component is responsible for displaying query results by applying one or more result templates.
  * @fires CustomEvent#quantic__registerresulttemplates
@@ -63,6 +65,8 @@ export default class QuanticResultList extends LightningElement {
   openPreviewId;
   /** @type {boolean} */
   hasInitializationError = false;
+  /** @type {string} */
+  fallbackSearchResponseId = `quantic-result-list-${++resultListFallbackId}`;
 
   labels = {
     loadingResults,
@@ -157,7 +161,8 @@ export default class QuanticResultList extends LightningElement {
   get results() {
     // We need to add a unique key to each result to make sure to re-render the LWC when the results change.
     // If the unique key is only the result uniqueId, the LWC will not re-render when the results change AND the same result is still in the results.
-    const searchResponseId = this?.state?.searchResponseId || Math.random();
+    const searchResponseId =
+      this.state?.searchResponseId || this.fallbackSearchResponseId;
     return (
       this.state?.results?.map((result) => ({
         ...result,

--- a/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js
@@ -66,7 +66,11 @@ export default class QuanticResultList extends LightningElement {
   /** @type {boolean} */
   hasInitializationError = false;
   /** @type {string} */
-  fallbackSearchResponseId = `quantic-result-list-${++resultListFallbackId}`;
+  fallbackSearchResponseIdPrefix = `quantic-result-list-${++resultListFallbackId}`;
+  /** @type {number} */
+  fallbackSearchResponseIdVersion = 0;
+  /** @type {ResultListState} */
+  fallbackSearchResponseState;
 
   labels = {
     loadingResults,
@@ -135,7 +139,9 @@ export default class QuanticResultList extends LightningElement {
   }
 
   updateState() {
-    this.state = this.resultList?.state;
+    const nextState = this.resultList?.state;
+    this.updateFallbackSearchResponseId(nextState);
+    this.state = nextState;
     this.numberOfResults = this.resultsPerPage?.state?.numberOfResults;
     this.showPlaceholder =
       this.searchStatus?.state?.isLoading &&
@@ -145,6 +151,20 @@ export default class QuanticResultList extends LightningElement {
     if (this.showPlaceholder) {
       this.loadingAriaLiveMessage.dispatchMessage(this.labels.loadingResults);
     }
+  }
+
+  /** @param {ResultListState} state */
+  updateFallbackSearchResponseId(state) {
+    if (
+      !state ||
+      state.searchResponseId ||
+      state === this.fallbackSearchResponseState
+    ) {
+      return;
+    }
+
+    this.fallbackSearchResponseState = state;
+    this.fallbackSearchResponseIdVersion++;
   }
 
   get fields() {
@@ -169,6 +189,10 @@ export default class QuanticResultList extends LightningElement {
         keyResultList: `${searchResponseId}_${result.uniqueId}`,
       })) || []
     );
+  }
+
+  get fallbackSearchResponseId() {
+    return `${this.fallbackSearchResponseIdPrefix}-${this.fallbackSearchResponseIdVersion}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace the `Math.random()` fallback used for Quantic result list render keys with stable per-instance fallback prefixes.
- Preserve the existing `state.searchResponseId` key prefix path when Headless provides it.
- Add fallback-path unit coverage for `quanticResultList` and `quanticFoldedResultList`.
- Add a patch changeset for `@coveo/quantic`.

## Validation
- `NODE_OPTIONS=--require=/private/tmp/ignore-canvas.js corepack pnpm --filter @coveo/quantic test:unit -- force-app/main/default/lwc/quanticResultList/__tests__/quanticResultList.test.js force-app/main/default/lwc/quanticFoldedResultList/__tests__/quanticFoldedResultList.test.js --runInBand`
- `PATH=/private/tmp/pnpm-shim:$PATH corepack pnpm run lint:fix`
- `rg -n "Math\\.random" packages/quantic/force-app/main/default/lwc/quanticResultList/quanticResultList.js packages/quantic/force-app/main/default/lwc/quanticFoldedResultList/quanticFoldedResultList.js` returned no matches.

## Notes
- Local Jest needed the temporary canvas ignore hook because jsdom was picking up a stale optional native `canvas` module from outside the repo.
- The branch is currently one commit behind `main`; no conflict was reported by the compare API.