### PR TITLE
fix: address accessibility violation on atomic result list

### DIFF
--- a/packages/atomic/src/components/common/item-link/item-link.ts
+++ b/packages/atomic/src/components/common/item-link/item-link.ts
@@ -10,6 +10,7 @@ export interface ItemLinkProps {
   className?: string;
   part?: string;
   title?: string;
+  ariaLabel?: string;
   stopPropagation?: boolean;
   ref?: RefOrCallback;
   attributes?: Attr[];
@@ -36,6 +37,7 @@ export const renderLinkWithItemAnalytics: FunctionalComponentWithChildren<
       className,
       part,
       title,
+      ariaLabel,
       stopPropagation = true,
       ref: refCallback,
       attributes,
@@ -59,6 +61,7 @@ export const renderLinkWithItemAnalytics: FunctionalComponentWithChildren<
         href=${filterProtocol(href)}
         target=${target}
         title=${ifDefined(title)}
+        aria-label=${ifDefined(ariaLabel)}
         rel=${ifDefined(rel)}
         ${ref((el) => {
           if (!el) {

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -29,8 +29,6 @@ import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-table-element/atomic-table-element.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
-const mockSearchApi = new MockSearchApi();
-
 const defaultTemplateContent = `<atomic-result-template>
   <template>
       <atomic-result-section-actions><atomic-quickview></atomic-quickview></atomic-result-section-actions>
@@ -78,6 +76,8 @@ const defaultTemplateContent = `<atomic-result-template>
   </template>
 </atomic-result-template>`;
 
+const searchApiHarness = new MockSearchApi();
+
 const {decorator, play} = wrapInSearchInterface({
   config: {
     search: {
@@ -121,9 +121,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
-    msw: {
-      handlers: [...mockSearchApi.handlers],
-    },
+    msw: {handlers: [...searchApiHarness.handlers]},
     layout: 'fullscreen',
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -29,12 +29,14 @@ import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-table-element/atomic-table-element.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
+const mockSearchApi = new MockSearchApi();
+
 const defaultTemplateContent = `<atomic-result-template>
   <template>
       <atomic-result-section-actions><atomic-quickview></atomic-quickview></atomic-result-section-actions>
       <atomic-result-section-visual>
         <atomic-result-icon class="icon"></atomic-result-icon>
-        <img loading="lazy" src="https://picsum.photos/seed/picsum/350" class="thumbnail" />
+        <img loading="lazy" src="https://picsum.photos/seed/picsum/350" class="thumbnail" alt="" />
       </atomic-result-section-visual>
       <atomic-result-section-badges>
         <atomic-field-condition must-match-sourcetype="Salesforce">
@@ -121,7 +123,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
-    msw: {handlers: [...searchApiHarness.handlers]},
+    msw: {
+      handlers: [...mockSearchApi.handlers],
+    },
     layout: 'fullscreen',
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -78,8 +78,6 @@ const defaultTemplateContent = `<atomic-result-template>
   </template>
 </atomic-result-template>`;
 
-const searchApiHarness = new MockSearchApi();
-
 const {decorator, play} = wrapInSearchInterface({
   config: {
     search: {

--- a/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.ts
+++ b/packages/atomic/src/components/search/atomic-result-printable-uri/atomic-result-printable-uri.ts
@@ -234,6 +234,7 @@ export class AtomicResultPrintableUri
     return renderLinkWithItemAnalytics({
       props: {
         href: this.result.clickUri,
+        ariaLabel: this.result.printableUri || this.result.clickUri,
         onSelect: () => this.interactiveResult.select(),
         onBeginDelayedSelect: () => this.interactiveResult.beginDelayedSelect(),
         onCancelPendingSelect: () =>


### PR DESCRIPTION
Fix a11y violations on the atomic-result-list component

### How to run
```bash
pnpm --filter @coveo/atomic run test:storybook src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
```

### Output

#### Before the fix
```bash
──────────────────────────────────────────────────────────────
 Accessibility violations detected
──────────────────────────────────────────────────────────────
 Components affected : 1
 Violations          : 4
 Affected nodes      : 480

• atomic-result-list
  └─ atomic-result-list--list-display-with-template
     • image-alt (critical) — 120 node(s) [WCAG 1.1.1]
       https://dequeuniversity.com/rules/axe/4.10/image-alt?application=axeAPI
     • link-name (serious) — 120 node(s) [WCAG 2.4.4, 4.1.2]
       https://dequeuniversity.com/rules/axe/4.10/link-name?application=axeAPI
  └─ atomic-result-list--grid-display-with-template
     • image-alt (critical) — 120 node(s) [WCAG 1.1.1]
       https://dequeuniversity.com/rules/axe/4.10/image-alt?application=axeAPI
     • link-name (serious) — 120 node(s) [WCAG 2.4.4, 4.1.2]
       https://dequeuniversity.com/rules/axe/4.10/link-name?application=axeAPI

 See reports/a11y-report.json for the full machine-readable report.
──────────────────────────────────────────────────────────────
```

#### After the fix
No violation detected on the atomic-result-list component


[KIT-5733](https://coveord.atlassian.net/browse/KIT-5733)


[KIT-5733]: https://coveord.atlassian.net/browse/KIT-5733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ