### PR TITLE
feat(atomic): add MSW handlers to search control stories

### DIFF
--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -1,8 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -20,6 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
@@ -2,12 +2,16 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-external/atomic-external.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
 import '@/src/components/search/atomic-refine-toggle/atomic-refine-toggle.js';
 import '@/src/components/search/atomic-search-interface/atomic-search-interface.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,6 +27,9 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: searchApiHarness.handlers,
+    },
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
@@ -2,9 +2,13 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -24,6 +28,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
@@ -3,8 +3,12 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {userEvent} from 'storybook/test';
 import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {wrapInSearchBox} from '@/storybook-utils/search/search-box-wrapper';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.js';
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator: searchInterfaceDecorator, play: searchInterfacePlay} =
   wrapInSearchInterface({}, false, false);
@@ -23,6 +27,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {testDisclosureA11y} from '@/storybook-utils/a11y/disclosure.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.js';
 
@@ -9,6 +10,9 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-smart-snippet-suggestions',
   {excludeCategories: ['methods']}
 );
+
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface({
   config: {
@@ -171,6 +175,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },


### PR DESCRIPTION
## Problem
Search control stories were not using MSW for API mocking.

## Solution
Added `MockSearchApi` handlers to 5 search control stories:
- `atomic-search-box-query-suggestions`
- `atomic-search-box-recent-queries`
- `atomic-query-summary`
- `atomic-refine-toggle`
- `atomic-smart-snippet-suggestions`

This ensures stories use deterministic mocked responses via MSW.