### PR TITLE
feat(headless-future): add build converse request body

### DIFF
--- a/.github/prompts/conversational-poc-plan.md
+++ b/.github/prompts/conversational-poc-plan.md
@@ -171,6 +171,17 @@ Completed checklist for 1.4:
 - [x] Added stream utility unit coverage in `src/api/shared/stream.test.ts`
 - [x] Verified package health with `pnpm --filter @coveo/headless-future test && pnpm --filter @coveo/headless-future build`
 
+Completed checklist for 1.5:
+
+- [x] Added `buildConverseRequestBody(engine, input)` in `src/api/conversation/build-converse-request-body.ts`
+- [x] Added `ConverseRequestBody` payload contract aligned to Barca-style converse body fields
+- [x] Mapped payload fields from engine state: configuration, conversation session, cart, and navigator context provider
+- [x] All payload fields are mandatory; missing values default to empty strings (or empty array for `cart`)
+- [x] Kept implementation flat — no helper functions; inlined `engine.getNavigatorContextProvider()?.()` directly
+- [x] Added unit coverage in `src/api/conversation/build-converse-request-body.test.ts`
+- [x] Exported `buildConverseRequestBody` and `ConverseRequestBody` from `src/api/index.ts`
+- [x] Verified package health with `pnpm --filter @coveo/headless-future test && pnpm --filter @coveo/headless-future build`
+
 ### Phase 2 — A2UI Surface Parsing
 
 - **2.0** A2UI protocol contract in `stream-types.ts`
@@ -197,7 +208,7 @@ Completed checklist for 1.4:
 | Phase 1.2 | add-navigator-context            | ✅ completed   |
 | Phase 1.3 | adjust-cart                      | ✅ completed   |
 | Phase 1.4 | add-stream-utils                 | ✅ completed   |
-| Phase 1.5 | —                                | ⬜ not started |
+| Phase 1.5 | add-build-converse-request-body  | ✅ completed   |
 | Phase 1.6 | —                                | ⬜ not started |
 | Phase 1.7 | —                                | ⬜ not started |
 | Phase 1.8 | —                                | ⬜ not started |

--- a/.github/prompts/conversational-poc-plan.md
+++ b/.github/prompts/conversational-poc-plan.md
@@ -178,8 +178,9 @@ Completed checklist for 1.5:
 - [x] Mapped payload fields from engine state: configuration, conversation session, cart, and navigator context provider
 - [x] Implemented raw pass-through payload semantics: no value transformation, preserving `null`/`undefined` from state and navigator context (with `cart` defaulting to `[]` only when cart state is absent)
 - [x] Kept implementation flat — no helper functions; inlined `engine.getNavigatorContextProvider()?.()` directly
+- [x] Extracted converse request payload typing into `src/api/conversation/converse-types.ts` with local cart item shape (no import from core cart types)
 - [x] Added unit coverage in `src/api/conversation/build-converse-request-body.test.ts`
-- [x] Exported `buildConverseRequestBody` and `ConverseRequestBody` from `src/api/index.ts`
+- [x] Kept request-builder details internal to Layer 1: `buildConverseRequestBody`, `ConverseRequestBody`, and shared helpers are no longer exposed from `src/api/index.ts`
 - [x] Verified package health with `pnpm --filter @coveo/headless-future test && pnpm --filter @coveo/headless-future build`
 
 ### Phase 2 — A2UI Surface Parsing

--- a/.github/prompts/conversational-poc-plan.md
+++ b/.github/prompts/conversational-poc-plan.md
@@ -176,7 +176,7 @@ Completed checklist for 1.5:
 - [x] Added `buildConverseRequestBody(engine, input)` in `src/api/conversation/build-converse-request-body.ts`
 - [x] Added `ConverseRequestBody` payload contract aligned to Barca-style converse body fields
 - [x] Mapped payload fields from engine state: configuration, conversation session, cart, and navigator context provider
-- [x] All payload fields are mandatory; missing values default to empty strings (or empty array for `cart`)
+- [x] Implemented raw pass-through payload semantics: no value transformation, preserving `null`/`undefined` from state and navigator context (with `cart` defaulting to `[]` only when cart state is absent)
 - [x] Kept implementation flat — no helper functions; inlined `engine.getNavigatorContextProvider()?.()` directly
 - [x] Added unit coverage in `src/api/conversation/build-converse-request-body.test.ts`
 - [x] Exported `buildConverseRequestBody` and `ConverseRequestBody` from `src/api/index.ts`

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
@@ -1,15 +1,50 @@
 import {describe, expect, it, vi} from 'vitest';
 import {Engine, getFullEngine} from '@/src/core/interface/engine/engine.js';
-import {cartSlice} from '@/src/core/internal/cart/cart-slice.js';
+import {
+  buildMockFullEngine,
+  MockNavigatorContext,
+} from '@/src/test/test-utils.js';
 import {conversationSlice} from '@/src/core/internal/conversation/conversation-slice.js';
-import * as cartMutators from '@/src/core/interface/cart/cart-mutators.js';
 import * as conversationMutators from '@/src/core/interface/conversation/conversation-mutators.js';
+import {buildCartController} from '@/src/public/controllers/cart/cart-controller.js';
 import {buildConverseRequestBody} from './build-converse-request-body.js';
 
+type BuildConverseEngine = Parameters<typeof buildConverseRequestBody>[0];
+
+type MockState = {
+  configuration?: {
+    trackingId?: string;
+    language?: string;
+    country?: string;
+    currency?: string;
+  };
+  conversation?: {
+    session?: {
+      conversationSessionId?: string;
+      conversationToken?: string;
+    };
+  };
+  cart?: {
+    items?: Array<{
+      productId: string;
+      name: string;
+      price: number;
+      quantity: number;
+    }>;
+  };
+};
+
+function buildMockEngine(
+  state: MockState,
+  navigatorContext?: MockNavigatorContext
+): BuildConverseEngine {
+  return buildMockFullEngine(state, navigatorContext) as BuildConverseEngine;
+}
+
 describe('buildConverseRequestBody()', () => {
-  it('builds a payload from engine state', async () => {
-    const engine = getFullEngine(
-      new Engine({
+  describe('integration (real engine)', () => {
+    it('builds a payload from engine state', async () => {
+      const engine = new Engine({
         configuration: {
           organizationId: 'org-id',
           accessToken: 'token',
@@ -24,14 +59,9 @@ describe('buildConverseRequestBody()', () => {
           referrer: 'https://example.com/home',
           userAgent: 'Mozilla/5.0',
         }),
-      })
-    );
-
-    await engine.adoptSlice(cartSlice);
-    await engine.adoptSlice(conversationSlice);
-
-    engine.mutate(
-      cartMutators.setItems({
+      });
+      const cartController = buildCartController({engine});
+      cartController.setItems({
         items: [
           {
             productId: 'sku-1',
@@ -40,181 +70,169 @@ describe('buildConverseRequestBody()', () => {
             quantity: 2,
           },
         ],
-      })
-    );
+      });
 
-    engine.mutate(
-      conversationMutators.setSession({
+      const fullEngine = getFullEngine(engine);
+      await fullEngine.adoptSlice(conversationSlice);
+      fullEngine.mutate(
+        conversationMutators.setSession({
+          conversationSessionId: 'session-123',
+          conversationToken: 'token-abc',
+        })
+      );
+
+      const payload = buildConverseRequestBody(
+        fullEngine,
+        'Need running shoes'
+      );
+
+      expect(payload).toEqual({
+        trackingId: 'market_123',
+        language: 'en',
+        country: 'CA',
+        currency: 'CAD',
+        clientId: 'client-1',
+        message: 'Need running shoes',
+        context: {
+          user: {
+            userAgent: 'Mozilla/5.0',
+          },
+          view: {
+            url: 'https://example.com/products',
+            referrer: 'https://example.com/home',
+          },
+          cart: [
+            {
+              productId: 'sku-1',
+              name: 'Shoe',
+              price: 120,
+              quantity: 2,
+            },
+          ],
+        },
         conversationSessionId: 'session-123',
         conversationToken: 'token-abc',
-      })
-    );
+        targetEngine: 'AGENT_CORE',
+      });
+    });
 
-    const payload = buildConverseRequestBody(engine, 'Need running shoes');
+    it('calls Engine navigator-provider warning path when provider is missing', () => {
+      const engine = new Engine();
+      const fullEngine = getFullEngine(engine);
+      const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    expect(payload).toEqual({
-      trackingId: 'market_123',
-      language: 'en',
-      country: 'CA',
-      currency: 'CAD',
-      clientId: 'client-1',
-      message: 'Need running shoes',
-      context: {
-        user: {
-          userAgent: 'Mozilla/5.0',
-        },
-        view: {
-          url: 'https://example.com/products',
-          referrer: 'https://example.com/home',
-        },
-        cart: [
-          {
-            productId: 'sku-1',
-            name: 'Shoe',
-            price: 120,
-            quantity: 2,
+      const payload = buildConverseRequestBody(fullEngine, 'hello');
+
+      expect(payload).toEqual({
+        trackingId: undefined,
+        language: undefined,
+        country: undefined,
+        currency: undefined,
+        clientId: undefined,
+        message: 'hello',
+        context: {
+          user: {
+            userAgent: undefined,
           },
-        ],
-      },
-      conversationSessionId: 'session-123',
-      conversationToken: 'token-abc',
-      targetEngine: 'AGENT_CORE',
+          view: {
+            url: undefined,
+            referrer: undefined,
+          },
+          cart: [],
+        },
+        conversationSessionId: undefined,
+        conversationToken: undefined,
+        targetEngine: 'AGENT_CORE',
+      });
+
+      expect(warningSpy).toHaveBeenCalledTimes(1);
+      expect(warningSpy.mock.calls[0][0]).toContain(
+        'Missing navigator context provider'
+      );
     });
   });
 
-  it('passes raw values from state including null', async () => {
-    const engine = getFullEngine(
-      new Engine({
-        configuration: {
-          organizationId: 'org-id',
-          accessToken: 'token',
-          trackingId: '',
-          language: '',
-          country: '',
-          currency: '',
+  describe('unit (mocked engine)', () => {
+    it('passes raw values from state including null', () => {
+      const engine = buildMockEngine(
+        {
+          configuration: {
+            trackingId: '',
+            language: '',
+            country: '',
+            currency: '',
+          },
+          conversation: {
+            session: {
+              conversationSessionId: '',
+            },
+          },
+          cart: {
+            items: [],
+          },
         },
-        navigatorContextProvider: () => ({
+        {
           clientId: '',
           location: null,
           referrer: null,
           userAgent: null,
-        }),
-      })
-    );
+        }
+      );
 
-    await engine.adoptSlice(conversationSlice);
+      const payload = buildConverseRequestBody(engine, 'hello');
 
-    engine.mutate(
-      conversationMutators.setSession({
+      expect(payload).toEqual({
+        trackingId: '',
+        language: '',
+        country: '',
+        currency: '',
+        clientId: '',
+        message: 'hello',
+        context: {
+          user: {
+            userAgent: null,
+          },
+          view: {
+            url: null,
+            referrer: null,
+          },
+          cart: [],
+        },
         conversationSessionId: '',
-      })
-    );
-
-    const payload = buildConverseRequestBody(engine, 'hello');
-
-    expect(payload).toEqual({
-      trackingId: '',
-      language: '',
-      country: '',
-      currency: '',
-      clientId: '',
-      message: 'hello',
-      context: {
-        user: {
-          userAgent: null,
-        },
-        view: {
-          url: null,
-          referrer: null,
-        },
-        cart: [],
-      },
-      conversationSessionId: '',
-      conversationToken: undefined,
-      targetEngine: 'AGENT_CORE',
-    });
-  });
-
-  it('calls Engine navigator-provider warning path when provider is missing', () => {
-    const engine = getFullEngine(new Engine());
-    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const payload = buildConverseRequestBody(engine, 'hello');
-
-    expect(payload).toEqual({
-      trackingId: undefined,
-      language: undefined,
-      country: undefined,
-      currency: undefined,
-      clientId: undefined,
-      message: 'hello',
-      context: {
-        user: {
-          userAgent: undefined,
-        },
-        view: {
-          url: undefined,
-          referrer: undefined,
-        },
-        cart: [],
-      },
-      conversationSessionId: undefined,
-      conversationToken: undefined,
-      targetEngine: 'AGENT_CORE',
+        conversationToken: undefined,
+        targetEngine: 'AGENT_CORE',
+      });
     });
 
-    expect(warningSpy).toHaveBeenCalledTimes(1);
-    expect(warningSpy.mock.calls[0][0]).toContain(
-      'Missing navigator context provider'
-    );
-  });
+    it('falls back to empty cart when cart slice is missing', () => {
+      const engine = buildMockEngine({
+        configuration: {},
+        conversation: {},
+      });
 
-  it('works when configuration slice is not adopted', async () => {
-    const engine = getFullEngine(new Engine());
-    await engine.adoptSlice(cartSlice);
+      const payload = buildConverseRequestBody(engine, 'show hats');
 
-    engine.mutate(
-      cartMutators.setItems({
-        items: [
-          {
-            productId: 'sku-2',
-            name: 'Hat',
-            price: 40,
-            quantity: 1,
+      expect(payload).toEqual({
+        trackingId: undefined,
+        language: undefined,
+        country: undefined,
+        currency: undefined,
+        clientId: undefined,
+        message: 'show hats',
+        context: {
+          user: {
+            userAgent: undefined,
           },
-        ],
-      })
-    );
-
-    const payload = buildConverseRequestBody(engine, 'show hats');
-
-    expect(payload).toEqual({
-      trackingId: undefined,
-      language: undefined,
-      country: undefined,
-      currency: undefined,
-      clientId: undefined,
-      message: 'show hats',
-      context: {
-        user: {
-          userAgent: undefined,
-        },
-        view: {
-          url: undefined,
-          referrer: undefined,
-        },
-        cart: [
-          {
-            productId: 'sku-2',
-            name: 'Hat',
-            price: 40,
-            quantity: 1,
+          view: {
+            url: undefined,
+            referrer: undefined,
           },
-        ],
-      },
-      conversationSessionId: undefined,
-      conversationToken: undefined,
-      targetEngine: 'AGENT_CORE',
+          cart: [],
+        },
+        conversationSessionId: undefined,
+        conversationToken: undefined,
+        targetEngine: 'AGENT_CORE',
+      });
     });
   });
 });

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
@@ -7,16 +7,16 @@ import * as conversationMutators from '@/src/core/interface/conversation/convers
 import {buildConverseRequestBody} from './build-converse-request-body.js';
 
 describe('buildConverseRequestBody()', () => {
-  it('builds a Barca-shaped payload from engine state', async () => {
+  it('builds a payload from engine state', async () => {
     const engine = getFullEngine(
       new Engine({
         configuration: {
           organizationId: 'org-id',
           accessToken: 'token',
           trackingId: 'market_123',
-          language: 'EN',
-          country: 'ca',
-          currency: 'cad',
+          language: 'en',
+          country: 'CA',
+          currency: 'CAD',
         },
         navigatorContextProvider: () => ({
           clientId: 'client-1',
@@ -54,9 +54,9 @@ describe('buildConverseRequestBody()', () => {
 
     expect(payload).toEqual({
       trackingId: 'market_123',
-      language: 'EN',
-      country: 'ca',
-      currency: 'cad',
+      language: 'en',
+      country: 'CA',
+      currency: 'CAD',
       clientId: 'client-1',
       message: 'Need running shoes',
       context: {

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
@@ -82,7 +82,7 @@ describe('buildConverseRequestBody()', () => {
     });
   });
 
-  it('defaults missing fields to empty strings', async () => {
+  it('passes raw values from state including null', async () => {
     const engine = getFullEngine(
       new Engine({
         configuration: {
@@ -121,16 +121,16 @@ describe('buildConverseRequestBody()', () => {
       message: 'hello',
       context: {
         user: {
-          userAgent: '',
+          userAgent: null,
         },
         view: {
-          url: '',
-          referrer: '',
+          url: null,
+          referrer: null,
         },
         cart: [],
       },
       conversationSessionId: '',
-      conversationToken: '',
+      conversationToken: undefined,
       targetEngine: 'AGENT_CORE',
     });
   });
@@ -142,24 +142,24 @@ describe('buildConverseRequestBody()', () => {
     const payload = buildConverseRequestBody(engine, 'hello');
 
     expect(payload).toEqual({
-      trackingId: '',
-      language: '',
-      country: '',
-      currency: '',
-      clientId: '',
+      trackingId: undefined,
+      language: undefined,
+      country: undefined,
+      currency: undefined,
+      clientId: undefined,
       message: 'hello',
       context: {
         user: {
-          userAgent: '',
+          userAgent: undefined,
         },
         view: {
-          url: '',
-          referrer: '',
+          url: undefined,
+          referrer: undefined,
         },
         cart: [],
       },
-      conversationSessionId: '',
-      conversationToken: '',
+      conversationSessionId: undefined,
+      conversationToken: undefined,
       targetEngine: 'AGENT_CORE',
     });
 
@@ -189,19 +189,19 @@ describe('buildConverseRequestBody()', () => {
     const payload = buildConverseRequestBody(engine, 'show hats');
 
     expect(payload).toEqual({
-      trackingId: '',
-      language: '',
-      country: '',
-      currency: '',
-      clientId: '',
+      trackingId: undefined,
+      language: undefined,
+      country: undefined,
+      currency: undefined,
+      clientId: undefined,
       message: 'show hats',
       context: {
         user: {
-          userAgent: '',
+          userAgent: undefined,
         },
         view: {
-          url: '',
-          referrer: '',
+          url: undefined,
+          referrer: undefined,
         },
         cart: [
           {
@@ -212,8 +212,8 @@ describe('buildConverseRequestBody()', () => {
           },
         ],
       },
-      conversationSessionId: '',
-      conversationToken: '',
+      conversationSessionId: undefined,
+      conversationToken: undefined,
       targetEngine: 'AGENT_CORE',
     });
   });

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.test.ts
@@ -1,0 +1,220 @@
+import {describe, expect, it, vi} from 'vitest';
+import {Engine, getFullEngine} from '@/src/core/interface/engine/engine.js';
+import {cartSlice} from '@/src/core/internal/cart/cart-slice.js';
+import {conversationSlice} from '@/src/core/internal/conversation/conversation-slice.js';
+import * as cartMutators from '@/src/core/interface/cart/cart-mutators.js';
+import * as conversationMutators from '@/src/core/interface/conversation/conversation-mutators.js';
+import {buildConverseRequestBody} from './build-converse-request-body.js';
+
+describe('buildConverseRequestBody()', () => {
+  it('builds a Barca-shaped payload from engine state', async () => {
+    const engine = getFullEngine(
+      new Engine({
+        configuration: {
+          organizationId: 'org-id',
+          accessToken: 'token',
+          trackingId: 'market_123',
+          language: 'EN',
+          country: 'ca',
+          currency: 'cad',
+        },
+        navigatorContextProvider: () => ({
+          clientId: 'client-1',
+          location: 'https://example.com/products',
+          referrer: 'https://example.com/home',
+          userAgent: 'Mozilla/5.0',
+        }),
+      })
+    );
+
+    await engine.adoptSlice(cartSlice);
+    await engine.adoptSlice(conversationSlice);
+
+    engine.mutate(
+      cartMutators.setItems({
+        items: [
+          {
+            productId: 'sku-1',
+            name: 'Shoe',
+            price: 120,
+            quantity: 2,
+          },
+        ],
+      })
+    );
+
+    engine.mutate(
+      conversationMutators.setSession({
+        conversationSessionId: 'session-123',
+        conversationToken: 'token-abc',
+      })
+    );
+
+    const payload = buildConverseRequestBody(engine, 'Need running shoes');
+
+    expect(payload).toEqual({
+      trackingId: 'market_123',
+      language: 'EN',
+      country: 'ca',
+      currency: 'cad',
+      clientId: 'client-1',
+      message: 'Need running shoes',
+      context: {
+        user: {
+          userAgent: 'Mozilla/5.0',
+        },
+        view: {
+          url: 'https://example.com/products',
+          referrer: 'https://example.com/home',
+        },
+        cart: [
+          {
+            productId: 'sku-1',
+            name: 'Shoe',
+            price: 120,
+            quantity: 2,
+          },
+        ],
+      },
+      conversationSessionId: 'session-123',
+      conversationToken: 'token-abc',
+      targetEngine: 'AGENT_CORE',
+    });
+  });
+
+  it('defaults missing fields to empty strings', async () => {
+    const engine = getFullEngine(
+      new Engine({
+        configuration: {
+          organizationId: 'org-id',
+          accessToken: 'token',
+          trackingId: '',
+          language: '',
+          country: '',
+          currency: '',
+        },
+        navigatorContextProvider: () => ({
+          clientId: '',
+          location: null,
+          referrer: null,
+          userAgent: null,
+        }),
+      })
+    );
+
+    await engine.adoptSlice(conversationSlice);
+
+    engine.mutate(
+      conversationMutators.setSession({
+        conversationSessionId: '',
+      })
+    );
+
+    const payload = buildConverseRequestBody(engine, 'hello');
+
+    expect(payload).toEqual({
+      trackingId: '',
+      language: '',
+      country: '',
+      currency: '',
+      clientId: '',
+      message: 'hello',
+      context: {
+        user: {
+          userAgent: '',
+        },
+        view: {
+          url: '',
+          referrer: '',
+        },
+        cart: [],
+      },
+      conversationSessionId: '',
+      conversationToken: '',
+      targetEngine: 'AGENT_CORE',
+    });
+  });
+
+  it('calls Engine navigator-provider warning path when provider is missing', () => {
+    const engine = getFullEngine(new Engine());
+    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const payload = buildConverseRequestBody(engine, 'hello');
+
+    expect(payload).toEqual({
+      trackingId: '',
+      language: '',
+      country: '',
+      currency: '',
+      clientId: '',
+      message: 'hello',
+      context: {
+        user: {
+          userAgent: '',
+        },
+        view: {
+          url: '',
+          referrer: '',
+        },
+        cart: [],
+      },
+      conversationSessionId: '',
+      conversationToken: '',
+      targetEngine: 'AGENT_CORE',
+    });
+
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+    expect(warningSpy.mock.calls[0][0]).toContain(
+      'Missing navigator context provider'
+    );
+  });
+
+  it('works when configuration slice is not adopted', async () => {
+    const engine = getFullEngine(new Engine());
+    await engine.adoptSlice(cartSlice);
+
+    engine.mutate(
+      cartMutators.setItems({
+        items: [
+          {
+            productId: 'sku-2',
+            name: 'Hat',
+            price: 40,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+
+    const payload = buildConverseRequestBody(engine, 'show hats');
+
+    expect(payload).toEqual({
+      trackingId: '',
+      language: '',
+      country: '',
+      currency: '',
+      clientId: '',
+      message: 'show hats',
+      context: {
+        user: {
+          userAgent: '',
+        },
+        view: {
+          url: '',
+          referrer: '',
+        },
+        cart: [
+          {
+            productId: 'sku-2',
+            name: 'Hat',
+            price: 40,
+            quantity: 1,
+          },
+        ],
+      },
+      conversationSessionId: '',
+      conversationToken: '',
+      targetEngine: 'AGENT_CORE',
+    });
+  });
+});

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.ts
@@ -1,59 +1,44 @@
-import type {CartItem} from '@/src/core/interface/cart/cart-types.js';
 import type {FullEngine} from '@/src/core/interface/engine/engine.js';
-
-type ConverseRequestBodyContext = {
-  user: {
-    userAgent: string | null | undefined;
-  };
-  view: {
-    url: string | null | undefined;
-    referrer: string | null | undefined;
-  };
-  cart: CartItem[];
-};
-
-export type ConverseRequestBody = {
-  trackingId: string | undefined;
-  language: string | undefined;
-  country: string | undefined;
-  currency: string | undefined;
-  clientId: string | undefined;
-  message: string;
-  context: ConverseRequestBodyContext;
-  conversationSessionId: string | undefined;
-  conversationToken: string | undefined;
-  targetEngine: 'AGENT_CORE';
-};
+import type {ConverseRequestBody} from './converse-types.js';
 
 export function buildConverseRequestBody(
   engine: FullEngine,
-  input: string
+  message: string
 ): ConverseRequestBody {
-  const configuration = engine.read((state) => state.configuration);
-  const conversation = engine.read((state) => state.conversation);
-  const cartItems = engine.read((state) => state.cart?.items) ?? [];
+  const {country, currency, language, trackingId} =
+    engine.read((state) => state.configuration) ?? {};
 
-  const navigatorContext = engine.getNavigatorContextProvider()?.();
+  const {
+    clientId,
+    referrer,
+    location: url,
+    userAgent,
+  } = engine.getNavigatorContextProvider()?.() ?? {};
+
+  const {items: cart} = engine.read((state) => state.cart) ?? {items: []};
+
+  const {conversationSessionId, conversationToken} =
+    engine.read((state) => state.conversation?.session) ?? {};
 
   return {
-    trackingId: configuration?.trackingId,
-    language: configuration?.language,
-    country: configuration?.country,
-    currency: configuration?.currency,
-    clientId: navigatorContext?.clientId,
-    message: input,
+    country,
+    currency,
+    language,
+    trackingId,
+    clientId,
     context: {
+      cart,
       user: {
-        userAgent: navigatorContext?.userAgent,
+        userAgent,
       },
       view: {
-        url: navigatorContext?.location,
-        referrer: navigatorContext?.referrer,
+        referrer,
+        url,
       },
-      cart: cartItems,
     },
-    conversationSessionId: conversation?.session.conversationSessionId,
-    conversationToken: conversation?.session.conversationToken,
+    conversationSessionId,
+    conversationToken,
+    message,
     targetEngine: 'AGENT_CORE',
   };
 }

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.ts
@@ -3,25 +3,25 @@ import type {FullEngine} from '@/src/core/interface/engine/engine.js';
 
 type ConverseRequestBodyContext = {
   user: {
-    userAgent: string;
+    userAgent: string | null | undefined;
   };
   view: {
-    url: string;
-    referrer: string;
+    url: string | null | undefined;
+    referrer: string | null | undefined;
   };
   cart: CartItem[];
 };
 
 export type ConverseRequestBody = {
-  trackingId: string;
-  language: string;
-  country: string;
-  currency: string;
-  clientId: string;
+  trackingId: string | undefined;
+  language: string | undefined;
+  country: string | undefined;
+  currency: string | undefined;
+  clientId: string | undefined;
   message: string;
   context: ConverseRequestBodyContext;
-  conversationSessionId: string;
-  conversationToken: string;
+  conversationSessionId: string | undefined;
+  conversationToken: string | undefined;
   targetEngine: 'AGENT_CORE';
 };
 
@@ -36,24 +36,24 @@ export function buildConverseRequestBody(
   const navigatorContext = engine.getNavigatorContextProvider()?.();
 
   return {
-    trackingId: configuration?.trackingId ?? '',
-    language: configuration?.language ?? '',
-    country: configuration?.country ?? '',
-    currency: configuration?.currency ?? '',
-    clientId: navigatorContext?.clientId ?? '',
+    trackingId: configuration?.trackingId,
+    language: configuration?.language,
+    country: configuration?.country,
+    currency: configuration?.currency,
+    clientId: navigatorContext?.clientId,
     message: input,
     context: {
       user: {
-        userAgent: navigatorContext?.userAgent ?? '',
+        userAgent: navigatorContext?.userAgent,
       },
       view: {
-        url: navigatorContext?.location ?? '',
-        referrer: navigatorContext?.referrer ?? '',
+        url: navigatorContext?.location,
+        referrer: navigatorContext?.referrer,
       },
       cart: cartItems,
     },
-    conversationSessionId: conversation?.session.conversationSessionId ?? '',
-    conversationToken: conversation?.session.conversationToken ?? '',
+    conversationSessionId: conversation?.session.conversationSessionId,
+    conversationToken: conversation?.session.conversationToken,
     targetEngine: 'AGENT_CORE',
   };
 }

--- a/packages/headless-future/src/api/conversation/build-converse-request-body.ts
+++ b/packages/headless-future/src/api/conversation/build-converse-request-body.ts
@@ -1,0 +1,59 @@
+import type {CartItem} from '@/src/core/interface/cart/cart-types.js';
+import type {FullEngine} from '@/src/core/interface/engine/engine.js';
+
+type ConverseRequestBodyContext = {
+  user: {
+    userAgent: string;
+  };
+  view: {
+    url: string;
+    referrer: string;
+  };
+  cart: CartItem[];
+};
+
+export type ConverseRequestBody = {
+  trackingId: string;
+  language: string;
+  country: string;
+  currency: string;
+  clientId: string;
+  message: string;
+  context: ConverseRequestBodyContext;
+  conversationSessionId: string;
+  conversationToken: string;
+  targetEngine: 'AGENT_CORE';
+};
+
+export function buildConverseRequestBody(
+  engine: FullEngine,
+  input: string
+): ConverseRequestBody {
+  const configuration = engine.read((state) => state.configuration);
+  const conversation = engine.read((state) => state.conversation);
+  const cartItems = engine.read((state) => state.cart?.items) ?? [];
+
+  const navigatorContext = engine.getNavigatorContextProvider()?.();
+
+  return {
+    trackingId: configuration?.trackingId ?? '',
+    language: configuration?.language ?? '',
+    country: configuration?.country ?? '',
+    currency: configuration?.currency ?? '',
+    clientId: navigatorContext?.clientId ?? '',
+    message: input,
+    context: {
+      user: {
+        userAgent: navigatorContext?.userAgent ?? '',
+      },
+      view: {
+        url: navigatorContext?.location ?? '',
+        referrer: navigatorContext?.referrer ?? '',
+      },
+      cart: cartItems,
+    },
+    conversationSessionId: conversation?.session.conversationSessionId ?? '',
+    conversationToken: conversation?.session.conversationToken ?? '',
+    targetEngine: 'AGENT_CORE',
+  };
+}

--- a/packages/headless-future/src/api/conversation/converse-types.ts
+++ b/packages/headless-future/src/api/conversation/converse-types.ts
@@ -1,0 +1,34 @@
+export type ConverseRequestBody = {
+  trackingId: string | undefined;
+  language: string | undefined;
+  country: string | undefined;
+  currency: string | undefined;
+  clientId: string | undefined;
+  message: string;
+  context: ConverseRequestBodyContext;
+  conversationSessionId: string | undefined;
+  conversationToken: string | undefined;
+  targetEngine: 'AGENT_CORE';
+};
+
+type ConverseRequestBodyUser = {
+  userAgent: string | null | undefined;
+};
+
+type ConverseRequestBodyView = {
+  url: string | null | undefined;
+  referrer: string | null | undefined;
+};
+
+type ConverseRequestBodyCartItem = {
+  productId: string;
+  name: string;
+  price: number;
+  quantity: number;
+};
+
+type ConverseRequestBodyContext = {
+  user: ConverseRequestBodyUser;
+  view: ConverseRequestBodyView;
+  cart: ConverseRequestBodyCartItem[];
+};

--- a/packages/headless-future/src/api/index.ts
+++ b/packages/headless-future/src/api/index.ts
@@ -10,20 +10,3 @@
 
 // Search API
 export {executeSearchAPI} from './search/search.js';
-
-// HTTP utilities (for future API clients)
-export {executeHttpRequest} from './shared/http.js';
-export type {HttpRequestOptions, HttpResponse} from './shared/http.js';
-
-// Stream utilities (for future conversational clients)
-export {readEventStream} from './shared/stream.js';
-export type {ReadEventStreamOptions} from './shared/stream.js';
-
-// Conversation request utilities
-export {
-  buildConverseRequestBody,
-  type ConverseRequestBody,
-} from './conversation/build-converse-request-body.js';
-
-// Error handling utilities (for future API clients)
-export {transformError, isSuccessResponse} from './shared/error-handling.js';

--- a/packages/headless-future/src/api/index.ts
+++ b/packages/headless-future/src/api/index.ts
@@ -19,5 +19,11 @@ export type {HttpRequestOptions, HttpResponse} from './shared/http.js';
 export {readEventStream} from './shared/stream.js';
 export type {ReadEventStreamOptions} from './shared/stream.js';
 
+// Conversation request utilities
+export {
+  buildConverseRequestBody,
+  type ConverseRequestBody,
+} from './conversation/build-converse-request-body.js';
+
 // Error handling utilities (for future API clients)
 export {transformError, isSuccessResponse} from './shared/error-handling.js';

--- a/packages/headless-future/src/core/index.ts
+++ b/packages/headless-future/src/core/index.ts
@@ -22,7 +22,7 @@
 // Engine Type
 // ============================================================================
 
-export {Engine} from './interface/engine/engine.js';
+export {Engine, getFullEngine} from './interface/engine/engine.js';
 export type {EngineOptions} from './interface/engine/engine-types.js';
 export type {
   NavigatorContext,

--- a/packages/headless-future/src/test/test-utils.ts
+++ b/packages/headless-future/src/test/test-utils.ts
@@ -4,7 +4,7 @@
  * Common helpers and mock data builders for unit tests
  */
 
-import {Engine} from '../core/interface/engine/engine.js';
+import {Engine, FullEngine} from '../core/interface/engine/engine.js';
 import type {
   SearchResult,
   FacetValue,
@@ -79,4 +79,22 @@ export function createMockFacetValues(count: number): FacetValue[] {
  */
 export function nextTick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+export type MockNavigatorContext = {
+  clientId?: string;
+  userAgent?: string | null;
+  location?: string | null;
+  referrer?: string | null;
+};
+
+export function buildMockFullEngine<TState>(
+  state: TState,
+  navigatorContext?: MockNavigatorContext
+): FullEngine {
+  return {
+    read: <T>(selector: (s: TState) => T) => selector(state),
+    getNavigatorContextProvider: () =>
+      navigatorContext ? () => navigatorContext : undefined,
+  } as unknown as FullEngine;
 }


### PR DESCRIPTION
Straightforward: function + types for building a request body for the /converse endpoint.

Request shape is based on what's in Barca Shop.