### PR TITLE
fix(headless): guard follow-up requests when capability is disabled

### DIFF
--- a/.changeset/smart-adults-hug.md
+++ b/.changeset/smart-adults-hug.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+fix(headless): guard follow-up requests when capability is disabled

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -659,6 +659,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
           ...getFollowUpAnswersInitialState(),
           conversationId,
           conversationToken,
+          isEnabled: true,
         },
       });
       const controller = createGeneratedAnswerWithFollowUps();
@@ -696,7 +697,31 @@ describe('GeneratedAnswerWithFollowUps', () => {
       expect(mockFollowUpAgent.runAgent).not.toHaveBeenCalled();
     });
 
+    it('does not run the agent when the follow-up capability is not enabled', () => {
+      engine = buildEngineWithGeneratedAnswer({
+        followUpAnswers: {
+          ...getFollowUpAnswersInitialState(),
+          conversationId,
+          conversationToken,
+          isEnabled: false,
+        },
+      });
+      const controller = createGeneratedAnswerWithFollowUps();
+
+      controller.askFollowUp(question);
+
+      expect(mockFollowUpAgent.abortRun).not.toHaveBeenCalled();
+      expect(mockCreateFollowUpAnswer).not.toHaveBeenCalled();
+      expect(mockFollowUpAgent.runAgent).not.toHaveBeenCalled();
+    });
+
     it('does not run the agent when the conversationId is missing', () => {
+      engine = buildEngineWithGeneratedAnswer({
+        followUpAnswers: {
+          ...getFollowUpAnswersInitialState(),
+          isEnabled: true,
+        },
+      });
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -718,6 +743,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
         followUpAnswers: {
           ...getFollowUpAnswersInitialState(),
           conversationId,
+          isEnabled: true,
         },
       });
       const consoleWarnSpy = vi
@@ -742,6 +768,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
           ...getFollowUpAnswersInitialState(),
           conversationId,
           conversationToken,
+          isEnabled: true,
         },
       });
       const controller = createGeneratedAnswerWithFollowUps();

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -689,6 +689,14 @@ describe('GeneratedAnswerWithFollowUps', () => {
     });
 
     it('does not run the agent when the question is empty', () => {
+      engine = buildEngineWithGeneratedAnswer({
+        followUpAnswers: {
+          ...getFollowUpAnswersInitialState(),
+          conversationId,
+          conversationToken,
+          isEnabled: true,
+        },
+      });
       const controller = createGeneratedAnswerWithFollowUps();
 
       controller.askFollowUp('   ');
@@ -720,6 +728,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
         followUpAnswers: {
           ...getFollowUpAnswersInitialState(),
           isEnabled: true,
+          conversationToken,
         },
       });
       const consoleWarnSpy = vi

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -697,7 +697,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
       expect(mockFollowUpAgent.runAgent).not.toHaveBeenCalled();
     });
 
-    it('does not run the agent when the follow-up capability is not enabled', () => {
+    it('does not run the follow-up agent when the follow-up capability is not enabled', () => {
       engine = buildEngineWithGeneratedAnswer({
         followUpAnswers: {
           ...getFollowUpAnswersInitialState(),

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -238,6 +238,9 @@ export function buildGeneratedAnswerWithFollowUps(
     },
 
     async askFollowUp(question: string) {
+      if (!this.state.followUpAnswers.isEnabled) {
+        return;
+      }
       if (!question || question.trim() === '') {
         return;
       }


### PR DESCRIPTION
## [SFINT-6797](https://coveord.atlassian.net/browse/SFINT-6797)

## Summary
This change prevents askFollowUp from trying to run the follow-up agent when the follow-up capability is disabled.

## What changed
  - Added an early return in GeneratedAnswerWithFollowUps.askFollowUp when followUpAnswers.isEnabled is false
  - Added a test to verify no follow-up work is triggered when the capability is disabled

## Why
`askFollowUp` should respect the follow-up feature state. Without this guard, callers could still try to trigger the follow-up behaviour even when the capability was not enabled.

[SFINT-6797]: https://coveord.atlassian.net/browse/SFINT-6797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ