### PR TITLE
feat(samples): create headless-commerce vanilla sample (KIT-5681)

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -80,6 +80,10 @@ export default {
     },
     'samples/headless-ssr/commerce-nextjs': {},
     'samples/headless-ssr/commerce-nextjs-v4': {},
+    'samples/headless/commerce': {
+      // Vanilla HTML sample - entry points are in HTML <script>/<link> tags, not traceable by knip.
+      ignore: ['**/*'],
+    },
     'utils/ci': {},
     'utils/cdn': {
       ignoreDependencies: ['local-web-server'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,6 +1334,19 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  samples/headless/commerce:
+    dependencies:
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/headless/commerce-react:
     dependencies:
       '@coveo/headless':

--- a/samples/headless/commerce/.gitignore
+++ b/samples/headless/commerce/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/samples/headless/commerce/index.html
+++ b/samples/headless/commerce/index.html
@@ -5,12 +5,39 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Headless Commerce Sample</title>
     <style>
-      body { font-family: sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
-      h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
-      p { color: #555; margin-bottom: 2rem; }
-      ul { list-style: none; padding: 0; display: flex; gap: 1rem; flex-wrap: wrap; }
-      a { display: inline-block; padding: 0.75rem 1.5rem; background: #1a73e8; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
-      a:hover { background: #1558b0; }
+      body {
+        font-family: sans-serif;
+        max-width: 600px;
+        margin: 4rem auto;
+        padding: 0 1rem;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        color: #555;
+        margin-bottom: 2rem;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      a {
+        display: inline-block;
+        padding: 0.75rem 1.5rem;
+        background: #1a73e8;
+        color: #fff;
+        border-radius: 6px;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      a:hover {
+        background: #1558b0;
+      }
     </style>
   </head>
   <body>

--- a/samples/headless/commerce/index.html
+++ b/samples/headless/commerce/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Headless Commerce Sample</title>
+    <style>
+      body { font-family: sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
+      h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+      p { color: #555; margin-bottom: 2rem; }
+      ul { list-style: none; padding: 0; display: flex; gap: 1rem; flex-wrap: wrap; }
+      a { display: inline-block; padding: 0.75rem 1.5rem; background: #1a73e8; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
+      a:hover { background: #1558b0; }
+    </style>
+  </head>
+  <body>
+    <h1>Coveo Headless Commerce</h1>
+    <p>Demonstrates Headless Commerce controllers with vanilla JS.</p>
+    <ul>
+      <li><a href="./search.html">Commerce Search</a></li>
+      <li><a href="./listing.html">Product Listing</a></li>
+    </ul>
+  </body>
+</html>

--- a/samples/headless/commerce/listing.html
+++ b/samples/headless/commerce/listing.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Product Listing — Headless Commerce Sample</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+    <div id="app">
+      <h1>Product Listing</h1>
+      <div id="main">
+        <aside id="facets"></aside>
+        <section id="results-section">
+          <div id="query-summary"></div>
+          <div id="sort"></div>
+          <div id="product-list"></div>
+          <div id="pager"></div>
+        </section>
+      </div>
+    </div>
+    <script type="module" src="/src/listing.ts"></script>
+  </body>
+</html>

--- a/samples/headless/commerce/package.json
+++ b/samples/headless/commerce/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@samples/headless-commerce",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/headless": "workspace:*"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/headless/commerce/playwright.config.ts
+++ b/samples/headless/commerce/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3003',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/headless/commerce/search.html
+++ b/samples/headless/commerce/search.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commerce Search — Headless Commerce Sample</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+    <div id="app">
+      <h1>Commerce Search</h1>
+      <div id="search-box"></div>
+      <div id="main">
+        <aside id="facets"></aside>
+        <section id="results-section">
+          <div id="query-summary"></div>
+          <div id="sort"></div>
+          <div id="product-list"></div>
+          <div id="pager"></div>
+        </section>
+      </div>
+    </div>
+    <script type="module" src="/src/search.ts"></script>
+  </body>
+</html>

--- a/samples/headless/commerce/src/engine.ts
+++ b/samples/headless/commerce/src/engine.ts
@@ -1,0 +1,28 @@
+import {
+  buildCommerceEngine,
+  getSampleCommerceEngineConfiguration,
+} from '@coveo/headless/commerce';
+
+function createEngine(viewUrl: string) {
+  const {context, ...rest} = getSampleCommerceEngineConfiguration();
+
+  return buildCommerceEngine({
+    configuration: {
+      ...rest,
+      context: {
+        ...context,
+        view: {url: viewUrl},
+      },
+    },
+  });
+}
+
+export function createSearchEngine() {
+  return createEngine('https://sports.barca.group/search');
+}
+
+export function createListingEngine() {
+  return createEngine(
+    'https://sports.barca.group/browse/promotions/ui-kit-testing'
+  );
+}

--- a/samples/headless/commerce/src/listing.ts
+++ b/samples/headless/commerce/src/listing.ts
@@ -1,0 +1,39 @@
+import {buildProductListing} from '@coveo/headless/commerce';
+import {createListingEngine} from './engine.js';
+import {
+  renderFacets,
+  renderPager,
+  renderProductList,
+  renderSort,
+  renderSummary,
+} from './render-utils.js';
+
+const engine = createListingEngine();
+const listing = buildProductListing(engine);
+const summary = listing.summary();
+const pager = listing.pagination({options: {pageSize: 9}});
+const facetGenerator = listing.facetGenerator();
+const sort = listing.sort();
+
+const querySummaryEl = document.getElementById('query-summary')!;
+const sortEl = document.getElementById('sort')!;
+const facetsEl = document.getElementById('facets')!;
+const productListEl = document.getElementById('product-list')!;
+const pagerEl = document.getElementById('pager')!;
+
+function renderListingPage() {
+  renderSummary(querySummaryEl, summary);
+  renderSort(sortEl, sort);
+  renderFacets(facetsEl, facetGenerator);
+  renderProductList(productListEl, listing.state.products);
+  renderPager(pagerEl, pager);
+}
+
+listing.subscribe(renderListingPage);
+summary.subscribe(renderListingPage);
+sort.subscribe(renderListingPage);
+facetGenerator.subscribe(renderListingPage);
+pager.subscribe(renderListingPage);
+
+renderListingPage();
+listing.executeFirstRequest();

--- a/samples/headless/commerce/src/render-utils.ts
+++ b/samples/headless/commerce/src/render-utils.ts
@@ -1,0 +1,361 @@
+import {
+  SortBy,
+  type CategoryFacet,
+  type DateFacet,
+  type FacetGenerator,
+  type NumericFacet,
+  type Pagination,
+  type Product,
+  type RegularFacet,
+  type SearchSummaryState,
+  type Sort,
+  type SortCriterion,
+  type Summary,
+} from '@coveo/headless/commerce';
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function renderProduct(product: Product): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'product-item';
+
+  const thumbnail = product.ec_thumbnails[0] || '';
+  const price =
+    product.ec_price != null ? `$${Number(product.ec_price).toFixed(2)}` : '';
+  const brand = product.ec_brand || '';
+  const category = product.ec_category.at(-1)?.split('|').at(-1) || '';
+  const title = escapeHtml(product.ec_name || product.permanentid);
+
+  item.innerHTML = `
+    ${thumbnail ? `<img src="${escapeHtml(thumbnail)}" alt="${title}" />` : '<div></div>'}
+    <div class="product-info">
+      <h3><a href="${escapeHtml(product.clickUri)}" target="_blank" rel="noreferrer">${title}</a></h3>
+      ${brand ? `<div class="brand">${escapeHtml(brand)}</div>` : ''}
+      ${category ? `<div class="category">${escapeHtml(category)}</div>` : ''}
+      ${price ? `<div class="price">${price}</div>` : ''}
+    </div>
+  `;
+  return item;
+}
+
+export function renderProductList(
+  productListEl: HTMLElement,
+  products: Product[],
+  emptyText = 'No products found'
+) {
+  productListEl.innerHTML = '';
+
+  if (products.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = emptyText;
+    productListEl.appendChild(empty);
+    return;
+  }
+
+  products.forEach((product) => {
+    productListEl.appendChild(renderProduct(product));
+  });
+}
+
+function getSortLabel(criterion: SortCriterion) {
+  switch (criterion.by) {
+    case SortBy.Relevance:
+      return 'Relevance';
+    case SortBy.Fields:
+      return criterion.fields.map((field) => field.displayName).join(', ');
+  }
+}
+
+export function renderSort(sortEl: HTMLElement, sort: Sort) {
+  sortEl.innerHTML = '';
+  const {availableSorts, appliedSort} = sort.state;
+
+  if (!availableSorts.length) {
+    return;
+  }
+
+  const label = document.createElement('label');
+  label.textContent = 'Sort by: ';
+  label.htmlFor = 'sort-select';
+
+  const select = document.createElement('select');
+  select.id = 'sort-select';
+  select.value = JSON.stringify(appliedSort);
+
+  availableSorts.forEach((sortOption) => {
+    const option = document.createElement('option');
+    option.value = JSON.stringify(sortOption);
+    option.textContent = getSortLabel(sortOption);
+    select.appendChild(option);
+  });
+
+  select.addEventListener('change', (event) => {
+    sort.sortBy(JSON.parse((event.target as HTMLSelectElement).value));
+  });
+
+  sortEl.append(label, select);
+}
+
+function appendFacetActions(
+  container: HTMLElement,
+  canShowLessValues: boolean,
+  canShowMoreValues: boolean,
+  showLessValues: () => void,
+  showMoreValues: () => void,
+  deselectAll?: () => void,
+  hasActiveValues?: boolean
+) {
+  const actions = document.createElement('div');
+  actions.className = 'facet-actions';
+
+  if (deselectAll && hasActiveValues) {
+    const clear = document.createElement('button');
+    clear.type = 'button';
+    clear.textContent = 'Clear';
+    clear.addEventListener('click', () => deselectAll());
+    actions.appendChild(clear);
+  }
+
+  if (canShowLessValues) {
+    const less = document.createElement('button');
+    less.type = 'button';
+    less.textContent = 'Show less';
+    less.addEventListener('click', () => showLessValues());
+    actions.appendChild(less);
+  }
+
+  if (canShowMoreValues) {
+    const more = document.createElement('button');
+    more.type = 'button';
+    more.textContent = 'Show more';
+    more.addEventListener('click', () => showMoreValues());
+    actions.appendChild(more);
+  }
+
+  if (actions.children.length) {
+    container.appendChild(actions);
+  }
+}
+
+function renderRegularFacet(container: HTMLElement, facet: RegularFacet) {
+  facet.state.values.forEach((value) => {
+    const label = document.createElement('label');
+    label.className = 'facet-value';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = value.state !== 'idle';
+    checkbox.addEventListener('change', () => facet.toggleSelect(value));
+
+    const text = document.createElement('span');
+    text.textContent = `${value.value} (${value.numberOfResults})`;
+
+    label.append(checkbox, text);
+    container.appendChild(label);
+  });
+
+  appendFacetActions(
+    container,
+    facet.state.canShowLessValues,
+    facet.state.canShowMoreValues,
+    facet.showLessValues,
+    facet.showMoreValues,
+    facet.deselectAll,
+    facet.state.hasActiveValues
+  );
+}
+
+function renderNumericFacet(container: HTMLElement, facet: NumericFacet) {
+  facet.state.values.forEach((value) => {
+    const label = document.createElement('label');
+    label.className = 'facet-value';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = value.state !== 'idle';
+    checkbox.addEventListener('change', () => facet.toggleSelect(value));
+
+    const text = document.createElement('span');
+    text.textContent = `${value.start} - ${value.end} (${value.numberOfResults})`;
+
+    label.append(checkbox, text);
+    container.appendChild(label);
+  });
+
+  appendFacetActions(
+    container,
+    facet.state.canShowLessValues,
+    facet.state.canShowMoreValues,
+    facet.showLessValues,
+    facet.showMoreValues,
+    facet.deselectAll,
+    facet.state.hasActiveValues
+  );
+}
+
+function renderDateFacet(container: HTMLElement, facet: DateFacet) {
+  facet.state.values.forEach((value) => {
+    const label = document.createElement('label');
+    label.className = 'facet-value';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = value.state !== 'idle';
+    checkbox.addEventListener('change', () => facet.toggleSelect(value));
+
+    const text = document.createElement('span');
+    text.textContent = `${value.start} - ${value.end} (${value.numberOfResults})`;
+
+    label.append(checkbox, text);
+    container.appendChild(label);
+  });
+
+  appendFacetActions(
+    container,
+    facet.state.canShowLessValues,
+    facet.state.canShowMoreValues,
+    facet.showLessValues,
+    facet.showMoreValues,
+    facet.deselectAll,
+    facet.state.hasActiveValues
+  );
+}
+
+function renderCategoryFacet(container: HTMLElement, facet: CategoryFacet) {
+  const values = facet.state.hasActiveValues
+    ? [
+        ...(facet.state.selectedValueAncestry ?? []),
+        ...((facet.state.selectedValueAncestry?.at(-1)?.children ?? []).filter(
+          (value) => !facet.isValueSelected(value)
+        )),
+      ]
+    : facet.state.values;
+
+  values.forEach((value) => {
+    const label = document.createElement('label');
+    label.className = 'facet-value';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = facet.isValueSelected(value);
+    checkbox.addEventListener('change', () => {
+      if (facet.isValueSelected(value)) {
+        facet.deselectAll();
+        return;
+      }
+      facet.toggleSelect(value);
+    });
+
+    const text = document.createElement('span');
+    text.textContent = `${value.value} (${value.numberOfResults})`;
+
+    label.append(checkbox, text);
+    container.appendChild(label);
+  });
+
+  appendFacetActions(
+    container,
+    facet.state.canShowLessValues,
+    facet.state.canShowMoreValues,
+    facet.showLessValues,
+    facet.showMoreValues,
+    facet.deselectAll,
+    facet.state.hasActiveValues
+  );
+}
+
+export function renderFacets(facetsEl: HTMLElement, facetGenerator: FacetGenerator) {
+  facetsEl.innerHTML = '';
+
+  facetGenerator.facets.forEach((facet) => {
+    const container = document.createElement('section');
+    container.className = 'facet';
+
+    const title = document.createElement('h3');
+    title.textContent = facet.state.displayName || facet.state.facetId;
+    container.appendChild(title);
+
+    const values = document.createElement('div');
+    values.className = 'facet-values';
+    container.appendChild(values);
+
+    switch (facet.type) {
+      case 'regular':
+        renderRegularFacet(values, facet);
+        break;
+      case 'numericalRange':
+        renderNumericFacet(values, facet);
+        break;
+      case 'dateRange':
+        renderDateFacet(values, facet);
+        break;
+      case 'hierarchical':
+        renderCategoryFacet(values, facet);
+        break;
+      default:
+        return;
+    }
+
+    facetsEl.appendChild(container);
+  });
+}
+
+export function renderSummary(
+  querySummaryEl: HTMLElement,
+  summary: Summary,
+  emptyText = 'No products found'
+) {
+  const state = summary.state as SearchSummaryState | Summary['state'];
+
+  if (state.isLoading && !state.firstRequestExecuted) {
+    querySummaryEl.textContent = 'Loading products...';
+    return;
+  }
+
+  if (!state.hasProducts) {
+    querySummaryEl.textContent = emptyText;
+    return;
+  }
+
+  querySummaryEl.textContent = `Products ${state.firstProduct}-${state.lastProduct} of ${state.totalNumberOfProducts}${'query' in state && state.query ? ` for "${state.query}"` : ''}`;
+}
+
+export function renderPager(pagerEl: HTMLElement, pager: Pagination) {
+  pagerEl.innerHTML = '';
+
+  if (pager.state.totalPages <= 1) {
+    return;
+  }
+
+  const {page, totalPages} = pager.state;
+
+  const previous = document.createElement('button');
+  previous.textContent = '← Previous';
+  previous.disabled = page === 0;
+  previous.addEventListener('click', () => pager.previousPage());
+  pagerEl.appendChild(previous);
+
+  const minDisplayed = Math.max(0, page - 2);
+  const maxDisplayed = Math.min(totalPages - 1, page + 2);
+  for (let i = minDisplayed; i <= maxDisplayed; i++) {
+    const button = document.createElement('button');
+    button.textContent = String(i + 1);
+    button.className = i === page ? 'active' : '';
+    button.addEventListener('click', () => pager.selectPage(i));
+    pagerEl.appendChild(button);
+  }
+
+  const next = document.createElement('button');
+  next.textContent = 'Next →';
+  next.disabled = page >= totalPages - 1;
+  next.addEventListener('click', () => pager.nextPage());
+  pagerEl.appendChild(next);
+}

--- a/samples/headless/commerce/src/render-utils.ts
+++ b/samples/headless/commerce/src/render-utils.ts
@@ -233,9 +233,9 @@ function renderCategoryFacet(container: HTMLElement, facet: CategoryFacet) {
   const values = facet.state.hasActiveValues
     ? [
         ...(facet.state.selectedValueAncestry ?? []),
-        ...((facet.state.selectedValueAncestry?.at(-1)?.children ?? []).filter(
+        ...(facet.state.selectedValueAncestry?.at(-1)?.children ?? []).filter(
           (value) => !facet.isValueSelected(value)
-        )),
+        ),
       ]
     : facet.state.values;
 
@@ -272,7 +272,10 @@ function renderCategoryFacet(container: HTMLElement, facet: CategoryFacet) {
   );
 }
 
-export function renderFacets(facetsEl: HTMLElement, facetGenerator: FacetGenerator) {
+export function renderFacets(
+  facetsEl: HTMLElement,
+  facetGenerator: FacetGenerator
+) {
   facetsEl.innerHTML = '';
 
   facetGenerator.facets.forEach((facet) => {

--- a/samples/headless/commerce/src/search.ts
+++ b/samples/headless/commerce/src/search.ts
@@ -1,0 +1,60 @@
+import {buildSearch, buildSearchBox} from '@coveo/headless/commerce';
+import {createSearchEngine} from './engine.js';
+import {
+  renderFacets,
+  renderPager,
+  renderProductList,
+  renderSort,
+  renderSummary,
+} from './render-utils.js';
+
+const engine = createSearchEngine();
+const search = buildSearch(engine);
+const searchBox = buildSearchBox(engine);
+const summary = search.summary();
+const pager = search.pagination({options: {pageSize: 9}});
+const facetGenerator = search.facetGenerator();
+const sort = search.sort();
+
+const searchBoxEl = document.getElementById('search-box')!;
+const querySummaryEl = document.getElementById('query-summary')!;
+const sortEl = document.getElementById('sort')!;
+const facetsEl = document.getElementById('facets')!;
+const productListEl = document.getElementById('product-list')!;
+const pagerEl = document.getElementById('pager')!;
+
+function renderSearchBox() {
+  searchBoxEl.innerHTML = '';
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.placeholder = 'Search products...';
+  input.value = searchBox.state.value;
+  input.addEventListener('input', (event) => {
+    searchBox.updateText((event.target as HTMLInputElement).value);
+  });
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      searchBox.submit();
+    }
+  });
+  searchBoxEl.appendChild(input);
+}
+
+function renderSearchPage() {
+  renderSummary(querySummaryEl, summary);
+  renderSort(sortEl, sort);
+  renderFacets(facetsEl, facetGenerator);
+  renderProductList(productListEl, search.state.products);
+  renderPager(pagerEl, pager);
+}
+
+searchBox.subscribe(renderSearchBox);
+search.subscribe(renderSearchPage);
+summary.subscribe(renderSearchPage);
+sort.subscribe(renderSearchPage);
+facetGenerator.subscribe(renderSearchPage);
+pager.subscribe(renderSearchPage);
+
+renderSearchBox();
+renderSearchPage();
+search.executeFirstSearch();

--- a/samples/headless/commerce/src/styles.css
+++ b/samples/headless/commerce/src/styles.css
@@ -1,0 +1,37 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; }
+nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
+nav a { color: #1a73e8; text-decoration: none; }
+nav a:hover { text-decoration: underline; }
+#app { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+h1 { margin-bottom: 1rem; font-size: 1.5rem; }
+#search-box { margin-bottom: 1rem; }
+#search-box input { width: 100%; padding: 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; }
+#main { display: grid; grid-template-columns: 250px 1fr; gap: 2rem; }
+#facets { border-right: 1px solid #eee; padding-right: 1rem; }
+.facet { margin-bottom: 1.5rem; }
+.facet h3 { font-size: 0.875rem; margin-bottom: 0.5rem; text-transform: uppercase; color: #666; }
+.facet-values { display: grid; gap: 0.25rem; }
+.facet-value { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer; font-size: 0.875rem; }
+.facet-value input { cursor: pointer; }
+.facet-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+.facet-actions button { padding: 0.25rem 0.5rem; font-size: 0.75rem; }
+#query-summary { font-size: 0.875rem; color: #666; margin-bottom: 0.5rem; }
+#sort { margin-bottom: 1rem; }
+#sort select { padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
+.product-item { display: grid; grid-template-columns: 100px 1fr; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid #eee; }
+.product-item img { width: 100px; height: 100px; object-fit: contain; }
+.product-info h3 { margin-bottom: 0.25rem; }
+.product-info h3 a { color: #1a73e8; text-decoration: none; }
+.product-info h3 a:hover { text-decoration: underline; }
+.product-info .price { font-weight: bold; color: #1a73e8; margin-top: 0.25rem; }
+.product-info .brand, .product-info .category { font-size: 0.875rem; color: #666; }
+.empty-state { padding: 2rem 0; color: #666; }
+#pager { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: center; flex-wrap: wrap; }
+#pager button { padding: 0.5rem 1rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: white; }
+#pager button.active { background: #1a73e8; color: white; border-color: #1a73e8; }
+#pager button:disabled { opacity: 0.5; cursor: not-allowed; }
+@media (max-width: 768px) {
+  #main { grid-template-columns: 1fr; }
+  #facets { border-right: 0; border-bottom: 1px solid #eee; padding-right: 0; padding-bottom: 1rem; }
+}

--- a/samples/headless/commerce/src/styles.css
+++ b/samples/headless/commerce/src/styles.css
@@ -1,37 +1,167 @@
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; }
-nav { padding: 0.75rem 1rem; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 0.875rem; }
-nav a { color: #1a73e8; text-decoration: none; }
-nav a:hover { text-decoration: underline; }
-#app { max-width: 1200px; margin: 0 auto; padding: 1rem; }
-h1 { margin-bottom: 1rem; font-size: 1.5rem; }
-#search-box { margin-bottom: 1rem; }
-#search-box input { width: 100%; padding: 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; }
-#main { display: grid; grid-template-columns: 250px 1fr; gap: 2rem; }
-#facets { border-right: 1px solid #eee; padding-right: 1rem; }
-.facet { margin-bottom: 1.5rem; }
-.facet h3 { font-size: 0.875rem; margin-bottom: 0.5rem; text-transform: uppercase; color: #666; }
-.facet-values { display: grid; gap: 0.25rem; }
-.facet-value { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer; font-size: 0.875rem; }
-.facet-value input { cursor: pointer; }
-.facet-actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
-.facet-actions button { padding: 0.25rem 0.5rem; font-size: 0.75rem; }
-#query-summary { font-size: 0.875rem; color: #666; margin-bottom: 0.5rem; }
-#sort { margin-bottom: 1rem; }
-#sort select { padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
-.product-item { display: grid; grid-template-columns: 100px 1fr; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid #eee; }
-.product-item img { width: 100px; height: 100px; object-fit: contain; }
-.product-info h3 { margin-bottom: 0.25rem; }
-.product-info h3 a { color: #1a73e8; text-decoration: none; }
-.product-info h3 a:hover { text-decoration: underline; }
-.product-info .price { font-weight: bold; color: #1a73e8; margin-top: 0.25rem; }
-.product-info .brand, .product-info .category { font-size: 0.875rem; color: #666; }
-.empty-state { padding: 2rem 0; color: #666; }
-#pager { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: center; flex-wrap: wrap; }
-#pager button { padding: 0.5rem 1rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: white; }
-#pager button.active { background: #1a73e8; color: white; border-color: #1a73e8; }
-#pager button:disabled { opacity: 0.5; cursor: not-allowed; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #333;
+}
+nav {
+  padding: 0.75rem 1rem;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+  font-size: 0.875rem;
+}
+nav a {
+  color: #1a73e8;
+  text-decoration: none;
+}
+nav a:hover {
+  text-decoration: underline;
+}
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+h1 {
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+#search-box {
+  margin-bottom: 1rem;
+}
+#search-box input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+#main {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 2rem;
+}
+#facets {
+  border-right: 1px solid #eee;
+  padding-right: 1rem;
+}
+.facet {
+  margin-bottom: 1.5rem;
+}
+.facet h3 {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  color: #666;
+}
+.facet-values {
+  display: grid;
+  gap: 0.25rem;
+}
+.facet-value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+.facet-value input {
+  cursor: pointer;
+}
+.facet-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.facet-actions button {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+#query-summary {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+#sort {
+  margin-bottom: 1rem;
+}
+#sort select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.product-item {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid #eee;
+}
+.product-item img {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+}
+.product-info h3 {
+  margin-bottom: 0.25rem;
+}
+.product-info h3 a {
+  color: #1a73e8;
+  text-decoration: none;
+}
+.product-info h3 a:hover {
+  text-decoration: underline;
+}
+.product-info .price {
+  font-weight: bold;
+  color: #1a73e8;
+  margin-top: 0.25rem;
+}
+.product-info .brand,
+.product-info .category {
+  font-size: 0.875rem;
+  color: #666;
+}
+.empty-state {
+  padding: 2rem 0;
+  color: #666;
+}
+#pager {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+#pager button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  background: white;
+}
+#pager button.active {
+  background: #1a73e8;
+  color: white;
+  border-color: #1a73e8;
+}
+#pager button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 @media (max-width: 768px) {
-  #main { grid-template-columns: 1fr; }
-  #facets { border-right: 0; border-bottom: 1px solid #eee; padding-right: 0; padding-bottom: 1rem; }
+  #main {
+    grid-template-columns: 1fr;
+  }
+  #facets {
+    border-right: 0;
+    border-bottom: 1px solid #eee;
+    padding-right: 0;
+    padding-bottom: 1rem;
+  }
 }

--- a/samples/headless/commerce/tests/smoke.spec.ts
+++ b/samples/headless/commerce/tests/smoke.spec.ts
@@ -1,0 +1,30 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Headless Commerce Sample', () => {
+  test('search page loads and displays products', async ({page}) => {
+    await page.goto('http://localhost:3003/search.html');
+
+    const querySummary = page.locator('#query-summary');
+    await expect(querySummary).not.toBeEmpty({timeout: 10000});
+
+    const products = page.locator('.product-item');
+    await expect(products.first()).toBeVisible();
+
+    const searchInput = page.locator('#search-box input');
+    await searchInput.fill('shoes');
+    await searchInput.press('Enter');
+
+    await expect(querySummary).toContainText('for "shoes"');
+    await expect(products.first()).toBeVisible();
+  });
+
+  test('listing page loads and displays products', async ({page}) => {
+    await page.goto('http://localhost:3003/listing.html');
+
+    const querySummary = page.locator('#query-summary');
+    await expect(querySummary).not.toBeEmpty({timeout: 10000});
+
+    const products = page.locator('.product-item');
+    await expect(products.first()).toBeVisible();
+  });
+});

--- a/samples/headless/commerce/tsconfig.json
+++ b/samples/headless/commerce/tsconfig.json
@@ -8,7 +8,9 @@
     "moduleResolution": "Node16",
     "noEmit": true,
     "paths": {
-      "@coveo/headless/commerce": ["../../../packages/headless/src/commerce.index.ts"],
+      "@coveo/headless/commerce": [
+        "../../../packages/headless/src/commerce.index.ts"
+      ],
       "@coveo/bueno": ["../../../packages/bueno/src/index.ts"]
     },
     "resolveJsonModule": true,

--- a/samples/headless/commerce/tsconfig.json
+++ b/samples/headless/commerce/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "noEmit": true,
+    "paths": {
+      "@coveo/headless/commerce": ["../../../packages/headless/src/commerce.index.ts"],
+      "@coveo/bueno": ["../../../packages/bueno/src/index.ts"]
+    },
+    "resolveJsonModule": true,
+    "strict": true,
+    "types": ["vite/client", "node", "@playwright/test"]
+  },
+  "include": ["src", "tests", "playwright.config.ts", "vite.config.ts"]
+}

--- a/samples/headless/commerce/vite.config.ts
+++ b/samples/headless/commerce/vite.config.ts
@@ -1,0 +1,18 @@
+import {resolve} from 'node:path';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  appType: 'mpa',
+  server: {
+    port: 3003,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        search: resolve(__dirname, 'search.html'),
+        listing: resolve(__dirname, 'listing.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
[KIT-5681](https://coveord.atlassian.net/browse/KIT-5681)

## Problem
We need a Headless Commerce vanilla sample that demonstrates using Headless Commerce controllers directly with plain HTML/JS.

## Solution
Create a new Vite + Headless Commerce sample from scratch with product listing, search, and recommendations using `searchuisamples` credentials.

[KIT-5681]: https://coveord.atlassian.net/browse/KIT-5681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ