### PR TITLE
fix(atomic): fix show-more aria-label in commerce breadbox

### DIFF
--- a/.changeset/fix-breadbox-show-more-aria-label.md
+++ b/.changeset/fix-breadbox-show-more-aria-label.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fixed the "Show More" button aria-label in `atomic-commerce-breadbox` to read "Show N more filters" instead of "Show + N more filters".

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
@@ -97,7 +97,7 @@ describe('atomic-commerce-breadbox', () => {
       hierarchical: () => page.getByTitle('Hierarchical'),
       numericalRange: () => page.getByTitle('Numerical Range'),
       dateRange: () => page.getByTitle('Date Range'),
-      showMore: () => page.getByLabelText(/Show \+ \d+ more filters/),
+      showMore: () => page.getByLabelText(/Show \d+ more filters/),
       showLess: () => page.getByText('Show less'),
       clearAll: () => page.getByLabelText('Clear All Filters'),
       parts: (element: AtomicCommerceBreadbox) => {
@@ -284,7 +284,7 @@ describe('atomic-commerce-breadbox', () => {
     const {showMore} = await renderBreadbox();
     await expect
       .element(showMore())
-      .toHaveAttribute('aria-label', 'Show + 3 more filters');
+      .toHaveAttribute('aria-label', 'Show 3 more filters');
   });
 
   it('should expand and collapse the number of breadcrumbs when clicking on the show more button and on the show less button', async () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
@@ -429,7 +429,7 @@ export class AtomicCommerceBreadbox
           numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
           value: this.showMoreText,
           ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
-            value: this.showMoreText,
+            value: this.numberOfCollapsedBreadcrumbs,
           }),
         },
       })}

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/page-object.ts
@@ -57,7 +57,7 @@ export class AtomicCommerceBreadboxPageObject extends BasePageObject {
   }
 
   getShowMorebutton() {
-    return this.page.getByLabel(/Show\s*\+\s*\d+\s+more filters/);
+    return this.page.getByLabel(/Show\s*\d+\s+more filters/);
   }
 
   getClearAllButton() {

--- a/packages/atomic/src/components/search/atomic-breadbox/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/e2e/page-object.ts
@@ -32,7 +32,7 @@ export class AtomicBreadboxPageObject extends BasePageObject {
   }
 
   getShowMoreButton() {
-    return this.page.getByLabel(/Show\s*\+\s*\d+\s+more filters/);
+    return this.page.getByLabel(/Show\s*\d+\s+more filters/);
   }
 
   getClearAllButton() {


### PR DESCRIPTION
[KIT-5708](https://coveord.atlassian.net/browse/KIT-5708)

## Problem
The "Show More" button in `atomic-commerce-breadbox` uses `showMoreText` (e.g., "+ 3") as the value for the aria-label i18n interpolation, producing "Show + 3 more filters". Screen readers read this as "Show plus 3 more filters" which is confusing.

## Solution
Pass `numberOfCollapsedBreadcrumbs` (the raw number) to the aria-label i18n call so it reads "Show 3 more filters". Also updated the e2e page object regexes to match the new label format.


[KIT-5708]: https://coveord.atlassian.net/browse/KIT-5708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ