### PR TITLE
feat(atomic): add MSW handlers to result-section stories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ packages/atomic/custom-elements.json
 
 samples/headless/headless-rga-angular/.angular
 *.tsbuildinfo
+packages/atomic/reports/

--- a/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-actions/atomic-result-section-actions.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-actions',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -34,6 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-badges/atomic-result-section-badges.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-badges',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-bottom-metadata',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-children/atomic-result-section-children.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-children',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-emphasized',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories.tsx
@@ -6,8 +6,11 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.js';
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -34,6 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-title-metadata',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-title/atomic-result-section-title.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-title',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -34,6 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.new.stories.tsx
@@ -6,6 +6,7 @@ import {
   getResultSectionArgTypes,
   getResultSectionDecorators,
 } from '@/storybook-utils/search/result-section-story-utils';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-visual/atomic-result-section-visual.js';
 
@@ -13,6 +14,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-visual',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
 
 const {play} = wrapInSearchInterface({
   config: {
@@ -33,6 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },


### PR DESCRIPTION
## Problem
Several `atomic-result-section-*` stories were not using MSW for API mocking, relying on the real Coveo sample API instead.

## Solution
Added `MockSearchApi` handlers to all 9 result-section stories:
- `atomic-result-section-title`
- `atomic-result-section-title-metadata`
- `atomic-result-section-excerpt`
- `atomic-result-section-emphasized`
- `atomic-result-section-children`
- `atomic-result-section-badges`
- `atomic-result-section-bottom-metadata`
- `atomic-result-section-actions`
- `atomic-result-section-visual`

This ensures stories use deterministic mocked responses via MSW.