### PR TITLE
SFINT-6796 fix(headless): answer api sendFeedback error log

### DIFF
--- a/.changeset/spotty-keys-cheer.md
+++ b/.changeset/spotty-keys-cheer.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+SFINT-6796 fix(headless): answer api sendFeedback error log

--- a/.changeset/spotty-keys-cheer.md
+++ b/.changeset/spotty-keys-cheer.md
@@ -2,4 +2,4 @@
 "@coveo/headless": patch
 ---
 
-SFINT-6796 fix(headless): answer api sendFeedback error log
+SFINT-6796 fix(headless): fix answer api sendFeedback logs error messages about non-serializable values

--- a/packages/headless/src/api/knowledge/answer-slice.ts
+++ b/packages/headless/src/api/knowledge/answer-slice.ts
@@ -38,10 +38,9 @@ const dynamicBaseQuery: BaseQueryFn<
       organizationId,
       environment
     );
-    const data = fetchBaseQuery({
+    return fetchBaseQuery({
       baseUrl: `${platformEndpoint}/rest/organizations/${organizationId}/answer/v1/configs/${answerConfigurationId}`,
     })(updatedArgs, api, extraOptions);
-    return {data};
   } catch (error) {
     return {error: error as FetchBaseQueryError};
   }

--- a/packages/headless/src/api/knowledge/post-answer-evaluation.test.ts
+++ b/packages/headless/src/api/knowledge/post-answer-evaluation.test.ts
@@ -1,0 +1,107 @@
+import {configureStore} from '@reduxjs/toolkit';
+import type {Mock} from 'vitest';
+import {
+  type AnswerEvaluationPOSTParams,
+  answerEvaluation,
+} from './post-answer-evaluation.js';
+
+const {Response} = await vi.importActual('node-fetch');
+const originalFetch = global.fetch;
+
+const mockEvaluationBody: AnswerEvaluationPOSTParams = {
+  additionalNotes: null,
+  answer: {
+    format: 'text/plain',
+    responseId: 'answer-id',
+    text: 'answer',
+  },
+  correctAnswerUrl: null,
+  details: {
+    correctTopic: null,
+    documented: null,
+    hallucinationFree: null,
+    readable: null,
+  },
+  helpful: false,
+  question: 'question',
+};
+
+const buildStore = () =>
+  configureStore({
+    reducer: {
+      configuration: (
+        state = {
+          accessToken: 'access-token',
+          environment: 'prod',
+          organizationId: 'myorg',
+        }
+      ) => state,
+      generatedAnswer: (
+        state = {
+          answerConfigurationId: 'answer-configuration-id',
+        }
+      ) => state,
+      [answerEvaluation.reducerPath]: answerEvaluation.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(answerEvaluation.middleware),
+  });
+
+describe('answerEvaluation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('treats a failed evaluation request as an RTK Query error and expects the correct error object', async () => {
+    (global.fetch as Mock).mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({message: 'boom'}), {
+          headers: {'content-type': 'application/json'},
+          status: 500,
+        })
+      )
+    );
+    const store = buildStore();
+
+    const result = store
+      .dispatch(answerEvaluation.endpoints.post.initiate(mockEvaluationBody))
+      .unwrap();
+    const expectation = expect(result).rejects.toMatchObject({
+      data: {message: 'boom'},
+      status: 500,
+    });
+    await vi.runAllTimersAsync();
+
+    await expectation;
+  });
+
+  it('treats a successful evaluation request as an RTK Query success and expects the correct result', async () => {
+    (global.fetch as Mock).mockImplementation(() =>
+      Promise.resolve(
+        new Response(null, {
+          headers: {'content-type': 'application/json'},
+          status: 204,
+        })
+      )
+    );
+    const store = buildStore();
+
+    const result = store
+      .dispatch(answerEvaluation.endpoints.post.initiate(mockEvaluationBody))
+      .unwrap();
+    const expectation = expect(result).resolves.toBeNull();
+    await vi.runAllTimersAsync();
+
+    await expectation;
+  });
+});


### PR DESCRIPTION
### SFINT-6796

## Summary
- Return the inner `fetchBaseQuery` result directly from the Answer API dynamic base query so RTK Query receives the standard top-level `{data, meta}` or `{error, meta}` shape.
- Add API-level coverage around `answerEvaluation.endpoints.post` using RTK Query `.unwrap()` behavior for success and failure cases.

## Impact Checked
- Checked the generated answer flow and confirmed `getAnswer` generate calls are not affected because that endpoint defines its own `queryFn`.
- RTK Query bypasses the API `baseQuery` whenever an endpoint provides `queryFn`, so `dynamicBaseQuery` is not used for the streaming generate request.
- The impacted consumer is `answerEvaluation.endpoints.post`, used by `sendFeedback` for the `/evaluations` call.
- With the previous wrapper, an HTTP failure from `fetchBaseQuery` was nested inside `data`, so RTK Query could treat a failed evaluation request as a fulfilled query.
- Returning the `fetchBaseQuery` result directly lets RTK Query classify failed evaluation requests as errors, run retry/error handling correctly, and keep successful empty responses as fulfilled `null` data.
- It also fixes error logging produced by RTK about a non-serializable value contained in the cache.

## Validation
- Added a test to validate that a rejected promise in a RTK query actually produces a 500 and the error is correctly handled by RTK instead of previously being invisible because of the wrong data structure.