### PR TITLE
fix: add environment to commit-artifact-upload for secret access

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -227,6 +227,7 @@ jobs:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
     runs-on: ubuntu-latest
+    environment: 'Prerelease (CDN)'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
[KIT-5662](https://coveord.atlassian.net/browse/KIT-5662)

## Problem

After merging PR #7509 (which removed the `environment: 'Prerelease (CDN)'` from the `commit-artifact-upload` job), the job now fails with:

```
Error: Parameter token or opts.auth is required
```

The `UI_KIT_CD_DISPATCHER` secret is scoped to the `'Prerelease (CDN)'` GitHub environment. Without specifying the environment on the job, the secret resolves to empty.

## Solution

Re-add `environment: 'Prerelease (CDN)'` to the `commit-artifact-upload` job. This is required for secret access, not as an approval gate (the environment has no required reviewers).

[KIT-5662]: https://coveord.atlassian.net/browse/KIT-5662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ