### PR TITLE
feat(atomic): add MSW handlers to facet stories

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -4,8 +4,12 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-facet', {
@@ -32,6 +36,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: searchApiHarness.handlers,
+    },
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -5,11 +5,18 @@ import {html} from 'lit';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-facet', {
@@ -37,7 +44,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: searchApiHarness.handlers,
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -3,11 +3,18 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-rating-facet/atomic-rating-facet.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -25,7 +32,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: searchApiHarness.handlers,
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -2,8 +2,12 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-rating-facet/atomic-rating-facet.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -20,6 +24,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: searchApiHarness.handlers,
+    },
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -3,11 +3,18 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -25,7 +32,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: searchApiHarness.handlers,
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -2,8 +2,12 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -20,6 +24,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: searchApiHarness.handlers,
+    },
     actions: {
       handles: events,
     },


### PR DESCRIPTION
## Problem
Facet stories were not using MSW for API mocking.

## Solution
Added `MockSearchApi` handlers to 3 facet stories:
- `atomic-facet`
- `atomic-rating-facet`
- `atomic-rating-range-facet`

This ensures stories use deterministic mocked responses via MSW.