### PR TITLE
feat(atomic): migrate product section stories to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-actions',
@@ -34,6 +37,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -46,6 +50,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-badges',
@@ -33,6 +36,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -45,6 +49,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-bottom-metadata',
@@ -32,6 +35,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +48,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-children/atomic-product-section-children.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-children',
@@ -32,6 +35,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +48,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-description/atomic-product-section-description.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {play} = wrapInCommerceInterface({
   engineConfig: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -45,6 +49,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-emphasized',
@@ -32,6 +35,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +48,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-metadata',
@@ -32,6 +35,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +48,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-name/atomic-product-section-name.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-name',
@@ -33,6 +36,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -45,6 +49,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {
   getProductSectionArgs,
@@ -8,6 +9,8 @@ import {
 } from '@/storybook-utils/commerce/product-section-story-utils';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-product-section-visual',
@@ -32,6 +35,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +48,9 @@ const meta: Meta = {
   argTypes: {
     ...argTypes,
     ...getProductSectionArgTypes(),
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 


### PR DESCRIPTION
## Problem
Commerce product section stories lack MSW (Mock Service Worker) API mocking, making them dependent on real API calls during testing.

## Solution
Add `MockCommerceApi` handlers to all 9 product section component stories:
- `atomic-product-section-name`
- `atomic-product-section-visual`
- `atomic-product-section-metadata`
- `atomic-product-section-description`
- `atomic-product-section-emphasized`
- `atomic-product-section-actions`
- `atomic-product-section-badges`
- `atomic-product-section-bottom-metadata`
- `atomic-product-section-children`

Each story now:
- Instantiates `MockCommerceApi` harness
- Registers MSW handlers via `parameters.msw`
- Clears endpoints in `beforeEach` for test isolation