### PR TITLE
feat(samples): create atomic-search-react sample (KIT-5686)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1142,6 +1142,43 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  samples/atomic/search-react:
+    dependencies:
+      '@coveo/atomic-react':
+        specifier: workspace:*
+        version: link:../../../packages/atomic-react
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/atomic/search-vuejs:
     dependencies:
       '@coveo/atomic':

--- a/samples/atomic/search-react/.gitignore
+++ b/samples/atomic/search-react/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+public/assets
+public/lang
+public/themes

--- a/samples/atomic/search-react/index.html
+++ b/samples/atomic/search-react/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="themes/coveo.css" />
+    <title>Atomic Search React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/atomic/search-react/package.json
+++ b/samples/atomic/search-react/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@samples/atomic-search-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-react/dist/assets public/assets ../../../packages/atomic-react/dist/lang public/lang ../../../packages/atomic/dist/themes public/themes",
+    "dev": "pnpm build:assets && pnpm dev:vite",
+    "dev:vite": "vite",
+    "build": "pnpm build:ts && pnpm build:vite",
+    "build:ts": "tsc -b",
+    "build:vite": "vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/atomic-react": "workspace:*",
+    "@coveo/headless": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/atomic/search-react/playwright.config.ts
+++ b/samples/atomic/search-react/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3004',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/atomic/search-react/src/App.css
+++ b/samples/atomic/search-react/src/App.css
@@ -1,0 +1,3 @@
+atomic-search-layout {
+  row-gap: var(--atomic-layout-spacing-y);
+}

--- a/samples/atomic/search-react/src/App.tsx
+++ b/samples/atomic/search-react/src/App.tsx
@@ -1,0 +1,7 @@
+import {SearchPage} from './pages/SearchPage';
+
+function App() {
+  return <SearchPage />;
+}
+
+export default App;

--- a/samples/atomic/search-react/src/main.tsx
+++ b/samples/atomic/search-react/src/main.tsx
@@ -1,0 +1,9 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './App.tsx';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/samples/atomic/search-react/src/pages/SearchPage.tsx
+++ b/samples/atomic/search-react/src/pages/SearchPage.tsx
@@ -1,0 +1,100 @@
+import {
+  AtomicBreadbox,
+  AtomicDidYouMean,
+  AtomicFacet,
+  AtomicFacetManager,
+  AtomicLayoutSection,
+  AtomicLoadMoreResults,
+  AtomicNoResults,
+  AtomicQueryError,
+  AtomicQuerySummary,
+  AtomicRefineToggle,
+  AtomicResultLink,
+  AtomicResultList,
+  AtomicResultSectionExcerpt,
+  AtomicResultSectionTitle,
+  AtomicResultText,
+  AtomicSearchBox,
+  AtomicSearchBoxQuerySuggestions,
+  AtomicSearchBoxRecentQueries,
+  AtomicSearchInterface,
+  AtomicSearchLayout,
+  AtomicSortDropdown,
+  AtomicSortExpression,
+} from '@coveo/atomic-react';
+import {
+  buildSearchEngine,
+  getSampleSearchEngineConfiguration,
+} from '@coveo/headless';
+import {useMemo} from 'react';
+import '../App.css';
+
+export const SearchPage = () => {
+  const engine = useMemo(
+    () =>
+      buildSearchEngine({
+        configuration: getSampleSearchEngineConfiguration(),
+      }),
+    []
+  );
+
+  return (
+    <AtomicSearchInterface engine={engine}>
+      <AtomicSearchLayout>
+        <AtomicLayoutSection section="search">
+          <AtomicSearchBox>
+            <AtomicSearchBoxQuerySuggestions />
+            <AtomicSearchBoxRecentQueries />
+          </AtomicSearchBox>
+        </AtomicLayoutSection>
+        <AtomicLayoutSection section="facets">
+          <AtomicFacetManager>
+            <AtomicFacet field="source" label="Source" />
+            <AtomicFacet field="objecttype" label="Type" />
+            <AtomicFacet field="author" label="Author" />
+          </AtomicFacetManager>
+        </AtomicLayoutSection>
+        <AtomicLayoutSection section="main">
+          <AtomicLayoutSection section="status">
+            <AtomicBreadbox />
+            <AtomicQuerySummary />
+            <AtomicRefineToggle />
+            <AtomicSortDropdown>
+              <AtomicSortExpression label="Relevance" expression="relevancy" />
+              <AtomicSortExpression
+                label="Date (newest)"
+                expression="date descending"
+              />
+              <AtomicSortExpression
+                label="Date (oldest)"
+                expression="date ascending"
+              />
+            </AtomicSortDropdown>
+            <AtomicDidYouMean />
+          </AtomicLayoutSection>
+          <AtomicLayoutSection section="results">
+            <AtomicResultList template={ResultTemplate} />
+            <AtomicQueryError />
+            <AtomicNoResults />
+          </AtomicLayoutSection>
+          <AtomicLayoutSection section="pagination">
+            <AtomicLoadMoreResults />
+          </AtomicLayoutSection>
+        </AtomicLayoutSection>
+      </AtomicSearchLayout>
+    </AtomicSearchInterface>
+  );
+};
+
+function ResultTemplate() {
+  return (
+    <>
+      <AtomicResultSectionTitle>
+        <AtomicResultLink />
+      </AtomicResultSectionTitle>
+      <AtomicResultSectionExcerpt>
+        <AtomicResultText field="excerpt" />
+      </AtomicResultSectionExcerpt>
+    </>
+  );
+}

--- a/samples/atomic/search-react/src/vite-env.d.ts
+++ b/samples/atomic/search-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/samples/atomic/search-react/tests/smoke.spec.ts
+++ b/samples/atomic/search-react/tests/smoke.spec.ts
@@ -1,0 +1,46 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Atomic Search React Sample', () => {
+  test('loads and performs a search', async ({page}) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('http://localhost:3004');
+
+    const searchBox = page.locator('atomic-search-box');
+    await expect(searchBox).toBeVisible();
+
+    const querySummary = page.locator('atomic-query-summary');
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
+    const textarea = searchBox.locator('textarea[part="textarea"]');
+    await textarea.fill('test');
+    await textarea.press('Enter');
+
+    const facet = page.locator('atomic-facet').first();
+    await expect(facet).toBeVisible();
+
+    await expect(querySummary).toBeVisible();
+
+    const summaryContainer = querySummary.locator('div[part="container"]');
+    await expect
+      .poll(
+        async () => {
+          const text = await summaryContainer.textContent();
+          return text ?? '';
+        },
+        {timeout: 5000}
+      )
+      .toMatch(/Results 1-[1-9].*for test/);
+
+    const filteredErrors = consoleErrors.filter(
+      (error) => !error.includes('MissingInterfaceParentError')
+    );
+    expect(filteredErrors).toEqual([]);
+  });
+});

--- a/samples/atomic/search-react/tsconfig.app.json
+++ b/samples/atomic/search-react/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/samples/atomic/search-react/tsconfig.json
+++ b/samples/atomic/search-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/samples/atomic/search-react/tsconfig.node.json
+++ b/samples/atomic/search-react/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/samples/atomic/search-react/vite.config.ts
+++ b/samples/atomic/search-react/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3004,
+  },
+});


### PR DESCRIPTION
[KIT-5686](https://coveord.atlassian.net/browse/KIT-5686)

## Problem
We need a dedicated Atomic Search + React sample, currently search and commerce are combined in one sample.

## Solution
Split the search portion from `samples/atomic/search-commerce-react` into a standalone React + Atomic Search project with search components wrapped in React.

[KIT-5686]: https://coveord.atlassian.net/browse/KIT-5686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ