### PR TITLE
ci: remove CDN-gated environment approvals for quantic-prod and docs-prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,6 @@ jobs:
     if: ${{ needs.release.outputs.published == 'true' }}
     needs: release
     runs-on: ubuntu-latest
-    environment: 'Quantic Production'
     permissions:
       contents: read
       packages: write
@@ -179,7 +178,6 @@ jobs:
     if: ${{ needs.release.outputs.published == 'true' }}
     needs: release
     runs-on: ubuntu-latest
-    environment: 'Docs Production'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
[KIT-5665](https://coveord.atlassian.net/browse/KIT-5665)

## Problem

The `quantic-prod` and `docs-prod` jobs in `cd.yml` are blocked behind environment approval gates (`Quantic Production` and `Docs Production`). These gates are programmatically approved by `ui-kit-cd`'s `prod.yml` workflow, which only runs AFTER the full CDN pipeline completes (S3 uploads → CloudFront invalidation → smoke tests → production-release phase).

This creates a ~2 hour delay between NPM publish and quantic/docs promotion, even though neither has any technical dependency on CDN.

## Solution

Remove the `environment` declarations from `quantic-prod` and `docs-prod` jobs. These jobs will now run immediately after the `release` job completes (NPM publish), eliminating the ~2 hour wait for CDN.

**Companion PR**: coveo-platform/ui-kit-cd#143 (removes `prod.yml` and the `production-release` pipeline phase)

**Approved by**: @jpmarceau

[KIT-5665]: https://coveord.atlassian.net/browse/KIT-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ