### PR TITLE
feat: add hotfix CDN workflow (KIT-5700)

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,13 +1,18 @@
 # Hotfix workflow
 #
-# Triggered on push to hotfix/* branches.
+# Triggered on push to hotfix/** branches.
 # Builds CDN artifacts and dispatches to ui-kit-cd to upload commit artifacts
-# and update stable pointers directly (skipping preview/bake).
+# and update major version pointers (vX/) directly, bypassing preview and bake.
+#
+# The 'hotfix' channel is a separate path from the normal stable promotion flow.
+# It writes to the same major version folders (vX/) but is routed through its own
+# job in update-cdn-pointers.yml, gated by the 'cdn-hotfix' environment in ui-kit-cd.
 #
 # Usage:
 #   git checkout -b hotfix/critical-fix v3.2.0   # branch from last release tag
 #   git cherry-pick <fix-sha>                     # cherry-pick the fix
 #   git push origin hotfix/critical-fix           # triggers this workflow
+#   # Approve the 'cdn-hotfix' environment gate in ui-kit-cd to deploy
 #
 # See: https://coveord.atlassian.net/browse/KIT-5700
 name: Hotfix CDN release
@@ -31,10 +36,9 @@ jobs:
       - uses: ./.github/actions/build-cdn
 
   hotfix-deploy:
-    name: Deploy hotfix to CDN (stable)
+    name: Deploy hotfix to CDN
     needs: build-cdn
     runs-on: ubuntu-latest
-    environment: 'Hotfix (CDN)'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -45,8 +49,8 @@ jobs:
         with:
           skip-build: 'true'
           load-cache: 'false'
-      - name: Trigger commit artifact upload and stable pointer update
+      - name: Trigger commit artifact upload and hotfix pointer update
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
           GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
-          CHANNELS: 'stable'
+          CHANNELS: 'hotfix'

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,52 @@
+# Hotfix workflow
+#
+# Triggered on push to hotfix/* branches.
+# Builds CDN artifacts and dispatches to ui-kit-cd to upload commit artifacts
+# and update stable pointers directly (skipping preview/bake).
+#
+# Usage:
+#   git checkout -b hotfix/critical-fix v3.2.0   # branch from last release tag
+#   git cherry-pick <fix-sha>                     # cherry-pick the fix
+#   git push origin hotfix/critical-fix           # triggers this workflow
+#
+# See: https://coveord.atlassian.net/browse/KIT-5700
+name: Hotfix CDN release
+on:
+  push:
+    branches: ['hotfix/**']
+
+permissions:
+  contents: read
+
+jobs:
+  build-cdn:
+    name: Build CDN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/build-cdn
+
+  hotfix-deploy:
+    name: Deploy hotfix to CDN (stable)
+    needs: build-cdn
+    runs-on: ubuntu-latest
+    environment: 'Hotfix (CDN)'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup
+        with:
+          skip-build: 'true'
+          load-cache: 'false'
+      - name: Trigger commit artifact upload and stable pointer update
+        run: node ./scripts/deploy/trigger-commit-upload.mjs
+        env:
+          GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          CHANNELS: 'stable'


### PR DESCRIPTION
[KIT-5700](https://coveord.atlassian.net/browse/KIT-5700)

## Problem

There is no way to ship a critical CDN fix immediately. The normal release flow requires a bake period (24-48h) which is unacceptable for production incidents.

## Solution

Add a `hotfix.yml` workflow triggered on `hotfix/**` branch pushes that:

1. Builds CDN artifacts (same as regular CI)
2. Dispatches to `ui-kit-cd` with `channels: "hotfix"`
3. In ui-kit-cd, the `hotfix-pointers` job updates stable pointers (`vX/`) directly — no preview, no bake

The approval gate lives in **ui-kit-cd** (the `cdn-hotfix` environment), not here. This means an accidental push to `hotfix/**` will build successfully but cannot mutate the CDN without explicit approval in ui-kit-cd.

### Usage

```bash
# Branch from the last release tag
git checkout -b hotfix/critical-fix v3.2.0

# Cherry-pick only the critical fix
git cherry-pick <fix-sha>

# Push triggers the hotfix workflow (builds CDN artifacts + dispatches to ui-kit-cd)
git push origin hotfix/critical-fix

# Approve the "cdn-hotfix" environment gate in ui-kit-cd to deploy
```

No NPM publish — CDN-only. The fix ships to NPM in the next regular release.

**Companion PR:** coveo-platform/ui-kit-cd#161 (adds `hotfix-pointers` job with `cdn-hotfix` approval gate)

[KIT-5700]: https://coveord.atlassian.net/browse/KIT-5700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ