### PR TITLE
fix(quantic): ignore IME composition keydowns

### DIFF
--- a/.changeset/quiet-lamps-wave.md
+++ b/.changeset/quiet-lamps-wave.md
@@ -1,0 +1,5 @@
+---
+'@coveo/quantic': patch
+---
+
+Prevent Quantic search boxes from submitting while IME text composition is being confirmed.

--- a/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticSearchBoxInput/quanticSearchBoxInput.js
@@ -223,6 +223,11 @@ export default class QuanticSearchBoxInput extends LightningElement {
    * @param {KeyboardEvent} event
    */
   onKeyDown(event) {
+    // Let the browser commit IME text before handling shortcuts like Enter. For japanese/korean/chinese input.
+    if (event.isComposing || event.keyCode === 229) {
+      return;
+    }
+
     // eslint-disable-next-line default-case
     switch (event.key) {
       case keys.ESC:


### PR DESCRIPTION
## Summary
- Skip Quantic search box keyboard shortcut handling while IME composition key events are active.
- Add a patch changeset for @coveo/quantic.

## Jira
SFINT-6771

## Testing
- pnpm run lint:fix
- pnpm --filter @coveo/quantic test:unit -- --testPathPattern=quanticSearchBoxInput
- pnpm --filter @coveo/quantic lint:check
- Manual Chrome/macOS Japanese IME validation