### PR TITLE
feat(samples): create atomic-commerce-react sample (KIT-5682)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,43 @@ importers:
         specifier: 'catalog:'
         version: 4.0.16(@types/node@24.12.2)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@20.0.3)(less@4.6.4)(lightningcss@1.32.0)(msw@2.13.4(@types/node@24.12.2)(typescript@6.0.3))(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
 
+  samples/atomic/commerce-react:
+    dependencies:
+      '@coveo/atomic-react':
+        specifier: workspace:*
+        version: link:../../../packages/atomic-react
+      '@coveo/headless':
+        specifier: workspace:*
+        version: link:../../../packages/headless
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.59.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   samples/atomic/search-commerce-angular:
     dependencies:
       '@angular/animations':

--- a/samples/atomic/commerce-react/.gitignore
+++ b/samples/atomic/commerce-react/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+playwright-report
+test-results
+public/assets
+public/lang
+public/themes

--- a/samples/atomic/commerce-react/index.html
+++ b/samples/atomic/commerce-react/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="themes/coveo.css" />
+    <title>Atomic Commerce React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/atomic/commerce-react/package.json
+++ b/samples/atomic/commerce-react/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@samples/atomic-commerce-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:assets": "node ../../../utils/ci/copy-files.mjs ../../../packages/atomic-react/dist/assets public/assets ../../../packages/atomic-react/dist/lang public/lang ../../../packages/atomic/dist/themes public/themes",
+    "dev": "pnpm build:assets && pnpm dev:vite",
+    "dev:vite": "vite",
+    "build": "pnpm build:ts && pnpm build:vite",
+    "build:ts": "tsc -b",
+    "build:vite": "vite build",
+    "e2e": "playwright test",
+    "e2e:watch": "playwright test --ui"
+  },
+  "dependencies": {
+    "@coveo/atomic-react": "workspace:*",
+    "@coveo/headless": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/samples/atomic/commerce-react/playwright.config.ts
+++ b/samples/atomic/commerce-react/playwright.config.ts
@@ -1,0 +1,25 @@
+import {defineConfig, devices} from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:3005',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/samples/atomic/commerce-react/src/App.css
+++ b/samples/atomic/commerce-react/src/App.css
@@ -1,0 +1,33 @@
+header nav {
+  padding: 0.75rem 1rem;
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+header nav button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+header nav button.active {
+  background: #1a73e8;
+  color: white;
+  border-color: #1a73e8;
+}
+
+atomic-commerce-recommendation-list {
+  margin-top: var(--atomic-layout-spacing-y);
+  --atomic-recs-number-of-columns: 3;
+}
+
+@media only screen and (max-width: 1024px) {
+  atomic-commerce-recommendation-list {
+    --atomic-recs-number-of-columns: 1;
+    --atomic-recs-number-of-rows: 3;
+  }
+}

--- a/samples/atomic/commerce-react/src/App.tsx
+++ b/samples/atomic/commerce-react/src/App.tsx
@@ -1,0 +1,35 @@
+import {useState} from 'react';
+import './App.css';
+import {CommerceSearchPage} from './pages/CommerceSearchPage';
+import {CommerceRecommendationPage} from './pages/CommerceRecommendationPage';
+
+const SEARCH_PAGE = 'Commerce Search';
+const RECOMMENDATIONS_PAGE = 'Recommendations';
+
+const pages = [SEARCH_PAGE, RECOMMENDATIONS_PAGE];
+
+function App() {
+  const [page, setPage] = useState(SEARCH_PAGE);
+
+  return (
+    <>
+      <header>
+        <nav>
+          {pages.map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              className={page === p ? 'active' : ''}
+            >
+              {p}
+            </button>
+          ))}
+        </nav>
+      </header>
+      {page === SEARCH_PAGE && <CommerceSearchPage />}
+      {page === RECOMMENDATIONS_PAGE && <CommerceRecommendationPage />}
+    </>
+  );
+}
+
+export default App;

--- a/samples/atomic/commerce-react/src/coveo-modules.d.ts
+++ b/samples/atomic/commerce-react/src/coveo-modules.d.ts
@@ -1,0 +1,37 @@
+declare module '@coveo/headless/commerce' {
+  export type Product = Record<string, unknown>;
+  export function buildCommerceEngine(options: {
+    configuration: unknown;
+  }): unknown;
+  export function getSampleCommerceEngineConfiguration(): unknown;
+}
+
+declare module '@coveo/atomic-react/commerce' {
+  import type {ComponentType} from 'react';
+
+  export const AtomicCommerceFacets: ComponentType<any>;
+  export const AtomicCommerceInterface: ComponentType<any>;
+  export const AtomicCommerceLayout: ComponentType<any>;
+  export const AtomicCommerceLoadMoreProducts: ComponentType<any>;
+  export const AtomicCommerceProductList: ComponentType<any>;
+  export const AtomicCommerceQuerySummary: ComponentType<any>;
+  export const AtomicCommerceRecommendationInterface: ComponentType<any>;
+  export const AtomicCommerceRecommendationList: ComponentType<any>;
+  export const AtomicCommerceSearchBox: ComponentType<any>;
+  export const AtomicCommerceSearchBoxInstantProducts: ComponentType<any>;
+  export const AtomicCommerceSearchBoxQuerySuggestions: ComponentType<any>;
+  export const AtomicCommerceSearchBoxRecentQueries: ComponentType<any>;
+  export const AtomicCommerceSortDropdown: ComponentType<any>;
+  export const AtomicLayoutSection: ComponentType<any>;
+  export const AtomicProductDescription: ComponentType<any>;
+  export const AtomicProductImage: ComponentType<any>;
+  export const AtomicProductLink: ComponentType<any>;
+  export const AtomicProductPrice: ComponentType<any>;
+  export const AtomicProductRating: ComponentType<any>;
+  export const AtomicProductSectionDescription: ComponentType<any>;
+  export const AtomicProductSectionEmphasized: ComponentType<any>;
+  export const AtomicProductSectionMetadata: ComponentType<any>;
+  export const AtomicProductSectionName: ComponentType<any>;
+  export const AtomicProductSectionVisual: ComponentType<any>;
+  export const AtomicProductText: ComponentType<any>;
+}

--- a/samples/atomic/commerce-react/src/main.tsx
+++ b/samples/atomic/commerce-react/src/main.tsx
@@ -1,0 +1,9 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './App.tsx';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/samples/atomic/commerce-react/src/pages/CommerceRecommendationPage.tsx
+++ b/samples/atomic/commerce-react/src/pages/CommerceRecommendationPage.tsx
@@ -1,0 +1,74 @@
+import {
+  AtomicCommerceLayout,
+  AtomicCommerceRecommendationInterface,
+  AtomicCommerceRecommendationList,
+  AtomicLayoutSection,
+  AtomicProductDescription,
+  AtomicProductImage,
+  AtomicProductLink,
+  AtomicProductPrice,
+  AtomicProductRating,
+  AtomicProductSectionDescription,
+  AtomicProductSectionEmphasized,
+  AtomicProductSectionMetadata,
+  AtomicProductSectionName,
+  AtomicProductSectionVisual,
+  AtomicProductText,
+} from '@coveo/atomic-react/commerce';
+import {
+  buildCommerceEngine,
+  getSampleCommerceEngineConfiguration,
+} from '@coveo/headless/commerce';
+import {useMemo} from 'react';
+
+export const CommerceRecommendationPage = () => {
+  const engine = useMemo(
+    () =>
+      buildCommerceEngine({
+        configuration: getSampleCommerceEngineConfiguration(),
+      }),
+    []
+  );
+
+  return (
+    <AtomicCommerceRecommendationInterface engine={engine}>
+      <AtomicCommerceLayout mobileBreakpoint="1024px">
+        <AtomicLayoutSection section="main">
+          <AtomicCommerceRecommendationList
+            imageSize="small"
+            display="list"
+            productsPerPage={3}
+            slotId="af4fb7ba-6641-4b67-9cf9-be67e9f30174"
+            template={MyTemplate}
+          ></AtomicCommerceRecommendationList>
+        </AtomicLayoutSection>
+      </AtomicCommerceLayout>
+    </AtomicCommerceRecommendationInterface>
+  );
+};
+
+function MyTemplate() {
+  return (
+    <>
+      <AtomicProductSectionName>
+        <AtomicProductLink />
+      </AtomicProductSectionName>
+      <AtomicProductSectionVisual>
+        <AtomicProductImage field="ec_thumbnails"></AtomicProductImage>
+      </AtomicProductSectionVisual>
+      <AtomicProductSectionMetadata>
+        <AtomicProductText
+          field="ec_brand"
+          className="text-neutral-dark block"
+        ></AtomicProductText>
+        <AtomicProductRating field="ec_rating"></AtomicProductRating>
+      </AtomicProductSectionMetadata>
+      <AtomicProductSectionEmphasized>
+        <AtomicProductPrice />
+      </AtomicProductSectionEmphasized>
+      <AtomicProductSectionDescription>
+        <AtomicProductDescription />
+      </AtomicProductSectionDescription>
+    </>
+  );
+}

--- a/samples/atomic/commerce-react/src/pages/CommerceSearchPage.tsx
+++ b/samples/atomic/commerce-react/src/pages/CommerceSearchPage.tsx
@@ -1,0 +1,100 @@
+import {
+  AtomicCommerceFacets,
+  AtomicCommerceInterface,
+  AtomicCommerceLayout,
+  AtomicCommerceLoadMoreProducts,
+  AtomicCommerceProductList,
+  AtomicCommerceQuerySummary,
+  AtomicCommerceSearchBox,
+  AtomicCommerceSearchBoxInstantProducts,
+  AtomicCommerceSearchBoxQuerySuggestions,
+  AtomicCommerceSearchBoxRecentQueries,
+  AtomicCommerceSortDropdown,
+  AtomicLayoutSection,
+  AtomicProductDescription,
+  AtomicProductImage,
+  AtomicProductLink,
+  AtomicProductPrice,
+  AtomicProductRating,
+  AtomicProductSectionDescription,
+  AtomicProductSectionEmphasized,
+  AtomicProductSectionMetadata,
+  AtomicProductSectionName,
+  AtomicProductSectionVisual,
+  AtomicProductText,
+} from '@coveo/atomic-react/commerce';
+import {
+  buildCommerceEngine,
+  getSampleCommerceEngineConfiguration,
+} from '@coveo/headless/commerce';
+import {useMemo} from 'react';
+
+export const CommerceSearchPage = () => {
+  const engine = useMemo(
+    () =>
+      buildCommerceEngine({
+        configuration: getSampleCommerceEngineConfiguration(),
+      }),
+    []
+  );
+
+  return (
+    <AtomicCommerceInterface engine={engine} type="search">
+      <AtomicCommerceLayout>
+        <AtomicLayoutSection section="search">
+          <AtomicCommerceSearchBox>
+            <AtomicCommerceSearchBoxRecentQueries></AtomicCommerceSearchBoxRecentQueries>
+            <AtomicCommerceSearchBoxQuerySuggestions></AtomicCommerceSearchBoxQuerySuggestions>
+            <AtomicCommerceSearchBoxInstantProducts image-size="small"></AtomicCommerceSearchBoxInstantProducts>
+          </AtomicCommerceSearchBox>
+        </AtomicLayoutSection>
+        <AtomicLayoutSection section="facets">
+          <AtomicCommerceFacets />
+        </AtomicLayoutSection>
+        <AtomicLayoutSection section="main">
+          <AtomicLayoutSection section="status">
+            <AtomicCommerceQuerySummary />
+            <AtomicCommerceSortDropdown />
+          </AtomicLayoutSection>
+          <AtomicLayoutSection section="products">
+            <AtomicCommerceProductList
+              display="grid"
+              density="compact"
+              image-size="small"
+              template={MyTemplate}
+            />
+          </AtomicLayoutSection>
+          <AtomicLayoutSection section="pagination">
+            <AtomicCommerceLoadMoreProducts />
+          </AtomicLayoutSection>
+        </AtomicLayoutSection>
+      </AtomicCommerceLayout>
+    </AtomicCommerceInterface>
+  );
+};
+
+function MyTemplate() {
+  return (
+    <>
+      <AtomicProductSectionName>
+        <AtomicProductLink />
+      </AtomicProductSectionName>
+      <AtomicProductSectionVisual>
+        <AtomicProductImage field="ec_thumbnails"></AtomicProductImage>
+      </AtomicProductSectionVisual>
+      <AtomicProductSectionMetadata>
+        <AtomicProductText
+          field="ec_brand"
+          className="text-neutral-dark block"
+        ></AtomicProductText>
+        <AtomicProductRating field="ec_rating"></AtomicProductRating>
+      </AtomicProductSectionMetadata>
+      <AtomicProductSectionEmphasized>
+        <AtomicProductPrice />
+      </AtomicProductSectionEmphasized>
+      <AtomicProductSectionDescription>
+        <AtomicProductDescription />
+      </AtomicProductSectionDescription>
+    </>
+  );
+}

--- a/samples/atomic/commerce-react/src/vendor/headless-package.ts
+++ b/samples/atomic/commerce-react/src/vendor/headless-package.ts
@@ -1,1 +1,0 @@
-export const version = '3.50.1';

--- a/samples/atomic/commerce-react/src/vendor/headless-package.ts
+++ b/samples/atomic/commerce-react/src/vendor/headless-package.ts
@@ -1,0 +1,1 @@
+export const version = '3.50.1';

--- a/samples/atomic/commerce-react/src/vite-env.d.ts
+++ b/samples/atomic/commerce-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/samples/atomic/commerce-react/tests/smoke.spec.ts
+++ b/samples/atomic/commerce-react/tests/smoke.spec.ts
@@ -1,0 +1,62 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Atomic Commerce React Sample', () => {
+  test('commerce search page loads and displays products', async ({page}) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('http://localhost:3005');
+
+    const searchBox = page.locator('atomic-commerce-search-box');
+    await expect(searchBox).toBeVisible({timeout: 30000});
+
+    const querySummary = page.locator('atomic-commerce-query-summary');
+    await querySummary.waitFor();
+    await querySummary.locator('div[part="container"]').waitFor();
+
+    const textarea = searchBox.locator('textarea[part="textarea"]');
+    await textarea.fill('shoe');
+    await textarea.press('Enter');
+
+    await expect(querySummary).toBeVisible();
+
+    const summaryContainer = querySummary.locator('div[part="container"]');
+    await expect
+      .poll(async () => {
+        const text = await summaryContainer.textContent();
+        return text ?? '';
+      }, {timeout: 5000})
+      .toMatch(/Products? 1-[1-9]?[0-9]* of \d+ for shoe/);
+
+    const productList = page.locator('atomic-commerce-product-list');
+    await expect(productList).toBeVisible();
+
+    const firstProduct = productList.locator('atomic-product').first();
+    await expect(firstProduct).toBeVisible();
+
+    const filteredErrors = consoleErrors.filter(
+      (error) => !error.includes('MissingInterfaceParentError')
+    );
+    expect(filteredErrors).toEqual([]);
+  });
+
+  test('commerce recommendation page loads', async ({page}) => {
+    await page.goto('http://localhost:3005');
+
+    const recommendationsButton = page.getByRole('button', {
+      name: 'Recommendations',
+    });
+    await expect(recommendationsButton).toBeVisible({timeout: 30000});
+    await recommendationsButton.click();
+
+    const recommendationList = page.locator('atomic-commerce-recommendation-list');
+    await expect(recommendationList).toBeVisible();
+
+    const firstProduct = recommendationList.locator('atomic-product').first();
+    await expect(firstProduct).toBeVisible();
+  });
+});

--- a/samples/atomic/commerce-react/tests/smoke.spec.ts
+++ b/samples/atomic/commerce-react/tests/smoke.spec.ts
@@ -26,10 +26,13 @@ test.describe('Atomic Commerce React Sample', () => {
 
     const summaryContainer = querySummary.locator('div[part="container"]');
     await expect
-      .poll(async () => {
-        const text = await summaryContainer.textContent();
-        return text ?? '';
-      }, {timeout: 5000})
+      .poll(
+        async () => {
+          const text = await summaryContainer.textContent();
+          return text ?? '';
+        },
+        {timeout: 5000}
+      )
       .toMatch(/Products? 1-[1-9]?[0-9]* of \d+ for shoe/);
 
     const productList = page.locator('atomic-commerce-product-list');
@@ -53,7 +56,9 @@ test.describe('Atomic Commerce React Sample', () => {
     await expect(recommendationsButton).toBeVisible({timeout: 30000});
     await recommendationsButton.click();
 
-    const recommendationList = page.locator('atomic-commerce-recommendation-list');
+    const recommendationList = page.locator(
+      'atomic-commerce-recommendation-list'
+    );
     await expect(recommendationList).toBeVisible();
 
     const firstProduct = recommendationList.locator('atomic-product').first();

--- a/samples/atomic/commerce-react/tsconfig.app.json
+++ b/samples/atomic/commerce-react/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/samples/atomic/commerce-react/tsconfig.json
+++ b/samples/atomic/commerce-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/samples/atomic/commerce-react/tsconfig.node.json
+++ b/samples/atomic/commerce-react/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/samples/atomic/commerce-react/vite.config.ts
+++ b/samples/atomic/commerce-react/vite.config.ts
@@ -1,0 +1,33 @@
+import {fileURLToPath, URL} from 'node:url';
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vite';
+
+const vendor = (file: string) =>
+  fileURLToPath(new URL(`./src/vendor/${file}`, import.meta.url));
+
+const root = (file: string) => fileURLToPath(new URL(file, import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '/bueno/v1.1.9/bueno.esm.js': root(
+        '../../../packages/bueno/dist/bueno.esm.js'
+      ),
+      '@coveo/headless/package.json': vendor('headless-package.ts'),
+      '@coveo/headless/commerce': root(
+        '../../../packages/headless/cdn/commerce/headless.esm.js'
+      ),
+      '@coveo/headless/insight': root(
+        '../../../packages/headless/cdn/insight/headless.esm.js'
+      ),
+      '@coveo/headless/recommendation': root(
+        '../../../packages/headless/cdn/recommendation/headless.esm.js'
+      ),
+      '@coveo/headless': root('../../../packages/headless/cdn/headless.esm.js'),
+    },
+  },
+  server: {
+    port: 3005,
+  },
+});


### PR DESCRIPTION
[KIT-5682](https://coveord.atlassian.net/browse/KIT-5682)

## Problem
We need a dedicated Atomic Commerce + React sample, currently search and commerce are combined in one sample.

## Solution
Split the commerce portion from `samples/atomic/search-commerce-react` into a standalone React + Atomic Commerce project.

[KIT-5682]: https://coveord.atlassian.net/browse/KIT-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ