### PR TITLE
feat(atomic): add disable-collapse attribute to breadbox components

### DIFF
--- a/.changeset/breadbox-disable-collapse.md
+++ b/.changeset/breadbox-disable-collapse.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': minor
+---
+
+Added `disable-collapse` boolean attribute to `atomic-breadbox` and `atomic-commerce-breadbox` components. When set, all breadcrumbs are always displayed in a wrapping layout instead of being collapsed into a single row with a "+ N" show more button.

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
@@ -44,12 +44,14 @@ describe('atomic-commerce-breadbox', () => {
   interface RenderBreadboxOptions {
     interfaceElementType?: 'product-listing' | 'search';
     pathLimit?: number;
+    disableCollapse?: boolean;
     state?: Partial<BreadcrumbManagerState>;
   }
 
   const renderBreadbox = async ({
     interfaceElementType = 'product-listing',
     pathLimit = 3,
+    disableCollapse,
     state = {},
   }: RenderBreadboxOptions = {}) => {
     mockedBreadcrumbManager = buildFakeBreadcrumbManager({
@@ -79,6 +81,7 @@ describe('atomic-commerce-breadbox', () => {
         template: html`<div>
           <atomic-commerce-breadbox
             path-limit=${ifDefined(pathLimit)}
+            ?disable-collapse=${disableCollapse}
           ></atomic-commerce-breadbox>
         </div>`,
         selector: 'atomic-commerce-breadbox',
@@ -427,5 +430,45 @@ describe('atomic-commerce-breadbox', () => {
     const disconnectSpy = vi.spyOn(ResizeObserver.prototype, 'disconnect');
     element.disconnectedCallback();
     expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  describe('disable-collapse', () => {
+    it('should show all breadcrumbs without a show-more button when disable-collapse is set', async () => {
+      await page.viewport(400, 100);
+      const {parts, element} = await renderBreadbox({
+        disableCollapse: true,
+      });
+
+      const breadcrumbButtons = element.shadowRoot?.querySelectorAll(
+        '[part="breadcrumb-button"]'
+      );
+      expect(breadcrumbButtons?.length).toBe(4);
+
+      const partsElements = parts(element);
+      expect(partsElements.showMore).toBeNull();
+      expect(partsElements.showLess).toBeNull();
+    });
+
+    it('should use flex-wrap on the breadcrumb list when disable-collapse is set', async () => {
+      const {parts, element} = await renderBreadbox({
+        disableCollapse: true,
+      });
+
+      const partsElements = parts(element);
+      expect(partsElements.breadcrumbList).toHaveClass('flex-wrap');
+      expect(partsElements.breadcrumbList).not.toHaveClass('flex-nowrap');
+    });
+
+    it('should not hide breadcrumbs when the viewport is small and disable-collapse is set', async () => {
+      await page.viewport(200, 100);
+      const {element} = await renderBreadbox({
+        disableCollapse: true,
+      });
+
+      const visibleBreadcrumbs = Array.from(
+        element.shadowRoot!.querySelectorAll('li.breadcrumb')
+      ).filter((el) => (el as HTMLElement).style.display !== 'none');
+      expect(visibleBreadcrumbs.length).toBe(4);
+    });
   });
 });

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
@@ -125,6 +125,15 @@ export class AtomicCommerceBreadbox
   @state() private isCollapsed = true;
   @state() private showMoreText = '';
 
+  /**
+   * Whether to disable the collapsing behavior of breadcrumbs.
+   *
+   * When set, all breadcrumbs are always displayed in a wrapping layout
+   * instead of being collapsed into a single row with a "+ N" show more button.
+   */
+  @property({type: Boolean, attribute: 'disable-collapse'})
+  disableCollapse = false;
+
   private breadboxAriaMessage = new AriaLiveRegionController(
     this,
     'breadbox',
@@ -166,7 +175,9 @@ export class AtomicCommerceBreadbox
     this.context = buildContext(this.bindings.engine);
     this.breadcrumbManager = this.searchOrListing.breadcrumbManager();
 
-    if (window.ResizeObserver && this.parentElement) {
+    if (this.disableCollapse) {
+      this.isCollapsed = false;
+    } else if (window.ResizeObserver && this.parentElement) {
       this.resizeObserver = new ResizeObserver(() => this.adaptBreadcrumbs());
       this.resizeObserver.observe(this.parentElement);
     }
@@ -224,7 +235,7 @@ export class AtomicCommerceBreadbox
   }
 
   private adaptBreadcrumbs() {
-    if (!this.breadcrumbs.length) {
+    if (this.disableCollapse || !this.breadcrumbs.length) {
       return;
     }
     this.showAllBreadcrumbs();
@@ -413,36 +424,38 @@ export class AtomicCommerceBreadbox
       },
     })(
       html`${this.renderBreadcrumbs(breadcrumbs)}
-      ${renderBreadcrumbShowMore({
-        props: {
-          refCallback: async (el) => {
-            await this.breadcrumbShowLessFocus.setTarget(el!);
-          },
-          onShowMore: () => {
-            this.firstExpandedBreadcrumbIndex =
-              this.numberOfBreadcrumbs - this.numberOfCollapsedBreadcrumbs;
-            this.breadcrumbShowMoreFocus.focusOnNextTarget();
-            this.isCollapsed = false;
-          },
-          isCollapsed: this.isCollapsed,
-          i18n: this.bindings.i18n,
-          numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
-          value: this.showMoreText,
-          ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
-            value: this.numberOfCollapsedBreadcrumbs,
-          }),
-        },
-      })}
-      ${renderBreadcrumbShowLess({
-        props: {
-          onShowLess: () => {
-            this.breadcrumbShowLessFocus.focusOnNextTarget();
-            this.isCollapsed = true;
-          },
-          isCollapsed: this.isCollapsed,
-          i18n: this.bindings.i18n,
-        },
-      })}
+      ${this.disableCollapse
+        ? nothing
+        : html`${renderBreadcrumbShowMore({
+            props: {
+              refCallback: async (el) => {
+                await this.breadcrumbShowLessFocus.setTarget(el!);
+              },
+              onShowMore: () => {
+                this.firstExpandedBreadcrumbIndex =
+                  this.numberOfBreadcrumbs - this.numberOfCollapsedBreadcrumbs;
+                this.breadcrumbShowMoreFocus.focusOnNextTarget();
+                this.isCollapsed = false;
+              },
+              isCollapsed: this.isCollapsed,
+              i18n: this.bindings.i18n,
+              numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
+              value: this.showMoreText,
+              ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
+                value: this.numberOfCollapsedBreadcrumbs,
+              }),
+            },
+          })}
+          ${renderBreadcrumbShowLess({
+            props: {
+              onShowLess: () => {
+                this.breadcrumbShowLessFocus.focusOnNextTarget();
+                this.isCollapsed = true;
+              },
+              isCollapsed: this.isCollapsed,
+              i18n: this.bindings.i18n,
+            },
+          })}`}
       ${renderBreadcrumbClearAll({
         props: {
           refCallback: async (ref) => {

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.spec.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.spec.ts
@@ -31,11 +31,13 @@ describe('atomic-breadbox', () => {
 
   interface RenderBreadboxOptions {
     pathLimit?: number;
+    disableCollapse?: boolean;
     breadcrumbState?: Partial<BreadcrumbManagerState>;
   }
 
   const renderBreadbox = async ({
     pathLimit = 3,
+    disableCollapse,
     breadcrumbState = {},
   }: RenderBreadboxOptions = {}) => {
     mockedBreadcrumbManager = buildFakeBreadcrumbManager({
@@ -52,6 +54,7 @@ describe('atomic-breadbox', () => {
     const {element} = await renderInAtomicSearchInterface<AtomicBreadbox>({
       template: html`<atomic-breadbox
         path-limit=${ifDefined(pathLimit)}
+        ?disable-collapse=${disableCollapse}
       ></atomic-breadbox>`,
       selector: 'atomic-breadbox',
       bindings: (bindings) => {
@@ -715,6 +718,66 @@ describe('atomic-breadbox', () => {
       expect(element).toBeDefined();
 
       window.ResizeObserver = originalResizeObserver;
+    });
+  });
+
+  describe('disable-collapse', () => {
+    const breadcrumbState: Partial<BreadcrumbManagerState> = {
+      facetBreadcrumbs: [
+        {
+          facetId: 'test-facet',
+          field: 'test-field',
+          values: Array.from({length: 5}, (_, i) => ({
+            value: {
+              value: `test-value-${i}`,
+              state: 'selected' as const,
+              numberOfResults: 1,
+            },
+            deselect: vi.fn(),
+          })),
+        },
+      ],
+    };
+
+    it('should show all breadcrumbs without a show-more button when disable-collapse is set', async () => {
+      await page.viewport(400, 100);
+      const {parts, element} = await renderBreadbox({
+        disableCollapse: true,
+        breadcrumbState,
+      });
+
+      const breadcrumbButtons = element.shadowRoot?.querySelectorAll(
+        '[part="breadcrumb-button"]'
+      );
+      expect(breadcrumbButtons?.length).toBe(5);
+
+      const partsElements = parts(element);
+      expect(partsElements.showMore).toBeNull();
+      expect(partsElements.showLess).toBeNull();
+    });
+
+    it('should use flex-wrap on the breadcrumb list when disable-collapse is set', async () => {
+      const {parts, element} = await renderBreadbox({
+        disableCollapse: true,
+        breadcrumbState,
+      });
+
+      const partsElements = parts(element);
+      expect(partsElements.breadcrumbList).toHaveClass('flex-wrap');
+      expect(partsElements.breadcrumbList).not.toHaveClass('flex-nowrap');
+    });
+
+    it('should not hide breadcrumbs when the viewport is small and disable-collapse is set', async () => {
+      await page.viewport(200, 100);
+      const {element} = await renderBreadbox({
+        disableCollapse: true,
+        breadcrumbState,
+      });
+
+      const visibleBreadcrumbs = Array.from(
+        element.shadowRoot!.querySelectorAll('li.breadcrumb')
+      ).filter((el) => (el as HTMLElement).style.display !== 'none');
+      expect(visibleBreadcrumbs.length).toBe(5);
     });
   });
 });

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
@@ -97,6 +97,15 @@ export class AtomicBreadbox
   @state() private isCollapsed = true;
   @state() private showMoreText = '';
 
+  /**
+   * Whether to disable the collapsing behavior of breadcrumbs.
+   *
+   * When set, all breadcrumbs are always displayed in a wrapping layout
+   * instead of being collapsed into a single row with a "+ N" show more button.
+   */
+  @property({type: Boolean, attribute: 'disable-collapse'})
+  disableCollapse = false;
+
   private breadboxAriaMessage = new AriaLiveRegionController(
     this,
     'breadbox',
@@ -133,7 +142,9 @@ export class AtomicBreadbox
     this.breadcrumbManager = buildBreadcrumbManager(this.bindings.engine);
     this.facetManager = buildFacetManager(this.bindings.engine);
 
-    if (window.ResizeObserver && this.parentElement) {
+    if (this.disableCollapse) {
+      this.isCollapsed = false;
+    } else if (window.ResizeObserver && this.parentElement) {
       this.resizeObserver = new ResizeObserver(() => this.adaptBreadcrumbs());
       this.resizeObserver.observe(this.parentElement);
     }
@@ -172,36 +183,38 @@ export class AtomicBreadbox
       },
     })(
       html`${this.renderBreadcrumbs(breadcrumbs)}
-      ${renderBreadcrumbShowMore({
-        props: {
-          refCallback: async (el) => {
-            await this.breadcrumbShowLessFocus.setTarget(el!);
-          },
-          onShowMore: () => {
-            this.firstExpandedBreadcrumbIndex =
-              this.numberOfBreadcrumbs - this.numberOfCollapsedBreadcrumbs;
-            this.breadcrumbShowMoreFocus.focusOnNextTarget();
-            this.isCollapsed = false;
-          },
-          isCollapsed: this.isCollapsed,
-          i18n: this.bindings.i18n,
-          numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
-          value: this.showMoreText,
-          ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
-            value: this.numberOfCollapsedBreadcrumbs,
-          }),
-        },
-      })}
-      ${renderBreadcrumbShowLess({
-        props: {
-          onShowLess: () => {
-            this.breadcrumbShowLessFocus.focusOnNextTarget();
-            this.isCollapsed = true;
-          },
-          isCollapsed: this.isCollapsed,
-          i18n: this.bindings.i18n,
-        },
-      })}
+      ${this.disableCollapse
+        ? nothing
+        : html`${renderBreadcrumbShowMore({
+            props: {
+              refCallback: async (el) => {
+                await this.breadcrumbShowLessFocus.setTarget(el!);
+              },
+              onShowMore: () => {
+                this.firstExpandedBreadcrumbIndex =
+                  this.numberOfBreadcrumbs - this.numberOfCollapsedBreadcrumbs;
+                this.breadcrumbShowMoreFocus.focusOnNextTarget();
+                this.isCollapsed = false;
+              },
+              isCollapsed: this.isCollapsed,
+              i18n: this.bindings.i18n,
+              numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
+              value: this.showMoreText,
+              ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
+                value: this.numberOfCollapsedBreadcrumbs,
+              }),
+            },
+          })}
+          ${renderBreadcrumbShowLess({
+            props: {
+              onShowLess: () => {
+                this.breadcrumbShowLessFocus.focusOnNextTarget();
+                this.isCollapsed = true;
+              },
+              isCollapsed: this.isCollapsed,
+              i18n: this.bindings.i18n,
+            },
+          })}`}
       ${renderBreadcrumbClearAll({
         props: {
           refCallback: async (ref) => {
@@ -259,7 +272,7 @@ export class AtomicBreadbox
   }
 
   private adaptBreadcrumbs() {
-    if (!this.breadcrumbs.length) {
+    if (this.disableCollapse || !this.breadcrumbs.length) {
       return;
     }
     this.showAllBreadcrumbs();


### PR DESCRIPTION
[KIT-5702](https://coveord.atlassian.net/browse/KIT-5702)

## Problem
From a [Discuss post (SUPPORT-00137506)](https://discuss.coveo.com/t/support-00137506-ability-to-never-see-the-1-show-more-option-in-breadcrumbs/14490): a client wants selected facets to always be displayed in full in the breadbox. They don't want the "+1" / "Show more" button to appear when longer facet values are selected.

The `atomic-breadbox` and `atomic-commerce-breadbox` components always collapse breadcrumbs into a single row with a "+ N" show more button when they overflow. There is no property to disable this behavior, and CSS workarounds don't work because the overflow detection and hiding is JavaScript-based (`display: none` on `<li>` elements).

## Solution
Added a `disable-collapse` boolean attribute to both `atomic-breadbox` and `atomic-commerce-breadbox` components.

- **Absent (default):** Breadcrumbs collapse into a single row with a `+ N` "Show more" button (current behavior).
- **Present:** All breadcrumbs are always shown in a wrapping layout — no collapsing, no show more/less buttons.

When `disable-collapse` is set:
- The `isCollapsed` state is initialized to `false` (wrapping layout)
- The `ResizeObserver` is not created (no overflow detection needed)
- The `adaptBreadcrumbs()` method is a no-op
- The show more and show less buttons are not rendered

Usage:
```html
<atomic-breadbox disable-collapse></atomic-breadbox>
<atomic-commerce-breadbox disable-collapse></atomic-commerce-breadbox>
```

[KIT-5702]: https://coveord.atlassian.net/browse/KIT-5702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ