### PR TITLE
ci: add entry field to cdn-manifest for pointer generation (KIT-5644)

### DIFF
--- a/cdn-manifest.jsonc
+++ b/cdn-manifest.jsonc
@@ -5,21 +5,25 @@
 //   - source:  Build output directory to upload
 //   - cdnPath: CDN path pattern. $VERSION is replaced with the semver version at deploy time.
 //              Most packages follow "{name}/v$VERSION"; exceptions have extra nesting.
+//   - entry:   Main entry file served from the CDN (used for pointer generation)
 [
   {
     "name": "bueno",
     "source": "packages/bueno/cdn",
     "cdnPath": "bueno/v$VERSION",
+    "entry": "bueno.esm.js",
   },
   {
     "name": "headless",
     "source": "packages/headless/cdn",
     "cdnPath": "headless/v$VERSION",
+    "entry": "headless.esm.js",
   },
   {
     "name": "atomic",
     "source": "packages/atomic/cdn",
     "cdnPath": "atomic/v$VERSION",
+    "entry": "atomic.esm.js",
   },
   {
     // Storybook is nested inside the atomic CDN directory
@@ -31,16 +35,19 @@
     "name": "atomic-react",
     "source": "packages/atomic-react/dist",
     "cdnPath": "atomic-react/v$VERSION",
+    "entry": "esm/atomic-react.mjs",
   },
   {
     // Hosted page has an extra subdirectory after the version
     "name": "atomic-hosted-page",
     "source": "packages/atomic-hosted-page/cdn",
     "cdnPath": "atomic-hosted-page/v$VERSION/atomic-hosted-page",
+    "entry": "atomic-hosted-page.esm.js",
   },
   {
     "name": "shopify",
     "source": "packages/shopify/cdn",
     "cdnPath": "shopify/v$VERSION",
+    "entry": "headless.esm.js",
   },
 ]

--- a/packages/atomic-hosted-page/scripts/esbuild.js
+++ b/packages/atomic-hosted-page/scripts/esbuild.js
@@ -41,6 +41,7 @@ const externalizeDependenciesPlugin = {
   },
 };
 
+// If the CDN entry point filename changes, update the `entry` field in cdn-manifest.jsonc
 esbuild
   .build({
     format: 'esm',

--- a/packages/atomic-react/rollup.config.js
+++ b/packages/atomic-react/rollup.config.js
@@ -126,6 +126,7 @@ const outputCJS = ({useCase}) => ({
   inlineDynamicImports: true,
 });
 
+// If this filename changes, update the `entry` field in cdn-manifest.jsonc
 /** @returns {import('rollup').OutputOptions} */
 const outputESM = ({useCase}) => ({
   file: `dist/esm/${useCase}atomic-react.mjs`,

--- a/packages/atomic/rsbuild.cdn.mjs
+++ b/packages/atomic/rsbuild.cdn.mjs
@@ -16,6 +16,7 @@ const rsbuild = await rsbuildApi.createRsbuild({
   cwd: __dirname,
   rsbuildConfig: {
     source: {
+      // If the 'atomic.esm' entry key changes, update the `entry` field in cdn-manifest.jsonc
       entry: {
         'atomic.esm': './src/cdn.ts',
         index: './src/loader.ts',

--- a/packages/bueno/esbuild.mjs
+++ b/packages/bueno/esbuild.mjs
@@ -40,6 +40,7 @@ function browserEsm() {
   return build({
     ...base,
     platform: 'browser',
+    // If this filename changes, update the `entry` field in cdn-manifest.jsonc
     outfile: 'cdn/bueno.esm.js',
     format: 'esm',
     watch: devMode,

--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -74,6 +74,7 @@ const base = {
 const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('cdn', useCase);
+  // If this filename changes, update the `entry` field in cdn-manifest.jsonc
   const outfile = `${outDir}/headless.esm.js`;
 
   const buenoPath = `/bueno/${buenoVersion}/bueno.esm.js`;

--- a/packages/shopify/esbuild.mjs
+++ b/packages/shopify/esbuild.mjs
@@ -25,6 +25,7 @@ const buenoPath = isCDN
  * @type {import('esbuild').BuildOptions}
  */
 
+// If these filenames change, update the `entry` field in cdn-manifest.jsonc
 const entries = [
   {
     entryPoint: 'src/headless/index.ts',


### PR DESCRIPTION
[KIT-5644](https://coveord.atlassian.net/browse/KIT-5644)

## Problem

The CDN pointer generation script in `ui-kit-cd` hardcodes entry filenames (`atomic.esm.js`, `headless.esm.js`, etc.) for each package. If these filenames change in ui-kit, the pointer generation would break silently.

## Solution

Add an `entry` field to `cdn-manifest.jsonc` — the existing source of truth for CDN package structure. This field specifies the main entry file served from the CDN for each package.

The unstable pointer generation script in ui-kit-cd will read from this manifest instead of maintaining a hardcoded list, keeping a single source of truth in ui-kit.

[KIT-5644]: https://coveord.atlassian.net/browse/KIT-5644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ