### PR TITLE
refactor(headless-future): call engine.mutate in mutators

### DIFF
--- a/packages/headless-future/docs/architecture.md
+++ b/packages/headless-future/docs/architecture.md
@@ -360,7 +360,7 @@ sequenceDiagram
 
 For engineers familiar with the current `@coveo/headless`:
 
-| Concept                    | Current Headless                                             | Headless-future                                                               |
+| Concept                    | Current Headless                                             | Headless-future                                                         |
 | -------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------- |
 | **State library**          | Redux exposed to consumers (actions, reducers, middleware)   | Redux hidden behind `Engine` abstraction                                |
 | **Creating the engine**    | `buildSearchEngine({ configuration })` with Redux middleware | `new Engine()` — empty store, configure via mutations                   |

--- a/packages/headless-future/src/api/search/search.test.ts
+++ b/packages/headless-future/src/api/search/search.test.ts
@@ -46,9 +46,9 @@ describe('executeSearchAPI()', () => {
     engine.adoptSlice(facetsSlice);
 
     // Configure engine
-    engine.mutate(configurationMutations.setOrganizationId('test-org'));
-    engine.mutate(configurationMutations.setAccessToken('test-token'));
-    engine.mutate(searchBoxMutations.setQuery('test query'));
+    configurationMutations.setOrganizationId(engine, 'test-org');
+    configurationMutations.setAccessToken(engine, 'test-token');
+    searchBoxMutations.setQuery(engine, 'test query');
 
     // Clear any previous mocks
     vi.restoreAllMocks();
@@ -117,7 +117,7 @@ describe('executeSearchAPI()', () => {
 
     it('should clear error before request', async () => {
       // Set initial error
-      engine.mutate(resultsMutations.setError('Previous error'));
+      resultsMutations.setError(engine, 'Previous error');
 
       vi.stubGlobal(
         'fetch',
@@ -138,7 +138,7 @@ describe('executeSearchAPI()', () => {
 
   describe('Request building', () => {
     it('should include query from state', async () => {
-      engine.mutate(searchBoxMutations.setQuery('laptops'));
+      searchBoxMutations.setQuery(engine, 'laptops');
 
       const mockFetch: MockedFunction<typeof fetch> = vi.fn(() =>
         Promise.resolve(
@@ -160,8 +160,8 @@ describe('executeSearchAPI()', () => {
 
     it('should include pagination parameters', async () => {
       // Note: setPageSize must be called before setPage because it resets page to 1
-      engine.mutate(paginationMutations.setPageSize(20));
-      engine.mutate(paginationMutations.setPage(2));
+      paginationMutations.setPageSize(engine, 20);
+      paginationMutations.setPage(engine, 2);
 
       const mockFetch: MockedFunction<typeof fetch> = vi.fn(() =>
         Promise.resolve(
@@ -183,14 +183,12 @@ describe('executeSearchAPI()', () => {
     });
 
     it('should build facet requests from state', async () => {
-      engine.mutate(
-        facetMutations.setFacet({
-          id: 'author',
-          label: 'Author',
-          values: [],
-          selectedValues: ['john', 'jane'],
-        })
-      );
+      facetMutations.setFacet(engine, {
+        id: 'author',
+        label: 'Author',
+        values: [],
+        selectedValues: ['john', 'jane'],
+      });
 
       const mockFetch: MockedFunction<typeof fetch> = vi.fn(() =>
         Promise.resolve(
@@ -216,22 +214,18 @@ describe('executeSearchAPI()', () => {
     });
 
     it('should build advanced query from facet selections', async () => {
-      engine.mutate(
-        facetMutations.setFacet({
-          id: 'author',
-          label: 'Author',
-          values: [],
-          selectedValues: ['john'],
-        })
-      );
-      engine.mutate(
-        facetMutations.setFacet({
-          id: 'category',
-          label: 'Category',
-          values: [],
-          selectedValues: ['blog', 'article'],
-        })
-      );
+      facetMutations.setFacet(engine, {
+        id: 'author',
+        label: 'Author',
+        values: [],
+        selectedValues: ['john'],
+      });
+      facetMutations.setFacet(engine, {
+        id: 'category',
+        label: 'Category',
+        values: [],
+        selectedValues: ['blog', 'article'],
+      });
 
       const mockFetch: MockedFunction<typeof fetch> = vi.fn(() =>
         Promise.resolve(
@@ -342,14 +336,12 @@ describe('executeSearchAPI()', () => {
 
     it('should update facet values from response', async () => {
       // Set up initial facet
-      engine.mutate(
-        facetMutations.setFacet({
-          id: 'author',
-          label: 'Author',
-          values: [],
-          selectedValues: [],
-        })
-      );
+      facetMutations.setFacet(engine, {
+        id: 'author',
+        label: 'Author',
+        values: [],
+        selectedValues: [],
+      });
 
       const mockResponse: CoveoSearchResponse = {
         totalCount: 10,
@@ -449,7 +441,7 @@ describe('executeSearchAPI()', () => {
 
     it('should not update results on error', async () => {
       // Set initial results
-      engine.mutate(resultsMutations.setResults(createMockSearchResults(3)));
+      resultsMutations.setResults(engine, createMockSearchResults(3));
 
       vi.stubGlobal(
         'fetch',

--- a/packages/headless-future/src/api/search/search.ts
+++ b/packages/headless-future/src/api/search/search.ts
@@ -54,8 +54,8 @@ import type {
  */
 export async function executeSearchAPI(engine: Engine): Promise<void> {
   // Set loading state before making the request
-  engine.mutate(resultsMutations.setLoading(true));
-  engine.mutate(resultsMutations.setError(null));
+  resultsMutations.setLoading(engine, true);
+  resultsMutations.setError(engine, null);
 
   try {
     // Read current state to build request
@@ -122,19 +122,17 @@ export async function executeSearchAPI(engine: Engine): Promise<void> {
     // Handle response
     if (!response.success) {
       // API call failed - update error state
-      engine.mutate(
-        resultsMutations.setError(response.error || 'Search failed')
-      );
-      engine.mutate(resultsMutations.setLoading(false));
+      resultsMutations.setError(engine, response.error || 'Search failed');
+      resultsMutations.setLoading(engine, false);
       return;
     }
 
     // Transform and update state with results
     const searchResults = transformCoveoResults(response.data!.results);
-    engine.mutate(resultsMutations.setResults(searchResults));
+    resultsMutations.setResults(engine, searchResults);
 
     // Update total count for pagination
-    engine.mutate(paginationMutations.setTotalCount(response.data!.totalCount));
+    paginationMutations.setTotalCount(engine, response.data!.totalCount);
 
     // Update facets with response data
     if (response.data!.facets) {
@@ -142,13 +140,13 @@ export async function executeSearchAPI(engine: Engine): Promise<void> {
     }
 
     // Clear loading state
-    engine.mutate(resultsMutations.setLoading(false));
+    resultsMutations.setLoading(engine, false);
   } catch (error) {
     // Unexpected error (should be rare since executeHttpRequest catches most errors)
     const errorMessage =
       error instanceof Error ? error.message : 'An unexpected error occurred';
-    engine.mutate(resultsMutations.setError(errorMessage));
-    engine.mutate(resultsMutations.setLoading(false));
+    resultsMutations.setError(engine, errorMessage);
+    resultsMutations.setLoading(engine, false);
   }
 }
 
@@ -231,6 +229,6 @@ function updateFacetsFromResponse(
     }));
 
     // Update facet values while preserving selections
-    engine.mutate(facetMutations.updateValues(coveoFacet.facetId, facetValues));
+    facetMutations.updateValues(engine, coveoFacet.facetId, facetValues);
   }
 }

--- a/packages/headless-future/src/api/shared/http-client.test.ts
+++ b/packages/headless-future/src/api/shared/http-client.test.ts
@@ -24,8 +24,8 @@ describe('executeHttpRequest()', () => {
     engine = createTestEngine();
     engine.adoptSlice(configurationSlice); // Ensure slice is loaded
     // Configure engine with required settings
-    engine.mutate(configurationMutations.setOrganizationId('test-org-id'));
-    engine.mutate(configurationMutations.setAccessToken('test-access-token'));
+    configurationMutations.setOrganizationId(engine, 'test-org-id');
+    configurationMutations.setAccessToken(engine, 'test-access-token');
 
     // Clear any previous fetch mocks
     vi.restoreAllMocks();
@@ -39,7 +39,7 @@ describe('executeHttpRequest()', () => {
     it('should return error when organizationId is not set', async () => {
       const emptyEngine = createTestEngine();
       emptyEngine.adoptSlice(configurationSlice);
-      emptyEngine.mutate(configurationMutations.setAccessToken('token'));
+      configurationMutations.setAccessToken(emptyEngine, 'token');
 
       const response = await executeHttpRequest(emptyEngine, {
         path: '/test',
@@ -53,7 +53,7 @@ describe('executeHttpRequest()', () => {
     it('should return error when accessToken is not set', async () => {
       const emptyEngine = createTestEngine();
       emptyEngine.adoptSlice(configurationSlice);
-      emptyEngine.mutate(configurationMutations.setOrganizationId('org-id'));
+      configurationMutations.setOrganizationId(emptyEngine, 'org-id');
 
       const response = await executeHttpRequest(emptyEngine, {
         path: '/test',
@@ -129,9 +129,7 @@ describe('executeHttpRequest()', () => {
     });
 
     it('should use custom endpoint when configured', async () => {
-      engine.mutate(
-        configurationMutations.setEndpoint('https://custom.coveo.com')
-      );
+      configurationMutations.setEndpoint(engine, 'https://custom.coveo.com');
 
       const mockFetch: MockedFunction<typeof fetch> = vi.fn(() =>
         Promise.resolve(new Response(JSON.stringify({}), {status: 200}))

--- a/packages/headless-future/src/core/interface/configuration/configuration-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/configuration/configuration-mutators.test.ts
@@ -1,215 +1,54 @@
-/**
- * Configuration Mutations Tests
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
-import {createTestEngine} from '@/src/test/test-utils.js';
-import * as selectors from './configuration-selectors.js';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as configurationMutations from './configuration-mutators.js';
 import {configurationSlice} from '@/src/core/internal/configuration/configuration-slice.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
 
 describe('configurationMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(configurationSlice); // Ensure slice is loaded for mutations
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
-  describe('setOrganizationId()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = configurationMutations.setOrganizationId('my-org-123');
+  it('setOrganizationId() should call engine.mutate with setOrganizationId action', () => {
+    configurationMutations.setOrganizationId(engine, 'my-org-123');
 
-      expect(mutation).toEqual({
-        type: 'configuration/setOrganizationId',
-        payload: 'my-org-123',
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(configurationMutations.setOrganizationId('test-org'));
-      expect(engine.read(selectors.organizationId)).toBe('test-org');
-    });
-
-    it('should accept empty string', () => {
-      engine.mutate(configurationMutations.setOrganizationId(''));
-      expect(engine.read(selectors.organizationId)).toBe('');
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      configurationSlice.actions.setOrganizationId('my-org-123')
+    );
   });
 
-  describe('setAccessToken()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = configurationMutations.setAccessToken('abc123token');
+  it('setAccessToken() should call engine.mutate with setAccessToken action', () => {
+    configurationMutations.setAccessToken(engine, 'abc123token');
 
-      expect(mutation).toEqual({
-        type: 'configuration/setAccessToken',
-        payload: 'abc123token',
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(configurationMutations.setAccessToken('my-token'));
-      expect(engine.read(selectors.accessToken)).toBe('my-token');
-    });
-
-    it('should accept empty string', () => {
-      engine.mutate(configurationMutations.setAccessToken(''));
-      expect(engine.read(selectors.accessToken)).toBe('');
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      configurationSlice.actions.setAccessToken('abc123token')
+    );
   });
 
-  describe('setEndpoint()', () => {
-    it('should return StateMutation object with endpoint', () => {
-      const mutation = configurationMutations.setEndpoint(
-        'https://custom.api.com'
-      );
+  it('setEndpoint() should call engine.mutate with setEndpoint action', () => {
+    configurationMutations.setEndpoint(engine, 'https://custom.api.com');
 
-      expect(mutation).toEqual({
-        type: 'configuration/setEndpoint',
-        payload: 'https://custom.api.com',
-      });
-    });
-
-    it('should return StateMutation object with undefined', () => {
-      const mutation = configurationMutations.setEndpoint(undefined);
-
-      expect(mutation).toEqual({
-        type: 'configuration/setEndpoint',
-        payload: undefined,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(
-        configurationMutations.setEndpoint('https://api.example.com')
-      );
-      expect(engine.read(selectors.endpoint)).toBe('https://api.example.com');
-    });
-
-    it('should clear endpoint with undefined', () => {
-      engine.mutate(configurationMutations.setEndpoint('https://api.com'));
-      engine.mutate(configurationMutations.setEndpoint(undefined));
-      expect(engine.read(selectors.endpoint)).toBeUndefined();
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      configurationSlice.actions.setEndpoint('https://custom.api.com')
+    );
   });
 
-  describe('setConfiguration()', () => {
-    it('should return StateMutation object', () => {
-      const config = {
-        organizationId: 'my-org',
-        accessToken: 'my-token',
-        endpoint: 'https://custom.api.com',
-      };
+  it('setConfiguration() should call engine.mutate with setConfiguration action', () => {
+    const config = {
+      organizationId: 'my-org',
+      accessToken: 'my-token',
+      endpoint: 'https://custom.api.com',
+    };
 
-      const mutation = configurationMutations.setConfiguration(config);
+    configurationMutations.setConfiguration(engine, config);
 
-      expect(mutation).toEqual({
-        type: 'configuration/setConfiguration',
-        payload: config,
-      });
-    });
-
-    it('should update entire configuration when used with mutate()', () => {
-      engine.mutate(
-        configurationMutations.setConfiguration({
-          organizationId: 'complete-org',
-          accessToken: 'complete-token',
-          endpoint: 'https://complete.api.com',
-        })
-      );
-
-      expect(engine.read(selectors.organizationId)).toBe('complete-org');
-      expect(engine.read(selectors.accessToken)).toBe('complete-token');
-      expect(engine.read(selectors.endpoint)).toBe('https://complete.api.com');
-    });
-
-    it('should accept configuration without endpoint', () => {
-      engine.mutate(
-        configurationMutations.setConfiguration({
-          organizationId: 'org',
-          accessToken: 'token',
-        })
-      );
-
-      expect(engine.read(selectors.organizationId)).toBe('org');
-      expect(engine.read(selectors.accessToken)).toBe('token');
-      expect(engine.read(selectors.endpoint)).toBeUndefined();
-    });
-
-    it('should replace previous configuration completely', () => {
-      engine.mutate(
-        configurationMutations.setConfiguration({
-          organizationId: 'old-org',
-          accessToken: 'old-token',
-          endpoint: 'https://old.api.com',
-        })
-      );
-
-      engine.mutate(
-        configurationMutations.setConfiguration({
-          organizationId: 'new-org',
-          accessToken: 'new-token',
-        })
-      );
-
-      expect(engine.read(selectors.organizationId)).toBe('new-org');
-      expect(engine.read(selectors.accessToken)).toBe('new-token');
-      expect(engine.read(selectors.endpoint)).toBeUndefined();
-    });
-  });
-
-  describe('Integration: configuration management', () => {
-    it('should handle sequential field updates', () => {
-      engine.mutate(configurationMutations.setOrganizationId('org-1'));
-      expect(engine.read(selectors.organizationId)).toBe('org-1');
-      expect(engine.read(selectors.accessToken)).toBe('');
-
-      engine.mutate(configurationMutations.setAccessToken('token-1'));
-      expect(engine.read(selectors.organizationId)).toBe('org-1');
-      expect(engine.read(selectors.accessToken)).toBe('token-1');
-
-      engine.mutate(
-        configurationMutations.setEndpoint('https://api.example.com')
-      );
-      expect(engine.read(selectors.organizationId)).toBe('org-1');
-      expect(engine.read(selectors.accessToken)).toBe('token-1');
-      expect(engine.read(selectors.endpoint)).toBe('https://api.example.com');
-    });
-
-    it('should allow updating individual fields after bulk set', () => {
-      engine.mutate(
-        configurationMutations.setConfiguration({
-          organizationId: 'initial-org',
-          accessToken: 'initial-token',
-          endpoint: 'https://initial.api.com',
-        })
-      );
-
-      // Update just organization ID
-      engine.mutate(configurationMutations.setOrganizationId('updated-org'));
-      expect(engine.read(selectors.organizationId)).toBe('updated-org');
-      expect(engine.read(selectors.accessToken)).toBe('initial-token');
-      expect(engine.read(selectors.endpoint)).toBe('https://initial.api.com');
-
-      // Update just access token
-      engine.mutate(configurationMutations.setAccessToken('updated-token'));
-      expect(engine.read(selectors.organizationId)).toBe('updated-org');
-      expect(engine.read(selectors.accessToken)).toBe('updated-token');
-      expect(engine.read(selectors.endpoint)).toBe('https://initial.api.com');
-    });
-
-    it('should persist through partial updates', () => {
-      engine.mutate(configurationMutations.setOrganizationId('persistent-org'));
-      engine.mutate(configurationMutations.setAccessToken('token-1'));
-
-      // Update token multiple times
-      engine.mutate(configurationMutations.setAccessToken('token-2'));
-      engine.mutate(configurationMutations.setAccessToken('token-3'));
-
-      // Organization ID should remain unchanged
-      expect(engine.read(selectors.organizationId)).toBe('persistent-org');
-      expect(engine.read(selectors.accessToken)).toBe('token-3');
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      configurationSlice.actions.setConfiguration(config)
+    );
   });
 });

--- a/packages/headless-future/src/core/interface/configuration/configuration-mutators.ts
+++ b/packages/headless-future/src/core/interface/configuration/configuration-mutators.ts
@@ -9,24 +9,27 @@
  */
 
 import {configurationSlice} from '@/src/core/internal/configuration/configuration-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 import type {ConfigurationState} from './configuration-types.js';
 
 /**
  * Configuration mutations
  */
-export const setOrganizationId = (organizationId: string): StateMutation => {
-  return configurationSlice.actions.setOrganizationId(organizationId);
+export const setOrganizationId = (engine: Engine, organizationId: string) => {
+  engine.mutate(configurationSlice.actions.setOrganizationId(organizationId));
 };
 
-export const setAccessToken = (accessToken: string): StateMutation => {
-  return configurationSlice.actions.setAccessToken(accessToken);
+export const setAccessToken = (engine: Engine, accessToken: string) => {
+  engine.mutate(configurationSlice.actions.setAccessToken(accessToken));
 };
 
-export const setEndpoint = (endpoint: string | undefined): StateMutation => {
-  return configurationSlice.actions.setEndpoint(endpoint);
+export const setEndpoint = (engine: Engine, endpoint: string | undefined) => {
+  engine.mutate(configurationSlice.actions.setEndpoint(endpoint));
 };
 
-export const setConfiguration = (config: ConfigurationState): StateMutation => {
-  return configurationSlice.actions.setConfiguration(config);
+export const setConfiguration = (
+  engine: Engine,
+  config: ConfigurationState
+) => {
+  engine.mutate(configurationSlice.actions.setConfiguration(config));
 };

--- a/packages/headless-future/src/core/interface/configuration/configuration-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/configuration/configuration-selectors.test.ts
@@ -30,7 +30,7 @@ describe('createConfigurationSelectors()', () => {
     });
 
     it('should return updated organization ID after mutation', () => {
-      engine.mutate(mutations.setOrganizationId('my-org-123'));
+      mutations.setOrganizationId(engine, 'my-org-123');
       const orgId = engine.read(selectors.organizationId);
       expect(orgId).toBe('my-org-123');
     });
@@ -43,7 +43,7 @@ describe('createConfigurationSelectors()', () => {
     });
 
     it('should return updated access token after mutation', () => {
-      engine.mutate(mutations.setAccessToken('abc123token'));
+      mutations.setAccessToken(engine, 'abc123token');
       const token = engine.read(selectors.accessToken);
       expect(token).toBe('abc123token');
     });
@@ -56,14 +56,14 @@ describe('createConfigurationSelectors()', () => {
     });
 
     it('should return updated endpoint after mutation', () => {
-      engine.mutate(mutations.setEndpoint('https://custom.api.com'));
+      mutations.setEndpoint(engine, 'https://custom.api.com');
       const endpoint = engine.read(selectors.endpoint);
       expect(endpoint).toBe('https://custom.api.com');
     });
 
     it('should return undefined when explicitly cleared', () => {
-      engine.mutate(mutations.setEndpoint('https://api.com'));
-      engine.mutate(mutations.setEndpoint(undefined));
+      mutations.setEndpoint(engine, 'https://api.com');
+      mutations.setEndpoint(engine, undefined);
       const endpoint = engine.read(selectors.endpoint);
       expect(endpoint).toBeUndefined();
     });
@@ -71,13 +71,11 @@ describe('createConfigurationSelectors()', () => {
 
   describe('Configuration selectors integration', () => {
     it('should reflect complete configuration state', () => {
-      engine.mutate(
-        mutations.setConfiguration({
-          organizationId: 'test-org',
-          accessToken: 'test-token',
-          endpoint: 'https://test.api.com',
-        })
-      );
+      mutations.setConfiguration(engine, {
+        organizationId: 'test-org',
+        accessToken: 'test-token',
+        endpoint: 'https://test.api.com',
+      });
 
       expect(engine.read(selectors.organizationId)).toBe('test-org');
       expect(engine.read(selectors.accessToken)).toBe('test-token');
@@ -85,14 +83,14 @@ describe('createConfigurationSelectors()', () => {
     });
 
     it('should reflect individual field updates', () => {
-      engine.mutate(mutations.setOrganizationId('org-1'));
+      mutations.setOrganizationId(engine, 'org-1');
       expect(engine.read(selectors.organizationId)).toBe('org-1');
 
-      engine.mutate(mutations.setAccessToken('token-2'));
+      mutations.setAccessToken(engine, 'token-2');
       expect(engine.read(selectors.accessToken)).toBe('token-2');
       expect(engine.read(selectors.organizationId)).toBe('org-1');
 
-      engine.mutate(mutations.setEndpoint('https://api.example.com'));
+      mutations.setEndpoint(engine, 'https://api.example.com');
       expect(engine.read(selectors.endpoint)).toBe('https://api.example.com');
       expect(engine.read(selectors.organizationId)).toBe('org-1');
       expect(engine.read(selectors.accessToken)).toBe('token-2');

--- a/packages/headless-future/src/core/interface/engine/engine.test.ts
+++ b/packages/headless-future/src/core/interface/engine/engine.test.ts
@@ -29,14 +29,14 @@ describe('Engine: read()', () => {
   });
 
   it('should return updated values after mutations', () => {
-    engine.mutate(searchBoxMutations.setQuery('laptops'));
+    searchBoxMutations.setQuery(engine, 'laptops');
     const query = engine.read(searchBoxSelectors.query);
 
     expect(query).toBe('laptops');
   });
 
   it('should work with inline selector functions', () => {
-    engine.mutate(searchBoxMutations.setQuery('test'));
+    searchBoxMutations.setQuery(engine, 'test');
 
     const query = engine.read((state: State) => state.searchBox?.query ?? '');
 
@@ -57,7 +57,7 @@ describe('Engine: subscribe()', () => {
     const callback = vi.fn();
 
     engine.subscribe(searchBoxSelectors.query, callback);
-    engine.mutate(searchBoxMutations.setQuery('laptops'));
+    searchBoxMutations.setQuery(engine, 'laptops');
 
     expect(callback).toHaveBeenCalledWith('laptops');
     expect(callback).toHaveBeenCalledTimes(1);
@@ -67,13 +67,13 @@ describe('Engine: subscribe()', () => {
     const callback = vi.fn();
 
     // Set initial value
-    engine.mutate(searchBoxMutations.setQuery('test'));
+    searchBoxMutations.setQuery(engine, 'test');
 
     // Subscribe after value is set
     engine.subscribe(searchBoxSelectors.query, callback);
 
     // Set to same value
-    engine.mutate(searchBoxMutations.setQuery('test'));
+    searchBoxMutations.setQuery(engine, 'test');
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -84,7 +84,7 @@ describe('Engine: subscribe()', () => {
     engine.subscribe(searchBoxSelectors.query, callback);
 
     // Change loading state, not query
-    engine.mutate(resultsMutations.setLoading(true));
+    resultsMutations.setLoading(engine, true);
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -94,9 +94,9 @@ describe('Engine: subscribe()', () => {
 
     engine.subscribe(searchBoxSelectors.query, callback);
 
-    engine.mutate(searchBoxMutations.setQuery('first'));
-    engine.mutate(searchBoxMutations.setQuery('second'));
-    engine.mutate(searchBoxMutations.setQuery('third'));
+    searchBoxMutations.setQuery(engine, 'first');
+    searchBoxMutations.setQuery(engine, 'second');
+    searchBoxMutations.setQuery(engine, 'third');
 
     expect(callback).toHaveBeenCalledTimes(3);
     expect(callback).toHaveBeenNthCalledWith(1, 'first');
@@ -116,14 +116,14 @@ describe('Engine: subscribe()', () => {
     const unsubscribe = engine.subscribe(searchBoxSelectors.query, callback);
 
     // Should trigger
-    engine.mutate(searchBoxMutations.setQuery('first'));
+    searchBoxMutations.setQuery(engine, 'first');
     expect(callback).toHaveBeenCalledTimes(1);
 
     // Unsubscribe
     unsubscribe();
 
     // Should not trigger
-    engine.mutate(searchBoxMutations.setQuery('second'));
+    searchBoxMutations.setQuery(engine, 'second');
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -134,7 +134,7 @@ describe('Engine: subscribe()', () => {
     engine.subscribe(searchBoxSelectors.query, callback1);
     engine.subscribe(searchBoxSelectors.query, callback2);
 
-    engine.mutate(searchBoxMutations.setQuery('test'));
+    searchBoxMutations.setQuery(engine, 'test');
 
     expect(callback1).toHaveBeenCalledWith('test');
     expect(callback2).toHaveBeenCalledWith('test');
@@ -151,14 +151,14 @@ describe('Engine: mutate()', () => {
   });
 
   it('should update state correctly', () => {
-    engine.mutate(searchBoxMutations.setQuery('test query'));
+    searchBoxMutations.setQuery(engine, 'test query');
 
     expect(engine.read(searchBoxSelectors.query)).toBe('test query');
   });
 
   it('should handle multiple mutations in sequence', () => {
-    engine.mutate(searchBoxMutations.setQuery('laptops'));
-    engine.mutate(resultsMutations.setLoading(true));
+    searchBoxMutations.setQuery(engine, 'laptops');
+    resultsMutations.setLoading(engine, true);
 
     expect(engine.read(searchBoxSelectors.query)).toBe('laptops');
     expect(engine.read(resultsSelectors.isLoading)).toBe(true);

--- a/packages/headless-future/src/core/interface/facets/facets-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/facets/facets-mutators.test.ts
@@ -1,271 +1,65 @@
-/**
- * Facets Mutations Tests
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as facetMutations from './facets-mutators.js';
-import * as selectors from './facets-selectors.js';
-import {
-  createTestEngine,
-  createMockFacetValues,
-} from '@/src/test/test-utils.js';
+import {createMockFacetValues} from '@/src/test/test-utils.js';
 import type {FacetState} from './facets-types.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
 import {facetsSlice} from '@/src/core/internal/facets/facets-slice.js';
 
 describe('facetMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(facetsSlice); // Ensure slice is loaded for mutations
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
-  describe('setFacet()', () => {
-    it('should return StateMutation object', () => {
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: [],
-        selectedValues: [],
-      };
+  it('setFacet() should call engine.mutate with setFacet action', () => {
+    const facet: FacetState = {
+      id: 'category',
+      label: 'Category',
+      values: createMockFacetValues(3),
+      selectedValues: [],
+    };
 
-      const mutation = facetMutations.setFacet(facet);
+    facetMutations.setFacet(engine, facet);
 
-      expect(mutation).toEqual({
-        type: 'facets/setFacet',
-        payload: facet,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(3),
-        selectedValues: [],
-      };
-
-      engine.mutate(facetMutations.setFacet(facet));
-
-      const result = engine.read(selectors.byId('category'));
-      expect(result).toEqual(facet);
-    });
-
-    it('should add multiple facets', () => {
-      const facet1: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: [],
-        selectedValues: [],
-      };
-      const facet2: FacetState = {
-        id: 'brand',
-        label: 'Brand',
-        values: [],
-        selectedValues: [],
-      };
-
-      engine.mutate(facetMutations.setFacet(facet1));
-      engine.mutate(facetMutations.setFacet(facet2));
-
-      const all = engine.read(selectors.all);
-      expect(Object.keys(all)).toHaveLength(2);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      facetsSlice.actions.setFacet(facet)
+    );
   });
 
-  describe('toggleValue()', () => {
-    beforeEach(() => {
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(5),
-        selectedValues: [],
-      };
-      engine.mutate(facetMutations.setFacet(facet));
-    });
+  it('toggleValue() should call engine.mutate with toggleFacetValue action', () => {
+    facetMutations.toggleValue(engine, 'category', 'value-1');
 
-    it('should return StateMutation object', () => {
-      const mutation = facetMutations.toggleValue('category', 'value-1');
-
-      expect(mutation).toEqual({
-        type: 'facets/toggleFacetValue',
-        payload: {facetId: 'category', valueId: 'value-1'},
-      });
-    });
-
-    it('should add value when not selected', () => {
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-
-      const selected = engine.read(selectors.selectedValues('category'));
-      expect(selected).toContain('value-1');
-    });
-
-    it('should remove value when already selected', () => {
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-
-      const selected = engine.read(selectors.selectedValues('category'));
-      expect(selected).not.toContain('value-1');
-    });
-
-    it('should handle multiple toggles', () => {
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-      engine.mutate(facetMutations.toggleValue('category', 'value-2'));
-      engine.mutate(facetMutations.toggleValue('category', 'value-3'));
-
-      const selected = engine.read(selectors.selectedValues('category'));
-      expect(selected).toHaveLength(3);
-      expect(selected).toContain('value-1');
-      expect(selected).toContain('value-2');
-      expect(selected).toContain('value-3');
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      facetsSlice.actions.toggleFacetValue({
+        facetId: 'category',
+        valueId: 'value-1',
+      })
+    );
   });
 
-  describe('clearSelections()', () => {
-    beforeEach(() => {
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(5),
-        selectedValues: ['value-1', 'value-2', 'value-3'],
-      };
-      engine.mutate(facetMutations.setFacet(facet));
-    });
+  it('clearSelections() should call engine.mutate with clearFacetSelections action', () => {
+    facetMutations.clearSelections(engine, 'category');
 
-    it('should return StateMutation object', () => {
-      const mutation = facetMutations.clearSelections('category');
-
-      expect(mutation).toEqual({
-        type: 'facets/clearFacetSelections',
-        payload: 'category',
-      });
-    });
-
-    it('should clear all selections', () => {
-      engine.mutate(facetMutations.clearSelections('category'));
-
-      const selected = engine.read(selectors.selectedValues('category'));
-      expect(selected).toEqual([]);
-    });
-
-    it('should not affect facet values', () => {
-      const initial = engine.read(selectors.byId('category'));
-      engine.mutate(facetMutations.clearSelections('category'));
-      const after = engine.read(selectors.byId('category'));
-
-      expect(after?.values).toEqual(initial?.values);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      facetsSlice.actions.clearFacetSelections('category')
+    );
   });
 
-  describe('updateValues()', () => {
-    beforeEach(() => {
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(3),
-        selectedValues: [],
-      };
-      engine.mutate(facetMutations.setFacet(facet));
-    });
+  it('updateValues() should call engine.mutate with updateFacetValues action', () => {
+    const values = createMockFacetValues(5);
 
-    it('should return StateMutation object', () => {
-      const newValues = createMockFacetValues(5);
-      const mutation = facetMutations.updateValues('category', newValues);
+    facetMutations.updateValues(engine, 'category', values);
 
-      expect(mutation).toEqual({
-        type: 'facets/updateFacetValues',
-        payload: {facetId: 'category', values: newValues},
-      });
-    });
-
-    it('should update facet values', () => {
-      const newValues = createMockFacetValues(5);
-      engine.mutate(facetMutations.updateValues('category', newValues));
-
-      const facet = engine.read(selectors.byId('category'));
-      expect(facet?.values).toEqual(newValues);
-      expect(facet?.values.length).toBe(5);
-    });
-
-    it('should not affect selected values', () => {
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-
-      const newValues = createMockFacetValues(2);
-      engine.mutate(facetMutations.updateValues('category', newValues));
-
-      const selected = engine.read(selectors.selectedValues('category'));
-      expect(selected).toContain('value-1');
-    });
-  });
-
-  describe('Integration: facet management workflow', () => {
-    it('should support complete facet lifecycle', () => {
-      // Create facet
-      const facet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(5),
-        selectedValues: [],
-      };
-      engine.mutate(facetMutations.setFacet(facet));
-
-      // Toggle some values
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-      engine.mutate(facetMutations.toggleValue('category', 'value-3'));
-      expect(engine.read(selectors.selectedValues('category'))).toHaveLength(2);
-
-      // Update available values
-      const newValues = createMockFacetValues(8);
-      engine.mutate(facetMutations.updateValues('category', newValues));
-      expect(engine.read(selectors.byId('category'))?.values.length).toBe(8);
-
-      // Selections should persist
-      expect(engine.read(selectors.selectedValues('category'))).toHaveLength(2);
-
-      // Clear selections
-      engine.mutate(facetMutations.clearSelections('category'));
-      expect(engine.read(selectors.selectedValues('category'))).toEqual([]);
-    });
-
-    it('should handle multiple facets independently', () => {
-      const categoryFacet: FacetState = {
-        id: 'category',
-        label: 'Category',
-        values: createMockFacetValues(3),
-        selectedValues: [],
-      };
-
-      const brandFacet: FacetState = {
-        id: 'brand',
-        label: 'Brand',
-        values: createMockFacetValues(4),
-        selectedValues: [],
-      };
-
-      engine.mutate(facetMutations.setFacet(categoryFacet));
-      engine.mutate(facetMutations.setFacet(brandFacet));
-
-      // Toggle in category
-      engine.mutate(facetMutations.toggleValue('category', 'value-1'));
-
-      // Toggle in brand
-      engine.mutate(facetMutations.toggleValue('brand', 'value-2'));
-
-      // Verify independence
-      expect(engine.read(selectors.selectedValues('category'))).toEqual([
-        'value-1',
-      ]);
-      expect(engine.read(selectors.selectedValues('brand'))).toEqual([
-        'value-2',
-      ]);
-
-      // Clear category doesn't affect brand
-      engine.mutate(facetMutations.clearSelections('category'));
-      expect(engine.read(selectors.selectedValues('category'))).toEqual([]);
-      expect(engine.read(selectors.selectedValues('brand'))).toEqual([
-        'value-2',
-      ]);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      facetsSlice.actions.updateFacetValues({
+        facetId: 'category',
+        values,
+      })
+    );
   });
 });

--- a/packages/headless-future/src/core/interface/facets/facets-mutators.ts
+++ b/packages/headless-future/src/core/interface/facets/facets-mutators.ts
@@ -9,27 +9,29 @@
  */
 
 import {facetsSlice} from '@/src/core/internal/facets/facets-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 import type {FacetState, FacetValue} from './facets-types.js';
 
 export const toggleValue = (
+  engine: Engine,
   facetId: string,
   valueId: string
-): StateMutation => {
-  return facetsSlice.actions.toggleFacetValue({facetId, valueId});
+) => {
+  engine.mutate(facetsSlice.actions.toggleFacetValue({facetId, valueId}));
 };
 
-export const clearSelections = (facetId: string): StateMutation => {
-  return facetsSlice.actions.clearFacetSelections(facetId);
+export const clearSelections = (engine: Engine, facetId: string) => {
+  engine.mutate(facetsSlice.actions.clearFacetSelections(facetId));
 };
 
-export const setFacet = (facet: FacetState): StateMutation => {
-  return facetsSlice.actions.setFacet(facet);
+export const setFacet = (engine: Engine, facet: FacetState) => {
+  engine.mutate(facetsSlice.actions.setFacet(facet));
 };
 
 export const updateValues = (
+  engine: Engine,
   facetId: string,
   values: FacetValue[]
-): StateMutation => {
-  return facetsSlice.actions.updateFacetValues({facetId, values});
+) => {
+  engine.mutate(facetsSlice.actions.updateFacetValues({facetId, values}));
 };

--- a/packages/headless-future/src/core/interface/facets/facets-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/facets/facets-selectors.test.ts
@@ -41,8 +41,8 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet1));
-      engine.mutate(mutations.setFacet(facet2));
+      mutations.setFacet(engine, facet1);
+      mutations.setFacet(engine, facet2);
 
       const all = engine.read(selectors.all);
       expect(Object.keys(all)).toHaveLength(2);
@@ -65,7 +65,7 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facetState));
+      mutations.setFacet(engine, facetState);
       const facet = engine.read(selectors.byId('category'));
 
       expect(facet).toEqual(facetState);
@@ -85,8 +85,8 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet1));
-      engine.mutate(mutations.setFacet(facet2));
+      mutations.setFacet(engine, facet1);
+      mutations.setFacet(engine, facet2);
 
       const category = engine.read(selectors.byId('category'));
       expect(category?.id).toBe('category');
@@ -107,7 +107,7 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet));
+      mutations.setFacet(engine, facet);
       const selected = engine.read(selectors.selectedValues('category'));
 
       expect(selected).toEqual([]);
@@ -121,7 +121,7 @@ describe('createFacetsSelectors()', () => {
         selectedValues: ['value-1', 'value-3'],
       };
 
-      engine.mutate(mutations.setFacet(facet));
+      mutations.setFacet(engine, facet);
       const selected = engine.read(selectors.selectedValues('category'));
 
       expect(selected).toEqual(['value-1', 'value-3']);
@@ -135,8 +135,8 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet));
-      engine.mutate(mutations.toggleValue('category', 'value-1'));
+      mutations.setFacet(engine, facet);
+      mutations.toggleValue(engine, 'category', 'value-1');
 
       const selected = engine.read(selectors.selectedValues('category'));
       expect(selected).toContain('value-1');
@@ -157,7 +157,7 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet));
+      mutations.setFacet(engine, facet);
       const all = engine.read(selectors.allSelectedValues);
 
       expect(all).toEqual([]);
@@ -171,7 +171,7 @@ describe('createFacetsSelectors()', () => {
         selectedValues: ['value-1', 'value-3'],
       };
 
-      engine.mutate(mutations.setFacet(facet));
+      mutations.setFacet(engine, facet);
       const all = engine.read(selectors.allSelectedValues);
 
       expect(all).toEqual([
@@ -195,8 +195,8 @@ describe('createFacetsSelectors()', () => {
         selectedValues: ['apple', 'samsung'],
       };
 
-      engine.mutate(mutations.setFacet(categoryFacet));
-      engine.mutate(mutations.setFacet(brandFacet));
+      mutations.setFacet(engine, categoryFacet);
+      mutations.setFacet(engine, brandFacet);
 
       const all = engine.read(selectors.allSelectedValues);
 
@@ -215,12 +215,12 @@ describe('createFacetsSelectors()', () => {
         selectedValues: [],
       };
 
-      engine.mutate(mutations.setFacet(facet));
+      mutations.setFacet(engine, facet);
 
       let all = engine.read(selectors.allSelectedValues);
       expect(all).toEqual([]);
 
-      engine.mutate(mutations.toggleValue('category', 'value-1'));
+      mutations.toggleValue(engine, 'category', 'value-1');
       all = engine.read(selectors.allSelectedValues);
 
       expect(all).toEqual([{facetId: 'category', valueId: 'value-1'}]);

--- a/packages/headless-future/src/core/interface/pagination/pagination-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/pagination/pagination-mutators.test.ts
@@ -1,195 +1,64 @@
-/**
- * Pagination Mutations Tests
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
-import {createTestEngine} from '@/src/test/test-utils.js';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as mutations from './pagination-mutators.js';
-import * as selectors from './pagination-selectors.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
 import {paginationSlice} from '@/src/core/internal/pagination/pagination-slice.js';
 
 describe('paginationMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(paginationSlice);
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
-  describe('setPage()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setPage(3);
+  it('setPage() should call engine.mutate with setPage action', () => {
+    mutations.setPage(engine, 3);
 
-      expect(mutation).toEqual({
-        type: 'pagination/setPage',
-        payload: 3,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setPage(5));
-      expect(engine.read(selectors.currentPage)).toBe(5);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.setPage(3)
+    );
   });
 
-  describe('setPageSize()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setPageSize(25);
+  it('setPageSize() should call engine.mutate with setPageSize action', () => {
+    mutations.setPageSize(engine, 25);
 
-      expect(mutation).toEqual({
-        type: 'pagination/setPageSize',
-        payload: 25,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setPageSize(20));
-      expect(engine.read(selectors.pageSize)).toBe(20);
-    });
-
-    it('should reset to page 1 when changed', () => {
-      engine.mutate(mutations.setPage(5));
-      engine.mutate(mutations.setPageSize(20));
-
-      expect(engine.read(selectors.currentPage)).toBe(1);
-      expect(engine.read(selectors.pageSize)).toBe(20);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.setPageSize(25)
+    );
   });
 
-  describe('setTotalCount()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setTotalCount(100);
+  it('setTotalCount() should call engine.mutate with setTotalCount action', () => {
+    mutations.setTotalCount(engine, 100);
 
-      expect(mutation).toEqual({
-        type: 'pagination/setTotalCount',
-        payload: 100,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setTotalCount(150));
-      expect(engine.read(selectors.totalCount)).toBe(150);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.setTotalCount(100)
+    );
   });
 
-  describe('nextPage()', () => {
-    it('should return StateMutation object without payload', () => {
-      const mutation = mutations.nextPage();
+  it('nextPage() should call engine.mutate with nextPage action', () => {
+    mutations.nextPage(engine);
 
-      expect(mutation).toEqual({
-        type: 'pagination/nextPage',
-      });
-    });
-
-    it('should increment page when used with mutate()', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.nextPage());
-
-      expect(engine.read(selectors.currentPage)).toBe(2);
-    });
-
-    it('should not exceed total pages', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPage(10));
-      engine.mutate(mutations.nextPage());
-
-      expect(engine.read(selectors.currentPage)).toBe(10);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.nextPage()
+    );
   });
 
-  describe('previousPage()', () => {
-    it('should return StateMutation object without payload', () => {
-      const mutation = mutations.previousPage();
+  it('previousPage() should call engine.mutate with previousPage action', () => {
+    mutations.previousPage(engine);
 
-      expect(mutation).toEqual({
-        type: 'pagination/previousPage',
-      });
-    });
-
-    it('should decrement page when used with mutate()', () => {
-      engine.mutate(mutations.setPage(3));
-      engine.mutate(mutations.previousPage());
-
-      expect(engine.read(selectors.currentPage)).toBe(2);
-    });
-
-    it('should not go below page 1', () => {
-      engine.mutate(mutations.previousPage());
-      expect(engine.read(selectors.currentPage)).toBe(1);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.previousPage()
+    );
   });
 
-  describe('resetToFirstPage()', () => {
-    it('should return StateMutation object without payload', () => {
-      const mutation = mutations.resetToFirstPage();
+  it('resetToFirstPage() should call engine.mutate with resetToFirstPage action', () => {
+    mutations.resetToFirstPage(engine);
 
-      expect(mutation).toEqual({
-        type: 'pagination/resetToFirstPage',
-      });
-    });
-
-    it('should reset to page 1 when used with mutate()', () => {
-      engine.mutate(mutations.setPage(8));
-      engine.mutate(mutations.resetToFirstPage());
-
-      expect(engine.read(selectors.currentPage)).toBe(1);
-    });
-  });
-
-  describe('Integration: navigation flow', () => {
-    beforeEach(() => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPageSize(10));
-    });
-
-    it('should handle sequential page navigation', () => {
-      // Start at page 1
-      expect(engine.read(selectors.currentPage)).toBe(1);
-
-      // Navigate forward
-      engine.mutate(mutations.nextPage());
-      expect(engine.read(selectors.currentPage)).toBe(2);
-
-      engine.mutate(mutations.nextPage());
-      expect(engine.read(selectors.currentPage)).toBe(3);
-
-      // Navigate backward
-      engine.mutate(mutations.previousPage());
-      expect(engine.read(selectors.currentPage)).toBe(2);
-
-      // Jump to specific page
-      engine.mutate(mutations.setPage(7));
-      expect(engine.read(selectors.currentPage)).toBe(7);
-
-      // Reset
-      engine.mutate(mutations.resetToFirstPage());
-      expect(engine.read(selectors.currentPage)).toBe(1);
-    });
-
-    it('should respect boundaries', () => {
-      // Try to go back from first page
-      engine.mutate(mutations.previousPage());
-      expect(engine.read(selectors.currentPage)).toBe(1);
-
-      // Go to last page
-      engine.mutate(mutations.setPage(10));
-      expect(engine.read(selectors.currentPage)).toBe(10);
-
-      // Try to go beyond last page
-      engine.mutate(mutations.nextPage());
-      expect(engine.read(selectors.currentPage)).toBe(10);
-    });
-
-    it('should handle page size change correctly', () => {
-      engine.mutate(mutations.setPage(5));
-      expect(engine.read(selectors.currentPage)).toBe(5);
-
-      // Changing page size should reset to page 1
-      engine.mutate(mutations.setPageSize(25));
-      expect(engine.read(selectors.currentPage)).toBe(1);
-      expect(engine.read(selectors.pageSize)).toBe(25);
-      expect(engine.read(selectors.totalPages)).toBe(4); // 100 / 25 = 4
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      paginationSlice.actions.resetToFirstPage()
+    );
   });
 });

--- a/packages/headless-future/src/core/interface/pagination/pagination-mutators.ts
+++ b/packages/headless-future/src/core/interface/pagination/pagination-mutators.ts
@@ -9,32 +9,32 @@
  */
 
 import {paginationSlice} from '@/src/core/internal/pagination/pagination-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 
 /**
  * Pagination mutations
  */
 
-export const setPage = (page: number): StateMutation => {
-  return paginationSlice.actions.setPage(page);
+export const setPage = (engine: Engine, page: number) => {
+  engine.mutate(paginationSlice.actions.setPage(page));
 };
 
-export const setPageSize = (pageSize: number): StateMutation => {
-  return paginationSlice.actions.setPageSize(pageSize);
+export const setPageSize = (engine: Engine, pageSize: number) => {
+  engine.mutate(paginationSlice.actions.setPageSize(pageSize));
 };
 
-export const setTotalCount = (totalCount: number): StateMutation => {
-  return paginationSlice.actions.setTotalCount(totalCount);
+export const setTotalCount = (engine: Engine, totalCount: number) => {
+  engine.mutate(paginationSlice.actions.setTotalCount(totalCount));
 };
 
-export const nextPage = (): StateMutation => {
-  return paginationSlice.actions.nextPage();
+export const nextPage = (engine: Engine) => {
+  engine.mutate(paginationSlice.actions.nextPage());
 };
 
-export const previousPage = (): StateMutation => {
-  return paginationSlice.actions.previousPage();
+export const previousPage = (engine: Engine) => {
+  engine.mutate(paginationSlice.actions.previousPage());
 };
 
-export const resetToFirstPage = (): StateMutation => {
-  return paginationSlice.actions.resetToFirstPage();
+export const resetToFirstPage = (engine: Engine) => {
+  engine.mutate(paginationSlice.actions.resetToFirstPage());
 };

--- a/packages/headless-future/src/core/interface/pagination/pagination-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/pagination/pagination-selectors.test.ts
@@ -24,7 +24,7 @@ describe('createPaginationSelectors()', () => {
     });
 
     it('should return updated page after mutation', () => {
-      engine.mutate(mutations.setPage(5));
+      mutations.setPage(engine, 5);
       const currentPage = engine.read(selectors.currentPage);
       expect(currentPage).toBe(5);
     });
@@ -37,7 +37,7 @@ describe('createPaginationSelectors()', () => {
     });
 
     it('should return updated page size after mutation', () => {
-      engine.mutate(mutations.setPageSize(25));
+      mutations.setPageSize(engine, 25);
       const pageSize = engine.read(selectors.pageSize);
       expect(pageSize).toBe(25);
     });
@@ -50,7 +50,7 @@ describe('createPaginationSelectors()', () => {
     });
 
     it('should return updated total count after mutation', () => {
-      engine.mutate(mutations.setTotalCount(100));
+      mutations.setTotalCount(engine, 100);
       const totalCount = engine.read(selectors.totalCount);
       expect(totalCount).toBe(100);
     });
@@ -63,26 +63,26 @@ describe('createPaginationSelectors()', () => {
     });
 
     it('should calculate total pages correctly', () => {
-      engine.mutate(mutations.setTotalCount(100));
+      mutations.setTotalCount(engine, 100);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(10); // 100 / 10 = 10 pages
     });
 
     it('should handle non-exact page divisions (ceiling)', () => {
-      engine.mutate(mutations.setTotalCount(95));
+      mutations.setTotalCount(engine, 95);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(10); // ceil(95 / 10) = 10 pages
     });
 
     it('should update when page size changes', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPageSize(20));
+      mutations.setTotalCount(engine, 100);
+      mutations.setPageSize(engine, 20);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(5); // 100 / 20 = 5 pages
     });
 
     it('should return 1 when totalCount is 1', () => {
-      engine.mutate(mutations.setTotalCount(1));
+      mutations.setTotalCount(engine, 1);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(1);
     });
@@ -95,26 +95,26 @@ describe('createPaginationSelectors()', () => {
     });
 
     it('should calculate total pages correctly', () => {
-      engine.mutate(mutations.setTotalCount(100));
+      mutations.setTotalCount(engine, 100);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(10);
     });
 
     it('should handle non-exact divisions', () => {
-      engine.mutate(mutations.setTotalCount(95));
+      mutations.setTotalCount(engine, 95);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(10);
     });
 
     it('should update when page size changes', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPageSize(25));
+      mutations.setTotalCount(engine, 100);
+      mutations.setPageSize(engine, 25);
       const totalPages = engine.read(selectors.totalPages);
       expect(totalPages).toBe(4);
     });
 
     it('should memoize results with same inputs', () => {
-      engine.mutate(mutations.setTotalCount(50));
+      mutations.setTotalCount(engine, 50);
       const result1 = engine.read(selectors.totalPages);
       const result2 = engine.read(selectors.totalPages);
       expect(result1).toBe(result2);
@@ -123,13 +123,13 @@ describe('createPaginationSelectors()', () => {
 
   describe('isFirstPage selector', () => {
     it('should return true when on first page', () => {
-      engine.mutate(mutations.setPage(1));
+      mutations.setPage(engine, 1);
       const isFirstPage = engine.read(selectors.isFirstPage);
       expect(isFirstPage).toBe(true);
     });
 
     it('should return false when not on first page', () => {
-      engine.mutate(mutations.setPage(2));
+      mutations.setPage(engine, 2);
       const isFirstPage = engine.read(selectors.isFirstPage);
       expect(isFirstPage).toBe(false);
     });
@@ -137,17 +137,17 @@ describe('createPaginationSelectors()', () => {
 
   describe('isLastPage selector', () => {
     it('should return true when on last page', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPageSize(10));
-      engine.mutate(mutations.setPage(10));
+      mutations.setTotalCount(engine, 100);
+      mutations.setPageSize(engine, 10);
+      mutations.setPage(engine, 10);
       const isLastPage = engine.read(selectors.isLastPage);
       expect(isLastPage).toBe(true);
     });
 
     it('should return false when not on last page', () => {
-      engine.mutate(mutations.setTotalCount(100));
-      engine.mutate(mutations.setPageSize(10));
-      engine.mutate(mutations.setPage(5));
+      mutations.setTotalCount(engine, 100);
+      mutations.setPageSize(engine, 10);
+      mutations.setPage(engine, 5);
       const isLastPage = engine.read(selectors.isLastPage);
       expect(isLastPage).toBe(false);
     });

--- a/packages/headless-future/src/core/interface/result/result-mutatators.ts
+++ b/packages/headless-future/src/core/interface/result/result-mutatators.ts
@@ -9,33 +9,41 @@
  */
 
 import {resultSlice} from '@/src/core/internal/result/result-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 
 /**
  * Initialize result UI state for a set of result IDs.
  * Replaces any existing state entirely.
  */
-export const initializeResults = (ids: string[]): StateMutation => {
-  return resultSlice.actions.initializeResults(ids);
+export const initializeResults = (engine: Engine, ids: string[]) => {
+  engine.mutate(resultSlice.actions.initializeResults(ids));
 };
 
 /**
  * Set whether a specific result is selected.
  */
-export const setSelected = (id: string, isSelected: boolean): StateMutation => {
-  return resultSlice.actions.setSelected({id, isSelected});
+export const setSelected = (
+  engine: Engine,
+  id: string,
+  isSelected: boolean
+) => {
+  engine.mutate(resultSlice.actions.setSelected({id, isSelected}));
 };
 
 /**
  * Set whether a specific result is expanded.
  */
-export const setExpanded = (id: string, isExpanded: boolean): StateMutation => {
-  return resultSlice.actions.setExpanded({id, isExpanded});
+export const setExpanded = (
+  engine: Engine,
+  id: string,
+  isExpanded: boolean
+) => {
+  engine.mutate(resultSlice.actions.setExpanded({id, isExpanded}));
 };
 
 /**
  * Clear all per-result UI state.
  */
-export const clearAll = (): StateMutation => {
-  return resultSlice.actions.clearAll();
+export const clearAll = (engine: Engine) => {
+  engine.mutate(resultSlice.actions.clearAll());
 };

--- a/packages/headless-future/src/core/interface/result/result-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/result/result-mutators.test.ts
@@ -1,150 +1,48 @@
-/**
- * Result Mutations Tests (Singular)
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as mutations from './result-mutatators.js';
-import * as selectors from './result-selectors.js';
 import {resultSlice} from '@/src/core/internal/result/result-slice.js';
-import {createTestEngine} from '@/src/test/test-utils.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
 
 describe('resultMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(resultSlice);
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
-  describe('initializeResults()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.initializeResults(['r1', 'r2']);
+  it('initializeResults() should call engine.mutate with initializeResults action', () => {
+    mutations.initializeResults(engine, ['r1', 'r2']);
 
-      expect(mutation).toEqual({
-        type: 'result/initializeResults',
-        payload: ['r1', 'r2'],
-      });
-    });
-
-    it('should populate state when used with mutate()', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2', 'r3']));
-
-      const all = engine.read(selectors.all);
-      expect(Object.keys(all)).toEqual(['r1', 'r2', 'r3']);
-      expect(all['r1']).toEqual({isSelected: false, isExpanded: false});
-    });
-
-    it('should replace previous state entirely', () => {
-      engine.mutate(mutations.initializeResults(['old']));
-      engine.mutate(mutations.initializeResults(['new1', 'new2']));
-
-      const all = engine.read(selectors.all);
-      expect(Object.keys(all)).toEqual(['new1', 'new2']);
-      expect(all['old']).toBeUndefined();
-    });
-
-    it('should accept empty array', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.initializeResults([]));
-
-      const all = engine.read(selectors.all);
-      expect(all).toEqual({});
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultSlice.actions.initializeResults(['r1', 'r2'])
+    );
   });
 
-  describe('setSelected()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setSelected('r1', true);
+  it('setSelected() should call engine.mutate with setSelected action', () => {
+    mutations.setSelected(engine, 'r1', true);
 
-      expect(mutation).toEqual({
-        type: 'result/setSelected',
-        payload: {id: 'r1', isSelected: true},
-      });
-    });
-
-    it('should update isSelected when used with mutate()', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setSelected('r1', true));
-
-      const r1 = engine.read(selectors.byId('r1'));
-      expect(r1?.isSelected).toBe(true);
-    });
-
-    it('should not affect non-existent result', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setSelected('unknown', true));
-
-      const all = engine.read(selectors.all);
-      expect(Object.keys(all)).toEqual(['r1']);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultSlice.actions.setSelected({id: 'r1', isSelected: true})
+    );
   });
 
-  describe('setExpanded()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setExpanded('r1', true);
+  it('setExpanded() should call engine.mutate with setExpanded action', () => {
+    mutations.setExpanded(engine, 'r1', true);
 
-      expect(mutation).toEqual({
-        type: 'result/setExpanded',
-        payload: {id: 'r1', isExpanded: true},
-      });
-    });
-
-    it('should update isExpanded when used with mutate()', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setExpanded('r1', true));
-
-      const r1 = engine.read(selectors.byId('r1'));
-      expect(r1?.isExpanded).toBe(true);
-    });
-
-    it('should not affect non-existent result', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setExpanded('unknown', true));
-
-      const all = engine.read(selectors.all);
-      expect(Object.keys(all)).toEqual(['r1']);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultSlice.actions.setExpanded({id: 'r1', isExpanded: true})
+    );
   });
 
-  describe('clearAll()', () => {
-    it('should return StateMutation object without payload', () => {
-      const mutation = mutations.clearAll();
+  it('clearAll() should call engine.mutate with clearAll action', () => {
+    mutations.clearAll(engine);
 
-      expect(mutation).toEqual({
-        type: 'result/clearAll',
-      });
-    });
-
-    it('should clear all result state when used with mutate()', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2']));
-      engine.mutate(mutations.setSelected('r1', true));
-      engine.mutate(mutations.clearAll());
-
-      const all = engine.read(selectors.all);
-      expect(all).toEqual({});
-    });
-  });
-
-  describe('Integration: multiple mutations', () => {
-    it('should handle selection + expansion flow', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2', 'r3']));
-      engine.mutate(mutations.setSelected('r1', true));
-      engine.mutate(mutations.setExpanded('r2', true));
-      engine.mutate(mutations.setSelected('r3', true));
-
-      expect(engine.read(selectors.selectedIds)).toEqual(['r1', 'r3']);
-      expect(engine.read(selectors.expandedIds)).toEqual(['r2']);
-    });
-
-    it('should handle re-initialization after state changes', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setSelected('r1', true));
-      engine.mutate(mutations.initializeResults(['r1', 'r2']));
-
-      // Re-initialization resets all state
-      const r1 = engine.read(selectors.byId('r1'));
-      expect(r1?.isSelected).toBe(false);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultSlice.actions.clearAll()
+    );
   });
 });

--- a/packages/headless-future/src/core/interface/result/result-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/result/result-selectors.test.ts
@@ -24,7 +24,7 @@ describe('result selectors', () => {
     });
 
     it('should return all result states after initialization', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2']));
+      mutations.initializeResults(engine, ['r1', 'r2']);
 
       const all = engine.read(selectors.all);
       expect(Object.keys(all)).toEqual(['r1', 'r2']);
@@ -40,15 +40,15 @@ describe('result selectors', () => {
     });
 
     it('should return state for an existing result', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
+      mutations.initializeResults(engine, ['r1']);
 
       const result = engine.read(selectors.byId('r1'));
       expect(result).toEqual({isSelected: false, isExpanded: false});
     });
 
     it('should reflect mutations', () => {
-      engine.mutate(mutations.initializeResults(['r1']));
-      engine.mutate(mutations.setSelected('r1', true));
+      mutations.initializeResults(engine, ['r1']);
+      mutations.setSelected(engine, 'r1', true);
 
       const result = engine.read(selectors.byId('r1'));
       expect(result?.isSelected).toBe(true);
@@ -63,19 +63,19 @@ describe('result selectors', () => {
     });
 
     it('should return IDs of selected results', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2', 'r3']));
-      engine.mutate(mutations.setSelected('r1', true));
-      engine.mutate(mutations.setSelected('r3', true));
+      mutations.initializeResults(engine, ['r1', 'r2', 'r3']);
+      mutations.setSelected(engine, 'r1', true);
+      mutations.setSelected(engine, 'r3', true);
 
       const ids = engine.read(selectors.selectedIds);
       expect(ids).toEqual(['r1', 'r3']);
     });
 
     it('should exclude deselected results', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2']));
-      engine.mutate(mutations.setSelected('r1', true));
-      engine.mutate(mutations.setSelected('r2', true));
-      engine.mutate(mutations.setSelected('r1', false));
+      mutations.initializeResults(engine, ['r1', 'r2']);
+      mutations.setSelected(engine, 'r1', true);
+      mutations.setSelected(engine, 'r2', true);
+      mutations.setSelected(engine, 'r1', false);
 
       const ids = engine.read(selectors.selectedIds);
       expect(ids).toEqual(['r2']);
@@ -89,18 +89,18 @@ describe('result selectors', () => {
     });
 
     it('should return IDs of expanded results', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2', 'r3']));
-      engine.mutate(mutations.setExpanded('r2', true));
+      mutations.initializeResults(engine, ['r1', 'r2', 'r3']);
+      mutations.setExpanded(engine, 'r2', true);
 
       const ids = engine.read(selectors.expandedIds);
       expect(ids).toEqual(['r2']);
     });
 
     it('should exclude collapsed results', () => {
-      engine.mutate(mutations.initializeResults(['r1', 'r2']));
-      engine.mutate(mutations.setExpanded('r1', true));
-      engine.mutate(mutations.setExpanded('r2', true));
-      engine.mutate(mutations.setExpanded('r1', false));
+      mutations.initializeResults(engine, ['r1', 'r2']);
+      mutations.setExpanded(engine, 'r1', true);
+      mutations.setExpanded(engine, 'r2', true);
+      mutations.setExpanded(engine, 'r1', false);
 
       const ids = engine.read(selectors.expandedIds);
       expect(ids).toEqual(['r2']);

--- a/packages/headless-future/src/core/interface/results/results-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/results/results-mutators.test.ts
@@ -1,160 +1,51 @@
-/**
- * Results Mutations Tests
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as mutations from './results-mutators.js';
-import {
-  createTestEngine,
-  createMockSearchResults,
-} from '@/src/test/test-utils.js';
-import * as selectors from './results-selectors.js';
+import {createMockSearchResults} from '@/src/test/test-utils.js';
 import {resultsSlice} from '@/src/core/internal/results/results-slice.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
 
 describe('resultsMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(resultsSlice);
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
-  describe('setResults()', () => {
-    it('should return StateMutation object', () => {
-      const results = createMockSearchResults(2);
-      const mutation = mutations.setResults(results);
+  it('setResults() should call engine.mutate with setResults action', () => {
+    const results = createMockSearchResults(2);
 
-      expect(mutation).toEqual({
-        type: 'results/setResults',
-        payload: results,
-      });
-    });
+    mutations.setResults(engine, results);
 
-    it('should update state when used with mutate()', () => {
-      const mockResults = createMockSearchResults(3);
-
-      engine.mutate(mutations.setResults(mockResults));
-
-      expect(engine.read(selectors.results)).toEqual(mockResults);
-    });
-
-    it('should accept empty array', () => {
-      engine.mutate(mutations.setResults([]));
-
-      expect(engine.read(selectors.results)).toEqual([]);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultsSlice.actions.setResults(results)
+    );
   });
 
-  describe('setLoading()', () => {
-    it('should return StateMutation object for true', () => {
-      const mutation = mutations.setLoading(true);
+  it('setLoading() should call engine.mutate with setLoading action', () => {
+    mutations.setLoading(engine, true);
 
-      expect(mutation).toEqual({
-        type: 'results/setLoading',
-        payload: true,
-      });
-    });
-
-    it('should return StateMutation object for false', () => {
-      const mutation = mutations.setLoading(false);
-
-      expect(mutation).toEqual({
-        type: 'results/setLoading',
-        payload: false,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setLoading(true));
-      expect(engine.read(selectors.isLoading)).toBe(true);
-
-      engine.mutate(mutations.setLoading(false));
-      expect(engine.read(selectors.isLoading)).toBe(false);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultsSlice.actions.setLoading(true)
+    );
   });
 
-  describe('setError()', () => {
-    it('should return StateMutation object with error message', () => {
-      const mutation = mutations.setError('Search failed');
+  it('setError() should call engine.mutate with setError action', () => {
+    mutations.setError(engine, 'Search failed');
 
-      expect(mutation).toEqual({
-        type: 'results/setError',
-        payload: 'Search failed',
-      });
-    });
-
-    it('should return StateMutation object with null', () => {
-      const mutation = mutations.setError(null);
-
-      expect(mutation).toEqual({
-        type: 'results/setError',
-        payload: null,
-      });
-    });
-
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setError('Error occurred'));
-
-      expect(engine.read(selectors.error)).toBe('Error occurred');
-    });
-
-    it('should clear error with null', () => {
-      engine.mutate(mutations.setError('Some error'));
-      engine.mutate(mutations.setError(null));
-
-      expect(engine.read(selectors.error)).toBeNull();
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultsSlice.actions.setError('Search failed')
+    );
   });
 
-  describe('clearResults()', () => {
-    it('should return StateMutation object without payload', () => {
-      const mutation = mutations.clearResults();
+  it('clearResults() should call engine.mutate with clearResults action', () => {
+    mutations.clearResults(engine);
 
-      expect(mutation).toEqual({
-        type: 'results/clearResults',
-      });
-    });
-
-    it('should clear results when used with mutate()', () => {
-      engine.mutate(mutations.setResults(createMockSearchResults(5)));
-      engine.mutate(mutations.clearResults());
-
-      expect(engine.read(selectors.results)).toEqual([]);
-    });
-
-    it('should clear error when used with mutate()', () => {
-      engine.mutate(mutations.setError('Some error'));
-      engine.mutate(mutations.clearResults());
-
-      expect(engine.read(selectors.error)).toBeNull();
-    });
-
-    it('should preserve loading state', () => {
-      engine.mutate(mutations.setLoading(true));
-      engine.mutate(mutations.clearResults());
-
-      expect(engine.read(selectors.isLoading)).toBe(true);
-    });
-  });
-
-  describe('Integration: multiple mutations', () => {
-    it('should work correctly in sequence', () => {
-      engine.mutate(mutations.setResults(createMockSearchResults(3)));
-      engine.mutate(mutations.setLoading(false));
-
-      expect(engine.read(selectors.results).length).toBe(3);
-      expect(engine.read(selectors.isLoading)).toBe(false);
-      expect(engine.read(selectors.error)).toBeNull();
-    });
-
-    it('should handle error flow', () => {
-      engine.mutate(mutations.setLoading(true));
-      engine.mutate(mutations.setError('API error'));
-      engine.mutate(mutations.setLoading(false));
-
-      expect(engine.read(selectors.error)).toBe('API error');
-      expect(engine.read(selectors.isLoading)).toBe(false);
-    });
+    expect(mutateSpy).toHaveBeenCalledExactlyOnceWith(
+      resultsSlice.actions.clearResults()
+    );
   });
 });

--- a/packages/headless-future/src/core/interface/results/results-mutators.ts
+++ b/packages/headless-future/src/core/interface/results/results-mutators.ts
@@ -9,25 +9,25 @@
  */
 
 import {resultsSlice} from '@/src/core/internal/results/results-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 import type {SearchResult} from './results-types.js';
 
 /**
  * Results mutations
  */
 
-export const setResults = (results: SearchResult[]): StateMutation => {
-  return resultsSlice.actions.setResults(results);
+export const setResults = (engine: Engine, results: SearchResult[]) => {
+  engine.mutate(resultsSlice.actions.setResults(results));
 };
 
-export const setLoading = (isLoading: boolean): StateMutation => {
-  return resultsSlice.actions.setLoading(isLoading);
+export const setLoading = (engine: Engine, isLoading: boolean) => {
+  engine.mutate(resultsSlice.actions.setLoading(isLoading));
 };
 
-export const setError = (error: string | null): StateMutation => {
-  return resultsSlice.actions.setError(error);
+export const setError = (engine: Engine, error: string | null) => {
+  engine.mutate(resultsSlice.actions.setError(error));
 };
 
-export const clearResults = (): StateMutation => {
-  return resultsSlice.actions.clearResults();
+export const clearResults = (engine: Engine) => {
+  engine.mutate(resultsSlice.actions.clearResults());
 };

--- a/packages/headless-future/src/core/interface/results/results-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/results/results-selectors.test.ts
@@ -28,7 +28,7 @@ describe('results selectors', () => {
 
     it('should return updated results after mutation', () => {
       const mockResults = createMockSearchResults(3);
-      engine.mutate(mutations.setResults(mockResults));
+      mutations.setResults(engine, mockResults);
 
       const results = engine.read(selectors.results);
       expect(results).toEqual(mockResults);
@@ -43,7 +43,7 @@ describe('results selectors', () => {
     });
 
     it('should return true when loading', () => {
-      engine.mutate(mutations.setLoading(true));
+      mutations.setLoading(engine, true);
       const isLoading = engine.read(selectors.isLoading);
       expect(isLoading).toBe(true);
     });
@@ -56,7 +56,7 @@ describe('results selectors', () => {
     });
 
     it('should return error message when set', () => {
-      engine.mutate(mutations.setError('Search failed'));
+      mutations.setError(engine, 'Search failed');
       const error = engine.read(selectors.error);
       expect(error).toBe('Search failed');
     });
@@ -69,7 +69,7 @@ describe('results selectors', () => {
     });
 
     it('should return true when results are present', () => {
-      engine.mutate(mutations.setResults(createMockSearchResults(2)));
+      mutations.setResults(engine, createMockSearchResults(2));
       const hasResults = engine.read(selectors.hasSearchResults);
       expect(hasResults).toBe(true);
     });

--- a/packages/headless-future/src/core/interface/search-box/search-box-mutators.test.ts
+++ b/packages/headless-future/src/core/interface/search-box/search-box-mutators.test.ts
@@ -1,42 +1,36 @@
-/**
- * SearchBox Mutations Tests
- */
-
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import * as mutations from './search-box-mutators.js';
-import {createTestEngine} from '@/src/test/test-utils.js';
-import * as selectors from './search-box-selectors.js';
-import {searchBoxSlice} from '@/src/core/internal/search-box/search-box-slice.js';
 import {Engine} from '@/src/core/interface/engine/engine.js';
+import {searchBoxSlice} from '@/src/core/internal/search-box/search-box-slice.js';
 
 describe('searchBoxMutations', () => {
   let engine: Engine;
+  let mutateSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    engine = createTestEngine();
-    engine.adoptSlice(searchBoxSlice);
+    mutateSpy = vi.fn();
+    engine = {
+      mutate: mutateSpy,
+    } as unknown as Engine;
   });
 
   describe('setQuery()', () => {
-    it('should return StateMutation object', () => {
-      const mutation = mutations.setQuery('laptops');
+    it('should call engine.mutate with the setQuery mutation', () => {
+      mutations.setQuery(engine, 'test query');
 
-      expect(mutation).toEqual({
-        type: 'searchBox/setQuery',
-        payload: 'laptops',
-      });
+      expect(mutateSpy).toHaveBeenCalledTimes(1);
+      expect(mutateSpy).toHaveBeenCalledWith(
+        searchBoxSlice.actions.setQuery('test query')
+      );
     });
 
-    it('should update state when used with mutate()', () => {
-      engine.mutate(mutations.setQuery('test query'));
+    it('should call engine.mutate with empty query', () => {
+      mutations.setQuery(engine, '');
 
-      expect(engine.read(selectors.query)).toBe('test query');
-    });
-
-    it('should accept empty string', () => {
-      engine.mutate(mutations.setQuery(''));
-
-      expect(engine.read(selectors.query)).toBe('');
+      expect(mutateSpy).toHaveBeenCalledTimes(1);
+      expect(mutateSpy).toHaveBeenCalledWith(
+        searchBoxSlice.actions.setQuery('')
+      );
     });
   });
 });

--- a/packages/headless-future/src/core/interface/search-box/search-box-mutators.ts
+++ b/packages/headless-future/src/core/interface/search-box/search-box-mutators.ts
@@ -9,12 +9,12 @@
  */
 
 import {searchBoxSlice} from '@/src/core/internal/search-box/search-box-slice.js';
-import type {StateMutation} from '@/src/core/interface/interface-types.js';
+import {Engine} from '@/src/core/interface/engine/engine.js';
 
 /**
  * SearchBox mutations
  */
 
-export const setQuery = (query: string): StateMutation => {
-  return searchBoxSlice.actions.setQuery(query);
+export const setQuery = (engine: Engine, query: string) => {
+  engine.mutate(searchBoxSlice.actions.setQuery(query));
 };

--- a/packages/headless-future/src/core/interface/search-box/search-box-selectors.test.ts
+++ b/packages/headless-future/src/core/interface/search-box/search-box-selectors.test.ts
@@ -1,7 +1,3 @@
-/**
- * SearchBox Selectors Tests
- */
-
 import {describe, it, expect, beforeEach} from 'vitest';
 import {createTestEngine} from '@/src/test/test-utils.js';
 import * as selectors from './search-box-selectors.js';
@@ -24,7 +20,7 @@ describe('searchBox selectors', () => {
     });
 
     it('should return updated query after mutation', () => {
-      engine.mutate(mutations.setQuery('laptops'));
+      mutations.setQuery(engine, 'laptops');
       const query = engine.read(selectors.query);
       expect(query).toBe('laptops');
     });

--- a/packages/headless-future/src/public/actions/search-box/search-box-actions.test.ts
+++ b/packages/headless-future/src/public/actions/search-box/search-box-actions.test.ts
@@ -34,7 +34,7 @@ describe('search-box actions', () => {
       const actions = loadSearchBoxActions(engine);
       await new Promise((r) => setTimeout(r, 0));
 
-      actions.setQuery('hello world');
+      actions.setQuery(engine, 'hello world');
       expect(engine.read(selectors.query)).toBe('hello world');
     });
 
@@ -42,8 +42,8 @@ describe('search-box actions', () => {
       const actions = loadSearchBoxActions(engine);
       await new Promise((r) => setTimeout(r, 0));
 
-      actions.setQuery('something');
-      actions.setQuery('');
+      actions.setQuery(engine, 'something');
+      actions.setQuery(engine, '');
       expect(engine.read(selectors.query)).toBe('');
     });
 
@@ -51,10 +51,10 @@ describe('search-box actions', () => {
       const actions = loadSearchBoxActions(engine);
       await new Promise((r) => setTimeout(r, 0));
 
-      actions.setQuery('first');
+      actions.setQuery(engine, 'first');
       expect(engine.read(selectors.query)).toBe('first');
 
-      actions.setQuery('second');
+      actions.setQuery(engine, 'second');
       expect(engine.read(selectors.query)).toBe('second');
     });
   });

--- a/packages/headless-future/src/public/actions/search-box/search-box-actions.ts
+++ b/packages/headless-future/src/public/actions/search-box/search-box-actions.ts
@@ -17,8 +17,8 @@ export const loadSearchBoxActions = (
   engine.adoptSlice(searchBoxSlice);
   loadedEngine.add(engine);
   return {
-    setQuery: (query: string) => {
-      engine.mutate(searchBoxMutators.setQuery(query));
+    setQuery: (engine, query: string) => {
+      searchBoxMutators.setQuery(engine, query);
     },
   };
 };
@@ -30,6 +30,6 @@ export const setQuery = (engine: Engine) => {
   }
 
   return (query: string) => {
-    engine.mutate(searchBoxMutators.setQuery(query));
+    searchBoxMutators.setQuery(engine, query);
   };
 };

--- a/packages/headless-future/src/public/controllers/search-box/search-box-controller.test.ts
+++ b/packages/headless-future/src/public/controllers/search-box/search-box-controller.test.ts
@@ -1,11 +1,8 @@
-/**
- * SearchBox Controller Tests
- */
-
 import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {createTestEngine} from '@/src/test/test-utils.js';
-import {Engine} from '@/src/core/interface/engine/engine.js';
 import * as searchBoxSelectors from '@/src/core/interface/search-box/search-box-selectors.js';
+import * as searchBoxMutators from '@/src/core/interface/search-box/search-box-mutators.js';
+import {searchBoxSlice} from '@/src/core/internal/search-box/search-box-slice.js';
+import {createMockEngine} from '@/src/test/test-utils.js';
 import {buildSearchBoxController} from './search-box-controller.js';
 
 vi.mock('@/src/api/index.js', () => ({
@@ -15,103 +12,96 @@ vi.mock('@/src/api/index.js', () => ({
 import {executeSearchAPI} from '@/src/api/index.js';
 
 describe('buildSearchBoxController', () => {
-  let engine: Engine;
+  let mockEngine: ReturnType<typeof createMockEngine>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    engine = createTestEngine();
+    mockEngine = createMockEngine();
   });
 
   it('should adopt the searchBox slice', () => {
-    buildSearchBoxController(engine);
+    buildSearchBoxController(mockEngine.engine);
 
-    // If the slice was adopted, reading from it should not throw
-    expect(engine.read(searchBoxSelectors.query)).toBe('');
+    expect(mockEngine.adoptSliceSpy).toHaveBeenCalledExactlyOnceWith(
+      searchBoxSlice
+    );
   });
 
   describe('updateQuery()', () => {
-    it('should update the query in state', () => {
-      const controller = buildSearchBoxController(engine);
+    it('should call setQuery mutator with engine and query', () => {
+      const setQuerySpy = vi
+        .spyOn(searchBoxMutators, 'setQuery')
+        .mockImplementation(() => {});
+      const controller = buildSearchBoxController(mockEngine.engine);
 
       controller.updateQuery('laptops');
 
-      expect(engine.read(searchBoxSelectors.query)).toBe('laptops');
-    });
-
-    it('should reset the query with an empty string', () => {
-      const controller = buildSearchBoxController(engine);
-
-      controller.updateQuery('something');
-      controller.updateQuery('');
-
-      expect(engine.read(searchBoxSelectors.query)).toBe('');
+      expect(setQuerySpy).toHaveBeenCalledExactlyOnceWith(
+        mockEngine.engine,
+        'laptops'
+      );
     });
   });
 
   describe('submit()', () => {
     it('should call executeSearchAPI with the engine', () => {
-      const controller = buildSearchBoxController(engine);
+      const controller = buildSearchBoxController(mockEngine.engine);
 
       controller.submit();
 
-      expect(executeSearchAPI).toHaveBeenCalledOnce();
-      expect(executeSearchAPI).toHaveBeenCalledWith(engine);
+      expect(executeSearchAPI).toHaveBeenCalledExactlyOnceWith(
+        mockEngine.engine
+      );
     });
   });
 
   describe('state getter', () => {
-    it('should return initial state', () => {
-      const controller = buildSearchBoxController(engine);
+    it('should call engine.read with a selector and return its output', () => {
+      mockEngine.readSpy.mockReturnValue({query: 'from-engine'});
+      const controller = buildSearchBoxController(mockEngine.engine);
 
-      expect(controller.state).toEqual({query: ''});
+      expect(controller.state).toEqual({query: 'from-engine'});
+      expect(mockEngine.readSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function)
+      );
     });
 
-    it('should reflect updated query', () => {
-      const controller = buildSearchBoxController(engine);
+    it('should use the same selector as subscribe()', () => {
+      const controller = buildSearchBoxController(mockEngine.engine);
+      const callback = vi.fn();
 
-      controller.updateQuery('test');
+      controller.subscribe(callback);
+      void controller.state;
 
-      expect(controller.state).toEqual({query: 'test'});
+      const subscribedSelector = mockEngine.subscribeSpy.mock.calls[0][0];
+      const stateSelector = mockEngine.readSpy.mock.calls[0][0];
+      expect(stateSelector).toBe(subscribedSelector);
     });
   });
 
   describe('query getter', () => {
-    it('should return the initial query', () => {
-      const controller = buildSearchBoxController(engine);
-
-      expect(controller.query).toBe('');
-    });
-
-    it('should return the updated query', () => {
-      const controller = buildSearchBoxController(engine);
-
-      controller.updateQuery('headphones');
+    it('should call engine.read with query selector', () => {
+      mockEngine.readSpy.mockReturnValue('headphones');
+      const controller = buildSearchBoxController(mockEngine.engine);
 
       expect(controller.query).toBe('headphones');
+      expect(mockEngine.readSpy).toHaveBeenCalledExactlyOnceWith(
+        searchBoxSelectors.query
+      );
     });
   });
 
   describe('subscribe()', () => {
-    it('should invoke callback when query changes', () => {
-      const controller = buildSearchBoxController(engine);
+    it('should call engine.subscribe with selector and callback', () => {
+      const controller = buildSearchBoxController(mockEngine.engine);
       const callback = vi.fn();
 
       controller.subscribe(callback);
-      controller.updateQuery('new query');
 
-      expect(callback).toHaveBeenCalledTimes(1);
-    });
-
-    it('should invoke callback for each distinct change', () => {
-      const controller = buildSearchBoxController(engine);
-      const callback = vi.fn();
-
-      controller.subscribe(callback);
-      controller.updateQuery('first');
-      controller.updateQuery('second');
-      controller.updateQuery('third');
-
-      expect(callback).toHaveBeenCalledTimes(3);
+      expect(mockEngine.subscribeSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+        callback
+      );
     });
   });
 });

--- a/packages/headless-future/src/public/controllers/search-box/search-box-controller.ts
+++ b/packages/headless-future/src/public/controllers/search-box/search-box-controller.ts
@@ -13,7 +13,7 @@ export const buildSearchBoxController = (engine: Engine) => {
   engine.adoptSlice(searchBoxSlice);
   return {
     updateQuery: (query: string) => {
-      engine.mutate(searchBoxMutators.setQuery(query));
+      searchBoxMutators.setQuery(engine, query);
     },
     submit: () => {
       executeSearchAPI(engine);

--- a/packages/headless-future/src/test/test-utils.ts
+++ b/packages/headless-future/src/test/test-utils.ts
@@ -4,6 +4,7 @@
  * Common helpers and mock data builders for unit tests
  */
 
+import {vi} from 'vitest';
 import {Engine} from '../core/interface/engine/engine.js';
 import type {
   SearchResult,
@@ -79,4 +80,32 @@ export function createMockFacetValues(count: number): FacetValue[] {
  */
 export function nextTick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Create a mock Engine for testing controller/integration logic
+ * Returns the engine mock and individual spy functions for assertions
+ */
+export function createMockEngine(): {
+  engine: Engine;
+  adoptSliceSpy: ReturnType<typeof vi.fn>;
+  readSpy: ReturnType<typeof vi.fn>;
+  subscribeSpy: ReturnType<typeof vi.fn>;
+} {
+  const adoptSliceSpy = vi.fn();
+  const readSpy = vi.fn();
+  const subscribeSpy = vi.fn();
+
+  const engine = {
+    adoptSlice: adoptSliceSpy,
+    read: readSpy,
+    subscribe: subscribeSpy,
+  } as unknown as Engine;
+
+  return {
+    engine,
+    adoptSliceSpy,
+    readSpy,
+    subscribeSpy,
+  };
 }


### PR DESCRIPTION
and ancillary adjustments

I also reworked the structure of the controller and mutator unit tests so that they're more "unit" and less "integration" tests.