### PR TITLE
feat(analytics): add experimental privacy control options for analytics

### DIFF
--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -54,6 +54,20 @@ export interface EngineConfiguration {
    * Defaults to `prod`.
    */
   environment?: PlatformEnvironment;
+  /**
+   * The experimental options. These options are not covered by semver and can be changed or removed without a major version bump.
+   * They are meant to be used for testing new features before they are officially released.
+   */
+  experimental?: ExperimentalEngineConfiguration;
+}
+
+interface ExperimentalEngineConfiguration {
+  /**
+   * Set to true to handle privacy control outside Headless, even with legacy analytics mode.
+   * This is useful for implementers who want to handle Do Not Track (DNT) or similar privacy controls on their own,
+   * without relying on Headless to do it for them.
+   */
+  useOwnPrivacyControl?: boolean;
 }
 
 /**

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -61,7 +61,7 @@ export interface EngineConfiguration {
   experimental?: ExperimentalEngineConfiguration;
 }
 
-interface ExperimentalEngineConfiguration {
+export interface ExperimentalEngineConfiguration {
   /**
    * Set to true to handle privacy control outside Headless, even with legacy analytics mode.
    * This is useful for implementers who want to handle Do Not Track (DNT) or similar privacy controls on their own,

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -213,6 +213,16 @@ export const engineConfigurationDefinitions: SchemaDefinition<EngineConfiguratio
       default: 'prod',
       constrainTo: ['prod', 'hipaa', 'stg', 'dev'],
     }),
+    experimental: new RecordValue({
+      options: {
+        required: false,
+      },
+      values: {
+        useOwnPrivacyControl: new BooleanValue({
+          required: false,
+        }),
+      },
+    }),
   };
 
 export function getSampleEngineConfiguration(): EngineConfiguration {

--- a/packages/headless/src/app/engine.test.ts
+++ b/packages/headless/src/app/engine.test.ts
@@ -7,9 +7,18 @@ import * as Store from '../app/store.js';
 import {updateAnalyticsConfiguration} from '../features/configuration/configuration-actions.js';
 import {buildMockNavigatorContextProvider} from '../test/mock-navigator-context-provider.js';
 import {buildMockThunkExtraArguments} from '../test/mock-thunk-extra-arguments.js';
+import {doNotTrack} from '../utils/utils.js';
 import {configuration} from './common-reducers.js';
 import {buildEngine, type CoreEngine, type EngineOptions} from './engine.js';
 import {getSampleEngineConfiguration} from './engine-configuration.js';
+
+vi.mock(import('../utils/utils.js'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    doNotTrack: vi.fn(() => false),
+  };
+});
 
 vi.mock(import('pino'), async (importOriginal) => {
   const mod = await importOriginal(); // type is inferred
@@ -32,6 +41,7 @@ describe('engine', () => {
   }
 
   beforeEach(() => {
+    vi.mocked(doNotTrack).mockReturnValue(false);
     organizationId = 'orgId';
     options = {
       configuration: {
@@ -103,6 +113,25 @@ describe('engine', () => {
     const {analytics} = engine.state.configuration;
     expect(analytics.enabled).toBe(true);
     expect(analytics.trackingId).toBeUndefined();
+  });
+
+  it('when doNotTrack is active and own privacy control is disabled, it disables analytics', () => {
+    options.configuration.analytics = {analyticsMode: 'legacy'};
+    vi.mocked(doNotTrack).mockReturnValue(true);
+
+    const engine = initEngine();
+
+    expect(engine.state.configuration.analytics.enabled).toBe(false);
+  });
+
+  it('when doNotTrack is active and own privacy control is enabled, it keeps analytics enabled', () => {
+    options.configuration.analytics = {analyticsMode: 'legacy'};
+    options.configuration.experimental = {useOwnPrivacyControl: true};
+    vi.mocked(doNotTrack).mockReturnValue(true);
+
+    const engine = initEngine();
+
+    expect(engine.state.configuration.analytics.enabled).toBe(true);
   });
 
   it('calling #enableAnalytics sets #analytics.enabled to true', () => {

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -196,6 +196,8 @@ function getUpdateAnalyticsConfigurationPayload(
   logger: Logger
 ): UpdateAnalyticsConfigurationActionCreatorPayload | null {
   const {analytics} = configuration;
+  const useOwnPrivacyControl =
+    configuration.experimental?.useOwnPrivacyControl ?? false;
   const {analyticsClientMiddleware: _, ...payload} = analytics ?? {};
 
   const payloadWithURL = {
@@ -207,7 +209,11 @@ function getUpdateAnalyticsConfigurationPayload(
   };
 
   // TODO KIT-2844
-  if (payloadWithURL.analyticsMode !== 'next' && doNotTrack()) {
+  if (
+    payloadWithURL.analyticsMode !== 'next' &&
+    !useOwnPrivacyControl &&
+    doNotTrack()
+  ) {
     logger.info('Analytics disabled since doNotTrack is active.');
     return {
       ...payloadWithURL,

--- a/packages/headless/src/case-assist.index.ts
+++ b/packages/headless/src/case-assist.index.ts
@@ -36,6 +36,7 @@ export type {
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
   EngineConfiguration,
+  ExperimentalEngineConfiguration,
 } from './app/engine-configuration.js';
 export type {LoggerOptions, LogLevel} from './app/logger.js';
 export type {NavigatorContext} from './app/navigator-context-provider.js';

--- a/packages/headless/src/commerce.index.ts
+++ b/packages/headless/src/commerce.index.ts
@@ -66,6 +66,7 @@ export type {
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
   EngineConfiguration,
+  ExperimentalEngineConfiguration,
 } from './app/engine-configuration.js';
 export type {LoggerOptions, LogLevel} from './app/logger.js';
 export type {NavigatorContext} from './app/navigator-context-provider.js';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -25,6 +25,7 @@ export type {
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
   EngineConfiguration,
+  ExperimentalEngineConfiguration,
 } from './app/engine-configuration.js';
 export type {LoggerOptions, LogLevel} from './app/logger.js';
 export type {NavigatorContext} from './app/navigator-context-provider.js';

--- a/packages/headless/src/insight.index.ts
+++ b/packages/headless/src/insight.index.ts
@@ -37,6 +37,7 @@ export type {
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
   EngineConfiguration,
+  ExperimentalEngineConfiguration,
 } from './app/engine-configuration.js';
 // Main App
 export type {

--- a/packages/headless/src/recommendation.index.ts
+++ b/packages/headless/src/recommendation.index.ts
@@ -29,6 +29,7 @@ export type {
   AnalyticsConfiguration,
   AnalyticsRuntimeEnvironment,
   EngineConfiguration,
+  ExperimentalEngineConfiguration,
 } from './app/engine-configuration.js';
 export type {LoggerOptions, LogLevel} from './app/logger.js';
 export type {NavigatorContext} from './app/navigator-context-provider.js';


### PR DESCRIPTION
This pull request introduces support for an experimental configuration option that allows clients to handle privacy controls (such as Do Not Track) outside of Headless, even when using legacy analytics mode. It adds a new `experimental` configuration section, updates the analytics initialization logic to respect this setting, and adds comprehensive tests to verify the new behavior.

Configuration enhancements:

* Added an `experimental` field to `EngineConfiguration`, including a `useOwnPrivacyControl` option that lets implementers bypass Headless's built-in Do Not Track handling for analytics.

Analytics logic updates:

* Modified analytics initialization in `engine.ts` so that analytics are only disabled for Do Not Track if `useOwnPrivacyControl` is not enabled in the experimental config. [[1]](diffhunk://#diff-2756d7c3682536d992d532be3f47ea63f800a8b389375dbe43bf54cf4c13d9fbR199-R200) [[2]](diffhunk://#diff-2756d7c3682536d992d532be3f47ea63f800a8b389375dbe43bf54cf4c13d9fbL210-R216)

Testing improvements:

* Added and updated tests in `engine.test.ts` to mock the Do Not Track utility and verify analytics behavior with and without the new experimental option. [[1]](diffhunk://#diff-2f7e394cce863a13f13f586f28794e3f5fac4c8768c53e0a0051154a7d8d56bcR10-R22) [[2]](diffhunk://#diff-2f7e394cce863a13f13f586f28794e3f5fac4c8768c53e0a0051154a7d8d56bcR44) [[3]](diffhunk://#diff-2f7e394cce863a13f13f586f28794e3f5fac4c8768c53e0a0051154a7d8d56bcR118-R136)