### PR TITLE
ci: rename CDN channels from canary/rc to private/preview (KIT-5644)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,10 +242,10 @@ jobs:
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
-          # Comma-separated list of CDN channels to update (e.g. "canary" or "canary,rc").
-          # On release commits, update both canary and RC pointers.
-          # On regular merges, only update canary pointers.
-          CHANNELS: ${{ needs.release.outputs.published == 'true' && 'canary,rc' || 'canary' }}
+          # Comma-separated list of CDN channels to update (e.g. "private" or "private,preview").
+          # On release commits, update both private and preview pointers.
+          # On regular merges, only update private pointers.
+          CHANNELS: ${{ needs.release.outputs.published == 'true' && 'private,preview' || 'private' }}
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
[KIT-5644](https://coveord.atlassian.net/browse/KIT-5644)

## Problem
The CDN channel naming was using `canary` and `rc`, but the architecture has been updated to use `unstable` (every merge to main) and `canary` (on release commits only).

## Solution
Renamed the `CHANNELS` values in the CD workflow:
- `canary` → `unstable` (updated on every merge to main)
- `rc` → `canary` (updated only on release commits)


[KIT-5644]: https://coveord.atlassian.net/browse/KIT-5644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ