### PR TITLE
ci: send channels parameter in commit artifact dispatch (KIT-5662)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,6 +241,7 @@ jobs:
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          # Comma-separated list of CDN channels to update (e.g. "canary" or "canary,rc").
           # On release commits, update both canary and RC pointers.
           # On regular merges, only update canary pointers.
           CHANNELS: ${{ needs.release.outputs.published == 'true' && 'canary,rc' || 'canary' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -225,8 +225,7 @@ jobs:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
   commit-artifact-upload:
     name: Upload commit artifacts to S3
-    needs: build-cdn
-    environment: 'Prerelease (CDN)'
+    needs: [build-cdn, release]
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -242,7 +241,7 @@ jobs:
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
-          CHANNELS: canary
+          CHANNELS: ${{ needs.release.outputs.published == 'true' && 'canary,rc' || 'canary' }}
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,6 +242,7 @@ jobs:
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          CHANNELS: canary
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,6 +241,8 @@ jobs:
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          # On release commits, update both canary and RC pointers.
+          # On regular merges, only update canary pointers.
           CHANNELS: ${{ needs.release.outputs.published == 'true' && 'canary,rc' || 'canary' }}
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -1,12 +1,14 @@
 import {context, getOctokit} from '@actions/github';
 
 const octokit = getOctokit(process.env.GH_TOKEN);
+const channels = process.env.CHANNELS || 'canary';
 
 await octokit.rest.repos.createDispatchEvent({
   event_type: 'deploy-commit',
   client_payload: {
-    run_Id: context.runId,
+    run_id: context.runId,
     sha: context.sha,
+    channels,
   },
   owner: 'coveo-platform',
   repo: 'ui-kit-cd',

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -6,7 +6,7 @@ const channels = process.env.CHANNELS;
 await octokit.rest.repos.createDispatchEvent({
   event_type: 'deploy-commit',
   client_payload: {
-    run_id: context.runId,
+    run_Id: context.runId,
     sha: context.sha,
     channels,
   },

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -1,7 +1,7 @@
 import {context, getOctokit} from '@actions/github';
 
 const octokit = getOctokit(process.env.GH_TOKEN);
-const channels = process.env.CHANNELS || 'canary';
+const channels = process.env.CHANNELS;
 
 await octokit.rest.repos.createDispatchEvent({
   event_type: 'deploy-commit',


### PR DESCRIPTION
[KIT-5662](https://coveord.atlassian.net/browse/KIT-5662)

## Problem

The `trigger-commit-upload.mjs` dispatch script does not send the `channels` field that `ui-kit-cd`'s `commit-upload.yml` and post-commit-deploy hook expect. It also has a typo (`run_Id` vs `run_id`).

## Solution

- Add `channels` to the `client_payload` (read from `CHANNELS` env var, defaults to `canary`)
- Fix `run_Id` → `run_id` to match what ui-kit-cd expects
- Pass `CHANNELS: canary` in the workflow step env

**Companion PR**: coveo-platform/ui-kit-cd#142 (post-commit-deploy hook that consumes channels)

[KIT-5662]: https://coveord.atlassian.net/browse/KIT-5662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ