### PR TITLE
feat(samples): create headless-search vanilla sample (KIT-5679)

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -80,6 +80,10 @@ export default {
     },
     'samples/headless-ssr/commerce-nextjs': {},
     'samples/headless-ssr/commerce-nextjs-v4': {},
+    'samples/headless/search': {
+      // Vanilla HTML sample - entry point is in HTML <script> tag, not traceable by knip.
+      ignore: ['**/*'],
+    },
     'utils/ci': {},
     'utils/cdn': {
       ignoreDependencies: ['local-web-server'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,6 +1447,19 @@ importers:
         specifier: 'catalog:'
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
 
+  samples/headless/search:
+    dependencies:
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/headless/search-react:
     dependencies:
       '@coveo/auth':

--- a/samples/headless/search/.gitignore
+++ b/samples/headless/search/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+playwright-report
+test-results
+.turbo

--- a/samples/headless/search/index.html
+++ b/samples/headless/search/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Headless Search Sample</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <h1>Coveo Headless Search</h1>
+      <div id="search-box"></div>
+      <div id="main">
+        <aside id="facets"></aside>
+        <section id="results-section">
+          <div id="query-summary"></div>
+          <div id="sort"></div>
+          <div id="result-list"></div>
+          <div id="pager"></div>
+        </section>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/samples/headless/search/package.json
+++ b/samples/headless/search/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@samples/headless-search",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/headless": "workspace:*"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/headless/search/playwright.config.ts
+++ b/samples/headless/search/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3002',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/headless/search/src/main.ts
+++ b/samples/headless/search/src/main.ts
@@ -95,12 +95,19 @@ sort.subscribe(renderSort);
 renderSort();
 
 // Facets
-const objectTypeFacet = buildFacet(engine, {options: {field: 'objecttype', facetId: 'objecttype'}});
-const authorFacet = buildFacet(engine, {options: {field: 'author', facetId: 'author'}});
+const objectTypeFacet = buildFacet(engine, {
+  options: {field: 'objecttype', facetId: 'objecttype'},
+});
+const authorFacet = buildFacet(engine, {
+  options: {field: 'author', facetId: 'author'},
+});
 
 const facetsEl = document.getElementById('facets')!;
 
-function renderFacet(facet: ReturnType<typeof buildFacet>, label: string): HTMLElement {
+function renderFacet(
+  facet: ReturnType<typeof buildFacet>,
+  label: string
+): HTMLElement {
   const container = document.createElement('div');
   container.className = 'facet';
   const h3 = document.createElement('h3');

--- a/samples/headless/search/src/main.ts
+++ b/samples/headless/search/src/main.ts
@@ -1,0 +1,194 @@
+import {
+  buildSearchEngine,
+  buildSearchBox,
+  buildResultList,
+  buildPager,
+  buildQuerySummary,
+  buildFacet,
+  buildSort,
+  buildRelevanceSortCriterion,
+  buildDateSortCriterion,
+  SortOrder,
+  type SearchEngine,
+  type Result,
+} from '@coveo/headless';
+
+const engine: SearchEngine = buildSearchEngine({
+  configuration: {
+    accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+    organizationId: 'searchuisamples',
+  },
+});
+
+// Search Box
+const searchBox = buildSearchBox(engine);
+const searchBoxEl = document.getElementById('search-box')!;
+
+function renderSearchBox() {
+  searchBoxEl.innerHTML = '';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'Search...';
+  input.value = searchBox.state.value;
+  input.addEventListener('input', (e) => {
+    searchBox.updateText((e.target as HTMLInputElement).value);
+  });
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      searchBox.submit();
+    }
+  });
+  searchBoxEl.appendChild(input);
+}
+
+searchBox.subscribe(renderSearchBox);
+renderSearchBox();
+
+// Query Summary
+const querySummary = buildQuerySummary(engine);
+const querySummaryEl = document.getElementById('query-summary')!;
+
+function renderQuerySummary() {
+  const state = querySummary.state;
+  if (!state.hasResults) {
+    querySummaryEl.textContent = state.hasError ? '' : 'No results';
+    return;
+  }
+  querySummaryEl.textContent = `Results ${state.firstResult}-${state.lastResult} of ${state.total}${state.hasQuery ? ` for "${state.query}"` : ''}`;
+}
+
+querySummary.subscribe(renderQuerySummary);
+renderQuerySummary();
+
+// Sort
+const relevance = buildRelevanceSortCriterion();
+const dateDescending = buildDateSortCriterion(SortOrder.Descending);
+const dateAscending = buildDateSortCriterion(SortOrder.Ascending);
+
+const criteria = [
+  {label: 'Relevance', criterion: relevance},
+  {label: 'Date (newest)', criterion: dateDescending},
+  {label: 'Date (oldest)', criterion: dateAscending},
+];
+
+const sort = buildSort(engine, {initialState: {criterion: relevance}});
+const sortEl = document.getElementById('sort')!;
+
+function renderSort() {
+  sortEl.innerHTML = '';
+  const select = document.createElement('select');
+  criteria.forEach(({label, criterion}, i) => {
+    const option = document.createElement('option');
+    option.value = String(i);
+    option.textContent = label;
+    option.selected = sort.isSortedBy(criterion);
+    select.appendChild(option);
+  });
+  select.addEventListener('change', (e) => {
+    const idx = Number((e.target as HTMLSelectElement).value);
+    sort.sortBy(criteria[idx].criterion);
+  });
+  sortEl.appendChild(select);
+}
+
+sort.subscribe(renderSort);
+renderSort();
+
+// Facets
+const objectTypeFacet = buildFacet(engine, {options: {field: 'objecttype', facetId: 'objecttype'}});
+const authorFacet = buildFacet(engine, {options: {field: 'author', facetId: 'author'}});
+
+const facetsEl = document.getElementById('facets')!;
+
+function renderFacet(facet: ReturnType<typeof buildFacet>, label: string): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'facet';
+  const h3 = document.createElement('h3');
+  h3.textContent = label;
+  container.appendChild(h3);
+
+  const state = facet.state;
+  state.values.forEach((value) => {
+    const div = document.createElement('div');
+    div.className = 'facet-value';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = value.state === 'selected';
+    checkbox.addEventListener('change', () => facet.toggleSelect(value));
+    const text = document.createElement('span');
+    text.textContent = `${value.value} (${value.numberOfResults})`;
+    div.appendChild(checkbox);
+    div.appendChild(text);
+    container.appendChild(div);
+  });
+
+  return container;
+}
+
+function renderFacets() {
+  facetsEl.innerHTML = '';
+  facetsEl.appendChild(renderFacet(objectTypeFacet, 'Type'));
+  facetsEl.appendChild(renderFacet(authorFacet, 'Author'));
+}
+
+objectTypeFacet.subscribe(renderFacets);
+authorFacet.subscribe(renderFacets);
+
+// Result List
+const resultList = buildResultList(engine);
+const resultListEl = document.getElementById('result-list')!;
+
+function renderResult(result: Result): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'result-item';
+  item.innerHTML = `
+    <h3><a href="${result.clickUri}" target="_blank">${result.title}</a></h3>
+    <p>${result.excerpt || ''}</p>
+  `;
+  return item;
+}
+
+function renderResultList() {
+  resultListEl.innerHTML = '';
+  resultList.state.results.forEach((result) => {
+    resultListEl.appendChild(renderResult(result));
+  });
+}
+
+resultList.subscribe(renderResultList);
+
+// Pager
+const pager = buildPager(engine);
+const pagerEl = document.getElementById('pager')!;
+
+function renderPager() {
+  pagerEl.innerHTML = '';
+  const state = pager.state;
+
+  if (state.hasPreviousPage) {
+    const prev = document.createElement('button');
+    prev.textContent = '← Previous';
+    prev.addEventListener('click', () => pager.previousPage());
+    pagerEl.appendChild(prev);
+  }
+
+  state.currentPages.forEach((pageNum) => {
+    const btn = document.createElement('button');
+    btn.textContent = String(pageNum);
+    btn.className = pageNum === state.currentPage ? 'active' : '';
+    btn.addEventListener('click', () => pager.selectPage(pageNum));
+    pagerEl.appendChild(btn);
+  });
+
+  if (state.hasNextPage) {
+    const next = document.createElement('button');
+    next.textContent = 'Next →';
+    next.addEventListener('click', () => pager.nextPage());
+    pagerEl.appendChild(next);
+  }
+}
+
+pager.subscribe(renderPager);
+
+// Execute first search
+engine.executeFirstSearch();

--- a/samples/headless/search/src/styles.css
+++ b/samples/headless/search/src/styles.css
@@ -1,0 +1,24 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; }
+#app { max-width: 1200px; margin: 0 auto; padding: 1rem; }
+h1 { margin-bottom: 1rem; font-size: 1.5rem; }
+#search-box { margin-bottom: 1rem; }
+#search-box input { width: 100%; padding: 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; }
+#main { display: grid; grid-template-columns: 250px 1fr; gap: 2rem; }
+#facets { border-right: 1px solid #eee; padding-right: 1rem; }
+.facet { margin-bottom: 1.5rem; }
+.facet h3 { font-size: 0.875rem; margin-bottom: 0.5rem; text-transform: uppercase; color: #666; }
+.facet-value { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer; font-size: 0.875rem; }
+.facet-value input { cursor: pointer; }
+#query-summary { font-size: 0.875rem; color: #666; margin-bottom: 0.5rem; }
+#sort { margin-bottom: 1rem; }
+#sort select { padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
+.result-item { padding: 1rem 0; border-bottom: 1px solid #eee; }
+.result-item h3 { margin-bottom: 0.25rem; }
+.result-item h3 a { color: #1a73e8; text-decoration: none; }
+.result-item h3 a:hover { text-decoration: underline; }
+.result-item p { font-size: 0.875rem; color: #555; line-height: 1.4; }
+#pager { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: center; }
+#pager button { padding: 0.5rem 1rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: white; }
+#pager button.active { background: #1a73e8; color: white; border-color: #1a73e8; }
+#pager button:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/samples/headless/search/src/styles.css
+++ b/samples/headless/search/src/styles.css
@@ -1,24 +1,112 @@
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #333; }
-#app { max-width: 1200px; margin: 0 auto; padding: 1rem; }
-h1 { margin-bottom: 1rem; font-size: 1.5rem; }
-#search-box { margin-bottom: 1rem; }
-#search-box input { width: 100%; padding: 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; }
-#main { display: grid; grid-template-columns: 250px 1fr; gap: 2rem; }
-#facets { border-right: 1px solid #eee; padding-right: 1rem; }
-.facet { margin-bottom: 1.5rem; }
-.facet h3 { font-size: 0.875rem; margin-bottom: 0.5rem; text-transform: uppercase; color: #666; }
-.facet-value { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; cursor: pointer; font-size: 0.875rem; }
-.facet-value input { cursor: pointer; }
-#query-summary { font-size: 0.875rem; color: #666; margin-bottom: 0.5rem; }
-#sort { margin-bottom: 1rem; }
-#sort select { padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
-.result-item { padding: 1rem 0; border-bottom: 1px solid #eee; }
-.result-item h3 { margin-bottom: 0.25rem; }
-.result-item h3 a { color: #1a73e8; text-decoration: none; }
-.result-item h3 a:hover { text-decoration: underline; }
-.result-item p { font-size: 0.875rem; color: #555; line-height: 1.4; }
-#pager { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: center; }
-#pager button { padding: 0.5rem 1rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: white; }
-#pager button.active { background: #1a73e8; color: white; border-color: #1a73e8; }
-#pager button:disabled { opacity: 0.5; cursor: not-allowed; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #333;
+}
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+h1 {
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+#search-box {
+  margin-bottom: 1rem;
+}
+#search-box input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+#main {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  gap: 2rem;
+}
+#facets {
+  border-right: 1px solid #eee;
+  padding-right: 1rem;
+}
+.facet {
+  margin-bottom: 1.5rem;
+}
+.facet h3 {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  color: #666;
+}
+.facet-value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+.facet-value input {
+  cursor: pointer;
+}
+#query-summary {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+#sort {
+  margin-bottom: 1rem;
+}
+#sort select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.result-item {
+  padding: 1rem 0;
+  border-bottom: 1px solid #eee;
+}
+.result-item h3 {
+  margin-bottom: 0.25rem;
+}
+.result-item h3 a {
+  color: #1a73e8;
+  text-decoration: none;
+}
+.result-item h3 a:hover {
+  text-decoration: underline;
+}
+.result-item p {
+  font-size: 0.875rem;
+  color: #555;
+  line-height: 1.4;
+}
+#pager {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  justify-content: center;
+}
+#pager button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  background: white;
+}
+#pager button.active {
+  background: #1a73e8;
+  color: white;
+  border-color: #1a73e8;
+}
+#pager button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/samples/headless/search/tests/smoke.spec.ts
+++ b/samples/headless/search/tests/smoke.spec.ts
@@ -1,0 +1,32 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Headless Search Sample', () => {
+  test('loads and displays search results', async ({page}) => {
+    await page.goto('http://localhost:3002');
+
+    // Wait for results to load
+    const querySummary = page.locator('#query-summary');
+    await expect(querySummary).not.toBeEmpty();
+
+    // Verify results appear
+    const results = page.locator('.result-item');
+    await expect(results.first()).toBeVisible();
+
+    // Perform a search
+    const searchInput = page.locator('#search-box input');
+    await searchInput.fill('test');
+    await searchInput.press('Enter');
+
+    // Wait for results to update
+    await expect(querySummary).toContainText('for "test"');
+    await expect(results.first()).toBeVisible();
+
+    // Verify facets are rendered
+    const facets = page.locator('.facet');
+    await expect(facets.first()).toBeVisible();
+
+    // Verify pager is rendered
+    const pager = page.locator('#pager button');
+    await expect(pager.first()).toBeVisible();
+  });
+});

--- a/samples/headless/search/vite.config.ts
+++ b/samples/headless/search/vite.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 3002,
+  },
+});


### PR DESCRIPTION
[KIT-5679](https://coveord.atlassian.net/browse/KIT-5679)

## Problem
We need a Headless Search vanilla sample that demonstrates using Headless controllers directly with plain HTML/JS.

## Solution
Create a new Vite + Headless Search sample from scratch with search box, result list, facets, and pager using `searchuisamples` credentials.

[KIT-5679]: https://coveord.atlassian.net/browse/KIT-5679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ