### PR TITLE
feat(atomic): add MSW handlers to navigation stories

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -3,9 +3,13 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
 import {expect, waitFor} from 'storybook/test';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-breadbox/atomic-breadbox.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,6 +27,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: searchApiHarness.handlers,
+    },
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -4,12 +4,19 @@ import {html} from 'lit/static-html.js';
 import {expect, waitFor} from 'storybook/test';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-breadbox/atomic-breadbox.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -28,7 +35,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: searchApiHarness.handlers,
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -2,11 +2,12 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-pager/atomic-pager.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-pager', {

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -1,8 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-pager/atomic-pager.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-pager', {
@@ -19,6 +23,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -1,8 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-results-per-page/atomic-results-per-page.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -20,6 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -2,11 +2,12 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-results-per-page/atomic-results-per-page.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -1,9 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -20,6 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -2,12 +2,13 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
@@ -4,12 +4,13 @@ import {html} from 'lit';
 import {testTabsA11y} from '@/storybook-utils/a11y/tabs.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
 
 const {decorator, play} = wrapInSearchInterface();
 

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
@@ -3,9 +3,13 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {testTabsA11y} from '@/storybook-utils/a11y/tabs.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 
@@ -26,6 +30,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },


### PR DESCRIPTION
## Problem
Navigation/pagination stories were not using MSW for API mocking.

## Solution
Added `MockSearchApi` handlers to 5 navigation stories:
- `atomic-pager`
- `atomic-results-per-page`
- `atomic-breadbox`
- `atomic-tab`
- `atomic-sort-dropdown`

This ensures stories use deterministic mocked responses via MSW.