### PR TITLE
docs(samples): update README and CONTRIBUTING for dual sample/scaffolding role

### DIFF
--- a/samples/CONTRIBUTING.md
+++ b/samples/CONTRIBUTING.md
@@ -1,94 +1,172 @@
-# UI-KIT Samples
+# Contributing to UI-Kit Samples
 
-This guide outlines the conventions and best practices for creating and maintaining samples in the ui-kit repository.
+This guide outlines the conventions and requirements for creating and maintaining samples in the ui-kit repository.
 
-## Overview
+## Dual Purpose: Samples & Scaffolding Starters
 
-The UI-Kit samples are organized into three main entry points that represent the primary ways developers interact with the UI-Kit:
+Every sample in this directory serves two roles:
+
+1. **Living documentation** — Demonstrates correct usage of Coveo libraries.
+2. **Scaffolding template** — Used by `npm create @coveo/ui` to bootstrap new projects.
+
+This means every sample must be **self-contained, zero-config, and runnable out of the box** without any Coveo platform credentials or OAuth setup.
+
+## Sample Requirements
+
+Every sample **must** have:
+
+| Requirement | Details |
+| --- | --- |
+| **No credentials needed** | Use the `searchuisamples` demo organization with sample credentials. No OAuth, no API keys, no search tokens. |
+| **`npm install && npm run dev` works** | A developer should be able to clone and run the sample with no additional setup. |
+| **README.md** | Purpose, how to run, key features demonstrated. |
+| **Playwright smoke tests** | At least one test verifying the sample loads and renders expected content. |
+| **Minimal configuration** | No custom styling, no complex initialization. Use vanilla fields that work with the sample org. |
+| **Single purpose** | Each sample focuses on one library + framework combination. |
+
+## Directory Structure
 
 ```
 samples/
-├── atomic/
-│   └── ...
-├── headless/
-│   └── ...
-└── headless-ssr/
-    └── ...
+├── atomic/           # @coveo/atomic and @coveo/atomic-react samples
+├── headless/         # @coveo/headless client-side rendering samples
+└── headless-ssr/     # @coveo/headless server-side rendering samples
 ```
 
-- **`atomic/`** - Samples using Atomic components in every form
-- **`headless/`** - Samples using headless controllers for custom UI implementations
-- **`headless-ssr/`** - Samples demonstrating server-side rendering with headless controllers
-
 ## Naming Convention
-
-All samples follow this standardized folder and package naming pattern:
 
 **Folder pattern:**
 
 ```
-<entry-point-folder>/<subpackage-name>-<framework>-<optional-details>
+<category>/<use-case>[-<framework>]
 ```
 
-**Package pattern (in `package.json`):**
+**Examples:**
+
+- `atomic/search` — Vanilla Atomic search (HTML/JS, no framework)
+- `atomic/commerce-react` — Atomic React commerce
+- `headless/search-react` — Headless search with React
+- `headless-ssr/commerce-nextjs` — Headless SSR commerce with Next.js
+
+**Package name in `package.json`:**
 
 ```
-@samples/<entry-point>/<subpackage>-<framework>-<optional-details>
+@coveo/sample-<category>-<use-case>[-<framework>]
 ```
 
-### Examples:
+### Guidelines
 
-- Folder: `atomic/commerce-angular`
-
-  Package: `@samples/atomic/commerce-angular`
-
-- Folder: `headless-ssr/search-nextjs`
-
-  Package: `@samples/headless-ssr-search-nextjs`
-
-- Folder: `atomic/search-react-vite`
-
-  Package: `@samples/atomic/search-react-vite`
-
-### Guidelines:
-
-- Use **kebab-case** for all folder and package names
-- **Subpackage names**: `commerce`, `search`, `insight`, etc.
-- **Framework names**: `react`, `angular`, `vuejs`, `nextjs`, `stencil`, etc.
-- **Optional details**: `vite`, `app-router`, etc.
-- Package name must exactly match the folder structure under `samples/`
+- Use **kebab-case** for all names
+- **Use cases**: `search`, `commerce`
+- **Framework names**: `react`, `angular`, `nextjs`, `vuejs`
+- Vanilla (no-framework) samples omit the framework suffix
 
 ## Creating a New Sample
 
-### 1. Choose the Correct Entry Point
+### 1. Choose the correct category
 
-Determine which entry point best fits your sample:
+- **`atomic/`** — Uses `@coveo/atomic` or `@coveo/atomic-react` components
+- **`headless/`** — Uses `@coveo/headless` controllers with client-side rendering
+- **`headless-ssr/`** — Uses `@coveo/headless-react` or similar with server-side rendering
 
-- **`atomic/`** - If using pre-built UI components from `@coveo/atomic`
-- **`headless/`** - If building custom UI with headless controllers from `@coveo/headless`
-- **`headless-ssr/`** - If implementing server-side rendering with headless
+### 2. Use sample credentials
 
-### 2. Create a README.md
+All samples connect to the `searchuisamples` organization. No authentication flow, no environment variables to configure.
 
-Every sample must include a README.md with:
+```typescript
+// Atomic
+await searchInterface.initialize(getSampleSearchEngineConfiguration());
 
-- **Purpose**: Brief description of what the sample demonstrates
-- **Prerequisites**: Required tools, versions, or accounts
-- **Key Features**: Highlighted functionality or components used
-- **Running**: How to start and use the sample
+// Headless
+import { getSampleSearchEngineConfiguration } from '@coveo/headless';
+```
 
-### 3. Add Smoke Tests
+### 3. Write a README.md
 
-Include basic tests to verify the sample works correctly:
+Include:
+- **Purpose** — One-liner on what the sample demonstrates
+- **Prerequisites** — Node version, etc.
+- **Running** — `npm install && npm run dev`
+- **Key features** — What components/controllers are showcased
 
-- Use Playwright
-- Have at least one test that verifies the sample loads and renders
+### 4. Add Playwright smoke tests
 
-## Sample Principles
+Every sample must include at least one Playwright test that:
+- Starts the dev server
+- Verifies the page loads without errors
+- Checks that key UI elements render (e.g., search box, results)
 
-- **Minimalism**: Include only files necessary for the demonstration
-- **Single Purpose**: Focus on one specific use case or functionality
-- **Avoid Redundancy**: Don't try to showcase every possible feature
-- **Clear Intent**: Make the sample's purpose immediately obvious
-- **Well-commented**: Explain complex logic or configuration
-- **Idiomatic**: Use framework and library best practices
+This acts as a safety net: if a library change breaks a sample, it likely introduced a breaking change.
+
+```typescript
+// e2e/smoke.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('sample loads and renders results', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('atomic-search-box')).toBeVisible();
+  await expect(page.locator('atomic-result-list')).toBeVisible();
+});
+```
+
+### 5. Keep it minimal
+
+- Include only files necessary for the demonstration
+- No custom CSS themes or complex layouts
+- No advanced configuration beyond what works with the sample org
+- Use default/vanilla field values
+
+## What Belongs in a Sample
+
+### Atomic Search
+
+Include every relevant component with minimal configuration. Use fields available in the `searchuisamples` organization.
+
+**Include:** search box, instant results, recent queries, facets (automatic, category, numeric, rating, timeframe), tabs, sort, breadbox, smart snippets, generated answer, result templates, pagination.
+
+**Exclude:** `atomic-external`, `atomic-html`, format components (unless demonstrating a facet that needs them).
+
+### Atomic Commerce
+
+- 1 search page
+- 2 product listing pages
+- 1 recommendations page
+
+### Headless Samples
+
+At minimum: search box, result list, pager. Can include facets and sort for a more complete demonstration.
+
+## Framework Version Support
+
+Officially support **current and immediate previous major versions** of Angular, React, and Next.js.
+
+## Relationship to Scaffolding
+
+When a developer runs:
+
+```bash
+npm create @coveo/ui my-project -- --atomic-search-react
+```
+
+The CLI clones the corresponding sample (`samples/atomic/search-react`) as their project starter. This is why samples must be:
+
+- **Zero-config** — Works immediately after `npm install`
+- **Self-contained** — No dependencies on the monorepo structure
+- **Tested** — Smoke tests give confidence the template works
+
+## Testing Locally
+
+From the sample directory:
+
+```bash
+npm install
+npm run dev          # Verify it runs
+npx playwright test  # Verify smoke tests pass
+```
+
+From the monorepo root, linting and knip must also pass:
+
+```bash
+pnpm run lint:check
+pnpm run knip
+```

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,57 +1,73 @@
 # Coveo UI-Kit Samples
 
-This directory contains code samples demonstrating how to use Coveo's UI-Kit in various frameworks and implementation patterns. These samples are designed to help developers quickly understand and implement Coveo search and commerce experiences.
+This directory contains code samples demonstrating how to use Coveo's UI-Kit libraries in various frameworks and implementation patterns.
+
+**These samples serve a dual purpose:**
+
+1. **Samples** — Living documentation showing how to use Coveo libraries correctly.
+2. **Scaffolding starters** — The source templates for `npm create @coveo/ui`, giving developers a working project in seconds.
+
+Because of this dual role, every sample must be **self-contained, runnable out of the box, and tested**. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full requirements.
 
 ## 📚 Sample Categories
 
-The samples are organized into three main categories based on the Coveo libraries they use:
+Samples are organized by the Coveo library they use:
 
 ### [Atomic Samples](./atomic/)
 
-Samples using `@coveo/atomic` or `@coveo/atomic-react` components for pre-built, customizable search and commerce interfaces.
+Pre-built, customizable search and commerce components from `@coveo/atomic` and `@coveo/atomic-react`.
 
-| Sample                                                       | Description                                                                  | Framework            | Use Case          |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------------- | ----------------- |
-| [search-commerce-angular](./atomic/search-commerce-angular/) | Search and commerce interfaces with Atomic components in Angular             | Angular              | Search & Commerce |
-| [search-commerce-react](./atomic/search-commerce-react/)     | Multiple search and commerce interface examples with Atomic React components | React + Vite         | Search & Commerce |
-| [search-nextjs](./atomic/search-nextjs/)                     | Atomic React with Next.js App Router                                         | Next.js (App Router) | Search            |
-| [search-vuejs](./atomic/search-vuejs/)                       | Atomic components integrated with Vue.js                                     | Vue.js + Vite        | Search            |
+| Sample | Description | Framework | Use Case |
+| --- | --- | --- | --- |
+| [search](./atomic/search/) | Vanilla Atomic search interface | HTML/JS (Vite) | Search |
+| [commerce](./atomic/commerce/) | Vanilla Atomic commerce interface | HTML/JS (Vite) | Commerce |
+| [search-react](./atomic/search-react/) | Atomic React search interface | React (Vite) | Search |
+| [commerce-react](./atomic/commerce-react/) | Atomic React commerce interface | React (Vite) | Commerce |
+| [search-commerce-angular](./atomic/search-commerce-angular/) | Atomic components in Angular | Angular | Search & Commerce |
+| [search-nextjs](./atomic/search-nextjs/) | Atomic React with Next.js App Router | Next.js | Search |
+| [search-vuejs](./atomic/search-vuejs/) | Atomic components with Vue.js | Vue.js (Vite) | Search |
 
 ### [Headless Samples](./headless/)
 
-Samples using `@coveo/headless` controllers to build fully custom search and commerce interfaces.
+Fully custom UIs built with `@coveo/headless` controllers (client-side rendering).
 
-| Sample                                       | Description                                                   | Framework | Use Case |
-| -------------------------------------------- | ------------------------------------------------------------- | --------- | -------- |
-| [commerce-react](./headless/commerce-react/) | Custom commerce interface using Headless commerce controllers | React     | Commerce |
-| [search-react](./headless/search-react/)     | Custom search interface using Headless search controllers     | React     | Search   |
+| Sample | Description | Framework | Use Case |
+| --- | --- | --- | --- |
+| [search](./headless/search/) | Custom search interface | TypeScript (Vite) | Search |
+| [commerce](./headless/commerce/) | Custom commerce interface | TypeScript (Vite) | Commerce |
+| [search-react](./headless/search-react/) | Custom search interface with React | React (Vite) | Search |
+| [commerce-react](./headless/commerce-react/) | Custom commerce interface with React | React (Vite) | Commerce |
 
 ### [Headless SSR Samples](./headless-ssr/)
 
-Samples demonstrating server-side rendering (SSR) with Headless controllers for improved performance and SEO.
+Server-side rendering with Headless controllers for improved performance and SEO.
 
-| Sample                                                         | Description                                                  | Framework            | Use Case |
-| -------------------------------------------------------------- | ------------------------------------------------------------ | -------------------- | -------- |
-| [commerce-express](./headless-ssr/commerce-express/)           | Generic SSR implementation with Express server               | Express + TypeScript | Commerce |
-| [commerce-nextjs](./headless-ssr/commerce-nextjs/)             | Commerce SSR with Next.js App Router (current version)       | Next.js (App Router) | Commerce |
-| [commerce-nextjs-v4](./headless-ssr/commerce-nextjs-v4/)       | Commerce SSR with Next.js App Router (preview - Headless V4) | Next.js (App Router) | Commerce |
-| [commerce-react-router](./headless-ssr/commerce-react-router/) | Commerce SSR with React Router                               | React Router         | Commerce |
-| [search-nextjs](./headless-ssr/search-nextjs/)                 | Search SSR example with Next.js App Router                   | Next.js (App Router) | Search   |
+| Sample | Description | Framework | Use Case |
+| --- | --- | --- | --- |
+| [commerce-nextjs](./headless-ssr/commerce-nextjs/) | Commerce SSR with Next.js App Router | Next.js | Commerce |
+| [search-nextjs](./headless-ssr/search-nextjs/) | Search SSR with Next.js App Router | Next.js | Search |
+| [commerce-express](./headless-ssr/commerce-express/) | Generic SSR with Express server | Express | Commerce |
+| [commerce-react-router](./headless-ssr/commerce-react-router/) | Commerce SSR with React Router | React Router | Commerce |
 
 ## 🚀 Quick Start
 
-Each sample includes its own README with specific setup instructions. Generally, to run any sample:
+Every sample can be run standalone:
 
 ```bash
-# Navigate to the sample directory
 cd samples/<category>/<sample-name>
-
-# Install dependencies
 npm install
-
-# Run the development server
 npm run dev
 ```
+
+No platform credentials are needed — all samples use the `searchuisamples` demo organization with pre-configured credentials.
+
+## 💡 Choosing the Right Approach
+
+**Atomic** — Use when you want pre-built, customizable components with minimal code. Best for rapid implementation.
+
+**Headless** — Use when you need full control over the UI or are integrating with an existing design system.
+
+**Headless SSR** — Use when SEO or initial page load performance is a priority.
 
 ## 📖 Documentation
 
@@ -59,32 +75,8 @@ npm run dev
 - [Coveo Headless Documentation](https://docs.coveo.com/en/headless/)
 - [Coveo for Commerce Documentation](https://docs.coveo.com/en/coveo-for-commerce/)
 
-## 🛠️ Contributing
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on creating and maintaining samples.
-
-## 💡 Choosing the Right Sample
-
-**Use Atomic samples when:**
-
-- You want pre-built, customizable components
-- You need a quick implementation with minimal custom code
-- You prefer declarative component configuration
-
-**Use Headless samples when:**
-
-- You need complete control over the UI and behavior
-- You want to build a custom design system
-- You're integrating with an existing component library
-
-**Use Headless SSR samples when:**
-
-- SEO is a priority
-- You need improved initial page load performance
-- You want server-side rendering capabilities
-
 ## 🔗 Related Resources
 
 - [Main Repository README](../README.md)
+- [Contributing Guide](./CONTRIBUTING.md)
 - [Coveo Developer Portal](https://docs.coveo.com/)
-- [Coveo Community](https://connect.coveo.com/)


### PR DESCRIPTION
[KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

## Problem

The samples `README.md` and `CONTRIBUTING.md` don't reflect the new dual purpose of samples: they now serve as both living documentation **and** scaffolding starters for `npm create @coveo/ui`.

## Solution

Updated both files to clearly define:
- The dual role of samples (documentation + scaffolding templates)
- Requirements every sample must meet (zero-config, Playwright smoke tests, sample credentials, etc.)
- Updated sample table with all new vanilla and React samples
- Clear naming conventions
- How the scaffolding CLI relates to the samples directory
- Framework version support policy

[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ