### PR TITLE
feat(atomic): migrate product component stories (A) to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
@@ -5,11 +5,14 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -44,6 +47,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -62,6 +66,9 @@ const meta: Meta = {
     commerceInterfaceDecorator,
   ],
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
@@ -11,10 +11,11 @@ import '@/src/components/commerce/atomic-product-section-visual/atomic-product-s
 
 const commerceApiHarness = new MockCommerceApi();
 
-// Limit to 2 products so carousel image indices are predictable in e2e tests
+// Order: non-carousel product first (1 image), carousel product second (2+ images)
+// This matches the e2e test page object: noCarouselImage=nth(0), carouselImage=nth(1)
 commerceApiHarness.productListingEndpoint.mock((response) => ({
   ...response,
-  products: response.products.slice(0, 2),
+  products: [response.products[1], response.products[0]],
   pagination: {
     ...response.pagination,
     totalCount: 2,

--- a/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
@@ -1,12 +1,27 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-image/atomic-product-image.js';
 import '@/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.js';
+
+const commerceApiHarness = new MockCommerceApi();
+
+// Limit to 2 products so carousel image indices are predictable in e2e tests
+commerceApiHarness.productListingEndpoint.mock((response) => ({
+  ...response,
+  products: response.products.slice(0, 2),
+  pagination: {
+    ...response.pagination,
+    totalCount: 2,
+    perPage: 2,
+    totalPages: 1,
+  },
+}));
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   type: 'product-listing',
@@ -55,6 +70,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -64,6 +80,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
@@ -1,11 +1,14 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-link/atomic-product-link.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   type: 'product-listing',
@@ -49,6 +52,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -58,6 +62,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
@@ -1,10 +1,26 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-price/atomic-product-price.js';
+
+const commerceApiHarness = new MockCommerceApi();
+
+// Limit to Blue Lagoon ($1000) + Locktron Padlock ($39/$36 promo) to avoid
+// strict-mode violations in e2e tests (getByText('$39.00') must match once)
+commerceApiHarness.productListingEndpoint.mock((response) => ({
+  ...response,
+  products: [response.products[0], response.products[8]],
+  pagination: {
+    ...response.pagination,
+    totalCount: 2,
+    perPage: 2,
+    totalPages: 1,
+  },
+}));
 
 const {
   decorator: commerceInterfaceDecorator,
@@ -61,6 +77,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -68,6 +85,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
@@ -11,6 +11,34 @@ import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
 
 const commerceApiHarness = new MockCommerceApi();
 
+// Mock search response with a product containing "kayak" in excerpt/name for highlight tests
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  products: [
+    {
+      ...response.products[0],
+      ec_name: 'Kayak Explorer 3000',
+      ec_description:
+        'A durable kayak for ocean and river adventures. This kayak features a comfortable seat and lightweight frame.',
+      ec_shortdesc:
+        'A durable kayak for ocean and river adventures. This kayak features a comfortable seat and lightweight frame.',
+      excerpt:
+        'A durable kayak for ocean and river adventures. This kayak features a comfortable seat and lightweight frame.',
+      nameHighlights: [{offset: 0, length: 5}],
+      excerptHighlights: [
+        {offset: 10, length: 5},
+        {offset: 53, length: 5},
+      ],
+    },
+  ],
+  pagination: {
+    ...response.pagination,
+    totalCount: 1,
+    perPage: 1,
+    totalPages: 1,
+  },
+}));
+
 const {
   decorator: commerceInterfaceDecorator,
   play: initializeCommerceInterface,

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
@@ -7,6 +8,8 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {updateQuery} from '../../../../../headless/src/features/commerce/query/query-actions';
 import '@/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.js';
 import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {
   decorator: commerceInterfaceDecorator,
@@ -49,6 +52,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -56,6 +60,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;


### PR DESCRIPTION
## Problem
Commerce storybook stories for product components don't use MSW for API mocking, making them less reliable and harder to test in isolation.

## Solution
Migrate atomic-product-price, atomic-product-image, atomic-product-link, atomic-product-text, and atomic-product-excerpt stories to use `MockCommerceApi` MSW handlers.

Each story now:
- Imports and instantiates `MockCommerceApi`
- Adds `msw: {handlers: [...commerceApiHarness.handlers]}` to parameters
- Adds `beforeEach: () => { commerceApiHarness.clearAll(); }` for test isolation