### PR TITLE
feat(samples): create atomic-search sample (KIT-5683)

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -80,6 +80,10 @@ export default {
     },
     'samples/headless-ssr/commerce-nextjs': {},
     'samples/headless-ssr/commerce-nextjs-v4': {},
+    'samples/atomic/search': {
+      // Vanilla HTML sample - deps are imported in inline <script> tags within HTML, not traceable by knip.
+      ignore: ['**/*'],
+    },
     'utils/ci': {},
     'utils/cdn': {
       ignoreDependencies: ['local-web-server'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,19 @@ importers:
         specifier: 'catalog:'
         version: 4.0.16(@types/node@24.12.2)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@20.0.3)(less@4.6.4)(lightningcss@1.32.0)(msw@2.13.4(@types/node@24.12.2)(typescript@6.0.3))(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
 
+  samples/atomic/search:
+    dependencies:
+      '@coveo/atomic':
+        specifier: workspace:*
+        version: link:../../../packages/atomic
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/atomic/search-commerce-angular:
     dependencies:
       '@angular/animations':

--- a/samples/atomic/search/.gitignore
+++ b/samples/atomic/search/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+public/lang
+public/assets
+playwright-report
+test-results

--- a/samples/atomic/search/index.html
+++ b/samples/atomic/search/index.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic Search Sample</title>
+    <script type="module">
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
+      defineCustomElements();
+    </script>
+    <script type="module">
+      await customElements.whenDefined('atomic-search-interface');
+      const searchInterface = document.querySelector('atomic-search-interface');
+
+      await searchInterface.initialize({
+        accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+        organizationId: 'searchuisamples',
+      });
+
+      searchInterface.executeFirstSearch();
+    </script>
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <atomic-search-interface>
+      <atomic-search-layout>
+        <atomic-layout-section section="search">
+          <atomic-search-box>
+            <atomic-search-box-recent-queries></atomic-search-box-recent-queries>
+            <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+          </atomic-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facet-manager>
+            <atomic-automatic-facet-generator desired-count="5"></atomic-automatic-facet-generator>
+            <atomic-facet field="objecttype" label="Type"></atomic-facet>
+            <atomic-facet field="filetype" label="File Type"></atomic-facet>
+            <atomic-facet field="author" label="Author"></atomic-facet>
+          </atomic-facet-manager>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-layout-section section="status">
+            <atomic-breadbox></atomic-breadbox>
+            <atomic-query-summary></atomic-query-summary>
+            <atomic-sort-dropdown>
+              <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>
+              <atomic-sort-expression label="Date (newest)" expression="date descending"></atomic-sort-expression>
+              <atomic-sort-expression label="Date (oldest)" expression="date ascending"></atomic-sort-expression>
+            </atomic-sort-dropdown>
+            <atomic-did-you-mean></atomic-did-you-mean>
+            <atomic-refine-toggle></atomic-refine-toggle>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <atomic-smart-snippet></atomic-smart-snippet>
+            <atomic-result-list>
+              <atomic-result-template>
+                <template>
+                  <atomic-result-section-title>
+                    <atomic-result-link></atomic-result-link>
+                  </atomic-result-section-title>
+                  <atomic-result-section-excerpt>
+                    <atomic-result-text field="excerpt"></atomic-result-text>
+                  </atomic-result-section-excerpt>
+                  <atomic-result-section-bottom-metadata>
+                    <atomic-result-fields-list>
+                      <atomic-field-condition if-defined="author">
+                        <atomic-result-text field="author"></atomic-result-text>
+                      </atomic-field-condition>
+                      <atomic-field-condition if-defined="source">
+                        <atomic-result-text field="source"></atomic-result-text>
+                      </atomic-field-condition>
+                    </atomic-result-fields-list>
+                  </atomic-result-section-bottom-metadata>
+                </template>
+              </atomic-result-template>
+            </atomic-result-list>
+            <atomic-query-error></atomic-query-error>
+            <atomic-no-results></atomic-no-results>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-pager></atomic-pager>
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-search-layout>
+    </atomic-search-interface>
+  </body>
+</html>

--- a/samples/atomic/search/index.html
+++ b/samples/atomic/search/index.html
@@ -38,7 +38,9 @@
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
-            <atomic-automatic-facet-generator desired-count="5"></atomic-automatic-facet-generator>
+            <atomic-automatic-facet-generator
+              desired-count="5"
+            ></atomic-automatic-facet-generator>
             <atomic-facet field="objecttype" label="Type"></atomic-facet>
             <atomic-facet field="filetype" label="File Type"></atomic-facet>
             <atomic-facet field="author" label="Author"></atomic-facet>
@@ -49,9 +51,18 @@
             <atomic-breadbox></atomic-breadbox>
             <atomic-query-summary></atomic-query-summary>
             <atomic-sort-dropdown>
-              <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>
-              <atomic-sort-expression label="Date (newest)" expression="date descending"></atomic-sort-expression>
-              <atomic-sort-expression label="Date (oldest)" expression="date ascending"></atomic-sort-expression>
+              <atomic-sort-expression
+                label="Relevance"
+                expression="relevancy"
+              ></atomic-sort-expression>
+              <atomic-sort-expression
+                label="Date (newest)"
+                expression="date descending"
+              ></atomic-sort-expression>
+              <atomic-sort-expression
+                label="Date (oldest)"
+                expression="date ascending"
+              ></atomic-sort-expression>
             </atomic-sort-dropdown>
             <atomic-did-you-mean></atomic-did-you-mean>
             <atomic-refine-toggle></atomic-refine-toggle>

--- a/samples/atomic/search/package.json
+++ b/samples/atomic/search/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@samples/atomic-search",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "copy-resources": "node ./scripts/copy-resources.mjs",
+    "dev": "pnpm copy-resources && vite",
+    "build": "pnpm copy-resources && vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/atomic": "workspace:*"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/atomic/search/playwright.config.ts
+++ b/samples/atomic/search/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/atomic/search/scripts/copy-resources.mjs
+++ b/samples/atomic/search/scripts/copy-resources.mjs
@@ -1,0 +1,24 @@
+import {cpSync, existsSync, mkdirSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const atomicPkg = resolve('./node_modules/@coveo/atomic');
+
+function findDir(name) {
+  const flat = resolve(atomicPkg, 'dist', name);
+  if (existsSync(flat)) return flat;
+  const nested = resolve(atomicPkg, 'dist', 'atomic', name);
+  if (existsSync(nested)) return nested;
+  return null;
+}
+
+for (const dir of ['lang', 'assets']) {
+  const src = findDir(dir);
+  if (!src) {
+    console.warn(`Could not find ${dir} directory, skipping`);
+    continue;
+  }
+  const dest = resolve('./public', dir);
+  mkdirSync(dest, {recursive: true});
+  cpSync(src, dest, {recursive: true});
+  console.log(`Copied ${src} → ${dest}`);
+}

--- a/samples/atomic/search/tests/smoke.spec.ts
+++ b/samples/atomic/search/tests/smoke.spec.ts
@@ -1,0 +1,52 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Atomic Search Sample', () => {
+  test('loads and performs a search', async ({page}) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('http://localhost:3000');
+
+    const searchBox = page.locator('atomic-search-box');
+    await expect(searchBox).toBeVisible();
+
+    const querySummary = page.locator('atomic-query-summary');
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
+    const textarea = searchBox.locator('textarea[part="textarea"]');
+    await textarea.fill('test');
+    await textarea.press('Enter');
+
+    const facet = page.locator('atomic-facet').first();
+    await expect(facet).toBeVisible();
+
+    await expect(querySummary).toBeVisible();
+
+    const summaryContainer = querySummary.locator('div[part="container"]');
+    await expect
+      .poll(
+        async () => {
+          const text = await summaryContainer.textContent();
+          return text ?? '';
+        },
+        {timeout: 5000}
+      )
+      .toMatch(/Results 1-[1-9].*for test/);
+
+    const resultList = page.locator('atomic-result-list');
+    await expect(resultList).toBeVisible();
+
+    const firstResult = resultList.locator('atomic-result').first();
+    await expect(firstResult).toBeVisible();
+
+    const filteredErrors = consoleErrors.filter(
+      (error) => !error.includes('MissingInterfaceParentError')
+    );
+    expect(filteredErrors).toEqual([]);
+  });
+});

--- a/samples/atomic/search/vite.config.ts
+++ b/samples/atomic/search/vite.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     alias: [
       {
         find: '@coveo/headless/package.json',
-        replacement: resolve(__dirname, '../../../packages/headless/package.json'),
+        replacement: resolve(
+          __dirname,
+          '../../../packages/headless/package.json'
+        ),
       },
       {
         find: '../../../generated/availableLocales.json',

--- a/samples/atomic/search/vite.config.ts
+++ b/samples/atomic/search/vite.config.ts
@@ -1,0 +1,23 @@
+import {resolve} from 'node:path';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@coveo/headless/package.json',
+        replacement: resolve(__dirname, '../../../packages/headless/package.json'),
+      },
+      {
+        find: '../../../generated/availableLocales.json',
+        replacement: resolve(
+          __dirname,
+          '../../../packages/atomic/dist/esm/generated/availableLocales.js'
+        ),
+      },
+    ],
+  },
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
[KIT-5683](https://coveord.atlassian.net/browse/KIT-5683)

## Problem
We need a standalone Atomic Search vanilla sample that serves as both a reference implementation and scaffolding template.

## Solution
Split the search portion from the existing `pkg-new-template` sample into a standalone Vite + Atomic Search project with all search components using minimal configuration against the `searchuisamples` organization.

[KIT-5683]: https://coveord.atlassian.net/browse/KIT-5683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ