### PR TITLE
fix(storybook): disable analytics on non-local environments j:kit-5701

### DIFF
--- a/.changeset/plenty-hounds-rescue.md
+++ b/.changeset/plenty-hounds-rescue.md
@@ -2,4 +2,4 @@
 "@coveo/atomic": patch
 ---
 
-fix disabling of analytics on production environments for storybook documentation
+disable Coveo analytics in Storybook when running outside of local environment (e.g., on the documentation site)

--- a/.changeset/plenty-hounds-rescue.md
+++ b/.changeset/plenty-hounds-rescue.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+fix(storybook): disable analytics on non-local environments j:kit-5701

--- a/.changeset/plenty-hounds-rescue.md
+++ b/.changeset/plenty-hounds-rescue.md
@@ -2,4 +2,4 @@
 "@coveo/atomic": patch
 ---
 
-fix disabling of analytics on production environments
+fix disabling of analytics on production environments for storybook documentation

--- a/.changeset/plenty-hounds-rescue.md
+++ b/.changeset/plenty-hounds-rescue.md
@@ -1,5 +1,0 @@
----
-"@coveo/atomic": patch
----
-
-disable Coveo analytics in Storybook when running outside of local environment (e.g., on the documentation site)

--- a/.changeset/plenty-hounds-rescue.md
+++ b/.changeset/plenty-hounds-rescue.md
@@ -2,4 +2,4 @@
 "@coveo/atomic": patch
 ---
 
-fix(storybook): disable analytics on non-local environments j:kit-5701
+fix disabling of analytics on production environments

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -2,8 +2,6 @@ import '@/src/themes/coveo.css';
 import type {Preview} from '@storybook/web-components-vite';
 import {setCustomElementsManifest} from '@storybook/web-components-vite';
 import {setStorybookHelpersConfig} from '@wc-toolkit/storybook-helpers';
-import {render} from 'lit';
-import {isTemplateResult} from 'lit/directive-helpers.js';
 import {initialize, mswLoader} from 'msw-storybook-addon';
 import {within} from 'shadow-dom-testing-library';
 import {create} from 'storybook/theming';
@@ -91,35 +89,6 @@ const preview: Preview = {
     },
     chromatic: {disableSnapshot: true},
   },
-  decorators: [
-    (Story) => {
-      const story = Story();
-
-      if (isTemplateResult(story)) {
-        const container = document.createElement('div');
-
-        render(story, container);
-
-        const isTestMode =
-          typeof window !== 'undefined' &&
-          window.location.href.includes('localhost');
-
-        if (!isTestMode) {
-          disableAnalytics(container, [
-            'atomic-recs-interface',
-            'atomic-insight-interface',
-            'atomic-search-interface',
-            'atomic-commerce-interface',
-            'atomic-commerce-recommendation-interface',
-          ]);
-        }
-
-        return story;
-      }
-
-      return story;
-    },
-  ],
   beforeEach({canvasElement, canvas}) {
     Object.assign(canvas, {...within(canvasElement)});
   },

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -37,14 +37,6 @@ setStorybookHelpersConfig({
   hideArgRef: true,
 });
 
-function disableAnalytics(container: Element, selectors: string[]) {
-  selectors.forEach((selector) => {
-    container.querySelectorAll(selector).forEach((element) => {
-      element.setAttribute('analytics', 'false');
-    });
-  });
-}
-
 const preview: Preview = {
   loaders: [mswLoader],
   parameters: {

--- a/packages/atomic/storybook-pages/commerce/product-listing.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/product-listing.new.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/storybook-utils/api/commerce/listing-response';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import '@/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.js';
@@ -80,11 +81,13 @@ const meta: Meta = {
       () => richResponse as unknown as typeof baseResponse
     );
   },
+
   render: () => html`
     <atomic-commerce-interface
       type="product-listing"
       language-assets-path="./lang"
       icon-assets-path="./assets"
+      analytics="${isTestMode()}"
     >
       <atomic-commerce-layout>
         <atomic-layout-section section="facets"

--- a/packages/atomic/storybook-pages/commerce/product-listing.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/product-listing.new.stories.tsx
@@ -87,7 +87,7 @@ const meta: Meta = {
       type="product-listing"
       language-assets-path="./lang"
       icon-assets-path="./assets"
-      analytics="${isTestMode()}"
+      .analytics=${isTestMode()}
     >
       <atomic-commerce-layout>
         <atomic-layout-section section="facets"

--- a/packages/atomic/storybook-pages/commerce/recommendation.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/recommendation.new.stories.tsx
@@ -60,7 +60,7 @@ const meta: Meta = {
     );
   },
   render: () => html`
-    <atomic-commerce-recommendation-interface analytics="${isTestMode()}">
+    <atomic-commerce-recommendation-interface .analytics=${isTestMode()}>
       <atomic-commerce-recommendation-list
         display="list"
         density="normal"

--- a/packages/atomic/storybook-pages/commerce/recommendation.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/recommendation.new.stories.tsx
@@ -10,6 +10,7 @@ import {
   richResponse,
 } from '@/storybook-utils/api/commerce/recommendation-response';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.js';
 import '@/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.js';
 import '@/src/components/commerce/atomic-product-children/atomic-product-children.js';
@@ -59,7 +60,7 @@ const meta: Meta = {
     );
   },
   render: () => html`
-    <atomic-commerce-recommendation-interface>
+    <atomic-commerce-recommendation-interface analytics="${isTestMode()}">
       <atomic-commerce-recommendation-list
         display="list"
         density="normal"

--- a/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
@@ -7,6 +7,7 @@ import {
   richResponse,
 } from '@/storybook-utils/api/commerce/search-response';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.js';
 import '@/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
@@ -73,6 +74,7 @@ const meta: Meta = {
       type="search"
       language-assets-path="./lang"
       icon-assets-path="./assets"
+      analytics="${isTestMode()}"
     >
       <atomic-commerce-layout>
         <atomic-layout-section section="search">

--- a/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/commerce/search.new.stories.tsx
@@ -74,7 +74,7 @@ const meta: Meta = {
       type="search"
       language-assets-path="./lang"
       icon-assets-path="./assets"
-      analytics="${isTestMode()}"
+      .analytics=${isTestMode()}
     >
       <atomic-commerce-layout>
         <atomic-layout-section section="search">

--- a/packages/atomic/storybook-pages/insight/insight.new.stories.tsx
+++ b/packages/atomic/storybook-pages/insight/insight.new.stories.tsx
@@ -7,6 +7,7 @@ import {
   richResponse,
 } from '@/storybook-utils/api/insight/search-response';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/search/atomic-facet-manager/atomic-facet-manager.js';
 import '@/src/components/search/atomic-field-condition/atomic-field-condition.js';
 import '@/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.js';
@@ -106,6 +107,7 @@ const meta: Meta = {
     <atomic-insight-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
+      analytics="${isTestMode()}"
     >
       <atomic-insight-full-search-button
         slot="full-search"

--- a/packages/atomic/storybook-pages/insight/insight.new.stories.tsx
+++ b/packages/atomic/storybook-pages/insight/insight.new.stories.tsx
@@ -107,7 +107,7 @@ const meta: Meta = {
     <atomic-insight-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
-      analytics="${isTestMode()}"
+      .analytics=${isTestMode()}
     >
       <atomic-insight-full-search-button
         slot="full-search"

--- a/packages/atomic/storybook-pages/ipx/ipx.new.stories.tsx
+++ b/packages/atomic/storybook-pages/ipx/ipx.new.stories.tsx
@@ -114,7 +114,7 @@ const meta: Meta = {
     <atomic-search-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
-      analytics="${isTestMode()}"
+      .analytics=${isTestMode()}
     >
       <atomic-ipx-modal is-open="true">
         <div slot="header">

--- a/packages/atomic/storybook-pages/ipx/ipx.new.stories.tsx
+++ b/packages/atomic/storybook-pages/ipx/ipx.new.stories.tsx
@@ -7,6 +7,7 @@ import {
   richResponse,
 } from '@/storybook-utils/api/search/search-response';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/search/atomic-did-you-mean/atomic-did-you-mean.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/search/atomic-field-condition/atomic-field-condition.js';
@@ -113,6 +114,7 @@ const meta: Meta = {
     <atomic-search-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
+      analytics="${isTestMode()}"
     >
       <atomic-ipx-modal is-open="true">
         <div slot="header">

--- a/packages/atomic/storybook-pages/recommendations/recommendations.new.stories.tsx
+++ b/packages/atomic/storybook-pages/recommendations/recommendations.new.stories.tsx
@@ -110,7 +110,7 @@ const meta: Meta = {
         fields-to-include='["author", "date", "category", "source"]'
         language-assets-path="./lang"
         icon-assets-path="./assets"
-        analytics="${isTestMode()}"
+        .analytics=${isTestMode()}
       >
         <atomic-recs-list
           label="Recommended Articles"

--- a/packages/atomic/storybook-pages/recommendations/recommendations.new.stories.tsx
+++ b/packages/atomic/storybook-pages/recommendations/recommendations.new.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {MockRecommendationApi} from '@/storybook-utils/api/recommendation/mock.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/search/atomic-field-condition/atomic-field-condition.js';
 import '@/src/components/recommendations/atomic-recs-error/atomic-recs-error.js';
 import '@/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.js';
@@ -109,6 +110,7 @@ const meta: Meta = {
         fields-to-include='["author", "date", "category", "source"]'
         language-assets-path="./lang"
         icon-assets-path="./assets"
+        analytics="${isTestMode()}"
       >
         <atomic-recs-list
           label="Recommended Articles"

--- a/packages/atomic/storybook-pages/search/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/search/search.new.stories.tsx
@@ -96,7 +96,7 @@ const meta: Meta = {
     <atomic-search-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
-      analytics="${isTestMode()}"
+      .analytics=${isTestMode()}
     >
       <atomic-search-layout>
         <atomic-layout-section section="search">

--- a/packages/atomic/storybook-pages/search/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/search/search.new.stories.tsx
@@ -7,6 +7,7 @@ import {
   richResponse,
 } from '@/storybook-utils/api/search/search-response';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters.js';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import '@/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.js';
 import '@/src/components/search/atomic-breadbox/atomic-breadbox.js';
 import '@/src/components/search/atomic-category-facet/atomic-category-facet.js';
@@ -95,6 +96,7 @@ const meta: Meta = {
     <atomic-search-interface
       language-assets-path="./lang"
       icon-assets-path="./assets"
+      analytics="${isTestMode()}"
     >
       <atomic-search-layout>
         <atomic-layout-section section="search">

--- a/packages/atomic/storybook-utils/commerce/commerce-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/commerce/commerce-interface-wrapper.tsx
@@ -5,6 +5,7 @@ import {
 import {Decorator, StoryContext} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {spreadProps} from '@open-wc/lit-helpers';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import type {AtomicCommerceInterface} from '@/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.js';
 import '@/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.js';
 
@@ -14,12 +15,14 @@ export const wrapInCommerceInterface = ({
   type = 'search',
   includeCodeRoot = true,
   disableStateReflectionInUrl = false,
+  analytics = isTestMode(),
 }: {
   engineConfig?: Partial<CommerceEngineConfiguration>;
   skipFirstRequest?: boolean;
   type?: 'search' | 'product-listing';
   includeCodeRoot?: boolean;
   disableStateReflectionInUrl?: boolean;
+  analytics?: boolean;
 } = {}): {
   decorator: Decorator;
   play: (context: StoryContext) => Promise<void>;
@@ -29,6 +32,7 @@ export const wrapInCommerceInterface = ({
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
       type="${type}"
       ?disable-state-reflection-in-url=${disableStateReflectionInUrl}
+      .analytics=${analytics}
     >
       ${story()}
     </atomic-commerce-interface>
@@ -39,14 +43,14 @@ export const wrapInCommerceInterface = ({
       canvasElement.querySelector<AtomicCommerceInterface>(
         'atomic-commerce-interface'
       )!;
-    await commerceInterface!.initialize({
+    await commerceInterface.initialize({
       ...getSampleCommerceEngineConfiguration(),
       ...engineConfig,
     });
     if (skipFirstRequest) {
       return;
     }
-    await commerceInterface!.executeFirstRequest();
+    await commerceInterface.executeFirstRequest();
   },
 });
 

--- a/packages/atomic/storybook-utils/commerce/commerce-recommendation-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/commerce/commerce-recommendation-interface-wrapper.tsx
@@ -21,7 +21,7 @@ export const wrapInCommerceRecommendationInterface = (
   decorator: (story) => html`
     <atomic-commerce-recommendation-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
-      .analytics="${analytics}"
+      .analytics=${analytics}
     >
       ${story()}
     </atomic-commerce-recommendation-interface>

--- a/packages/atomic/storybook-utils/commerce/commerce-recommendation-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/commerce/commerce-recommendation-interface-wrapper.tsx
@@ -6,12 +6,14 @@ import {
 import {Decorator, StoryContext} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {spreadProps} from '@open-wc/lit-helpers';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import type {AtomicCommerceRecommendationInterface} from '@/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.js';
 import '@/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.js';
 
 export const wrapInCommerceRecommendationInterface = (
   engineConfig?: Partial<CommerceEngineConfiguration>,
-  includeCodeRoot: boolean = true
+  includeCodeRoot: boolean = true,
+  analytics = isTestMode()
 ): {
   decorator: Decorator;
   play: (context: StoryContext) => Promise<void>;
@@ -19,6 +21,7 @@ export const wrapInCommerceRecommendationInterface = (
   decorator: (story) => html`
     <atomic-commerce-recommendation-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
+      .analytics="${analytics}"
     >
       ${story()}
     </atomic-commerce-recommendation-interface>

--- a/packages/atomic/storybook-utils/common/is-test-mode.ts
+++ b/packages/atomic/storybook-utils/common/is-test-mode.ts
@@ -1,0 +1,5 @@
+export function isTestMode(): boolean {
+  return (
+    typeof window !== 'undefined' && window.location.href.includes('localhost')
+  );
+}

--- a/packages/atomic/storybook-utils/common/is-test-mode.ts
+++ b/packages/atomic/storybook-utils/common/is-test-mode.ts
@@ -1,5 +1,6 @@
 export function isTestMode(): boolean {
   return (
-    typeof window !== 'undefined' && window.location.href.includes('localhost')
+    typeof window !== 'undefined' &&
+    ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)
   );
 }

--- a/packages/atomic/storybook-utils/common/is-test-mode.ts
+++ b/packages/atomic/storybook-utils/common/is-test-mode.ts
@@ -1,6 +1,6 @@
 export function isTestMode(): boolean {
   return (
     typeof window !== 'undefined' &&
-    ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)
+    ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname)
   );
 }

--- a/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
@@ -31,7 +31,7 @@ export const wrapInInsightInterface = (
     </style>
     <atomic-insight-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
-      .analytics=${isTestMode()}
+      .analytics=${analytics}
     >
       ${story()}
     </atomic-insight-interface>

--- a/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
@@ -31,7 +31,7 @@ export const wrapInInsightInterface = (
     </style>
     <atomic-insight-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
-      .analytics="${analytics}"
+      .analytics=${isTestMode()}
     >
       ${story()}
     </atomic-insight-interface>

--- a/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/insight/insight-interface-wrapper.tsx
@@ -5,13 +5,15 @@ import {
 import {Decorator, StoryContext} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {spreadProps} from '@open-wc/lit-helpers';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import type {AtomicInsightInterface} from '@/src/components/insight/atomic-insight-interface/atomic-insight-interface.js';
 import '@/src/components/insight/atomic-insight-interface/atomic-insight-interface.js';
 
 export const wrapInInsightInterface = (
   config?: Partial<InsightEngineConfiguration>,
   skipFirstSearch = false,
-  includeCodeRoot: boolean = true
+  includeCodeRoot: boolean = true,
+  analytics = isTestMode()
 ): {
   decorator: Decorator;
   play: (context: StoryContext) => Promise<void>;
@@ -29,6 +31,7 @@ export const wrapInInsightInterface = (
     </style>
     <atomic-insight-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
+      .analytics="${analytics}"
     >
       ${story()}
     </atomic-insight-interface>

--- a/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
@@ -28,7 +28,7 @@ export const wrapInRecommendationInterface = ({
   decorator: (story) => html`
     <atomic-recs-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
-      .analytics=${isTestMode()}
+      .analytics=${analytics}
     >
       ${story()}
     </atomic-recs-interface>

--- a/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
@@ -28,7 +28,7 @@ export const wrapInRecommendationInterface = ({
   decorator: (story) => html`
     <atomic-recs-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
-      .analytics="${analytics}"
+      .analytics=${isTestMode()}
     >
       ${story()}
     </atomic-recs-interface>

--- a/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/search/recs-interface-wrapper.tsx
@@ -5,6 +5,7 @@ import {
 import {Decorator, StoryContext} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {spreadProps} from '@open-wc/lit-helpers';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import type {AtomicRecsInterface} from '@/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.js';
 import '@/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.js';
 
@@ -13,11 +14,13 @@ export const wrapInRecommendationInterface = ({
   skipFirstQuery = false,
   skipInitialization = false,
   includeCodeRoot = true,
+  analytics = isTestMode(),
 }: {
   config?: Partial<RecommendationEngineConfiguration>;
   skipFirstQuery?: boolean;
   skipInitialization?: boolean;
   includeCodeRoot?: boolean;
+  analytics?: boolean;
 } = {}): {
   decorator: Decorator;
   play: (context: StoryContext) => Promise<void>;
@@ -25,6 +28,7 @@ export const wrapInRecommendationInterface = ({
   decorator: (story) => html`
     <atomic-recs-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
+      .analytics="${analytics}"
     >
       ${story()}
     </atomic-recs-interface>

--- a/packages/atomic/storybook-utils/search/search-interface-wrapper.tsx
+++ b/packages/atomic/storybook-utils/search/search-interface-wrapper.tsx
@@ -5,6 +5,7 @@ import {
 import {Decorator, StoryContext} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {spreadProps} from '@open-wc/lit-helpers';
+import {isTestMode} from '@/storybook-utils/common/is-test-mode';
 import type {AtomicSearchInterface} from '@/src/components/search/atomic-search-interface/atomic-search-interface.js';
 import '@/src/components/search/atomic-search-interface/atomic-search-interface.js';
 
@@ -13,11 +14,13 @@ export const wrapInSearchInterface = ({
   skipFirstSearch = false,
   includeCodeRoot = true,
   disableStateReflectionInUrl = false,
+  analytics = isTestMode(),
 }: {
   config?: Partial<SearchEngineConfiguration>;
   skipFirstSearch?: boolean;
   includeCodeRoot?: boolean;
   disableStateReflectionInUrl?: boolean;
+  analytics?: boolean;
 } = {}): {
   decorator: Decorator;
   play: (context: StoryContext) => Promise<void>;
@@ -26,6 +29,7 @@ export const wrapInSearchInterface = ({
     <atomic-search-interface
       ${spreadProps(includeCodeRoot ? {id: 'code-root'} : {})}
       ?disable-state-reflection-in-url=${disableStateReflectionInUrl}
+      .analytics=${analytics}
     >
       ${story()}
     </atomic-search-interface>
@@ -34,9 +38,9 @@ export const wrapInSearchInterface = ({
     await customElements.whenDefined('atomic-search-interface');
     const searchInterface = canvasElement.querySelector<AtomicSearchInterface>(
       'atomic-search-interface'
-    );
+    )!;
     await step('Render the Search Interface', async () => {
-      await searchInterface!.initialize({
+      await searchInterface.initialize({
         ...getSampleSearchEngineConfiguration(),
         ...config,
       });
@@ -45,7 +49,7 @@ export const wrapInSearchInterface = ({
       return;
     }
     await step('Execute the first search', async () => {
-      await searchInterface!.executeFirstSearch();
+      await searchInterface.executeFirstSearch();
       await new Promise((resolve) => requestAnimationFrame(resolve));
     });
   },

--- a/packages/atomic/tsconfig.storybook.json
+++ b/packages/atomic/tsconfig.storybook.json
@@ -7,8 +7,8 @@
   },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": [
-    "storybookUtils/**/*.ts",
-    "storybookUtils/**/*.tsx",
+    "storybook-utils/**/*.ts",
+    "storybook-utils/**/*.tsx",
     "src/**/*.d.ts",
     "src/**/*.stories.ts",
     "src/**/*.stories.js",


### PR DESCRIPTION
# [KIT-5701 - Atomic: Fix disabling analytics for storybook](https://coveord.atlassian.net/browse/KIT-5701)

### Fix and replace hardcoded analytics control with distributed approach

This refactoring replaces the previous "magical" approach with explicit, configurable analytics management at the story level.

- Fixes analytics being incorrectly disabled on non-local environments (production, staging, etc.)
- Removed non-functional global analytics control from `preview.ts` that used a hardcoded component list
- Moved analytics control to individual story pages and interface wrappers
- Story pages now set `analytics="${isTestMode()}"` directly on interface components
- Interface wrappers (commerce, insight, search, recs) now accept an optional `analytics` parameter (defaults to `isTestMode()`) for reusability in other stories
- Created centralized `isTestMode()` utility function for consistent test environment detection across all stories