### PR TITLE
fix(quantic) issue with slow quickview for webpages when the keywords to highlights are long

### DIFF
--- a/.changeset/cool-bears-tickle.md
+++ b/.changeset/cool-bears-tickle.md
@@ -1,0 +1,5 @@
+---
+'@coveo/quantic': patch
+---
+
+Unwrap result objects before passing them to child components to reduce Locker proxy layering overhead.

--- a/packages/quantic/force-app/main/default/lwc/quanticResultHighlightedTextField/quanticResultHighlightedTextField.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultHighlightedTextField/quanticResultHighlightedTextField.js
@@ -4,6 +4,7 @@ import {
   initializeWithHeadless,
   getHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
+import {unwrapLockerProxiedObject} from 'c/quanticUtils';
 import {LightningElement, api} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
@@ -28,7 +29,13 @@ export default class QuanticResultHighlightedTextField extends LightningElement 
    * @api
    * @type {Result}
    */
-  @api result;
+  @api
+  get result() {
+    return this._result;
+  }
+  set result(result) {
+    this._result = unwrapLockerProxiedObject(result);
+  }
   /**
    * (Optional) The label to display.
    * @api
@@ -49,6 +56,8 @@ export default class QuanticResultHighlightedTextField extends LightningElement 
   isInitialized = false;
   /** @type {boolean} */
   validated = false;
+  /** @type {Result} */
+  _result;
 
   connectedCallback() {
     this.validateProps();

--- a/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultLink/quanticResultLink.js
@@ -4,7 +4,7 @@ import {
   getHeadlessBundle,
   getHeadlessEnginePromise,
 } from 'c/quanticHeadlessLoader';
-import {ResultUtils} from 'c/quanticUtils';
+import {ResultUtils, unwrapLockerProxiedObject} from 'c/quanticUtils';
 import {NavigationMixin} from 'lightning/navigation';
 import {LightningElement, api} from 'lwc';
 
@@ -38,7 +38,13 @@ export default class QuanticResultLink extends NavigationMixin(
    * @api
    * @type {Result}
    */
-  @api result;
+  @api
+  get result() {
+    return this._result;
+  }
+  set result(result) {
+    this._result = unwrapLockerProxiedObject(result);
+  }
   /**
    * Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>).
    * The following keywords have special meanings for where to load the URL:
@@ -75,6 +81,8 @@ export default class QuanticResultLink extends NavigationMixin(
   engine;
   /** @type {AnyHeadless} */
   headless;
+  /** @type {Result} */
+  _result;
   /** @type {string} */
   salesforceRecordUrl;
 
@@ -113,8 +121,7 @@ export default class QuanticResultLink extends NavigationMixin(
     this.engine = engine;
     ResultUtils.bindClickEventsOnResult(
       this.engine,
-      // Destructuring transforms the Proxy object created by Salesforce to a normal object so no unexpected behaviour will occur with the Headless library.
-      {...this.result, raw: {...this.result.raw}},
+      this.result,
       this.template,
       this.headless.buildInteractiveResult
     );

--- a/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticResultQuickview/quanticResultQuickview.js
@@ -8,7 +8,11 @@ import {
   HeadlessBundleNames,
   isHeadlessBundle,
 } from 'c/quanticHeadlessLoader';
-import {I18nUtils, getLastFocusableElement} from 'c/quanticUtils';
+import {
+  I18nUtils,
+  getLastFocusableElement,
+  unwrapLockerProxiedObject,
+} from 'c/quanticUtils';
 import {LightningElement, api, track} from 'lwc';
 
 /** @typedef {import("coveo").Result} Result */
@@ -42,7 +46,13 @@ export default class QuanticResultQuickview extends LightningElement {
    * @api
    * @type {ResultWithFolding}
    */
-  @api result;
+  @api
+  get result() {
+    return this._result;
+  }
+  set result(result) {
+    this._result = unwrapLockerProxiedObject(result);
+  }
   /**
    * The maximum preview size to retrieve, in bytes. By default, the full preview is retrieved.
    * @api
@@ -84,6 +94,8 @@ export default class QuanticResultQuickview extends LightningElement {
 
   /** @type {Quickview} */
   quickview;
+  /** @type {ResultWithFolding} */
+  _result;
   /** @type {boolean} */
   isQuickviewOpen = false;
   /** @type {Function} */

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/__tests__/quanticUtils.test.js
@@ -2,6 +2,7 @@ import {
   I18nUtils,
   buildTemplateTextFromResult,
   copyToClipboard,
+  unwrapLockerProxiedObject,
 } from 'c/quanticUtils';
 
 describe('c/quanticUtils', () => {
@@ -198,6 +199,35 @@ describe('c/quanticUtils', () => {
       ).toBe(
         `<a href="${testResult.clickUri}">${testResult.title}</a><br/><br/><quote></quote>`
       );
+    });
+  });
+
+  describe('unwrapLockerObject', () => {
+    it('should deeply clone complex objects while preserving primitive values', () => {
+      const original = {
+        title: 'Example',
+        raw: {
+          foo: 'bar',
+          tags: ['a', {value: 'b'}],
+        },
+        score: 42,
+      };
+
+      const unwrapped = unwrapLockerProxiedObject(original);
+
+      expect(unwrapped).toEqual(original);
+      expect(unwrapped).not.toBe(original);
+      expect(unwrapped.raw).not.toBe(original.raw);
+      expect(unwrapped.raw.tags).not.toBe(original.raw.tags);
+      expect(unwrapped.raw.tags[1]).not.toBe(original.raw.tags[1]);
+    });
+
+    it('should return primitive values as-is', () => {
+      expect(unwrapLockerProxiedObject(undefined)).toBeUndefined();
+      expect(unwrapLockerProxiedObject(null)).toBeNull();
+      expect(unwrapLockerProxiedObject('value')).toBe('value');
+      expect(unwrapLockerProxiedObject(0)).toBe(0);
+      expect(unwrapLockerProxiedObject(false)).toBe(false);
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticUtils/quanticUtils.js
@@ -260,6 +260,30 @@ export function parseXML(string) {
 }
 
 /**
+ * Recursively clones objects to break Locker proxy chains.
+ * @param {any} value
+ * @returns {any}
+ */
+export function unwrapLockerProxiedObject(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => unwrapLockerProxiedObject(item));
+  }
+
+  const unwrappedValue = {};
+  for (const key in value) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      unwrappedValue[key] = unwrapLockerProxiedObject(value[key]);
+    }
+  }
+
+  return unwrappedValue;
+}
+
+/**
  * Utility class for managing a simple in-memory store.
  * Supports registering and retrieving facet and sort option data.
  */


### PR DESCRIPTION
[SFINT-6772](https://coveord.atlassian.net/browse/SFINT-6772)

⚠️ This PR is a bit wordy, scroll down for TLDR

## Summary

  Fixed a performance issue in Quantic quickview where Salesforce Locker/LWS proxy layers accumulated as a search result object moved through multiple Lightning Web Component boundaries.

## Issue

  In HIP, the `Result` object is passed through several components before reaching the highlighted title field in quickview:

  `quantic-result-list -> quantic-result -> quantic-result-quickview -> quantic-result-link -> quantic-result-highlighted-text-field`

  Each component boundary can wrap the result object in another Salesforce proxy layer. By the time `quantic-result-highlighted-text-field` receives the result from quickview, the object can have
several nested proxy layers. Rendering highlighted fields then becomes slow because those proxy layers are expensive to unwrap.

## Original Fix --> BAD

  Added cached parsed result objects at the Quantic result handoff points. Components now clone the received result with:

```
  JSON.parse(JSON.stringify(result))
```
  and pass the parsed object to child components instead of forwarding the proxied object directly.

This was bad because it is very CPU intensive to parse.stringify, and if you do it at every level, you pay the cost of walking through every single key in your object every time you do this.

## New fix --> Better, simpler

- Added a utils function that recursively clones the result object to break Locker proxy chains.
- Used a bottom-up approach to localize this "temporary" fix in Quantic ONLY: `quanticResultHighlightedTextField -> quanticResultLink -> quanticResultQuickview`. Only that resulted in significant performance improvement.
- Components set the result to the unwrapped result object.


### Why this fix?

- It is simple and efficient
- Easy to revert when we find the actual solution for the issue.
- It requires only changes in Quantic.
- No breaking changes.
- It significantly improves the performance without that many changes.

## Next Steps:

- While this fix is ok and doesnt create a breaking change, its not ideal. We have the following ideas for better fix that will require breaking changes so we will have to do that in UI-KIT v4:

1. passing only the fields we need to the components
2. creating a result “store” and subscribing to it for accessing the result object
3. passing accessor functions down the components

I created a JIRA ticket to keep track of this issue and we will eventually fix it properly.



## TLDR:

- The issue is due to Locker service proxy wrappers around the result object in Quantic
- Fix aims to unwrapped some layers of those wrappers to improve performance using a util function 
- This fix is temporary until UIKIT V4

DEMO:

https://github.com/user-attachments/assets/ddc55d0a-a120-4ead-a2f9-f6298a1b423d




[SFINT-6772]: https://coveord.atlassian.net/browse/SFINT-6772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ