### PR TITLE
docs: add prerequisites section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md
 
+## Prerequisites
+
+- **Node.js**: Version pinned in `.nvmrc` (use `nvm use` or the devcontainer)
+- **pnpm**: Pinned in `package.json` `packageManager` field. Run `corepack enable` to activate it.
+
 ## Commands
 
 - **Build all packages**: `pnpm run build`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Node.js**: Version pinned in `.nvmrc` (use `nvm use` or the devcontainer)
-- **pnpm**: Pinned in `package.json` `packageManager` field. Run `corepack enable` to activate it.
+- **pnpm**: Pinned in `package.json` `packageManager` field. Run `corepack enable` to activate it
 
 ## Commands
 


### PR DESCRIPTION
## Problem

The root `AGENTS.md` listed commands and structure but didn't explicitly state the prerequisites (Node.js version and pnpm activation) at the top. Agents and new contributors had to infer setup steps from `.nvmrc` and `package.json` separately.

## Solution

Added a `## Prerequisites` section at the top of `AGENTS.md` with:
- Node.js version reference (pinned in `.nvmrc`, use `nvm use` or the devcontainer)
- pnpm activation via `corepack enable`

## Validation

- `pnpm run lint:check` passes
- No changeset required (documentation-only change, no public package source code modified)