### PR TITLE
feat(samples): create atomic-commerce sample (KIT-5684)

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -80,6 +80,10 @@ export default {
     },
     'samples/headless-ssr/commerce-nextjs': {},
     'samples/headless-ssr/commerce-nextjs-v4': {},
+    'samples/atomic/commerce': {
+      // Vanilla HTML sample - deps are imported in inline <script> tags within HTML, not traceable by knip.
+      ignore: ['**/*'],
+    },
     'utils/ci': {},
     'utils/cdn': {
       ignoreDependencies: ['local-web-server'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,22 @@ importers:
         specifier: 'catalog:'
         version: 4.0.16(@types/node@24.12.2)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@20.0.3)(less@4.6.4)(lightningcss@1.32.0)(msw@2.13.4(@types/node@24.12.2)(typescript@6.0.3))(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
 
+  samples/atomic/commerce:
+    dependencies:
+      '@coveo/atomic':
+        specifier: workspace:*
+        version: link:../../../packages/atomic
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/atomic/search-commerce-angular:
     dependencies:
       '@angular/animations':

--- a/samples/atomic/commerce/.gitignore
+++ b/samples/atomic/commerce/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+public/lang
+public/assets

--- a/samples/atomic/commerce/index.html
+++ b/samples/atomic/commerce/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic Commerce Sample</title>
+    <style>
+      body { font-family: sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
+      h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+      p { color: #555; margin-bottom: 2rem; }
+      ul { list-style: none; padding: 0; display: flex; gap: 1rem; flex-wrap: wrap; }
+      a { display: inline-block; padding: 0.75rem 1.5rem; background: #1a73e8; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
+      a:hover { background: #1558b0; }
+    </style>
+  </head>
+  <body>
+    <h1>Coveo Atomic Commerce Sample</h1>
+    <p>Pick a page to explore commerce components.</p>
+    <ul>
+      <li><a href="./search.html">Commerce Search</a></li>
+      <li><a href="./listing.html">Product Listing</a></li>
+      <li><a href="./recommendations.html">Recommendations</a></li>
+    </ul>
+  </body>
+</html>

--- a/samples/atomic/commerce/index.html
+++ b/samples/atomic/commerce/index.html
@@ -5,12 +5,39 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Atomic Commerce Sample</title>
     <style>
-      body { font-family: sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
-      h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
-      p { color: #555; margin-bottom: 2rem; }
-      ul { list-style: none; padding: 0; display: flex; gap: 1rem; flex-wrap: wrap; }
-      a { display: inline-block; padding: 0.75rem 1.5rem; background: #1a73e8; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
-      a:hover { background: #1558b0; }
+      body {
+        font-family: sans-serif;
+        max-width: 600px;
+        margin: 4rem auto;
+        padding: 0 1rem;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        color: #555;
+        margin-bottom: 2rem;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      a {
+        display: inline-block;
+        padding: 0.75rem 1.5rem;
+        background: #1a73e8;
+        color: #fff;
+        border-radius: 6px;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      a:hover {
+        background: #1558b0;
+      }
     </style>
   </head>
   <body>

--- a/samples/atomic/commerce/listing.html
+++ b/samples/atomic/commerce/listing.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Product Listing — Atomic Commerce Sample</title>
+    <script type="module">
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
+      defineCustomElements();
+    </script>
+    <script type="module">
+      import {
+        buildCommerceEngine,
+        getSampleCommerceEngineConfiguration,
+      } from '@coveo/headless/commerce';
+
+      const {context, ...rest} = getSampleCommerceEngineConfiguration();
+      const engine = buildCommerceEngine({
+        configuration: {
+          ...rest,
+          context: {
+            ...context,
+            view: {url: 'https://sports.barca.group/browse/promotions/ui-kit-testing'},
+          },
+        },
+      });
+
+      await customElements.whenDefined('atomic-commerce-interface');
+      const commerceInterface = document.querySelector('atomic-commerce-interface');
+      await commerceInterface.initializeWithEngine(engine);
+      commerceInterface.executeFirstRequest();
+    </script>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
+      nav a { color: #1a73e8; text-decoration: none; }
+      nav a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+
+    <atomic-commerce-interface type="product-listing">
+      <atomic-commerce-layout>
+        <atomic-layout-section section="facets">
+          <atomic-commerce-facets></atomic-commerce-facets>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-layout-section section="status">
+            <atomic-commerce-breadbox></atomic-commerce-breadbox>
+            <atomic-commerce-query-summary></atomic-commerce-query-summary>
+            <atomic-commerce-sort-dropdown></atomic-commerce-sort-dropdown>
+            <atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>
+          </atomic-layout-section>
+          <atomic-layout-section section="products">
+            <atomic-commerce-product-list display="grid" density="compact" image-size="small">
+              <atomic-product-template>
+                <template>
+                  <atomic-product-section-name>
+                    <atomic-product-link></atomic-product-link>
+                  </atomic-product-section-name>
+                  <atomic-product-section-visual>
+                    <atomic-product-field-condition if-defined="ec_thumbnails">
+                      <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                    </atomic-product-field-condition>
+                  </atomic-product-section-visual>
+                  <atomic-product-section-metadata>
+                    <atomic-product-field-condition if-defined="ec_brand">
+                      <atomic-product-text field="ec_brand"></atomic-product-text>
+                    </atomic-product-field-condition>
+                  </atomic-product-section-metadata>
+                  <atomic-product-section-emphasized>
+                    <atomic-product-price></atomic-product-price>
+                  </atomic-product-section-emphasized>
+                </template>
+              </atomic-product-template>
+            </atomic-commerce-product-list>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-commerce-pager></atomic-commerce-pager>
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-commerce-layout>
+    </atomic-commerce-interface>
+  </body>
+</html>

--- a/samples/atomic/commerce/listing.html
+++ b/samples/atomic/commerce/listing.html
@@ -21,21 +21,38 @@
           ...rest,
           context: {
             ...context,
-            view: {url: 'https://sports.barca.group/browse/promotions/ui-kit-testing'},
+            view: {
+              url: 'https://sports.barca.group/browse/promotions/ui-kit-testing',
+            },
           },
         },
       });
 
       await customElements.whenDefined('atomic-commerce-interface');
-      const commerceInterface = document.querySelector('atomic-commerce-interface');
+      const commerceInterface = document.querySelector(
+        'atomic-commerce-interface'
+      );
       await commerceInterface.initializeWithEngine(engine);
       commerceInterface.executeFirstRequest();
     </script>
     <style>
-      body { margin: 0; font-family: sans-serif; }
-      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
-      nav a { color: #1a73e8; text-decoration: none; }
-      nav a:hover { text-decoration: underline; }
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      nav {
+        padding: 0.75rem 1rem;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+        font-size: 0.875rem;
+      }
+      nav a {
+        color: #1a73e8;
+        text-decoration: none;
+      }
+      nav a:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>
@@ -54,7 +71,11 @@
             <atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>
           </atomic-layout-section>
           <atomic-layout-section section="products">
-            <atomic-commerce-product-list display="grid" density="compact" image-size="small">
+            <atomic-commerce-product-list
+              display="grid"
+              density="compact"
+              image-size="small"
+            >
               <atomic-product-template>
                 <template>
                   <atomic-product-section-name>
@@ -62,12 +83,16 @@
                   </atomic-product-section-name>
                   <atomic-product-section-visual>
                     <atomic-product-field-condition if-defined="ec_thumbnails">
-                      <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                      <atomic-product-image
+                        field="ec_thumbnails"
+                      ></atomic-product-image>
                     </atomic-product-field-condition>
                   </atomic-product-section-visual>
                   <atomic-product-section-metadata>
                     <atomic-product-field-condition if-defined="ec_brand">
-                      <atomic-product-text field="ec_brand"></atomic-product-text>
+                      <atomic-product-text
+                        field="ec_brand"
+                      ></atomic-product-text>
                     </atomic-product-field-condition>
                   </atomic-product-section-metadata>
                   <atomic-product-section-emphasized>

--- a/samples/atomic/commerce/package.json
+++ b/samples/atomic/commerce/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@samples/atomic-commerce",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "copy-resources": "node ./scripts/copy-resources.mjs",
+    "dev": "pnpm copy-resources && vite",
+    "build": "pnpm copy-resources && vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/atomic": "workspace:*",
+    "@coveo/headless": "workspace:*"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/atomic/commerce/playwright.config.ts
+++ b/samples/atomic/commerce/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/atomic/commerce/recommendations.html
+++ b/samples/atomic/commerce/recommendations.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Recommendations — Atomic Commerce Sample</title>
+    <script type="module">
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
+      defineCustomElements();
+    </script>
+    <script type="module">
+      import {
+        buildCommerceEngine,
+        getSampleCommerceEngineConfiguration,
+      } from '@coveo/headless/commerce';
+
+      const engine = buildCommerceEngine({
+        configuration: getSampleCommerceEngineConfiguration(),
+      });
+
+      await customElements.whenDefined('atomic-commerce-recommendation-interface');
+      const recsInterface = document.querySelector('atomic-commerce-recommendation-interface');
+      await recsInterface.initializeWithEngine(engine);
+    </script>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
+      nav a { color: #1a73e8; text-decoration: none; }
+      nav a:hover { text-decoration: underline; }
+      h2 { padding: 1rem; }
+    </style>
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+    <h2>Product Recommendations</h2>
+
+    <atomic-commerce-recommendation-interface>
+      <atomic-commerce-recommendation-list
+        slot-id="af4fb7ba-6641-4b67-9cf9-be67e9f30174"
+        products-per-page="6"
+      >
+        <atomic-product-template>
+          <template>
+            <atomic-product-section-name>
+              <atomic-product-link></atomic-product-link>
+            </atomic-product-section-name>
+            <atomic-product-section-visual>
+              <atomic-product-field-condition if-defined="ec_thumbnails">
+                <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+              </atomic-product-field-condition>
+            </atomic-product-section-visual>
+            <atomic-product-section-metadata>
+              <atomic-product-field-condition if-defined="ec_brand">
+                <atomic-product-text field="ec_brand"></atomic-product-text>
+              </atomic-product-field-condition>
+            </atomic-product-section-metadata>
+            <atomic-product-section-emphasized>
+              <atomic-product-price></atomic-product-price>
+            </atomic-product-section-emphasized>
+          </template>
+        </atomic-product-template>
+      </atomic-commerce-recommendation-list>
+    </atomic-commerce-recommendation-interface>
+  </body>
+</html>

--- a/samples/atomic/commerce/recommendations.html
+++ b/samples/atomic/commerce/recommendations.html
@@ -19,16 +19,35 @@
         configuration: getSampleCommerceEngineConfiguration(),
       });
 
-      await customElements.whenDefined('atomic-commerce-recommendation-interface');
-      const recsInterface = document.querySelector('atomic-commerce-recommendation-interface');
+      await customElements.whenDefined(
+        'atomic-commerce-recommendation-interface'
+      );
+      const recsInterface = document.querySelector(
+        'atomic-commerce-recommendation-interface'
+      );
       await recsInterface.initializeWithEngine(engine);
     </script>
     <style>
-      body { margin: 0; font-family: sans-serif; }
-      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
-      nav a { color: #1a73e8; text-decoration: none; }
-      nav a:hover { text-decoration: underline; }
-      h2 { padding: 1rem; }
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      nav {
+        padding: 0.75rem 1rem;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+        font-size: 0.875rem;
+      }
+      nav a {
+        color: #1a73e8;
+        text-decoration: none;
+      }
+      nav a:hover {
+        text-decoration: underline;
+      }
+      h2 {
+        padding: 1rem;
+      }
     </style>
   </head>
   <body>
@@ -47,7 +66,9 @@
             </atomic-product-section-name>
             <atomic-product-section-visual>
               <atomic-product-field-condition if-defined="ec_thumbnails">
-                <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                <atomic-product-image
+                  field="ec_thumbnails"
+                ></atomic-product-image>
               </atomic-product-field-condition>
             </atomic-product-section-visual>
             <atomic-product-section-metadata>

--- a/samples/atomic/commerce/scripts/copy-resources.mjs
+++ b/samples/atomic/commerce/scripts/copy-resources.mjs
@@ -1,0 +1,24 @@
+import {cpSync, existsSync, mkdirSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const atomicPkg = resolve('./node_modules/@coveo/atomic');
+
+function findDir(name) {
+  const flat = resolve(atomicPkg, 'dist', name);
+  if (existsSync(flat)) return flat;
+  const nested = resolve(atomicPkg, 'dist', 'atomic', name);
+  if (existsSync(nested)) return nested;
+  return null;
+}
+
+for (const dir of ['lang', 'assets']) {
+  const src = findDir(dir);
+  if (!src) {
+    console.warn(`Could not find ${dir} directory, skipping`);
+    continue;
+  }
+  const dest = resolve('./public', dir);
+  mkdirSync(dest, {recursive: true});
+  cpSync(src, dest, {recursive: true});
+  console.log(`Copied ${src} → ${dest}`);
+}

--- a/samples/atomic/commerce/search.html
+++ b/samples/atomic/commerce/search.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commerce Search — Atomic Commerce Sample</title>
+    <script type="module">
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
+      defineCustomElements();
+    </script>
+    <script type="module">
+      import {
+        buildCommerceEngine,
+        getSampleCommerceEngineConfiguration,
+      } from '@coveo/headless/commerce';
+
+      const {context, ...rest} = getSampleCommerceEngineConfiguration();
+      const engine = buildCommerceEngine({
+        configuration: {
+          ...rest,
+          context: {
+            ...context,
+            view: {url: 'https://sports.barca.group/search'},
+          },
+        },
+      });
+
+      await customElements.whenDefined('atomic-commerce-interface');
+      const commerceInterface = document.querySelector('atomic-commerce-interface');
+      await commerceInterface.initializeWithEngine(engine);
+      commerceInterface.executeFirstRequest();
+    </script>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
+      nav a { color: #1a73e8; text-decoration: none; }
+      nav a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+
+    <atomic-commerce-interface type="search">
+      <atomic-commerce-layout>
+        <atomic-layout-section section="search">
+          <atomic-commerce-search-box>
+            <atomic-commerce-search-box-recent-queries></atomic-commerce-search-box-recent-queries>
+            <atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>
+          </atomic-commerce-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-commerce-facets></atomic-commerce-facets>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-layout-section section="status">
+            <atomic-commerce-breadbox></atomic-commerce-breadbox>
+            <atomic-commerce-query-summary></atomic-commerce-query-summary>
+            <atomic-commerce-sort-dropdown></atomic-commerce-sort-dropdown>
+            <atomic-commerce-did-you-mean></atomic-commerce-did-you-mean>
+            <atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>
+          </atomic-layout-section>
+          <atomic-layout-section section="products">
+            <atomic-commerce-product-list display="grid" density="compact" image-size="small">
+              <atomic-product-template>
+                <template>
+                  <atomic-product-section-name>
+                    <atomic-product-link></atomic-product-link>
+                  </atomic-product-section-name>
+                  <atomic-product-section-visual>
+                    <atomic-product-field-condition if-defined="ec_thumbnails">
+                      <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                    </atomic-product-field-condition>
+                  </atomic-product-section-visual>
+                  <atomic-product-section-metadata>
+                    <atomic-product-field-condition if-defined="ec_brand">
+                      <atomic-product-text field="ec_brand"></atomic-product-text>
+                    </atomic-product-field-condition>
+                  </atomic-product-section-metadata>
+                  <atomic-product-section-emphasized>
+                    <atomic-product-price></atomic-product-price>
+                  </atomic-product-section-emphasized>
+                </template>
+              </atomic-product-template>
+            </atomic-commerce-product-list>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-commerce-pager></atomic-commerce-pager>
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-commerce-layout>
+    </atomic-commerce-interface>
+  </body>
+</html>

--- a/samples/atomic/commerce/search.html
+++ b/samples/atomic/commerce/search.html
@@ -27,15 +27,30 @@
       });
 
       await customElements.whenDefined('atomic-commerce-interface');
-      const commerceInterface = document.querySelector('atomic-commerce-interface');
+      const commerceInterface = document.querySelector(
+        'atomic-commerce-interface'
+      );
       await commerceInterface.initializeWithEngine(engine);
       commerceInterface.executeFirstRequest();
     </script>
     <style>
-      body { margin: 0; font-family: sans-serif; }
-      nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
-      nav a { color: #1a73e8; text-decoration: none; }
-      nav a:hover { text-decoration: underline; }
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      nav {
+        padding: 0.75rem 1rem;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+        font-size: 0.875rem;
+      }
+      nav a {
+        color: #1a73e8;
+        text-decoration: none;
+      }
+      nav a:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>
@@ -61,7 +76,11 @@
             <atomic-commerce-refine-toggle></atomic-commerce-refine-toggle>
           </atomic-layout-section>
           <atomic-layout-section section="products">
-            <atomic-commerce-product-list display="grid" density="compact" image-size="small">
+            <atomic-commerce-product-list
+              display="grid"
+              density="compact"
+              image-size="small"
+            >
               <atomic-product-template>
                 <template>
                   <atomic-product-section-name>
@@ -69,12 +88,16 @@
                   </atomic-product-section-name>
                   <atomic-product-section-visual>
                     <atomic-product-field-condition if-defined="ec_thumbnails">
-                      <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+                      <atomic-product-image
+                        field="ec_thumbnails"
+                      ></atomic-product-image>
                     </atomic-product-field-condition>
                   </atomic-product-section-visual>
                   <atomic-product-section-metadata>
                     <atomic-product-field-condition if-defined="ec_brand">
-                      <atomic-product-text field="ec_brand"></atomic-product-text>
+                      <atomic-product-text
+                        field="ec_brand"
+                      ></atomic-product-text>
                     </atomic-product-field-condition>
                   </atomic-product-section-metadata>
                   <atomic-product-section-emphasized>

--- a/samples/atomic/commerce/tests/smoke.spec.ts
+++ b/samples/atomic/commerce/tests/smoke.spec.ts
@@ -1,0 +1,49 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Atomic Commerce Sample', () => {
+  test('search page loads and displays products', async ({page}) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('http://localhost:3001/search.html');
+
+    const searchBox = page.locator('atomic-commerce-search-box');
+    await expect(searchBox).toBeVisible();
+
+    const querySummary = page.locator('atomic-commerce-query-summary');
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
+    const productList = page.locator('atomic-commerce-product-list');
+    await expect(productList).toBeVisible();
+
+    const firstProduct = productList.locator('atomic-product').first();
+    await expect(firstProduct).toBeVisible();
+
+    const filteredErrors = consoleErrors.filter(
+      (error) => !error.includes('MissingInterfaceParentError')
+    );
+    expect(filteredErrors).toEqual([]);
+  });
+
+  test('listing page loads and displays products', async ({page}) => {
+    await page.goto('http://localhost:3001/listing.html');
+
+    const productList = page.locator('atomic-commerce-product-list');
+    await expect(productList).toBeVisible();
+
+    const firstProduct = productList.locator('atomic-product').first();
+    await expect(firstProduct).toBeVisible();
+  });
+
+  test('recommendations page loads', async ({page}) => {
+    await page.goto('http://localhost:3001/recommendations.html');
+
+    const recsList = page.locator('atomic-commerce-recommendation-list');
+    await expect(recsList).toBeVisible();
+  });
+});

--- a/samples/atomic/commerce/vite.config.ts
+++ b/samples/atomic/commerce/vite.config.ts
@@ -1,0 +1,21 @@
+import {fileURLToPath} from 'node:url';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  appType: 'mpa',
+  server: {
+    port: 3001,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        index: fileURLToPath(new URL('./index.html', import.meta.url)),
+        search: fileURLToPath(new URL('./search.html', import.meta.url)),
+        listing: fileURLToPath(new URL('./listing.html', import.meta.url)),
+        recommendations: fileURLToPath(
+          new URL('./recommendations.html', import.meta.url)
+        ),
+      },
+    },
+  },
+});


### PR DESCRIPTION
[KIT-5684](https://coveord.atlassian.net/browse/KIT-5684)

## Problem
We need a standalone Atomic Commerce vanilla sample that serves as both a reference implementation and scaffolding template.

## Solution
Split the commerce portion from the existing `pkg-new-template` sample into a standalone Vite + Atomic Commerce project with search page, product listing pages, and recommendations.

[KIT-5684]: https://coveord.atlassian.net/browse/KIT-5684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ