### PR TITLE
fix(quantic): fix TypeScript 6 compilation errors in build scripts

### DIFF
--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -23,6 +23,7 @@
     "test:unit:watch": "lwc-jest --watch",
     "test:unit:coverage": "lwc-jest --coverage",
     "validate:types": "tsc",
+    "validate:types:build-scripts": "tsc --noEmit --project scripts/build/tsconfig.json",
     "e2e:playwright": "npx playwright test",
     "e2e:playwright:lws-enabled": "npx playwright test --project=LWS-enabled",
     "e2e:playwright:lws-disabled": "npx playwright test --project=LWS-disabled",

--- a/packages/quantic/scripts/build/create-package.ts
+++ b/packages/quantic/scripts/build/create-package.ts
@@ -43,7 +43,7 @@ async function getMatchingPackageVersion(versionNumber: string) {
 
 async function getIsPublished(): Promise<boolean> {
   const matchingVersion = await getMatchingPackageVersion(pack.version);
-  return matchingVersion?.IsReleased;
+  return matchingVersion?.IsReleased ?? false;
 }
 
 async function getPackageVersion(log: StepLogger): Promise<string> {
@@ -128,7 +128,7 @@ async function createPackage(
 
   const response = await sfdx.createPackageVersion({
     packageId: options.packageId,
-    packageVersion: options.packageVersion,
+    packageVersion: options.packageVersion!,
     timeout: 30,
   });
 
@@ -154,6 +154,10 @@ async function createGithubDiscussionPost(
   const packageDetails = (await sfdx.getPackageVersionList(0)).result.find(
     (pack) => pack.SubscriberPackageVersionId === packageVersionId
   );
+  if (!packageDetails) {
+    log(`Could not find package details for ${packageVersionId}. Skipping discussion.`);
+    return;
+  }
   const discussionTitle = `${packageDetails.Package2Name} v${options.packageVersion}`;
   const discussionBody = `Package ID: ${packageDetails.SubscriberPackageVersionId}\nInstallation URL: ${packageDetails.InstallUrl}`;
 
@@ -163,9 +167,15 @@ async function createGithubDiscussionPost(
       {owner: 'coveo', name: 'ui-kit'},
       token
     );
-    const announcementCategoryId = repository.discussionCategories.edges.find(
-      (edge) => edge.node.name === 'Announcements'
-    ).node.id;
+    const announcementCategoryId =
+      repository.discussionCategories?.edges?.find(
+        (edge) => edge?.node?.name === 'Announcements'
+      )?.node?.id;
+
+    if (!announcementCategoryId) {
+      log('Could not find Announcements category. Skipping discussion.');
+      return;
+    }
 
     const discussion = await createDiscussion(
       {
@@ -176,7 +186,11 @@ async function createGithubDiscussionPost(
       },
       token
     );
-    log(`Github discussion ID: ${discussion.id} created.`);
+    if (discussion) {
+      log(`Github discussion ID: ${discussion.id} created.`);
+    } else {
+      log('Discussion creation returned no result.');
+    }
   } catch (error) {
     log(`Discussion creation FAILED: ${(error as Error).message}`);
   }
@@ -201,14 +215,15 @@ async function createGithubDiscussionPost(
     runner.add(async (log) => {
       packageVersionId = (await createPackage(log, options)).result
         .SubscriberPackageVersionId;
-      !options.promote &&
+      if (!options.promote) {
         log(
           JSON.stringify(
-            await getMatchingPackageVersion(options.packageVersion),
+            await getMatchingPackageVersion(options.packageVersion!),
             null,
             2
           )
         );
+      }
     });
     options.promote &&
       runner

--- a/packages/quantic/scripts/build/tsconfig.json
+++ b/packages/quantic/scripts/build/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "CommonJS",
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "strict": true,
     "types": ["node"]
   },
   "include": ["./**/*.ts"]

--- a/packages/quantic/scripts/build/util/github.ts
+++ b/packages/quantic/scripts/build/util/github.ts
@@ -38,7 +38,7 @@ export async function getRepoCategoryData(
 export async function createDiscussion(
   args: CreateDiscussionInput,
   token: string
-): Promise<Discussion> {
+): Promise<Discussion | undefined> {
   const graphqlWithAuth = graphql.defaults({
     headers: {
       authorization: `token ${token}`,
@@ -54,5 +54,5 @@ export async function createDiscussion(
     }
   `;
   return (await graphqlWithAuth<Mutation>(query, args)).createDiscussion
-    ?.discussion;
+    ?.discussion ?? undefined;
 }

--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -39,7 +39,7 @@
     },
     "test": {
       "outputs": [],
-      "dependsOn": ["test:unit", "lint:check:tests", "validate:types"]
+      "dependsOn": ["test:unit", "lint:check:tests", "validate:types", "validate:types:build-scripts"]
     },
     "test:unit": {
       "dependsOn": ["build"],
@@ -47,6 +47,9 @@
     },
     "validate:types": {
       "dependsOn": ["build"],
+      "outputs": []
+    },
+    "validate:types:build-scripts": {
       "outputs": []
     },
     "lint:check:tests": {


### PR DESCRIPTION
[KIT-5664](https://coveord.atlassian.net/browse/KIT-5664)

## Problem

The `packages/quantic/scripts/build/create-package.ts` script fails to compile under TypeScript 6.0.2 due to stricter null/undefined narrowing. This broke the `quantic-prod` job during the last release ([run 25119310392](https://github.com/coveo/ui-kit/actions/runs/25119310392/job/73616447463)).

The script is only executed at release time via `ts-node`, so the TS6 upgrade (PR #7477) didn't catch these errors during normal CI.

## Solution

- Add proper null guards for `.find()` results (`packageDetails`, `edges`)
- Use `?? false` for `boolean | undefined` return values
- Use non-null assertions where values are guaranteed by prior control flow
- Fix `createDiscussion` return type to include `undefined`
- Enable `strict: true` in `scripts/build/tsconfig.json`
- Add `validate:types:build-scripts` task to the turbo `test` pipeline so these scripts are type-checked in CI going forward

[KIT-5664]: https://coveord.atlassian.net/browse/KIT-5664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ