### PR TITLE
fix(atomic): prevent text overlap in feedback modal radio buttons on iPhone

### DIFF
--- a/.changeset/fix-feedback-modal-text-overlap.md
+++ b/.changeset/fix-feedback-modal-text-overlap.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fixed "Not sure" button text overlapping borders in the generated answer feedback modal on iPhone devices by adding `whitespace-nowrap` to prevent text wrapping within the radio button options.

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
@@ -298,7 +298,7 @@ export class AtomicGeneratedAnswerFeedbackModal
         onChecked: () => {
           this.setCurrentAnswer(correspondingAnswer, option);
         },
-        class: `min-w-20 flex items-center justify-center px-3 py-1.5 mr-1 text-neutral-dark ${isSelected ? 'active' : ''}`,
+        class: `min-w-20 flex items-center justify-center whitespace-nowrap px-3 py-1.5 mr-1 text-neutral-dark ${isSelected ? 'active' : ''}`,
         text: this.bindings.i18n.t(option),
       },
     });


### PR DESCRIPTION
[KIT-5706](https://coveord.atlassian.net/browse/KIT-5706)

## Problem
On iPhone devices (iPhone 13, iPhone 15) in Chrome and Safari, the "Not sure" text in the generated answer feedback modal radio buttons overlaps the button borders. The text wraps within the minimum width constraint of the buttons, causing visual misalignment.

### Before 

<img width="699" height="1047" alt="image" src="https://github.com/user-attachments/assets/9086e022-bfdd-4e39-ad21-cde2f826f33d" />


### After
<img width="593" height="1032" alt="image" src="https://github.com/user-attachments/assets/46919b7c-b1de-40bb-a154-3558c341f53d" />


## Solution
Added `whitespace-nowrap` to the radio button options in the feedback modal to prevent text from wrapping within the button boundaries. This ensures the button expands to fit its content rather than allowing the text to overflow and overlap borders.

[KIT-5706]: https://coveord.atlassian.net/browse/KIT-5706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ